### PR TITLE
catalog/from-k8s: Use correct ServicePollPeriod

### DIFF
--- a/catalog/from-k8s/syncer.go
+++ b/catalog/from-k8s/syncer.go
@@ -212,7 +212,7 @@ func (s *ConsulSyncer) watchService(ctx context.Context, name string) {
 			return
 
 		// Wait for our poll period
-		case <-time.After(s.SyncPeriod):
+		case <-time.After(s.ServicePollPeriod):
 		default:
 		}
 


### PR DESCRIPTION
I think this is correct, but it seems otherwise, this value isn't used
anywhere, and based on the corresponding doc strings, it seems we should
be using ServicePollPeriod instead.