### PR TITLE
Add support for ClusterIP Services

### DIFF
--- a/catalog/from-k8s/resource.go
+++ b/catalog/from-k8s/resource.go
@@ -162,10 +162,8 @@ func (t *ServiceResource) shouldSync(svc *apiv1.Service) bool {
 	}
 
 	// Ignore ClusterIP services if ClusterIP sync is disabled
-	if svc.Spec.Type == apiv1.ServiceTypeClusterIP {
-		if !t.ClusterIPSync {
-			return false
-		}
+	if svc.Spec.Type == apiv1.ServiceTypeClusterIP && !t.ClusterIPSync {
+		return false
 	}
 
 	raw, ok := svc.Annotations[annotationServiceSync]

--- a/catalog/from-k8s/resource_test.go
+++ b/catalog/from-k8s/resource_test.go
@@ -1,9 +1,11 @@
 package catalog
 
 import (
+	"io/ioutil"
 	"testing"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/hashicorp/consul-k8s/helper/controller"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
@@ -14,6 +16,7 @@ import (
 )
 
 func init() {
+	logrus.SetOutput(ioutil.Discard)
 	hclog.DefaultOptions.Level = hclog.Debug
 }
 
@@ -538,6 +541,339 @@ func TestServiceResource_nodePort(t *testing.T) {
 		Spec: apiv1.ServiceSpec{
 			Type: apiv1.ServiceTypeNodePort,
 			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), NodePort: 30000},
+				apiv1.ServicePort{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000), NodePort: 30001},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	node1 := "ip-10-11-12-13.ec2.internal"
+	node2 := "ip-10-11-12-14.ec2.internal"
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node2, IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify what we got
+	syncer.Lock()
+	defer syncer.Unlock()
+	actual := syncer.Registrations
+	require.Len(actual, 2)
+	require.Equal("foo", actual[0].Service.Service)
+	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(8080, actual[0].Service.Port)
+	require.Equal(node1, actual[0].Node)
+	require.Equal("foo", actual[1].Service.Service)
+	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(8080, actual[1].Service.Port)
+	require.Equal(node2, actual[1].Node)
+	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
+}
+
+// Test that a NodePort created earlier works (doesn't require an Endpoints
+// update event).
+func TestServiceResource_nodePortInitial(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client := fake.NewSimpleClientset()
+	syncer := &TestSyncer{}
+
+	// Start the controller
+	closer := controller.TestControllerRun(&ServiceResource{
+		Log:    hclog.Default(),
+		Client: client,
+		Syncer: syncer,
+	})
+	defer closer()
+	time.Sleep(100 * time.Millisecond)
+
+	node1 := "ip-10-11-12-13.ec2.internal"
+	node2 := "ip-10-11-12-14.ec2.internal"
+	// Insert the endpoints
+	_, err := client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node2, IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+	time.Sleep(200 * time.Millisecond)
+
+	// Insert the service
+	_, err = client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeNodePort,
+			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), NodePort: 30000},
+				apiv1.ServicePort{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000), NodePort: 30001},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(400 * time.Millisecond)
+
+	// Verify what we got
+	syncer.Lock()
+	defer syncer.Unlock()
+	actual := syncer.Registrations
+	require.Len(actual, 2)
+	require.Equal("foo", actual[0].Service.Service)
+	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(8080, actual[0].Service.Port)
+	require.Equal(node1, actual[0].Node)
+	require.Equal("foo", actual[1].Service.Service)
+	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(8080, actual[1].Service.Port)
+	require.Equal(node2, actual[1].Node)
+}
+
+// Test that the proper registrations are generated for a NodePort with annotated port.
+func TestServiceResource_nodePortAnnotatedPort(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client := fake.NewSimpleClientset()
+	syncer := &TestSyncer{}
+
+	// Start the controller
+	closer := controller.TestControllerRun(&ServiceResource{
+		Log:    hclog.Default(),
+		Client: client,
+		Syncer: syncer,
+	})
+	defer closer()
+
+	// Insert the service
+	_, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+			Annotations: map[string]string{annotationServicePort: "rpc"},
+		},
+
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeNodePort,
+			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), NodePort: 30000},
+				apiv1.ServicePort{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000), NodePort: 30001},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	node1 := "ip-10-11-12-13.ec2.internal"
+	node2 := "ip-10-11-12-14.ec2.internal"
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node2, IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify what we got
+	syncer.Lock()
+	defer syncer.Unlock()
+	actual := syncer.Registrations
+	require.Len(actual, 2)
+	require.Equal("foo", actual[0].Service.Service)
+	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(2000, actual[0].Service.Port)
+	require.Equal(node1, actual[0].Node)
+	require.Equal("foo", actual[1].Service.Service)
+	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(2000, actual[1].Service.Port)
+	require.Equal(node2, actual[1].Node)
+	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
+}
+
+// Test that the proper registrations are generated for a ClusterIP type.
+func TestServiceResource_clusterIP(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client := fake.NewSimpleClientset()
+	syncer := &TestSyncer{}
+
+	// Start the controller
+	closer := controller.TestControllerRun(&ServiceResource{
+		Log:    hclog.Default(),
+		Client: client,
+		Syncer: syncer,
+	})
+	defer closer()
+
+	// Insert the service
+	_, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeClusterIP,
+			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Port: 8080},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Port: 8080},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify what we got
+	syncer.Lock()
+	defer syncer.Unlock()
+	actual := syncer.Registrations
+	require.Len(actual, 2)
+	require.Equal("foo", actual[0].Service.Service)
+	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(8080, actual[0].Service.Port)
+	require.Equal("foo", actual[1].Service.Service)
+	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(8080, actual[1].Service.Port)
+	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
+}
+
+// Test that the proper registrations are generated for a ClusterIP type with multiple ports.
+func TestServiceResource_clusterIPMultiEndpoint(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client := fake.NewSimpleClientset()
+	syncer := &TestSyncer{}
+
+	// Start the controller
+	closer := controller.TestControllerRun(&ServiceResource{
+		Log:    hclog.Default(),
+		Client: client,
+		Syncer: syncer,
+	})
+	defer closer()
+
+	// Insert the service
+	_, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeClusterIP,
+			Ports: []apiv1.ServicePort{
 				apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)},
 				apiv1.ServicePort{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000)},
 			},
@@ -559,11 +895,19 @@ func TestServiceResource_nodePort(t *testing.T) {
 				Addresses: []apiv1.EndpointAddress{
 					apiv1.EndpointAddress{IP: "1.2.3.4"},
 				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
 			},
 
 			apiv1.EndpointSubset{
 				Addresses: []apiv1.EndpointAddress{
 					apiv1.EndpointAddress{IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
 				},
 			},
 		},
@@ -580,14 +924,15 @@ func TestServiceResource_nodePort(t *testing.T) {
 	require.Len(actual, 2)
 	require.Equal("foo", actual[0].Service.Service)
 	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(8080, actual[0].Service.Port)
 	require.Equal("foo", actual[1].Service.Service)
 	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(8080, actual[1].Service.Port)
 	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
 }
 
-// Test that a NodePort created earlier works (doesn't require an Endpoints
-// update event).
-func TestServiceResource_nodePortInitial(t *testing.T) {
+// Test that the proper registrations are generated for a ClusterIP type with annotated override.
+func TestServiceResource_clusterIPAnnotatedPort(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
@@ -600,39 +945,16 @@ func TestServiceResource_nodePortInitial(t *testing.T) {
 		Syncer: syncer,
 	})
 	defer closer()
-	time.Sleep(100 * time.Millisecond)
-
-	// Insert the endpoints
-	_, err := client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "foo",
-		},
-
-		Subsets: []apiv1.EndpointSubset{
-			apiv1.EndpointSubset{
-				Addresses: []apiv1.EndpointAddress{
-					apiv1.EndpointAddress{IP: "1.2.3.4"},
-				},
-			},
-
-			apiv1.EndpointSubset{
-				Addresses: []apiv1.EndpointAddress{
-					apiv1.EndpointAddress{IP: "2.3.4.5"},
-				},
-			},
-		},
-	})
-	require.NoError(err)
-	time.Sleep(200 * time.Millisecond)
 
 	// Insert the service
-	_, err = client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+	_, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "foo",
+			Name:        "foo",
+			Annotations: map[string]string{annotationServicePort: "rpc"},
 		},
 
 		Spec: apiv1.ServiceSpec{
-			Type: apiv1.ServiceTypeNodePort,
+			Type: apiv1.ServiceTypeClusterIP,
 			Ports: []apiv1.ServicePort{
 				apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)},
 				apiv1.ServicePort{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000)},
@@ -642,7 +964,40 @@ func TestServiceResource_nodePortInitial(t *testing.T) {
 	require.NoError(err)
 
 	// Wait a bit
-	time.Sleep(400 * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
+
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
 
 	// Verify what we got
 	syncer.Lock()
@@ -651,8 +1006,11 @@ func TestServiceResource_nodePortInitial(t *testing.T) {
 	require.Len(actual, 2)
 	require.Equal("foo", actual[0].Service.Service)
 	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(2000, actual[0].Service.Port)
 	require.Equal("foo", actual[1].Service.Service)
 	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(2000, actual[1].Service.Port)
+	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
 }
 
 // testService returns a service that will result in a registration.

--- a/catalog/from-k8s/resource_test.go
+++ b/catalog/from-k8s/resource_test.go
@@ -590,11 +590,11 @@ func TestServiceResource_nodePort(t *testing.T) {
 	require.Len(actual, 2)
 	require.Equal("foo", actual[0].Service.Service)
 	require.Equal("1.2.3.4", actual[0].Service.Address)
-	require.Equal(8080, actual[0].Service.Port)
+	require.Equal(30000, actual[0].Service.Port)
 	require.Equal(node1, actual[0].Node)
 	require.Equal("foo", actual[1].Service.Service)
 	require.Equal("2.3.4.5", actual[1].Service.Address)
-	require.Equal(8080, actual[1].Service.Port)
+	require.Equal(30000, actual[1].Service.Port)
 	require.Equal(node2, actual[1].Node)
 	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
 }
@@ -675,11 +675,11 @@ func TestServiceResource_nodePortInitial(t *testing.T) {
 	require.Len(actual, 2)
 	require.Equal("foo", actual[0].Service.Service)
 	require.Equal("1.2.3.4", actual[0].Service.Address)
-	require.Equal(8080, actual[0].Service.Port)
+	require.Equal(30000, actual[0].Service.Port)
 	require.Equal(node1, actual[0].Node)
 	require.Equal("foo", actual[1].Service.Service)
 	require.Equal("2.3.4.5", actual[1].Service.Address)
-	require.Equal(8080, actual[1].Service.Port)
+	require.Equal(30000, actual[1].Service.Port)
 	require.Equal(node2, actual[1].Node)
 }
 
@@ -760,11 +760,14 @@ func TestServiceResource_nodePortAnnotatedPort(t *testing.T) {
 	require.Len(actual, 2)
 	require.Equal("foo", actual[0].Service.Service)
 	require.Equal("1.2.3.4", actual[0].Service.Address)
-	require.Equal(2000, actual[0].Service.Port)
+
+	// This is an odd case-- currently if there are multiple NodePorts configured
+	// for a service, we'll take the last one.
+	require.Equal(30001, actual[0].Service.Port)
 	require.Equal(node1, actual[0].Node)
 	require.Equal("foo", actual[1].Service.Service)
 	require.Equal("2.3.4.5", actual[1].Service.Address)
-	require.Equal(2000, actual[1].Service.Port)
+	require.Equal(30001, actual[1].Service.Port)
 	require.Equal(node2, actual[1].Node)
 	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
 }
@@ -814,17 +817,11 @@ func TestServiceResource_clusterIP(t *testing.T) {
 				Addresses: []apiv1.EndpointAddress{
 					apiv1.EndpointAddress{IP: "1.2.3.4"},
 				},
-				Ports: []apiv1.EndpointPort{
-					apiv1.EndpointPort{Port: 8080},
-				},
 			},
 
 			apiv1.EndpointSubset{
 				Addresses: []apiv1.EndpointAddress{
 					apiv1.EndpointAddress{IP: "2.3.4.5"},
-				},
-				Ports: []apiv1.EndpointPort{
-					apiv1.EndpointPort{Port: 8080},
 				},
 			},
 		},
@@ -841,10 +838,10 @@ func TestServiceResource_clusterIP(t *testing.T) {
 	require.Len(actual, 2)
 	require.Equal("foo", actual[0].Service.Service)
 	require.Equal("1.2.3.4", actual[0].Service.Address)
-	require.Equal(8080, actual[0].Service.Port)
+	require.Equal(80, actual[0].Service.Port)
 	require.Equal("foo", actual[1].Service.Service)
 	require.Equal("2.3.4.5", actual[1].Service.Address)
-	require.Equal(8080, actual[1].Service.Port)
+	require.Equal(80, actual[1].Service.Port)
 	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
 }
 
@@ -894,19 +891,11 @@ func TestServiceResource_clusterIPMultiEndpoint(t *testing.T) {
 				Addresses: []apiv1.EndpointAddress{
 					apiv1.EndpointAddress{IP: "1.2.3.4"},
 				},
-				Ports: []apiv1.EndpointPort{
-					apiv1.EndpointPort{Name: "http", Port: 8080},
-					apiv1.EndpointPort{Name: "rpc", Port: 2000},
-				},
 			},
 
 			apiv1.EndpointSubset{
 				Addresses: []apiv1.EndpointAddress{
 					apiv1.EndpointAddress{IP: "2.3.4.5"},
-				},
-				Ports: []apiv1.EndpointPort{
-					apiv1.EndpointPort{Name: "http", Port: 8080},
-					apiv1.EndpointPort{Name: "rpc", Port: 2000},
 				},
 			},
 		},
@@ -923,10 +912,10 @@ func TestServiceResource_clusterIPMultiEndpoint(t *testing.T) {
 	require.Len(actual, 2)
 	require.Equal("foo", actual[0].Service.Service)
 	require.Equal("1.2.3.4", actual[0].Service.Address)
-	require.Equal(8080, actual[0].Service.Port)
+	require.Equal(80, actual[0].Service.Port)
 	require.Equal("foo", actual[1].Service.Service)
 	require.Equal("2.3.4.5", actual[1].Service.Address)
-	require.Equal(8080, actual[1].Service.Port)
+	require.Equal(80, actual[1].Service.Port)
 	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
 }
 
@@ -977,19 +966,11 @@ func TestServiceResource_clusterIPAnnotatedPort(t *testing.T) {
 				Addresses: []apiv1.EndpointAddress{
 					apiv1.EndpointAddress{IP: "1.2.3.4"},
 				},
-				Ports: []apiv1.EndpointPort{
-					apiv1.EndpointPort{Name: "http", Port: 8080},
-					apiv1.EndpointPort{Name: "rpc", Port: 2000},
-				},
 			},
 
 			apiv1.EndpointSubset{
 				Addresses: []apiv1.EndpointAddress{
 					apiv1.EndpointAddress{IP: "2.3.4.5"},
-				},
-				Ports: []apiv1.EndpointPort{
-					apiv1.EndpointPort{Name: "http", Port: 8080},
-					apiv1.EndpointPort{Name: "rpc", Port: 2000},
 				},
 			},
 		},
@@ -1006,10 +987,10 @@ func TestServiceResource_clusterIPAnnotatedPort(t *testing.T) {
 	require.Len(actual, 2)
 	require.Equal("foo", actual[0].Service.Service)
 	require.Equal("1.2.3.4", actual[0].Service.Address)
-	require.Equal(2000, actual[0].Service.Port)
+	require.Equal(8500, actual[0].Service.Port)
 	require.Equal("foo", actual[1].Service.Service)
 	require.Equal("2.3.4.5", actual[1].Service.Address)
-	require.Equal(2000, actual[1].Service.Port)
+	require.Equal(8500, actual[1].Service.Port)
 	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
 }
 
@@ -1059,17 +1040,11 @@ func TestServiceResource_clusterIPSyncDisabled(t *testing.T) {
 				Addresses: []apiv1.EndpointAddress{
 					apiv1.EndpointAddress{IP: "1.2.3.4"},
 				},
-				Ports: []apiv1.EndpointPort{
-					apiv1.EndpointPort{Port: 8080},
-				},
 			},
 
 			apiv1.EndpointSubset{
 				Addresses: []apiv1.EndpointAddress{
 					apiv1.EndpointAddress{IP: "2.3.4.5"},
-				},
-				Ports: []apiv1.EndpointPort{
-					apiv1.EndpointPort{Port: 8080},
 				},
 			},
 		},

--- a/subcommand/sync-catalog/command.go
+++ b/subcommand/sync-catalog/command.go
@@ -27,17 +27,18 @@ import (
 type Command struct {
 	UI cli.Ui
 
-	flags                  *flag.FlagSet
-	http                   *flags.HTTPFlags
-	k8s                    *k8sflags.K8SFlags
-	flagToConsul           bool
-	flagToK8S              bool
-	flagConsulDomain       string
-	flagK8SDefault         bool
-	flagK8SServicePrefix   string
-	flagK8SSourceNamespace string
-	flagK8SWriteNamespace  string
-	flagConsulWritePeriod  flags.DurationValue
+	flags                     *flag.FlagSet
+	http                      *flags.HTTPFlags
+	k8s                       *k8sflags.K8SFlags
+	flagToConsul              bool
+	flagToK8S                 bool
+	flagConsulDomain          string
+	flagK8SDefault            bool
+	flagK8SServicePrefix      string
+	flagK8SSourceNamespace    string
+	flagK8SWriteNamespace     string
+	flagConsulWritePeriod     flags.DurationValue
+	flagSyncClusterIPServices bool
 
 	once sync.Once
 	help string
@@ -69,6 +70,9 @@ func (c *Command) init() {
 		"The interval to perform syncing operations creating Consul services. "+
 			"All changes are merged and write calls are only made on this "+
 			"interval. Defaults to 30 seconds.")
+	c.flags.BoolVar(&c.flagSyncClusterIPServices, "sync-clusterip-services", true,
+		"If true, all valid ClusterIP services in K8S are synced by default. If false, "+
+			"ClusterIP services are not synced to Consul.")
 
 	c.http = &flags.HTTPFlags{}
 	c.k8s = &k8sflags.K8SFlags{}
@@ -137,6 +141,7 @@ func (c *Command) Run(args []string) int {
 				Syncer:         syncer,
 				Namespace:      c.flagK8SSourceNamespace,
 				ExplicitEnable: !c.flagK8SDefault,
+				ClusterIPSync:  c.flagSyncClusterIPServices,
 			},
 		}
 


### PR DESCRIPTION
This takes the great [PR](https://github.com/hashicorp/consul-k8s/pull/18) from @jipperinbham that adds ClusterIP service sync support and adds a flag to make it optional. Since there are many Kubernetes environments where ClusterIPs aren't externally routeable, this allows people in those environments an easier way to only sync routeable services.