### PR TITLE
Add prepared_query annotation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## UNRELEASED
+
 ## 0.5.0 (February 8, 2019)
 
 Improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Improvements:
 
 * Clarify the format of the `consul-write-interval` flag for `consul-k8s` [[GH 61](https://github.com/hashicorp/consul-k8s/issues/61)]
 * Add datacenter support to inject annotation
+* Update connect injector logging to remove healthcheck log spam and make important messages more visible
 
 Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## UNRELEASED
+## 0.5.0 (February 8, 2019)
 
 Improvements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 Improvements:
 
 * Clarify the format of the `consul-write-interval` flag for `consul-k8s` [[GH 61](https://github.com/hashicorp/consul-k8s/issues/61)]
+* Add datacenter support to inject annotation
 
 Bug fixes:
 
 * Fix service registration naming when using Connect [[GH 36](https://github.com/hashicorp/consul-k8s/issues/36)]
 * Fix catalog sync so that agents don't incorrectly deregister Kubernetes services [[GH 40](https://github.com/hashicorp/consul-k8s/issues/40)][[GH 59](https://github.com/hashicorp/consul-k8s/issues/59)]
+* Fix performance issue for the k8s -> Consul catalog sync [[GH 60](https://github.com/hashicorp/consul-k8s/issues/60)]
 
 ## 0.4.0 (January 11, 2019)
 Improvements:

--- a/build-support/docker/Build-Go.dockerfile
+++ b/build-support/docker/Build-Go.dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.11.0
+ARG GOLANG_VERSION=1.11.5
 FROM golang:${GOLANG_VERSION}
 
 ARG GOTOOLS="github.com/magiconair/vendorfmt/cmd/vendorfmt \

--- a/build-support/docker/Dev.dockerfile
+++ b/build-support/docker/Dev.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.0 as builder
+FROM golang:1.11.5 as builder
 ARG GIT_COMMIT
 ARG GIT_DIRTY
 ARG GIT_DESCRIBE

--- a/catalog/from-k8s/syncer.go
+++ b/catalog/from-k8s/syncer.go
@@ -216,7 +216,6 @@ func (s *ConsulSyncer) watchService(ctx context.Context, name string) {
 
 		// Wait for our poll period
 		case <-time.After(s.SyncPeriod):
-		default:
 		}
 
 		// Wait for service changes

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -133,9 +133,9 @@ services {
     upstreams {
       destination_name = "{{ .Name }}"
       local_bind_port = {{ .LocalPort }}
-			{{- if .Datacenter }}
+      {{- if .Datacenter }}
       datacenter = "{{ .Datacenter }}"
-			{{- end}}
+      {{- end}}
     }
     {{ end }}
   }

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -15,8 +15,9 @@ type initContainerCommandData struct {
 }
 
 type initContainerCommandUpstreamData struct {
-	Name      string
-	LocalPort int32
+	Name       string
+	LocalPort  int32
+	Datacenter string
 }
 
 // containerInit returns the init container spec for registering the Consul
@@ -42,12 +43,20 @@ func (h *Handler) containerInit(pod *corev1.Pod) (corev1.Container, error) {
 	// If upstreams are specified, configure those
 	if raw, ok := pod.Annotations[annotationUpstreams]; ok && raw != "" {
 		for _, raw := range strings.Split(raw, ",") {
-			parts := strings.SplitN(raw, ":", 2)
+			parts := strings.SplitN(raw, ":", 3)
 			port, _ := portValue(pod, strings.TrimSpace(parts[1]))
+
+			// parse the optional datacenter
+			datacenter := ""
+			if len(parts) > 2 {
+				datacenter = strings.TrimSpace(parts[2])
+			}
+
 			if port > 0 {
 				data.Upstreams = append(data.Upstreams, initContainerCommandUpstreamData{
-					Name:      strings.TrimSpace(parts[0]),
-					LocalPort: port,
+					Name:       strings.TrimSpace(parts[0]),
+					LocalPort:  port,
+					Datacenter: datacenter,
 				})
 			}
 		}
@@ -124,6 +133,9 @@ services {
     upstreams {
       destination_name = "{{ .Name }}"
       local_bind_port = {{ .LocalPort }}
+			{{ if .Datacenter }}
+			datacenter = {{ .Datacenter }}
+			{{ end }}
     }
     {{ end }}
   }

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -134,7 +134,7 @@ services {
       destination_name = "{{ .Name }}"
       local_bind_port = {{ .LocalPort }}
 			{{ if .Datacenter }}
-			datacenter = {{ .Datacenter }}
+			datacenter = "{{ .Datacenter }}"
 			{{ end }}
     }
     {{ end }}

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -133,9 +133,9 @@ services {
     upstreams {
       destination_name = "{{ .Name }}"
       local_bind_port = {{ .LocalPort }}
-			{{ if .Datacenter }}
-			datacenter = "{{ .Datacenter }}"
-			{{ end }}
+			{{- if .Datacenter }}
+      datacenter = "{{ .Datacenter }}"
+			{{- end}}
     }
     {{ end }}
   }

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -91,6 +91,27 @@ func TestHandlerContainerInit(t *testing.T) {
 			"",
 			`datacenter`,
 		},
+		{
+			"Prepared Query specified",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				pod.Annotations[annotationUpstreams] = "prepared_query:handle:1234"
+				return pod
+			},
+			`destination_type = "prepared_query"`,
+			"",
+		},
+
+		{
+			"Prepared Query specified",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				pod.Annotations[annotationUpstreams] = "prepared_query:handle:1234"
+				return pod
+			},
+			`destination_name = "handle"`,
+			"",
+		},
 
 		{
 			"Service ID set to POD_NAME env var",

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -1,6 +1,7 @@
 package connectinject
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -89,7 +90,7 @@ func TestHandlerContainerInit(t *testing.T) {
 				return pod
 			},
 			"",
-			`datacenter = "dc1"`,
+			`datacenter"`,
 		},
 
 		{
@@ -123,6 +124,7 @@ func TestHandlerContainerInit(t *testing.T) {
 			container, err := h.containerInit(tt.Pod(minimal()))
 			require.NoError(err)
 			actual := strings.Join(container.Command, " ")
+			fmt.Println(actual)
 			require.Contains(actual, tt.Cmd)
 			if tt.CmdNot != "" {
 				require.NotContains(actual, tt.CmdNot)

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -71,6 +71,28 @@ func TestHandlerContainerInit(t *testing.T) {
 		},
 
 		{
+			"Upstream datacenter specified",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				pod.Annotations[annotationUpstreams] = "db:1234:dc1"
+				return pod
+			},
+			"datacenter = dc1",
+			"",
+		},
+
+		{
+			"No Upstream datacenter specified",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				pod.Annotations[annotationUpstreams] = "db:1234"
+				return pod
+			},
+			"",
+			"datacenter = dc1",
+		},
+
+		{
 			"Service ID set to POD_NAME env var",
 			func(pod *corev1.Pod) *corev1.Pod {
 				pod.Annotations[annotationService] = "web"

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -1,7 +1,6 @@
 package connectinject
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -90,7 +89,7 @@ func TestHandlerContainerInit(t *testing.T) {
 				return pod
 			},
 			"",
-			`datacenter"`,
+			`datacenter`,
 		},
 
 		{
@@ -124,7 +123,6 @@ func TestHandlerContainerInit(t *testing.T) {
 			container, err := h.containerInit(tt.Pod(minimal()))
 			require.NoError(err)
 			actual := strings.Join(container.Command, " ")
-			fmt.Println(actual)
 			require.Contains(actual, tt.Cmd)
 			if tt.CmdNot != "" {
 				require.NotContains(actual, tt.CmdNot)

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -77,7 +77,7 @@ func TestHandlerContainerInit(t *testing.T) {
 				pod.Annotations[annotationUpstreams] = "db:1234:dc1"
 				return pod
 			},
-			"datacenter = dc1",
+			`datacenter = "dc1"`,
 			"",
 		},
 
@@ -89,7 +89,7 @@ func TestHandlerContainerInit(t *testing.T) {
 				return pod
 			},
 			"",
-			"datacenter = dc1",
+			`datacenter = "dc1"`,
 		},
 
 		{

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -92,7 +92,7 @@ func TestHandlerContainerInit(t *testing.T) {
 			`datacenter`,
 		},
 		{
-			"Prepared Query specified",
+			"Check Destination Type Query Annotation",
 			func(pod *corev1.Pod) *corev1.Pod {
 				pod.Annotations[annotationService] = "web"
 				pod.Annotations[annotationUpstreams] = "prepared_query:handle:1234"
@@ -103,7 +103,7 @@ func TestHandlerContainerInit(t *testing.T) {
 		},
 
 		{
-			"Prepared Query specified",
+			"Check Destination Name Query Annotation",
 			func(pod *corev1.Pod) *corev1.Pod {
 				pod.Annotations[annotationService] = "web"
 				pod.Annotations[annotationUpstreams] = "prepared_query:handle:1234"

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/mattbaird/jsonpatch"
 	"k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -71,14 +72,21 @@ type Handler struct {
 	// RequireAnnotation means that the annotation must be given to inject.
 	// If this is false, injection is default.
 	RequireAnnotation bool
+
+	// Log
+	Log hclog.Logger
 }
 
 // Handle is the http.HandlerFunc implementation that actually handles the
 // webhook request for admission control. This should be registered or
 // served via an HTTP server.
 func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
+	h.Log.Info("Request received", "Method", r.Method, "URL", r.URL)
+
 	if ct := r.Header.Get("Content-Type"); ct != "application/json" {
-		http.Error(w, fmt.Sprintf("Invalid content-type: %q", ct), http.StatusBadRequest)
+		msg := fmt.Sprintf("Invalid content-type: %q", ct)
+		http.Error(w, msg, http.StatusBadRequest)
+		h.Log.Error("Error on request", "Error", msg, "Code", http.StatusBadRequest)
 		return
 	}
 
@@ -86,20 +94,23 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 	if r.Body != nil {
 		var err error
 		if body, err = ioutil.ReadAll(r.Body); err != nil {
-			http.Error(w, fmt.Sprintf(
-				"Error reading request body: %s", err), http.StatusBadRequest)
+			msg := fmt.Sprintf("Error reading request body: %s", err)
+			http.Error(w, msg, http.StatusBadRequest)
+			h.Log.Error("Error on request", "Error", msg, "Code", http.StatusBadRequest)
 			return
 		}
 	}
 	if len(body) == 0 {
-		http.Error(w, "Empty request body", http.StatusBadRequest)
+		msg := "Empty request body"
+		http.Error(w, msg, http.StatusBadRequest)
+		h.Log.Error("Error on request", "Error", msg, "Code", http.StatusBadRequest)
 		return
 	}
 
 	var admReq v1beta1.AdmissionReview
 	var admResp v1beta1.AdmissionReview
 	if _, _, err := deserializer.Decode(body, nil, &admReq); err != nil {
-		log.Printf("Could not decode admission request: %s", err)
+		h.Log.Error("Could not decode admission request", "Error", err)
 		admResp.Response = admissionError(err)
 	} else {
 		admResp.Response = h.Mutate(admReq.Request)
@@ -107,14 +118,14 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := json.Marshal(&admResp)
 	if err != nil {
-		http.Error(w, fmt.Sprintf(
-			"Error marshalling admission response: %s", err),
-			http.StatusInternalServerError)
+		msg := fmt.Sprintf("Error marshalling admission response: %s", err)
+		http.Error(w, msg, http.StatusInternalServerError)
+		h.Log.Error("Error on request", "Error", msg, "Code", http.StatusInternalServerError)
 		return
 	}
 
 	if _, err := w.Write(resp); err != nil {
-		log.Printf("error writing response: %s", err)
+		h.Log.Error("Error writing response", "Error", err)
 	}
 }
 

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/mattbaird/jsonpatch"
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/admission/v1beta1"
@@ -32,7 +33,7 @@ func TestHandlerHandle(t *testing.T) {
 	}{
 		{
 			"kube-system namespace",
-			Handler{},
+			Handler{Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -46,7 +47,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"already injected",
-			Handler{},
+			Handler{Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -64,7 +65,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"empty pod basic",
-			Handler{},
+			Handler{Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					Spec: basicSpec,
@@ -97,7 +98,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"pod with upstreams specified",
-			Handler{},
+			Handler{Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -152,7 +153,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"empty pod with injection disabled",
-			Handler{},
+			Handler{Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -170,7 +171,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"empty pod with injection truthy",
-			Handler{},
+			Handler{Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -238,7 +239,7 @@ func TestHandlerHandle_badContentType(t *testing.T) {
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "text/plain")
 
-	var h Handler
+	h := Handler{Log: hclog.Default().Named("handler")}
 	rec := httptest.NewRecorder()
 	h.Handle(rec, req)
 	require.Equal(t, http.StatusBadRequest, rec.Code)
@@ -251,7 +252,7 @@ func TestHandlerHandle_noBody(t *testing.T) {
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
-	var h Handler
+	h := Handler{Log: hclog.Default().Named("handler")}
 	rec := httptest.NewRecorder()
 	h.Handle(rec, req)
 	require.Equal(t, http.StatusBadRequest, rec.Code)

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -7,16 +7,15 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/gorilla/handlers"
 	"github.com/hashicorp/consul-k8s/connect-inject"
 	"github.com/hashicorp/consul-k8s/helper/cert"
 	"github.com/hashicorp/consul/command/flags"
+	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -105,12 +104,12 @@ func (c *Command) Run(args []string) int {
 		ImageConsul:       c.flagConsulImage,
 		ImageEnvoy:        c.flagEnvoyImage,
 		RequireAnnotation: !c.flagDefaultInject,
+		Log:               hclog.Default().Named("handler"),
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mutate", injector.Handle)
 	mux.HandleFunc("/health/ready", c.handleReady)
 	var handler http.Handler = mux
-	handler = handlers.LoggingHandler(os.Stdout, handler)
 	server := &http.Server{
 		Addr:      c.flagListen,
 		Handler:   handler,

--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ var (
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = ""
+	VersionPrerelease = "dev"
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable

--- a/version/version.go
+++ b/version/version.go
@@ -14,12 +14,12 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
-	Version = "0.4.0"
+	Version = "0.5.0"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
This PR adds support to specify the [prepared query](https://www.consul.io/docs/connect/proxies.html#upstreams) for consul connect upstream from the K8s annotation.

```
annotations:
  "consul.hashicorp.com/connect-service-upstreams": "prepared_query:[query name]:[port]"
```
Services named `prepared_query` will caught in the prepared query logic, if that does occur.  
