### PR TITLE
Add new lifecycle-sidecar command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -6,6 +6,7 @@ import (
 	cmdACLInit "github.com/hashicorp/consul-k8s/subcommand/acl-init"
 	cmdDeleteCompletedJob "github.com/hashicorp/consul-k8s/subcommand/delete-completed-job"
 	cmdInjectConnect "github.com/hashicorp/consul-k8s/subcommand/inject-connect"
+	cmdLifecycleSidecar "github.com/hashicorp/consul-k8s/subcommand/lifecycle-sidecar"
 	cmdServerACLInit "github.com/hashicorp/consul-k8s/subcommand/server-acl-init"
 	cmdSyncCatalog "github.com/hashicorp/consul-k8s/subcommand/sync-catalog"
 	cmdVersion "github.com/hashicorp/consul-k8s/subcommand/version"
@@ -26,6 +27,10 @@ func init() {
 
 		"inject-connect": func() (cli.Command, error) {
 			return &cmdInjectConnect.Command{UI: ui}, nil
+		},
+
+		"lifecycle-sidecar": func() (cli.Command, error) {
+			return &cmdLifecycleSidecar.Command{UI: ui}, nil
 		},
 
 		"server-acl-init": func() (cli.Command, error) {

--- a/connect-inject/envoy_sidecar.go
+++ b/connect-inject/envoy_sidecar.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (h *Handler) containerSidecar(pod *corev1.Pod) (corev1.Container, error) {
+func (h *Handler) envoySidecar(pod *corev1.Pod) (corev1.Container, error) {
 
 	// Render the command
 	var buf bytes.Buffer

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -90,6 +90,10 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
+					Path:      "/spec/containers/-",
+				},
+				{
+					Operation: "add",
 					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationStatus),
 				},
 			},
@@ -138,6 +142,10 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/spec/initContainers",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/-",
 				},
 				{
 					Operation: "add",
@@ -202,6 +210,10 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
+					Path:      "/spec/containers/-",
+				},
+				{
+					Operation: "add",
 					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationStatus),
 				},
 			},
@@ -229,6 +241,10 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/spec/initContainers",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/-",
 				},
 				{
 					Operation: "add",
@@ -271,6 +287,10 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
+					Path:      "/spec/containers/-",
+				},
+				{
+					Operation: "add",
 					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationStatus),
 				},
 			},
@@ -301,6 +321,10 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/spec/initContainers",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/-",
 				},
 				{
 					Operation: "add",

--- a/connect-inject/lifecycle_sidecar.go
+++ b/connect-inject/lifecycle_sidecar.go
@@ -1,0 +1,46 @@
+package connectinject
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"strings"
+)
+
+func (h *Handler) lifecycleSidecar(pod *corev1.Pod) corev1.Container {
+	command := []string{
+		"consul-k8s",
+		"lifecycle-sidecar",
+		"-service-config", "/consul/connect-inject/service.hcl",
+	}
+	if h.AuthMethod != "" {
+		command = append(command, "-token-file=/consul/connect-inject/acl-token")
+	}
+	if period, ok := pod.Annotations[annotationSyncPeriod]; ok {
+		command = append(command, "-sync-period="+strings.TrimSpace(period))
+	}
+
+	return corev1.Container{
+		Name:  "consul-connect-lifecycle-sidecar",
+		Image: h.ImageConsulK8S,
+		Env: []corev1.EnvVar{
+			{
+				Name: "HOST_IP",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
+				},
+			},
+			// Kubernetes will interpolate HOST_IP when creating this environment
+			// variable.
+			{
+				Name:  "CONSUL_HTTP_ADDR",
+				Value: "$(HOST_IP):8500",
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      volumeName,
+				MountPath: "/consul/connect-inject",
+			},
+		},
+		Command: command,
+	}
+}

--- a/connect-inject/lifecycle_sidecar_test.go
+++ b/connect-inject/lifecycle_sidecar_test.go
@@ -1,0 +1,113 @@
+package connectinject
+
+import (
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+// NOTE: This is tested here rather than in handler_test because doing it there
+// would require a lot of boilerplate to get at the underlying patches that would
+// complicate understanding the tests (which are simple).
+
+// Test that the lifecycle sidecar is as expected.
+func TestLifecycleSidecar_Default(t *testing.T) {
+	handler := Handler{
+		Log:            hclog.Default().Named("handler"),
+		ImageConsulK8S: "hashicorp/consul-k8s:9.9.9",
+	}
+	container := handler.lifecycleSidecar(&corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "web",
+				},
+			},
+		},
+	})
+	require.Equal(t, corev1.Container{
+		Name:  "consul-connect-lifecycle-sidecar",
+		Image: "hashicorp/consul-k8s:9.9.9",
+		Env: []corev1.EnvVar{
+			{
+				Name: "HOST_IP",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
+				},
+			},
+			{
+				Name:  "CONSUL_HTTP_ADDR",
+				Value: "$(HOST_IP):8500",
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      volumeName,
+				MountPath: "/consul/connect-inject",
+			},
+		},
+		Command: []string{
+			"consul-k8s", "lifecycle-sidecar",
+			"-service-config", "/consul/connect-inject/service.hcl",
+		},
+	}, container)
+}
+
+// Test that if there's an auth method we set the -token-file flag
+// and if there isn't we don't.
+func TestLifecycleSidecar_AuthMethod(t *testing.T) {
+	for _, authMethod := range []string{"", "auth-method"} {
+		t.Run("authmethod: "+authMethod, func(t *testing.T) {
+			handler := Handler{
+				Log:            hclog.Default().Named("handler"),
+				AuthMethod:     authMethod,
+				ImageConsulK8S: "hashicorp/consul-k8s:9.9.9",
+			}
+			container := handler.lifecycleSidecar(&corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "web",
+						},
+					},
+				},
+			})
+
+			if authMethod == "" {
+				require.NotContains(t, container.Command, "-token-file=/consul/connect-inject/acl-token")
+			} else {
+				require.Contains(t,
+					container.Command,
+					"-token-file=/consul/connect-inject/acl-token",
+				)
+			}
+		})
+	}
+}
+
+// Test that if there's an annotation on the original pod that changes the sync
+// period we use that value.
+func TestLifecycleSidecar_SyncPeriodAnnotation(t *testing.T) {
+	handler := Handler{
+		Log:            hclog.Default().Named("handler"),
+		ImageConsulK8S: "hashicorp/consul-k8s:9.9.9",
+	}
+	container := handler.lifecycleSidecar(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"consul.hashicorp.com/connect-sync-period": "55s",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "web",
+				},
+			},
+		},
+	})
+
+	require.Contains(t, container.Command, "-sync-period=55s")
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/SAP/go-hdb v0.12.1 // indirect
 	github.com/SermoDigital/jose v0.9.1 // indirect
 	github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f // indirect
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf // indirect
 	github.com/cenkalti/backoff v2.1.1+incompatible
@@ -42,13 +44,14 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/prometheus/client_golang v0.8.0 // indirect
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 // indirect
-	github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e // indirect
+	github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e
 	github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273 // indirect
 	github.com/radovskyb/watcher v1.0.2
 	github.com/shirou/gopsutil v2.17.12+incompatible // indirect
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.4.0
 	github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926 // indirect
 	google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107 // indirect
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect
 	k8s.io/api v0.0.0-20190325185214-7544f9db76f6
 	k8s.io/apimachinery v0.0.0-20190223001710-c182ff3b9841

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,10 @@ github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f h1:5ZfJxyXo8KyX8
 github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af h1:DBNMBMuMiWYu0b+8KMJuWmfCkcxl09JwdlqwDZZ6U14=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e h1:QEF07wC0T1rKkctt1RINW/+RMTVmiwxETico2l3gxJA=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da h1:8GUt8eRujhVEGZFFEjBj46YV4rDjvGrNxb0KMWYkL2I=
@@ -382,6 +386,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9 h1:/Bsw4C+DEdqPjt8vAqaC9LAqpAQnaCQQqmolqq3S1T4=
 github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9/go.mod h1:RHkNRtSLfOK7qBTHaeSX1D6BNpI3qw7NTxsmNr4RvN8=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926 h1:G3dpKMzFDjgEh2q1Z7zUUtKa8ViPtH+ocF0bE0g00O8=
@@ -447,6 +453,8 @@ google.golang.org/grpc v1.19.0 h1:cfg4PD8YEdSFnm7qLV4++93WcmhH2nIUhMjhdCvl3j8=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 gopkg.in/airbrake/gobrake.v2 v2.0.9 h1:7z2uVWwn7oVeeugY1DtlPAy5H+KYgB1KeKTnqjNatLo=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -466,6 +474,8 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkep
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -33,6 +33,7 @@ type Command struct {
 	flagDefaultInject   bool   // True to inject by default
 	flagConsulImage     string // Docker image for Consul
 	flagEnvoyImage      string // Docker image for Envoy
+	flagConsulK8sImage  string // Docker image for consul-k8s
 	flagACLAuthMethod   string // Auth Method to use for ACLs, if enabled
 	flagCentralConfig   bool   // True to enable central config injection
 	flagDefaultProtocol string // Default protocol for use with central config
@@ -59,6 +60,8 @@ func (c *Command) init() {
 		"Docker image for Consul. Defaults to an Consul 1.3.0.")
 	c.flagSet.StringVar(&c.flagEnvoyImage, "envoy-image", connectinject.DefaultEnvoyImage,
 		"Docker image for Envoy. Defaults to Envoy 1.8.0.")
+	c.flagSet.StringVar(&c.flagConsulK8sImage, "consul-k8s-image", "",
+		"Docker image for consul-k8s. Used for the connect sidecar.")
 	c.flagSet.StringVar(&c.flagACLAuthMethod, "acl-auth-method", "",
 		"The name of the Kubernetes Auth Method to use for connectInjection if ACLs are enabled.")
 	c.flagSet.BoolVar(&c.flagCentralConfig, "enable-central-config", false,
@@ -71,6 +74,12 @@ func (c *Command) init() {
 func (c *Command) Run(args []string) int {
 	c.once.Do(c.init)
 	if err := c.flagSet.Parse(args); err != nil {
+		return 1
+	}
+
+	// Validate flags.
+	if c.flagConsulK8sImage == "" {
+		c.UI.Error("-consul-k8s-image must be set")
 		return 1
 	}
 
@@ -112,6 +121,7 @@ func (c *Command) Run(args []string) int {
 	injector := connectinject.Handler{
 		ImageConsul:          c.flagConsulImage,
 		ImageEnvoy:           c.flagEnvoyImage,
+		ImageConsulK8S:       c.flagConsulK8sImage,
 		RequireAnnotation:    !c.flagDefaultInject,
 		AuthMethod:           c.flagACLAuthMethod,
 		WriteServiceDefaults: c.flagCentralConfig,

--- a/subcommand/inject-connect/command_test.go
+++ b/subcommand/inject-connect/command_test.go
@@ -1,0 +1,31 @@
+package subcommand
+
+import (
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestRun_FlagValidation(t *testing.T) {
+	cases := []struct {
+		Flags  []string
+		ExpErr string
+	}{
+		{
+			Flags:  []string{},
+			ExpErr: "-consul-k8s-image must be set",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.ExpErr, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI: ui,
+			}
+			code := cmd.Run([]string{})
+			require.Equal(t, 1, code)
+			require.Contains(t, ui.ErrorWriter.String(), c.ExpErr)
+		})
+	}
+}

--- a/subcommand/lifecycle-sidecar/command.go
+++ b/subcommand/lifecycle-sidecar/command.go
@@ -1,0 +1,167 @@
+package subcommand
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/command/flags"
+	"github.com/hashicorp/consul/command/services"
+	"github.com/hashicorp/go-hclog"
+	"github.com/mitchellh/cli"
+	"github.com/prometheus/common/log"
+	"os"
+	"os/signal"
+	"sync"
+	"time"
+)
+
+type Command struct {
+	UI cli.Ui
+
+	http              *flags.HTTPFlags
+	flagServiceConfig string
+	flagSyncPeriod    string
+	flagSet           *flag.FlagSet
+	flagLogLevel      string
+
+	once         sync.Once
+	help         string
+	consulClient *api.Client
+	sigCh        chan os.Signal
+}
+
+func (c *Command) init() {
+	c.flagSet = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flagSet.StringVar(&c.flagServiceConfig, "service-config", "", "Path to the service config file")
+	c.flagSet.StringVar(&c.flagSyncPeriod, "sync-period", "10s", "Time between syncing the service registration. Defaults to 10s.")
+	c.flagSet.StringVar(&c.flagLogLevel, "log-level", "info",
+		"Log verbosity level. Supported values (in order of detail) are \"trace\", "+
+			"\"debug\", \"info\", \"warn\", and \"error\". Defaults to info.")
+
+	c.help = flags.Usage(help, c.flagSet)
+	c.http = &flags.HTTPFlags{}
+	flags.Merge(c.flagSet, c.http.ClientFlags())
+	c.help = flags.Usage(help, c.flagSet)
+	c.sigCh = make(chan os.Signal, 1)
+}
+
+// Run continually re-registers the service with Consul.
+// This is needed because if the Consul Client pod is restarted, it loses all
+// its service registrations.
+// This command expects to be run as a sidecar and to be injected by the
+// mutating webhook.
+func (c *Command) Run(args []string) int {
+	c.once.Do(c.init)
+	if err := c.flagSet.Parse(args); err != nil {
+		return 1
+	}
+	syncPeriod, logLevel, err := c.validateFlags()
+	if err != nil {
+		c.UI.Error("Error: " + err.Error())
+		return 1
+	}
+	logger := hclog.New(&hclog.LoggerOptions{
+		Level:  logLevel,
+		Output: os.Stderr,
+	})
+
+	// Set up Consul client (may already exist in tests).
+	if c.consulClient == nil {
+		var err error
+		c.consulClient, err = c.http.APIClient()
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error creating Consul client: %s", err))
+			return 1
+		}
+	}
+
+	// This config file should have been written by the init Pod.
+	// Its existence is checked in validateFlags().
+	svcs, err := services.ServicesFromFiles([]string{c.flagServiceConfig})
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error: %s", err))
+		return 1
+	}
+	if len(svcs) != 2 {
+		c.UI.Error(fmt.Sprintf(
+			"Error: expected 2 services to be defined in %s, found %d", c.flagServiceConfig, len(svcs)))
+		return 1
+	}
+
+	// Set up channel for graceful SIGINT shutdown.
+	signal.Notify(c.sigCh, os.Interrupt)
+
+	// The main work loop. We continually re-register our service every
+	// syncPeriod. Consul is smart enough to know when the service hasn't changed
+	// and so won't update any indices. This means we won't be causing a lot
+	// of traffic within the cluster. We tolerate Consul Clients going down
+	// and will simply re-register once it's back up.
+	//
+	// The loop will only exit when the Pod is shut down and we receive a SIGINT.
+	for {
+		for _, svc := range svcs {
+			err := c.consulClient.Agent().ServiceRegister(svc)
+			if err != nil {
+				logger.Error("failed to sync service", "id", svc.ID, "err", err)
+			} else {
+				logger.Info("successfully synced service", "id", svc.ID)
+			}
+		}
+
+		// Re-loop after syncPeriod or exit if we receive an interrupt.
+		select {
+		case <-time.After(syncPeriod):
+			continue
+		case <-c.sigCh:
+			log.Info("SIGINT received, shutting down")
+			return 0
+		}
+	}
+}
+
+// validateFlags validates the flags and returns the parsed syncPeriod and
+// logLevel.
+func (c *Command) validateFlags() (syncPeriod time.Duration, logLevel hclog.Level, err error) {
+	if c.flagServiceConfig == "" {
+		err = errors.New("-service-config must be set")
+		return
+	}
+	syncPeriod, err = time.ParseDuration(c.flagSyncPeriod)
+	if err != nil {
+		err = fmt.Errorf("-sync-period is invalid: %s", err)
+		return
+	}
+	_, err = os.Stat(c.flagServiceConfig)
+	if os.IsNotExist(err) {
+		err = fmt.Errorf("-service-config file %q not found", c.flagServiceConfig)
+		return
+	}
+	logLevel = hclog.LevelFromString(c.flagLogLevel)
+	if logLevel == hclog.NoLevel {
+		err = fmt.Errorf("unknown log level: %s", c.flagLogLevel)
+		return
+	}
+	return
+}
+
+// interrupt sends os.Interrupt signal to the command
+// so it can exit gracefully. This function is needed for tests
+func (c *Command) interrupt() {
+	c.sigCh <- os.Interrupt
+}
+
+func (c *Command) Synopsis() string { return synopsis }
+func (c *Command) Help() string {
+	c.once.Do(c.init)
+	return c.help
+}
+
+const synopsis = "Connect lifecycle sidecar."
+const help = `
+Usage: consul-k8s lifecycle-sidecar [options]
+
+  Run as a sidecar to your Connect service. Ensures that your service
+  is registered with the local Consul client.
+
+`

--- a/subcommand/lifecycle-sidecar/command_test.go
+++ b/subcommand/lifecycle-sidecar/command_test.go
@@ -1,0 +1,219 @@
+package subcommand
+
+import (
+	"fmt"
+	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/sdk/freeport"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRun_FlagValidation(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		Flags  []string
+		ExpErr string
+	}{
+		{
+			Flags:  []string{""},
+			ExpErr: "-service-config must be set",
+		},
+		{
+			Flags:  []string{"-service-config=/config.hcl", "-sync-period=notparseable"},
+			ExpErr: "-sync-period is invalid: time: invalid duration notparseable",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.ExpErr, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI: ui,
+			}
+			responseCode := cmd.Run(c.Flags)
+			require.Equal(t, 1, responseCode, ui.ErrorWriter.String())
+			require.Contains(t, ui.ErrorWriter.String(), c.ExpErr)
+		})
+	}
+}
+
+func TestRun_ServiceConfigFileMissing(t *testing.T) {
+	t.Parallel()
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI: ui,
+	}
+	responseCode := cmd.Run([]string{"-service-config=/does/not/exist"})
+	require.Equal(t, 1, responseCode, ui.ErrorWriter.String())
+	require.Contains(t, ui.ErrorWriter.String(), "-service-config file \"/does/not/exist\" not found")
+}
+
+func TestRun_ServiceConfigFileInvalid(t *testing.T) {
+	t.Parallel()
+	tmpDir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer func() { os.RemoveAll(tmpDir) }()
+
+	cases := []struct {
+		FileContents string
+		ExpErr       string
+	}{
+		{
+			FileContents: "",
+			ExpErr:       "expected 2 services to be defined",
+		},
+		{
+			FileContents: "'",
+			ExpErr:       "At 1:1: illegal char",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.ExpErr, func(t *testing.T) {
+			configFile := filepath.Join(tmpDir, "svc.hcl")
+			err = ioutil.WriteFile(configFile, []byte(c.FileContents), 0600)
+			require.NoError(t, err)
+			defer func() { os.Remove(configFile) }()
+
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI: ui,
+			}
+
+			responseCode := cmd.Run([]string{"-service-config", configFile})
+			require.Equal(t, 1, responseCode, ui.ErrorWriter.String())
+			require.Contains(t, ui.ErrorWriter.String(), c.ExpErr)
+		})
+	}
+}
+
+// Test that we register the services.
+func TestRun_ServicesRegistration(t *testing.T) {
+	t.Parallel()
+	tmpDir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer func() { os.RemoveAll(tmpDir) }()
+
+	configFile := filepath.Join(tmpDir, "svc.hcl")
+	err = ioutil.WriteFile(configFile, []byte(servicesRegistration), 0600)
+	require.NoError(t, err)
+
+	a := agent.NewTestAgent(t, t.Name(), `primary_datacenter = "dc1"`)
+	defer a.Shutdown()
+
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI:           ui,
+		consulClient: a.Client(),
+	}
+
+	// Run async because we need to kill it when the test is over.
+	exitChan := runCommandAsynchronously(&cmd, []string{
+		"-http-addr", a.HTTPAddr(),
+		"-service-config", configFile,
+		"-sync-period", "100ms",
+	})
+	defer stopCommand(t, &cmd, exitChan)
+
+	timer := &retry.Timer{Timeout: 1 * time.Second, Wait: 100 * time.Millisecond}
+	retry.RunWith(timer, t, func(r *retry.R) {
+		svc, _, err := a.Client().Agent().Service("service-id", nil)
+		require.NoError(r, err)
+		require.Equal(r, 80, svc.Port)
+
+		svcProxy, _, err := a.Client().Agent().Service("service-id-sidecar-proxy", nil)
+		require.NoError(r, err)
+		require.Equal(r, 2000, svcProxy.Port)
+	})
+}
+
+// Test that we register services when the Consul agent is down at first.
+func TestRun_ServicesRegistration_ConsulDown(t *testing.T) {
+	t.Parallel()
+	tmpDir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer func() { os.RemoveAll(tmpDir) }()
+
+	configFile := filepath.Join(tmpDir, "svc.hcl")
+	err = ioutil.WriteFile(configFile, []byte(servicesRegistration), 0600)
+	require.NoError(t, err)
+
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI: ui,
+	}
+	randomPort := freeport.Get(1)[0]
+	// Run async because we need to kill it when the test is over.
+	exitChan := runCommandAsynchronously(&cmd, []string{
+		"-http-addr", fmt.Sprintf("127.0.0.1:%d", randomPort),
+		"-service-config", configFile,
+		"-sync-period", "100ms",
+	})
+	defer stopCommand(t, &cmd, exitChan)
+
+	// Start the Consul agent after 500ms.
+	time.Sleep(500 * time.Millisecond)
+	a := agent.NewTestAgent(t, t.Name(), fmt.Sprintf(`primary_datacenter = "dc1"
+ports {
+  http = %d
+}`, randomPort))
+	defer a.Shutdown()
+
+	// The services should be registered when the Consul agent comes up
+	// within 500ms.
+	timer := &retry.Timer{Timeout: 500 * time.Millisecond, Wait: 100 * time.Millisecond}
+	retry.RunWith(timer, t, func(r *retry.R) {
+		svc, _, err := a.Client().Agent().Service("service-id", nil)
+		require.NoError(r, err)
+		require.Equal(r, 80, svc.Port)
+
+		svcProxy, _, err := a.Client().Agent().Service("service-id-sidecar-proxy", nil)
+		require.NoError(r, err)
+		require.Equal(r, 2000, svcProxy.Port)
+	})
+}
+
+// This function starts the command asynchronously and returns a non-blocking chan.
+// When finished, the command will send its exit code to the channel.
+// Note that it's the responsibility of the caller to terminate the command by calling stopCommand,
+// otherwise it can run forever.
+func runCommandAsynchronously(cmd *Command, args []string) chan int {
+	exitChan := make(chan int, 1)
+	go func() {
+		exitChan <- cmd.Run(args)
+	}()
+	return exitChan
+}
+
+func stopCommand(t *testing.T, cmd *Command, exitChan chan int) {
+	if len(exitChan) == 0 {
+		cmd.interrupt()
+	}
+	select {
+	case c := <-exitChan:
+		require.Equal(t, 0, c, string(cmd.UI.(*cli.MockUi).ErrorWriter.Bytes()))
+	}
+}
+
+const servicesRegistration = `
+services {
+	id   = "service-id"
+	name = "service"
+	port = 80
+}
+services {
+	id   = "service-id-sidecar-proxy"
+	name = "service-sidecar-proxy"
+	port = 2000
+	kind = "connect-proxy"
+	proxy {
+	  destination_service_name = "service"
+	  destination_service_id = "service-id"
+	  local_service_port = 80
+	}
+}`


### PR DESCRIPTION
This command is expected to run in a sidecar in all Connect
injected Pods. The command ensures that the service is registered with
the node's Consul client by re-registering the service on a configurable
period. This is necessary because if the Consul Client is restarted,
e.g. during an upgrade, it loses its registrations. With this sidecar,
the service will be re-registered once the new Client starts.

The command is generically named "lifecycle-sidecar" (i.e. rather than
re-registerer) to make room for more functionality in the future, e.g.
renewing tokens.

This change also updates the mutating webhook code to add the
connect-sidecar as a sidecar to Connect injected Pods. It adds a new
required flag to connect-inject: `-consul-k8s-image` that controls the
image used for the sidecar.

Fixes #161, #171

Design decisions that deserve scrutiny:
* naming of the command and sidecar (`connect-sidecar`) (*update* this is now lifecycle-sidecar)
* the new annotation on the Pods that can be used to control the sync-period `consul.hashicorp.com/connect-sync-period`
* the default sync period (`10s`)
* the name "sync period"
* the design of the work loop (clearly coded? good error handling?)

To run yourself
* Edit the connect-inject-deployment.yaml as follows:
   ```diff
    {{ if .Values.connectInject.imageEnvoy -}}
    -envoy-image="{{ .Values.connectInject.imageEnvoy }}" \
    {{ end -}}
  + -consul-k8s-image="{{ default .Values.global.imageK8S .Values.connectInject.image }}" \
   ```
* Use Helm config:
  ```yaml
  connectInject:
    enabled: true
  global:
    imageK8S: lkysow/consul-k8s-dev:dec11
    bootstrapACLs: true # or false, should work with both
  ```
* Apply the Pod:
  ```yaml
  apiVersion: v1
  kind: ServiceAccount
  metadata:
    name: static-server
  ---
  apiVersion: v1
  kind: Pod
  metadata:
    name: static-server
    annotations:
      "consul.hashicorp.com/connect-inject": "true"
  spec:
    containers:
      # This name will be the service name in Consul.
      - name: static-server
        image: hashicorp/http-echo:latest
        args:
          - -text="hello world"
          - -listen=:8080
        ports:
          - containerPort: 8080
            name: http
     # If ACLs are enabled, the serviceAccountName must match the Consul service name.
    serviceAccountName: static-server
  ```
* Note that the Pod comes up with 3 containers and that the `consul-connect-sidecar` container is running
* Find the Node that the Pod is on and the corresponding Consul client on that node
* Delete the Consul client Pod
* When the Pod restarts, the service should be re-registered in Consul