### PR TITLE
Enable TLS for connect-inject

### DIFF
--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -46,7 +46,8 @@ func TestHandlerContainerInit(t *testing.T) {
 				pod.Annotations[annotationService] = "web"
 				return pod
 			},
-			`/bin/sh -ec export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
+			`/bin/sh -ec 
+export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 
 # Register the service. The HCL is stored in the volume so that
@@ -731,4 +732,42 @@ EOF`)
 /bin/consul config write -cas -modify-index 0 \
   -token-file="/consul/connect-inject/acl-token" \
   /consul/connect-inject/service-defaults.hcl || true`)
+}
+
+// If Consul CA cert is set,
+// Consul addresses should use HTTPS
+// and CA cert should be set as env variable
+func TestHandlerContainerInit_WithTLS(t *testing.T) {
+	require := require.New(t)
+	h := Handler{
+		ConsulCACert: "consul-ca-cert",
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotationService: "foo",
+			},
+		},
+
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "web",
+				},
+			},
+		},
+	}
+	container, err := h.containerInit(pod)
+	require.NoError(err)
+	actual := strings.Join(container.Command, " ")
+	require.Contains(actual, `
+export CONSUL_HTTP_ADDR="https://${HOST_IP}:8501"
+export CONSUL_GRPC_ADDR="https://${HOST_IP}:8502"
+export CONSUL_CACERT=/consul/connect-inject/consul-ca.pem
+cat <<EOF >/consul/connect-inject/consul-ca.pem
+consul-ca-cert
+EOF`)
+	require.NotContains(actual, `
+export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
+export CONSUL_GRPC_ADDR="${HOST_IP}:8502"`)
 }

--- a/connect-inject/container_sidecar_test.go
+++ b/connect-inject/container_sidecar_test.go
@@ -1,0 +1,137 @@
+package connectinject
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestHandlerContainerSidecar(t *testing.T) {
+	require := require.New(t)
+	h := Handler{}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotationService: "foo",
+			},
+		},
+
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "web",
+				},
+			},
+		},
+	}
+	container, err := h.envoySidecar(pod)
+	require.NoError(err)
+	require.Equal(container.Command, []string{
+		"envoy",
+		"--max-obj-name-len", "256",
+		"--config-path", "/consul/connect-inject/envoy-bootstrap.yaml",
+	})
+
+	preStopCommand := strings.Join(container.Lifecycle.PreStop.Exec.Command, " ")
+	require.Equal(preStopCommand, `/bin/sh -ec /consul/connect-inject/consul services deregister \
+  /consul/connect-inject/service.hcl`)
+
+	require.Equal(container.VolumeMounts, []corev1.VolumeMount{
+		{
+			Name:      volumeName,
+			MountPath: "/consul/connect-inject",
+		},
+	})
+
+	require.Equal(container.Env, []corev1.EnvVar{
+		{
+			Name: "HOST_IP",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
+			},
+		},
+		{
+			Name:  "CONSUL_HTTP_ADDR",
+			Value: "$(HOST_IP):8500",
+		},
+	})
+}
+
+// Test that if AuthMethod is set
+// the preStop command includes a token
+func TestHandlerContainerSidecar_AuthMethod(t *testing.T) {
+	require := require.New(t)
+	h := Handler{
+		AuthMethod: "test-auth-method",
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotationService: "foo",
+			},
+		},
+
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "web",
+				},
+			},
+		},
+	}
+	container, err := h.envoySidecar(pod)
+	require.NoError(err)
+
+	preStopCommand := strings.Join(container.Lifecycle.PreStop.Exec.Command, " ")
+	require.Equal(preStopCommand, `/bin/sh -ec /consul/connect-inject/consul services deregister \
+  -token-file="/consul/connect-inject/acl-token" \
+  /consul/connect-inject/service.hcl
+&& /consul/connect-inject/consul logout \
+  -token-file="/consul/connect-inject/acl-token"`)
+}
+
+// If Consul CA cert is set,
+// Consul addresses should use HTTPS
+// and CA cert should be set as env variable
+func TestHandlerContainerSidecar_WithTLS(t *testing.T) {
+	require := require.New(t)
+	h := Handler{
+		ConsulCACert: "consul-ca-cert",
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotationService: "foo",
+			},
+		},
+
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "web",
+				},
+			},
+		},
+	}
+	container, err := h.envoySidecar(pod)
+	require.NoError(err)
+	require.Equal(container.Env, []corev1.EnvVar{
+		{
+			Name: "HOST_IP",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
+			},
+		},
+		{
+			Name:  "CONSUL_CACERT",
+			Value: "/consul/connect-inject/consul-ca.pem",
+		},
+		{
+			Name:  "CONSUL_HTTP_ADDR",
+			Value: "https://$(HOST_IP):8501",
+		},
+	})
+}

--- a/connect-inject/envoy_sidecar.go
+++ b/connect-inject/envoy_sidecar.go
@@ -19,7 +19,7 @@ func (h *Handler) envoySidecar(pod *corev1.Pod) (corev1.Container, error) {
 		return corev1.Container{}, err
 	}
 
-	return corev1.Container{
+	container := corev1.Container{
 		Name:  "consul-connect-envoy-sidecar",
 		Image: h.ImageEnvoy,
 		Env: []corev1.EnvVar{
@@ -31,7 +31,7 @@ func (h *Handler) envoySidecar(pod *corev1.Pod) (corev1.Container, error) {
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
-			corev1.VolumeMount{
+			{
 				Name:      volumeName,
 				MountPath: "/consul/connect-inject",
 			},
@@ -52,11 +52,27 @@ func (h *Handler) envoySidecar(pod *corev1.Pod) (corev1.Container, error) {
 			"--max-obj-name-len", "256",
 			"--config-path", "/consul/connect-inject/envoy-bootstrap.yaml",
 		},
-	}, nil
+	}
+	if h.ConsulCACert != "" {
+		caCertEnvVar := corev1.EnvVar{
+			Name:  "CONSUL_CACERT",
+			Value: "/consul/connect-inject/consul-ca.pem",
+		}
+		consulAddrEnvVar := corev1.EnvVar{
+			Name:  "CONSUL_HTTP_ADDR",
+			Value: "https://$(HOST_IP):8501",
+		}
+		container.Env = append(container.Env, caCertEnvVar, consulAddrEnvVar)
+	} else {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  "CONSUL_HTTP_ADDR",
+			Value: "$(HOST_IP):8500",
+		})
+	}
+	return container, nil
 }
 
 const sidecarPreStopCommandTpl = `
-export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 /consul/connect-inject/consul services deregister \
   {{- if . }}
   -token-file="/consul/connect-inject/acl-token" \

--- a/connect-inject/envoy_sidecar_test.go
+++ b/connect-inject/envoy_sidecar_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestHandlerContainerSidecar(t *testing.T) {
+func TestHandlerEnvoySidecar(t *testing.T) {
 	require := require.New(t)
 	h := Handler{}
 	pod := &corev1.Pod{
@@ -62,7 +62,7 @@ func TestHandlerContainerSidecar(t *testing.T) {
 
 // Test that if AuthMethod is set
 // the preStop command includes a token
-func TestHandlerContainerSidecar_AuthMethod(t *testing.T) {
+func TestHandlerEnvoySidecar_AuthMethod(t *testing.T) {
 	require := require.New(t)
 	h := Handler{
 		AuthMethod: "test-auth-method",
@@ -96,7 +96,7 @@ func TestHandlerContainerSidecar_AuthMethod(t *testing.T) {
 // If Consul CA cert is set,
 // Consul addresses should use HTTPS
 // and CA cert should be set as env variable
-func TestHandlerContainerSidecar_WithTLS(t *testing.T) {
+func TestHandlerEnvoySidecar_WithTLS(t *testing.T) {
 	require := require.New(t)
 	h := Handler{
 		ConsulCACert: "consul-ca-cert",

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -119,6 +119,10 @@ type Handler struct {
 	// registrations. It will be overridden by a specific annotation.
 	DefaultProtocol string
 
+	// The PEM-encoded CA certificate string
+	// to use when communicating with Consul clients
+	ConsulCACert string
+
 	// Log
 	Log hclog.Logger
 }

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -120,7 +120,8 @@ type Handler struct {
 	DefaultProtocol string
 
 	// The PEM-encoded CA certificate string
-	// to use when communicating with Consul clients
+	// to use when communicating with Consul clients over HTTPS.
+	// If not set, will use HTTP.
 	ConsulCACert string
 
 	// Log

--- a/connect-inject/lifecycle_sidecar.go
+++ b/connect-inject/lifecycle_sidecar.go
@@ -14,6 +14,12 @@ func (h *Handler) lifecycleSidecar(pod *corev1.Pod) corev1.Container {
 	if h.AuthMethod != "" {
 		command = append(command, "-token-file=/consul/connect-inject/acl-token")
 	}
+	if h.ConsulCACert != "" {
+		command = append(command, "-http-addr", "https://${HOST_IP}:8501")
+		command = append(command, "-ca-file", "/consul/connect-inject/consul-ca.pem")
+	} else {
+		command = append(command, "-http-addr", "${HOST_IP}:8500")
+	}
 	if period, ok := pod.Annotations[annotationSyncPeriod]; ok {
 		command = append(command, "-sync-period="+strings.TrimSpace(period))
 	}
@@ -27,12 +33,6 @@ func (h *Handler) lifecycleSidecar(pod *corev1.Pod) corev1.Container {
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
 				},
-			},
-			// Kubernetes will interpolate HOST_IP when creating this environment
-			// variable.
-			{
-				Name:  "CONSUL_HTTP_ADDR",
-				Value: "$(HOST_IP):8500",
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{

--- a/connect-inject/lifecycle_sidecar_test.go
+++ b/connect-inject/lifecycle_sidecar_test.go
@@ -37,6 +37,10 @@ func TestLifecycleSidecar_Default(t *testing.T) {
 					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
 				},
 			},
+			{
+				Name:  "CONSUL_HTTP_ADDR",
+				Value: "$(HOST_IP):8500",
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -47,7 +51,6 @@ func TestLifecycleSidecar_Default(t *testing.T) {
 		Command: []string{
 			"consul-k8s", "lifecycle-sidecar",
 			"-service-config", "/consul/connect-inject/service.hcl",
-			"-http-addr", "${HOST_IP}:8500",
 		},
 	}, container)
 }
@@ -136,6 +139,14 @@ func TestLifecycleSidecar_TLS(t *testing.T) {
 					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
 				},
 			},
+			{
+				Name:  "CONSUL_HTTP_ADDR",
+				Value: "https://$(HOST_IP):8501",
+			},
+			{
+				Name:  "CONSUL_CACERT",
+				Value: "/consul/connect-inject/consul-ca.pem",
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -146,8 +157,6 @@ func TestLifecycleSidecar_TLS(t *testing.T) {
 		Command: []string{
 			"consul-k8s", "lifecycle-sidecar",
 			"-service-config", "/consul/connect-inject/service.hcl",
-			"-http-addr", "https://${HOST_IP}:8501",
-			"-ca-file", "/consul/connect-inject/consul-ca.pem",
 		},
 	}, container)
 }

--- a/connect-inject/lifecycle_sidecar_test.go
+++ b/connect-inject/lifecycle_sidecar_test.go
@@ -37,10 +37,6 @@ func TestLifecycleSidecar_Default(t *testing.T) {
 					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
 				},
 			},
-			{
-				Name:  "CONSUL_HTTP_ADDR",
-				Value: "$(HOST_IP):8500",
-			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -51,6 +47,7 @@ func TestLifecycleSidecar_Default(t *testing.T) {
 		Command: []string{
 			"consul-k8s", "lifecycle-sidecar",
 			"-service-config", "/consul/connect-inject/service.hcl",
+			"-http-addr", "${HOST_IP}:8500",
 		},
 	}, container)
 }
@@ -110,4 +107,47 @@ func TestLifecycleSidecar_SyncPeriodAnnotation(t *testing.T) {
 	})
 
 	require.Contains(t, container.Command, "-sync-period=55s")
+}
+
+// Test that the Consul address uses HTTPS
+// and that the CA is provided
+func TestLifecycleSidecar_TLS(t *testing.T) {
+	handler := Handler{
+		Log:            hclog.Default().Named("handler"),
+		ImageConsulK8S: "hashicorp/consul-k8s:9.9.9",
+		ConsulCACert:   "consul-ca-cert",
+	}
+	container := handler.lifecycleSidecar(&corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "web",
+				},
+			},
+		},
+	})
+	require.Equal(t, corev1.Container{
+		Name:  "consul-connect-lifecycle-sidecar",
+		Image: "hashicorp/consul-k8s:9.9.9",
+		Env: []corev1.EnvVar{
+			{
+				Name: "HOST_IP",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
+				},
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      volumeName,
+				MountPath: "/consul/connect-inject",
+			},
+		},
+		Command: []string{
+			"consul-k8s", "lifecycle-sidecar",
+			"-service-config", "/consul/connect-inject/service.hcl",
+			"-http-addr", "https://${HOST_IP}:8501",
+			"-ca-file", "/consul/connect-inject/consul-ca.pem",
+		},
+	}, container)
 }

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -38,7 +38,7 @@ type Command struct {
 	flagACLAuthMethod   string // Auth Method to use for ACLs, if enabled
 	flagCentralConfig   bool   // True to enable central config injection
 	flagDefaultProtocol string // Default protocol for use with central config
-	flagConsulCACert    string // CA Certificate to use when communicating with Consul clients
+	flagConsulCACert    string // Path to CA Certificate to use when communicating with Consul clients
 	flagSet             *flag.FlagSet
 
 	once sync.Once

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -126,7 +126,7 @@ func (c *Command) Run(args []string) int {
 		var err error
 		consulCACert, err = ioutil.ReadFile(c.flagConsulCACert)
 		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error reading Consul's CA cert file: %s", err))
+			c.UI.Error(fmt.Sprintf("Error reading Consul's CA cert file %s: %s", c.flagConsulCACert, err))
 			return 1
 		}
 	}

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -71,7 +71,7 @@ func (c *Command) init() {
 	c.flagSet.StringVar(&c.flagDefaultProtocol, "default-protocol", "",
 		"The default protocol to use in central config registrations.")
 	c.flagSet.StringVar(&c.flagConsulCACert, "consul-ca-cert", "",
-		"Path to CA certificate to use when communicating with Consul clients.")
+		"Path to CA certificate to use if communicating with Consul clients over HTTPS.")
 	c.help = flags.Usage(help, c.flagSet)
 }
 


### PR DESCRIPTION
* Add new flag -consul-ca-cert
* Make Consul addresses use HTTPS if CA is provided
* Provide CA certificate to the init and both sidecar containers,
  so that service registration and envoy bootstrapping
  can use TLS.

This PR has a slightly different approach to what was proposed in #30 and assumes the implementation in the hashicorp/consul-helm#313.

Fixes #79 