### PR TITLE
Register Connect services along with their proxies

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -18,7 +18,7 @@ type initContainerCommandUpstreamData struct {
 	Name       string
 	LocalPort  int32
 	Datacenter string
-	Query	   string
+	Query      string
 }
 
 // containerInit returns the init container spec for registering the Consul
@@ -59,14 +59,14 @@ func (h *Handler) containerInit(pod *corev1.Pod) (corev1.Container, error) {
 				if len(parts) > 2 {
 					datacenter = strings.TrimSpace(parts[2])
 				}
-			} 
+			}
 
 			if port > 0 {
 				data.Upstreams = append(data.Upstreams, initContainerCommandUpstreamData{
 					Name:       service_name,
 					LocalPort:  port,
 					Datacenter: datacenter,
-					Query: 	prepared_query,
+					Query:      prepared_query,
 				})
 			}
 		}
@@ -168,6 +168,13 @@ services {
     name = "Destination Alias"
     alias_service = "{{ .ServiceName }}"
   }
+}
+
+services {
+  id   = "${POD_NAME}-{{ .ServiceName }}"
+  name = "{{ .ServiceName }}"
+  address = "${POD_IP}"
+  port = {{ .ServicePort }}
 }
 EOF
 


### PR DESCRIPTION
This allows both services and their proxies to show up in the Consul
catalog. It makes it easier to find services in the Intentions UI.

These services are registered through the client pod on their local node,
like the proxies are, so unlike services in the catalog sync, they
are not connected to the `k8s-sync` synthetic node.

Note: it looks like there are a couple of whitespace gofmt changes
included as well. They do not change any functionality.