### PR TITLE
Namespaces tests for catalog sync, fix races

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       - image: circleci/golang:1.13
     environment:
       - TEST_RESULTS: /tmp/test-results # path to where test results are saved
-      - CONSUL_VERSION: 1.6.3 # Consul's OSS version to use in tests
+      - CONSUL_VERSION: 1.7.0 # Consul's OSS version to use in tests
       - CONSUL_ENT_VERSION: 1.7.0+ent # Consul's enterprise version to use in tests
 
 jobs:

--- a/catalog/to-consul/consul_node_services_client.go
+++ b/catalog/to-consul/consul_node_services_client.go
@@ -18,35 +18,37 @@ type ConsulService struct {
 
 // ConsulNodeServicesClient is used to query for node services.
 type ConsulNodeServicesClient interface {
-	// NodeServicesWithTag returns consul services with the corresponding tag
+	// NodeServices returns consul services with the corresponding tag
 	// registered to the Consul node with nodeName. opts is used as the
 	// query options in the API call to consul. It returns the list of services
 	// (not service instances) and the query meta from the API call.
-	NodeServicesWithTag(client *api.Client, tag string, nodeName string, opts *api.QueryOptions) ([]ConsulService, *api.QueryMeta, error)
+	NodeServices(tag string, nodeName string, opts api.QueryOptions) ([]ConsulService, *api.QueryMeta, error)
 }
 
-// ConsulPreOnePointSevenNodeServicesClient implements ConsulNodeServicesClient
+// ConsulPreNamespacesNodeServicesClient implements ConsulNodeServicesClient
 // for Consul < 1.7 which does not support namespaces.
-type ConsulPreOnePointSevenNodeServicesClient struct{}
+type ConsulPreNamespacesNodeServicesClient struct {
+	Client *api.Client
+}
 
-// NodeServicesWithTag returns Consul services tagged with
+// NodeServices returns Consul services tagged with
 // tag registered on nodeName using a Consul API that is supported in
 // Consul versions before 1.7. Consul versions after 1.7 still support
 // this API but the API is not namespace-aware.
-func (s *ConsulPreOnePointSevenNodeServicesClient) NodeServicesWithTag(
-	client *api.Client,
+func (s *ConsulPreNamespacesNodeServicesClient) NodeServices(
 	tag string,
 	nodeName string,
-	opts *api.QueryOptions) ([]ConsulService, *api.QueryMeta, error) {
+	opts api.QueryOptions) ([]ConsulService, *api.QueryMeta, error) {
 	// NOTE: We're not using tag filtering here so we can support Consul
 	// < 1.5.
-	node, meta, err := client.Catalog().Node(nodeName, opts)
+	node, meta, err := s.Client.Catalog().Node(nodeName, &opts)
 	if err != nil {
 		return nil, nil, err
 	}
 	if node == nil {
 		return nil, meta, nil
 	}
+
 	var svcs []ConsulService
 	// seenServices is used to ensure the svcs list is unique.
 	seenServices := make(map[string]bool)
@@ -73,34 +75,33 @@ func (s *ConsulPreOnePointSevenNodeServicesClient) NodeServicesWithTag(
 	return svcs, meta, nil
 }
 
-// ConsulOnePointSevenNodeServicesClient implements ConsulNodeServicesClient
+// ConsulNamespacesNodeServicesClient implements ConsulNodeServicesClient
 // for Consul >= 1.7 which supports namespaces.
-type ConsulOnePointSevenNodeServicesClient struct{}
+type ConsulNamespacesNodeServicesClient struct {
+	Client *api.Client
+}
 
-// NodeServicesWithTag returns Consul services tagged with
+// NodeServices returns Consul services tagged with
 // tag registered on nodeName using a Consul API that is supported in
 // Consul versions >= 1.7. If opts.Namespace is set to
 // "*", services from all namespaces will be returned.
-func (s *ConsulOnePointSevenNodeServicesClient) NodeServicesWithTag(
-	client *api.Client,
+func (s *ConsulNamespacesNodeServicesClient) NodeServices(
 	tag string,
 	nodeName string,
-	opts *api.QueryOptions) ([]ConsulService, *api.QueryMeta, error) {
-	if opts == nil {
-		opts = &api.QueryOptions{}
-	}
+	opts api.QueryOptions) ([]ConsulService, *api.QueryMeta, error) {
 	opts.Filter = fmt.Sprintf("\"%s\" in Tags", tag)
-	nodeCatalog, meta, err := client.Catalog().NodeServiceList(nodeName, opts)
+	nodeCatalog, meta, err := s.Client.Catalog().NodeServiceList(nodeName, &opts)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var svcs []ConsulService
 	// seenServices is used to ensure the svcs list is unique. Its keys are
-	// <service name>/<namespace>.
+	// <namespace>/<service name>.
 	seenSvcs := make(map[string]bool)
 	for _, svcInstance := range nodeCatalog.Services {
 		svcName := svcInstance.Service
-		key := fmt.Sprintf("%s/%s", svcName, svcInstance.Namespace)
+		key := fmt.Sprintf("%s/%s", svcInstance.Namespace, svcName)
 		if _, ok := seenSvcs[key]; !ok {
 			svcs = append(svcs, ConsulService{
 				Namespace: svcInstance.Namespace,

--- a/catalog/to-consul/consul_node_services_client.go
+++ b/catalog/to-consul/consul_node_services_client.go
@@ -1,0 +1,113 @@
+package catalog
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/consul/api"
+)
+
+// ConsulService is service registered in Consul.
+type ConsulService struct {
+	// Namespace is the Consul namespace the service is registered in.
+	// If namespaces are disabled this will always be the empty string even
+	// though the namespace is technically "default".
+	Namespace string
+	// Name is the name of the service in Consul.
+	Name string
+}
+
+// ConsulNodeServicesClient is used to query for node services.
+type ConsulNodeServicesClient interface {
+	// NodeServicesWithTag returns consul services with the corresponding tag
+	// registered to the Consul node with nodeName. opts is used as the
+	// query options in the API call to consul. It returns the list of services
+	// (not service instances) and the query meta from the API call.
+	NodeServicesWithTag(client *api.Client, tag string, nodeName string, opts *api.QueryOptions) ([]ConsulService, *api.QueryMeta, error)
+}
+
+// ConsulPreOnePointSevenNodeServicesClient implements ConsulNodeServicesClient
+// for Consul < 1.7 which does not support namespaces.
+type ConsulPreOnePointSevenNodeServicesClient struct{}
+
+// NodeServicesWithTag returns Consul services tagged with
+// tag registered on nodeName using a Consul API that is supported in
+// Consul versions before 1.7. Consul versions after 1.7 still support
+// this API but the API is not namespace-aware.
+func (s *ConsulPreOnePointSevenNodeServicesClient) NodeServicesWithTag(
+	client *api.Client,
+	tag string,
+	nodeName string,
+	opts *api.QueryOptions) ([]ConsulService, *api.QueryMeta, error) {
+	// NOTE: We're not using tag filtering here so we can support Consul
+	// < 1.5.
+	node, meta, err := client.Catalog().Node(nodeName, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	if node == nil {
+		return nil, meta, nil
+	}
+	var svcs []ConsulService
+	// seenServices is used to ensure the svcs list is unique.
+	seenServices := make(map[string]bool)
+	for _, svcInstance := range node.Services {
+		svcName := svcInstance.Service
+		if _, ok := seenServices[svcName]; ok {
+			continue
+		}
+		for _, svcTag := range svcInstance.Tags {
+			if svcTag == tag {
+				if _, ok := seenServices[svcName]; !ok {
+					svcs = append(svcs, ConsulService{
+						// If namespaces are not enabled we use empty
+						// string.
+						Namespace: "",
+						Name:      svcName,
+					})
+					seenServices[svcName] = true
+				}
+				break
+			}
+		}
+	}
+	return svcs, meta, nil
+}
+
+// ConsulOnePointSevenNodeServicesClient implements ConsulNodeServicesClient
+// for Consul >= 1.7 which supports namespaces.
+type ConsulOnePointSevenNodeServicesClient struct{}
+
+// NodeServicesWithTag returns Consul services tagged with
+// tag registered on nodeName using a Consul API that is supported in
+// Consul versions >= 1.7. If opts.Namespace is set to
+// "*", services from all namespaces will be returned.
+func (s *ConsulOnePointSevenNodeServicesClient) NodeServicesWithTag(
+	client *api.Client,
+	tag string,
+	nodeName string,
+	opts *api.QueryOptions) ([]ConsulService, *api.QueryMeta, error) {
+	if opts == nil {
+		opts = &api.QueryOptions{}
+	}
+	opts.Filter = fmt.Sprintf("\"%s\" in Tags", tag)
+	nodeCatalog, meta, err := client.Catalog().NodeServiceList(nodeName, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	var svcs []ConsulService
+	// seenServices is used to ensure the svcs list is unique. Its keys are
+	// <service name>/<namespace>.
+	seenSvcs := make(map[string]bool)
+	for _, svcInstance := range nodeCatalog.Services {
+		svcName := svcInstance.Service
+		key := fmt.Sprintf("%s/%s", svcName, svcInstance.Namespace)
+		if _, ok := seenSvcs[key]; !ok {
+			svcs = append(svcs, ConsulService{
+				Namespace: svcInstance.Namespace,
+				Name:      svcName,
+			})
+			seenSvcs[key] = true
+		}
+	}
+	return svcs, meta, nil
+}

--- a/catalog/to-consul/consul_node_services_client_ent_test.go
+++ b/catalog/to-consul/consul_node_services_client_ent_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Test the Consul 1.7 client against Consul Enterprise.
-func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
+func TestConsulNamespacesNodeServicesClient_NodeServices(t *testing.T) {
 	t.Parallel()
 	cases := map[string]struct {
 		ConsulServices []api.CatalogRegistration
@@ -48,10 +48,10 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 			},
 			Exp: nil,
 		},
-		"service on k8s node but without tag": {
+		"service on k8s node without any tags": {
 			ConsulServices: []api.CatalogRegistration{
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id",
@@ -62,10 +62,24 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 			},
 			Exp: nil,
 		},
+		"service on k8s node without k8s tag": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    ConsulSyncNodeName,
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    []string{"not-k8s", "foo"},
+					},
+				},
+			},
+			Exp: nil,
+		},
 		"service on k8s node with k8s tag": {
 			ConsulServices: []api.CatalogRegistration{
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id",
@@ -84,7 +98,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 		"multiple services": {
 			ConsulServices: []api.CatalogRegistration{
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc1-id",
@@ -93,7 +107,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc2-id2",
@@ -116,7 +130,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 		"multiple service instances": {
 			ConsulServices: []api.CatalogRegistration{
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id1",
@@ -125,7 +139,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id2",
@@ -144,7 +158,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 		"services across multiple namespaces": {
 			ConsulServices: []api.CatalogRegistration{
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id1",
@@ -153,7 +167,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:        "svc-ns-id",
@@ -177,7 +191,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 		"services with same name across multiple namespaces": {
 			ConsulServices: []api.CatalogRegistration{
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id",
@@ -186,7 +200,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:        "svc-id",
@@ -210,7 +224,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 		"multiple services across multiple namespaces": {
 			ConsulServices: []api.CatalogRegistration{
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id1",
@@ -219,7 +233,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id2",
@@ -228,7 +242,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:        "svc-id1",
@@ -238,7 +252,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:        "svc-id2",
@@ -248,7 +262,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc2-id1",
@@ -257,7 +271,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc2-id2",
@@ -266,7 +280,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:        "svc2-id1",
@@ -276,7 +290,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:        "svc2-id2",
@@ -308,6 +322,9 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 	}
 
 	for name, c := range cases {
+		if name != "multiple services across multiple namespaces" {
+			continue
+		}
 		t.Run(name, func(tt *testing.T) {
 			require := require.New(tt)
 			svr, err := testutil.NewTestServerT(tt)
@@ -329,8 +346,10 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 				require.NoError(err)
 			}
 
-			client := ConsulOnePointSevenNodeServicesClient{}
-			svcs, _, err := client.NodeServicesWithTag(consulClient, "k8s", "k8s-sync", &api.QueryOptions{
+			client := ConsulNamespacesNodeServicesClient{
+				Client: consulClient,
+			}
+			svcs, _, err := client.NodeServices("k8s", ConsulSyncNodeName, api.QueryOptions{
 				Namespace: "*",
 			})
 			require.NoError(err)

--- a/catalog/to-consul/consul_node_services_client_ent_test.go
+++ b/catalog/to-consul/consul_node_services_client_ent_test.go
@@ -1,0 +1,343 @@
+// +build enterprise
+
+package catalog
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// Test the Consul 1.7 client against Consul Enterprise.
+func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		ConsulServices []api.CatalogRegistration
+		Exp            []ConsulService
+	}{
+		"no services": {
+			ConsulServices: nil,
+			Exp:            nil,
+		},
+		"no services on k8s node": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "not-k8s",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+					},
+				},
+			},
+			Exp: nil,
+		},
+		"service with k8s tag on different node": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "not-k8s",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: nil,
+		},
+		"service on k8s node but without tag": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    nil,
+					},
+				},
+			},
+			Exp: nil,
+		},
+		"service on k8s node with k8s tag": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "default",
+					Name:      "svc",
+				},
+			},
+		},
+		"multiple services": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc1-id",
+						Service: "svc1",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc2-id2",
+						Service: "svc2",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "default",
+					Name:      "svc1",
+				},
+				{
+					Namespace: "default",
+					Name:      "svc2",
+				},
+			},
+		},
+		"multiple service instances": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id1",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id2",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "default",
+					Name:      "svc",
+				},
+			},
+		},
+		"services across multiple namespaces": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id1",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:        "svc-ns-id",
+						Service:   "svc-ns",
+						Tags:      []string{"k8s"},
+						Namespace: "ns",
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "default",
+					Name:      "svc",
+				},
+				{
+					Namespace: "ns",
+					Name:      "svc-ns",
+				},
+			},
+		},
+		"services with same name across multiple namespaces": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:        "svc-id",
+						Service:   "svc",
+						Tags:      []string{"k8s"},
+						Namespace: "ns",
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "default",
+					Name:      "svc",
+				},
+				{
+					Namespace: "ns",
+					Name:      "svc",
+				},
+			},
+		},
+		"multiple services across multiple namespaces": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id1",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id2",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:        "svc-id1",
+						Service:   "svc",
+						Tags:      []string{"k8s"},
+						Namespace: "ns",
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:        "svc-id2",
+						Service:   "svc",
+						Tags:      []string{"k8s"},
+						Namespace: "ns",
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc2-id1",
+						Service: "svc2",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc2-id2",
+						Service: "svc2",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:        "svc2-id1",
+						Service:   "svc2",
+						Tags:      []string{"k8s"},
+						Namespace: "ns",
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:        "svc2-id2",
+						Service:   "svc2",
+						Tags:      []string{"k8s"},
+						Namespace: "ns",
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "default",
+					Name:      "svc",
+				},
+				{
+					Namespace: "default",
+					Name:      "svc2",
+				},
+				{
+					Namespace: "ns",
+					Name:      "svc",
+				},
+				{
+					Namespace: "ns",
+					Name:      "svc2",
+				},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(tt *testing.T) {
+			require := require.New(tt)
+			svr, err := testutil.NewTestServerT(tt)
+			require.NoError(err)
+			defer svr.Stop()
+
+			consulClient, err := api.NewClient(&api.Config{
+				Address: svr.HTTPAddr,
+			})
+			require.NoError(err)
+			for _, registration := range c.ConsulServices {
+				if registration.Service.Namespace != "" && registration.Service.Namespace != "default" {
+					_, _, err = consulClient.Namespaces().Create(&api.Namespace{
+						Name: registration.Service.Namespace,
+					}, nil)
+					require.NoError(err)
+				}
+				_, err = consulClient.Catalog().Register(&registration, nil)
+				require.NoError(err)
+			}
+
+			client := ConsulOnePointSevenNodeServicesClient{}
+			svcs, _, err := client.NodeServicesWithTag(consulClient, "k8s", "k8s-sync", &api.QueryOptions{
+				Namespace: "*",
+			})
+			require.NoError(err)
+			require.Len(svcs, len(c.Exp))
+			for _, expSvc := range c.Exp {
+				require.Contains(svcs, expSvc)
+			}
+		})
+	}
+}

--- a/catalog/to-consul/consul_node_services_client_test.go
+++ b/catalog/to-consul/consul_node_services_client_test.go
@@ -1,0 +1,168 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		ConsulServices []api.CatalogRegistration
+		Exp            []ConsulService
+	}{
+		"no services": {
+			ConsulServices: nil,
+			Exp:            nil,
+		},
+		"no services on k8s node": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "not-k8s",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+					},
+				},
+			},
+			Exp: nil,
+		},
+		"service with k8s tag on different node": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "not-k8s",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: nil,
+		},
+		"service on k8s node but without tag": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    nil,
+					},
+				},
+			},
+			Exp: nil,
+		},
+		"service on k8s node with k8s tag": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "",
+					Name:      "svc",
+				},
+			},
+		},
+		"multiple services": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc1-id",
+						Service: "svc1",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc2-id2",
+						Service: "svc2",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "",
+					Name:      "svc1",
+				},
+				{
+					Namespace: "",
+					Name:      "svc2",
+				},
+			},
+		},
+		"multiple service instances": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id1",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id2",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "",
+					Name:      "svc",
+				},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(tt *testing.T) {
+			require := require.New(tt)
+			svr, err := testutil.NewTestServerT(tt)
+			require.NoError(err)
+			defer svr.Stop()
+
+			consulClient, err := api.NewClient(&api.Config{
+				Address: svr.HTTPAddr,
+			})
+			require.NoError(err)
+			for _, registration := range c.ConsulServices {
+				_, err = consulClient.Catalog().Register(&registration, nil)
+				require.NoError(err)
+			}
+
+			client := ConsulPreOnePointSevenNodeServicesClient{}
+			svcs, _, err := client.NodeServicesWithTag(consulClient, "k8s", "k8s-sync", nil)
+			require.NoError(err)
+			require.Len(svcs, len(c.Exp))
+			for _, expSvc := range c.Exp {
+				require.Contains(svcs, expSvc)
+			}
+		})
+	}
+}

--- a/catalog/to-consul/resource.go
+++ b/catalog/to-consul/resource.go
@@ -326,7 +326,7 @@ func (t *ServiceResource) generateRegistrations(key string) {
 	// shallow copied for each instance.
 	baseNode := consulapi.CatalogRegistration{
 		SkipNodeUpdate: true,
-		Node:           "k8s-sync",
+		Node:           ConsulSyncNodeName,
 		Address:        "127.0.0.1",
 		NodeMeta: map[string]string{
 			ConsulSourceKey: ConsulSourceValue,

--- a/catalog/to-consul/syncer.go
+++ b/catalog/to-consul/syncer.go
@@ -165,7 +165,7 @@ func (s *ConsulSyncer) watchReapableServices(ctx context.Context) {
 		var meta *api.QueryMeta
 		err := backoff.Retry(func() error {
 			var err error
-			services, meta, err = s.ConsulNodeServicesClient.NodeServicesWithTag(s.Client, s.ConsulK8STag, ConsulSyncNodeName, opts)
+			services, meta, err = s.ConsulNodeServicesClient.NodeServices(s.ConsulK8STag, ConsulSyncNodeName, *opts)
 			return err
 		}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
 

--- a/catalog/to-consul/syncer_ent_test.go
+++ b/catalog/to-consul/syncer_ent_test.go
@@ -23,7 +23,9 @@ func TestConsulSyncer_ConsulNamespaces(t *testing.T) {
 
 	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
 		s.EnableNamespaces = true
-		s.ConsulNodeServicesClient = &ConsulOnePointSevenNodeServicesClient{}
+		s.ConsulNodeServicesClient = &ConsulNamespacesNodeServicesClient{
+			Client: client,
+		}
 	})
 	defer closer()
 
@@ -70,7 +72,9 @@ func TestConsulSyncer_ReapConsulNamespace(t *testing.T) {
 
 	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
 		s.EnableNamespaces = true
-		s.ConsulNodeServicesClient = &ConsulOnePointSevenNodeServicesClient{}
+		s.ConsulNodeServicesClient = &ConsulNamespacesNodeServicesClient{
+			Client: client,
+		}
 	})
 	defer closer()
 
@@ -133,7 +137,9 @@ func TestConsulSyncer_reapServiceInstanceNamespacesEnabled(t *testing.T) {
 	})
 	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
 		s.EnableNamespaces = true
-		s.ConsulNodeServicesClient = &ConsulOnePointSevenNodeServicesClient{}
+		s.ConsulNodeServicesClient = &ConsulNamespacesNodeServicesClient{
+			Client: client,
+		}
 	})
 	defer closer()
 

--- a/catalog/to-consul/syncer_ent_test.go
+++ b/catalog/to-consul/syncer_ent_test.go
@@ -1,0 +1,168 @@
+// +build enterprise
+
+package catalog
+
+import (
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// Test that the syncer registers services in Consul namespaces.
+func TestConsulSyncer_ConsulNamespaces(t *testing.T) {
+	t.Parallel()
+	a, err := testutil.NewTestServerT(t)
+	require.NoError(t, err)
+	defer a.Stop()
+	client, err := api.NewClient(&api.Config{
+		Address: a.HTTPAddr,
+	})
+	require.NoError(t, err)
+
+	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
+		s.EnableNamespaces = true
+	})
+	defer closer()
+
+	// We expect services to be created in the default and foo namespaces.
+	namespaces := []string{"default", "foo"}
+	var registrations []*api.CatalogRegistration
+	for _, ns := range namespaces {
+		registrations = append(registrations,
+			// The services will be named the same as their namespaces.
+			testRegistrationNS(ConsulSyncNodeName, ns, ns, ns))
+	}
+	s.Sync(registrations)
+
+	retry.Run(t, func(r *retry.R) {
+		for _, ns := range namespaces {
+			svcInstances, _, err := client.Catalog().Service(ns, "k8s", &api.QueryOptions{
+				Namespace: ns,
+			})
+			require.NoError(r, err)
+			require.Len(r, svcInstances, 1)
+			instance := svcInstances[0]
+			require.Equal(r, ConsulSyncNodeName, instance.Node)
+			require.Equal(r, "127.0.0.1", instance.Address)
+			require.Equal(r, map[string]string{ConsulSourceKey: "k8s"}, instance.NodeMeta)
+			require.Equal(r, map[string]string{
+				ConsulSourceKey: "k8s",
+				ConsulK8SNS:     ns,
+			}, instance.ServiceMeta)
+		}
+	})
+}
+
+// Test the syncer reaps services that weren't registered by us
+// across all Consul namespaces.
+func TestConsulSyncer_ReapConsulNamespace(t *testing.T) {
+	t.Parallel()
+	a, err := testutil.NewTestServerT(t)
+	require.NoError(t, err)
+	defer a.Stop()
+	client, err := api.NewClient(&api.Config{
+		Address: a.HTTPAddr,
+	})
+	require.NoError(t, err)
+
+	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
+		s.EnableNamespaces = true
+	})
+	defer closer()
+
+	// We expect services to be created in the default and foo namespaces.
+	s.Sync([]*api.CatalogRegistration{
+		testRegistrationNS(ConsulSyncNodeName, "default", "default", "default"),
+		testRegistrationNS(ConsulSyncNodeName, "foo", "foo", "foo"),
+	})
+
+	// We create services we expect to be deleted in the bar and baz namespaces.
+	expEmptiedNamespaces := []string{"bar", "baz"}
+	for _, ns := range expEmptiedNamespaces {
+		svc := testRegistrationNS(ConsulSyncNodeName, ns, ns, ns)
+		_, _, err := client.Namespaces().Create(&api.Namespace{
+			Name: ns,
+		}, nil)
+		require.NoError(t, err)
+		_, err = client.Catalog().Register(svc, &api.WriteOptions{
+			Namespace: ns,
+		})
+		require.NoError(t, err)
+	}
+
+	retry.Run(t, func(r *retry.R) {
+		// Invalid services should be deleted.
+		for _, ns := range expEmptiedNamespaces {
+			svcs, _, err := client.Catalog().Services(&api.QueryOptions{
+				Namespace: ns,
+			})
+			require.NoError(r, err)
+			require.Len(r, svcs, 0)
+		}
+
+		// The services in the foo and default namespaces should still exist.
+		for _, ns := range []string{"default", "foo"} {
+			svcs, _, err := client.Catalog().Services(&api.QueryOptions{
+				Namespace: ns,
+			})
+			require.NoError(r, err)
+			// The default namespace should have the consul service registered
+			// so its count should be 2.
+			if ns == "default" {
+				require.Len(r, svcs, 2)
+			} else {
+				require.Len(r, svcs, 1)
+			}
+		}
+	})
+}
+
+// Test that the syncer reaps individual invalid service instances when
+// namespaces are enabled.
+func TestConsulSyncer_reapServiceInstanceNamespacesEnabled(t *testing.T) {
+	t.Parallel()
+	a, err := testutil.NewTestServerT(t)
+	require.NoError(t, err)
+	defer a.Stop()
+	client, err := api.NewClient(&api.Config{
+		Address: a.HTTPAddr,
+	})
+	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
+		s.EnableNamespaces = true
+	})
+	defer closer()
+
+	// We'll create one service in the foo namespace. It should only have one
+	// instance.
+	s.Sync([]*api.CatalogRegistration{
+		testRegistrationNS(ConsulSyncNodeName, "foo", "foo", "foo"),
+	})
+
+	// Create an invalid instance service directly in Consul.
+	_, _, err = client.Namespaces().Create(&api.Namespace{
+		Name: "foo",
+	}, nil)
+	require.NoError(t, err)
+	svc := testRegistrationNS(ConsulSyncNodeName, "foo", "foo", "foo")
+	svc.Service.ID = serviceID("k8s-sync", "foo2")
+	_, err = client.Catalog().Register(svc, nil)
+	require.NoError(t, err)
+
+	// Test that the invalid instance is reaped.
+	retry.Run(t, func(r *retry.R) {
+		services, _, err := client.Catalog().Service("foo", "", &api.QueryOptions{
+			Namespace: "foo",
+		})
+		require.NoError(r, err)
+		require.Len(r, services, 1)
+		require.Equal(r, "foo", services[0].ServiceName)
+	})
+}
+
+func testRegistrationNS(node, service, k8sSrcNS, consulDestNS string) *api.CatalogRegistration {
+	r := testRegistration(node, service, k8sSrcNS)
+	r.Service.Namespace = consulDestNS
+	return r
+}

--- a/catalog/to-consul/syncer_ent_test.go
+++ b/catalog/to-consul/syncer_ent_test.go
@@ -23,6 +23,7 @@ func TestConsulSyncer_ConsulNamespaces(t *testing.T) {
 
 	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
 		s.EnableNamespaces = true
+		s.ConsulNodeServicesClient = &ConsulOnePointSevenNodeServicesClient{}
 	})
 	defer closer()
 
@@ -69,6 +70,7 @@ func TestConsulSyncer_ReapConsulNamespace(t *testing.T) {
 
 	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
 		s.EnableNamespaces = true
+		s.ConsulNodeServicesClient = &ConsulOnePointSevenNodeServicesClient{}
 	})
 	defer closer()
 
@@ -131,6 +133,7 @@ func TestConsulSyncer_reapServiceInstanceNamespacesEnabled(t *testing.T) {
 	})
 	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
 		s.EnableNamespaces = true
+		s.ConsulNodeServicesClient = &ConsulOnePointSevenNodeServicesClient{}
 	})
 	defer closer()
 

--- a/catalog/to-consul/syncer_test.go
+++ b/catalog/to-consul/syncer_test.go
@@ -217,12 +217,14 @@ func testConsulSyncer(client *api.Client) (*ConsulSyncer, func()) {
 // prior to starting via the configurator method.
 func testConsulSyncerWithConfig(client *api.Client, configurator func(*ConsulSyncer)) (*ConsulSyncer, func()) {
 	s := &ConsulSyncer{
-		Client:                   client,
-		Log:                      hclog.Default(),
-		SyncPeriod:               200 * time.Millisecond,
-		ServicePollPeriod:        50 * time.Millisecond,
-		ConsulK8STag:             TestConsulK8STag,
-		ConsulNodeServicesClient: &ConsulPreOnePointSevenNodeServicesClient{},
+		Client:            client,
+		Log:               hclog.Default(),
+		SyncPeriod:        200 * time.Millisecond,
+		ServicePollPeriod: 50 * time.Millisecond,
+		ConsulK8STag:      TestConsulK8STag,
+		ConsulNodeServicesClient: &ConsulPreNamespacesNodeServicesClient{
+			Client: client,
+		},
 	}
 	configurator(s)
 	s.init()

--- a/catalog/to-consul/syncer_test.go
+++ b/catalog/to-consul/syncer_test.go
@@ -2,12 +2,12 @@ package catalog
 
 import (
 	"context"
+	"github.com/hashicorp/consul/sdk/testutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	"github.com/deckarep/golang-set"
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -25,12 +25,12 @@ func TestConsulSyncer_register(t *testing.T) {
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	client := a.Client()
 
-	s, closer := testConsulSyncer(t, client)
+	s, closer := testConsulSyncer(client)
 	defer closer()
 
 	// Sync
 	s.Sync([]*api.CatalogRegistration{
-		testRegistration("k8s-sync", "bar", "default"),
+		testRegistration(ConsulSyncNodeName, "bar", "default"),
 	})
 
 	// Read the service back out
@@ -52,59 +52,7 @@ func TestConsulSyncer_register(t *testing.T) {
 	require.Equal("127.0.0.1", service.Address)
 }
 
-// Test that the syncer reaps invalid services
-func TestConsulSyncer_reapService(t *testing.T) {
-	t.Parallel()
-	require := require.New(t)
-
-	a := agent.NewTestAgent(t, t.Name(), ``)
-	defer a.Shutdown()
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
-	client := a.Client()
-
-	s, closer := testConsulSyncer(t, client)
-	defer closer()
-
-	// Sync
-	s.Sync([]*api.CatalogRegistration{
-		testRegistration("k8s-sync", "bar", "default"),
-	})
-
-	// Create an invalid service directly in Consul
-	_, err := client.Catalog().Register(testRegistration("k8s-sync", "baz", "default"), nil)
-	require.NoError(err)
-
-	// Reaped service should not exist
-	retry.Run(t, func(r *retry.R) {
-		services, _, err := client.Catalog().Service("baz", "", nil)
-		if err != nil {
-			r.Fatalf("err: %s", err)
-		}
-		if len(services) > 0 {
-			r.Fatal("service still exists")
-		}
-	})
-
-	// Valid service should exist
-	var service *api.CatalogService
-	retry.Run(t, func(r *retry.R) {
-		services, _, err := client.Catalog().Service("bar", "", nil)
-		if err != nil {
-			r.Fatalf("err: %s", err)
-		}
-		if len(services) == 0 {
-			r.Fatal("service not found")
-		}
-		service = services[0]
-	})
-
-	// Verify the settings
-	require.Equal("k8s-sync", service.Node)
-	require.Equal("bar", service.ServiceName)
-	require.Equal("127.0.0.1", service.Address)
-}
-
-// Test that the syncer reaps invalid services by instance
+// Test that the syncer reaps individual invalid service instances.
 func TestConsulSyncer_reapServiceInstance(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
@@ -114,12 +62,12 @@ func TestConsulSyncer_reapServiceInstance(t *testing.T) {
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	client := a.Client()
 
-	s, closer := testConsulSyncer(t, client)
+	s, closer := testConsulSyncer(client)
 	defer closer()
 
 	// Sync
 	s.Sync([]*api.CatalogRegistration{
-		testRegistration("k8s-sync", "bar", "default"),
+		testRegistration(ConsulSyncNodeName, "bar", "default"),
 	})
 
 	// Wait for the first service
@@ -134,7 +82,7 @@ func TestConsulSyncer_reapServiceInstance(t *testing.T) {
 	})
 
 	// Create an invalid service directly in Consul
-	svc := testRegistration("k8s-sync", "bar", "default")
+	svc := testRegistration(ConsulSyncNodeName, "bar", "default")
 	svc.Service.ID = serviceID("k8s-sync", "bar2")
 	_, err := client.Catalog().Register(svc, nil)
 	require.NoError(err)
@@ -159,93 +107,52 @@ func TestConsulSyncer_reapServiceInstance(t *testing.T) {
 	require.Equal("127.0.0.1", service.Address)
 }
 
-// Test that the syncer does not reap services in another NS.
-// func TestConsulSyncer_reapServiceOtherNamespace(t *testing.T) {
-// 	t.Parallel()
-// 	require := require.New(t)
-
-// 	a := agent.NewTestAgent(t, t.Name(), ``)
-// 	defer a.Shutdown()
-// 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
-// 	client := a.Client()
-
-// 	s, closer := testConsulSyncer(t, client)
-// 	// Restrict namespace allow list to a single namespace
-// 	allowSet := mapset.NewSet("namespace")
-// 	s.AllowK8sNamespacesSet = allowSet
-// 	defer closer()
-
-// 	// Sync
-// 	s.Sync([]*api.CatalogRegistration{
-// 		testRegistration("foo", "bar", "namespace"),
-// 	})
-
-// 	// Create an invalid service directly in Consul
-// 	svc := testRegistration("foo", "baz")
-// 	svc.Service.Meta[ConsulK8SNS] = "other"
-// 	_, err := client.Catalog().Register(svc, nil)
-// 	require.NoError(err)
-
-// 	// Sleep for a bit
-// 	time.Sleep(500 * time.Millisecond)
-
-// 	// Valid service should exist
-// 	services, _, err := client.Catalog().Service("baz", "", nil)
-// 	require.NoError(err)
-// 	require.Len(services, 1)
-// }
-
-// Test that the syncer reaps services with no NS set.
-func TestConsulSyncer_reapServiceSameNamespace(t *testing.T) {
+// Test that the syncer reaps services not registered by us that are tagged
+// with k8s.
+func TestConsulSyncer_reapService(t *testing.T) {
 	t.Parallel()
-	require := require.New(t)
 
-	a := agent.NewTestAgent(t, t.Name(), ``)
-	defer a.Shutdown()
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
-	client := a.Client()
+	sourceK8sNamespaceAnnotations := []string{"", "other", "default"}
+	for _, k8sNS := range sourceK8sNamespaceAnnotations {
+		t.Run(k8sNS, func(tt *testing.T) {
+			a, err := testutil.NewTestServerT(tt)
+			require.NoError(tt, err)
+			defer a.Stop()
+			client, err := api.NewClient(&api.Config{
+				Address: a.HTTPAddr,
+			})
+			require.NoError(tt, err)
+			s, closer := testConsulSyncer(client)
+			defer closer()
 
-	s, closer := testConsulSyncer(t, client)
-	defer closer()
+			s.Sync([]*api.CatalogRegistration{
+				testRegistration(ConsulSyncNodeName, "bar", "default"),
+			})
 
-	// Sync
-	s.Sync([]*api.CatalogRegistration{
-		testRegistration("k8s-sync", "bar", "default"),
-	})
+			// Create a service directly in Consul. Since it was created directly we
+			// expect it to be deleted.
+			svc := testRegistration(ConsulSyncNodeName, "baz", "default")
+			svc.Service.Meta[ConsulK8SNS] = k8sNS
+			_, err = client.Catalog().Register(svc, nil)
+			require.NoError(tt, err)
 
-	// Create an invalid service directly in Consul
-	svc := testRegistration("k8s-sync", "baz", "")
-	_, err := client.Catalog().Register(svc, nil)
-	require.NoError(err)
+			retry.Run(tt, func(r *retry.R) {
+				// Invalid service should be deleted.
+				bazInstances, _, err := client.Catalog().Service("baz", "", nil)
+				require.NoError(r, err)
+				require.Len(r, bazInstances, 0)
 
-	// Reaped service should not exist
-	retry.Run(t, func(r *retry.R) {
-		services, _, err := client.Catalog().Service("baz", "", nil)
-		if err != nil {
-			r.Fatalf("err: %s", err)
-		}
-		if len(services) > 0 {
-			r.Fatal("service still exists")
-		}
-	})
-
-	// Valid service should exist
-	var service *api.CatalogService
-	retry.Run(t, func(r *retry.R) {
-		services, _, err := client.Catalog().Service("bar", "", nil)
-		if err != nil {
-			r.Fatalf("err: %s", err)
-		}
-		if len(services) == 0 {
-			r.Fatal("service not found")
-		}
-		service = services[0]
-	})
-
-	// Verify the settings
-	require.Equal("k8s-sync", service.Node)
-	require.Equal("bar", service.ServiceName)
-	require.Equal("127.0.0.1", service.Address)
+				// Valid service should still be registered.
+				barInstances, _, err := client.Catalog().Service("bar", "", nil)
+				require.NoError(r, err)
+				require.Len(r, barInstances, 1)
+				service := barInstances[0]
+				require.Equal(r, ConsulSyncNodeName, service.Node)
+				require.Equal(r, "bar", service.ServiceName)
+				require.Equal(r, "127.0.0.1", service.Address)
+			})
+		})
+	}
 }
 
 // Test that when the syncer is stopped, we don't continue to call the Consul
@@ -271,7 +178,7 @@ func TestConsulSyncer_stopsGracefully(t *testing.T) {
 		Address: consulServer.URL,
 	})
 	require.NoError(t, err)
-	s, closer := testConsulSyncer(t, client)
+	s, closer := testConsulSyncer(client)
 	s.Sync([]*api.CatalogRegistration{
 		testRegistration("k8s-sync", "bar", "default"),
 	})
@@ -284,7 +191,7 @@ func TestConsulSyncer_stopsGracefully(t *testing.T) {
 	require.LessOrEqual(t, callCount-beforeStopAPICount, 2)
 }
 
-func testRegistration(node, service, namespace string) *api.CatalogRegistration {
+func testRegistration(node, service, k8sSrcNamespace string) *api.CatalogRegistration {
 	return &api.CatalogRegistration{
 		Node:           node,
 		Address:        "127.0.0.1",
@@ -296,26 +203,28 @@ func testRegistration(node, service, namespace string) *api.CatalogRegistration 
 			Tags:    []string{TestConsulK8STag},
 			Meta: map[string]string{
 				ConsulSourceKey: TestConsulK8STag,
-				ConsulK8SNS:     namespace,
+				ConsulK8SNS:     k8sSrcNamespace,
 			},
 		},
 	}
 }
 
-func testConsulSyncer(t *testing.T, client *api.Client) (*ConsulSyncer, func()) {
-	// Set up required allow and deny sets
-	allowSet := mapset.NewSet("*")
-	denySet := mapset.NewSet()
+func testConsulSyncer(client *api.Client) (*ConsulSyncer, func()) {
+	return testConsulSyncerWithConfig(client, func(syncer *ConsulSyncer) {})
+}
 
+// testConsulSyncerWithConfig starts a consul syncer that can be configured
+// prior to starting via the configurator method.
+func testConsulSyncerWithConfig(client *api.Client, configurator func(*ConsulSyncer)) (*ConsulSyncer, func()) {
 	s := &ConsulSyncer{
-		Client:                client,
-		Log:                   hclog.Default(),
-		SyncPeriod:            200 * time.Millisecond,
-		ServicePollPeriod:     50 * time.Millisecond,
-		AllowK8sNamespacesSet: allowSet,
-		DenyK8sNamespacesSet:  denySet,
-		ConsulK8STag:          TestConsulK8STag,
+		Client:            client,
+		Log:               hclog.Default(),
+		SyncPeriod:        200 * time.Millisecond,
+		ServicePollPeriod: 50 * time.Millisecond,
+		ConsulK8STag:      TestConsulK8STag,
 	}
+	configurator(s)
+	s.init()
 
 	ctx, cancelF := context.WithCancel(context.Background())
 	doneCh := make(chan struct{})

--- a/catalog/to-consul/syncer_test.go
+++ b/catalog/to-consul/syncer_test.go
@@ -217,11 +217,12 @@ func testConsulSyncer(client *api.Client) (*ConsulSyncer, func()) {
 // prior to starting via the configurator method.
 func testConsulSyncerWithConfig(client *api.Client, configurator func(*ConsulSyncer)) (*ConsulSyncer, func()) {
 	s := &ConsulSyncer{
-		Client:            client,
-		Log:               hclog.Default(),
-		SyncPeriod:        200 * time.Millisecond,
-		ServicePollPeriod: 50 * time.Millisecond,
-		ConsulK8STag:      TestConsulK8STag,
+		Client:                   client,
+		Log:                      hclog.Default(),
+		SyncPeriod:               200 * time.Millisecond,
+		ServicePollPeriod:        50 * time.Millisecond,
+		ConsulK8STag:             TestConsulK8STag,
+		ConsulNodeServicesClient: &ConsulPreOnePointSevenNodeServicesClient{},
 	}
 	configurator(s)
 	s.init()

--- a/subcommand/sync-catalog/command.go
+++ b/subcommand/sync-catalog/command.go
@@ -224,9 +224,13 @@ func (c *Command) Run(args []string) int {
 		// enabled we use a client that queries the older API endpoint.
 		var svcsClient catalogtoconsul.ConsulNodeServicesClient
 		if c.flagEnableNamespaces {
-			svcsClient = &catalogtoconsul.ConsulOnePointSevenNodeServicesClient{}
+			svcsClient = &catalogtoconsul.ConsulNamespacesNodeServicesClient{
+				Client: c.consulClient,
+			}
 		} else {
-			svcsClient = &catalogtoconsul.ConsulPreOnePointSevenNodeServicesClient{}
+			svcsClient = &catalogtoconsul.ConsulPreNamespacesNodeServicesClient{
+				Client: c.consulClient,
+			}
 		}
 		// Build the Consul sync and start it
 		syncer := &catalogtoconsul.ConsulSyncer{

--- a/subcommand/sync-catalog/command_ent_test.go
+++ b/subcommand/sync-catalog/command_ent_test.go
@@ -1,0 +1,488 @@
+// +build enterprise
+
+package synccatalog
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/go-hclog"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// Test syncing to a single destination consul namespace.
+func TestRun_ToConsulSingleDestinationNamespace(t *testing.T) {
+	t.Parallel()
+
+	consulDestNamespaces := []string{"default", "destination"}
+	for _, consulDestNamespace := range consulDestNamespaces {
+		t.Run(consulDestNamespace, func(tt *testing.T) {
+			k8s, testAgent := completeSetupEnterprise(tt)
+			defer testAgent.Stop()
+
+			// Run the command.
+			ui := cli.NewMockUi()
+			consulClient, err := api.NewClient(&api.Config{
+				Address: testAgent.HTTPAddr,
+			})
+			require.NoError(tt, err)
+
+			cmd := Command{
+				UI:           ui,
+				clientset:    k8s,
+				consulClient: consulClient,
+				logger: hclog.New(&hclog.LoggerOptions{
+					Name:  tt.Name(),
+					Level: hclog.Debug,
+				}),
+			}
+
+			// Create two services in k8s in default and foo namespaces.
+			_, err = k8s.CoreV1().Services(metav1.NamespaceDefault).Create(lbService("default", "1.1.1.1"))
+			require.NoError(tt, err)
+			_, err = k8s.CoreV1().Namespaces().Create(&apiv1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			})
+			require.NoError(tt, err)
+			_, err = k8s.CoreV1().Services("foo").Create(lbService("foo", "1.1.1.1"))
+			require.NoError(tt, err)
+
+			exitChan := runCommandAsynchronously(&cmd, []string{
+				"-consul-write-interval", "500ms",
+				"-add-k8s-namespace-suffix",
+				"-log-level=debug",
+				"-enable-namespaces",
+				"-consul-destination-namespace", consulDestNamespace,
+				"-allow-k8s-namespace=*",
+				"-add-k8s-namespace-suffix=false",
+			})
+			defer stopCommand(tt, &cmd, exitChan)
+
+			timer := &retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}
+			retry.RunWith(timer, tt, func(r *retry.R) {
+				// Both services should have been created in the destination namespace.
+				for _, svcName := range []string{"default", "foo"} {
+					instances, _, err := consulClient.Catalog().Service(svcName, "k8s", &api.QueryOptions{
+						Namespace: consulDestNamespace,
+					})
+					require.NoError(r, err)
+					require.Len(r, instances, 1)
+					require.Equal(r, instances[0].ServiceName, svcName)
+				}
+			})
+		})
+	}
+}
+
+// Test syncing with mirroring and different prefixes.
+func TestRun_ToConsulMirroringNamespaces(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		// MirroringPrefix is the value passed to -k8s-namespace-mirroring-prefix.
+		MirroringPrefix string
+		// ExtraFlags are extra flags for the command.
+		ExtraFlags []string
+		// ExpectNamespaceSuffix controls whether we expect the service names
+		// to have their namespaces as a suffix.
+		ExpectNamespaceSuffix bool
+	}{
+		"no prefix, no suffix": {
+			MirroringPrefix:       "",
+			ExtraFlags:            []string{"-add-k8s-namespace-suffix=false"},
+			ExpectNamespaceSuffix: false,
+		},
+		"no prefix, with suffix": {
+			MirroringPrefix:       "",
+			ExtraFlags:            []string{"-add-k8s-namespace-suffix=true"},
+			ExpectNamespaceSuffix: true,
+		},
+		"with prefix, no suffix": {
+			MirroringPrefix:       "prefix-",
+			ExtraFlags:            []string{"-add-k8s-namespace-suffix=false"},
+			ExpectNamespaceSuffix: false,
+		},
+		"with prefix, with suffix": {
+			MirroringPrefix:       "prefix-",
+			ExtraFlags:            []string{"-add-k8s-namespace-suffix=true"},
+			ExpectNamespaceSuffix: true,
+		},
+		"no prefix, no suffix, with destination namespace flag": {
+			MirroringPrefix: "",
+			// Mirroring takes precedence over the -consul-destination-namespace
+			// flag so it should have no effect.
+			ExtraFlags:            []string{"-add-k8s-namespace-suffix=false", "-consul-destination-namespace=dest"},
+			ExpectNamespaceSuffix: false,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(tt *testing.T) {
+			k8s, testAgent := completeSetupEnterprise(tt)
+			defer testAgent.Stop()
+
+			// Run the command.
+			ui := cli.NewMockUi()
+			consulClient, err := api.NewClient(&api.Config{
+				Address: testAgent.HTTPAddr,
+			})
+			require.NoError(tt, err)
+
+			cmd := Command{
+				UI:           ui,
+				clientset:    k8s,
+				consulClient: consulClient,
+				logger: hclog.New(&hclog.LoggerOptions{
+					Name:  tt.Name(),
+					Level: hclog.Debug,
+				}),
+			}
+
+			// Create two services in k8s in default and foo namespaces.
+			_, err = k8s.CoreV1().Services(metav1.NamespaceDefault).Create(lbService("default", "1.1.1.1"))
+			require.NoError(tt, err)
+			_, err = k8s.CoreV1().Namespaces().Create(&apiv1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			})
+			require.NoError(tt, err)
+			_, err = k8s.CoreV1().Services("foo").Create(lbService("foo", "1.1.1.1"))
+			require.NoError(tt, err)
+
+			args := append([]string{
+				"-consul-write-interval", "500ms",
+				"-add-k8s-namespace-suffix",
+				"-log-level=debug",
+				"-enable-namespaces",
+				"-allow-k8s-namespace=*",
+				"-enable-k8s-namespace-mirroring",
+				"-k8s-namespace-mirroring-prefix", c.MirroringPrefix,
+			}, c.ExtraFlags...)
+			exitChan := runCommandAsynchronously(&cmd, args)
+			defer stopCommand(tt, &cmd, exitChan)
+
+			timer := &retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}
+			retry.RunWith(timer, tt, func(r *retry.R) {
+				// Each service should have been created in a mirrored namespace.
+				for _, svcName := range []string{"default", "foo"} {
+					// NOTE: svcName is the same as the kubernetes namespace.
+					expNamespace := c.MirroringPrefix + svcName
+					if c.ExpectNamespaceSuffix {
+						// Since the service name is the same as the namespace,
+						// in the case of the namespace suffix we expect
+						// the service name to be suffixed.
+						svcName = fmt.Sprintf("%s-%s", svcName, svcName)
+					}
+					instances, _, err := consulClient.Catalog().Service(svcName, "k8s", &api.QueryOptions{
+						Namespace: expNamespace,
+					})
+					require.NoError(r, err)
+					require.Len(r, instances, 1)
+					require.Equal(r, instances[0].ServiceName, svcName)
+				}
+			})
+		})
+	}
+}
+
+// Test that when flags are changed and the command re-run, old services
+// are deleted and new services are created where expected.
+func TestRun_ToConsulChangingNamespaceFlags(t *testing.T) {
+	t.Parallel()
+
+	// There are many different settings:
+	//   1. Namespaces enabled with a single destination namespace (single-dest-ns)
+	//   2. Namespaces enabled with mirroring namespaces (mirroring-ns)
+	//   3. Namespaces enabled with mirroring namespaces and prefixes (mirroring-ns-prefix)
+	//
+	// NOTE: In all cases, two services will be created in Kubernetes:
+	//   1. namespace: default, name: default
+	//   2. namespace: foo, name: foo
+
+	cases := map[string]struct {
+		// FirstRunFlags are the command flags for the first run of the command.
+		FirstRunFlags []string
+		// FirstRunExpServices are the services we expect to be created on the
+		// first run. They're specified as "name/namespace".
+		FirstRunExpServices []string
+		// SecondRunFlags are the command flags for the second run of the command.
+		SecondRunFlags []string
+		// SecondRunExpServices are the services we expect to be created on the
+		// second run. They're specified as "name/namespace".
+		SecondRunExpServices []string
+		// SecondRunExpDeletedServices are the services we expect to be deleted
+		// on the second run. They're specified as "name/namespace".
+		SecondRunExpDeletedServices []string
+	}{
+		"namespaces-disabled => single-dest-ns=default": {
+			FirstRunFlags:       nil,
+			FirstRunExpServices: []string{"foo/default", "default/default"},
+			SecondRunFlags: []string{
+				"-enable-namespaces",
+				"-consul-destination-namespace=default",
+			},
+			SecondRunExpServices:        []string{"foo/default", "default/default"},
+			SecondRunExpDeletedServices: nil,
+		},
+		"namespaces-disabled => single-dest-ns=dest": {
+			FirstRunFlags:       nil,
+			FirstRunExpServices: []string{"foo/default", "default/default"},
+			SecondRunFlags: []string{
+				"-enable-namespaces",
+				"-consul-destination-namespace=dest",
+			},
+			SecondRunExpServices:        []string{"foo/dest", "default/dest"},
+			SecondRunExpDeletedServices: []string{"foo/default", "default/default"},
+		},
+		"namespaces-disabled => mirroring-ns": {
+			FirstRunFlags:       nil,
+			FirstRunExpServices: []string{"foo/default", "default/default"},
+			SecondRunFlags: []string{
+				"-enable-namespaces",
+				"-enable-k8s-namespace-mirroring",
+			},
+			SecondRunExpServices:        []string{"foo/foo", "default/default"},
+			SecondRunExpDeletedServices: []string{"foo/default"},
+		},
+		"namespaces-disabled => mirroring-ns-prefix": {
+			FirstRunFlags:       nil,
+			FirstRunExpServices: []string{"foo/default", "default/default"},
+			SecondRunFlags: []string{
+				"-enable-namespaces",
+				"-enable-k8s-namespace-mirroring",
+				"-k8s-namespace-mirroring-prefix=prefix-",
+			},
+			SecondRunExpServices:        []string{"foo/prefix-foo", "default/prefix-default"},
+			SecondRunExpDeletedServices: []string{"foo/default", "default/default"},
+		},
+		"single-dest-ns=first => single-dest-ns=second": {
+			FirstRunFlags: []string{
+				"-enable-namespaces",
+				"-consul-destination-namespace=first",
+			},
+			FirstRunExpServices: []string{"foo/first", "default/first"},
+			SecondRunFlags: []string{
+				"-enable-namespaces",
+				"-consul-destination-namespace=second",
+			},
+			SecondRunExpServices:        []string{"foo/second", "default/second"},
+			SecondRunExpDeletedServices: []string{"foo/first", "default/first"},
+		},
+		"single-dest-ns => mirroring-ns": {
+			FirstRunFlags: []string{
+				"-enable-namespaces",
+				"-consul-destination-namespace=first",
+			},
+			FirstRunExpServices: []string{"foo/first", "default/first"},
+			SecondRunFlags: []string{
+				"-enable-namespaces",
+				"-enable-k8s-namespace-mirroring",
+			},
+			SecondRunExpServices:        []string{"foo/foo", "default/default"},
+			SecondRunExpDeletedServices: []string{"foo/first", "default/first"},
+		},
+		"single-dest-ns => mirroring-ns-prefix": {
+			FirstRunFlags: []string{
+				"-enable-namespaces",
+				"-consul-destination-namespace=first",
+			},
+			FirstRunExpServices: []string{"foo/first", "default/first"},
+			SecondRunFlags: []string{
+				"-enable-namespaces",
+				"-enable-k8s-namespace-mirroring",
+				"-k8s-namespace-mirroring-prefix=prefix-",
+			},
+			SecondRunExpServices:        []string{"foo/prefix-foo", "default/prefix-default"},
+			SecondRunExpDeletedServices: []string{"foo/first", "default/first"},
+		},
+		"mirroring-ns => single-dest-ns": {
+			FirstRunFlags: []string{
+				"-enable-namespaces",
+				"-enable-k8s-namespace-mirroring",
+			},
+			FirstRunExpServices: []string{"foo/foo", "default/default"},
+			SecondRunFlags: []string{
+				"-enable-namespaces",
+				"-consul-destination-namespace=second",
+			},
+			SecondRunExpServices:        []string{"foo/second", "default/second"},
+			SecondRunExpDeletedServices: []string{"foo/foo", "default/default"},
+		},
+		"mirroring-ns => mirroring-ns-prefix": {
+			FirstRunFlags: []string{
+				"-enable-namespaces",
+				"-enable-k8s-namespace-mirroring",
+			},
+			FirstRunExpServices: []string{"foo/foo", "default/default"},
+			SecondRunFlags: []string{
+				"-enable-namespaces",
+				"-enable-k8s-namespace-mirroring",
+				"-k8s-namespace-mirroring-prefix=prefix-",
+			},
+			SecondRunExpServices:        []string{"foo/prefix-foo", "default/prefix-default"},
+			SecondRunExpDeletedServices: []string{"foo/foo", "default/default"},
+		},
+		"mirroring-ns-prefix => single-dest-ns": {
+			FirstRunFlags: []string{
+				"-enable-namespaces",
+				"-enable-k8s-namespace-mirroring",
+				"-k8s-namespace-mirroring-prefix=prefix-",
+			},
+			FirstRunExpServices: []string{"foo/prefix-foo", "default/prefix-default"},
+			SecondRunFlags: []string{
+				"-enable-namespaces",
+				"-consul-destination-namespace=second",
+			},
+			SecondRunExpServices:        []string{"foo/second", "default/second"},
+			SecondRunExpDeletedServices: []string{"foo/prefix-foo", "default/prefix-default"},
+		},
+		"mirroring-ns-prefix => mirroring-ns": {
+			FirstRunFlags: []string{
+				"-enable-namespaces",
+				"-enable-k8s-namespace-mirroring",
+				"-k8s-namespace-mirroring-prefix=prefix-",
+			},
+			FirstRunExpServices: []string{"foo/prefix-foo", "default/prefix-default"},
+			SecondRunFlags: []string{
+				"-enable-namespaces",
+				"-enable-k8s-namespace-mirroring",
+			},
+			SecondRunExpServices:        []string{"foo/foo", "default/default"},
+			SecondRunExpDeletedServices: []string{"foo/prefix-foo", "default/prefix-default"},
+		},
+	}
+
+	nameAndNS := func(s string) (string, string) {
+		split := strings.Split(s, "/")
+		return split[0], split[1]
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(tt *testing.T) {
+			k8s, testAgent := completeSetupEnterprise(tt)
+			defer testAgent.Stop()
+			ui := cli.NewMockUi()
+			consulClient, err := api.NewClient(&api.Config{
+				Address: testAgent.HTTPAddr,
+			})
+			require.NoError(tt, err)
+
+			commonArgs := []string{
+				"-consul-write-interval", "500ms",
+				"-log-level=debug",
+				"-allow-k8s-namespace=*",
+			}
+
+			// Create two services in k8s in default and foo namespaces.
+			{
+				_, err = k8s.CoreV1().Services(metav1.NamespaceDefault).Create(lbService("default", "1.1.1.1"))
+				require.NoError(tt, err)
+				_, err = k8s.CoreV1().Namespaces().Create(&apiv1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+					},
+				})
+				require.NoError(tt, err)
+				_, err = k8s.CoreV1().Services("foo").Create(lbService("foo", "1.1.1.1"))
+				require.NoError(tt, err)
+
+			}
+
+			// Run the first command.
+			{
+				firstCmd := Command{
+					UI:           ui,
+					clientset:    k8s,
+					consulClient: consulClient,
+					logger: hclog.New(&hclog.LoggerOptions{
+						Name:  tt.Name() + "-firstrun",
+						Level: hclog.Debug,
+					}),
+				}
+				exitChan := runCommandAsynchronously(&firstCmd, append(commonArgs, c.FirstRunFlags...))
+
+				// Wait until the expected services are synced.
+				timer := &retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}
+				retry.RunWith(timer, tt, func(r *retry.R) {
+					for _, svcNamespace := range c.FirstRunExpServices {
+						svcName, ns := nameAndNS(svcNamespace)
+						instances, _, err := consulClient.Catalog().Service(svcName, "k8s", &api.QueryOptions{
+							Namespace: ns,
+						})
+						require.NoError(r, err)
+						require.Len(r, instances, 1)
+						require.Equal(r, instances[0].ServiceName, svcName)
+					}
+				})
+				stopCommand(tt, &firstCmd, exitChan)
+			}
+			tt.Log("first command run complete")
+
+			// Run the second command.
+			{
+				secondCmd := Command{
+					UI:           ui,
+					clientset:    k8s,
+					consulClient: consulClient,
+					logger: hclog.New(&hclog.LoggerOptions{
+						Name:  tt.Name() + "-secondrun",
+						Level: hclog.Debug,
+					}),
+				}
+				exitChan := runCommandAsynchronously(&secondCmd, append(commonArgs, c.SecondRunFlags...))
+				defer stopCommand(tt, &secondCmd, exitChan)
+
+				// Wait until the expected services are synced and the old ones
+				// deleted.
+				timer := &retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}
+				retry.RunWith(timer, tt, func(r *retry.R) {
+					for _, svcNamespace := range c.SecondRunExpServices {
+						svcName, ns := nameAndNS(svcNamespace)
+						instances, _, err := consulClient.Catalog().Service(svcName, "k8s", &api.QueryOptions{
+							Namespace: ns,
+						})
+						require.NoError(r, err)
+						require.Len(r, instances, 1)
+						require.Equal(r, instances[0].ServiceName, svcName)
+					}
+				})
+				tt.Log("existing services verified")
+
+				timer = &retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}
+				retry.RunWith(timer, tt, func(r *retry.R) {
+					for _, svcNamespace := range c.SecondRunExpDeletedServices {
+						svcName, ns := nameAndNS(svcNamespace)
+						instances, _, err := consulClient.Catalog().Service(svcName, "k8s", &api.QueryOptions{
+							Namespace: ns,
+						})
+						require.NoError(r, err)
+						require.Len(r, instances, 0)
+					}
+				})
+				tt.Log("deleted services verified")
+			}
+		})
+	}
+}
+
+// Set up test consul agent and fake kubernetes cluster client
+// todo: use this setup method everywhere. The old one (completeSetup) uses
+// the test agent instead of the testserver.
+func completeSetupEnterprise(t *testing.T) (*fake.Clientset, *testutil.TestServer) {
+	k8s := fake.NewSimpleClientset()
+	svr, err := testutil.NewTestServerT(t)
+	require.NoError(t, err)
+	return k8s, svr
+}

--- a/subcommand/sync-catalog/command_test.go
+++ b/subcommand/sync-catalog/command_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
 	apiv1 "k8s.io/api/core/v1"
@@ -25,6 +26,10 @@ func TestRun_Defaults_SyncsConsulServiceToK8s(t *testing.T) {
 	cmd := Command{
 		UI:        ui,
 		clientset: k8s,
+		logger: hclog.New(&hclog.LoggerOptions{
+			Name:  t.Name(),
+			Level: hclog.Debug,
+		}),
 	}
 
 	exitChan := runCommandAsynchronously(&cmd, []string{
@@ -52,9 +57,13 @@ func TestRun_ToConsulWithAddK8SNamespaceSuffix(t *testing.T) {
 	// Run the command.
 	ui := cli.NewMockUi()
 	cmd := Command{
-		UI:                         ui,
-		clientset:                  k8s,
-		consulClient:               testAgent.Client(),
+		UI:           ui,
+		clientset:    k8s,
+		consulClient: testAgent.Client(),
+		logger: hclog.New(&hclog.LoggerOptions{
+			Name:  t.Name(),
+			Level: hclog.Debug,
+		}),
 		flagAllowK8sNamespacesList: []string{"*"},
 	}
 
@@ -89,9 +98,13 @@ func TestCommand_Run_ToConsulChangeAddK8SNamespaceSuffixToTrue(t *testing.T) {
 	// Run the command.
 	ui := cli.NewMockUi()
 	cmd := Command{
-		UI:                         ui,
-		clientset:                  k8s,
-		consulClient:               testAgent.Client(),
+		UI:           ui,
+		clientset:    k8s,
+		consulClient: testAgent.Client(),
+		logger: hclog.New(&hclog.LoggerOptions{
+			Name:  t.Name(),
+			Level: hclog.Debug,
+		}),
 		flagAllowK8sNamespacesList: []string{"*"},
 	}
 
@@ -142,9 +155,13 @@ func TestCommand_Run_ToConsulTwoServicesSameNameDifferentNamespace(t *testing.T)
 	// Run the command.
 	ui := cli.NewMockUi()
 	cmd := Command{
-		UI:                         ui,
-		clientset:                  k8s,
-		consulClient:               testAgent.Client(),
+		UI:           ui,
+		clientset:    k8s,
+		consulClient: testAgent.Client(),
+		logger: hclog.New(&hclog.LoggerOptions{
+			Name:  t.Name(),
+			Level: hclog.Debug,
+		}),
 		flagAllowK8sNamespacesList: []string{"*"},
 	}
 
@@ -175,6 +192,284 @@ func TestCommand_Run_ToConsulTwoServicesSameNameDifferentNamespace(t *testing.T)
 	})
 }
 
+// Test the allow/deny list combinations.
+func TestRun_ToConsulAllowDenyLists(t *testing.T) {
+	t.Parallel()
+
+	// NOTE: In all cases, two services will be created in Kubernetes:
+	//   1. namespace: default, name: default
+	//   2. namespace: foo, name: foo
+
+	cases := map[string]struct {
+		AllowList   []string
+		DenyList    []string
+		ExpServices []string
+	}{
+		"empty lists": {
+			AllowList:   nil,
+			DenyList:    nil,
+			ExpServices: nil,
+		},
+		"only from allow list": {
+			AllowList:   []string{"foo"},
+			DenyList:    nil,
+			ExpServices: []string{"foo"},
+		},
+		"both in allow and deny": {
+			AllowList:   []string{"foo"},
+			DenyList:    []string{"foo"},
+			ExpServices: nil,
+		},
+		"deny removes one from allow": {
+			AllowList:   []string{"foo", "default"},
+			DenyList:    []string{"foo"},
+			ExpServices: []string{"default"},
+		},
+		"* in allow": {
+			AllowList:   []string{"*"},
+			DenyList:    nil,
+			ExpServices: []string{"foo", "default"},
+		},
+		"* in allow with one denied": {
+			AllowList:   []string{"*"},
+			DenyList:    []string{"foo"},
+			ExpServices: []string{"default"},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(tt *testing.T) {
+			k8s, testAgent := completeSetup(tt)
+			defer testAgent.Shutdown()
+			ui := cli.NewMockUi()
+			consulClient := testAgent.Client()
+
+			// Create two services in k8s in default and foo namespaces.
+			{
+				_, err := k8s.CoreV1().Services(metav1.NamespaceDefault).Create(lbService("default", "1.1.1.1"))
+				require.NoError(tt, err)
+				_, err = k8s.CoreV1().Namespaces().Create(&apiv1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+					},
+				})
+				require.NoError(tt, err)
+				_, err = k8s.CoreV1().Services("foo").Create(lbService("foo", "1.1.1.1"))
+				require.NoError(tt, err)
+			}
+
+			flags := []string{
+				"-consul-write-interval", "500ms",
+				"-log-level=debug",
+			}
+			for _, allow := range c.AllowList {
+				flags = append(flags, "-allow-k8s-namespace", allow)
+			}
+			for _, deny := range c.DenyList {
+				flags = append(flags, "-deny-k8s-namespace", deny)
+			}
+
+			cmd := Command{
+				UI:           ui,
+				clientset:    k8s,
+				consulClient: consulClient,
+				logger: hclog.New(&hclog.LoggerOptions{
+					Name:  tt.Name(),
+					Level: hclog.Debug,
+				}),
+			}
+			exitChan := runCommandAsynchronously(&cmd, flags)
+			defer stopCommand(tt, &cmd, exitChan)
+
+			timer := &retry.Timer{Timeout: 2 * time.Second, Wait: 500 * time.Millisecond}
+			retry.RunWith(timer, tt, func(r *retry.R) {
+				svcs, _, err := consulClient.Catalog().Services(nil)
+				require.NoError(r, err)
+				// There should be the number of expected services plus one
+				// for the default Consul service.
+				require.Len(r, svcs, len(c.ExpServices)+1)
+				for _, svc := range c.ExpServices {
+					instances, _, err := consulClient.Catalog().Service(svc, "k8s", nil)
+					require.NoError(r, err)
+					require.Len(r, instances, 1)
+					require.Equal(r, instances[0].ServiceName, svc)
+				}
+			})
+		})
+	}
+}
+
+// Test that when flags are changed and the command re-run, old services
+// are deleted and new services are created where expected.
+func TestRun_ToConsulChangingFlags(t *testing.T) {
+	t.Parallel()
+
+	// NOTE: In all cases, two services will be created in Kubernetes:
+	//   1. namespace: default, name: default
+	//   2. namespace: foo, name: foo
+	//
+	// NOTE: We're not testing all permutations the allow/deny lists. That is
+	// tested in TestRun_ToConsulAllowDenyLists. We assume that that test
+	// ensures the allow/deny lists are working and so all we need to test here
+	// is that if the resulting set of namespaces changes, we add/remove services
+	// accordingly.
+
+	cases := map[string]struct {
+		// FirstRunFlags are the command flags for the first run of the command.
+		FirstRunFlags []string
+		// FirstRunExpServices are the services we expect to be created on the
+		// first run.
+		FirstRunExpServices []string
+		// SecondRunFlags are the command flags for the second run of the command.
+		SecondRunFlags []string
+		// SecondRunExpServices are the services we expect to be created on the
+		// second run.
+		SecondRunExpServices []string
+		// SecondRunExpDeletedServices are the services we expect to be deleted
+		// on the second run.
+		SecondRunExpDeletedServices []string
+	}{
+		"service-suffix-false => service-suffix-true": {
+			FirstRunFlags: []string{
+				"-allow-k8s-namespace=*",
+				"-add-k8s-namespace-suffix=false",
+			},
+			FirstRunExpServices: []string{"foo", "default"},
+			SecondRunFlags: []string{
+				"-allow-k8s-namespace=*",
+				"-add-k8s-namespace-suffix=true",
+			},
+			SecondRunExpServices:        []string{"foo-foo", "default-default"},
+			SecondRunExpDeletedServices: []string{"foo", "default"},
+		},
+		"service-suffix-true => service-suffix-false": {
+			FirstRunFlags: []string{
+				"-allow-k8s-namespace=*",
+				"-add-k8s-namespace-suffix=true",
+			},
+			FirstRunExpServices: []string{"foo-foo", "default-default"},
+			SecondRunFlags: []string{
+				"-allow-k8s-namespace=*",
+				"-add-k8s-namespace-suffix=false",
+			},
+			SecondRunExpServices:        []string{"foo", "default"},
+			SecondRunExpDeletedServices: []string{"foo-default", "default-default"},
+		},
+		"allow-k8s-namespace=* => allow-k8s-namespace=default": {
+			FirstRunFlags: []string{
+				"-allow-k8s-namespace=*",
+			},
+			FirstRunExpServices: []string{"foo", "default"},
+			SecondRunFlags: []string{
+				"-allow-k8s-namespace=default",
+			},
+			SecondRunExpServices:        []string{"default"},
+			SecondRunExpDeletedServices: []string{"foo"},
+		},
+		"allow-k8s-namespace=default => allow-k8s-namespace=*": {
+			FirstRunFlags: []string{
+				"-allow-k8s-namespace=default",
+			},
+			FirstRunExpServices: []string{"default"},
+			SecondRunFlags: []string{
+				"-allow-k8s-namespace=*",
+			},
+			SecondRunExpServices:        []string{"foo", "default"},
+			SecondRunExpDeletedServices: nil,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(tt *testing.T) {
+			k8s, testAgent := completeSetup(tt)
+			defer testAgent.Shutdown()
+			ui := cli.NewMockUi()
+			consulClient := testAgent.Client()
+
+			commonArgs := []string{
+				"-consul-write-interval", "500ms",
+				"-log-level=debug",
+			}
+
+			// Create two services in k8s in default and foo namespaces.
+			{
+				_, err := k8s.CoreV1().Services(metav1.NamespaceDefault).Create(lbService("default", "1.1.1.1"))
+				require.NoError(tt, err)
+				_, err = k8s.CoreV1().Namespaces().Create(&apiv1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+					},
+				})
+				require.NoError(tt, err)
+				_, err = k8s.CoreV1().Services("foo").Create(lbService("foo", "1.1.1.1"))
+				require.NoError(tt, err)
+			}
+
+			// Run the first command.
+			{
+				firstCmd := Command{
+					UI:           ui,
+					clientset:    k8s,
+					consulClient: consulClient,
+					logger: hclog.New(&hclog.LoggerOptions{
+						Name:  tt.Name() + "-firstrun",
+						Level: hclog.Debug,
+					}),
+				}
+				exitChan := runCommandAsynchronously(&firstCmd, append(commonArgs, c.FirstRunFlags...))
+
+				// Wait until the expected services are synced.
+				timer := &retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}
+				retry.RunWith(timer, tt, func(r *retry.R) {
+					for _, svcName := range c.FirstRunExpServices {
+						instances, _, err := consulClient.Catalog().Service(svcName, "k8s", nil)
+						require.NoError(r, err)
+						require.Len(r, instances, 1)
+						require.Equal(r, instances[0].ServiceName, svcName)
+					}
+				})
+				stopCommand(tt, &firstCmd, exitChan)
+			}
+			tt.Log("first command run complete")
+
+			// Run the second command.
+			{
+				secondCmd := Command{
+					UI:           ui,
+					clientset:    k8s,
+					consulClient: consulClient,
+					logger: hclog.New(&hclog.LoggerOptions{
+						Name:  tt.Name() + "-secondrun",
+						Level: hclog.Debug,
+					}),
+				}
+				exitChan := runCommandAsynchronously(&secondCmd, append(commonArgs, c.SecondRunFlags...))
+				defer stopCommand(tt, &secondCmd, exitChan)
+
+				// Wait until the expected services are synced and the old ones
+				// deleted.
+				timer := &retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}
+				retry.RunWith(timer, tt, func(r *retry.R) {
+					for _, svcName := range c.SecondRunExpServices {
+						instances, _, err := consulClient.Catalog().Service(svcName, "k8s", nil)
+						require.NoError(r, err)
+						require.Len(r, instances, 1)
+						require.Equal(r, instances[0].ServiceName, svcName)
+					}
+					tt.Log("existing services verified")
+
+					for _, svcName := range c.SecondRunExpDeletedServices {
+						instances, _, err := consulClient.Catalog().Service(svcName, "k8s", nil)
+						require.NoError(r, err)
+						require.Len(r, instances, 0)
+					}
+					tt.Log("deleted services verified")
+				})
+			}
+		})
+	}
+}
+
 // Set up test consul agent and fake kubernetes cluster client
 func completeSetup(t *testing.T) (*fake.Clientset, *agent.TestAgent) {
 	k8s := fake.NewSimpleClientset()
@@ -188,6 +483,11 @@ func completeSetup(t *testing.T) (*fake.Clientset, *agent.TestAgent) {
 // Note that it's the responsibility of the caller to terminate the command by calling stopCommand,
 // otherwise it can run forever.
 func runCommandAsynchronously(cmd *Command, args []string) chan int {
+	// We have to run cmd.init() to ensure that the channel the command is
+	// using to watch for os interrupts is initialized. If we don't do this,
+	// then if stopCommand is called immediately, it will block forever
+	// because it calls interrupt() which will attempt to send on a nil channel.
+	cmd.init()
 	exitChan := make(chan int, 1)
 
 	go func() {


### PR DESCRIPTION
Add tests for catalog sync. Note that these tests currently require Consul 1.7.0. With the addition of https://github.com/hashicorp/consul-k8s/pull/205, the OSS tests will work with older versions of Consul.

There some important non-test changes to note here:
1. `logger` is being made a field of `Command`. This allows me to pass in a named logger in the tests with the name of the test. This results in logs like:
      ```
      2020-02-13T11:18:06.779-0700 [DEBUG] TestRun_ToConsulChangingNamespaceFlags/mirroring-ns_=>_mirroring-ns-prefix-secondrun.to-consul/source: [generateRegistrations] generating registration: key=foo/foo
      ```
    which make it possible to debug issues when there are tests running concurrently (which is always because we use `t.Parallel()`. This logging made it possible for me to fix the race conditions making the tests flaky. I think we should keep it like this so if tests fail in the future we'll have the logs we need to debug.

1. Another race condition was occurring between
   ```go
   exitChan := runCommandAsynchronously(&cmd, flags)
   defer stopCommand(tt, &cmd, exitChan)
   ```
   Usually, `runCommandAsynchronously` calls the command's `Run()` method which initializes `c.sigCh`. The race condition occurs if `defer` is called immediately (which happens when the test exits quickly). `stopCommand` calls `cmd.interrupt()` which is defined as:
   ```go
   func (c *Command) interrupt() {
	c.sigCh <- os.Interrupt
   }
   ```

    In the race condition, `c.sigCh` was actually `nil`! This caused `stopCommand` to run forever and the command to also run forever because it never got its context closed. `c.sigCh` was nil because `Run` hadn't been run yet to initialize it.

    The fix is to call `cmd.init()` inside the `runCommandAsynchronously` function and to move initialization of the channel to `cmd.init()` from `Run`.