### PR TITLE
Handle error output from central config write command

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -225,7 +225,7 @@ EOF
   {{- if .AuthMethod }}
   -token-file="/consul/connect-inject/acl-token" \
   {{- end }}
-  /consul/connect-inject/central-config.hcl
+  /consul/connect-inject/central-config.hcl || true
 {{- end }}
 
 /bin/consul services register \


### PR DESCRIPTION
The addition of the `-cas` flag to the `consul config write` keeps the
system from doing the additional work of writing the central config again
if it already exists. However, if the config does exist, this call
returns an error code. This update handles that case.