### PR TITLE
use service's namespace while get endpoints to register

### DIFF
--- a/catalog/from-k8s/resource.go
+++ b/catalog/from-k8s/resource.go
@@ -122,7 +122,7 @@ func (t *ServiceResource) Upsert(key string, raw interface{}) error {
 	// If we care about endpoints, we should do the initial endpoints load.
 	if t.shouldTrackEndpoints(key) {
 		endpoints, err := t.Client.CoreV1().
-			Endpoints(t.namespace()).
+			Endpoints(service.Namespace)).
 			Get(service.Name, metav1.GetOptions{})
 		if err != nil {
 			t.Log.Warn("error loading initial endpoints",

--- a/catalog/from-k8s/resource.go
+++ b/catalog/from-k8s/resource.go
@@ -122,7 +122,7 @@ func (t *ServiceResource) Upsert(key string, raw interface{}) error {
 	// If we care about endpoints, we should do the initial endpoints load.
 	if t.shouldTrackEndpoints(key) {
 		endpoints, err := t.Client.CoreV1().
-			Endpoints(service.Namespace)).
+			Endpoints(service.Namespace).
 			Get(service.Name, metav1.GetOptions{})
 		if err != nil {
 			t.Log.Warn("error loading initial endpoints",

--- a/catalog/from-k8s/resource_test.go
+++ b/catalog/from-k8s/resource_test.go
@@ -1672,6 +1672,84 @@ func TestServiceResource_clusterIPSyncDisabled(t *testing.T) {
 	require.Len(actual, 0)
 }
 
+
+
+// Test that the ClusterIP services are synced when watching all namespaces
+func TestServiceResource_clusterIPAllNamespaces(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	client := fake.NewSimpleClientset()
+	syncer := &TestSyncer{}
+	testNamespace := "test_namespace"
+
+	// Start the controller
+	closer := controller.TestControllerRun(&ServiceResource{
+		Log:           hclog.Default(),
+		Client:        client,
+		Syncer:        syncer,
+		Namespace:     apiv1.NamespaceAll,
+		ClusterIPSync: true,
+	})
+	defer closer()
+
+
+	// Insert the service
+	_, err := client.CoreV1().Services(testNamespace).Create(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeClusterIP,
+			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Insert the endpoints
+	_, err = client.CoreV1().Endpoints(testNamespace).Create(&apiv1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+
+		Subsets: []apiv1.EndpointSubset{
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{IP: "1.2.3.4"},
+				},
+			},
+
+			apiv1.EndpointSubset{
+				Addresses: []apiv1.EndpointAddress{
+					apiv1.EndpointAddress{IP: "2.3.4.5"},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Wait a bit
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify what we got
+	syncer.Lock()
+	defer syncer.Unlock()
+	actual := syncer.Registrations
+	require.Len(actual, 2)
+	require.Equal("foo", actual[0].Service.Service)
+	require.Equal("1.2.3.4", actual[0].Service.Address)
+	require.Equal(80, actual[0].Service.Port)
+	require.Equal("foo", actual[1].Service.Service)
+	require.Equal("2.3.4.5", actual[1].Service.Address)
+	require.Equal(80, actual[1].Service.Port)
+	require.NotEqual(actual[0].Service.ID, actual[1].Service.ID)
+}
+
 // testService returns a service that will result in a registration.
 func testService(name string) *apiv1.Service {
 	return &apiv1.Service{


### PR DESCRIPTION
after this fix registration works when consul-k8s observe all namespaces