### PR TITLE
Add prepared_query annotation support 

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -141,7 +141,7 @@ services {
 
     {{ range .Upstreams -}}
     upstreams {
-		{{- if .Name }}
+      {{- if .Name }}
       destination_type = "service" 
       destination_name = "{{ .Name }}"
       {{- end}}

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -91,6 +91,27 @@ func TestHandlerContainerInit(t *testing.T) {
 			"",
 			`datacenter`,
 		},
+		{
+			"Prepared Query specified",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				pod.Annotations[annotationUpstreams] = "prepared_query:handle:1234"
+				return pod
+			},
+			`destination_type = "prepared_query"`,
+			"",
+		},
+
+		{
+			"Prepared Query specified",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				pod.Annotations[annotationUpstreams] = "prepared_query:handle:1234"
+				return pod
+			},
+			`destination_name = "handle"`,
+			"",
+		},
 
 		{
 			"Service ID set to POD_NAME env var",

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -99,7 +99,7 @@ func TestHandlerContainerInit(t *testing.T) {
 				return pod
 			},
 			`destination_type = "prepared_query"`,
-			"",
+			`destination_type = "service"`,
 		},
 
 		{

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -92,7 +92,7 @@ func TestHandlerContainerInit(t *testing.T) {
 			`datacenter`,
 		},
 		{
-			"Prepared Query specified",
+			"Check Destination Type Query Annotation",
 			func(pod *corev1.Pod) *corev1.Pod {
 				pod.Annotations[annotationService] = "web"
 				pod.Annotations[annotationUpstreams] = "prepared_query:handle:1234"
@@ -103,7 +103,7 @@ func TestHandlerContainerInit(t *testing.T) {
 		},
 
 		{
-			"Prepared Query specified",
+			"Check Destination Name Query Annotation",
 			func(pod *corev1.Pod) *corev1.Pod {
 				pod.Annotations[annotationService] = "web"
 				pod.Annotations[annotationUpstreams] = "prepared_query:handle:1234"


### PR DESCRIPTION
Fixes Git Issue on #70 


This PR adds support to specify the [prepared query](https://www.consul.io/docs/connect/proxies.html#upstreams) for consul connect upstream from the K8s annotation.

```
annotations:
  "consul.hashicorp.com/connect-service-upstreams": "prepared_query:[query name]:[port]"
```
Services named `prepared_query` will caught in the prepared query logic, if that does occur.