### PR TITLE
Add service Metadata

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -65,18 +65,12 @@ func (h *Handler) containerInit(pod *corev1.Pod) (corev1.Container, error) {
 	}
 
 	// If there is metadata specified split into a map and create
-	if raw, ok := pod.Annotations[annotationMeta]; ok && raw != "" {
-		meta := strings.Split(raw, ",")
-		metaMap := map[string]string{}
-
-		for _, m := range meta {
-			parts := strings.Split(m, ":")
-			if len(parts) == 2 {
-				metaMap[strings.Trim(parts[0], " ")] = strings.Trim(parts[1], " ")
-			}
+	data.Meta = make(map[string]string)
+	for k, v := range pod.Annotations {
+		if strings.HasPrefix(k, annotationMeta) && v != "" {
+			md := strings.Split(k, annotationMeta)
+			data.Meta[md[1]] = v
 		}
-
-		data.Meta = metaMap
 	}
 
 	// If upstreams are specified, configure those

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -1,6 +1,7 @@
 package connectinject
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -193,7 +194,8 @@ func TestHandlerContainerInit(t *testing.T) {
 			"Metadata specified",
 			func(pod *corev1.Pod) *corev1.Pod {
 				pod.Annotations[annotationService] = "web"
-				pod.Annotations[annotationMeta] = "name:abc, version:2"
+				pod.Annotations[fmt.Sprintf("%sname", annotationMeta)] = "abc"
+				pod.Annotations[fmt.Sprintf("%sversion", annotationMeta)] = "2"
 				return pod
 			},
 			`meta = {

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -156,6 +156,62 @@ func TestHandlerContainerInit(t *testing.T) {
 			"",
 			`tags`,
 		},
+
+		/*
+			{
+			          "services": [{
+			            "name": "api",
+			            "ID": "api-{{ env "NOMAD_ALLOC_ID" }}",
+			            "port": {{ env "NOMAD_PORT_postie_http" }},
+			            "meta": {
+			              "version": "2"
+			            },
+			            "tags":["v2"],
+			            "connect": {
+			              "sidecar_service": {
+			                "port": {{ env "NOMAD_PORT_sidecar_ingress" }},
+			                "proxy": {
+			                  "local_service_address": "127.0.0.1",
+			                  "config": {
+			                    "protocol": "http",
+			                    "envoy_prometheus_bind_addr": "0.0.0.0:{{ env "NOMAD_PORT_sidecar_metrics" }}"
+			                  }
+			                }
+			              }
+			            }
+			          },
+			          {
+			            "name": "metrics",
+			            "ID": "metrics-{{ env "NOMAD_ALLOC_ID" }}",
+			            "port": {{ env "NOMAD_PORT_sidecar_metrics" }},
+			            "tags":["v2"]
+			          }]
+			        }
+		*/
+
+		{
+			"Metadata specified",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				pod.Annotations[annotationMeta] = "name:abc, version:2"
+				return pod
+			},
+			`meta = {
+    name = "abc"
+    version = "2"
+  }`,
+			"",
+		},
+
+		{
+			"No Metadata specified",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				return pod
+			},
+			"",
+			`meta`,
+		},
 	}
 
 	for _, tt := range cases {

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -56,6 +56,10 @@ const (
 	// annotationTags is a list of tags to register with the service
 	// this is specified as a comma separated list e.g. abc,123
 	annotationTags = "consul.hashicorp.com/connect-service-tags"
+
+	// annotationMeta is a list of metadata key/value pairs to add to the service
+	// registration. This is specified in the format `<key>:<value>,...`
+	annotationMeta = "consul.hashicorp.com/connect-service-meta"
 )
 
 var (

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -58,8 +58,9 @@ const (
 	annotationTags = "consul.hashicorp.com/connect-service-tags"
 
 	// annotationMeta is a list of metadata key/value pairs to add to the service
-	// registration. This is specified in the format `<key>:<value>,...`
-	annotationMeta = "consul.hashicorp.com/connect-service-meta"
+	// registration. This is specified in the format `<key>:<value>`
+	// e.g. consul.hashicorp.com/service-meta-foo:bar
+	annotationMeta = "consul.hashicorp.com/service-meta-"
 )
 
 var (


### PR DESCRIPTION
This PR supersedes https://github.com/hashicorp/consul-k8s/pull/118

Adding annotation to allow configuration of service metadata on registration:

```
      annotations:
        consul.hashicorp.com/connect-inject: "true"
        consul.hashicorp.com/service-meta-foo": "bar"
        consul.hashicorp.com/service-meta-version": "1"
        consul.hashicorp.com/connect-service-protocol: "http"
        consul.hashicorp.com/connect-service-tags: "v1"
        prometheus.io/port: "9102"
        prometheus.io/scrape: "true"
```

I will raise a separate PR to normalize the tags annotation in line with metadata.