### PR TITLE
Switch logging scheme to limit log spam from health checks

### DIFF
--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/mattbaird/jsonpatch"
 	"k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -71,14 +72,21 @@ type Handler struct {
 	// RequireAnnotation means that the annotation must be given to inject.
 	// If this is false, injection is default.
 	RequireAnnotation bool
+
+	// Log
+	Log hclog.Logger
 }
 
 // Handle is the http.HandlerFunc implementation that actually handles the
 // webhook request for admission control. This should be registered or
 // served via an HTTP server.
 func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
+	h.Log.Info("Request received", "Method", r.Method, "URL", r.URL)
+
 	if ct := r.Header.Get("Content-Type"); ct != "application/json" {
-		http.Error(w, fmt.Sprintf("Invalid content-type: %q", ct), http.StatusBadRequest)
+		msg := fmt.Sprintf("Invalid content-type: %q", ct)
+		http.Error(w, msg, http.StatusBadRequest)
+		h.Log.Error("Error on request", "Error", msg, "Code", http.StatusBadRequest)
 		return
 	}
 
@@ -86,20 +94,23 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 	if r.Body != nil {
 		var err error
 		if body, err = ioutil.ReadAll(r.Body); err != nil {
-			http.Error(w, fmt.Sprintf(
-				"Error reading request body: %s", err), http.StatusBadRequest)
+			msg := fmt.Sprintf("Error reading request body: %s", err)
+			http.Error(w, msg, http.StatusBadRequest)
+			h.Log.Error("Error on request", "Error", msg, "Code", http.StatusBadRequest)
 			return
 		}
 	}
 	if len(body) == 0 {
-		http.Error(w, "Empty request body", http.StatusBadRequest)
+		msg := "Empty request body"
+		http.Error(w, msg, http.StatusBadRequest)
+		h.Log.Error("Error on request", "Error", msg, "Code", http.StatusBadRequest)
 		return
 	}
 
 	var admReq v1beta1.AdmissionReview
 	var admResp v1beta1.AdmissionReview
 	if _, _, err := deserializer.Decode(body, nil, &admReq); err != nil {
-		log.Printf("Could not decode admission request: %s", err)
+		h.Log.Error("Could not decode admission request", "Error", err)
 		admResp.Response = admissionError(err)
 	} else {
 		admResp.Response = h.Mutate(admReq.Request)
@@ -107,14 +118,14 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := json.Marshal(&admResp)
 	if err != nil {
-		http.Error(w, fmt.Sprintf(
-			"Error marshalling admission response: %s", err),
-			http.StatusInternalServerError)
+		msg := fmt.Sprintf("Error marshalling admission response: %s", err)
+		http.Error(w, msg, http.StatusInternalServerError)
+		h.Log.Error("Error on request", "Error", msg, "Code", http.StatusInternalServerError)
 		return
 	}
 
 	if _, err := w.Write(resp); err != nil {
-		log.Printf("error writing response: %s", err)
+		h.Log.Error("Error writing response", "Error", err)
 	}
 }
 

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/mattbaird/jsonpatch"
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/admission/v1beta1"
@@ -32,7 +33,7 @@ func TestHandlerHandle(t *testing.T) {
 	}{
 		{
 			"kube-system namespace",
-			Handler{},
+			Handler{Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -46,7 +47,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"already injected",
-			Handler{},
+			Handler{Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -64,7 +65,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"empty pod basic",
-			Handler{},
+			Handler{Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					Spec: basicSpec,
@@ -93,7 +94,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"pod with upstreams specified",
-			Handler{},
+			Handler{Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -144,7 +145,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"empty pod with injection disabled",
-			Handler{},
+			Handler{Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -162,7 +163,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"empty pod with injection truthy",
-			Handler{},
+			Handler{Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -226,7 +227,7 @@ func TestHandlerHandle_badContentType(t *testing.T) {
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "text/plain")
 
-	var h Handler
+	h := Handler{Log: hclog.Default().Named("handler")}
 	rec := httptest.NewRecorder()
 	h.Handle(rec, req)
 	require.Equal(t, http.StatusBadRequest, rec.Code)
@@ -239,7 +240,7 @@ func TestHandlerHandle_noBody(t *testing.T) {
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
-	var h Handler
+	h := Handler{Log: hclog.Default().Named("handler")}
 	rec := httptest.NewRecorder()
 	h.Handle(rec, req)
 	require.Equal(t, http.StatusBadRequest, rec.Code)

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -7,16 +7,15 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/gorilla/handlers"
 	"github.com/hashicorp/consul-k8s/connect-inject"
 	"github.com/hashicorp/consul-k8s/helper/cert"
 	"github.com/hashicorp/consul/command/flags"
+	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -105,12 +104,12 @@ func (c *Command) Run(args []string) int {
 		ImageConsul:       c.flagConsulImage,
 		ImageEnvoy:        c.flagEnvoyImage,
 		RequireAnnotation: !c.flagDefaultInject,
+		Log:               hclog.Default().Named("handler"),
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mutate", injector.Handle)
 	mux.HandleFunc("/health/ready", c.handleReady)
 	var handler http.Handler = mux
-	handler = handlers.LoggingHandler(os.Stdout, handler)
 	server := &http.Server{
 		Addr:      c.flagListen,
 		Handler:   handler,


### PR DESCRIPTION
This removes the LoggingHandler and instead uses a normal handler
with specific logging for things that are useful to have in the logs.
Previously, the logs were completely overrun with health check logs,
making it difficult to find useful information.