### PR TITLE
Use stale flag

### DIFF
--- a/catalog/from-consul/source.go
+++ b/catalog/from-consul/source.go
@@ -19,13 +19,14 @@ type Source struct {
 	Sink   Sink         // Sink is the sink to update with services
 	Prefix string       // Prefix is a prefix to prepend to services
 	Log    hclog.Logger // Logger
+	Stale  bool         // Stale enables stale reads from Consul servers
 }
 
 // Run is the long-running runloop for watching Consul services and
 // updating the Sink.
 func (s *Source) Run(ctx context.Context) {
 	opts := (&api.QueryOptions{
-		AllowStale: true,
+		AllowStale: s.Stale,
 		WaitIndex:  1,
 		WaitTime:   1 * time.Minute,
 	}).WithContext(ctx)

--- a/subcommand/sync-catalog/command.go
+++ b/subcommand/sync-catalog/command.go
@@ -125,6 +125,7 @@ func (c *Command) Run(args []string) int {
 			Namespace:         c.flagK8SSourceNamespace,
 			SyncPeriod:        syncInterval,
 			ServicePollPeriod: syncInterval * 2,
+			Stale:             c.http.Stale(),
 		}
 		go syncer.Run(ctx)
 
@@ -162,6 +163,7 @@ func (c *Command) Run(args []string) int {
 			Sink:   sink,
 			Prefix: c.flagK8SServicePrefix,
 			Log:    hclog.Default().Named("to-k8s/source"),
+			Stale:  c.http.Stale(),
 		}
 		go source.Run(ctx)
 


### PR DESCRIPTION
I noticed that there is a `-stale` flag provided by `flags.HTTPFlags` but it is not actually used. This PR changes it so that the value of the flag is being pushed down to the request.

This however changes the behaviour since before `stale` was always enabled and now it is disabled by default.