### PR TITLE
govet and gofmt cleanup

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -18,7 +18,7 @@ type initContainerCommandUpstreamData struct {
 	Name       string
 	LocalPort  int32
 	Datacenter string
-	Query	   string
+	Query      string
 }
 
 // containerInit returns the init container spec for registering the Consul
@@ -59,14 +59,14 @@ func (h *Handler) containerInit(pod *corev1.Pod) (corev1.Container, error) {
 				if len(parts) > 2 {
 					datacenter = strings.TrimSpace(parts[2])
 				}
-			} 
+			}
 
 			if port > 0 {
 				data.Upstreams = append(data.Upstreams, initContainerCommandUpstreamData{
 					Name:       service_name,
 					LocalPort:  port,
 					Datacenter: datacenter,
-					Query: 	prepared_query,
+					Query:      prepared_query,
 				})
 			}
 		}

--- a/helper/cert/notify.go
+++ b/helper/cert/notify.go
@@ -29,6 +29,8 @@ type Notify struct {
 // be called. In either case, Stop will block until the notifier is stopped.
 func (n *Notify) Start(ctx context.Context) {
 	ctx, cancelFunc := context.WithCancel(ctx)
+	defer cancelFunc()
+
 	doneCh := make(chan struct{})
 	defer close(doneCh)
 

--- a/helper/coalesce/coalesce.go
+++ b/helper/coalesce/coalesce.go
@@ -52,6 +52,7 @@ func Coalesce(ctx context.Context, quiet, max time.Duration, f func(context.Cont
 
 		// Create a context with our quiet period
 		curCtx, curCancel = context.WithTimeout(ctx, quiet)
+		defer curCancel()
 
 		// Call the function
 		f(curCtx)


### PR DESCRIPTION
These are just a few small changes while working on putting this repo into CircleCI. Govet had the following complaints:
```
# github.com/hashicorp/consul-k8s/helper/cert
helper/cert/notify.go:31: the cancelFunc function is not used on all paths (possible context leak)
helper/cert/notify.go:38: this return statement may be reached without using the cancelFunc var defined on line 31
# github.com/hashicorp/consul-k8s/helper/coalesce
helper/coalesce/coalesce.go:54: the curCancel function is not used on all paths (possible context leak)
helper/coalesce/coalesce.go:63: this return statement may be reached without using the curCancel var defined on line 54
```
Instead of deferring `curCancel()` after the context creation which could bubble up an _infinite_ number of `cancelFunc()` calls or placing it in the error check which is what `go vet` is complaining about (since I don't think it knows about the defer call outside the loop), I opted to refactor the for loop a bit to both make the code more readble while also cancelling the contexts in a way that is more straightforward.