### PR TITLE
catalog/from-k8s: Don't spin loop on watchService

### DIFF
--- a/catalog/from-k8s/syncer.go
+++ b/catalog/from-k8s/syncer.go
@@ -213,7 +213,6 @@ func (s *ConsulSyncer) watchService(ctx context.Context, name string) {
 
 		// Wait for our poll period
 		case <-time.After(s.SyncPeriod):
-		default:
 		}
 
 		// Wait for service changes


### PR DESCRIPTION
With the `default:` clause here, the time.After doesn't work and just
falls through to `default` causing a spin loop on the consul agent.