### PR TITLE
Allow ClusterIP Services to sync as Endpoints or as ClusterIP

### DIFF
--- a/catalog/to-consul/annotation.go
+++ b/catalog/to-consul/annotation.go
@@ -15,6 +15,12 @@ const (
 	// service or an integer value.
 	annotationServicePort = "consul.hashicorp.com/service-port"
 
+	// annotationServiceAsEndpoints is valid only on ClusterIP services.
+	// It specifics whether or not to sync the service with each individual endpoint or
+	// as the singular IP of the service. If this isn't set then the
+	// default based on the syncer configuration is chosen.
+	annotationServiceAsEndpoints = "consul.hashicorp.com/service-as-endpoints"
+
 	// annotationServiceTags specifies the tags for the registered service
 	// instance. Multiple tags should be comma separated. Whitespace around
 	// the tags is automatically trimmed.

--- a/catalog/to-consul/resource.go
+++ b/catalog/to-consul/resource.go
@@ -241,8 +241,7 @@ func (t *ServiceResource) shouldSync(svc *apiv1.Service) bool {
 // shouldSyncAsEndpoints returns true if service-as-endpoints is true or
 // ClusterIPAsEndpoints is true
 func (t *ServiceResource) shouldSyncClusterIPAsEndpoints(svc *apiv1.Service) bool {
-	var asEndpoints bool
-	asEndpoints = t.ClusterIPAsEndpoints
+	asEndpoints := t.ClusterIPAsEndpoints
 
 	// allow an annotation to override the config behavior
 	endpointsAnnotation, ok := svc.Annotations[annotationServiceAsEndpoints]
@@ -274,13 +273,10 @@ func (t *ServiceResource) shouldTrackEndpoints(key string) bool {
 		return false
 	}
 
-  // We should only watch endpoints if we're actually going to sync them
-  if svc.Spec.Type == apiv1.ServiceTypeClusterIP {
-	  if !t.shouldSyncClusterIPAsEndpoints(svc) {
-	  	return false
-	  }
-		return true
-  }
+	// We should only watch endpoints if we're actually going to sync them
+	if svc.Spec.Type == apiv1.ServiceTypeClusterIP {
+		return t.shouldSyncClusterIPAsEndpoints(svc)
+	}
 
 	return svc.Spec.Type == apiv1.ServiceTypeNodePort
 }

--- a/catalog/to-consul/resource.go
+++ b/catalog/to-consul/resource.go
@@ -596,7 +596,9 @@ func (t *ServiceResource) generateRegistrations(key string) {
 
 		} else {
 			addr := svc.Spec.ClusterIP
-			if addr == "" {
+			// "None" is valid here for Headless Services but impossible to sync
+			// Should Headless Services always be asEndpoints?
+			if addr == "" || addr == "None" {
 				return
 			}
 

--- a/catalog/to-consul/resource.go
+++ b/catalog/to-consul/resource.go
@@ -249,6 +249,10 @@ func (t *ServiceResource) shouldSyncClusterIPAsEndpoints(svc *apiv1.Service) boo
 		value, err := strconv.ParseBool(endpointsAnnotation)
 		if err == nil {
 			asEndpoints = value
+		} else {
+			t.Log.Warn("error parsing service-as-endpoints annotation",
+				"service-name", t.addPrefixAndK8SNamespace(svc.Name, svc.Namespace),
+				"err", err)
 		}
 	}
 

--- a/catalog/to-consul/resource.go
+++ b/catalog/to-consul/resource.go
@@ -255,6 +255,25 @@ func (t *ServiceResource) shouldTrackEndpoints(key string) bool {
 		return false
 	}
 
+  // We should only watch endpoints if we're actually going to sync them
+  // Should service-as-endpoints be false or ClusterIPAsEndpoints be false
+  // then don't track the endpoints of the service
+	var asEndpoints bool
+	asEndpoints = t.ClusterIPAsEndpoints
+
+	// allow an annotation to override the config behavior
+	endpointsAnnotation, ok := svc.Annotations[annotationServiceAsEndpoints]
+	if ok {
+		value, err := strconv.ParseBool(endpointsAnnotation)
+		if err == nil {
+			asEndpoints = value
+		}
+	}
+
+	if !asEndpoints {
+		return false
+	}
+
 	return svc.Spec.Type == apiv1.ServiceTypeNodePort || svc.Spec.Type == apiv1.ServiceTypeClusterIP
 }
 

--- a/catalog/to-consul/resource.go
+++ b/catalog/to-consul/resource.go
@@ -259,7 +259,6 @@ func (t *ServiceResource) shouldSyncClusterIPAsEndpoints(svc *apiv1.Service) boo
 	return asEndpoints
 }
 
-
 // shouldTrackEndpoints returns true if the endpoints for the given key
 // should be tracked.
 //

--- a/catalog/to-consul/resource_test.go
+++ b/catalog/to-consul/resource_test.go
@@ -1019,6 +1019,7 @@ func TestServiceResource_clusterIP(t *testing.T) {
 		Client:        client,
 		Syncer:        syncer,
 		ClusterIPSync: true,
+		ClusterIPAsEndpoints: true,
 	})
 	defer closer()
 
@@ -1059,6 +1060,7 @@ func TestServiceResource_clusterIPPrefix(t *testing.T) {
 		Client:              client,
 		Syncer:              syncer,
 		ClusterIPSync:       true,
+		ClusterIPAsEndpoints: true,
 		ConsulServicePrefix: "prefix",
 	})
 	defer closer()
@@ -1101,6 +1103,7 @@ func TestServiceResource_clusterIPAnnotatedPortName(t *testing.T) {
 		Client:        client,
 		Syncer:        syncer,
 		ClusterIPSync: true,
+		ClusterIPAsEndpoints: true,
 	})
 	defer closer()
 
@@ -1144,6 +1147,7 @@ func TestServiceResource_clusterIPAnnotatedPortNumber(t *testing.T) {
 		Client:        client,
 		Syncer:        syncer,
 		ClusterIPSync: true,
+		ClusterIPAsEndpoints: true,
 	})
 	defer closer()
 
@@ -1186,6 +1190,7 @@ func TestServiceResource_clusterIPUnnamedPorts(t *testing.T) {
 		Client:        client,
 		Syncer:        syncer,
 		ClusterIPSync: true,
+		ClusterIPAsEndpoints: true,
 	})
 	defer closer()
 
@@ -1267,6 +1272,7 @@ func TestServiceResource_clusterIPAllNamespaces(t *testing.T) {
 		Syncer:        syncer,
 		Namespace:     apiv1.NamespaceAll,
 		ClusterIPSync: true,
+		ClusterIPAsEndpoints: true,
 	})
 	defer closer()
 
@@ -1307,6 +1313,7 @@ func TestServiceResource_clusterIPTargetPortNamed(t *testing.T) {
 		Client:        client,
 		Syncer:        syncer,
 		ClusterIPSync: true,
+		ClusterIPAsEndpoints: true,
 	})
 	defer closer()
 

--- a/catalog/to-consul/resource_test.go
+++ b/catalog/to-consul/resource_test.go
@@ -686,6 +686,7 @@ func TestServiceResource_nodePort(t *testing.T) {
 		Client:       client,
 		Syncer:       syncer,
 		NodePortSync: ExternalOnly,
+		ClusterIPAsEndpoints: true,
 	})
 	defer closer()
 
@@ -728,6 +729,7 @@ func TestServiceResource_nodePortPrefix(t *testing.T) {
 		Client:              client,
 		Syncer:              syncer,
 		NodePortSync:        ExternalOnly,
+		ClusterIPAsEndpoints: true,
 		ConsulServicePrefix: "prefix",
 	})
 	defer closer()
@@ -773,6 +775,7 @@ func TestServiceResource_nodePort_singleEndpoint(t *testing.T) {
 		Client:       client,
 		Syncer:       syncer,
 		NodePortSync: ExternalOnly,
+		ClusterIPAsEndpoints: true,
 	})
 	defer closer()
 
@@ -829,6 +832,7 @@ func TestServiceResource_nodePortAnnotatedPort(t *testing.T) {
 		Client:       client,
 		Syncer:       syncer,
 		NodePortSync: ExternalOnly,
+		ClusterIPAsEndpoints: true,
 	})
 	defer closer()
 
@@ -874,6 +878,7 @@ func TestServiceResource_nodePortUnnamedPort(t *testing.T) {
 		Client:       client,
 		Syncer:       syncer,
 		NodePortSync: ExternalOnly,
+		ClusterIPAsEndpoints: true,
 	})
 	defer closer()
 
@@ -924,6 +929,7 @@ func TestServiceResource_nodePort_internalOnlySync(t *testing.T) {
 		Client:       client,
 		Syncer:       syncer,
 		NodePortSync: InternalOnly,
+		ClusterIPAsEndpoints: true,
 	})
 	defer closer()
 
@@ -968,6 +974,7 @@ func TestServiceResource_nodePort_externalFirstSync(t *testing.T) {
 		Client:       client,
 		Syncer:       syncer,
 		NodePortSync: ExternalFirst,
+		ClusterIPAsEndpoints: true,
 	})
 	defer closer()
 

--- a/subcommand/sync-catalog/command.go
+++ b/subcommand/sync-catalog/command.go
@@ -44,6 +44,7 @@ type Command struct {
 	flagK8SWriteNamespace     string
 	flagConsulWritePeriod     flags.DurationValue
 	flagSyncClusterIPServices bool
+	flagSyncClusterIPServicesAsEndpoints bool
 	flagNodePortSyncType      string
 	flagAddK8SNamespaceSuffix bool
 	flagLogLevel              string
@@ -91,6 +92,9 @@ func (c *Command) init() {
 	c.flags.BoolVar(&c.flagSyncClusterIPServices, "sync-clusterip-services", true,
 		"If true, all valid ClusterIP services in K8S are synced by default. If false, "+
 			"ClusterIP services are not synced to Consul.")
+	c.flags.BoolVar(&c.flagSyncClusterIPServicesAsEndpoints, "sync-clusterip-services-as-endpoints", true,
+		"If true, ClusterIP services in K8S are synced by endpoint addresses, not the IP of the service."+
+			"If false, ClusterIP services are to Consul with the IP of the service. Defaults to true.")
 	c.flags.StringVar(&c.flagNodePortSyncType, "node-port-sync-type", "ExternalOnly",
 		"Defines the type of sync for NodePort services. Valid options are ExternalOnly, "+
 			"InternalOnly and ExternalFirst.")
@@ -186,6 +190,7 @@ func (c *Command) Run(args []string) int {
 				Namespace:             c.flagK8SSourceNamespace,
 				ExplicitEnable:        !c.flagK8SDefault,
 				ClusterIPSync:         c.flagSyncClusterIPServices,
+				ClusterIPAsEndpoints:  c.flagSyncClusterIPServicesAsEndpoints,
 				NodePortSync:          catalogtoconsul.NodePortSyncType(c.flagNodePortSyncType),
 				ConsulK8STag:          c.flagConsulK8STag,
 				ConsulServicePrefix:   c.flagConsulServicePrefix,

--- a/subcommand/sync-catalog/command.go
+++ b/subcommand/sync-catalog/command.go
@@ -29,25 +29,25 @@ import (
 type Command struct {
 	UI cli.Ui
 
-	flags                     *flag.FlagSet
-	http                      *flags.HTTPFlags
-	k8s                       *k8sflags.K8SFlags
-	flagListen                string
-	flagToConsul              bool
-	flagToK8S                 bool
-	flagConsulDomain          string
-	flagConsulK8STag          string
-	flagK8SDefault            bool
-	flagK8SServicePrefix      string
-	flagConsulServicePrefix   string
-	flagK8SSourceNamespace    string
-	flagK8SWriteNamespace     string
-	flagConsulWritePeriod     flags.DurationValue
-	flagSyncClusterIPServices bool
+	flags                                *flag.FlagSet
+	http                                 *flags.HTTPFlags
+	k8s                                  *k8sflags.K8SFlags
+	flagListen                           string
+	flagToConsul                         bool
+	flagToK8S                            bool
+	flagConsulDomain                     string
+	flagConsulK8STag                     string
+	flagK8SDefault                       bool
+	flagK8SServicePrefix                 string
+	flagConsulServicePrefix              string
+	flagK8SSourceNamespace               string
+	flagK8SWriteNamespace                string
+	flagConsulWritePeriod                flags.DurationValue
+	flagSyncClusterIPServices            bool
 	flagSyncClusterIPServicesAsEndpoints bool
-	flagNodePortSyncType      string
-	flagAddK8SNamespaceSuffix bool
-	flagLogLevel              string
+	flagNodePortSyncType                 string
+	flagAddK8SNamespaceSuffix            bool
+	flagLogLevel                         string
 
 	consulClient *api.Client
 	clientset    kubernetes.Interface


### PR DESCRIPTION
Fixes/allows for the use cases outlined in https://github.com/hashicorp/consul-k8s/issues/99.

A new configuration option is added, which details to true, that defines whether or not ClusterIP services are sync'd as Endpoints (the Pod addresses). An annotation is also allowed to override the configuration option on a per Service basis.

Should this option or annotation be false, then the service is sync'd as a single instance with the address of the actual in-cluster ClusterIP.

The only open question is if Headless Services always be sync'd as Endpoints given their lack of an in-cluster ClusterIP. Right now if the option or annotation is false for a Headless Service it is just not sync'd at all.