### PR TITLE
Make dev-docker target faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ dev:
 	@$(SHELL) $(CURDIR)/build-support/scripts/build-local.sh -o $(GOOS) -a $(GOARCH)
 
 dev-docker:
+	@$(SHELL) $(CURDIR)/build-support/scripts/build-local.sh -o linux -a amd64
 	@docker build -t '$(DEV_IMAGE)' --build-arg 'GIT_COMMIT=$(GIT_COMMIT)' --build-arg 'GIT_DIRTY=$(GIT_DIRTY)' --build-arg 'GIT_DESCRIBE=$(GIT_DESCRIBE)' -f $(CURDIR)/build-support/docker/Dev.dockerfile $(CURDIR)
 
 dev-tree:

--- a/build-support/docker/Dev.dockerfile
+++ b/build-support/docker/Dev.dockerfile
@@ -1,13 +1,2 @@
-FROM golang:1.11.5 as builder
-ARG GIT_COMMIT
-ARG GIT_DIRTY
-ARG GIT_DESCRIBE
-ENV CONSUL_DEV=1
-ENV COLORIZE=0
-Add . /opt/build
-WORKDIR /opt/build
-RUN make
-
 FROM consul:latest
-
-COPY --from=builder /opt/build/bin/consul-k8s /bin
+COPY pkg/bin/linux_amd64/consul-k8s /bin


### PR DESCRIPTION
Previously it was building consul-k8s inside a new container. This meant
it had to download all its dependencies inside the container. This
change builds consul-k8s on the host machine and then copies the binary
to the new container. Since the host machine already has all the
dependencies this is much faster.