### PR TITLE
add resources to injector for sidecar/init container

### DIFF
--- a/connect-inject/container_sidecar.go
+++ b/connect-inject/container_sidecar.go
@@ -6,9 +6,28 @@ import (
 	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+type sidecarContainerResources struct {
+	Resources corev1.ResourceRequirements
+}
+
 func (h *Handler) containerSidecar(pod *corev1.Pod) (corev1.Container, error) {
+
+	scr := sidecarContainerResources{}
+	if h.Resources {
+		scr.Resources = corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(h.CPULimit),
+				corev1.ResourceMemory: resource.MustParse(h.MemoryLimit),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(h.CPULimit),
+				corev1.ResourceMemory: resource.MustParse(h.MemoryLimit),
+			},
+		}
+	}
 
 	// Render the command
 	var buf bytes.Buffer
@@ -30,6 +49,7 @@ func (h *Handler) containerSidecar(pod *corev1.Pod) (corev1.Container, error) {
 				},
 			},
 		},
+		Resources: scr.Resources,
 		VolumeMounts: []corev1.VolumeMount{
 			corev1.VolumeMount{
 				Name:      volumeName,

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -92,6 +92,19 @@ type Handler struct {
 	// registrations. It will be overridden by a specific annotation.
 	DefaultProtocol string
 
+	// Resources checks if cpu and memory resources for sidecar pods and
+	// init containers should be set. If this is false, no resources
+	// will be set.
+	Resources bool
+	// CPULimit sets cpu limit for pods
+	CPULimit string
+	// MemoryLimit sets memory limit for pods
+	MemoryLimit string
+	// CPURequest sets cpu requests for pods
+	CPURequest string
+	// MemoryRequest sets memory requests for pods
+	MemoryRequest string
+
 	// Log
 	Log hclog.Logger
 }

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -281,6 +281,39 @@ func TestHandlerHandle(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			"enable resources",
+			Handler{Resources: true, CPULimit: "1", MemoryLimit: "100Mi", CPURequest: "1", MemoryRequest: "100Mi", Log: hclog.Default().Named("handler")},
+			v1beta1.AdmissionRequest{
+				Object: encodeRaw(t, &corev1.Pod{
+					Spec: basicSpec,
+				}),
+			},
+			"",
+			[]jsonpatch.JsonPatchOperation{
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/volumes",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/-",
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationStatus),
+				},
+			},
+		},
 	}
 
 	for _, tt := range cases {

--- a/go.sum
+++ b/go.sum
@@ -478,6 +478,7 @@ k8s.io/apimachinery v0.0.0-20180821005732-488889b0007f h1:V0PkbgaYp5JqCmzLyRmssD
 k8s.io/apimachinery v0.0.0-20180821005732-488889b0007f/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/apimachinery v0.0.0-20190223001710-c182ff3b9841 h1:Q4RZrHNtlC/mSdC1sTrcZ5RchC/9vxLVj57pWiCBKv4=
 k8s.io/apimachinery v0.0.0-20190223001710-c182ff3b9841/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/apimachinery v0.0.0-20190620073744-d16981aedf33 h1:Lkd+QNFOB3DqrDyWo796aodJgFJautn/M+t9IGearPc=
 k8s.io/client-go v8.0.0+incompatible h1:tTI4hRmb1DRMl4fG6Vclfdi6nTM82oIrTT7HfitmxC4=
 k8s.io/client-go v8.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c h1:3KSCztE7gPitlZmWbNwue/2U0YruD65DqX3INopDAQM=

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/consul-k8s/connect-inject"
+	connectinject "github.com/hashicorp/consul-k8s/connect-inject"
 	"github.com/hashicorp/consul-k8s/helper/cert"
 	"github.com/hashicorp/consul/command/flags"
 	"github.com/hashicorp/go-hclog"
@@ -37,6 +37,11 @@ type Command struct {
 	flagCentralConfig   bool   // True to enable central config injection
 	flagDefaultProtocol string // Default protocol for use with central config
 	flagSet             *flag.FlagSet
+	flagResources       bool   // True to enable resources for init and sidecar pods
+	flagCPULimit        string // CPU Limits
+	flagMemoryLimit     string // Memory Limits
+	flagCPURequest      string // CPU Requests
+	flagMemoryRequest   string // Memory Limits
 
 	once sync.Once
 	help string
@@ -64,6 +69,12 @@ func (c *Command) init() {
 	c.flagSet.BoolVar(&c.flagCentralConfig, "enable-central-config", false, "Enable central config.")
 	c.flagSet.StringVar(&c.flagDefaultProtocol, "default-protocol", "",
 		"The default protocol to use in central config registrations.")
+	c.flagSet.BoolVar(&c.flagResources, "enable-resources", false,
+		"Enable to set custom resources for init and sidecar pods")
+	c.flagSet.StringVar(&c.flagCPULimit, "cpu-limit", "", "CPU Limits for init and sidecar pods")
+	c.flagSet.StringVar(&c.flagMemoryLimit, "memory-limit", "", "Memory Limits for init and sidecar pods")
+	c.flagSet.StringVar(&c.flagCPURequest, "cpu-request", "", "CPU Requests for init and sidecar pods")
+	c.flagSet.StringVar(&c.flagMemoryRequest, "memory-request", "", "Memory Requests for init and sidecar pods")
 	c.help = flags.Usage(help, c.flagSet)
 }
 
@@ -115,6 +126,11 @@ func (c *Command) Run(args []string) int {
 		AuthMethod:        c.flagACLAuthMethod,
 		CentralConfig:     c.flagCentralConfig,
 		DefaultProtocol:   c.flagDefaultProtocol,
+		Resources:         c.flagResources,
+		CPULimit:          c.flagCPULimit,
+		MemoryLimit:       c.flagMemoryLimit,
+		CPURequest:        c.flagCPURequest,
+		MemoryRequest:     c.flagMemoryRequest,
 		Log:               hclog.Default().Named("handler"),
 	}
 	mux := http.NewServeMux()


### PR DESCRIPTION
if resource quotas for namespace are set, init container and sidecar pod require to set cpu and memory resources, else they are not able to start. the init container uses the same resources as are specified for the sidecar pod. the resources for the injector are disabled by default.

related PR https://github.com/hashicorp/consul-helm/pull/200