### PR TITLE
catalog/from-k8s: adds support for ClusterIP Service

### DIFF
--- a/catalog/from-k8s/resource_test.go
+++ b/catalog/from-k8s/resource_test.go
@@ -1,9 +1,11 @@
 package catalog
 
 import (
+	"io/ioutil"
 	"testing"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/hashicorp/consul-k8s/helper/controller"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
@@ -14,6 +16,7 @@ import (
 )
 
 func init() {
+	logrus.SetOutput(ioutil.Discard)
 	hclog.DefaultOptions.Level = hclog.Debug
 }
 
@@ -538,6 +541,339 @@ func TestServiceResource_nodePort(t *testing.T) {
 		Spec: apiv1.ServiceSpec{
 			Type: apiv1.ServiceTypeNodePort,
 			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), NodePort: 30000},
+				apiv1.ServicePort{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000), NodePort: 30001},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	node1 := "ip-10-11-12-13.ec2.internal"
+	node2 := "ip-10-11-12-14.ec2.internal"
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node2, IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify what we got
+	syncer.Lock()
+	defer syncer.Unlock()
+	actual := syncer.Registrations
+	require.Len(actual, 2)
+	require.Equal("foo", actual[0].Service.Service)
+	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(8080, actual[0].Service.Port)
+	require.Equal(node1, actual[0].Node)
+	require.Equal("foo", actual[1].Service.Service)
+	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(8080, actual[1].Service.Port)
+	require.Equal(node2, actual[1].Node)
+	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
+}
+
+// Test that a NodePort created earlier works (doesn't require an Endpoints
+// update event).
+func TestServiceResource_nodePortInitial(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client := fake.NewSimpleClientset()
+	syncer := &TestSyncer{}
+
+	// Start the controller
+	closer := controller.TestControllerRun(&ServiceResource{
+		Log:    hclog.Default(),
+		Client: client,
+		Syncer: syncer,
+	})
+	defer closer()
+	time.Sleep(100 * time.Millisecond)
+
+	node1 := "ip-10-11-12-13.ec2.internal"
+	node2 := "ip-10-11-12-14.ec2.internal"
+	// Insert the endpoints
+	_, err := client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node2, IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+	time.Sleep(200 * time.Millisecond)
+
+	// Insert the service
+	_, err = client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeNodePort,
+			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), NodePort: 30000},
+				apiv1.ServicePort{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000), NodePort: 30001},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(400 * time.Millisecond)
+
+	// Verify what we got
+	syncer.Lock()
+	defer syncer.Unlock()
+	actual := syncer.Registrations
+	require.Len(actual, 2)
+	require.Equal("foo", actual[0].Service.Service)
+	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(8080, actual[0].Service.Port)
+	require.Equal(node1, actual[0].Node)
+	require.Equal("foo", actual[1].Service.Service)
+	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(8080, actual[1].Service.Port)
+	require.Equal(node2, actual[1].Node)
+}
+
+// Test that the proper registrations are generated for a NodePort with annotated port.
+func TestServiceResource_nodePortAnnotatedPort(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client := fake.NewSimpleClientset()
+	syncer := &TestSyncer{}
+
+	// Start the controller
+	closer := controller.TestControllerRun(&ServiceResource{
+		Log:    hclog.Default(),
+		Client: client,
+		Syncer: syncer,
+	})
+	defer closer()
+
+	// Insert the service
+	_, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+			Annotations: map[string]string{annotationServicePort: "rpc"},
+		},
+
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeNodePort,
+			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), NodePort: 30000},
+				apiv1.ServicePort{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000), NodePort: 30001},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	node1 := "ip-10-11-12-13.ec2.internal"
+	node2 := "ip-10-11-12-14.ec2.internal"
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node2, IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify what we got
+	syncer.Lock()
+	defer syncer.Unlock()
+	actual := syncer.Registrations
+	require.Len(actual, 2)
+	require.Equal("foo", actual[0].Service.Service)
+	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(2000, actual[0].Service.Port)
+	require.Equal(node1, actual[0].Node)
+	require.Equal("foo", actual[1].Service.Service)
+	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(2000, actual[1].Service.Port)
+	require.Equal(node2, actual[1].Node)
+	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
+}
+
+// Test that the proper registrations are generated for a ClusterIP type.
+func TestServiceResource_clusterIP(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client := fake.NewSimpleClientset()
+	syncer := &TestSyncer{}
+
+	// Start the controller
+	closer := controller.TestControllerRun(&ServiceResource{
+		Log:    hclog.Default(),
+		Client: client,
+		Syncer: syncer,
+	})
+	defer closer()
+
+	// Insert the service
+	_, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeClusterIP,
+			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Port: 8080},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Port: 8080},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify what we got
+	syncer.Lock()
+	defer syncer.Unlock()
+	actual := syncer.Registrations
+	require.Len(actual, 2)
+	require.Equal("foo", actual[0].Service.Service)
+	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(8080, actual[0].Service.Port)
+	require.Equal("foo", actual[1].Service.Service)
+	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(8080, actual[1].Service.Port)
+	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
+}
+
+// Test that the proper registrations are generated for a ClusterIP type with multiple ports.
+func TestServiceResource_clusterIPMultiEndpoint(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client := fake.NewSimpleClientset()
+	syncer := &TestSyncer{}
+
+	// Start the controller
+	closer := controller.TestControllerRun(&ServiceResource{
+		Log:    hclog.Default(),
+		Client: client,
+		Syncer: syncer,
+	})
+	defer closer()
+
+	// Insert the service
+	_, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeClusterIP,
+			Ports: []apiv1.ServicePort{
 				apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)},
 				apiv1.ServicePort{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000)},
 			},
@@ -559,11 +895,19 @@ func TestServiceResource_nodePort(t *testing.T) {
 				Addresses: []apiv1.EndpointAddress{
 					apiv1.EndpointAddress{IP: "1.2.3.4"},
 				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
 			},
 
 			apiv1.EndpointSubset{
 				Addresses: []apiv1.EndpointAddress{
 					apiv1.EndpointAddress{IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
 				},
 			},
 		},
@@ -580,14 +924,15 @@ func TestServiceResource_nodePort(t *testing.T) {
 	require.Len(actual, 2)
 	require.Equal("foo", actual[0].Service.Service)
 	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(8080, actual[0].Service.Port)
 	require.Equal("foo", actual[1].Service.Service)
 	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(8080, actual[1].Service.Port)
 	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
 }
 
-// Test that a NodePort created earlier works (doesn't require an Endpoints
-// update event).
-func TestServiceResource_nodePortInitial(t *testing.T) {
+// Test that the proper registrations are generated for a ClusterIP type with annotated override.
+func TestServiceResource_clusterIPAnnotatedPort(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
@@ -600,39 +945,16 @@ func TestServiceResource_nodePortInitial(t *testing.T) {
 		Syncer: syncer,
 	})
 	defer closer()
-	time.Sleep(100 * time.Millisecond)
-
-	// Insert the endpoints
-	_, err := client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "foo",
-		},
-
-		Subsets: []apiv1.EndpointSubset{
-			apiv1.EndpointSubset{
-				Addresses: []apiv1.EndpointAddress{
-					apiv1.EndpointAddress{IP: "1.2.3.4"},
-				},
-			},
-
-			apiv1.EndpointSubset{
-				Addresses: []apiv1.EndpointAddress{
-					apiv1.EndpointAddress{IP: "2.3.4.5"},
-				},
-			},
-		},
-	})
-	require.NoError(err)
-	time.Sleep(200 * time.Millisecond)
 
 	// Insert the service
-	_, err = client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+	_, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "foo",
+			Name:        "foo",
+			Annotations: map[string]string{annotationServicePort: "rpc"},
 		},
 
 		Spec: apiv1.ServiceSpec{
-			Type: apiv1.ServiceTypeNodePort,
+			Type: apiv1.ServiceTypeClusterIP,
 			Ports: []apiv1.ServicePort{
 				apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)},
 				apiv1.ServicePort{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000)},
@@ -642,7 +964,40 @@ func TestServiceResource_nodePortInitial(t *testing.T) {
 	require.NoError(err)
 
 	// Wait a bit
-	time.Sleep(400 * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
+
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
 
 	// Verify what we got
 	syncer.Lock()
@@ -651,8 +1006,11 @@ func TestServiceResource_nodePortInitial(t *testing.T) {
 	require.Len(actual, 2)
 	require.Equal("foo", actual[0].Service.Service)
 	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(2000, actual[0].Service.Port)
 	require.Equal("foo", actual[1].Service.Service)
 	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(2000, actual[1].Service.Port)
+	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
 }
 
 // testService returns a service that will result in a registration.


### PR DESCRIPTION
addresses #4 

In order to get the correct port, it has to loop through the endpoint ports while looping through the subsets. Also, in order to locate the correct "main" port, I moved the `main` variable outside the if ports condition to be referenced in the `switch`. 

I believe this covers all the cases for ClusterIP services:
- 1 port w/ no name
- multiple ports (take first port defined in the service)
- multiple ports with annotated override