### PR TITLE
fix: proxy's destination service id is not service id

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -3,6 +3,7 @@ package connectinject
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -10,8 +11,9 @@ import (
 )
 
 type initContainerCommandData struct {
-	ServiceName string
-	ServicePort int32
+	ServiceName      string
+	ProxyServiceName string
+	ServicePort      int32
 	// ServiceProtocol is the protocol for the service-defaults config
 	// that will be written if WriteServiceDefaults is true.
 	ServiceProtocol string
@@ -46,6 +48,7 @@ func (h *Handler) containerInit(pod *corev1.Pod) (corev1.Container, error) {
 	writeServiceDefaults := h.WriteServiceDefaults && protocol != ""
 	data := initContainerCommandData{
 		ServiceName:          pod.Annotations[annotationService],
+		ProxyServiceName: fmt.Sprintf("%s-sidecar-proxy", pod.Annotations[annotationService]),
 		ServiceProtocol:      protocol,
 		AuthMethod:           h.AuthMethod,
 		WriteServiceDefaults: writeServiceDefaults,
@@ -179,6 +182,14 @@ func (h *Handler) containerInit(pod *corev1.Pod) (corev1.Container, error) {
 					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
 				},
 			},
+			{
+				Name:  "SERVICE_ID",
+				Value: fmt.Sprintf("$(POD_NAME)-%s", data.ServiceName),
+			},
+			{
+				Name:  "PROXY_SERVICE_ID",
+				Value: fmt.Sprintf("$(POD_NAME)-%s", data.ProxyServiceName),
+			},
 		},
 		VolumeMounts: volMounts,
 		Command:      []string{"/bin/sh", "-ec", buf.String()},
@@ -195,8 +206,8 @@ export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 # the preStop hook can access it to deregister the service.
 cat <<EOF >/consul/connect-inject/service.hcl
 services {
-  id   = "${POD_NAME}-{{ .ServiceName }}-sidecar-proxy"
-  name = "{{ .ServiceName }}-sidecar-proxy"
+  id   = "${PROXY_SERVICE_ID}"
+  name = "{{ .ProxyServiceName }}"
   kind = "connect-proxy"
   address = "${POD_IP}"
   port = 20000
@@ -213,7 +224,7 @@ services {
 
   proxy {
     destination_service_name = "{{ .ServiceName }}"
-    destination_service_id = "{{ .ServiceName }}"
+    destination_service_id = "${SERVICE_ID}"
     {{- if (gt .ServicePort 0) }}
     local_service_address = "127.0.0.1"
     local_service_port = {{ .ServicePort }}
@@ -250,7 +261,7 @@ services {
 }
 
 services {
-  id   = "${POD_NAME}-{{ .ServiceName }}"
+  id   = "${SERVICE_ID}"
   name = "{{ .ServiceName }}"
   address = "${POD_IP}"
   port = {{ .ServicePort }}
@@ -299,7 +310,7 @@ EOF
 
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
-  -proxy-id="${POD_NAME}-{{ .ServiceName }}-sidecar-proxy" \
+  -proxy-id="${PROXY_SERVICE_ID}" \
   {{- if .AuthMethod }}
   -token-file="/consul/connect-inject/acl-token" \
   {{- end }}

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -48,7 +48,7 @@ func (h *Handler) containerInit(pod *corev1.Pod) (corev1.Container, error) {
 	writeServiceDefaults := h.WriteServiceDefaults && protocol != ""
 	data := initContainerCommandData{
 		ServiceName:          pod.Annotations[annotationService],
-		ProxyServiceName: fmt.Sprintf("%s-sidecar-proxy", pod.Annotations[annotationService]),
+		ProxyServiceName:     fmt.Sprintf("%s-sidecar-proxy", pod.Annotations[annotationService]),
 		ServiceProtocol:      protocol,
 		AuthMethod:           h.AuthMethod,
 		WriteServiceDefaults: writeServiceDefaults,

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -53,7 +53,7 @@ export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 # the preStop hook can access it to deregister the service.
 cat <<EOF >/consul/connect-inject/service.hcl
 services {
-  id   = "${POD_NAME}-web-sidecar-proxy"
+  id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
   address = "${POD_IP}"
@@ -61,7 +61,7 @@ services {
 
   proxy {
     destination_service_name = "web"
-    destination_service_id = "web"
+    destination_service_id = "${SERVICE_ID}"
   }
 
   checks {
@@ -78,7 +78,7 @@ services {
 }
 
 services {
-  id   = "${POD_NAME}-web"
+  id   = "${SERVICE_ID}"
   name = "web"
   address = "${POD_IP}"
   port = 0
@@ -90,7 +90,7 @@ EOF
 
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
-  -proxy-id="${POD_NAME}-web-sidecar-proxy" \
+  -proxy-id="${PROXY_SERVICE_ID}" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
 
 # Copy the Consul binary
@@ -106,7 +106,7 @@ cp /bin/consul /consul/connect-inject/consul`,
 				return pod
 			},
 			`services {
-  id   = "${POD_NAME}-web-sidecar-proxy"
+  id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
   address = "${POD_IP}"
@@ -114,7 +114,7 @@ cp /bin/consul /consul/connect-inject/consul`,
 
   proxy {
     destination_service_name = "web"
-    destination_service_id = "web"
+    destination_service_id = "${SERVICE_ID}"
     local_service_address = "127.0.0.1"
     local_service_port = 1234
   }
@@ -133,7 +133,7 @@ cp /bin/consul /consul/connect-inject/consul`,
 }
 
 services {
-  id   = "${POD_NAME}-web"
+  id   = "${SERVICE_ID}"
   name = "web"
   address = "${POD_IP}"
   port = 1234
@@ -150,7 +150,7 @@ services {
 			},
 			`proxy {
     destination_service_name = "web"
-    destination_service_id = "web"
+    destination_service_id = "${SERVICE_ID}"
     upstreams {
       destination_type = "service" 
       destination_name = "db"
@@ -169,7 +169,7 @@ services {
 			},
 			`proxy {
     destination_service_name = "web"
-    destination_service_id = "web"
+    destination_service_id = "${SERVICE_ID}"
     upstreams {
       destination_type = "service" 
       destination_name = "db"
@@ -199,7 +199,7 @@ services {
 			},
 			`proxy {
     destination_service_name = "web"
-    destination_service_id = "web"
+    destination_service_id = "${SERVICE_ID}"
     upstreams {
       destination_type = "prepared_query" 
       destination_name = "handle"
@@ -218,7 +218,7 @@ services {
 				return pod
 			},
 			`services {
-  id   = "${POD_NAME}-web-sidecar-proxy"
+  id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
   address = "${POD_IP}"
@@ -227,7 +227,7 @@ services {
 
   proxy {
     destination_service_name = "web"
-    destination_service_id = "web"
+    destination_service_id = "${SERVICE_ID}"
     local_service_address = "127.0.0.1"
     local_service_port = 1234
   }
@@ -246,7 +246,7 @@ services {
 }
 
 services {
-  id   = "${POD_NAME}-web"
+  id   = "${SERVICE_ID}"
   name = "web"
   address = "${POD_IP}"
   port = 1234
@@ -264,7 +264,7 @@ services {
 				return pod
 			},
 			`services {
-  id   = "${POD_NAME}-web-sidecar-proxy"
+  id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
   address = "${POD_IP}"
@@ -273,7 +273,7 @@ services {
 
   proxy {
     destination_service_name = "web"
-    destination_service_id = "web"
+    destination_service_id = "${SERVICE_ID}"
     local_service_address = "127.0.0.1"
     local_service_port = 1234
   }
@@ -292,7 +292,7 @@ services {
 }
 
 services {
-  id   = "${POD_NAME}-web"
+  id   = "${SERVICE_ID}"
   name = "web"
   address = "${POD_IP}"
   port = 1234
@@ -310,7 +310,7 @@ services {
 				return pod
 			},
 			`services {
-  id   = "${POD_NAME}-web-sidecar-proxy"
+  id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
   address = "${POD_IP}"
@@ -319,7 +319,7 @@ services {
 
   proxy {
     destination_service_name = "web"
-    destination_service_id = "web"
+    destination_service_id = "${SERVICE_ID}"
     local_service_address = "127.0.0.1"
     local_service_port = 1234
   }
@@ -338,7 +338,7 @@ services {
 }
 
 services {
-  id   = "${POD_NAME}-web"
+  id   = "${SERVICE_ID}"
   name = "web"
   address = "${POD_IP}"
   port = 1234
@@ -357,7 +357,7 @@ services {
 				return pod
 			},
 			`services {
-  id   = "${POD_NAME}-web-sidecar-proxy"
+  id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
   address = "${POD_IP}"
@@ -366,7 +366,7 @@ services {
 
   proxy {
     destination_service_name = "web"
-    destination_service_id = "web"
+    destination_service_id = "${SERVICE_ID}"
     local_service_address = "127.0.0.1"
     local_service_port = 1234
   }
@@ -385,7 +385,7 @@ services {
 }
 
 services {
-  id   = "${POD_NAME}-web"
+  id   = "${SERVICE_ID}"
   name = "web"
   address = "${POD_IP}"
   port = 1234
@@ -413,7 +413,7 @@ services {
 				return pod
 			},
 			`services {
-  id   = "${POD_NAME}-web-sidecar-proxy"
+  id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
   address = "${POD_IP}"
@@ -425,7 +425,7 @@ services {
 
   proxy {
     destination_service_name = "web"
-    destination_service_id = "web"
+    destination_service_id = "${SERVICE_ID}"
     local_service_address = "127.0.0.1"
     local_service_port = 1234
   }
@@ -444,7 +444,7 @@ services {
 }
 
 services {
-  id   = "${POD_NAME}-web"
+  id   = "${SERVICE_ID}"
   name = "web"
   address = "${POD_IP}"
   port = 1234
@@ -581,7 +581,7 @@ EOF
 
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
-  -proxy-id="${POD_NAME}-foo-sidecar-proxy" \
+  -proxy-id="${PROXY_SERVICE_ID}" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
 
 # Copy the Consul binary
@@ -630,7 +630,7 @@ func TestHandlerContainerInit_authMethod(t *testing.T) {
 
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
-  -proxy-id="${POD_NAME}-foo-sidecar-proxy" \
+  -proxy-id="${PROXY_SERVICE_ID}" \
   -token-file="/consul/connect-inject/acl-token" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`)
 }
@@ -688,7 +688,7 @@ EOF
 
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
-  -proxy-id="${POD_NAME}-foo-sidecar-proxy" \
+  -proxy-id="${PROXY_SERVICE_ID}" \
   -token-file="/consul/connect-inject/acl-token" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
 `)

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -533,7 +533,7 @@ EOF
 
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
-  -proxy-id="${POD_NAME}-foo-sidecar-proxy" \
+  -proxy-id="${PROXY_SERVICE_ID}" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
 
 # Copy the Consul binary


### PR DESCRIPTION
See https://github.com/hashicorp/consul-k8s/issues/163 for bug description.
The fix is to make the service id and proxy service id environment variables (since they're dynamic based on the pod name) so that they can be interpolated in the bash script without copy paste errors.

* Carries https://github.com/hashicorp/consul-k8s/pull/164. Just needed a rebase and a test update.
* Fixes https://github.com/hashicorp/consul-k8s/issues/163