### PR TITLE
Enforce services listing at startup to not remove them from consul if still needed

### DIFF
--- a/catalog/to-consul/syncer_test.go
+++ b/catalog/to-consul/syncer_test.go
@@ -262,6 +262,9 @@ func testRegistration(node, service string) *api.CatalogRegistration {
 }
 
 func testConsulSyncer(t *testing.T, client *api.Client) (*ConsulSyncer, func()) {
+	waitForServicesCh := make(chan int)
+	close(waitForServicesCh)
+
 	s := &ConsulSyncer{
 		Client:            client,
 		Log:               hclog.Default(),
@@ -269,6 +272,7 @@ func testConsulSyncer(t *testing.T, client *api.Client) (*ConsulSyncer, func()) 
 		ServicePollPeriod: 50 * time.Millisecond,
 		Namespace:         "default",
 		ConsulK8STag:      TestConsulK8STag,
+		WaitForServicesCh: waitForServicesCh,
 	}
 
 	ctx, cancelF := context.WithCancel(context.Background())


### PR DESCRIPTION
Currently , at startup the servces map in ConsulSyncer is empty, due to that the watchReapableServices can remove some services from consul that are still needed
but for which the controller had not enough time to add them in the services map.

This PR enforce the listing of all services at startup so we do not remove from consul still existing ones