### PR TITLE
Use go 1.13 in builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   go:
     docker:
-      - image: circleci/golang:1.11.5
+      - image: circleci/golang:1.13
     environment:
       - TEST_RESULTS: /tmp/test-results # path to where test results are saved
 


### PR DESCRIPTION
Trying to fix these errors that have suddenly shown up in CI (https://app.circleci.com/jobs/github/hashicorp/consul-k8s/429)

```
2 errors occurred:
--> windows/amd64 error: exit status 2
Stderr: # golang.org/x/sys/windows
/go/pkg/mod/golang.org/x/sys@v0.0.0-20191007154456-ef33b2fb2c41/windows/dll_windows.go:21:6: missing function body
/go/pkg/mod/golang.org/x/sys@v0.0.0-20191007154456-ef33b2fb2c41/windows/dll_windows.go:24:6: missing function body
note: module requires Go 1.12
--> windows/386 error: exit status 2
Stderr: # golang.org/x/sys/windows
/go/pkg/mod/golang.org/x/sys@v0.0.0-20191007154456-ef33b2fb2c41/windows/dll_windows.go:21:6: missing function body
/go/pkg/mod/golang.org/x/sys@v0.0.0-20191007154456-ef33b2fb2c41/windows/dll_windows.go:24:6: missing function body
note: module requires Go 1.12
tput: No value for $TERM and no -T specified
tput: No value for $TERM and no -T specified
ERROR: Failed to build Consul
tput: No value for $TERM and no -T specified
Exited with code 1
CircleCI received exit code 1
```