### PR TITLE
Support fullnameOverride

### DIFF
--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -56,7 +56,7 @@ func (c *Command) init() {
 	c.flags.StringVar(&c.flagReleaseName, "release-name", "",
 		"Name of Consul Helm release")
 	c.flags.StringVar(&c.flagResourcePrefix, "resource-prefix", "",
-		"Prefix to use for Kubernetes resources. If not set, will default to ${release-name}-consul.")
+		"Prefix to use for Kubernetes resources. If not set, the \"<release-name>-consul\" prefix is used, where <release-name> is the value set by the -release-name flag.")
 	c.flags.IntVar(&c.flagReplicas, "expected-replicas", 1,
 		"Number of expected Consul server replicas")
 	c.flags.StringVar(&c.flagNamespace, "k8s-namespace", "",

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -24,81 +24,115 @@ var ns = "default"
 var releaseName = "release-name"
 var resourcePrefix = "release-name-consul"
 
-func TestRun_ReleaseNameFlagNotSet(t *testing.T) {
-	ui := cli.NewMockUi()
-	cmd := Command{
-		UI: ui,
+func TestRun_FlagValidation(t *testing.T) {
+	cases := []struct {
+		Flags  []string
+		ExpErr string
+	}{
+		{
+			Flags:  []string{},
+			ExpErr: "-release-name or -server-label-selector must be set",
+		},
+		{
+			Flags:  []string{"-release-name=name", "-server-label-selector=hi"},
+			ExpErr: "-release-name and -server-label-selector cannot both be set",
+		},
+		{
+			Flags:  []string{"-server-label-selector=hi"},
+			ExpErr: "if -server-label-selector is set -resource-prefix must also be set",
+		},
 	}
-	cmd.init()
-	responseCode := cmd.Run([]string{})
-	require.Equal(t, 1, responseCode, ui.ErrorWriter.String())
-	require.Contains(t, ui.ErrorWriter.String(), "-release-name must be set")
+
+	for _, c := range cases {
+		t.Run(c.ExpErr, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI: ui,
+			}
+			responseCode := cmd.Run(c.Flags)
+			require.Equal(t, 1, responseCode, ui.ErrorWriter.String())
+			require.Contains(t, ui.ErrorWriter.String(), c.ExpErr)
+		})
+	}
 }
 
+// Test what happens if no extra flags were set (i.e. the defaults apply).
+// We test with both the deprecated -release-name and the new -server-label-selector
+// flags.
 func TestRun_Defaults(t *testing.T) {
 	t.Parallel()
-	k8s, testAgent := completeSetup(t, resourcePrefix)
-	defer testAgent.Shutdown()
-	require := require.New(t)
+	for _, flags := range [][]string{
+		{"-release-name=" + releaseName},
+		{
+			"-server-label-selector=component=server,app=consul,release=" + releaseName,
+			"-resource-prefix=" + resourcePrefix,
+		},
+	} {
+		t.Run(flags[0], func(t *testing.T) {
+			k8s, testAgent := completeSetup(t, resourcePrefix)
+			defer testAgent.Shutdown()
+			require := require.New(t)
 
-	// Run the command.
-	ui := cli.NewMockUi()
-	cmd := Command{
-		UI:        ui,
-		clientset: k8s,
+			// Run the command.
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI:        ui,
+				clientset: k8s,
+			}
+			args := append([]string{
+				"-k8s-namespace=" + ns,
+				"-expected-replicas=1",
+			}, flags...)
+			responseCode := cmd.Run(args)
+			require.Equal(0, responseCode, ui.ErrorWriter.String())
+
+			// Test that the bootstrap kube secret is created.
+			bootToken := getBootToken(t, k8s, resourcePrefix)
+
+			// Check that it has the right policies.
+			consul := testAgent.Client()
+			tokenData, _, err := consul.ACL().TokenReadSelf(&api.QueryOptions{Token: bootToken})
+			require.NoError(err)
+			require.Equal("global-management", tokenData.Policies[0].Name)
+
+			// Check that the agent policy was created.
+			policies, _, err := consul.ACL().PolicyList(&api.QueryOptions{Token: bootToken})
+			require.NoError(err)
+			found := false
+			for _, p := range policies {
+				if p.Name == "agent-token" {
+					found = true
+					break
+				}
+			}
+			require.True(found, "agent-token policy was not found")
+
+			// We should also test that the server's token was updated, however I
+			// couldn't find a way to test that with the test agent. Instead we test
+			// that in another test when we're using an httptest server instead of
+			// the test agent and we can assert that the /v1/agent/token/agent
+			// endpoint was called.
+		})
 	}
-	cmd.init()
-	responseCode := cmd.Run([]string{
-		"-release-name=" + releaseName,
-		"-resource-prefix=" + resourcePrefix,
-		"-k8s-namespace=" + ns,
-		"-expected-replicas=1",
-	})
-	require.Equal(0, responseCode, ui.ErrorWriter.String())
-
-	// Test that the bootstrap kube secret is created.
-	bootToken := getBootToken(t, k8s, resourcePrefix)
-
-	// Check that it has the right policies.
-	consul := testAgent.Client()
-	tokenData, _, err := consul.ACL().TokenReadSelf(&api.QueryOptions{Token: bootToken})
-	require.NoError(err)
-	require.Equal("global-management", tokenData.Policies[0].Name)
-
-	// Check that the agent policy was created.
-	policies, _, err := consul.ACL().PolicyList(&api.QueryOptions{Token: bootToken})
-	require.NoError(err)
-	found := false
-	for _, p := range policies {
-		if p.Name == "agent-token" {
-			found = true
-			break
-		}
-	}
-	require.True(found, "agent-token policy was not found")
-
-	// We should also test that the server's token was updated, however I
-	// couldn't find a way to test that with the test agent. Instead we test
-	// that in another test when we're using an httptest server instead of
-	// the test agent and we can assert that the /v1/agent/token/agent
-	// endpoint was called.
 }
 
 // Test the different flags that should create tokens and save them as
-// Kubernetes secrets. We also test using the -resource-prefix flag
-// to ensure the secrets are created with the right prefix.
+// Kubernetes secrets. We test using the -release-name flag vs using the
+// -resource-prefix flag.
 func TestRun_Tokens(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]struct {
 		TokenFlag          string
 		ResourcePrefixFlag string
+		ReleaseNameFlag    string
 		TokenName          string
 		SecretName         string
 	}{
-		"client token": {
+		"client token -release-name": {
 			TokenFlag:          "-create-client-token",
 			ResourcePrefixFlag: "",
+			ReleaseNameFlag:    "release-name",
 			TokenName:          "client",
 			SecretName:         "release-name-consul-client-acl-token",
 		},
@@ -108,9 +142,10 @@ func TestRun_Tokens(t *testing.T) {
 			TokenName:          "client",
 			SecretName:         "my-prefix-client-acl-token",
 		},
-		"catalog-sync token": {
+		"catalog-sync token -release-name": {
 			TokenFlag:          "-create-sync-token",
 			ResourcePrefixFlag: "",
+			ReleaseNameFlag:    "release-name",
 			TokenName:          "catalog-sync",
 			SecretName:         "release-name-consul-catalog-sync-acl-token",
 		},
@@ -120,9 +155,10 @@ func TestRun_Tokens(t *testing.T) {
 			TokenName:          "catalog-sync",
 			SecretName:         "my-prefix-catalog-sync-acl-token",
 		},
-		"enterprise-license token": {
+		"enterprise-license token -release-name": {
 			TokenFlag:          "-create-enterprise-license-token",
 			ResourcePrefixFlag: "",
+			ReleaseNameFlag:    "release-name",
 			TokenName:          "enterprise-license",
 			SecretName:         "release-name-consul-enterprise-license-acl-token",
 		},
@@ -132,15 +168,17 @@ func TestRun_Tokens(t *testing.T) {
 			TokenName:          "enterprise-license",
 			SecretName:         "my-prefix-enterprise-license-acl-token",
 		},
-		"mesh-gateway token": {
+		"mesh-gateway token -release-name": {
 			TokenFlag:          "-create-mesh-gateway-token",
 			ResourcePrefixFlag: "",
+			ReleaseNameFlag:    "release-name",
 			TokenName:          "mesh-gateway",
 			SecretName:         "release-name-consul-mesh-gateway-acl-token",
 		},
 		"mesh-gateway token -resource-prefix": {
 			TokenFlag:          "-create-mesh-gateway-token",
 			ResourcePrefixFlag: "my-prefix",
+			ReleaseNameFlag:    "release-name",
 			TokenName:          "mesh-gateway",
 			SecretName:         "my-prefix-mesh-gateway-acl-token",
 		},
@@ -163,13 +201,17 @@ func TestRun_Tokens(t *testing.T) {
 			}
 			cmd.init()
 			cmdArgs := []string{
-				"-release-name=" + releaseName,
 				"-k8s-namespace=" + ns,
 				"-expected-replicas=1",
 				c.TokenFlag,
 			}
 			if c.ResourcePrefixFlag != "" {
-				cmdArgs = append(cmdArgs, "-resource-prefix="+c.ResourcePrefixFlag)
+				// If using the -resource-prefix flag, we expect the -server-label-selector
+				// flag to also be set.
+				labelSelector := fmt.Sprintf("release=%s,component=server,app=consul", releaseName)
+				cmdArgs = append(cmdArgs, "-resource-prefix="+c.ResourcePrefixFlag, "-server-label-selector="+labelSelector)
+			} else {
+				cmdArgs = append(cmdArgs, "-release-name="+c.ReleaseNameFlag)
 			}
 			responseCode := cmd.Run(cmdArgs)
 			require.Equal(0, responseCode, ui.ErrorWriter.String())
@@ -229,7 +271,7 @@ func TestRun_AllowDNS(t *testing.T) {
 	}
 	cmd.init()
 	cmdArgs := []string{
-		"-release-name=" + releaseName,
+		"-server-label-selector=component=server,app=consul,release=" + releaseName,
 		"-resource-prefix=" + resourcePrefix,
 		"-k8s-namespace=" + ns,
 		"-expected-replicas=1",
@@ -325,7 +367,7 @@ func TestRun_ConnectInjectToken(t *testing.T) {
 	cmd.init()
 	bindingRuleSelector := "serviceaccount.name!=default"
 	cmdArgs := []string{
-		"-release-name=" + releaseName,
+		"-server-label-selector=component=server,app=consul,release=" + releaseName,
 		"-resource-prefix=" + resourcePrefix,
 		"-k8s-namespace=" + ns,
 		"-expected-replicas=1",
@@ -411,7 +453,7 @@ func TestRun_DelayedServerPods(t *testing.T) {
 	var responseCode int
 	go func() {
 		responseCode = cmd.Run([]string{
-			"-release-name=" + releaseName,
+			"-server-label-selector=component=server,app=consul,release=" + releaseName,
 			"-resource-prefix=" + resourcePrefix,
 			"-k8s-namespace=" + ns,
 			"-expected-replicas=1",
@@ -596,7 +638,7 @@ func TestRun_InProgressDeployment(t *testing.T) {
 	var responseCode int
 	go func() {
 		responseCode = cmd.Run([]string{
-			"-release-name=" + releaseName,
+			"-server-label-selector=component=server,app=consul,release=" + releaseName,
 			"-resource-prefix=" + resourcePrefix,
 			"-k8s-namespace=" + ns,
 			"-expected-replicas=1",
@@ -766,7 +808,7 @@ func TestRun_NoLeader(t *testing.T) {
 	var responseCode int
 	go func() {
 		responseCode = cmd.Run([]string{
-			"-release-name=" + releaseName,
+			"-server-label-selector=component=server,app=consul,release=" + releaseName,
 			"-resource-prefix=" + resourcePrefix,
 			"-k8s-namespace=" + ns,
 			"-expected-replicas=1",
@@ -918,7 +960,7 @@ func TestRun_ClientTokensRetry(t *testing.T) {
 	}
 	cmd.init()
 	responseCode := cmd.Run([]string{
-		"-release-name=" + releaseName,
+		"-server-label-selector=component=server,app=consul,release=" + releaseName,
 		"-resource-prefix=" + resourcePrefix,
 		"-k8s-namespace=" + ns,
 		"-expected-replicas=1",
@@ -1056,7 +1098,7 @@ func TestRun_AlreadyBootstrapped(t *testing.T) {
 	}
 	cmd.init()
 	responseCode := cmd.Run([]string{
-		"-release-name=" + releaseName,
+		"-server-label-selector=component=server,app=consul,release=" + releaseName,
 		"-resource-prefix=" + resourcePrefix,
 		"-k8s-namespace=" + ns,
 		"-expected-replicas=1",
@@ -1095,7 +1137,7 @@ func TestRun_Timeout(t *testing.T) {
 	}
 	cmd.init()
 	responseCode := cmd.Run([]string{
-		"-release-name=" + releaseName,
+		"-server-label-selector=component=server,app=consul,release=" + releaseName,
 		"-resource-prefix=" + resourcePrefix,
 		"-k8s-namespace=" + ns,
 		"-expected-replicas=1",


### PR DESCRIPTION
In the Helm chart there is an undocumented value that allows users to
override the prefix we usually apply to the resources. The default
prefix is <helm release name>-consul. This change adds two flags to the
server-acl-init command (the only command that is affected by the
prefix): `-resource-prefix` and `-server-label-selector`.

If set, we will use the correct prefix,
both for finding resources that we expect to be created by the helm
chart, e.g. Consul servers, and for creating our own resources, e.g.
Kubernetes secrets.

The flags are backwards compatible. Users can upgrade consul-k8s and not require any changes to their consul-helm version. There is a corresponding consul-helm update that uses these flags. That is only required if users want to take advantage of this bugfix (which now fully supports the name override values).

* Fixes https://github.com/hashicorp/consul-k8s/issues/165
* Corresponding consul-helm PR: https://github.com/hashicorp/consul-helm/pull/307