### PR TITLE
Idempotent server-acl-init command

### DIFF
--- a/subcommand/acl-init/command.go
+++ b/subcommand/acl-init/command.go
@@ -126,7 +126,7 @@ func (c *Command) Help() string {
 	return c.help
 }
 
-const synopsis = "Initialize ACLs on Consul servers."
+const synopsis = "Initialize ACLs on non-server components."
 const help = `
 Usage: consul-k8s acl-init [options]
 

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -1,12 +1,13 @@
 package serveraclinit
 
 import (
-	"errors"
 	"flag"
-	"fmt"
 	"os"
+	"strings"
 	"sync"
+	"time"
 
+	"fmt"
 	"github.com/hashicorp/consul-k8s/subcommand"
 	k8sflags "github.com/hashicorp/consul-k8s/subcommand/flags"
 	"github.com/hashicorp/consul/api"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
 	apiv1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -36,7 +38,7 @@ type Command struct {
 	flagCreateMeshGatewayToken   bool
 	flagLogLevel                 string
 
-	clientset *kubernetes.Clientset
+	clientset kubernetes.Interface
 
 	once sync.Once
 	help string
@@ -75,6 +77,17 @@ func (c *Command) init() {
 	c.help = flags.Usage(help, c.flags)
 }
 
+func (c *Command) Synopsis() string { return synopsis }
+func (c *Command) Help() string {
+	c.once.Do(c.init)
+	return c.help
+}
+
+// Run bootstraps ACLs on Consul servers and writes the bootstrap token to a
+// Kubernetes secret.
+// Given various flags, it will also create policies and associated ACL tokens
+// and store the tokens as Kubernetes Secrets.
+// The function will retry its tasks indefinitely until they are complete.
 func (c *Command) Run(args []string) int {
 	c.once.Do(c.init)
 	if err := c.flags.Parse(args); err != nil {
@@ -85,326 +98,459 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	config, err := subcommand.K8SConfig(c.k8s.KubeConfig())
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error retrieving Kubernetes auth: %s", err))
-		return 1
+	// The ClientSet might already be set if we're in a test.
+	if c.clientset == nil {
+		if err := c.configureKubeClient(); err != nil {
+			c.UI.Error(err.Error())
+			return 1
+		}
 	}
 
-	// Create the Kubernetes clientset
-	c.clientset, err = kubernetes.NewForConfig(config)
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error initializing Kubernetes client: %s", err))
-		return 1
-	}
-
+	// Configure our logger.
 	level := hclog.LevelFromString(c.flagLogLevel)
 	if level == hclog.NoLevel {
 		c.UI.Error(fmt.Sprintf("Unknown log level: %s", c.flagLogLevel))
 		return 1
 	}
-
 	logger := hclog.New(&hclog.LoggerOptions{
 		Level:  level,
 		Output: os.Stderr,
 	})
 
-	// Use the client to get statefulset pods
-	labelSelector := fmt.Sprintf("component=server, app=consul, release=%s", c.flagReleaseName)
-
-	serverPods, err := c.clientset.CoreV1().Pods(c.flagNamespace).List(metav1.ListOptions{LabelSelector: labelSelector})
-	if err != nil {
-		logger.Error(err.Error())
-		return 1
-	}
-
-	if len(serverPods.Items) == 0 {
-		logger.Error("No pods were found")
-		return 1
-	}
-
-	// Pull the addresses out of each pod
-	var podAddresses []string
+	// Get Consul Server Pods and construct their addresses.
+	serverPods := c.getConsulServers(logger)
+	var serverPodAddrs []string
 	for _, pod := range serverPods.Items {
-		address := fmt.Sprintf("%s:8500", pod.Status.PodIP)
-		if pod.Status.PodIP != "" {
-			podAddresses = append(podAddresses, address)
-			logger.Info(address)
+		var httpPort int32
+		for _, p := range pod.Spec.Containers[0].Ports {
+			if p.Name == "http" {
+				httpPort = p.ContainerPort
+			}
 		}
+		if httpPort == 0 {
+			c.UI.Error(fmt.Sprintf("pod %s has no port labeled 'http'", pod.Name))
+			return 1
+		}
+		addr := fmt.Sprintf("%s:%d", pod.Status.PodIP, httpPort)
+		serverPodAddrs = append(serverPodAddrs, addr)
 	}
+	logger.Info(fmt.Sprintf("Found %d Consul servers", len(serverPodAddrs)),
+		"addrs", strings.Join(serverPodAddrs, ","))
 
-	if len(podAddresses) < c.flagReplicas {
-		logger.Error(fmt.Sprintf("Not enough pod addresses were found: %d", len(podAddresses)))
-		return 1
-	}
-
-	// Pick the first pod to connect to for bootstrapping & set up connection
-	consulConfig := api.Config{
-		Address: podAddresses[0],
+	// Pick the first pod to connect to for bootstrapping and set up connection.
+	firstServerAddr := serverPodAddrs[0]
+	consulClient, err := api.NewClient(&api.Config{
+		Address: firstServerAddr,
 		Scheme:  "http",
-	}
-
-	consulClient, err := api.NewClient(&consulConfig)
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
-		return 1
-	}
-
-	// Bootstrap the ACLs
-	bootstrapToken, _, err := consulClient.ACL().Bootstrap()
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error bootstrapping Consul agent: %s", err))
-		return 1
-	}
-
-	// Write bootstrap token to a Kubernetes secret
-	_, err = c.clientset.CoreV1().Secrets(c.flagNamespace).Create(&apiv1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-consul-bootstrap-acl-token", c.flagReleaseName),
-		},
-		StringData: map[string]string{
-			"token": bootstrapToken.SecretID,
-		},
 	})
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error creating bootstrap token secret: %s", err))
+		// This should not happen but if it does it's likely unrecoverable.
+		c.UI.Error(fmt.Sprintf("Error creating Consul API client: %s", err))
 		return 1
 	}
 
-	// Create agent policy
+	// Bootstrap ACLs.
+	bootstrapToken, err := c.bootstrapACLs(logger, consulClient)
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	// Override our original client with a new one that has the bootstrap token
+	// set.
+	consulClient, err = api.NewClient(&api.Config{
+		Address: firstServerAddr,
+		Scheme:  "http",
+		Token:   bootstrapToken,
+	})
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error creating Consul client for addr %q: %s", firstServerAddr, err))
+		return 1
+	}
+
+	// Create new tokens for each server and apply them.
+	if err := c.setServerTokens(logger, consulClient, serverPods, serverPodAddrs, bootstrapToken); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	if c.flagCreateClientToken {
+		c.createACL("client", agentRules, consulClient, logger)
+	}
+
+	if c.flagAllowDNS {
+		c.configureDNSPolicies(logger, consulClient)
+	}
+
+	if c.flagCreateSyncToken {
+		c.createACL("catalog-sync", syncRules, consulClient, logger)
+	}
+
+	if c.flagCreateEntLicenseToken {
+		c.createACL("enterprise-license", entLicenseRules, consulClient, logger)
+	}
+
+	if c.flagCreateSnapshotAgentToken {
+		c.createACL("client-snapshot-agent", snapshotAgentRules, consulClient, logger)
+	}
+
+	if c.flagCreateMeshGatewayToken {
+		c.createACL("mesh-gateway", meshGatewayRules, consulClient, logger)
+	}
+
+	if c.flagCreateInjectAuthMethod {
+		c.configureConnectInject(logger, consulClient)
+	}
+
+	logger.Info("server-acl-init completed successfully")
+	return 0
+}
+
+func (c *Command) configureKubeClient() error {
+	config, err := subcommand.K8SConfig(c.k8s.KubeConfig())
+	if err != nil {
+		return fmt.Errorf("error retrieving Kubernetes auth: %s", err)
+	}
+	c.clientset, err = kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("error initializing Kubernetes client: %s", err)
+	}
+	return nil
+}
+
+func (c *Command) getConsulServers(logger hclog.Logger) *apiv1.PodList {
+	var serverPods *apiv1.PodList
+	c.untilSucceeds("discovering Consul server pods",
+		func() error {
+			labelSelector := fmt.Sprintf("component=server, app=consul, release=%s", c.flagReleaseName)
+			var err error
+			serverPods, err = c.clientset.CoreV1().Pods(c.flagNamespace).List(metav1.ListOptions{LabelSelector: labelSelector})
+			if err != nil {
+				return err
+			}
+
+			if len(serverPods.Items) == 0 {
+				return fmt.Errorf("no server pods with labels %q found", labelSelector)
+			}
+
+			if len(serverPods.Items) < c.flagReplicas {
+				return fmt.Errorf("found %d servers, require %d", len(serverPods.Items), c.flagReplicas)
+			}
+
+			for _, pod := range serverPods.Items {
+				if pod.Status.PodIP == "" {
+					return fmt.Errorf("pod %s has no IP", pod.Name)
+				}
+			}
+			return nil
+		}, logger)
+	return serverPods
+}
+
+func (c *Command) bootstrapACLs(logger hclog.Logger, consulClient *api.Client) (string, error) {
+	// Bootstrap the ACLs unless already bootstrapped.
+	alreadyBootstrapped := false
+	var bootstrapToken string
+	c.untilSucceeds("bootstrapping ACLs - PUT /v1/acl/bootstrap",
+		func() error {
+			bootstrapResp, _, err := consulClient.ACL().Bootstrap()
+			if err == nil {
+				bootstrapToken = bootstrapResp.SecretID
+				return nil
+			}
+
+			// Check if already bootstrapped.
+			if strings.Contains(err.Error(), "Unexpected response code: 403") {
+				alreadyBootstrapped = true
+				logger.Info("ACLs already bootstrapped")
+				return nil
+			}
+
+			if isNoLeaderErr(err) {
+				// Return a more descriptive error in the case of no leader
+				// being elected.
+				return fmt.Errorf("no leader elected: %s", err)
+			}
+			return err
+		}, logger)
+
+	bootTokenSecretName := fmt.Sprintf("%s-consul-bootstrap-acl-token", c.flagReleaseName)
+	if alreadyBootstrapped {
+		// Retrieve the bootstrap token from the Kubernetes secret.
+		secret, err := c.clientset.CoreV1().Secrets(c.flagNamespace).Get(bootTokenSecretName, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return "", fmt.Errorf("Bootstrap token secret %q was not found."+
+					" We can't proceed because the bootstrap token is lost."+
+					" You must reset ACLs.", bootTokenSecretName)
+			}
+			return "", fmt.Errorf("Error getting bootstrap token Secret %q: %s", bootTokenSecretName, err)
+		}
+		var ok bool
+		bootstrapToken, ok = secret.StringData["token"]
+		if !ok {
+			return "", fmt.Errorf("Secret %q does not have data key 'token'", bootTokenSecretName)
+		}
+		logger.Info(fmt.Sprintf("Got bootstrap token from Secret %q", bootTokenSecretName))
+	} else {
+		// Write bootstrap token to a Kubernetes secret.
+		c.untilSucceeds(fmt.Sprintf("writing bootstrap Secret %q", bootTokenSecretName),
+			func() error {
+				secret := &apiv1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bootTokenSecretName,
+					},
+					StringData: map[string]string{
+						"token": bootstrapToken,
+					},
+				}
+				_, err := c.clientset.CoreV1().Secrets(c.flagNamespace).Create(secret)
+				if k8serrors.IsAlreadyExists(err) {
+					// If it already exists, update it.
+					logger.Info(fmt.Sprintf("Secret %q already exists, updating it with new token", bootTokenSecretName))
+					_, err = c.clientset.CoreV1().Secrets(c.flagNamespace).Update(secret)
+					return err
+				}
+				return err
+			}, logger)
+	}
+	return bootstrapToken, nil
+}
+
+func (c *Command) setServerTokens(logger hclog.Logger, consulClient *api.Client,
+	serverPods *apiv1.PodList, serverPodAddrs []string, bootstrapToken string) error {
+	// Create agent policy.
 	agentPolicy := api.ACLPolicy{
 		Name:        "agent-token",
 		Description: "Agent Token Policy",
 		Rules:       agentRules,
 	}
+	c.untilSucceeds("creating agent policy - PUT /v1/acl/policy",
+		func() error {
+			_, _, err := consulClient.ACL().PolicyCreate(&agentPolicy, nil)
+			if isPolicyExistsErr(err, agentPolicy.Name) {
+				logger.Info(fmt.Sprintf("Policy %q already exists", agentPolicy.Name))
+				return nil
+			}
+			return err
+		}, logger)
 
-	aclAgentPolicy, _, err := consulClient.ACL().PolicyCreate(&agentPolicy, &api.WriteOptions{Token: bootstrapToken.SecretID})
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error creating agent policy: %s", err))
-		return 1
-	}
-
-	// Create agent token for each server agent
+	// Create agent token for each server agent.
 	var serverTokens []api.ACLToken
+	for i := 0; i < len(serverPodAddrs); i++ {
+		podName := serverPods.Items[i].Name
 
-	for i := 0; i < len(podAddresses); i++ {
-		// Include the pod name into the token description
-		token := api.ACLToken{
-			Description: fmt.Sprintf("Server Agent Token for %s", serverPods.Items[i].Name),
-			Policies:    []*api.ACLTokenPolicyLink{&api.ACLTokenPolicyLink{Name: aclAgentPolicy.Name}},
-		}
-
-		newToken, _, err := consulClient.ACL().TokenCreate(&token, &api.WriteOptions{Token: bootstrapToken.SecretID})
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error creating agent token %v: %s", i, err))
-			return 1
-		}
-		serverTokens = append(serverTokens, *newToken)
+		var token *api.ACLToken
+		c.untilSucceeds(fmt.Sprintf("creating server token for %s - PUT /v1/acl/token", podName),
+			func() error {
+				tokenReq := api.ACLToken{
+					Description: fmt.Sprintf("Server Token for %s", podName),
+					Policies:    []*api.ACLTokenPolicyLink{{Name: agentPolicy.Name}},
+				}
+				var err error
+				token, _, err = consulClient.ACL().TokenCreate(&tokenReq, nil)
+				return err
+			}, logger)
+		serverTokens = append(serverTokens, *token)
 	}
 
-	// Pass out agent tokens and restart the servers
-	for i := 0; i < len(podAddresses); i++ {
-		// Connect to other pods
-		consulConfig := api.Config{
-			Address: podAddresses[i],
+	// Pass out agent tokens to servers.
+	for i := 0; i < len(serverPodAddrs); i++ {
+		// We create a new client for each server because we need to call each
+		// server specifically.
+		serverClient, err := api.NewClient(&api.Config{
+			Address: serverPodAddrs[i],
 			Scheme:  "http",
-			Token:   bootstrapToken.SecretID,
-		}
-
-		consulClient, err = api.NewClient(&consulConfig)
+			Token:   bootstrapToken,
+		})
 		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error connecting to Consul agent %v: %s", i, err))
-			return 1
+			return fmt.Errorf("Error creating Consul client for addr %q: %s", serverPodAddrs[i], err)
 		}
+		podName := serverPods.Items[i].Name
 
-		// Apply token
-		_, err = consulClient.Agent().UpdateAgentACLToken(serverTokens[i].SecretID, &api.WriteOptions{})
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error applying agent token %v: %s", i, err))
-			return 1
-		}
-
-		// Restart
-		err = consulClient.Agent().Reload()
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error restarting agent %v: %s", i, err))
-			return 1
-		}
+		// Update token.
+		c.untilSucceeds(fmt.Sprintf("updating server token for %s - PUT /v1/agent/token/agent", podName),
+			func() error {
+				_, err := serverClient.Agent().UpdateAgentACLToken(serverTokens[i].SecretID, nil)
+				return err
+			}, logger)
 	}
-
-	// Create client agent token
-	if c.flagCreateClientToken {
-		if err := c.createACL("client", agentRules, consulClient); err != nil {
-			c.UI.Error(err.Error())
-			return 1
-		}
-	}
-
-	// Update anonymous token to allow DNS to work
-	if c.flagAllowDNS {
-		// Create policy for the anonymous token
-		dnsPolicy := api.ACLPolicy{
-			Name:        "dns-policy",
-			Description: "DNS Policy",
-			Rules:       dnsRules,
-		}
-
-		aclDNSPolicy, _, err := consulClient.ACL().PolicyCreate(&dnsPolicy, &api.WriteOptions{})
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error creating dns policy: %s", err))
-			return 1
-		}
-
-		// Create token to get sent to TokenUpdate
-		aToken := api.ACLToken{
-			AccessorID: "00000000-0000-0000-0000-000000000002",
-			Policies:   []*api.ACLTokenPolicyLink{&api.ACLTokenPolicyLink{Name: aclDNSPolicy.Name}},
-		}
-
-		// Update anonymous token to include this policy
-		_, _, err = consulClient.ACL().TokenUpdate(&aToken, &api.WriteOptions{})
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error updating anonymous token: %s", err))
-			return 1
-		}
-	}
-
-	// Create catalog sync token if necessary
-	if c.flagCreateSyncToken {
-		if err := c.createACL("catalog-sync", syncRules, consulClient); err != nil {
-			c.UI.Error(err.Error())
-			return 1
-		}
-	}
-
-	// Create enterprise license token if necessary
-	if c.flagCreateEntLicenseToken {
-		if err := c.createACL("enterprise-license", entLicenseRules, consulClient); err != nil {
-			c.UI.Error(err.Error())
-			return 1
-		}
-	}
-
-	// Create snapshot agent token if necessary
-	if c.flagCreateSnapshotAgentToken {
-		if err := c.createACL("client-snapshot-agent", snapshotAgentRules, consulClient); err != nil {
-			c.UI.Error(err.Error())
-			return 1
-		}
-	}
-
-	if c.flagCreateMeshGatewayToken {
-		if err := c.createACL("mesh-gateway", meshGatewayRules, consulClient); err != nil {
-			c.UI.Error(err.Error())
-			return 1
-		}
-	}
-
-	// Support ConnectInject using Kubernetes as an auth method
-	if c.flagCreateInjectAuthMethod {
-		// Get the Kubernetes service IP address - kubernetes.default.svc
-		k8sService, err := c.clientset.CoreV1().Services("default").Get("kubernetes", metav1.GetOptions{})
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error getting kubernetes service: %s", err))
-			return 1
-		}
-
-		// Get auth method service account JWT
-		saName := fmt.Sprintf("%s-consul-connect-injector-authmethod-svc-account", c.flagReleaseName)
-		amServiceAccount, err := c.clientset.CoreV1().ServiceAccounts(c.flagNamespace).Get(saName, metav1.GetOptions{})
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error getting service account: %s", err))
-			return 1
-		}
-
-		// Assume the jwt is the first secret attached to the service account
-		saSecret, err := c.clientset.CoreV1().Secrets(c.flagNamespace).Get(amServiceAccount.Secrets[0].Name, metav1.GetOptions{})
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error getting service account JWT secret: %s", err))
-			return 1
-		}
-
-		// Set up auth method
-		aam := api.ACLAuthMethod{
-			Name:        fmt.Sprintf("%s-consul-k8s-auth-method", c.flagReleaseName),
-			Description: fmt.Sprintf("Consul %s default Kubernetes AuthMethod", c.flagReleaseName),
-			Type:        "kubernetes",
-			Config: map[string]interface{}{
-				"Host":              fmt.Sprintf("https://%s:443", k8sService.Spec.ClusterIP),
-				"CACert":            string(saSecret.Data["ca.crt"]),
-				"ServiceAccountJWT": string(saSecret.Data["token"]),
-			},
-		}
-
-		authMethod, _, err := consulClient.ACL().AuthMethodCreate(&aam, &api.WriteOptions{})
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error creating auth method: %s", err))
-			return 1
-		}
-
-		// Register binding rule
-		abr := api.ACLBindingRule{
-			Description: fmt.Sprintf("Consul %s default binding rule", c.flagReleaseName),
-			AuthMethod:  authMethod.Name,
-			BindType:    api.BindingRuleBindTypeService,
-			BindName:    "${serviceaccount.name}",
-			Selector:    c.flagBindingRuleSelector,
-		}
-
-		_, _, err = consulClient.ACL().BindingRuleCreate(&abr, nil)
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error creating binding rule: %s", err))
-			return 1
-		}
-	}
-
-	return 0
+	return nil
 }
 
-func (c *Command) createACL(name, rules string, consulClient *api.Client) error {
-	// Create policy
-	policy := api.ACLPolicy{
+func (c *Command) createACL(name, rules string, consulClient *api.Client, logger hclog.Logger) {
+	// Create policy with the given rules.
+	policyTmpl := api.ACLPolicy{
 		Name:        fmt.Sprintf("%s-token", name),
 		Description: fmt.Sprintf("%s Token Policy", name),
 		Rules:       rules,
 	}
+	c.untilSucceeds(fmt.Sprintf("creating %s policy", policyTmpl.Name),
+		func() error {
+			_, _, err := consulClient.ACL().PolicyCreate(&policyTmpl, &api.WriteOptions{})
+			if isPolicyExistsErr(err, policyTmpl.Name) {
+				logger.Info(fmt.Sprintf("Policy %q already exists", policyTmpl.Name))
+				return nil
+			}
+			return err
+		}, logger)
 
-	createdPolicy, _, err := consulClient.ACL().PolicyCreate(&policy, &api.WriteOptions{})
-	if err != nil {
-		return fmt.Errorf("Error creating %s policy: %s", name, err)
-	}
-
-	token := api.ACLToken{
+	// Create token for the policy.
+	tokenTmpl := api.ACLToken{
 		Description: fmt.Sprintf("%s Token", name),
-		Policies:    []*api.ACLTokenPolicyLink{&api.ACLTokenPolicyLink{Name: createdPolicy.Name}},
+		Policies:    []*api.ACLTokenPolicyLink{{Name: policyTmpl.Name}},
 	}
+	var token string
+	c.untilSucceeds(fmt.Sprintf("creating token for policy %s", policyTmpl.Name),
+		func() error {
+			createdToken, _, err := consulClient.ACL().TokenCreate(&tokenTmpl, &api.WriteOptions{})
+			if err == nil {
+				token = createdToken.SecretID
+			}
+			return err
+		}, logger)
 
-	// Create token
-	createdToken, _, err := consulClient.ACL().TokenCreate(&token, &api.WriteOptions{})
-	if err != nil {
-		return fmt.Errorf("Error creating %s token: %s", name, err)
-	}
-
-	// Write token to a Kubernetes secret
-	_, err = c.clientset.CoreV1().Secrets(c.flagNamespace).Create(&apiv1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-consul-%s-acl-token", c.flagReleaseName, name),
-		},
-		StringData: map[string]string{
-			"token": createdToken.SecretID,
-		},
-	})
-	if err != nil {
-		return errors.New(fmt.Sprintf("Error creating %s token secret: %s", name, err))
-	}
-
-	return nil
+	// Write token to a Kubernetes secret.
+	c.untilSucceeds(fmt.Sprintf("writing Secret for token %s", policyTmpl.Name),
+		func() error {
+			secret := &apiv1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s-consul-%s-acl-token", c.flagReleaseName, name),
+				},
+				StringData: map[string]string{
+					"token": token,
+				},
+			}
+			_, err := c.clientset.CoreV1().Secrets(c.flagNamespace).Create(secret)
+			if k8serrors.IsAlreadyExists(err) {
+				// If the secret already exists, update it.
+				_, err := c.clientset.CoreV1().Secrets(c.flagNamespace).Update(secret)
+				return err
+			}
+			return err
+		}, logger)
 }
 
-func (c *Command) Synopsis() string { return synopsis }
-func (c *Command) Help() string {
-	c.once.Do(c.init)
-	return c.help
+func (c *Command) configureDNSPolicies(logger hclog.Logger, consulClient *api.Client) {
+	// Create policy for the anonymous token
+	dnsPolicy := api.ACLPolicy{
+		Name:        "dns-policy",
+		Description: "DNS Policy",
+		Rules:       dnsRules,
+	}
+
+	c.untilSucceeds("creating dns policy - PUT /v1/acl/policy",
+		func() error {
+			_, _, err := consulClient.ACL().PolicyCreate(&dnsPolicy, nil)
+			if isPolicyExistsErr(err, dnsPolicy.Name) {
+				logger.Info(fmt.Sprintf("Policy %q already exists", dnsPolicy.Name))
+				return nil
+			}
+			return err
+		}, logger)
+
+	// Create token to get sent to TokenUpdate
+	aToken := api.ACLToken{
+		AccessorID: "00000000-0000-0000-0000-000000000002",
+		Policies:   []*api.ACLTokenPolicyLink{{Name: dnsPolicy.Name}},
+	}
+
+	// Update anonymous token to include this policy
+	c.untilSucceeds("updating anonymous token with DNS policy",
+		func() error {
+			_, _, err := consulClient.ACL().TokenUpdate(&aToken, &api.WriteOptions{})
+			return err
+		}, logger)
+}
+
+func (c *Command) configureConnectInject(logger hclog.Logger, consulClient *api.Client) {
+	var kubeSvc *apiv1.Service
+	c.untilSucceeds("getting kubernetes service IP",
+		func() error {
+			var err error
+			kubeSvc, err = c.clientset.CoreV1().Services("default").Get("kubernetes", metav1.GetOptions{})
+			return err
+		}, logger)
+
+	// Get the Secret name for the auth method ServiceAccount.
+	var authMethodServiceAccount *apiv1.ServiceAccount
+	saName := fmt.Sprintf("%s-consul-connect-injector-authmethod-svc-account", c.flagReleaseName)
+	c.untilSucceeds(fmt.Sprintf("getting %s ServiceAccount", saName),
+		func() error {
+			var err error
+			authMethodServiceAccount, err = c.clientset.CoreV1().ServiceAccounts(c.flagNamespace).Get(saName, metav1.GetOptions{})
+			return err
+		}, logger)
+
+	// ServiceAccounts always have a secret name. The secret
+	// contains the JWT token.
+	saSecretName := authMethodServiceAccount.Secrets[0].Name
+
+	// Get the secret that will contain the ServiceAccount JWT token.
+	var saSecret *apiv1.Secret
+	c.untilSucceeds(fmt.Sprintf("getting %s Secret", saSecretName),
+		func() error {
+			var err error
+			saSecret, err = c.clientset.CoreV1().Secrets(c.flagNamespace).Get(saSecretName, metav1.GetOptions{})
+			return err
+		}, logger)
+
+	// Now we're ready to set up Consul's auth method.
+	authMethodTmpl := api.ACLAuthMethod{
+		Name:        fmt.Sprintf("%s-consul-k8s-auth-method", c.flagReleaseName),
+		Description: fmt.Sprintf("Consul %s default Kubernetes AuthMethod", c.flagReleaseName),
+		Type:        "kubernetes",
+		Config: map[string]interface{}{
+			"Host":              fmt.Sprintf("https://%s:443", kubeSvc.Spec.ClusterIP),
+			"CACert":            string(saSecret.Data["ca.crt"]),
+			"ServiceAccountJWT": string(saSecret.Data["token"]),
+		},
+	}
+	var authMethod *api.ACLAuthMethod
+	c.untilSucceeds(fmt.Sprintf("creating auth method %s", authMethodTmpl.Name),
+		func() error {
+			var err error
+			authMethod, _, err = consulClient.ACL().AuthMethodCreate(&authMethodTmpl, &api.WriteOptions{})
+			return err
+		}, logger)
+
+	// Create the binding rule.
+	abr := api.ACLBindingRule{
+		Description: fmt.Sprintf("Consul %s default binding rule", c.flagReleaseName),
+		AuthMethod:  authMethod.Name,
+		BindType:    api.BindingRuleBindTypeService,
+		BindName:    "${serviceaccount.name}",
+		Selector:    c.flagBindingRuleSelector,
+	}
+	c.untilSucceeds(fmt.Sprintf("creating acl binding rule for %s", authMethodTmpl.Name),
+		func() error {
+			_, _, err := consulClient.ACL().BindingRuleCreate(&abr, nil)
+			return err
+		}, logger)
+}
+
+func (c *Command) untilSucceeds(opName string, op func() error, logger hclog.Logger) {
+	for {
+		err := op()
+		if err == nil {
+			logger.Info(fmt.Sprintf("Success: %s", opName))
+			break
+		}
+		logger.Error(fmt.Sprintf("Failure: %s", opName), "err", err)
+		logger.Info("Retrying in 1s")
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func isNoLeaderErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "Unexpected response code: 500") &&
+		strings.Contains(err.Error(), "The ACL system is currently in legacy mode.")
+}
+
+func isPolicyExistsErr(err error, policyName string) bool {
+	return err != nil &&
+		strings.Contains(err.Error(), "Unexpected response code: 500") &&
+		strings.Contains(err.Error(), fmt.Sprintf("Invalid Policy: A Policy with Name %q already exists", policyName))
 }
 
 const synopsis = "Initialize ACLs on Consul servers."

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -1,0 +1,964 @@
+package serveraclinit
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/api"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+)
+
+var ns = "default"
+var releaseName = "release-name"
+
+// Set up test consul agent and kubernetes clusters with
+func completeSetup(t *testing.T) (*fake.Clientset, *agent.TestAgent) {
+	require := require.New(t)
+	k8s := fake.NewSimpleClientset()
+
+	a := agent.NewTestAgent(t, t.Name(), `
+	primary_datacenter = "dc1"
+	acl {
+		enabled = true
+	}`)
+
+	consulURL, err := url.Parse("http://" + a.HTTPAddr())
+	require.NoError(err)
+	port, err := strconv.Atoi(consulURL.Port())
+	require.NoError(err)
+
+	// Create Consul server Pod.
+	_, err = k8s.CoreV1().Pods(ns).Create(&v1.Pod{
+		ObjectMeta: v12.ObjectMeta{
+			Name: releaseName + "-consul-server-0",
+			Labels: map[string]string{
+				"component": "server",
+				"app":       "consul",
+				"release":   releaseName,
+			},
+		},
+		Status: v1.PodStatus{
+			PodIP: consulURL.Hostname(),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "consul",
+					Ports: []v1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: int32(port),
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+	return k8s, a
+}
+
+func TestRun_Defaults(t *testing.T) {
+	t.Parallel()
+	k8s, testAgent := completeSetup(t)
+	defer testAgent.Shutdown()
+	require := require.New(t)
+
+	// Run the command.
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI:        ui,
+		clientset: k8s,
+	}
+	cmd.init()
+	responseCode := cmd.Run([]string{
+		"-release-name=" + releaseName,
+		"-k8s-namespace=" + ns,
+		"-expected-replicas=1",
+	})
+	require.Equal(0, responseCode, ui.ErrorWriter.String())
+
+	// Test that the bootstrap kube secret is created.
+	bootToken := getBootToken(t, k8s, releaseName)
+
+	// Check that it has the right policies.
+	consul := testAgent.Client()
+	tokenData, _, err := consul.ACL().TokenReadSelf(&api.QueryOptions{Token: bootToken})
+	require.NoError(err)
+	require.Equal("global-management", tokenData.Policies[0].Name)
+
+	// Check that the agent policy was created.
+	policies, _, err := consul.ACL().PolicyList(&api.QueryOptions{Token: bootToken})
+	require.NoError(err)
+	found := false
+	for _, p := range policies {
+		if p.Name == "agent-token" {
+			found = true
+			break
+		}
+	}
+	require.True(found, "agent-token policy was not found")
+
+	// We should also test that the server's token was updated, however I
+	// couldn't find a way to test that with the test agent. Instead we test
+	// that in another test when we're using an httptest server instead of
+	// the test agent and we can assert that the /v1/agent/token/agent
+	// endpoint was called.
+}
+
+// Test the different flags that should create tokens and save them as
+// Kubernetes secrets.
+func TestRun_Tokens(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		Flag      string
+		TokenName string
+	}{
+		"client token": {
+			"-create-client-token",
+			"client",
+		},
+		"catalog-sync token": {
+			"-create-sync-token",
+			"catalog-sync",
+		},
+		"enterprise-license token": {
+			"-create-enterprise-license-token",
+			"enterprise-license",
+		},
+		"snapshot-agent token": {
+			"-create-snapshot-agent-token",
+			"client-snapshot-agent",
+		},
+		"mesh-gateway token": {
+			"-create-mesh-gateway-token",
+			"mesh-gateway",
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			k8s, testAgent := completeSetup(t)
+			defer testAgent.Shutdown()
+			require := require.New(t)
+
+			// Run the command.
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI:        ui,
+				clientset: k8s,
+			}
+			cmd.init()
+			responseCode := cmd.Run([]string{
+				"-release-name=" + releaseName,
+				"-k8s-namespace=" + ns,
+				"-expected-replicas=1",
+				c.Flag,
+			})
+			require.Equal(0, responseCode, ui.ErrorWriter.String())
+
+			// Check that the client policy was created.
+			bootToken := getBootToken(t, k8s, releaseName)
+			consul := testAgent.Client()
+			policies, _, err := consul.ACL().PolicyList(&api.QueryOptions{Token: bootToken})
+			require.NoError(err)
+			found := false
+			for _, p := range policies {
+				if p.Name == c.TokenName+"-token" {
+					found = true
+					break
+				}
+			}
+
+			// Test that the token was created as a Kubernetes Secret.
+			require.True(found, "%s-token policy was not found", c.TokenName)
+			tokenSecret, err := k8s.CoreV1().Secrets(ns).Get(fmt.Sprintf("%s-consul-%s-acl-token", releaseName, c.TokenName), metav1.GetOptions{})
+			require.NoError(err)
+			require.NotNil(tokenSecret)
+			token, ok := tokenSecret.StringData["token"]
+			require.True(ok)
+
+			// Test that the token has the expected policies in Consul.
+			tokenData, _, err := consul.ACL().TokenReadSelf(&api.QueryOptions{Token: token})
+			require.NoError(err)
+			require.Equal(c.TokenName+"-token", tokenData.Policies[0].Name)
+		})
+	}
+}
+
+func TestRun_AllowDNS(t *testing.T) {
+	t.Parallel()
+	k8s, testAgent := completeSetup(t)
+	defer testAgent.Shutdown()
+	require := require.New(t)
+
+	// Run the command.
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI:        ui,
+		clientset: k8s,
+	}
+	cmd.init()
+	responseCode := cmd.Run([]string{
+		"-release-name=" + releaseName,
+		"-k8s-namespace=" + ns,
+		"-expected-replicas=1",
+		"-allow-dns",
+	})
+	require.Equal(0, responseCode, ui.ErrorWriter.String())
+
+	// Check that the dns policy was created.
+	bootToken := getBootToken(t, k8s, releaseName)
+	consul := testAgent.Client()
+	policies, _, err := consul.ACL().PolicyList(&api.QueryOptions{Token: bootToken})
+	require.NoError(err)
+	found := false
+	for _, p := range policies {
+		if p.Name == "dns-policy" {
+			found = true
+			break
+		}
+	}
+	require.True(found, "Did not find dns-policy")
+
+	// Check that the anonymous token has the DNS policy.
+	tokenData, _, err := consul.ACL().TokenReadSelf(&api.QueryOptions{Token: "anonymous"})
+	require.NoError(err)
+	require.Equal("dns-policy", tokenData.Policies[0].Name)
+}
+
+func TestRun_ConnectInjectToken(t *testing.T) {
+	t.Parallel()
+	k8s, testAgent := completeSetup(t)
+	defer testAgent.Shutdown()
+	require := require.New(t)
+
+	// Create Kubernetes Service.
+	_, err := k8s.CoreV1().Services(ns).Create(&v1.Service{
+		Spec: v1.ServiceSpec{
+			ClusterIP: "1.2.3.4",
+		},
+		ObjectMeta: v12.ObjectMeta{
+			Name: "kubernetes",
+		},
+	})
+	require.NoError(err)
+
+	// Create ServiceAccount for the injector that the helm chart creates.
+	_, err = k8s.CoreV1().ServiceAccounts(ns).Create(&v1.ServiceAccount{
+		ObjectMeta: v12.ObjectMeta{
+			Name: releaseName + "-consul-connect-injector-authmethod-svc-account",
+		},
+		Secrets: []v1.ObjectReference{
+			{
+				Name: releaseName + "-consul-connect-injector-authmethod-svc-accohndbv",
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Create the ServiceAccount Secret.
+	caCertBytes, err := base64.StdEncoding.DecodeString(serviceAccountCACert)
+	require.NoError(err)
+	tokenBytes, err := base64.StdEncoding.DecodeString(serviceAccountToken)
+	require.NoError(err)
+	_, err = k8s.CoreV1().Secrets(ns).Create(&v1.Secret{
+		ObjectMeta: v12.ObjectMeta{
+			Name: releaseName + "-consul-connect-injector-authmethod-svc-accohndbv",
+		},
+		Data: map[string][]byte{
+			"ca.crt": caCertBytes,
+			"token":  tokenBytes,
+		},
+	})
+	require.NoError(err)
+
+	// Run the command.
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI:        ui,
+		clientset: k8s,
+	}
+	cmd.init()
+	bindingRuleSelector := "serviceaccount.name!=default"
+	responseCode := cmd.Run([]string{
+		"-release-name=" + releaseName,
+		"-k8s-namespace=" + ns,
+		"-expected-replicas=1",
+		"-create-inject-token",
+		"-acl-binding-rule-selector=" + bindingRuleSelector,
+	})
+	require.Equal(0, responseCode, ui.ErrorWriter.String())
+
+	// Check that the auth method was created.
+	bootToken := getBootToken(t, k8s, releaseName)
+	consul := testAgent.Client()
+	authMethodName := releaseName + "-consul-k8s-auth-method"
+	authMethod, _, err := consul.ACL().AuthMethodRead(authMethodName,
+		&api.QueryOptions{Token: bootToken})
+	require.NoError(err)
+	require.Contains(authMethod.Config, "Host")
+	require.Equal(authMethod.Config["Host"], "https://1.2.3.4:443")
+	require.Contains(authMethod.Config, "CACert")
+	require.Equal(authMethod.Config["CACert"], string(caCertBytes))
+	require.Contains(authMethod.Config, "ServiceAccountJWT")
+	require.Equal(authMethod.Config["ServiceAccountJWT"], string(tokenBytes))
+
+	// Check that the binding rule was created.
+	rules, _, err := consul.ACL().BindingRuleList(authMethodName, &api.QueryOptions{Token: bootToken})
+	require.NoError(err)
+	require.Len(rules, 1)
+	require.Equal("service", string(rules[0].BindType))
+	require.Equal("${serviceaccount.name}", rules[0].BindName)
+	require.Equal(bindingRuleSelector, rules[0].Selector)
+}
+
+// Test that if the server pods aren't available at first that bootstrap
+// still succeeds.
+func TestRun_DelayedServerPods(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	k8s := fake.NewSimpleClientset()
+
+	type APICall struct {
+		Method string
+		Path   string
+	}
+	var consulAPICalls []APICall
+	consulServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Record all the API calls made.
+		consulAPICalls = append(consulAPICalls, APICall{
+			Method: r.Method,
+			Path:   r.URL.Path,
+		})
+
+		// Send an empty JSON response with code 200 to all calls.
+		fmt.Fprintln(w, "{}")
+	}))
+	defer consulServer.Close()
+	serverURL, err := url.Parse(consulServer.URL)
+	require.NoError(err)
+	port, err := strconv.Atoi(serverURL.Port())
+	require.NoError(err)
+
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI:        ui,
+		clientset: k8s,
+	}
+	cmd.init()
+
+	// Start the command before the Pod exist.
+	// Run in a goroutine so we can create the Pods asynchronously
+	done := make(chan bool)
+	var responseCode int
+	go func() {
+		responseCode = cmd.Run([]string{
+			"-release-name=" + releaseName,
+			"-k8s-namespace=" + ns,
+			"-expected-replicas=1",
+		})
+		close(done)
+	}()
+
+	// Asynchronously create the server Pod after a delay.
+	go func() {
+		// Create the Pods after a delay between 100 and 500ms.
+		// It's randomized to ensure we're not relying on specific timing.
+		delay := 100 + rand.Intn(400)
+		time.Sleep(time.Duration(delay) * time.Millisecond)
+
+		pods := k8s.CoreV1().Pods(ns)
+		_, err = pods.Create(&v1.Pod{
+			ObjectMeta: v12.ObjectMeta{
+				Name: releaseName + "-consul-server-0",
+				Labels: map[string]string{
+					"component": "server",
+					"app":       "consul",
+					"release":   releaseName,
+				},
+			},
+			Status: v1.PodStatus{
+				PodIP: serverURL.Hostname(),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "consul",
+						Ports: []v1.ContainerPort{
+							{
+								Name:          "http",
+								ContainerPort: int32(port),
+							},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(err)
+	}()
+
+	// Wait for the command to exit.
+	select {
+	case <-done:
+		require.Equal(0, responseCode, ui.ErrorWriter.String())
+	case <-time.After(2 * time.Second):
+		require.FailNow("command did not exit after 2s")
+	}
+
+	// Test that the bootstrap kube secret is created.
+	getBootToken(t, k8s, releaseName)
+
+	// Test that the expected API calls were made.
+	require.Equal([]APICall{
+		{
+			"PUT",
+			"/v1/acl/bootstrap",
+		},
+		{
+			"PUT",
+			"/v1/acl/policy",
+		},
+		{
+			"PUT",
+			"/v1/acl/token",
+		},
+		{
+			"PUT",
+			"/v1/agent/token/agent",
+		},
+		{
+			"PUT",
+			"/v1/acl/policy",
+		},
+		{
+			"PUT",
+			"/v1/acl/token",
+		},
+	}, consulAPICalls)
+}
+
+// Test that if there's no leader, we retry until one is elected.
+func TestRun_NoLeader(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	k8s := fake.NewSimpleClientset()
+
+	type APICall struct {
+		Method string
+		Path   string
+	}
+	var consulAPICalls []APICall
+
+	// Start the Consul server.
+	numACLBootCalls := 0
+	consulServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Record all the API calls made.
+		consulAPICalls = append(consulAPICalls, APICall{
+			Method: r.Method,
+			Path:   r.URL.Path,
+		})
+
+		switch r.URL.Path {
+		case "/v1/acl/bootstrap":
+			// On the first two calls, return the error that results from no leader
+			// being elected.
+			if numACLBootCalls < 2 {
+				w.WriteHeader(500)
+				fmt.Fprintln(w, "The ACL system is currently in legacy mode.")
+			} else {
+				fmt.Fprintln(w, "{}")
+			}
+			numACLBootCalls++
+		default:
+			fmt.Fprintln(w, "{}")
+		}
+	}))
+	defer consulServer.Close()
+
+	// Create the Server Pods.
+	serverURL, err := url.Parse(consulServer.URL)
+	require.NoError(err)
+	port, err := strconv.Atoi(serverURL.Port())
+	require.NoError(err)
+	pods := k8s.CoreV1().Pods(ns)
+	_, err = pods.Create(&v1.Pod{
+		ObjectMeta: v12.ObjectMeta{
+			Name: releaseName + "-consul-server-0",
+			Labels: map[string]string{
+				"component": "server",
+				"app":       "consul",
+				"release":   releaseName,
+			},
+		},
+		Status: v1.PodStatus{
+			PodIP: serverURL.Hostname(),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "consul",
+					Ports: []v1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: int32(port),
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Run the command.
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI:        ui,
+		clientset: k8s,
+	}
+	cmd.init()
+
+	done := make(chan bool)
+	var responseCode int
+	go func() {
+		responseCode = cmd.Run([]string{
+			"-release-name=" + releaseName,
+			"-k8s-namespace=" + ns,
+			"-expected-replicas=1",
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		require.Equal(0, responseCode, ui.ErrorWriter.String())
+	case <-time.After(5 * time.Second):
+		require.FailNow("command did not complete within 5s")
+	}
+
+	// Test that the bootstrap kube secret is created.
+	getBootToken(t, k8s, releaseName)
+
+	// Test that the expected API calls were made.
+	require.Equal([]APICall{
+		// Bootstrap will have been called 3 times.
+		{
+			"PUT",
+			"/v1/acl/bootstrap",
+		},
+		{
+			"PUT",
+			"/v1/acl/bootstrap",
+		},
+		{
+			"PUT",
+			"/v1/acl/bootstrap",
+		},
+		{
+			"PUT",
+			"/v1/acl/policy",
+		},
+		{
+			"PUT",
+			"/v1/acl/token",
+		},
+		{
+			"PUT",
+			"/v1/agent/token/agent",
+		},
+		{
+			"PUT",
+			"/v1/acl/policy",
+		},
+		{
+			"PUT",
+			"/v1/acl/token",
+		},
+	}, consulAPICalls)
+}
+
+// Test that if already bootstrapped, we continue on to next steps.
+func TestRun_AlreadyBootstrapped(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	k8s := fake.NewSimpleClientset()
+
+	type APICall struct {
+		Method string
+		Path   string
+	}
+	var consulAPICalls []APICall
+
+	// Start the Consul server.
+	consulServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Record all the API calls made.
+		consulAPICalls = append(consulAPICalls, APICall{
+			Method: r.Method,
+			Path:   r.URL.Path,
+		})
+
+		switch r.URL.Path {
+		// If ACLs are already bootstrapped then the bootstrap endpoint returns this error.
+		case "/v1/acl/bootstrap":
+			w.WriteHeader(403)
+			fmt.Fprintln(w, "Permission denied: rpc error making call: ACL bootstrap no longer allowed (reset index: 14)")
+		default:
+			fmt.Fprintln(w, "{}")
+		}
+	}))
+	defer consulServer.Close()
+
+	// Create the Server Pods.
+	serverURL, err := url.Parse(consulServer.URL)
+	require.NoError(err)
+	port, err := strconv.Atoi(serverURL.Port())
+	require.NoError(err)
+	pods := k8s.CoreV1().Pods(ns)
+	_, err = pods.Create(&v1.Pod{
+		ObjectMeta: v12.ObjectMeta{
+			Name: releaseName + "-consul-server-0",
+			Labels: map[string]string{
+				"component": "server",
+				"app":       "consul",
+				"release":   releaseName,
+			},
+		},
+		Status: v1.PodStatus{
+			PodIP: serverURL.Hostname(),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "consul",
+					Ports: []v1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: int32(port),
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Create the bootstrap secret since this should have already been created.
+	_, err = k8s.CoreV1().Secrets(ns).Create(&v1.Secret{
+		ObjectMeta: v12.ObjectMeta{
+			Name: releaseName + "-consul-bootstrap-acl-token",
+		},
+		StringData: map[string]string{
+			"token": "bootstrap-token",
+		},
+	})
+	require.NoError(err)
+
+	// Run the command.
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI:        ui,
+		clientset: k8s,
+	}
+	cmd.init()
+	responseCode := cmd.Run([]string{
+		"-release-name=" + releaseName,
+		"-k8s-namespace=" + ns,
+		"-expected-replicas=1",
+	})
+	require.Equal(0, responseCode, ui.ErrorWriter.String())
+
+	// Test that the expected API calls were made.
+	require.Equal([]APICall{
+		{
+			"PUT",
+			"/v1/acl/bootstrap",
+		},
+		{
+			"PUT",
+			"/v1/acl/policy",
+		},
+		{
+			"PUT",
+			"/v1/acl/token",
+		},
+		{
+			"PUT",
+			"/v1/agent/token/agent",
+		},
+		{
+			"PUT",
+			"/v1/acl/policy",
+		},
+		{
+			"PUT",
+			"/v1/acl/token",
+		},
+	}, consulAPICalls)
+}
+
+// Test that if creating client tokens fails at first, we retry.
+func TestRun_ClientTokensRetry(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	k8s := fake.NewSimpleClientset()
+
+	type APICall struct {
+		Method string
+		Path   string
+	}
+	var consulAPICalls []APICall
+
+	// Start the Consul server.
+	numPolicyCalls := 0
+	consulServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Record all the API calls made.
+		consulAPICalls = append(consulAPICalls, APICall{
+			Method: r.Method,
+			Path:   r.URL.Path,
+		})
+
+		switch r.URL.Path {
+		// The second call to create a policy will fail. This is the client
+		// token call.
+		case "/v1/acl/policy":
+			if numPolicyCalls == 1 {
+				w.WriteHeader(500)
+				fmt.Fprintln(w, "The ACL system is currently in legacy mode.")
+			} else {
+				fmt.Fprintln(w, "{}")
+			}
+			numPolicyCalls++
+		default:
+			fmt.Fprintln(w, "{}")
+		}
+	}))
+	defer consulServer.Close()
+
+	// Create the Server Pods.
+	serverURL, err := url.Parse(consulServer.URL)
+	require.NoError(err)
+	port, err := strconv.Atoi(serverURL.Port())
+	require.NoError(err)
+	pods := k8s.CoreV1().Pods(ns)
+	_, err = pods.Create(&v1.Pod{
+		ObjectMeta: v12.ObjectMeta{
+			Name: releaseName + "-consul-server-0",
+			Labels: map[string]string{
+				"component": "server",
+				"app":       "consul",
+				"release":   releaseName,
+			},
+		},
+		Status: v1.PodStatus{
+			PodIP: serverURL.Hostname(),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "consul",
+					Ports: []v1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: int32(port),
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Run the command.
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI:        ui,
+		clientset: k8s,
+	}
+	cmd.init()
+	responseCode := cmd.Run([]string{
+		"-release-name=" + releaseName,
+		"-k8s-namespace=" + ns,
+		"-expected-replicas=1",
+	})
+	require.Equal(0, responseCode, ui.ErrorWriter.String())
+
+	// Test that the expected API calls were made.
+	require.Equal([]APICall{
+		{
+			"PUT",
+			"/v1/acl/bootstrap",
+		},
+		{
+			"PUT",
+			"/v1/acl/policy",
+		},
+		{
+			"PUT",
+			"/v1/acl/token",
+		},
+		{
+			"PUT",
+			"/v1/agent/token/agent",
+		},
+		// This call should happen twice since the first will fail.
+		{
+			"PUT",
+			"/v1/acl/policy",
+		},
+		{
+			"PUT",
+			"/v1/acl/policy",
+		},
+		{
+			"PUT",
+			"/v1/acl/token",
+		},
+	}, consulAPICalls)
+}
+
+// Test if there is an old bootstrap Secret we update it.
+func TestRun_BootstrapTokenExists(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	k8s := fake.NewSimpleClientset()
+
+	type APICall struct {
+		Method string
+		Path   string
+	}
+	var consulAPICalls []APICall
+
+	// Start the Consul server.
+	consulServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Record all the API calls made.
+		consulAPICalls = append(consulAPICalls, APICall{
+			Method: r.Method,
+			Path:   r.URL.Path,
+		})
+
+		switch r.URL.Path {
+		default:
+			fmt.Fprintln(w, "{}")
+		}
+	}))
+	defer consulServer.Close()
+
+	// Create the Server Pods.
+	serverURL, err := url.Parse(consulServer.URL)
+	require.NoError(err)
+	port, err := strconv.Atoi(serverURL.Port())
+	require.NoError(err)
+	pods := k8s.CoreV1().Pods(ns)
+	_, err = pods.Create(&v1.Pod{
+		ObjectMeta: v12.ObjectMeta{
+			Name: releaseName + "-consul-server-0",
+			Labels: map[string]string{
+				"component": "server",
+				"app":       "consul",
+				"release":   releaseName,
+			},
+		},
+		Status: v1.PodStatus{
+			PodIP: serverURL.Hostname(),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "consul",
+					Ports: []v1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: int32(port),
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Create the old bootstrap secret.
+	_, err = k8s.CoreV1().Secrets(ns).Create(&v1.Secret{
+		ObjectMeta: v12.ObjectMeta{
+			Name: releaseName + "-consul-bootstrap-acl-token",
+		},
+		StringData: map[string]string{
+			"token": "old-token",
+		},
+	})
+	require.NoError(err)
+
+	// Run the command.
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI:        ui,
+		clientset: k8s,
+	}
+	cmd.init()
+	responseCode := cmd.Run([]string{
+		"-release-name=" + releaseName,
+		"-k8s-namespace=" + ns,
+		"-expected-replicas=1",
+	})
+	require.Equal(0, responseCode, ui.ErrorWriter.String())
+
+	// Test that the Secret was updated.
+	secret, err := k8s.CoreV1().Secrets(ns).Get(releaseName+"-consul-bootstrap-acl-token", metav1.GetOptions{})
+	require.NoError(err)
+	require.Contains(secret.StringData, "token")
+	require.NotEqual("old-token", secret.StringData["token"])
+
+	// Test that the expected API calls were made.
+	require.Equal([]APICall{
+		{
+			"PUT",
+			"/v1/acl/bootstrap",
+		},
+		{
+			"PUT",
+			"/v1/acl/policy",
+		},
+		{
+			"PUT",
+			"/v1/acl/token",
+		},
+		{
+			"PUT",
+			"/v1/agent/token/agent",
+		},
+		{
+			"PUT",
+			"/v1/acl/policy",
+		},
+		{
+			"PUT",
+			"/v1/acl/token",
+		},
+	}, consulAPICalls)
+}
+
+// getBootToken gets the bootstrap token from the Kubernetes secret. It will
+// cause a test failure if the Secret doesn't exist or is malformed.
+func getBootToken(t *testing.T, k8s *fake.Clientset, releaseName string) string {
+	bootstrapSecret, err := k8s.CoreV1().Secrets(ns).Get(fmt.Sprintf("%s-consul-bootstrap-acl-token", releaseName), metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, bootstrapSecret)
+	bootToken, ok := bootstrapSecret.StringData["token"]
+	require.True(t, ok)
+	return bootToken
+}
+
+var serviceAccountCACert = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURDekNDQWZPZ0F3SUJBZ0lRS3pzN05qbDlIczZYYzhFWG91MjVoekFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlRMU9XVTJaR00wTVMweU1EaG1MVFF3T1RVdFlUSTRPUzB4Wm1NM01EQmhZekZqWXpndwpIaGNOTVRrd05qQTNNVEF4TnpNeFdoY05NalF3TmpBMU1URXhOek14V2pBdk1TMHdLd1lEVlFRREV5UTFPV1UyClpHTTBNUzB5TURobUxUUXdPVFV0WVRJNE9TMHhabU0zTURCaFl6RmpZemd3Z2dFaU1BMEdDU3FHU0liM0RRRUIKQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURaakh6d3FvZnpUcEdwYzBNZElDUzdldXZmdWpVS0UzUEMvYXBmREFnQgo0anpFRktBNzgvOStLVUd3L2MvMFNIZVNRaE4rYThnd2xIUm5BejFOSmNmT0lYeTRkd2VVdU9rQWlGeEg4cGh0CkVDd2tlTk83ejhEb1Y4Y2VtaW5DUkhHamFSbW9NeHBaN2cycFpBSk5aZVB4aTN5MWFOa0ZBWGU5Z1NVU2RqUloKUlhZa2E3d2gyQU85azJkbEdGQVlCK3Qzdld3SjZ0d2pHMFR0S1FyaFlNOU9kMS9vTjBFMDFMekJjWnV4a04xawo4Z2ZJSHk3Yk9GQ0JNMldURURXLzBhQXZjQVByTzhETHFESis2TWpjM3I3K3psemw4YVFzcGIwUzA4cFZ6a2k1CkR6Ly84M2t5dTBwaEp1aWo1ZUI4OFY3VWZQWHhYRi9FdFY2ZnZyTDdNTjRmQWdNQkFBR2pJekFoTUE0R0ExVWQKRHdFQi93UUVBd0lDQkRBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCdgpRc2FHNnFsY2FSa3RKMHpHaHh4SjUyTm5SVjJHY0lZUGVOM1p2MlZYZTNNTDNWZDZHMzJQVjdsSU9oangzS21BCi91TWg2TmhxQnpzZWtrVHowUHVDM3dKeU0yT0dvblZRaXNGbHF4OXNGUTNmVTJtSUdYQ2Ezd0M4ZS9xUDhCSFMKdzcvVmVBN2x6bWozVFFSRS9XMFUwWkdlb0F4bjliNkp0VDBpTXVjWXZQMGhYS1RQQldsbnpJaWphbVU1MHIyWQo3aWEwNjVVZzJ4VU41RkxYL3Z4T0EzeTRyanBraldvVlFjdTFwOFRaclZvTTNkc0dGV3AxMGZETVJpQUhUdk9ICloyM2pHdWs2cm45RFVIQzJ4UGozd0NUbWQ4U0dFSm9WMzFub0pWNWRWZVE5MHd1c1h6M3ZURzdmaWNLbnZIRlMKeHRyNVBTd0gxRHVzWWZWYUdIMk8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+var serviceAccountToken = "ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNklpSjkuZXlKcGMzTWlPaUpyZFdKbGNtNWxkR1Z6TDNObGNuWnBZMlZoWTJOdmRXNTBJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5dVlXMWxjM0JoWTJVaU9pSmtaV1poZFd4MElpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl6WldOeVpYUXVibUZ0WlNJNkltdG9ZV3RwTFdGeVlXTm9ibWxrTFdOdmJuTjFiQzFqYjI1dVpXTjBMV2x1YW1WamRHOXlMV0YxZEdodFpYUm9iMlF0YzNaakxXRmpZMjlvYm1SaWRpSXNJbXQxWW1WeWJtVjBaWE11YVc4dmMyVnlkbWxqWldGalkyOTFiblF2YzJWeWRtbGpaUzFoWTJOdmRXNTBMbTVoYldVaU9pSnJhR0ZyYVMxaGNtRmphRzVwWkMxamIyNXpkV3d0WTI5dWJtVmpkQzFwYm1wbFkzUnZjaTFoZFhSb2JXVjBhRzlrTFhOMll5MWhZMk52ZFc1MElpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl6WlhKMmFXTmxMV0ZqWTI5MWJuUXVkV2xrSWpvaU4yVTVOV1V4TWprdFpUUTNNeTB4TVdVNUxUaG1ZV0V0TkRJd01UQmhPREF3TVRJeUlpd2ljM1ZpSWpvaWMzbHpkR1Z0T25ObGNuWnBZMlZoWTJOdmRXNTBPbVJsWm1GMWJIUTZhMmhoYTJrdFlYSmhZMmh1YVdRdFkyOXVjM1ZzTFdOdmJtNWxZM1F0YVc1cVpXTjBiM0l0WVhWMGFHMWxkR2h2WkMxemRtTXRZV05qYjNWdWRDSjkuWWk2M01NdHpoNU1CV0tLZDNhN2R6Q0pqVElURTE1aWtGeV9UbnBka19Bd2R3QTlKNEFNU0dFZUhONXZXdEN1dUZqb19sTUpxQkJQSGtLMkFxYm5vRlVqOW01Q29wV3lxSUNKUWx2RU9QNGZVUS1SYzBXMVBfSmpVMXJaRVJIRzM5YjVUTUxnS1BRZ3V5aGFpWkVKNkNqVnRtOXdVVGFncmdpdXFZVjJpVXFMdUY2U1lObTZTckt0a1BTLWxxSU8tdTdDMDZ3Vms1bTV1cXdJVlFOcFpTSUNfNUxzNWFMbXlaVTNuSHZILVY3RTNIbUJoVnlaQUI3NmpnS0IwVHlWWDFJT3NrdDlQREZhck50VTNzdVp5Q2p2cUMtVUpBNnNZZXlTZTRkQk5Lc0tsU1o2WXV4VVVtbjFSZ3YzMllNZEltbnNXZzhraGYtekp2cWdXazdCNUVB"


### PR DESCRIPTION
This PR fixes #138 and https://github.com/hashicorp/consul-helm/issues/186

* The `server-acl-init` command would previously exit on any failure. Now it runs indefinitely, retrying each of its tasks until they are complete. It will retry every 1s.
* It can be run before Consul servers are up and will wait for a leader to be elected.
* It is now idempotent and will handle objects in Consul and Kubernetes that have already been created, either by bypassing those steps or updating the values (e.g. if the bootstrap Secret already exists it will update its data) 
* I've added tests for this behaviour using the Consul testagent and also a simple httpserver mock