### PR TITLE
Don't fail when there are many binaries in $GOBIN

### DIFF
--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -280,7 +280,7 @@ function build_consul_local {
             then
                GOBIN_EXTRA="${os}_${arch}/"
             fi
-            CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go install -ldflags "${GOLDFLAGS}" -tags "${GOTAGS}" && cp "${MAIN_GOPATH}/bin/${GOBIN_EXTRA}"* "${outdir}/consul-k8s"
+            CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go install -ldflags "${GOLDFLAGS}" -tags "${GOTAGS}" && cp "${MAIN_GOPATH}/bin/${GOBIN_EXTRA}"/consul-k8s "${outdir}/consul-k8s"
             if test $? -ne 0
             then
                err "ERROR: Failed to build Consul for ${osarch}"


### PR DESCRIPTION
If you have more than one binary in your `$GOBIN` already,
running make dev and make dev-docker will fail
because it tries to copy everything in the `$GOBIN`
with a glob. Instead, it should copy the binary
it just installed, namely `consul-k8s`.