### PR TITLE
Fix duplicated service ID

### DIFF
--- a/catalog/from-k8s/resource.go
+++ b/catalog/from-k8s/resource.go
@@ -440,7 +440,7 @@ func (t *ServiceResource) generateRegistrations(key string) {
 						r := baseNode
 						rs := baseService
 						r.Service = &rs
-						r.Service.ID = serviceID(r.Service.Service, address.Address)
+						r.Service.ID = serviceID(r.Service.Service, subsetAddr.IP)
 						r.Service.Address = address.Address
 
 						t.consulMap[key] = append(t.consulMap[key], &r)
@@ -455,7 +455,7 @@ func (t *ServiceResource) generateRegistrations(key string) {
 							r := baseNode
 							rs := baseService
 							r.Service = &rs
-							r.Service.ID = serviceID(r.Service.Service, address.Address)
+							r.Service.ID = serviceID(r.Service.Service, subsetAddr.IP)
 							r.Service.Address = address.Address
 
 							t.consulMap[key] = append(t.consulMap[key], &r)


### PR DESCRIPTION
This PR is to fix duplicated service ID. In my case, I would like to register my service with the same service name, but different deployments. Unfortunately, it is possible that those services are deploy on the same node. Then, the node IP is not unique enough to generate the service ID anymore and that’s why sometimes my registered services appear and disappear randomly from catalog API.

So I change the way to generate service ID from service name with node IP to service name with endpoints IP instead.