### PR TITLE
Add consul-k8s agent hostname meta to default AgentService

### DIFF
--- a/catalog/to-consul/resource.go
+++ b/catalog/to-consul/resource.go
@@ -26,6 +26,10 @@ const (
 	// ConsulK8SNS is the key used in the meta to record the namespace
 	// of the service/node registration.
 	ConsulK8SNS = "external-k8s-ns"
+
+	// SyncCatalogPodNameMeta is the key used in the meta to track hostname
+	// of the consul-k8s agent syncing.
+	SyncCatalogPodNameMeta = "sync-catalog-pod-name"
 )
 
 type NodePortSyncType string
@@ -92,6 +96,9 @@ type ServiceResource struct {
 	// It's populated via Consul's API and lets us diff what is actually in
 	// Consul vs. what we expect to be there.
 	consulMap map[string][]*consulapi.CatalogRegistration
+
+	// SyncCatalogPodName is the name of the pod running the sync catalog.
+	SyncCatalogPodName string
 }
 
 // Informer implements the controller.Resource interface.
@@ -290,8 +297,9 @@ func (t *ServiceResource) generateRegistrations(key string) {
 		Service: t.addPrefixAndK8SNamespace(svc.Name, svc.Namespace),
 		Tags:    []string{t.ConsulK8STag},
 		Meta: map[string]string{
-			ConsulSourceKey: ConsulSourceValue,
-			ConsulK8SNS:     t.namespace(),
+			ConsulSourceKey:        ConsulSourceValue,
+			ConsulK8SNS:            t.namespace(),
+			SyncCatalogPodNameMeta: t.SyncCatalogPodName,
 		},
 	}
 

--- a/subcommand/sync-catalog/command.go
+++ b/subcommand/sync-catalog/command.go
@@ -190,6 +190,7 @@ func (c *Command) Run(args []string) int {
 				ConsulK8STag:          c.flagConsulK8STag,
 				ConsulServicePrefix:   c.flagConsulServicePrefix,
 				AddK8SNamespaceSuffix: c.flagAddK8SNamespaceSuffix,
+				SyncCatalogPodName:    c.getHostName(),
 			},
 		}
 
@@ -289,6 +290,14 @@ func (c *Command) handleReady(rw http.ResponseWriter, req *http.Request) {
 	rw.WriteHeader(204)
 }
 
+func (c *Command) getHostName() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Failed to get hostname for sync-catalog pod, setting it to <unknown>: #{err}"))
+		hostname = "<unknown>"
+	}
+	return hostname
+}
 func (c *Command) Synopsis() string { return synopsis }
 func (c *Command) Help() string {
 	c.once.Do(c.init)


### PR DESCRIPTION
We had an issue with consul services ,managed by consul-k8s sync-catalog agent, flapping.
This was due to 2 agents running on 2 different kubernetes clusters with same configuration (same 
<consul-k8s-tag>) exposing same services.
As no information from the agent exposing those service is available in the service it took us some times to identify the issue.
This PR is to add the hostname of the agent to the service definition so we can fastly identify which agents manage it