### PR TITLE
Make sure the kubernetes service is looked up in the default namespace

### DIFF
--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -344,9 +344,9 @@ service_prefix "" {
 	// Support ConnectInject using Kubernetes as an auth method
 	if c.flagCreateInjectAuthMethod {
 		// Get the Kubernetes service IP address
-		k8sService, err := clientset.CoreV1().Services(c.flagNamespace).Get("kubernetes", metav1.GetOptions{})
+		k8sService, err := clientset.CoreV1().Services("default").Get("kubernetes", metav1.GetOptions{})
 		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error getting kubernetes service: %s", err))
+			c.UI.Error(fmt.Sprintf("Error getting the default namespace kubernetes service: %s", err))
 			return 1
 		}
 


### PR DESCRIPTION
During the bootstrap and initialization process, the kubernetes service is looked up in the same namespace as the Consul servers are running. This works well as long as they actually are in the same namespace (the default namespace), but fails when Consul servers are placed in a custom namespace.
 
This patch makes sure that the kubernetes service is always looked up in the default namespace. The code is only run with ACLs are enabled and automatic inject using Kubernetes as Auth method - as far as I can see and I've only validated that the patch works with the Helm chart.