### PR TITLE
Add tag annotation to Connect service registration

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -2,6 +2,7 @@ package connectinject
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"text/template"
 
@@ -15,6 +16,7 @@ type initContainerCommandData struct {
 	AuthMethod      string
 	CentralConfig   bool
 	Upstreams       []initContainerCommandUpstreamData
+	Tags            string
 }
 
 type initContainerCommandUpstreamData struct {
@@ -45,6 +47,17 @@ func (h *Handler) containerInit(pod *corev1.Pod) (corev1.Container, error) {
 		if port, _ := portValue(pod, raw); port > 0 {
 			data.ServicePort = port
 		}
+	}
+
+	// If tags are specified split the string into an array and create
+	// the tags string
+	if raw, ok := pod.Annotations[annotationTags]; ok && raw != "" {
+		tags := strings.Split(raw, ",")
+
+		// Create json array from the annotations
+		jsonTags, _ := json.Marshal(tags)
+
+		data.Tags = string(jsonTags)
 	}
 
 	// If upstreams are specified, configure those
@@ -201,6 +214,9 @@ services {
   name = "{{ .ServiceName }}"
   address = "${POD_IP}"
   port = {{ .ServicePort }}
+  {{- if .Tags}}
+  tags = {{.Tags}}
+  {{- end}}
 }
 EOF
 

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -55,7 +55,10 @@ func (h *Handler) containerInit(pod *corev1.Pod) (corev1.Container, error) {
 		tags := strings.Split(raw, ",")
 
 		// Create json array from the annotations
-		jsonTags, _ := json.Marshal(tags)
+		jsonTags, err := json.Marshal(tags)
+		if err != nil {
+			h.Log.Error("Error json marshaling tags", "Error", err, "Tags", tags)
+		}
 
 		data.Tags = string(jsonTags)
 	}

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -134,6 +134,28 @@ func TestHandlerContainerInit(t *testing.T) {
 			`-proxy-id="${POD_NAME}-web-sidecar-proxy"`,
 			"",
 		},
+
+		{
+			"Tags specified",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				pod.Annotations[annotationUpstreams] = "db:1234:dc1"
+				pod.Annotations[annotationTags] = "abc,123"
+				return pod
+			},
+			`tags = ["abc","123"]`,
+			"",
+		},
+
+		{
+			"No Tags specified",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				return pod
+			},
+			"",
+			`tags`,
+		},
 	}
 
 	for _, tt := range cases {

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -52,6 +52,10 @@ const (
 	// is the local port in the pod that the listener will bind to. It can
 	// be a named port.
 	annotationUpstreams = "consul.hashicorp.com/connect-service-upstreams"
+
+	// annotationTags is a list of tags to register with the service
+	// this is specified as a comma separated list e.g. abc,123
+	annotationTags = "consul.hashicorp.com/connect-service-tags"
 )
 
 var (


### PR DESCRIPTION
Allows users to add Consul tags to their services via a Kubernetes
annotation.