### PR TITLE
Add datacenter support to inject annotation

### DIFF
--- a/build-support/docker/Dev.dockerfile
+++ b/build-support/docker/Dev.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.0 as builder
+FROM golang:1.11.5 as builder
 ARG GIT_COMMIT
 ARG GIT_DIRTY
 ARG GIT_DESCRIBE

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -15,8 +15,9 @@ type initContainerCommandData struct {
 }
 
 type initContainerCommandUpstreamData struct {
-	Name      string
-	LocalPort int32
+	Name       string
+	LocalPort  int32
+	Datacenter string
 }
 
 // containerInit returns the init container spec for registering the Consul
@@ -42,12 +43,20 @@ func (h *Handler) containerInit(pod *corev1.Pod) (corev1.Container, error) {
 	// If upstreams are specified, configure those
 	if raw, ok := pod.Annotations[annotationUpstreams]; ok && raw != "" {
 		for _, raw := range strings.Split(raw, ",") {
-			parts := strings.SplitN(raw, ":", 2)
+			parts := strings.SplitN(raw, ":", 3)
 			port, _ := portValue(pod, strings.TrimSpace(parts[1]))
+
+			// parse the optional datacenter
+			datacenter := ""
+			if len(parts) > 2 {
+				datacenter = strings.TrimSpace(parts[2])
+			}
+
 			if port > 0 {
 				data.Upstreams = append(data.Upstreams, initContainerCommandUpstreamData{
-					Name:      strings.TrimSpace(parts[0]),
-					LocalPort: port,
+					Name:       strings.TrimSpace(parts[0]),
+					LocalPort:  port,
+					Datacenter: datacenter,
 				})
 			}
 		}
@@ -124,6 +133,9 @@ services {
     upstreams {
       destination_name = "{{ .Name }}"
       local_bind_port = {{ .LocalPort }}
+			{{ if .Datacenter }}
+			datacenter = {{ .Datacenter }}
+			{{ end }}
     }
     {{ end }}
   }

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -134,7 +134,7 @@ services {
       destination_name = "{{ .Name }}"
       local_bind_port = {{ .LocalPort }}
 			{{ if .Datacenter }}
-			datacenter = {{ .Datacenter }}
+			datacenter = "{{ .Datacenter }}"
 			{{ end }}
     }
     {{ end }}

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -133,9 +133,9 @@ services {
     upstreams {
       destination_name = "{{ .Name }}"
       local_bind_port = {{ .LocalPort }}
-			{{ if .Datacenter }}
-			datacenter = "{{ .Datacenter }}"
-			{{ end }}
+			{{- if .Datacenter }}
+      datacenter = "{{ .Datacenter }}"
+			{{- end}}
     }
     {{ end }}
   }

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -1,6 +1,7 @@
 package connectinject
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -89,7 +90,7 @@ func TestHandlerContainerInit(t *testing.T) {
 				return pod
 			},
 			"",
-			`datacenter = "dc1"`,
+			`datacenter"`,
 		},
 
 		{
@@ -123,6 +124,7 @@ func TestHandlerContainerInit(t *testing.T) {
 			container, err := h.containerInit(tt.Pod(minimal()))
 			require.NoError(err)
 			actual := strings.Join(container.Command, " ")
+			fmt.Println(actual)
 			require.Contains(actual, tt.Cmd)
 			if tt.CmdNot != "" {
 				require.NotContains(actual, tt.CmdNot)

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -71,6 +71,28 @@ func TestHandlerContainerInit(t *testing.T) {
 		},
 
 		{
+			"Upstream datacenter specified",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				pod.Annotations[annotationUpstreams] = "db:1234:dc1"
+				return pod
+			},
+			"datacenter = dc1",
+			"",
+		},
+
+		{
+			"No Upstream datacenter specified",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				pod.Annotations[annotationUpstreams] = "db:1234"
+				return pod
+			},
+			"",
+			"datacenter = dc1",
+		},
+
+		{
 			"Service ID set to POD_NAME env var",
 			func(pod *corev1.Pod) *corev1.Pod {
 				pod.Annotations[annotationService] = "web"

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -77,7 +77,7 @@ func TestHandlerContainerInit(t *testing.T) {
 				pod.Annotations[annotationUpstreams] = "db:1234:dc1"
 				return pod
 			},
-			"datacenter = dc1",
+			`datacenter = "dc1"`,
 			"",
 		},
 
@@ -89,7 +89,7 @@ func TestHandlerContainerInit(t *testing.T) {
 				return pod
 			},
 			"",
-			"datacenter = dc1",
+			`datacenter = "dc1"`,
 		},
 
 		{


### PR DESCRIPTION
This PR adds support to specify the datacenter for a consul connect upstream from the K8s annotation.
https://www.consul.io/docs/connect/proxies.html#datacenter

The new format has the form of the following example:
```
annotations:
  "consul.hashicorp.com/connect-service-upstreams": "[service]:[port]:[datacenter]"
```

`datacenter` is an optional parameter 

If this is all OK I will raise a separate PR for the consul.io docs