### PR TITLE
Don't retry when context cancelled.

### DIFF
--- a/catalog/to-consul/syncer.go
+++ b/catalog/to-consul/syncer.go
@@ -176,10 +176,10 @@ func (s *ConsulSyncer) watchReapableServices(ctx context.Context) {
 		}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
 		if err != nil {
 			s.Log.Warn("error querying services, will retry", "err", err)
-			continue
+		} else {
+			s.Log.Debug("[watchReapableServices] services returned from NodeServiceList",
+				"services", nodeCatalog.Services)
 		}
-		s.Log.Debug("[watchReapableServices] services returned from NodeServiceList",
-			"services", nodeCatalog.Services)
 
 		// Wait our minimum time before continuing or retrying
 		select {


### PR DESCRIPTION
Previously, when the context was cancelled we would enter the error
handling clause and the loop would be re-executed. Then the
backoff.Retry would exit immediately because the context was cancelled
and we'd run in a tight loop until the program was killed.

With this change, when we exit the backoff.Retry with an error, we check
if the context is done. If so, we exit immediately.

This functionality already existed in `syncer.go`:

```go
		// Get all services with tags.
		var serviceMap map[string][]string
		var meta *api.QueryMeta
		err := backoff.Retry(func() error {
			var err error
			serviceMap, meta, err = s.Client.Catalog().Services(opts)
			return err
		}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))

		// If the context is ended, then we end
		if ctx.Err() != nil {
			return
		}
```