### PR TITLE
connect-inject: use Deployment/ReplicaSet name for service registration if available

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -23,8 +23,13 @@ type initContainerCommandUpstreamData struct {
 // containerInit returns the init container spec for registering the Consul
 // service, setting up the Envoy bootstrap, etc.
 func (h *Handler) containerInit(pod *corev1.Pod) (corev1.Container, error) {
+	var podName string
+	if podName = pod.Name; podName == "" {
+		podName = strings.Trim(pod.GenerateName, "-")
+	}
+
 	data := initContainerCommandData{
-		PodName:     pod.Name,
+		PodName:     podName,
 		ServiceName: pod.Annotations[annotationService],
 	}
 	if data.ServiceName == "" {


### PR DESCRIPTION
When creating Pods via Deployments or ReplicaSets, the Pod name is generated and therefore the `Name` attribute is not explicitly set. This PR allows service registration to use the generated prefix in lieu of the Pod name if the Pod name is not available.

For example, a Pod named `mypod` will generate the service name:
`mypod-<service-name-or-first-container>-proxy`.

For example, a Deployment named `mydeploy` will generate the service name:
`mydeploy-<random-hash>-<service-name-or-first-container>-proxy`.