### PR TITLE
Add a flag to specify Kubernetes NodePort service register IP address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /bin
 /pkg
+vendor/

--- a/catalog/from-k8s/resource.go
+++ b/catalog/from-k8s/resource.go
@@ -406,7 +406,7 @@ func (t *ServiceResource) generateRegistrations(key string) {
 				// Find the external ip address for the node and
 				// create the Consul service using it
 				for _, address := range node.Status.Addresses {
-					if address.Type == apiv1.NodeExternalIP {
+					if address.Type == apiv1.NodeExternalIP || address.Type == apiv1.NodeInternalIP {
 						r := baseNode
 						rs := baseService
 						r.Service = &rs


### PR DESCRIPTION
Kubernetes NodePort service, whether using ExternalIP or InternalIP, Node IP should be registered.

NodePort service the default exposed port is on the Node IP
NodeHostName, NodeExternalDNS, NodeInternalDNS for the time being, I don't know how to use it. I will use it again. :D

k8s.io/api/core/v1/types.go:
const (
    NodeHostName    NodeAddressType = "Hostname"                                                                                                                           NodeExternalIP  NodeAddressType = "ExternalIP"
    NodeInternalIP  NodeAddressType = "InternalIP"                                                                                                                         NodeExternalDNS NodeAddressType = "ExternalDNS"
    NodeInternalDNS NodeAddressType = "InternalDNS"                                                                                                                    )
