### PR TITLE
Support unnamed ports for annotation defaults

### DIFF
--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -279,7 +279,11 @@ func (h *Handler) defaultAnnotations(pod *corev1.Pod) error {
 	if _, ok := pod.ObjectMeta.Annotations[annotationPort]; !ok {
 		if cs := pod.Spec.Containers; len(cs) > 0 {
 			if ps := cs[0].Ports; len(ps) > 0 {
-				pod.ObjectMeta.Annotations[annotationPort] = ps[0].Name
+				if ps[0].Name != "" {
+					pod.ObjectMeta.Annotations[annotationPort] = ps[0].Name
+				} else {
+					pod.ObjectMeta.Annotations[annotationPort] = strconv.Itoa(int(ps[0].ContainerPort))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Currently, a default port is only set if it has an associated name.
This uses the first Pod's ContainerPort directly even if it doesn't
have an associated name.

All of the documentation already supports this design.

Adds a test case for this scenario, as well as tests for the `portValue`
function that parses the name or direct port string.