### PR TITLE
Service annotation

### DIFF
--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -156,39 +156,6 @@ func TestHandlerContainerInit(t *testing.T) {
 			"",
 			`tags`,
 		},
-
-		/*
-			{
-			          "services": [{
-			            "name": "api",
-			            "ID": "api-{{ env "NOMAD_ALLOC_ID" }}",
-			            "port": {{ env "NOMAD_PORT_postie_http" }},
-			            "meta": {
-			              "version": "2"
-			            },
-			            "tags":["v2"],
-			            "connect": {
-			              "sidecar_service": {
-			                "port": {{ env "NOMAD_PORT_sidecar_ingress" }},
-			                "proxy": {
-			                  "local_service_address": "127.0.0.1",
-			                  "config": {
-			                    "protocol": "http",
-			                    "envoy_prometheus_bind_addr": "0.0.0.0:{{ env "NOMAD_PORT_sidecar_metrics" }}"
-			                  }
-			                }
-			              }
-			            }
-			          },
-			          {
-			            "name": "metrics",
-			            "ID": "metrics-{{ env "NOMAD_ALLOC_ID" }}",
-			            "port": {{ env "NOMAD_PORT_sidecar_metrics" }},
-			            "tags":["v2"]
-			          }]
-			        }
-		*/
-
 		{
 			"Metadata specified",
 			func(pod *corev1.Pod) *corev1.Pod {

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -156,6 +156,62 @@ func TestHandlerContainerInit(t *testing.T) {
 			"",
 			`tags`,
 		},
+
+		/*
+			{
+			          "services": [{
+			            "name": "api",
+			            "ID": "api-{{ env "NOMAD_ALLOC_ID" }}",
+			            "port": {{ env "NOMAD_PORT_postie_http" }},
+			            "meta": {
+			              "version": "2"
+			            },
+			            "tags":["v2"],
+			            "connect": {
+			              "sidecar_service": {
+			                "port": {{ env "NOMAD_PORT_sidecar_ingress" }},
+			                "proxy": {
+			                  "local_service_address": "127.0.0.1",
+			                  "config": {
+			                    "protocol": "http",
+			                    "envoy_prometheus_bind_addr": "0.0.0.0:{{ env "NOMAD_PORT_sidecar_metrics" }}"
+			                  }
+			                }
+			              }
+			            }
+			          },
+			          {
+			            "name": "metrics",
+			            "ID": "metrics-{{ env "NOMAD_ALLOC_ID" }}",
+			            "port": {{ env "NOMAD_PORT_sidecar_metrics" }},
+			            "tags":["v2"]
+			          }]
+			        }
+		*/
+
+		{
+			"Metadata specified",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				pod.Annotations[annotationMeta] = "name:abc, version:2"
+				return pod
+			},
+			`meta = {
+    name = "abc"
+    version = "2"
+  }`,
+			"",
+		},
+
+		{
+			"No Metadata specified",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				return pod
+			},
+			"",
+			`meta`,
+		},
 	}
 
 	for _, tt := range cases {

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -56,6 +56,10 @@ const (
 	// annotationTags is a list of tags to register with the service
 	// this is specified as a comma separated list e.g. abc,123
 	annotationTags = "consul.hashicorp.com/connect-service-tags"
+
+	// annotationMeta is a list of metadata key/value pairs to add to the service
+	// registration. This is specified in the format `<key>:<value>,...`
+	annotationMeta = "consul.hashicorp.com/connect-service-meta"
 )
 
 var (


### PR DESCRIPTION
This PR adds the ability to add meta data to services registered with consul connect injector. metadata is a common way of configuring service splitting.

```
      annotations:
        consul.hashicorp.com/connect-inject: "true"
        consul.hashicorp.com/connect-service-meta: "version:1, foo:bar"
        consul.hashicorp.com/connect-service-protocol: "http"
        consul.hashicorp.com/connect-service-tags: "v1"
        prometheus.io/port: "9102"
        prometheus.io/scrape: "true"
```