### PR TITLE
Only write service-defaults if protocol set

### DIFF
--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -101,10 +101,10 @@ type Handler struct {
 	// use for identity with connectInjection if ACLs are enabled
 	AuthMethod string
 
-	// CentralConfig tracks whether injection should register services
-	// to central config as well as normal service registration.
+	// WriteServiceDefaults controls whether injection should write a
+	// service-defaults config entry for each service.
 	// Requires an additional `protocol` parameter.
-	CentralConfig bool
+	WriteServiceDefaults bool
 
 	// DefaultProtocol is the default protocol to use for central config
 	// registrations. It will be overridden by a specific annotation.
@@ -364,9 +364,9 @@ func (h *Handler) defaultAnnotations(pod *corev1.Pod, patches *[]jsonpatch.JsonP
 		}
 	}
 
-	if h.CentralConfig {
+	if h.WriteServiceDefaults {
 		// Default protocol is specified by a flag if not explicitly annotated
-		if _, ok := pod.ObjectMeta.Annotations[annotationProtocol]; !ok {
+		if _, ok := pod.ObjectMeta.Annotations[annotationProtocol]; !ok && h.DefaultProtocol != "" {
 			if cs := pod.Spec.Containers; len(cs) > 0 {
 				// Create the patch for this first, so that the Annotation
 				// object will be created if necessary

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -208,8 +208,8 @@ func TestHandlerHandle(t *testing.T) {
 		},
 
 		{
-			"empty pod basic, protocol in annotation",
-			Handler{CentralConfig: true, Log: hclog.Default().Named("handler")},
+			"empty pod basic, no default protocol",
+			Handler{WriteServiceDefaults: true, DefaultProtocol: "", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					Spec: basicSpec,
@@ -224,8 +224,39 @@ func TestHandlerHandle(t *testing.T) {
 			[]jsonpatch.JsonPatchOperation{
 				{
 					Operation: "add",
-					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationProtocol),
+					Path:      "/spec/volumes",
 				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/-",
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationStatus),
+				},
+			},
+		},
+
+		{
+			"empty pod basic, protocol in annotation",
+			Handler{WriteServiceDefaults: true, Log: hclog.Default().Named("handler")},
+			v1beta1.AdmissionRequest{
+				Object: encodeRaw(t, &corev1.Pod{
+					Spec: basicSpec,
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							annotationService:  "foo",
+							annotationProtocol: "grpc",
+						},
+					},
+				}),
+			},
+			"",
+			[]jsonpatch.JsonPatchOperation{
 				{
 					Operation: "add",
 					Path:      "/spec/volumes",
@@ -247,7 +278,7 @@ func TestHandlerHandle(t *testing.T) {
 
 		{
 			"empty pod basic, default protocol specified",
-			Handler{CentralConfig: true, DefaultProtocol: "http", Log: hclog.Default().Named("handler")},
+			Handler{WriteServiceDefaults: true, DefaultProtocol: "http", Log: hclog.Default().Named("handler")},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					Spec: basicSpec,

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -61,7 +61,8 @@ func (c *Command) init() {
 		"Docker image for Envoy. Defaults to Envoy 1.8.0.")
 	c.flagSet.StringVar(&c.flagACLAuthMethod, "acl-auth-method", "",
 		"The name of the Kubernetes Auth Method to use for connectInjection if ACLs are enabled.")
-	c.flagSet.BoolVar(&c.flagCentralConfig, "enable-central-config", false, "Enable central config.")
+	c.flagSet.BoolVar(&c.flagCentralConfig, "enable-central-config", false,
+		"Write a service-defaults config for every Connect service using protocol from -default-protocol or Pod annotation.")
 	c.flagSet.StringVar(&c.flagDefaultProtocol, "default-protocol", "",
 		"The default protocol to use in central config registrations.")
 	c.help = flags.Usage(help, c.flagSet)
@@ -109,13 +110,13 @@ func (c *Command) Run(args []string) int {
 
 	// Build the HTTP handler and server
 	injector := connectinject.Handler{
-		ImageConsul:       c.flagConsulImage,
-		ImageEnvoy:        c.flagEnvoyImage,
-		RequireAnnotation: !c.flagDefaultInject,
-		AuthMethod:        c.flagACLAuthMethod,
-		CentralConfig:     c.flagCentralConfig,
-		DefaultProtocol:   c.flagDefaultProtocol,
-		Log:               hclog.Default().Named("handler"),
+		ImageConsul:          c.flagConsulImage,
+		ImageEnvoy:           c.flagEnvoyImage,
+		RequireAnnotation:    !c.flagDefaultInject,
+		AuthMethod:           c.flagACLAuthMethod,
+		WriteServiceDefaults: c.flagCentralConfig,
+		DefaultProtocol:      c.flagDefaultProtocol,
+		Log:                  hclog.Default().Named("handler"),
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mutate", injector.Handle)


### PR DESCRIPTION
Previously, we would write a service-defaults config regardless of the
value of the -default-protocol flag or the Pod's protocol annotation. If
neither of these were set, we would write a config with protocol set to
the empty string. This is the same as setting it to tcp. So for every
service, we were by default setting its protocol to tcp.

If a user explicitly created a global proxy-defaults config and set the
protocol to, say, http. Then our service-defaults config would override
that protocol. This behaviour was unexpected because users had never
explicitly told us to write a service-defaults config and it wasn't
helping them.

This change will cause us to only write a service-defaults config if the
protocol is explicitly set–either via the -default-protocol flag or via
the Pod annotation.

I've also renamed the CentralConfig field to WriteServiceDefaults
because there are many types of central config now so it's best to be
explicit.

Fixes #168