### PR TITLE
Delete completed job command and fix server-acl-init

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	cmdACLInit "github.com/hashicorp/consul-k8s/subcommand/acl-init"
+	cmdDeleteCompletedJob "github.com/hashicorp/consul-k8s/subcommand/delete-completed-job"
 	cmdInjectConnect "github.com/hashicorp/consul-k8s/subcommand/inject-connect"
 	cmdServerACLInit "github.com/hashicorp/consul-k8s/subcommand/server-acl-init"
 	cmdSyncCatalog "github.com/hashicorp/consul-k8s/subcommand/sync-catalog"
@@ -33,6 +34,10 @@ func init() {
 
 		"sync-catalog": func() (cli.Command, error) {
 			return &cmdSyncCatalog.Command{UI: ui}, nil
+		},
+
+		"delete-completed-job": func() (cli.Command, error) {
+			return &cmdDeleteCompletedJob.Command{UI: ui}, nil
 		},
 
 		"version": func() (cli.Command, error) {

--- a/subcommand/delete-completed-job/command.go
+++ b/subcommand/delete-completed-job/command.go
@@ -47,9 +47,9 @@ func (c *Command) init() {
 	flags.Merge(c.flags, c.k8s.Flags())
 	c.help = flags.Usage(help, c.flags)
 
-	// Default retry to 30s. This is exposed for setting in tests.
+	// Default retry to 1s. This is exposed for setting in tests.
 	if c.retryDuration == 0 {
-		c.retryDuration = 30 * time.Second
+		c.retryDuration = 1 * time.Second
 	}
 }
 

--- a/subcommand/delete-completed-job/command.go
+++ b/subcommand/delete-completed-job/command.go
@@ -25,7 +25,7 @@ type Command struct {
 	flags         *flag.FlagSet
 	k8s           *k8sflags.K8SFlags
 	flagNamespace string
-	flagTimeout string
+	flagTimeout   string
 
 	once      sync.Once
 	help      string

--- a/subcommand/delete-completed-job/command.go
+++ b/subcommand/delete-completed-job/command.go
@@ -41,14 +41,14 @@ func (c *Command) init() {
 	c.k8s = &k8sflags.K8SFlags{}
 	c.flags.StringVar(&c.flagNamespace, "k8s-namespace", "",
 		"Name of Kubernetes namespace where the job is deployed")
-	c.flags.StringVar(&c.flagTimeout, "timeout", "10m",
+	c.flags.StringVar(&c.flagTimeout, "timeout", "30m",
 		"How long we'll wait for the job to complete before timing out, e.g. 1ms, 2s, 3m")
 	flags.Merge(c.flags, c.k8s.Flags())
 	c.help = flags.Usage(help, c.flags)
 
-	// Default retry to 5s. This is exposed for setting in tests.
+	// Default retry to 30s. This is exposed for setting in tests.
 	if c.retryDuration == 0 {
-		c.retryDuration = 5 * time.Second
+		c.retryDuration = 30 * time.Second
 	}
 }
 

--- a/subcommand/delete-completed-job/command_test.go
+++ b/subcommand/delete-completed-job/command_test.go
@@ -1,0 +1,170 @@
+package deletecompletedjob
+
+import (
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+	batch "k8s.io/api/batch/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestRun_ArgValidation(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		args   []string
+		expErr string
+	}{
+		{
+			[]string{},
+			"Must have one arg: the job name to delete.",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.expErr, func(t *testing.T) {
+			k8s := fake.NewSimpleClientset()
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI:        ui,
+				k8sClient: k8s,
+			}
+			cmd.init()
+			responseCode := cmd.Run(c.args)
+			require.Equal(t, 1, responseCode)
+			require.Contains(t, ui.ErrorWriter.String(), c.expErr)
+		})
+	}
+}
+
+func TestRun_JobDoesNotExist(t *testing.T) {
+	t.Parallel()
+	ns := "default"
+	jobName := "job"
+	k8s := fake.NewSimpleClientset()
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI:        ui,
+		k8sClient: k8s,
+	}
+	cmd.init()
+
+	responseCode := cmd.Run([]string{
+		"-k8s-namespace", ns,
+		jobName,
+	})
+	require.Equal(t, 0, responseCode, ui.ErrorWriter.String())
+}
+
+// Test when the job condition changes to either success or failed.
+func TestRun_JobConditionChanges(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	cases := map[string]struct {
+		EventualStatus batch.JobStatus
+		ExpDelete      bool
+	}{
+		"job fails": {
+			EventualStatus: batch.JobStatus{
+				Active: 0,
+				Failed: 1,
+				Conditions: []batch.JobCondition{
+					{
+						Type:    batch.JobFailed,
+						Status:  "True",
+						Reason:  "BackoffLimitExceeded",
+						Message: "Job has reached the specified backoff limit",
+					},
+				},
+			},
+			ExpDelete: false,
+		},
+		"job succeeds": {
+			EventualStatus: batch.JobStatus{
+				Succeeded: 1,
+				Conditions: []batch.JobCondition{
+					{
+						Type:   batch.JobComplete,
+						Status: "True",
+					},
+				},
+			},
+			ExpDelete: true,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			ns := "default"
+			jobName := "job"
+			k8s := fake.NewSimpleClientset()
+
+			// Create the job that's not complete.
+			_, err := k8s.BatchV1().Jobs(ns).Create(&batch.Job{
+				ObjectMeta: meta.ObjectMeta{
+					Name: jobName,
+				},
+				Status: batch.JobStatus{
+					Active: 1,
+				},
+			})
+			require.NoError(err)
+
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI:        ui,
+				k8sClient: k8s,
+				// Set a low retry for tests.
+				retryDuration: 20 * time.Millisecond,
+			}
+			cmd.init()
+
+			// Start the command before the Pod exist.
+			// Run in a goroutine so we can create the Pods asynchronously
+			done := make(chan bool)
+			var responseCode int
+			go func() {
+				responseCode = cmd.Run([]string{
+					"-k8s-namespace", ns,
+					jobName,
+				})
+				close(done)
+			}()
+
+			// Asynchronously update the job to be complete.
+			go func() {
+				// Update after a delay between 100 and 500ms.
+				// It's randomized to ensure we're not relying on specific timing.
+				delay := 100 + rand.Intn(400)
+				time.Sleep(time.Duration(delay) * time.Millisecond)
+
+				_, err := k8s.BatchV1().Jobs(ns).Update(&batch.Job{
+					ObjectMeta: meta.ObjectMeta{
+						Name: jobName,
+					},
+					Status: c.EventualStatus,
+				})
+				require.NoError(err)
+			}()
+
+			// Wait for the command to exit.
+			select {
+			case <-done:
+				require.Equal(0, responseCode, ui.ErrorWriter.String())
+			case <-time.After(2 * time.Second):
+				require.FailNow("command did not exit after 2s")
+			}
+
+			// Check job deletion.
+			_, err = k8s.BatchV1().Jobs(ns).Get(jobName, meta.GetOptions{})
+			if c.ExpDelete {
+				require.True(k8serrors.IsNotFound(err))
+			} else {
+				require.NoError(err)
+			}
+		})
+	}
+}

--- a/subcommand/delete-completed-job/command_test.go
+++ b/subcommand/delete-completed-job/command_test.go
@@ -76,6 +76,7 @@ func TestRun_JobConditionChanges(t *testing.T) {
 	cases := map[string]struct {
 		EventualStatus batch.JobStatus
 		ExpDelete      bool
+		ExpCode        int
 	}{
 		"job fails": {
 			EventualStatus: batch.JobStatus{
@@ -91,6 +92,7 @@ func TestRun_JobConditionChanges(t *testing.T) {
 				},
 			},
 			ExpDelete: false,
+			ExpCode:   1,
 		},
 		"job succeeds": {
 			EventualStatus: batch.JobStatus{
@@ -103,6 +105,7 @@ func TestRun_JobConditionChanges(t *testing.T) {
 				},
 			},
 			ExpDelete: true,
+			ExpCode:   0,
 		},
 	}
 
@@ -164,7 +167,7 @@ func TestRun_JobConditionChanges(t *testing.T) {
 			// Wait for the command to exit.
 			select {
 			case <-done:
-				require.Equal(0, responseCode, ui.ErrorWriter.String())
+				require.Equal(c.ExpCode, responseCode, ui.ErrorWriter.String())
 			case <-time.After(2 * time.Second):
 				require.FailNow("command did not exit after 2s")
 			}
@@ -221,7 +224,7 @@ func TestRun_Timeout(t *testing.T) {
 	// Wait for the command to exit.
 	select {
 	case <-done:
-		require.Equal(0, responseCode, ui.ErrorWriter.String())
+		require.Equal(1, responseCode, ui.ErrorWriter.String())
 	case <-time.After(2 * time.Second):
 		require.FailNow("command did not exit after 2s")
 	}

--- a/subcommand/delete-completed-job/command_test.go
+++ b/subcommand/delete-completed-job/command_test.go
@@ -201,8 +201,8 @@ func TestRun_Timeout(t *testing.T) {
 
 	ui := cli.NewMockUi()
 	cmd := Command{
-		UI:        ui,
-		k8sClient: k8s,
+		UI:            ui,
+		k8sClient:     k8s,
 		retryDuration: 100 * time.Millisecond,
 	}
 	cmd.init()

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -115,7 +115,10 @@ func (c *Command) Run(args []string) int {
 		c.UI.Error(fmt.Sprintf("%q is not a valid timeout: %s", c.flagTimeout, err))
 		return 1
 	}
-	c.cmdTimeout, _ = context.WithTimeout(context.Background(), timeout)
+	var cancel context.CancelFunc
+	c.cmdTimeout, cancel = context.WithTimeout(context.Background(), timeout)
+	// The context will only ever be intentionally ended by the timeout.
+	defer cancel()
 
 	// The ClientSet might already be set if we're in a test.
 	if c.clientset == nil {

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -234,7 +234,7 @@ func (c *Command) getConsulServers(logger hclog.Logger, n int) ([]podAddr, error
 			}
 
 			if len(serverPods.Items) < n {
-				return fmt.Errorf("found %d servers, require %d", len(serverPods.Items), c.flagReplicas)
+				return fmt.Errorf("found %d servers, require %d", len(serverPods.Items), n)
 			}
 
 			for _, pod := range serverPods.Items {

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -1043,7 +1043,6 @@ func TestRun_Timeout(t *testing.T) {
 		"-timeout=500ms",
 	})
 	require.Equal(1, responseCode, ui.ErrorWriter.String())
-	require.Contains(ui.ErrorWriter.String(), "reached command timeout")
 }
 
 // Set up test consul agent and kubernetes clusters with

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -150,7 +150,7 @@ func TestRun_Tokens(t *testing.T) {
 			require.Equal(c.TokenName+"-token", tokenData.Policies[0].Name)
 
 			// Test that if the same command is run again, it doesn't error.
-			t.Run(name + "-retried", func(t *testing.T) {
+			t.Run(name+"-retried", func(t *testing.T) {
 				ui := cli.NewMockUi()
 				cmd := Command{
 					UI:        ui,


### PR DESCRIPTION
Add new `delete-completed-job` command that is used to delete the `server-acl-init` Kubernetes Job once it's completed. This enables us to keep the `server-acl-init` job as **not** a Helm hook. When it was a helm hook it got deleted by Helm which was great, however as a helm hook it caused deadlock when users ran helm with `--wait` because it needs to run concurrently with everything coming up.

This command will run in its own Job and clean up the `server-acl-init` job.

Also fixes server-acl-init as follows:
- previously, if already bootstrapped it would still try to pass out the bootstrap token and reload all the servers. Now it assumes that if the bootstrap Secret is created, all the servers are bootstrapped. I think it's a safe assumption because the Job won't complete until it performs all those actions. If we were to validate that each step in that chain had completed, the complexity of the job would increase immensely. So we're just shortcutting and assuming that if the bootstrap token exists then we can skip bootstrapping
- fixes a bug where even if the ACL Tokens for the other components existed (e.g. client or sync-catalog) we'd try to generate new tokens and update the secrets. This is unnecessary if the Secret already exists and was previously failing because the job didn't have permissions to update secrets.
- adds retry tests to all the tests where we re-run the command and expect it to be successful