### PR TITLE
Add the —max-obj-name-len parameter to the injected Envoy container

### DIFF
--- a/connect-inject/container_sidecar.go
+++ b/connect-inject/container_sidecar.go
@@ -49,6 +49,7 @@ func (h *Handler) containerSidecar(pod *corev1.Pod) (corev1.Container, error) {
 		},
 		Command: []string{
 			"envoy",
+			"--max-obj-name-len", "256",
 			"--config-path", "/consul/connect-inject/envoy-bootstrap.yaml",
 		},
 	}, nil


### PR DESCRIPTION
Fixes #120

I think I added this properly but let me know if it should have been somewhere else.