### PR TITLE
Exclude system namespaces from Connect injection

### DIFF
--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -164,7 +164,7 @@ func (h *Handler) Mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespon
 
 	// Check if we should inject, for example we don't inject in the
 	// system namespaces.
-	if shouldInject, err := h.shouldInject(&pod); err != nil {
+	if shouldInject, err := h.shouldInject(&pod, req.Namespace); err != nil {
 		return &v1beta1.AdmissionResponse{
 			Result: &metav1.Status{
 				Message: fmt.Sprintf("Error checking if should inject: %s", err),
@@ -244,10 +244,11 @@ func (h *Handler) Mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespon
 	return resp
 }
 
-func (h *Handler) shouldInject(pod *corev1.Pod) (bool, error) {
+func (h *Handler) shouldInject(pod *corev1.Pod, namespace string) (bool, error) {
+
 	// Don't inject in the Kubernetes system namespaces
 	for _, ns := range kubeSystemNamespaces {
-		if pod.ObjectMeta.Namespace == ns {
+		if namespace == ns {
 			return false, nil
 		}
 	}

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -35,10 +35,9 @@ func TestHandlerHandle(t *testing.T) {
 			"kube-system namespace",
 			Handler{Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
+				Namespace: metav1.NamespaceSystem,
 				Object: encodeRaw(t, &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: metav1.NamespaceSystem,
-					},
+					Spec: basicSpec,
 				}),
 			},
 			"",
@@ -228,7 +227,7 @@ func TestHandlerHandle(t *testing.T) {
 					actual[i].Value = nil
 				}
 			}
-			require.Equal(actual, tt.Patches)
+			require.Equal(tt.Patches, actual)
 		})
 	}
 }


### PR DESCRIPTION
A pod's namespace is not present in the pod's metadata section at the
time of injection, so we must exclude based on the namespace included
in the AdmissionRequest that we decode.

This updates the test for this scenario, as well as updating the actual/
expected variable order in `require.Equal` to match the spec.