### PR TITLE
Customizable Consul sync tag (fixes #42)

### DIFF
--- a/catalog/from-consul/source.go
+++ b/catalog/from-consul/source.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
-	fromk8s "github.com/hashicorp/consul-k8s/catalog/from-k8s"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
 )
@@ -14,11 +13,12 @@ import (
 // Source is the source for the sync that watches Consul services and
 // updates a Sink whenever the set of services to register changes.
 type Source struct {
-	Client *api.Client  // Consul API client
-	Domain string       // Consul DNS domain
-	Sink   Sink         // Sink is the sink to update with services
-	Prefix string       // Prefix is a prefix to prepend to services
-	Log    hclog.Logger // Logger
+	Client       *api.Client  // Consul API client
+	Domain       string       // Consul DNS domain
+	Sink         Sink         // Sink is the sink to update with services
+	Prefix       string       // Prefix is a prefix to prepend to services
+	Log          hclog.Logger // Logger
+	ConsulK8STag string       // The tag value for services registered
 }
 
 // Run is the long-running runloop for watching Consul services and
@@ -62,7 +62,7 @@ func (s *Source) Run(ctx context.Context) {
 			// check here.
 			k8s := false
 			for _, t := range tags {
-				if t == fromk8s.ConsulK8STag {
+				if t == s.ConsulK8STag {
 					k8s = true
 					break
 				}

--- a/catalog/from-consul/source_test.go
+++ b/catalog/from-consul/source_test.go
@@ -108,7 +108,7 @@ func TestSource_ignoreK8S(t *testing.T) {
 	require.NoError(err)
 	_, err = client.Catalog().Register(testRegistration("hostB", "svcA", nil), nil)
 	require.NoError(err)
-	_, err = client.Catalog().Register(testRegistration("hostB", "svcB", []string{fromk8s.ConsulK8STag}), nil)
+	_, err = client.Catalog().Register(testRegistration("hostB", "svcB", []string{fromk8s.TestConsulK8STag}), nil)
 	require.NoError(err)
 
 	_, sink, closer := testSource(t, client)
@@ -249,10 +249,11 @@ func testRegistration(node, service string, tags []string) *api.CatalogRegistrat
 func testSource(t *testing.T, client *api.Client) (*Source, *TestSink, func()) {
 	sink := &TestSink{}
 	s := &Source{
-		Client: client,
-		Domain: "test",
-		Sink:   sink,
-		Log:    hclog.Default(),
+		Client:       client,
+		Domain:       "test",
+		Sink:         sink,
+		Log:          hclog.Default(),
+		ConsulK8STag: fromk8s.TestConsulK8STag,
 	}
 
 	ctx, cancelF := context.WithCancel(context.Background())

--- a/catalog/from-k8s/resource.go
+++ b/catalog/from-k8s/resource.go
@@ -25,9 +25,6 @@ const (
 	// ConsulK8SNS is the key used in the meta to record the namespace
 	// of the service/node registration.
 	ConsulK8SNS = "external-k8s-ns"
-
-	// ConsulK8STag is the tag value for services registered.
-	ConsulK8STag = "k8s"
 )
 
 // ServiceResource implements controller.Resource to sync Service resource
@@ -37,6 +34,9 @@ type ServiceResource struct {
 	Client    kubernetes.Interface
 	Syncer    Syncer
 	Namespace string // K8S namespace to watch
+
+	// ConsulK8STag is the tag value for services registered.
+	ConsulK8STag string
 
 	// ExplictEnable should be set to true to require explicit enabling
 	// using annotations. If this is false, then services are implicitly
@@ -240,7 +240,7 @@ func (t *ServiceResource) generateRegistrations(key string) {
 
 	baseService := consulapi.AgentService{
 		Service: svc.Name,
-		Tags:    []string{ConsulK8STag},
+		Tags:    []string{t.ConsulK8STag},
 		Meta: map[string]string{
 			ConsulSourceKey: ConsulSourceValue,
 			ConsulK8SNS:     t.namespace(),

--- a/catalog/from-k8s/resource_test.go
+++ b/catalog/from-k8s/resource_test.go
@@ -463,9 +463,10 @@ func TestServiceResource_lbAnnotatedTags(t *testing.T) {
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
-		Log:    hclog.Default(),
-		Client: client,
-		Syncer: syncer,
+		Log:          hclog.Default(),
+		Client:       client,
+		Syncer:       syncer,
+		ConsulK8STag: TestConsulK8STag,
 	})
 	defer closer()
 

--- a/catalog/from-k8s/syncer_test.go
+++ b/catalog/from-k8s/syncer_test.go
@@ -247,14 +247,14 @@ func testRegistration(node, service string) *api.CatalogRegistration {
 	return &api.CatalogRegistration{
 		Node:           node,
 		Address:        "127.0.0.1",
-		NodeMeta:       map[string]string{ConsulSourceKey: ConsulK8STag},
+		NodeMeta:       map[string]string{ConsulSourceKey: TestConsulK8STag},
 		SkipNodeUpdate: true,
 		Service: &api.AgentService{
 			ID:      serviceID(node, service),
 			Service: service,
-			Tags:    []string{ConsulK8STag},
+			Tags:    []string{TestConsulK8STag},
 			Meta: map[string]string{
-				ConsulSourceKey: ConsulK8STag,
+				ConsulSourceKey: TestConsulK8STag,
 				ConsulK8SNS:     "default",
 			},
 		},
@@ -268,6 +268,7 @@ func testConsulSyncer(t *testing.T, client *api.Client) (*ConsulSyncer, func()) 
 		SyncPeriod:        200 * time.Millisecond,
 		ServicePollPeriod: 50 * time.Millisecond,
 		Namespace:         "default",
+		ConsulK8STag:      TestConsulK8STag,
 	}
 
 	ctx, cancelF := context.WithCancel(context.Background())

--- a/catalog/from-k8s/testing.go
+++ b/catalog/from-k8s/testing.go
@@ -6,6 +6,10 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
+const (
+	TestConsulK8STag = "k8s"
+)
+
 // TestSyncer implements Syncer for tests, giving easy access to the
 // set of registrations.
 type TestSyncer struct {

--- a/subcommand/sync-catalog/command.go
+++ b/subcommand/sync-catalog/command.go
@@ -33,6 +33,7 @@ type Command struct {
 	flagToConsul              bool
 	flagToK8S                 bool
 	flagConsulDomain          string
+	flagConsulK8STag       	  string
 	flagK8SDefault            bool
 	flagK8SServicePrefix      string
 	flagK8SSourceNamespace    string
@@ -66,6 +67,8 @@ func (c *Command) init() {
 	c.flags.StringVar(&c.flagConsulDomain, "consul-domain", "consul",
 		"The domain for Consul services to use when writing services to "+
 			"Kubernetes. Defaults to consul.")
+	c.flags.StringVar(&c.flagConsulK8STag, "consul-k8s-tag", "k8s",
+		"Tag value for K8S services registered in Consul")
 	c.flags.Var(&c.flagConsulWritePeriod, "consul-write-interval",
 		"The interval to perform syncing operations creating Consul services. "+
 			"All changes are merged and write calls are only made on this "+
@@ -129,6 +132,7 @@ func (c *Command) Run(args []string) int {
 			Namespace:         c.flagK8SSourceNamespace,
 			SyncPeriod:        syncInterval,
 			ServicePollPeriod: syncInterval * 2,
+			ConsulK8STag:      c.flagConsulK8STag,
 		}
 		go syncer.Run(ctx)
 
@@ -142,6 +146,7 @@ func (c *Command) Run(args []string) int {
 				Namespace:      c.flagK8SSourceNamespace,
 				ExplicitEnable: !c.flagK8SDefault,
 				ClusterIPSync:  c.flagSyncClusterIPServices,
+				ConsulK8STag:   c.flagConsulK8STag,
 			},
 		}
 
@@ -162,11 +167,12 @@ func (c *Command) Run(args []string) int {
 		}
 
 		source := &catalogFromConsul.Source{
-			Client: consulClient,
-			Domain: c.flagConsulDomain,
-			Sink:   sink,
-			Prefix: c.flagK8SServicePrefix,
-			Log:    hclog.Default().Named("to-k8s/source"),
+			Client:       consulClient,
+			Domain:       c.flagConsulDomain,
+			Sink:         sink,
+			Prefix:       c.flagK8SServicePrefix,
+			Log:          hclog.Default().Named("to-k8s/source"),
+			ConsulK8STag: c.flagConsulK8STag,
 		}
 		go source.Run(ctx)
 


### PR DESCRIPTION
Customizable Consul catalog sync tag makes it possible to share a single Consul cluster with more than one K8S cluster. With the hardcoded tag ("k8s"), all catalog-sync processes would delete each other's services from Consul.
Controlled via "-consul-k8s-tag" flag.  