### PR TITLE
acl-token file readable by lifecycle sidecar

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -291,6 +291,9 @@ EOF
   -bearer-token-file="/var/run/secrets/kubernetes.io/serviceaccount/token" \
   -token-sink-file="/consul/connect-inject/acl-token" \
   -meta="pod=${POD_NAMESPACE}/${POD_NAME}"
+{{- /* The acl token file needs to be read by the lifecycle-sidecar which runs
+       as non-root user consul-k8s. */}}
+chmod 444 /consul/connect-inject/acl-token
 {{- end }}
 {{- if .WriteServiceDefaults }}
 {{- /* We use -cas and -modify-index 0 so that if a service-defaults config

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -623,6 +623,7 @@ func TestHandlerContainerInit_authMethod(t *testing.T) {
   -bearer-token-file="/var/run/secrets/kubernetes.io/serviceaccount/token" \
   -token-sink-file="/consul/connect-inject/acl-token" \
   -meta="pod=${POD_NAMESPACE}/${POD_NAME}"
+chmod 444 /consul/connect-inject/acl-token
 
 /bin/consul services register \
   -token-file="/consul/connect-inject/acl-token" \
@@ -678,6 +679,7 @@ EOF
   -bearer-token-file="/var/run/secrets/kubernetes.io/serviceaccount/token" \
   -token-sink-file="/consul/connect-inject/acl-token" \
   -meta="pod=${POD_NAMESPACE}/${POD_NAME}"
+chmod 444 /consul/connect-inject/acl-token
 /bin/consul config write -cas -modify-index 0 \
   -token-file="/consul/connect-inject/acl-token" \
   /consul/connect-inject/service-defaults.hcl || true


### PR DESCRIPTION
Fix bug where the lifecycle sidecar (which runs as user consul-k8s)
could not read the acl-token because it was owned by root