### PR TITLE
All creation of metadata and tags from k8s annotations

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -181,6 +181,16 @@ services {
   kind = "connect-proxy"
   address = "${POD_IP}"
   port = 20000
+  {{- if .Tags}}
+  tags = {{.Tags}}
+  {{- end}}
+  {{- if .Meta}}
+  meta = {
+    {{- range $key, $value := .Meta }}
+    {{$key}} = "{{$value}}"
+    {{- end }}
+  }
+  {{- end}}
 
   proxy {
     destination_service_name = "{{ .ServiceName }}"

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -137,7 +137,19 @@ func TestHandlerContainerInit(t *testing.T) {
 		},
 
 		{
-			"Tags specified",
+			"Single Tag specified",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				pod.Annotations[annotationUpstreams] = "db:1234:dc1"
+				pod.Annotations[annotationTags] = "abc"
+				return pod
+			},
+			`tags = ["abc"]`,
+			"",
+		},
+
+		{
+			"Multiple Tags specified",
 			func(pod *corev1.Pod) *corev1.Pod {
 				pod.Annotations[annotationService] = "web"
 				pod.Annotations[annotationUpstreams] = "db:1234:dc1"

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -55,7 +55,7 @@ const (
 
 	// annotationTags is a list of tags to register with the service
 	// this is specified as a comma separated list e.g. abc,123
-	annotationTags = "consul.hashicorp.com/connect-service-tags"
+	annotationTags = "consul.hashicorp.com/service-tags"
 )
 
 var (


### PR DESCRIPTION
This PR is a roll up of previous PRs as I found a bug. The original code was not setting the tags and service metadata for the proxy. While the tests were passing for this as the test only searches for the existence of tags in the command. Since this data was present on the service config the test passed however for Consul L7 config tags and metadata need to be present on the proxy.

**Content:**
Add annotation to allow the configuration of service tags in Consul

`consul.hashicorp.com/service-tags`, value is a comma separated string of tags to add to the service

```
      annotations:
        "consul.hashicorp.com/connect-inject": "true"
        "consul.hashicorp.com/service-tags": "v1, k8s"
```

Add annotation to allow the configuration of service metadata in Consul service catalog

`consul.hashicorp.com/service-meta-<key>` individual annotations are specified with the metadata key in the annotation name. Key is the name of the metadata key to store in the Consul service catalog. Value of the annotation is the value set against the metadata.

```
      annotations:
        "consul.hashicorp.com/connect-inject": "true"
        "consul.hashicorp.com/service-meta-version": "1"
        "consul.hashicorp.com/service-meta-foo": "bar"
```

A test docker container for this branch can be found at `nicholasjackson/consul-k8s-dev:beta`