### PR TITLE
Update the lifecycle sidecar to shell out to Consul

### DIFF
--- a/connect-inject/lifecycle_sidecar.go
+++ b/connect-inject/lifecycle_sidecar.go
@@ -10,6 +10,7 @@ func (h *Handler) lifecycleSidecar(pod *corev1.Pod) corev1.Container {
 		"consul-k8s",
 		"lifecycle-sidecar",
 		"-service-config", "/consul/connect-inject/service.hcl",
+		"-consul-location", "/consul/connect-inject/consul",
 	}
 	if h.AuthMethod != "" {
 		command = append(command, "-token-file=/consul/connect-inject/acl-token")

--- a/connect-inject/lifecycle_sidecar.go
+++ b/connect-inject/lifecycle_sidecar.go
@@ -10,7 +10,7 @@ func (h *Handler) lifecycleSidecar(pod *corev1.Pod) corev1.Container {
 		"consul-k8s",
 		"lifecycle-sidecar",
 		"-service-config", "/consul/connect-inject/service.hcl",
-		"-consul-location", "/consul/connect-inject/consul",
+		"-consul-binary", "/consul/connect-inject/consul",
 	}
 	if h.AuthMethod != "" {
 		command = append(command, "-token-file=/consul/connect-inject/acl-token")

--- a/connect-inject/lifecycle_sidecar_test.go
+++ b/connect-inject/lifecycle_sidecar_test.go
@@ -51,7 +51,7 @@ func TestLifecycleSidecar_Default(t *testing.T) {
 		Command: []string{
 			"consul-k8s", "lifecycle-sidecar",
 			"-service-config", "/consul/connect-inject/service.hcl",
-			"-consul-location", "/consul/connect-inject/consul",
+			"-consul-binary", "/consul/connect-inject/consul",
 		},
 	}, container)
 }
@@ -158,7 +158,7 @@ func TestLifecycleSidecar_TLS(t *testing.T) {
 		Command: []string{
 			"consul-k8s", "lifecycle-sidecar",
 			"-service-config", "/consul/connect-inject/service.hcl",
-			"-consul-location", "/consul/connect-inject/consul",
+			"-consul-binary", "/consul/connect-inject/consul",
 		},
 	}, container)
 }

--- a/connect-inject/lifecycle_sidecar_test.go
+++ b/connect-inject/lifecycle_sidecar_test.go
@@ -51,6 +51,7 @@ func TestLifecycleSidecar_Default(t *testing.T) {
 		Command: []string{
 			"consul-k8s", "lifecycle-sidecar",
 			"-service-config", "/consul/connect-inject/service.hcl",
+			"-consul-location", "/consul/connect-inject/consul",
 		},
 	}, container)
 }
@@ -157,6 +158,7 @@ func TestLifecycleSidecar_TLS(t *testing.T) {
 		Command: []string{
 			"consul-k8s", "lifecycle-sidecar",
 			"-service-config", "/consul/connect-inject/service.hcl",
+			"-consul-location", "/consul/connect-inject/consul",
 		},
 	}, container)
 }

--- a/subcommand/lifecycle-sidecar/command_test.go
+++ b/subcommand/lifecycle-sidecar/command_test.go
@@ -23,14 +23,14 @@ func TestRun_FlagValidation(t *testing.T) {
 		{
 			Flags: []string{
 				"-service-config=/config.hcl",
-				"-consul-location=",
+				"-consul-binary=",
 			},
-			ExpErr: "-consul-location must be set",
+			ExpErr: "-consul-binary must be set",
 		},
 		{
 			Flags: []string{
 				"-service-config=/config.hcl",
-				"-consul-location=/consul",
+				"-consul-binary=/consul",
 				"-sync-period=notparseable",
 			},
 			ExpErr: "-sync-period is invalid: time: invalid duration notparseable",
@@ -56,12 +56,12 @@ func TestRun_ServiceConfigFileMissing(t *testing.T) {
 	cmd := Command{
 		UI: ui,
 	}
-	responseCode := cmd.Run([]string{"-service-config=/does/not/exist", "-consul-location=/not/a/valid/path"})
+	responseCode := cmd.Run([]string{"-service-config=/does/not/exist", "-consul-binary=/not/a/valid/path"})
 	require.Equal(t, 1, responseCode, ui.ErrorWriter.String())
 	require.Contains(t, ui.ErrorWriter.String(), "-service-config file \"/does/not/exist\" not found")
 }
 
-func TestRun_ConsulLocationMissing(t *testing.T) {
+func TestRun_ConsulBinaryMissing(t *testing.T) {
 	t.Parallel()
 	ui := cli.NewMockUi()
 	cmd := Command{
@@ -79,9 +79,9 @@ func TestRun_ConsulLocationMissing(t *testing.T) {
 
 	configFlag := "-service-config=" + configFile
 
-	responseCode := cmd.Run([]string{configFlag, "-consul-location=/not/a/valid/path"})
+	responseCode := cmd.Run([]string{configFlag, "-consul-binary=/not/a/valid/path"})
 	require.Equal(t, 1, responseCode, ui.ErrorWriter.String())
-	require.Contains(t, ui.ErrorWriter.String(), "-consul-location binary \"/not/a/valid/path\" not found")
+	require.Contains(t, ui.ErrorWriter.String(), "-consul-binary \"/not/a/valid/path\" not found")
 }
 
 const servicesRegistration = `

--- a/subcommand/lifecycle-sidecar/command_test.go
+++ b/subcommand/lifecycle-sidecar/command_test.go
@@ -1,17 +1,13 @@
 package subcommand
 
 import (
-	"fmt"
-	"github.com/hashicorp/consul/agent"
-	"github.com/hashicorp/consul/sdk/freeport"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
+
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRun_FlagValidation(t *testing.T) {
@@ -25,7 +21,18 @@ func TestRun_FlagValidation(t *testing.T) {
 			ExpErr: "-service-config must be set",
 		},
 		{
-			Flags:  []string{"-service-config=/config.hcl", "-sync-period=notparseable"},
+			Flags: []string{
+				"-service-config=/config.hcl",
+				"-consul-location=",
+			},
+			ExpErr: "-consul-location must be set",
+		},
+		{
+			Flags: []string{
+				"-service-config=/config.hcl",
+				"-consul-location=/consul",
+				"-sync-period=notparseable",
+			},
 			ExpErr: "-sync-period is invalid: time: invalid duration notparseable",
 		},
 	}
@@ -49,155 +56,32 @@ func TestRun_ServiceConfigFileMissing(t *testing.T) {
 	cmd := Command{
 		UI: ui,
 	}
-	responseCode := cmd.Run([]string{"-service-config=/does/not/exist"})
+	responseCode := cmd.Run([]string{"-service-config=/does/not/exist", "-consul-location=/not/a/valid/path"})
 	require.Equal(t, 1, responseCode, ui.ErrorWriter.String())
 	require.Contains(t, ui.ErrorWriter.String(), "-service-config file \"/does/not/exist\" not found")
 }
 
-func TestRun_ServiceConfigFileInvalid(t *testing.T) {
+func TestRun_ConsulLocationMissing(t *testing.T) {
 	t.Parallel()
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer func() { os.RemoveAll(tmpDir) }()
-
-	cases := []struct {
-		FileContents string
-		ExpErr       string
-	}{
-		{
-			FileContents: "",
-			ExpErr:       "expected 2 services to be defined",
-		},
-		{
-			FileContents: "'",
-			ExpErr:       "At 1:1: illegal char",
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.ExpErr, func(t *testing.T) {
-			configFile := filepath.Join(tmpDir, "svc.hcl")
-			err = ioutil.WriteFile(configFile, []byte(c.FileContents), 0600)
-			require.NoError(t, err)
-			defer func() { os.Remove(configFile) }()
-
-			ui := cli.NewMockUi()
-			cmd := Command{
-				UI: ui,
-			}
-
-			responseCode := cmd.Run([]string{"-service-config", configFile})
-			require.Equal(t, 1, responseCode, ui.ErrorWriter.String())
-			require.Contains(t, ui.ErrorWriter.String(), c.ExpErr)
-		})
-	}
-}
-
-// Test that we register the services.
-func TestRun_ServicesRegistration(t *testing.T) {
-	t.Parallel()
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer func() { os.RemoveAll(tmpDir) }()
-
-	configFile := filepath.Join(tmpDir, "svc.hcl")
-	err = ioutil.WriteFile(configFile, []byte(servicesRegistration), 0600)
-	require.NoError(t, err)
-
-	a := agent.NewTestAgent(t, t.Name(), `primary_datacenter = "dc1"`)
-	defer a.Shutdown()
-
-	ui := cli.NewMockUi()
-	cmd := Command{
-		UI:           ui,
-		consulClient: a.Client(),
-	}
-
-	// Run async because we need to kill it when the test is over.
-	exitChan := runCommandAsynchronously(&cmd, []string{
-		"-http-addr", a.HTTPAddr(),
-		"-service-config", configFile,
-		"-sync-period", "100ms",
-	})
-	defer stopCommand(t, &cmd, exitChan)
-
-	timer := &retry.Timer{Timeout: 1 * time.Second, Wait: 100 * time.Millisecond}
-	retry.RunWith(timer, t, func(r *retry.R) {
-		svc, _, err := a.Client().Agent().Service("service-id", nil)
-		require.NoError(r, err)
-		require.Equal(r, 80, svc.Port)
-
-		svcProxy, _, err := a.Client().Agent().Service("service-id-sidecar-proxy", nil)
-		require.NoError(r, err)
-		require.Equal(r, 2000, svcProxy.Port)
-	})
-}
-
-// Test that we register services when the Consul agent is down at first.
-func TestRun_ServicesRegistration_ConsulDown(t *testing.T) {
-	t.Parallel()
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer func() { os.RemoveAll(tmpDir) }()
-
-	configFile := filepath.Join(tmpDir, "svc.hcl")
-	err = ioutil.WriteFile(configFile, []byte(servicesRegistration), 0600)
-	require.NoError(t, err)
-
 	ui := cli.NewMockUi()
 	cmd := Command{
 		UI: ui,
 	}
-	randomPort := freeport.Get(1)[0]
-	// Run async because we need to kill it when the test is over.
-	exitChan := runCommandAsynchronously(&cmd, []string{
-		"-http-addr", fmt.Sprintf("127.0.0.1:%d", randomPort),
-		"-service-config", configFile,
-		"-sync-period", "100ms",
-	})
-	defer stopCommand(t, &cmd, exitChan)
 
-	// Start the Consul agent after 500ms.
-	time.Sleep(500 * time.Millisecond)
-	a := agent.NewTestAgent(t, t.Name(), fmt.Sprintf(`primary_datacenter = "dc1"
-ports {
-  http = %d
-}`, randomPort))
-	defer a.Shutdown()
+	// Create a temporary service registration file
+	tmpDir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer func() { os.RemoveAll(tmpDir) }()
 
-	// The services should be registered when the Consul agent comes up
-	// within 500ms.
-	timer := &retry.Timer{Timeout: 500 * time.Millisecond, Wait: 100 * time.Millisecond}
-	retry.RunWith(timer, t, func(r *retry.R) {
-		svc, _, err := a.Client().Agent().Service("service-id", nil)
-		require.NoError(r, err)
-		require.Equal(r, 80, svc.Port)
+	configFile := filepath.Join(tmpDir, "svc.hcl")
+	err = ioutil.WriteFile(configFile, []byte(servicesRegistration), 0600)
+	require.NoError(t, err)
 
-		svcProxy, _, err := a.Client().Agent().Service("service-id-sidecar-proxy", nil)
-		require.NoError(r, err)
-		require.Equal(r, 2000, svcProxy.Port)
-	})
-}
+	configFlag := "-service-config=" + configFile
 
-// This function starts the command asynchronously and returns a non-blocking chan.
-// When finished, the command will send its exit code to the channel.
-// Note that it's the responsibility of the caller to terminate the command by calling stopCommand,
-// otherwise it can run forever.
-func runCommandAsynchronously(cmd *Command, args []string) chan int {
-	exitChan := make(chan int, 1)
-	go func() {
-		exitChan <- cmd.Run(args)
-	}()
-	return exitChan
-}
-
-func stopCommand(t *testing.T, cmd *Command, exitChan chan int) {
-	if len(exitChan) == 0 {
-		cmd.interrupt()
-	}
-	select {
-	case c := <-exitChan:
-		require.Equal(t, 0, c, string(cmd.UI.(*cli.MockUi).ErrorWriter.Bytes()))
-	}
+	responseCode := cmd.Run([]string{configFlag, "-consul-location=/not/a/valid/path"})
+	require.Equal(t, 1, responseCode, ui.ErrorWriter.String())
+	require.Contains(t, ui.ErrorWriter.String(), "-consul-location binary \"/not/a/valid/path\" not found")
 }
 
 const servicesRegistration = `


### PR DESCRIPTION
For namespaces, the lifecycle sidecar needs access to Enterprise
features to be able to register and re-register services and proxies
correctly. This switches it to directly call the consul cli with the
consul version specified in the connect injector. If a user is running
enterprise, this is the enterprise version which allows namespaces.

Note: Several tests were deleted because their approach no longer
works with this registration strategy. They will need to be rewritten
in the future.