### PR TITLE
Add option to name K8s Node in Consul

### DIFF
--- a/catalog/from-k8s/resource.go
+++ b/catalog/from-k8s/resource.go
@@ -255,7 +255,7 @@ func (t *ServiceResource) generateRegistrations(key string) {
 	// shallow copied for each instance.
 	baseNode := consulapi.CatalogRegistration{
 		SkipNodeUpdate: true,
-		Node:           "k8s-sync",
+		Node:           t.Syncer.Node(),
 		Address:        "127.0.0.1",
 		NodeMeta: map[string]string{
 			ConsulSourceKey: ConsulSourceValue,

--- a/catalog/from-k8s/resource_test.go
+++ b/catalog/from-k8s/resource_test.go
@@ -27,7 +27,7 @@ func TestServiceResource_createDelete(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -58,7 +58,7 @@ func TestServiceResource_defaultEnable(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -85,7 +85,7 @@ func TestServiceResource_defaultEnableDisable(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -114,7 +114,7 @@ func TestServiceResource_defaultDisable(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -143,7 +143,7 @@ func TestServiceResource_defaultDisableEnable(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -173,7 +173,7 @@ func TestServiceResource_system(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -201,7 +201,7 @@ func TestServiceResource_externalIP(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -253,7 +253,7 @@ func TestServiceResource_externalIPPrefix(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -306,7 +306,7 @@ func TestServiceResource_lb(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -355,7 +355,7 @@ func TestServiceResource_lbPrefix(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -406,7 +406,7 @@ func TestServiceResource_lbMultiEndpoint(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -461,7 +461,7 @@ func TestServiceResource_lbAnnotatedName(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -491,7 +491,7 @@ func TestServiceResource_lbPort(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -526,7 +526,7 @@ func TestServiceResource_lbAnnotatedPort(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -562,7 +562,7 @@ func TestServiceResource_lbAnnotatedTags(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -593,7 +593,7 @@ func TestServiceResource_lbAnnotatedMeta(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -623,7 +623,7 @@ func TestServiceResource_nodePort(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -739,7 +739,7 @@ func TestServiceResource_nodePortPrefix(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -856,7 +856,7 @@ func TestServiceResource_nodePort_singleEndpoint(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -956,7 +956,7 @@ func TestServiceResource_nodePortInitial(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -1070,7 +1070,7 @@ func TestServiceResource_nodePortAnnotatedPort(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -1187,7 +1187,7 @@ func TestServiceResource_nodePortUnnamedPort(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -1303,7 +1303,7 @@ func TestServiceResource_nodePort_internalOnlySync(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -1419,7 +1419,7 @@ func TestServiceResource_nodePort_externalFirstSync(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -1534,7 +1534,7 @@ func TestServiceResource_clusterIP(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -1607,7 +1607,7 @@ func TestServiceResource_clusterIPPrefix(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -1681,7 +1681,7 @@ func TestServiceResource_clusterIPMultiEndpoint(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -1755,7 +1755,7 @@ func TestServiceResource_clusterIPAnnotatedPort(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -1830,7 +1830,7 @@ func TestServiceResource_clusterIPUnnamedPorts(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -1905,7 +1905,7 @@ func TestServiceResource_clusterIPSyncDisabled(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 
 	// Start the controller
 	closer := controller.TestControllerRun(&ServiceResource{
@@ -1971,7 +1971,7 @@ func TestServiceResource_clusterIPAllNamespaces(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	testNamespace := "test_namespace"
 
 	// Start the controller

--- a/catalog/from-k8s/syncer.go
+++ b/catalog/from-k8s/syncer.go
@@ -27,6 +27,7 @@ const (
 type Syncer interface {
 	// Sync is called to sync the full set of registrations.
 	Sync([]*api.CatalogRegistration)
+	Node() string
 }
 
 // ConsulSyncer is a Syncer that takes the set of registrations and
@@ -62,6 +63,9 @@ type ConsulSyncer struct {
 	// ConsulK8STag is the tag value for services registered.
 	ConsulK8STag string
 
+	// The Consul node name to register for this syncer.
+	NodeName string
+
 	lock     sync.Mutex
 	once     sync.Once
 	services map[string]struct{} // set of valid service names
@@ -74,6 +78,10 @@ type ConsulSyncer struct {
 type consulSyncState struct {
 	// Services keeps track of the valid services on this node (by service ID)
 	Services map[string]*api.CatalogRegistration
+}
+
+func (s *ConsulSyncer) Node() string {
+	return s.NodeName
 }
 
 // Sync implements Syncer

--- a/catalog/from-k8s/testing.go
+++ b/catalog/from-k8s/testing.go
@@ -15,6 +15,12 @@ const (
 type TestSyncer struct {
 	sync.Mutex    // Lock should be held while accessing Registrations
 	Registrations []*api.CatalogRegistration
+	// The Consul node name to register for this syncer.
+	NodeName string
+}
+
+func (s *TestSyncer) Node() string {
+	return s.NodeName
 }
 
 // Sync implements Syncer
@@ -22,4 +28,8 @@ func (s *TestSyncer) Sync(rs []*api.CatalogRegistration) {
 	s.Lock()
 	defer s.Unlock()
 	s.Registrations = rs
+}
+
+func NewTestSyncer() *TestSyncer {
+	return &TestSyncer{NodeName: "k8s-sync"}
 }

--- a/subcommand/sync-catalog/command.go
+++ b/subcommand/sync-catalog/command.go
@@ -46,6 +46,7 @@ type Command struct {
 	flagSyncClusterIPServices bool
 	flagNodePortSyncType      string
 	flagLogLevel              string
+	flagNodeName              string
 
 	consulClient *api.Client
 
@@ -94,6 +95,8 @@ func (c *Command) init() {
 	c.flags.StringVar(&c.flagLogLevel, "log-level", "info",
 		"Log verbosity level. Supported values (in order of detail) are \"trace\", "+
 			"\"debug\", \"info\", \"warn\", and \"error\".")
+	c.flags.StringVar(&c.flagNodeName, "node-name", "k8s-sync",
+		"The Consul node name to register for k8s-sync. Defaults to k8s-sync.")
 
 	c.http = &flags.HTTPFlags{}
 	c.k8s = &k8sflags.K8SFlags{}
@@ -161,6 +164,7 @@ func (c *Command) Run(args []string) int {
 			SyncPeriod:        syncInterval,
 			ServicePollPeriod: syncInterval * 2,
 			ConsulK8STag:      c.flagConsulK8STag,
+			NodeName:          c.flagNodeName,
 		}
 		go syncer.Run(ctx)
 


### PR DESCRIPTION
This change adds an Consul node name option to sync-catalog, which resolves https://github.com/hashicorp/consul-k8s/issues/101

I'm not sure if the changes I made make much sense, but I will try the build tomorrow to at least see if it has the desired functionality.

Next up would be adding tests and updating the helm chart with an option to specify the node name.

As @lkysow mentioned in #101 it would be nice to default to kubernetes cluster name, but the closest concept there is to a cluster name in kubernetes is `cluster.local`, which is afaik rarely changed anyway. I've instead kept the original `k8s-sync` as the default.