### PR TITLE
Add information about PRs being merged using `rebase`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,15 @@ To create a docker image with your local changes:
 ```shell
 $ make dev-docker
 ```
+
+### Rebasing contributions against master
+
+PRs in this repo are merged using the [`rebase`](https://git-scm.com/docs/git-rebase) method. This keeps
+the git history clean by adding the PR commits to the most recent end of the commit history. It also has
+the benefit of keeping all the relevant commits for a given PR together, rather than spread throughout the
+git history based on when the commits were first created.
+
+If the changes in your PR do not conflict with any of the existing code in the project, then Github supports
+automatic rebasing when the PR is accepted into the code. However, if there are conflicts (there will be
+a warning on the PR that reads "This branch cannot be rebased due to conflicts"), you will need to manually
+rebase the branch on master, fixing any conflicts along the way before the code can be merged.


### PR DESCRIPTION
After running into an issue merging a PR where someone had
merged master into their branch, I realized it was important to
be explicit about the merging strategy we're following in this
repo. Hopefully this will help clarify things for future contributors.