### PR TITLE
Nodeport syncing updates

### DIFF
--- a/catalog/from-k8s/resource.go
+++ b/catalog/from-k8s/resource.go
@@ -252,34 +252,59 @@ func (t *ServiceResource) generateRegistrations(key string) {
 		baseService.Service = strings.TrimSpace(v)
 	}
 
-	// Determine the default port
+	// Determine the default port and set port annotations
 	if len(svc.Spec.Ports) > 0 {
-		nodePort := svc.Spec.Type == apiv1.ServiceTypeNodePort
-		main := svc.Spec.Ports[0].Name
+		// Create port variable, defaults to 0
+		var port int
+
+		// Flag identifying whether the service is of NodePort type
+		isNodePort := svc.Spec.Type == apiv1.ServiceTypeNodePort
 
 		// If a specific port is specified, then use that port value
-		if target, ok := svc.Annotations[annotationServicePort]; ok {
-			main = target
+		target, ok := svc.Annotations[annotationServicePort]
+		if ok {
 			if v, err := strconv.ParseInt(target, 0, 0); err == nil {
-				baseService.Port = int(v)
+				port = int(v)
 			}
 		}
 
-		// Go through the ports so we can add them to the service meta. We
-		// also use this opportunity to find our default port.
+		// For when the port was a name instead of an int
+		if port == 0 && target != "" {
+			// Find the named port
+			for _, p := range svc.Spec.Ports {
+				if p.Name == target {
+					// Pick the right port based on the type of service
+					if isNodePort && p.NodePort > 0 {
+						port = int(p.NodePort)
+					} else {
+						port = int(p.Port)
+					}
+				}
+			}
+		}
+
+		// If the port was not set above, set it with the first port
+		// based on the service type
+		if port == 0 && isNodePort {
+			// Find first defined NodePort
+			for _, p := range svc.Spec.Ports {
+				if p.NodePort > 0 {
+					port = int(p.NodePort)
+					break
+				}
+			}
+		}
+		if port == 0 && !isNodePort {
+			port = int(svc.Spec.Ports[0].Port)
+		}
+
+		// Set service port based on defined port
+		baseService.Port = port
+
+		// Add all the ports as annotations
 		for _, p := range svc.Spec.Ports {
-			target := p.Port
-			if nodePort && p.NodePort > 0 {
-				target = p.NodePort
-			}
-
 			// Set the tag
-			baseService.Meta["port-"+p.Name] = strconv.FormatInt(int64(target), 10)
-
-			// If the name matches our main port, set our main port
-			if p.Name == main {
-				baseService.Port = int(target)
-			}
+			baseService.Meta["port-"+p.Name] = strconv.FormatInt(int64(p.Port), 10)
 		}
 	}
 

--- a/catalog/from-k8s/resource_test.go
+++ b/catalog/from-k8s/resource_test.go
@@ -557,6 +557,36 @@ func TestServiceResource_nodePort(t *testing.T) {
 		},
 	})
 	require.NoError(err)
+	time.Sleep(200 * time.Millisecond)
+
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node2, IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+		},
+	})
 	require.NoError(err)
 
 	// Wait a bit
@@ -595,6 +625,104 @@ func TestServiceResource_nodePort(t *testing.T) {
 	require.Equal(30000, actual[1].Service.Port)
 	require.Equal(node2, actual[1].Node)
 	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
+}
+
+// Test that the proper registrations are generated for a NodePort type.
+func TestServiceResource_nodePort_singleEndpoint(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client := fake.NewSimpleClientset()
+	syncer := &TestSyncer{}
+
+	// Start the controller
+	closer := controller.TestControllerRun(&ServiceResource{
+		Log:    hclog.Default(),
+		Client: client,
+		Syncer: syncer,
+	})
+	defer closer()
+
+	node1 := "ip-10-11-12-13.ec2.internal"
+	node2 := "ip-10-11-12-14.ec2.internal"
+	// Insert the nodes
+	_, err := client.CoreV1().Nodes().Create(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: node1,
+		},
+
+		Status: apiv1.NodeStatus{
+			Addresses: []apiv1.NodeAddress{
+				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "1.2.3.4"},
+			},
+		},
+	})
+	require.NoError(err)
+
+	_, err = client.CoreV1().Nodes().Create(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: node2,
+		},
+
+		Status: apiv1.NodeStatus{
+			Addresses: []apiv1.NodeAddress{
+				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "2.3.4.5"},
+			},
+		},
+	})
+	require.NoError(err)
+	time.Sleep(200 * time.Millisecond)
+
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Insert the service
+	_, err = client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeNodePort,
+			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), NodePort: 30000},
+				apiv1.ServicePort{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000), NodePort: 30001},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify what we got
+	syncer.Lock()
+	defer syncer.Unlock()
+	actual := syncer.Registrations
+	require.Len(actual, 1)
+	require.Equal("foo", actual[0].Service.Service)
+	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(30000, actual[0].Service.Port)
+	require.Equal(node1, actual[0].Node)
 }
 
 // Test that a NodePort created earlier works (doesn't require an Endpoints
@@ -643,6 +771,39 @@ func TestServiceResource_nodePortInitial(t *testing.T) {
 	})
 	require.NoError(err)
 	time.Sleep(200 * time.Millisecond)
+
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node2, IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
 
 	// Insert the service
 	_, err = client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
@@ -717,6 +878,39 @@ func TestServiceResource_nodePortAnnotatedPort(t *testing.T) {
 		Status: apiv1.NodeStatus{
 			Addresses: []apiv1.NodeAddress{
 				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "2.3.4.5"},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node2, IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
 			},
 		},
 	})

--- a/catalog/from-k8s/resource_test.go
+++ b/catalog/from-k8s/resource_test.go
@@ -523,10 +523,10 @@ func TestServiceResource_nodePort(t *testing.T) {
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
-		Log:                hclog.Default(),
-		Client:             client,
-		Syncer:             syncer,
-		NodeExternalIPSync: true,
+		Log:          hclog.Default(),
+		Client:       client,
+		Syncer:       syncer,
+		NodePortSync: ExternalOnly,
 	})
 	defer closer()
 
@@ -639,10 +639,10 @@ func TestServiceResource_nodePort_singleEndpoint(t *testing.T) {
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
-		Log:                hclog.Default(),
-		Client:             client,
-		Syncer:             syncer,
-		NodeExternalIPSync: true,
+		Log:          hclog.Default(),
+		Client:       client,
+		Syncer:       syncer,
+		NodePortSync: ExternalOnly,
 	})
 	defer closer()
 
@@ -739,10 +739,10 @@ func TestServiceResource_nodePortInitial(t *testing.T) {
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
-		Log:                hclog.Default(),
-		Client:             client,
-		Syncer:             syncer,
-		NodeExternalIPSync: true,
+		Log:          hclog.Default(),
+		Client:       client,
+		Syncer:       syncer,
+		NodePortSync: ExternalOnly,
 	})
 	defer closer()
 	time.Sleep(100 * time.Millisecond)
@@ -853,10 +853,10 @@ func TestServiceResource_nodePortAnnotatedPort(t *testing.T) {
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
-		Log:                hclog.Default(),
-		Client:             client,
-		Syncer:             syncer,
-		NodeExternalIPSync: true,
+		Log:          hclog.Default(),
+		Client:       client,
+		Syncer:       syncer,
+		NodePortSync: ExternalOnly,
 	})
 	defer closer()
 
@@ -970,10 +970,10 @@ func TestServiceResource_nodePortUnnamedPort(t *testing.T) {
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
-		Log:                hclog.Default(),
-		Client:             client,
-		Syncer:             syncer,
-		NodeExternalIPSync: true,
+		Log:          hclog.Default(),
+		Client:       client,
+		Syncer:       syncer,
+		NodePortSync: ExternalOnly,
 	})
 	defer closer()
 
@@ -1078,7 +1078,7 @@ func TestServiceResource_nodePortUnnamedPort(t *testing.T) {
 }
 
 // Test that the proper registrations are generated for a NodePort type.
-func TestServiceResource_nodePort_internalIP(t *testing.T) {
+func TestServiceResource_nodePort_internalOnlySync(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
@@ -1086,10 +1086,10 @@ func TestServiceResource_nodePort_internalIP(t *testing.T) {
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
-		Log:                hclog.Default(),
-		Client:             client,
-		Syncer:             syncer,
-		NodeExternalIPSync: false,
+		Log:          hclog.Default(),
+		Client:       client,
+		Syncer:       syncer,
+		NodePortSync: InternalOnly,
 	})
 	defer closer()
 
@@ -1188,6 +1188,121 @@ func TestServiceResource_nodePort_internalIP(t *testing.T) {
 	require.Equal(node1, actual[0].Node)
 	require.Equal("foo", actual[1].Service.Service)
 	require.Equal("3.4.5.6", actual[1].Service.Address)
+	require.Equal(30000, actual[1].Service.Port)
+	require.Equal(node2, actual[1].Node)
+	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
+}
+
+// Test that the proper registrations are generated for a NodePort type.
+func TestServiceResource_nodePort_externalFirstSync(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client := fake.NewSimpleClientset()
+	syncer := &TestSyncer{}
+
+	// Start the controller
+	closer := controller.TestControllerRun(&ServiceResource{
+		Log:          hclog.Default(),
+		Client:       client,
+		Syncer:       syncer,
+		NodePortSync: ExternalFirst,
+	})
+	defer closer()
+
+	node1 := "ip-10-11-12-13.ec2.internal"
+	node2 := "ip-10-11-12-14.ec2.internal"
+	// Insert the nodes
+	_, err := client.CoreV1().Nodes().Create(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: node1,
+		},
+
+		Status: apiv1.NodeStatus{
+			Addresses: []apiv1.NodeAddress{
+				apiv1.NodeAddress{Type: apiv1.NodeInternalIP, Address: "4.5.6.7"},
+			},
+		},
+	})
+	require.NoError(err)
+
+	_, err = client.CoreV1().Nodes().Create(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: node2,
+		},
+
+		Status: apiv1.NodeStatus{
+			Addresses: []apiv1.NodeAddress{
+				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "2.3.4.5"},
+				apiv1.NodeAddress{Type: apiv1.NodeInternalIP, Address: "3.4.5.6"},
+			},
+		},
+	})
+	require.NoError(err)
+	time.Sleep(200 * time.Millisecond)
+
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node2, IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Insert the service
+	_, err = client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeNodePort,
+			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), NodePort: 30000},
+				apiv1.ServicePort{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000), NodePort: 30001},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify what we got
+	syncer.Lock()
+	defer syncer.Unlock()
+	actual := syncer.Registrations
+	require.Len(actual, 2)
+	require.Equal("foo", actual[0].Service.Service)
+	require.Equal("4.5.6.7", actual[0].Service.Address)
+	require.Equal(30000, actual[0].Service.Port)
+	require.Equal(node1, actual[0].Node)
+	require.Equal("foo", actual[1].Service.Service)
+	require.Equal("2.3.4.5", actual[1].Service.Address)
 	require.Equal(30000, actual[1].Service.Port)
 	require.Equal(node2, actual[1].Node)
 	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)

--- a/catalog/from-k8s/resource_test.go
+++ b/catalog/from-k8s/resource_test.go
@@ -529,8 +529,41 @@ func TestServiceResource_nodePort(t *testing.T) {
 	})
 	defer closer()
 
+	node1 := "ip-10-11-12-13.ec2.internal"
+	node2 := "ip-10-11-12-14.ec2.internal"
+	// Insert the nodes
+	_, err := client.CoreV1().Nodes().Create(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: node1,
+		},
+
+		Status: apiv1.NodeStatus{
+			Addresses: []apiv1.NodeAddress{
+				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "1.2.3.4"},
+			},
+		},
+	})
+	require.NoError(err)
+
+	_, err = client.CoreV1().Nodes().Create(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: node2,
+		},
+
+		Status: apiv1.NodeStatus{
+			Addresses: []apiv1.NodeAddress{
+				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "2.3.4.5"},
+			},
+		},
+	})
+	require.NoError(err)
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
 	// Insert the service
-	_, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+	_, err = client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo",
 		},
@@ -540,41 +573,6 @@ func TestServiceResource_nodePort(t *testing.T) {
 			Ports: []apiv1.ServicePort{
 				apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), NodePort: 30000},
 				apiv1.ServicePort{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000), NodePort: 30001},
-			},
-		},
-	})
-	require.NoError(err)
-
-	// Wait a bit
-	time.Sleep(300 * time.Millisecond)
-
-	node1 := "ip-10-11-12-13.ec2.internal"
-	node2 := "ip-10-11-12-14.ec2.internal"
-	// Insert the endpoints
-	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "foo",
-		},
-
-		Subsets: []apiv1.EndpointSubset{
-			apiv1.EndpointSubset{
-				Addresses: []apiv1.EndpointAddress{
-					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
-				},
-				Ports: []apiv1.EndpointPort{
-					apiv1.EndpointPort{Name: "http", Port: 8080},
-					apiv1.EndpointPort{Name: "rpc", Port: 2000},
-				},
-			},
-
-			apiv1.EndpointSubset{
-				Addresses: []apiv1.EndpointAddress{
-					apiv1.EndpointAddress{NodeName: &node2, IP: "2.3.4.5"},
-				},
-				Ports: []apiv1.EndpointPort{
-					apiv1.EndpointPort{Name: "http", Port: 8080},
-					apiv1.EndpointPort{Name: "rpc", Port: 2000},
-				},
 			},
 		},
 	})
@@ -618,31 +616,28 @@ func TestServiceResource_nodePortInitial(t *testing.T) {
 
 	node1 := "ip-10-11-12-13.ec2.internal"
 	node2 := "ip-10-11-12-14.ec2.internal"
-	// Insert the endpoints
-	_, err := client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+	// Insert the nodes
+	_, err := client.CoreV1().Nodes().Create(&apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "foo",
+			Name: node1,
 		},
 
-		Subsets: []apiv1.EndpointSubset{
-			apiv1.EndpointSubset{
-				Addresses: []apiv1.EndpointAddress{
-					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
-				},
-				Ports: []apiv1.EndpointPort{
-					apiv1.EndpointPort{Name: "http", Port: 8080},
-					apiv1.EndpointPort{Name: "rpc", Port: 2000},
-				},
+		Status: apiv1.NodeStatus{
+			Addresses: []apiv1.NodeAddress{
+				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "1.2.3.4"},
 			},
+		},
+	})
+	require.NoError(err)
 
-			apiv1.EndpointSubset{
-				Addresses: []apiv1.EndpointAddress{
-					apiv1.EndpointAddress{NodeName: &node2, IP: "2.3.4.5"},
-				},
-				Ports: []apiv1.EndpointPort{
-					apiv1.EndpointPort{Name: "http", Port: 8080},
-					apiv1.EndpointPort{Name: "rpc", Port: 2000},
-				},
+	_, err = client.CoreV1().Nodes().Create(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: node2,
+		},
+
+		Status: apiv1.NodeStatus{
+			Addresses: []apiv1.NodeAddress{
+				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "2.3.4.5"},
 			},
 		},
 	})
@@ -698,8 +693,40 @@ func TestServiceResource_nodePortAnnotatedPort(t *testing.T) {
 	})
 	defer closer()
 
+	node1 := "ip-10-11-12-13.ec2.internal"
+	node2 := "ip-10-11-12-14.ec2.internal"
+	// Insert the nodes
+	_, err := client.CoreV1().Nodes().Create(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: node1,
+		},
+
+		Status: apiv1.NodeStatus{
+			Addresses: []apiv1.NodeAddress{
+				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "1.2.3.4"},
+			},
+		},
+	})
+	require.NoError(err)
+
+	_, err = client.CoreV1().Nodes().Create(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: node2,
+		},
+
+		Status: apiv1.NodeStatus{
+			Addresses: []apiv1.NodeAddress{
+				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "2.3.4.5"},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
 	// Insert the service
-	_, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+	_, err = client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "foo",
 			Annotations: map[string]string{annotationServicePort: "rpc"},
@@ -710,41 +737,6 @@ func TestServiceResource_nodePortAnnotatedPort(t *testing.T) {
 			Ports: []apiv1.ServicePort{
 				apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), NodePort: 30000},
 				apiv1.ServicePort{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000), NodePort: 30001},
-			},
-		},
-	})
-	require.NoError(err)
-
-	// Wait a bit
-	time.Sleep(300 * time.Millisecond)
-
-	node1 := "ip-10-11-12-13.ec2.internal"
-	node2 := "ip-10-11-12-14.ec2.internal"
-	// Insert the endpoints
-	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "foo",
-		},
-
-		Subsets: []apiv1.EndpointSubset{
-			apiv1.EndpointSubset{
-				Addresses: []apiv1.EndpointAddress{
-					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
-				},
-				Ports: []apiv1.EndpointPort{
-					apiv1.EndpointPort{Name: "http", Port: 8080},
-					apiv1.EndpointPort{Name: "rpc", Port: 2000},
-				},
-			},
-
-			apiv1.EndpointSubset{
-				Addresses: []apiv1.EndpointAddress{
-					apiv1.EndpointAddress{NodeName: &node2, IP: "2.3.4.5"},
-				},
-				Ports: []apiv1.EndpointPort{
-					apiv1.EndpointPort{Name: "http", Port: 8080},
-					apiv1.EndpointPort{Name: "rpc", Port: 2000},
-				},
 			},
 		},
 	})

--- a/catalog/from-k8s/resource_test.go
+++ b/catalog/from-k8s/resource_test.go
@@ -946,14 +946,126 @@ func TestServiceResource_nodePortAnnotatedPort(t *testing.T) {
 	require.Len(actual, 2)
 	require.Equal("foo", actual[0].Service.Service)
 	require.Equal("1.2.3.4", actual[0].Service.Address)
-
-	// This is an odd case-- currently if there are multiple NodePorts configured
-	// for a service, we'll take the last one.
 	require.Equal(30001, actual[0].Service.Port)
 	require.Equal(node1, actual[0].Node)
 	require.Equal("foo", actual[1].Service.Service)
 	require.Equal("2.3.4.5", actual[1].Service.Address)
 	require.Equal(30001, actual[1].Service.Port)
+	require.Equal(node2, actual[1].Node)
+	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
+}
+
+// Test that the proper registrations are generated for a NodePort with annotated port.
+func TestServiceResource_nodePortUnnamedPort(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client := fake.NewSimpleClientset()
+	syncer := &TestSyncer{}
+
+	// Start the controller
+	closer := controller.TestControllerRun(&ServiceResource{
+		Log:    hclog.Default(),
+		Client: client,
+		Syncer: syncer,
+	})
+	defer closer()
+
+	node1 := "ip-10-11-12-13.ec2.internal"
+	node2 := "ip-10-11-12-14.ec2.internal"
+	// Insert the nodes
+	_, err := client.CoreV1().Nodes().Create(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: node1,
+		},
+
+		Status: apiv1.NodeStatus{
+			Addresses: []apiv1.NodeAddress{
+				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "1.2.3.4"},
+			},
+		},
+	})
+	require.NoError(err)
+
+	_, err = client.CoreV1().Nodes().Create(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: node2,
+		},
+
+		Status: apiv1.NodeStatus{
+			Addresses: []apiv1.NodeAddress{
+				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "2.3.4.5"},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Port: 8080},
+					apiv1.EndpointPort{Port: 2000},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node2, IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Port: 8080},
+					apiv1.EndpointPort{Port: 2000},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Insert the service
+	_, err = client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeNodePort,
+			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080), NodePort: 30000},
+				apiv1.ServicePort{Port: 8500, TargetPort: intstr.FromInt(2000), NodePort: 30001},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify what we got
+	syncer.Lock()
+	defer syncer.Unlock()
+	actual := syncer.Registrations
+	require.Len(actual, 2)
+	require.Equal("foo", actual[0].Service.Service)
+	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(30000, actual[0].Service.Port)
+	require.Equal(node1, actual[0].Node)
+	require.Equal("foo", actual[1].Service.Service)
+	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(30000, actual[1].Service.Port)
 	require.Equal(node2, actual[1].Node)
 	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
 }
@@ -1177,6 +1289,80 @@ func TestServiceResource_clusterIPAnnotatedPort(t *testing.T) {
 	require.Equal("foo", actual[1].Service.Service)
 	require.Equal("2.3.4.5", actual[1].Service.Address)
 	require.Equal(8500, actual[1].Service.Port)
+	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
+}
+
+// Test that the proper registrations are generated for a ClusterIP type with unnamed ports.
+func TestServiceResource_clusterIPUnnamedPorts(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client := fake.NewSimpleClientset()
+	syncer := &TestSyncer{}
+
+	// Start the controller
+	closer := controller.TestControllerRun(&ServiceResource{
+		Log:           hclog.Default(),
+		Client:        client,
+		Syncer:        syncer,
+		ClusterIPSync: true,
+	})
+	defer closer()
+
+	// Insert the service
+	_, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeClusterIP,
+			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)},
+				apiv1.ServicePort{Port: 8500, TargetPort: intstr.FromInt(2000)},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{IP: "1.2.3.4"},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{IP: "2.3.4.5"},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify what we got
+	syncer.Lock()
+	defer syncer.Unlock()
+	actual := syncer.Registrations
+	require.Len(actual, 2)
+	require.Equal("foo", actual[0].Service.Service)
+	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(80, actual[0].Service.Port)
+	require.Equal("foo", actual[1].Service.Service)
+	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(80, actual[1].Service.Port)
 	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
 }
 

--- a/catalog/from-k8s/resource_test.go
+++ b/catalog/from-k8s/resource_test.go
@@ -523,9 +523,10 @@ func TestServiceResource_nodePort(t *testing.T) {
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
-		Log:    hclog.Default(),
-		Client: client,
-		Syncer: syncer,
+		Log:                hclog.Default(),
+		Client:             client,
+		Syncer:             syncer,
+		NodeExternalIPSync: true,
 	})
 	defer closer()
 
@@ -540,6 +541,7 @@ func TestServiceResource_nodePort(t *testing.T) {
 		Status: apiv1.NodeStatus{
 			Addresses: []apiv1.NodeAddress{
 				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "1.2.3.4"},
+				apiv1.NodeAddress{Type: apiv1.NodeInternalIP, Address: "4.5.6.7"},
 			},
 		},
 	})
@@ -553,6 +555,7 @@ func TestServiceResource_nodePort(t *testing.T) {
 		Status: apiv1.NodeStatus{
 			Addresses: []apiv1.NodeAddress{
 				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "2.3.4.5"},
+				apiv1.NodeAddress{Type: apiv1.NodeInternalIP, Address: "3.4.5.6"},
 			},
 		},
 	})
@@ -636,9 +639,10 @@ func TestServiceResource_nodePort_singleEndpoint(t *testing.T) {
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
-		Log:    hclog.Default(),
-		Client: client,
-		Syncer: syncer,
+		Log:                hclog.Default(),
+		Client:             client,
+		Syncer:             syncer,
+		NodeExternalIPSync: true,
 	})
 	defer closer()
 
@@ -735,9 +739,10 @@ func TestServiceResource_nodePortInitial(t *testing.T) {
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
-		Log:    hclog.Default(),
-		Client: client,
-		Syncer: syncer,
+		Log:                hclog.Default(),
+		Client:             client,
+		Syncer:             syncer,
+		NodeExternalIPSync: true,
 	})
 	defer closer()
 	time.Sleep(100 * time.Millisecond)
@@ -848,9 +853,10 @@ func TestServiceResource_nodePortAnnotatedPort(t *testing.T) {
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
-		Log:    hclog.Default(),
-		Client: client,
-		Syncer: syncer,
+		Log:                hclog.Default(),
+		Client:             client,
+		Syncer:             syncer,
+		NodeExternalIPSync: true,
 	})
 	defer closer()
 
@@ -964,9 +970,10 @@ func TestServiceResource_nodePortUnnamedPort(t *testing.T) {
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
-		Log:    hclog.Default(),
-		Client: client,
-		Syncer: syncer,
+		Log:                hclog.Default(),
+		Client:             client,
+		Syncer:             syncer,
+		NodeExternalIPSync: true,
 	})
 	defer closer()
 
@@ -1065,6 +1072,122 @@ func TestServiceResource_nodePortUnnamedPort(t *testing.T) {
 	require.Equal(node1, actual[0].Node)
 	require.Equal("foo", actual[1].Service.Service)
 	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(30000, actual[1].Service.Port)
+	require.Equal(node2, actual[1].Node)
+	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
+}
+
+// Test that the proper registrations are generated for a NodePort type.
+func TestServiceResource_nodePort_internalIP(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client := fake.NewSimpleClientset()
+	syncer := &TestSyncer{}
+
+	// Start the controller
+	closer := controller.TestControllerRun(&ServiceResource{
+		Log:                hclog.Default(),
+		Client:             client,
+		Syncer:             syncer,
+		NodeExternalIPSync: false,
+	})
+	defer closer()
+
+	node1 := "ip-10-11-12-13.ec2.internal"
+	node2 := "ip-10-11-12-14.ec2.internal"
+	// Insert the nodes
+	_, err := client.CoreV1().Nodes().Create(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: node1,
+		},
+
+		Status: apiv1.NodeStatus{
+			Addresses: []apiv1.NodeAddress{
+				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "1.2.3.4"},
+				apiv1.NodeAddress{Type: apiv1.NodeInternalIP, Address: "4.5.6.7"},
+			},
+		},
+	})
+	require.NoError(err)
+
+	_, err = client.CoreV1().Nodes().Create(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: node2,
+		},
+
+		Status: apiv1.NodeStatus{
+			Addresses: []apiv1.NodeAddress{
+				apiv1.NodeAddress{Type: apiv1.NodeExternalIP, Address: "2.3.4.5"},
+				apiv1.NodeAddress{Type: apiv1.NodeInternalIP, Address: "3.4.5.6"},
+			},
+		},
+	})
+	require.NoError(err)
+	time.Sleep(200 * time.Millisecond)
+
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node1, IP: "1.2.3.4"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{NodeName: &node2, IP: "2.3.4.5"},
+				},
+				Ports: []apiv1.EndpointPort{
+					apiv1.EndpointPort{Name: "http", Port: 8080},
+					apiv1.EndpointPort{Name: "rpc", Port: 2000},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Insert the service
+	_, err = client.CoreV1().Services(metav1.NamespaceDefault).Create(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeNodePort,
+			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), NodePort: 30000},
+				apiv1.ServicePort{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000), NodePort: 30001},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify what we got
+	syncer.Lock()
+	defer syncer.Unlock()
+	actual := syncer.Registrations
+	require.Len(actual, 2)
+	require.Equal("foo", actual[0].Service.Service)
+	require.Equal("4.5.6.7", actual[0].Service.Address)
+	require.Equal(30000, actual[0].Service.Port)
+	require.Equal(node1, actual[0].Node)
+	require.Equal("foo", actual[1].Service.Service)
+	require.Equal("3.4.5.6", actual[1].Service.Address)
 	require.Equal(30000, actual[1].Service.Port)
 	require.Equal(node2, actual[1].Node)
 	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)

--- a/subcommand/sync-catalog/command.go
+++ b/subcommand/sync-catalog/command.go
@@ -39,7 +39,7 @@ type Command struct {
 	flagK8SWriteNamespace     string
 	flagConsulWritePeriod     flags.DurationValue
 	flagSyncClusterIPServices bool
-	flagSyncNodeExternalIP    bool
+	flagNodePortSyncType      string
 
 	once sync.Once
 	help string
@@ -74,9 +74,9 @@ func (c *Command) init() {
 	c.flags.BoolVar(&c.flagSyncClusterIPServices, "sync-clusterip-services", true,
 		"If true, all valid ClusterIP services in K8S are synced by default. If false, "+
 			"ClusterIP services are not synced to Consul.")
-	c.flags.BoolVar(&c.flagSyncNodeExternalIP, "sync-node-external-ip", true,
-		"If true, NodePort services will be synced using the node's external ip address. "+
-			"If false, NodePort services will be synced with the node's internal ip address.")
+	c.flags.StringVar(&c.flagNodePortSyncType, "node-port-sync-type", "ExternalOnly",
+		"Defines the type of sync for NodePort services. Valid options are ExternalOnly, "+
+			"InternalOnly and ExternalFirst.")
 
 	c.http = &flags.HTTPFlags{}
 	c.k8s = &k8sflags.K8SFlags{}
@@ -140,13 +140,13 @@ func (c *Command) Run(args []string) int {
 		ctl := &controller.Controller{
 			Log: hclog.Default().Named("to-consul/controller"),
 			Resource: &catalogFromK8S.ServiceResource{
-				Log:                hclog.Default().Named("to-consul/source"),
-				Client:             clientset,
-				Syncer:             syncer,
-				Namespace:          c.flagK8SSourceNamespace,
-				ExplicitEnable:     !c.flagK8SDefault,
-				ClusterIPSync:      c.flagSyncClusterIPServices,
-				NodeExternalIPSync: c.flagSyncNodeExternalIP,
+				Log:            hclog.Default().Named("to-consul/source"),
+				Client:         clientset,
+				Syncer:         syncer,
+				Namespace:      c.flagK8SSourceNamespace,
+				ExplicitEnable: !c.flagK8SDefault,
+				ClusterIPSync:  c.flagSyncClusterIPServices,
+				NodePortSync:   catalogFromK8S.NodePortSyncType(c.flagNodePortSyncType),
 			},
 		}
 


### PR DESCRIPTION
This updates the NodePort sync logic to use the node's ip address, rather than the pod's ip. This puts a fully routable address into the sync, making it possible to externally sync with these services.

Additionally, it updates the port determination logic to take the first defined NodePort when there are multiples. It also now takes the first address when the ports are unnamed, as well as adding tests for this case.