### PR TITLE
Fixes to the lifecycle sidecar cmd, plus tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ executors:
       - image: circleci/golang:1.13
     environment:
       - TEST_RESULTS: /tmp/test-results # path to where test results are saved
+      - CONSUL_VERSION: 1.6.3 # this can be OSS or enterprise, e.g., 1.7.0+ent-beta4
 
 jobs:
   go-fmt-and-vet:
@@ -54,6 +55,10 @@ jobs:
 
       # run go tests with gotestsum
       - run: |
+          # download and install the consul binary
+          wget https://releases.hashicorp.com/consul/"${CONSUL_VERSION}"/consul_"${CONSUL_VERSION}"_linux_amd64.zip && \
+               unzip consul_"${CONSUL_VERSION}"_linux_amd64.zip -d /home/circleci/bin &&
+               rm consul_"${CONSUL_VERSION}"_linux_amd64.zip
           PACKAGE_NAMES=$(go list ./...)
           gotestsum --junitfile $TEST_RESULTS/gotestsum-report.xml -- -p 4 $PACKAGE_NAMES
 

--- a/subcommand/lifecycle-sidecar/command_test.go
+++ b/subcommand/lifecycle-sidecar/command_test.go
@@ -1,14 +1,29 @@
 package subcommand
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/freeport"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRun_Defaults(t *testing.T) {
+	t.Parallel()
+	var cmd Command
+	cmd.init()
+	require.Equal(t, 10*time.Second, cmd.flagSyncPeriod)
+	require.Equal(t, "info", cmd.flagLogLevel)
+	require.Equal(t, "consul", cmd.flagConsulBinary)
+}
 
 func TestRun_FlagValidation(t *testing.T) {
 	t.Parallel()
@@ -27,14 +42,6 @@ func TestRun_FlagValidation(t *testing.T) {
 			},
 			ExpErr: "-consul-binary must be set",
 		},
-		{
-			Flags: []string{
-				"-service-config=/config.hcl",
-				"-consul-binary=/consul",
-				"-sync-period=notparseable",
-			},
-			ExpErr: "-sync-period is invalid: time: invalid duration notparseable",
-		},
 	}
 
 	for _, c := range cases {
@@ -50,7 +57,7 @@ func TestRun_FlagValidation(t *testing.T) {
 	}
 }
 
-func TestRun_ServiceConfigFileMissing(t *testing.T) {
+func TestRun_FlagValidation_ServiceConfigFileMissing(t *testing.T) {
 	t.Parallel()
 	ui := cli.NewMockUi()
 	cmd := Command{
@@ -61,7 +68,7 @@ func TestRun_ServiceConfigFileMissing(t *testing.T) {
 	require.Contains(t, ui.ErrorWriter.String(), "-service-config file \"/does/not/exist\" not found")
 }
 
-func TestRun_ConsulBinaryMissing(t *testing.T) {
+func TestRun_FlagValidation_ConsulBinaryMissing(t *testing.T) {
 	t.Parallel()
 	ui := cli.NewMockUi()
 	cmd := Command{
@@ -69,19 +76,153 @@ func TestRun_ConsulBinaryMissing(t *testing.T) {
 	}
 
 	// Create a temporary service registration file
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer func() { os.RemoveAll(tmpDir) }()
-
-	configFile := filepath.Join(tmpDir, "svc.hcl")
-	err = ioutil.WriteFile(configFile, []byte(servicesRegistration), 0600)
-	require.NoError(t, err)
+	tmpDir, configFile := createServicesTmpFile(t)
+	defer os.RemoveAll(tmpDir)
 
 	configFlag := "-service-config=" + configFile
 
 	responseCode := cmd.Run([]string{configFlag, "-consul-binary=/not/a/valid/path"})
 	require.Equal(t, 1, responseCode, ui.ErrorWriter.String())
 	require.Contains(t, ui.ErrorWriter.String(), "-consul-binary \"/not/a/valid/path\" not found")
+}
+
+func TestRun_FlagValidation_InvalidLogLevel(t *testing.T) {
+	t.Parallel()
+	tmpDir, configFile := createServicesTmpFile(t)
+	defer os.RemoveAll(tmpDir)
+
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI: ui,
+	}
+	responseCode := cmd.Run([]string{"-service-config", configFile, "-consul-binary=consul", "-log-level=foo"})
+	require.Equal(t, 1, responseCode, ui.ErrorWriter.String())
+	require.Contains(t, ui.ErrorWriter.String(), "unknown log level: foo")
+}
+
+// Test that we register the services.
+func TestRun_ServicesRegistration(t *testing.T) {
+	t.Parallel()
+	tmpDir, configFile := createServicesTmpFile(t)
+	defer os.RemoveAll(tmpDir)
+
+	a, err := testutil.NewTestServerT(t)
+	require.NoError(t, err)
+	defer a.Stop()
+
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI: ui,
+	}
+
+	// Run async because we need to kill it when the test is over.
+	exitChan := runCommandAsynchronously(&cmd, []string{
+		"-http-addr", a.HTTPAddr,
+		"-service-config", configFile,
+		"-sync-period", "100ms",
+		"-consul-binary", "consul",
+	})
+	defer stopCommand(t, &cmd, exitChan)
+
+	client, err := api.NewClient(&api.Config{
+		Address: a.HTTPAddr,
+	})
+	require.NoError(t, err)
+
+	timer := &retry.Timer{Timeout: 1 * time.Second, Wait: 100 * time.Millisecond}
+	retry.RunWith(timer, t, func(r *retry.R) {
+		svc, _, err := client.Agent().Service("service-id", nil)
+		require.NoError(r, err)
+		require.Equal(r, 80, svc.Port)
+
+		svcProxy, _, err := client.Agent().Service("service-id-sidecar-proxy", nil)
+		require.NoError(r, err)
+		require.Equal(r, 2000, svcProxy.Port)
+	})
+}
+
+// Test that we register services when the Consul agent is down at first.
+func TestRun_ServicesRegistration_ConsulDown(t *testing.T) {
+	t.Parallel()
+	tmpDir, configFile := createServicesTmpFile(t)
+	defer os.RemoveAll(tmpDir)
+
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI: ui,
+	}
+	randomPort := freeport.MustTake(1)[0]
+	// Run async because we need to kill it when the test is over.
+	exitChan := runCommandAsynchronously(&cmd, []string{
+		"-http-addr", fmt.Sprintf("127.0.0.1:%d", randomPort),
+		"-service-config", configFile,
+		"-sync-period", "100ms",
+		"-consul-binary", "consul",
+	})
+	defer stopCommand(t, &cmd, exitChan)
+
+	// Start the Consul agent after 500ms.
+	time.Sleep(500 * time.Millisecond)
+	a, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
+		c.Ports = &testutil.TestPortConfig{
+			HTTP: randomPort,
+		}
+	})
+	require.NoError(t, err)
+	defer a.Stop()
+
+	client, err := api.NewClient(&api.Config{
+		Address: a.HTTPAddr,
+	})
+	require.NoError(t, err)
+
+	// The services should be registered when the Consul agent comes up
+	// within 500ms.
+	timer := &retry.Timer{Timeout: 500 * time.Millisecond, Wait: 100 * time.Millisecond}
+	retry.RunWith(timer, t, func(r *retry.R) {
+		svc, _, err := client.Agent().Service("service-id", nil)
+		require.NoError(r, err)
+		require.Equal(r, 80, svc.Port)
+
+		svcProxy, _, err := client.Agent().Service("service-id-sidecar-proxy", nil)
+		require.NoError(r, err)
+		require.Equal(r, 2000, svcProxy.Port)
+	})
+}
+
+// This function starts the command asynchronously and returns a non-blocking chan.
+// When finished, the command will send its exit code to the channel.
+// Note that it's the responsibility of the caller to terminate the command by calling stopCommand,
+// otherwise it can run forever.
+func runCommandAsynchronously(cmd *Command, args []string) chan int {
+	exitChan := make(chan int, 1)
+	go func() {
+		exitChan <- cmd.Run(args)
+	}()
+	return exitChan
+}
+
+func stopCommand(t *testing.T, cmd *Command, exitChan chan int) {
+	if len(exitChan) == 0 {
+		cmd.interrupt()
+	}
+	select {
+	case c := <-exitChan:
+		require.Equal(t, 0, c, string(cmd.UI.(*cli.MockUi).ErrorWriter.Bytes()))
+	}
+}
+
+// createServicesTmpFile creates a temp directory
+// and writes servicesRegistration as an HCL file there.
+func createServicesTmpFile(t *testing.T) (string, string) {
+	tmpDir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+
+	configFile := filepath.Join(tmpDir, "svc.hcl")
+	err = ioutil.WriteFile(configFile, []byte(servicesRegistration), 0600)
+	require.NoError(t, err)
+
+	return tmpDir, configFile
 }
 
 const servicesRegistration = `


### PR DESCRIPTION
This PR makes the following changes:
- Previously, we were calling `consul services register service.hcl -token-file ...`, but it needed to be `consul services register -token-file ... service.hcl`
- Additionally, we weren't passing any other HTTP flags to the underlying Consul command
- Adds tests back in
- Changes CI test job to download the Consul binary