### PR TITLE
Migrate tests to retry.Run dynamic sleep intervals

### DIFF
--- a/catalog/from-k8s/syncer_test.go
+++ b/catalog/from-k8s/syncer_test.go
@@ -159,7 +159,6 @@ func TestConsulSyncer_reapServiceInstance(t *testing.T) {
 // Test that the syncer does not reap services in another NS.
 func TestConsulSyncer_reapServiceOtherNamespace(t *testing.T) {
 	t.Parallel()
-	require := require.New(t)
 
 	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
@@ -178,15 +177,14 @@ func TestConsulSyncer_reapServiceOtherNamespace(t *testing.T) {
 	svc := testRegistration("foo", "baz")
 	svc.Service.Meta[ConsulK8SNS] = "other"
 	_, err := client.Catalog().Register(svc, nil)
-	require.NoError(err)
+	require.NoError(t, err)
 
-	// Sleep for a bit
-	time.Sleep(500 * time.Millisecond)
-
-	// Valid service should exist
-	services, _, err := client.Catalog().Service("baz", "", nil)
-	require.NoError(err)
-	require.Len(services, 1)
+	retry.Run(t, func(r *retry.R) {
+		// Valid service should exist
+		services, _, err := client.Catalog().Service("baz", "", nil)
+		require.NoError(r, err)
+		require.Len(r, services, 1)
+	})
 }
 
 // Test that the syncer reaps services with no NS set.


### PR DESCRIPTION
Currently many tests in the `catalog` package use sleeps with hardcoded durations to wait for registrations. 

This leads to a couple issues:
- Tests can become flaky in CI if registrations take longer than expected to show up
- Hard-coded sleep durations lead to longer test run times

This PR adds retries from `consul/sdk/testutil` over hard-coded sleeps where appropriate. 

Note: This conversion was not made in tests that verify that a sync was **not** performed, such as: TestServiceResource_clusterIPSyncDisabled. 

In those cases sleeps were preserved, since we need to allow for the time typically needed to register the services.