### PR TITLE
Add CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,29 +52,10 @@ jobs:
           keys:
             - consul-k8s-modcache-v1-{{ checksum "go.mod" }}
 
-      # Use CircleCI test splitting by classname. Since there are no classes in go,
-      # we fake it by taking everything after github.com/hashicorp/consul-k8s/ and setting
-      # it as the classname.
-
-      # This first loop writes go test results to <reportname>.xml per go package
+      # run go tests with gotestsum
       - run: |
-          for pkg in $(go list ./... | tr '\n' ' '); do
-            reportname=$(echo $pkg | cut -d '/' -f3- | sed "s#/#_#g")
-            gotestsum --format=short-verbose --junitfile $TEST_RESULTS/$reportname.xml -- $pkg
-          done
-
-      # This loop goes through all the test result files and renames classname for
-      # CircleCI's test metadata according to the filename (package) the test was in.
-      - run:
-          command: |
-            for file in $(ls $TEST_RESULTS/*.xml); do
-              classname=$(basename $file | cut -f 1 -d '.' | sed "s#_#/#g")
-              sed -i "s#classname=\"[^\"]*\"#classname=\"github.com/hashicorp/$classname\"#g" $file
-            done
-          when: always
-
-      # remove all test results files that are empty
-      - run: find $TEST_RESULTS -empty -type f -delete
+          PACKAGE_NAMES=$(go list ./...)
+          gotestsum --junitfile $TEST_RESULTS/gotestsum-report.xml -- $PACKAGE_NAMES
 
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,113 @@
+version: 2.1
+# reusable 'executor' object for jobs
+executors:
+  go:
+    docker:
+      - image: circleci/golang:1.11.5
+    environment:
+      - TEST_RESULTS: /tmp/test-results # path to where test results are saved
+
+jobs:
+  go-fmt-and-vet:
+    executor: go
+    steps:
+      - checkout
+
+      # Restore go module cache if there is one
+      - restore_cache:
+          keys:
+            - consul-k8s-modcache-v1-{{ checksum "go.mod" }}
+
+      - run: go mod download
+
+      # Save go module cache if the go.mod file has changed
+      - save_cache:
+          key: consul-k8s-modcache-v1-{{ checksum "go.mod" }}
+          paths:
+            - "/go/pkg/mod"
+
+      # check go fmt output because it does not report non-zero when there are fmt changes
+      - run:
+          name: check go fmt
+          command: |
+            files=$(go fmt ./...)
+            if [ -n "$files" ]; then
+              echo "The following file(s) do not conform to go fmt:"
+              echo "$files"
+              exit 1
+            fi
+      - run: go vet ./...
+
+  test:
+    executor: go
+    environment:
+      TEST_RESULTS: /tmp/test-results
+    parallelism: 1
+    steps:
+      - checkout
+      - run: mkdir -p $TEST_RESULTS
+
+      # Restore go module cache if there is one
+      - restore_cache:
+          keys:
+            - consul-k8s-modcache-v1-{{ checksum "go.mod" }}
+
+      # Use CircleCI test splitting by classname. Since there are no classes in go,
+      # we fake it by taking everything after github.com/hashicorp/consul-k8s/ and setting
+      # it as the classname.
+
+      # This first loop writes go test results to <reportname>.xml per go package
+      - run: |
+          for pkg in $(go list ./... | tr '\n' ' '); do
+            reportname=$(echo $pkg | cut -d '/' -f3- | sed "s#/#_#g")
+            gotestsum --format=short-verbose --junitfile $TEST_RESULTS/$reportname.xml -- $pkg
+          done
+
+      # This loop goes through all the test result files and renames classname for
+      # CircleCI's test metadata according to the filename (package) the test was in.
+      - run:
+          command: |
+            for file in $(ls $TEST_RESULTS/*.xml); do
+              classname=$(basename $file | cut -f 1 -d '.' | sed "s#_#/#g")
+              sed -i "s#classname=\"[^\"]*\"#classname=\"github.com/hashicorp/$classname\"#g" $file
+            done
+          when: always
+
+      # remove all test results files that are empty
+      - run: find $TEST_RESULTS -empty -type f -delete
+
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+
+  build-distros:
+    executor: go
+    environment:
+      GOXPARALLEL: 2 # CircleCI containers are 2 CPU x 4GB RAM
+    steps:
+      - checkout
+
+      # Restore go module cache if there is one
+      - restore_cache:
+          keys:
+            - consul-k8s-modcache-v1-{{ checksum "go.mod" }}
+
+      - run: make tools
+      - run: ./build-support/scripts/build-local.sh
+
+      # save dev build to CircleCI
+      - store_artifacts:
+          path: ./pkg/bin
+
+workflows:
+  version: 2
+  test-and-build:
+    jobs:
+      - go-fmt-and-vet
+      - test:
+          requires:
+            - go-fmt-and-vet
+      - build-distros:
+          requires:
+            - test

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,7 @@ GOTOOLS = \
 	github.com/magiconair/vendorfmt/cmd/vendorfmt \
 	github.com/mitchellh/gox \
 	golang.org/x/tools/cmd/cover \
-	golang.org/x/tools/cmd/stringer \
-	github.com/axw/gocov/gocov \
-	gopkg.in/matm/v1/gocov-html
+	golang.org/x/tools/cmd/stringer
 
 DEV_IMAGE?=consul-k8s-dev
 GO_BUILD_TAG?=consul-k8s-build-go

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ dev-tree:
 test:
 	go test ./...
 
+cov:
+	go test ./... -coverprofile=coverage.out
+	go tool cover -html=coverage.out
+
 tools:
 	go get -u -v $(GOTOOLS)
 

--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -181,7 +181,8 @@ function build_consul_local {
    #   If the XC_OS or the XC_ARCH environment vars are present then only those platforms/architectures
    #   will be built. Otherwise all supported platform/architectures are built
    #   The NOGOX environment variable will be used if present. This will prevent using gox and instead
-   #   build with go install
+   #   build with go install.
+   #   The GOXPARALLEL environment variable is used if set
 
    if ! test -d "$1"
    then
@@ -241,6 +242,7 @@ function build_consul_local {
          -arch="${build_arch}" \
          -osarch="!darwin/arm !darwin/arm64" \
          -ldflags="${GOLDFLAGS}" \
+         -parallel="${GOXPARALLEL:-"-1"}" \
          -output "pkg.bin.new/${extra_dir}{{.OS}}_{{.Arch}}/consul-k8s" \
          -tags="${GOTAGS}" \
          .
@@ -278,7 +280,7 @@ function build_consul_local {
             then
                GOBIN_EXTRA="${os}_${arch}/"
             fi
-            CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go install -ldflags "${GOLDFLAGS}" -tags "${GOTAGS}" && cp "${MAIN_GOPATH}/bin/${GOBIN_EXTRA}consul-k8s" "${outdir}/consul-k8s"
+            CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go install -ldflags "${GOLDFLAGS}" -tags "${GOTAGS}" && cp "${MAIN_GOPATH}/bin/${GOBIN_EXTRA}"* "${outdir}/consul-k8s"
             if test $? -ne 0
             then
                err "ERROR: Failed to build Consul for ${osarch}"


### PR DESCRIPTION
This PR adds CircleCI configuration to run a few things on all branches: 
* go fmt
* go vet
* run go tests
* build binaries for all our supported distros
* save all of these artifacts in CircleCI so they can be downloaded and tested if needed

Outside of CI configuration:
* removed gocov since `go test` can also produce coverage reports. Also added a new make target to run coverage reports if needed (`make cov`) 
* add an environment variable to pass the parallel flag to gox since `runtime.NumCPU()` reports the wrong CPU count on containers in CircleCI
* glob the binaries when copying out to support the `.exe` extension for windows

The most recent run of this pipeline is here: https://circleci.com/workflow-run/4430c58b-f6a4-46bd-9f5d-595e0b226796

The artifact uploading can be seen here:
![image](https://user-images.githubusercontent.com/17609145/54836013-b7de0980-4c99-11e9-9c36-0df34dc3f8ad.png)
