### PR TITLE
connect-inject: adds TLS support for communicating with Consul

### DIFF
--- a/connect-inject/container_sidecar.go
+++ b/connect-inject/container_sidecar.go
@@ -2,40 +2,65 @@ package connectinject
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
+type sidecarContainerCommandData struct {
+	AuthMethod    string
+	HttpTLS       bool
+	TLSServerName string
+}
+
 func (h *Handler) containerSidecar(pod *corev1.Pod) (corev1.Container, error) {
+	data := sidecarContainerCommandData{
+		AuthMethod:    h.AuthMethod,
+		HttpTLS:       h.ConsulHTTPSSL,
+		TLSServerName: h.ConsulTLSServerName,
+	}
+
+	volMounts := []corev1.VolumeMount{
+		corev1.VolumeMount{
+			Name:      volumeName,
+			MountPath: "/consul/connect-inject",
+		},
+	}
+
+	envVars := []corev1.EnvVar{
+		{
+			Name: "HOST_IP",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
+			},
+		},
+	}
+
+	if parts := strings.SplitN(h.ConsulCACert, ":", 2); len(parts) == 2 {
+		volMounts = append(volMounts, corev1.VolumeMount{
+			Name:      volumeNameCA,
+			MountPath: filepath.Dir(parts[1]),
+		})
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "CONSUL_CACERT",
+			Value: parts[1],
+		})
+	}
 
 	// Render the command
 	var buf bytes.Buffer
-	tpl := template.Must(template.New("root").Parse(strings.TrimSpace(
-		sidecarPreStopCommandTpl)))
-	err := tpl.Execute(&buf, h.AuthMethod)
-	if err != nil {
+	tpl := template.Must(template.New("root").Parse(strings.TrimSpace(sidecarPreStopCommandTpl)))
+	if err := tpl.Execute(&buf, &data); err != nil {
 		return corev1.Container{}, err
 	}
 
 	return corev1.Container{
-		Name:  "consul-connect-envoy-sidecar",
-		Image: h.ImageEnvoy,
-		Env: []corev1.EnvVar{
-			{
-				Name: "HOST_IP",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
-				},
-			},
-		},
-		VolumeMounts: []corev1.VolumeMount{
-			corev1.VolumeMount{
-				Name:      volumeName,
-				MountPath: "/consul/connect-inject",
-			},
-		},
+		Name:         "consul-connect-envoy-sidecar",
+		Image:        h.ImageEnvoy,
+		Env:          envVars,
+		VolumeMounts: volMounts,
 		Lifecycle: &corev1.Lifecycle{
 			PreStop: &corev1.Handler{
 				Exec: &corev1.ExecAction{
@@ -56,13 +81,16 @@ func (h *Handler) containerSidecar(pod *corev1.Pod) (corev1.Container, error) {
 }
 
 const sidecarPreStopCommandTpl = `
-export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
+export CONSUL_HTTP_ADDR="{{ if .HttpTLS -}}https://{{ end -}}${HOST_IP}:8500"
+{{ if .TLSServerName -}}
+export CONSUL_TLS_SERVER_NAME="{{ .TLSServerName }}"
+{{ end -}}
 /consul/connect-inject/consul services deregister \
-  {{- if . }}
+  {{- if .AuthMethod }}
   -token-file="/consul/connect-inject/acl-token" \
   {{- end }}
   /consul/connect-inject/service.hcl
-{{- if . }}
+{{- if .AuthMethod }}
 && /consul/connect-inject/consul logout \
   -token-file="/consul/connect-inject/acl-token"
 {{- end}}

--- a/connect-inject/container_volume.go
+++ b/connect-inject/container_volume.go
@@ -1,12 +1,20 @@
 package connectinject
 
 import (
+	"fmt"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
-// volumeName is the name of the volume that is created to store the
-// Consul Connect injection data.
-const volumeName = "consul-connect-inject-data"
+const (
+	// volumeName is the name of the volume that is created to store the
+	// Consul Connect injection data.
+	volumeName = "consul-connect-inject-data"
+	// volumeNameCA is the name of the volume that is created to store the
+	// provided CA certificate if configured with TLS support.
+	volumeNameCA = "consul-tls-ca"
+)
 
 // containerVolume returns the volume data to add to the pod. This volume
 // is used for shared data between containers.
@@ -15,6 +23,25 @@ func (h *Handler) containerVolume() corev1.Volume {
 		Name: volumeName,
 		VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+}
+
+// containerVolumeCA returns the volume data to add to the pod. This volume
+// is used if a CA certificate secret is defined for use with Consul.
+func (h *Handler) containerVolumeCA() corev1.Volume {
+	var parts []string
+
+	if parts = strings.SplitN(h.ConsulCACert, ":", 2); len(parts) < 2 {
+		panic(fmt.Sprintf("Expected valid secret name and mount path for ConsulCACert. Got: %s", h.ConsulCACert))
+	}
+
+	return corev1.Volume{
+		Name: volumeNameCA,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: parts[0],
+			},
 		},
 	}
 }

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -112,6 +112,14 @@ type Handler struct {
 
 	// Log
 	Log hclog.Logger
+
+	// Various options for communicating with Consul over HTTP/GRPC. If TLS
+	// is enabled in your cluster, then you will most likely need to also
+	// inject a CA and configure the client.
+	ConsulCACert        string
+	ConsulTLSServerName string
+	ConsulHTTPSSL       bool
+	ConsulGRPCSSL       bool
 }
 
 // Handle is the http.HandlerFunc implementation that actually handles the


### PR DESCRIPTION
This pull request in general adds support for TLS communication to Consul with the connect-inject web hook. I have a cluster that enforces TLS for both HTTP and GRPC and uses an internal certificate authority. For this reason, it was necessary to augment some of the ways in which both the init containers and sidecar containers are created. 

It adds the following flags to the `connect-inject` command:
- `-consul-cacert`: Kubernetes secret name and mount path for the CA certificate to use for Consul communication.
  - e.g. `-consul-cacert=my-secret-name:/path/to/ca.crt`
- `-consul-tls-server-name`: SNI hostname to use for Consul communication over TLS.
  - e.g. `-consul-tls-server-name=client.us-east-1.consul`
- `-consul-http-ssl`: Whether or not to enable TLS for Consul communication over HTTP.
- `-consul-grpc-ssl`: Whether or not to enable TLS for Consul communication over GRPC.