### PR TITLE
Add namespace tests to the lifecycle sidecar command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,8 @@ executors:
       - image: circleci/golang:1.13
     environment:
       - TEST_RESULTS: /tmp/test-results # path to where test results are saved
-      - CONSUL_VERSION: 1.6.3 # this can be OSS or enterprise, e.g., 1.7.0+ent-beta4
+      - CONSUL_VERSION: 1.6.3 # Consul's OSS version to use in tests
+      - CONSUL_ENT_VERSION: 1.7.0+ent-beta4 # Consul's enterprise version to use in tests
 
 jobs:
   go-fmt-and-vet:
@@ -67,6 +68,34 @@ jobs:
       - store_artifacts:
           path: /tmp/test-results
 
+  test_enterprise:
+    executor: go
+    environment:
+      TEST_RESULTS: /tmp/test-results
+    parallelism: 1
+    steps:
+      - checkout
+      - run: mkdir -p $TEST_RESULTS
+
+      # Restore go module cache if there is one
+      - restore_cache:
+          keys:
+            - consul-k8s-modcache-v1-{{ checksum "go.mod" }}
+
+      # run go tests with gotestsum
+      - run: |
+          # download and install the consul binary
+          wget https://releases.hashicorp.com/consul/"${CONSUL_ENT_VERSION}"/consul_"${CONSUL_ENT_VERSION}"_linux_amd64.zip && \
+               unzip consul_"${CONSUL_ENT_VERSION}"_linux_amd64.zip -d /home/circleci/bin &&
+               rm consul_"${CONSUL_ENT_VERSION}"_linux_amd64.zip
+      - run: |
+          PACKAGE_NAMES=$(go list ./...)
+          gotestsum --junitfile $TEST_RESULTS/gotestsum-report.xml -- -tags=enterprise -p 4 $PACKAGE_NAMES
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+
   build-distros:
     executor: go
     environment:
@@ -92,6 +121,9 @@ workflows:
     jobs:
       - go-fmt-and-vet
       - test:
+          requires:
+            - go-fmt-and-vet
+      - test_enterprise:
           requires:
             - go-fmt-and-vet
       - build-distros:

--- a/subcommand/lifecycle-sidecar/command.go
+++ b/subcommand/lifecycle-sidecar/command.go
@@ -60,14 +60,14 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	logLevel, err := c.validateFlags()
+	err := c.validateFlags()
 	if err != nil {
 		c.UI.Error("Error: " + err.Error())
 		return 1
 	}
 
 	logger := hclog.New(&hclog.LoggerOptions{
-		Level:  logLevel,
+		Level:  hclog.LevelFromString(c.flagLogLevel),
 		Output: os.Stderr,
 	})
 
@@ -113,41 +113,36 @@ func (c *Command) Run(args []string) int {
 	}
 }
 
-// validateFlags validates the flags and returns the parsed syncPeriod and
-// logLevel.
-func (c *Command) validateFlags() (logLevel hclog.Level, err error) {
+// validateFlags validates the flags and returns the logLevel.
+func (c *Command) validateFlags() error {
 	if c.flagServiceConfig == "" {
-		err = errors.New("-service-config must be set")
-		return
+		return errors.New("-service-config must be set")
 	}
 	if c.flagConsulBinary == "" {
-		err = errors.New("-consul-binary must be set")
-		return
+		return errors.New("-consul-binary must be set")
 	}
 	if c.flagSyncPeriod == 0 {
 		// if sync period is 0, then the select loop will
 		// always pick the first case, and it'll be impossible
 		// to terminate the command gracefully with SIGINT.
-		err = errors.New("-sync-period must be greater than 0")
-		return
+		return errors.New("-sync-period must be greater than 0")
 	}
 
-	_, err = os.Stat(c.flagServiceConfig)
+	_, err := os.Stat(c.flagServiceConfig)
 	if os.IsNotExist(err) {
 		err = fmt.Errorf("-service-config file %q not found", c.flagServiceConfig)
-		return
+		return fmt.Errorf("-service-config file %q not found", c.flagServiceConfig)
 	}
 	_, err = exec.LookPath(c.flagConsulBinary)
 	if err != nil {
-		err = fmt.Errorf("-consul-binary %q not found: %s", c.flagConsulBinary, err)
-		return
+		return fmt.Errorf("-consul-binary %q not found: %s", c.flagConsulBinary, err)
 	}
-	logLevel = hclog.LevelFromString(c.flagLogLevel)
+	logLevel := hclog.LevelFromString(c.flagLogLevel)
 	if logLevel == hclog.NoLevel {
-		err = fmt.Errorf("unknown log level: %s", c.flagLogLevel)
-		return
+		return fmt.Errorf("unknown log level: %s", c.flagLogLevel)
 	}
-	return
+
+	return nil
 }
 
 // parseConsulFlags creates Consul client command flags

--- a/subcommand/lifecycle-sidecar/command_ent_test.go
+++ b/subcommand/lifecycle-sidecar/command_ent_test.go
@@ -1,0 +1,89 @@
+// +build enterprise
+
+package subcommand
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+// Test that we register the services with namespaces.
+func TestRun_ServicesRegistration_Namespaces(t *testing.T) {
+	t.Parallel()
+	tmpDir, configFile := createServicesTmpFile(t, servicesRegistrationWithNamespaces)
+	defer os.RemoveAll(tmpDir)
+
+	a, err := testutil.NewTestServerT(t)
+	require.NoError(t, err)
+	defer a.Stop()
+
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI: ui,
+	}
+
+	// Run async because we need to kill it when the test is over.
+	exitChan := runCommandAsynchronously(&cmd, []string{
+		"-http-addr", a.HTTPAddr,
+		"-service-config", configFile,
+		"-sync-period", "100ms",
+	})
+	defer stopCommand(t, &cmd, exitChan)
+
+	client, err := api.NewClient(&api.Config{
+		Address: a.HTTPAddr,
+	})
+	require.NoError(t, err)
+
+	// create necessary namespaces first
+	_, _, err = client.Namespaces().Create(&api.Namespace{Name: "namespace"}, nil)
+	require.NoError(t, err)
+
+	timer := &retry.Timer{Timeout: 1 * time.Second, Wait: 100 * time.Millisecond}
+	retry.RunWith(timer, t, func(r *retry.R) {
+		svc, _, err := client.Agent().Service("service-id", &api.QueryOptions{Namespace: "namespace"})
+		require.NoError(r, err)
+		require.Equal(r, 80, svc.Port)
+		require.Equal(r, "namespace", svc.Namespace)
+
+		svcProxy, _, err := client.Agent().Service("service-id-sidecar-proxy", &api.QueryOptions{Namespace: "namespace"})
+		require.NoError(r, err)
+		require.Equal(r, 2000, svcProxy.Port)
+		require.Equal(r, svcProxy.Namespace, "namespace")
+		require.Len(r, svcProxy.Proxy.Upstreams, 1)
+		require.Equal(r, svcProxy.Proxy.Upstreams[0].DestinationNamespace, "dest-namespace")
+	})
+}
+
+const servicesRegistrationWithNamespaces = `
+services {
+	id   = "service-id"
+	name = "service"
+	port = 80
+	namespace = "namespace"
+}
+services {
+	id   = "service-id-sidecar-proxy"
+	name = "service-sidecar-proxy"
+	namespace = "namespace"
+	port = 2000
+	kind = "connect-proxy"
+	proxy {
+		destination_service_name = "service"
+		destination_service_id = "service-id"
+		local_service_port = 80
+		upstreams {
+			destination_type = "service"
+			destination_name = "dest-name"
+			destination_namespace = "dest-namespace"
+			local_bind_port = 1234
+		}
+	}
+}`


### PR DESCRIPTION
This PR adds enterprise namespaces tests to the lifecycle command.  

It also fixes a bug with sync period. After switching to `time.Duration`,
we didn't need to parse it anymore, however, validateFlags function
always instantiated and returned `syncPeriod` variable, which was 0 by
default.

Additionally, we no longer allow sync period to be equal to 0. If it is,
then it's impossible to stop command gracefully because the select loop
will always choose 'case <-time.After(c.flagSyncPeriod)' even if
the `SIGINT` signal has been sent.