### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,26 @@ Improvements:
 * Connect: Add TLS support [[GH-181](https://github.com/hashicorp/consul-k8s/pull/181)].
 * Bootstrap ACLs: Add TLS support [[GH-183](https://github.com/hashicorp/consul-k8s/pull/183)].
 
+Notes:
+
+* Build: Our darwin releases for this version and up will be signed and notarized according to Apple's requirements.
+Prior to this release, MacOS 10.15+ users attempting to run our software may see the error: "'consul-k8s' cannot be opened because the developer cannot be verified." This error affected all MacOS 10.15+ users who downloaded our software directly via web browsers, and was caused by changes to Apple's third-party software requirements.
+
+  MacOS 10.15+ users should plan to upgrade to 0.11.0+.
+* Build: ARM release binaries: Starting with 0.11.0, `consul-k8s` will ship three separate versions of ARM builds. The previous ARM binaries of Consul could potentially crash due to the way the Go runtime manages internal pointers to its Go routine management constructs and how it keeps track of them especially during signal handling (https://github.com/golang/go/issues/32912). From 0.11.0 forward, it is recommended to use:
+
+  consul-k8s\_{version}\_linux_armelv5.zip for all 32-bit armel systems
+  consul-k8s\_{version}\_linux_armhfv6.zip for all armhf systems with v6+ architecture
+  consul-k8s\_{version}\_linux_arm64.zip for all v8 64-bit architectures
+* Build: The `freebsd_arm` variant has been removed.
+
+
 ## 0.10.1 (December 17, 2019)
 
 Bug Fixes:
 
 * Connect: Fix bug where the new lifecycle sidecar didn't have permissions to
-  read the ACL token file. [[GH-182](https://github.com/hashicorp/consul-k8s/pull/182)]  
+  read the ACL token file. [[GH-182](https://github.com/hashicorp/consul-k8s/pull/182)]
 
 ## 0.10.0 (December 17, 2019)
 
@@ -20,12 +34,12 @@ Bug Fixes:
 
 * Connect: Fix critical bug where Connect-registered services instances would be deregistered
   when the Consul client on the same node was restarted. This fix adds a new
-  sidecar that ensures the service instance is always registered. [[GH-161](https://github.com/hashicorp/consul-k8s/issues/161)]  
-  
+  sidecar that ensures the service instance is always registered. [[GH-161](https://github.com/hashicorp/consul-k8s/issues/161)]
+
 * Connect: Fix bug where UI links between sidecar and service didn't work because
-  the wrong service ID was being used. [[GH-163](https://github.com/hashicorp/consul-k8s/issues/163)]  
-  
-* Bootstrap ACLs: Support bootstrapACLs for users setting the `nameOverride` config. [[GH-165](https://github.com/hashicorp/consul-k8s/issues/165)]  
+  the wrong service ID was being used. [[GH-163](https://github.com/hashicorp/consul-k8s/issues/163)]
+
+* Bootstrap ACLs: Support bootstrapACLs for users setting the `nameOverride` config. [[GH-165](https://github.com/hashicorp/consul-k8s/issues/165)]
 
 ## 0.9.5 (December 5, 2019)
 
@@ -36,9 +50,9 @@ Bug Fixes:
   This prevents service name collisions in Consul when there
   are two services with the same name in different
   namespaces in Kubernetes [[GH-139](https://github.com/hashicorp/consul-k8s/issues/139)]
-  
+
 * Connect: Only write a `service-defaults` config during Connect injection if
-  the protocol is set explicitly [[GH-169](https://github.com/hashicorp/consul-k8s/pull/169)]  
+  the protocol is set explicitly [[GH-169](https://github.com/hashicorp/consul-k8s/pull/169)]
 
 ## 0.9.4 (October 28, 2019)
 


### PR DESCRIPTION
This includes three notes of things introduced in 0.11.0:
* MacOS notarization for MacOS 10.15+
* new ARM variants built with CGO
* removal of freebsd_arm variant