### PR TITLE
Support older versions of Consul in sync catalog

### DIFF
--- a/catalog/to-consul/consul_node_services_client.go
+++ b/catalog/to-consul/consul_node_services_client.go
@@ -18,35 +18,37 @@ type ConsulService struct {
 
 // ConsulNodeServicesClient is used to query for node services.
 type ConsulNodeServicesClient interface {
-	// NodeServicesWithTag returns consul services with the corresponding tag
+	// NodeServices returns consul services with the corresponding tag
 	// registered to the Consul node with nodeName. opts is used as the
 	// query options in the API call to consul. It returns the list of services
 	// (not service instances) and the query meta from the API call.
-	NodeServicesWithTag(client *api.Client, tag string, nodeName string, opts *api.QueryOptions) ([]ConsulService, *api.QueryMeta, error)
+	NodeServices(tag string, nodeName string, opts api.QueryOptions) ([]ConsulService, *api.QueryMeta, error)
 }
 
-// ConsulPreOnePointSevenNodeServicesClient implements ConsulNodeServicesClient
+// ConsulPreNamespacesNodeServicesClient implements ConsulNodeServicesClient
 // for Consul < 1.7 which does not support namespaces.
-type ConsulPreOnePointSevenNodeServicesClient struct{}
+type ConsulPreNamespacesNodeServicesClient struct {
+	Client *api.Client
+}
 
-// NodeServicesWithTag returns Consul services tagged with
+// NodeServices returns Consul services tagged with
 // tag registered on nodeName using a Consul API that is supported in
 // Consul versions before 1.7. Consul versions after 1.7 still support
 // this API but the API is not namespace-aware.
-func (s *ConsulPreOnePointSevenNodeServicesClient) NodeServicesWithTag(
-	client *api.Client,
+func (s *ConsulPreNamespacesNodeServicesClient) NodeServices(
 	tag string,
 	nodeName string,
-	opts *api.QueryOptions) ([]ConsulService, *api.QueryMeta, error) {
+	opts api.QueryOptions) ([]ConsulService, *api.QueryMeta, error) {
 	// NOTE: We're not using tag filtering here so we can support Consul
 	// < 1.5.
-	node, meta, err := client.Catalog().Node(nodeName, opts)
+	node, meta, err := s.Client.Catalog().Node(nodeName, &opts)
 	if err != nil {
 		return nil, nil, err
 	}
 	if node == nil {
 		return nil, meta, nil
 	}
+
 	var svcs []ConsulService
 	// seenServices is used to ensure the svcs list is unique.
 	seenServices := make(map[string]bool)
@@ -73,34 +75,33 @@ func (s *ConsulPreOnePointSevenNodeServicesClient) NodeServicesWithTag(
 	return svcs, meta, nil
 }
 
-// ConsulOnePointSevenNodeServicesClient implements ConsulNodeServicesClient
+// ConsulNamespacesNodeServicesClient implements ConsulNodeServicesClient
 // for Consul >= 1.7 which supports namespaces.
-type ConsulOnePointSevenNodeServicesClient struct{}
+type ConsulNamespacesNodeServicesClient struct {
+	Client *api.Client
+}
 
-// NodeServicesWithTag returns Consul services tagged with
+// NodeServices returns Consul services tagged with
 // tag registered on nodeName using a Consul API that is supported in
 // Consul versions >= 1.7. If opts.Namespace is set to
 // "*", services from all namespaces will be returned.
-func (s *ConsulOnePointSevenNodeServicesClient) NodeServicesWithTag(
-	client *api.Client,
+func (s *ConsulNamespacesNodeServicesClient) NodeServices(
 	tag string,
 	nodeName string,
-	opts *api.QueryOptions) ([]ConsulService, *api.QueryMeta, error) {
-	if opts == nil {
-		opts = &api.QueryOptions{}
-	}
+	opts api.QueryOptions) ([]ConsulService, *api.QueryMeta, error) {
 	opts.Filter = fmt.Sprintf("\"%s\" in Tags", tag)
-	nodeCatalog, meta, err := client.Catalog().NodeServiceList(nodeName, opts)
+	nodeCatalog, meta, err := s.Client.Catalog().NodeServiceList(nodeName, &opts)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var svcs []ConsulService
 	// seenServices is used to ensure the svcs list is unique. Its keys are
-	// <service name>/<namespace>.
+	// <namespace>/<service name>.
 	seenSvcs := make(map[string]bool)
 	for _, svcInstance := range nodeCatalog.Services {
 		svcName := svcInstance.Service
-		key := fmt.Sprintf("%s/%s", svcName, svcInstance.Namespace)
+		key := fmt.Sprintf("%s/%s", svcInstance.Namespace, svcName)
 		if _, ok := seenSvcs[key]; !ok {
 			svcs = append(svcs, ConsulService{
 				Namespace: svcInstance.Namespace,

--- a/catalog/to-consul/consul_node_services_client.go
+++ b/catalog/to-consul/consul_node_services_client.go
@@ -1,0 +1,113 @@
+package catalog
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/consul/api"
+)
+
+// ConsulService is service registered in Consul.
+type ConsulService struct {
+	// Namespace is the Consul namespace the service is registered in.
+	// If namespaces are disabled this will always be the empty string even
+	// though the namespace is technically "default".
+	Namespace string
+	// Name is the name of the service in Consul.
+	Name string
+}
+
+// ConsulNodeServicesClient is used to query for node services.
+type ConsulNodeServicesClient interface {
+	// NodeServicesWithTag returns consul services with the corresponding tag
+	// registered to the Consul node with nodeName. opts is used as the
+	// query options in the API call to consul. It returns the list of services
+	// (not service instances) and the query meta from the API call.
+	NodeServicesWithTag(client *api.Client, tag string, nodeName string, opts *api.QueryOptions) ([]ConsulService, *api.QueryMeta, error)
+}
+
+// ConsulPreOnePointSevenNodeServicesClient implements ConsulNodeServicesClient
+// for Consul < 1.7 which does not support namespaces.
+type ConsulPreOnePointSevenNodeServicesClient struct{}
+
+// NodeServicesWithTag returns Consul services tagged with
+// tag registered on nodeName using a Consul API that is supported in
+// Consul versions before 1.7. Consul versions after 1.7 still support
+// this API but the API is not namespace-aware.
+func (s *ConsulPreOnePointSevenNodeServicesClient) NodeServicesWithTag(
+	client *api.Client,
+	tag string,
+	nodeName string,
+	opts *api.QueryOptions) ([]ConsulService, *api.QueryMeta, error) {
+	// NOTE: We're not using tag filtering here so we can support Consul
+	// < 1.5.
+	node, meta, err := client.Catalog().Node(nodeName, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	if node == nil {
+		return nil, meta, nil
+	}
+	var svcs []ConsulService
+	// seenServices is used to ensure the svcs list is unique.
+	seenServices := make(map[string]bool)
+	for _, svcInstance := range node.Services {
+		svcName := svcInstance.Service
+		if _, ok := seenServices[svcName]; ok {
+			continue
+		}
+		for _, svcTag := range svcInstance.Tags {
+			if svcTag == tag {
+				if _, ok := seenServices[svcName]; !ok {
+					svcs = append(svcs, ConsulService{
+						// If namespaces are not enabled we use empty
+						// string.
+						Namespace: "",
+						Name:      svcName,
+					})
+					seenServices[svcName] = true
+				}
+				break
+			}
+		}
+	}
+	return svcs, meta, nil
+}
+
+// ConsulOnePointSevenNodeServicesClient implements ConsulNodeServicesClient
+// for Consul >= 1.7 which supports namespaces.
+type ConsulOnePointSevenNodeServicesClient struct{}
+
+// NodeServicesWithTag returns Consul services tagged with
+// tag registered on nodeName using a Consul API that is supported in
+// Consul versions >= 1.7. If opts.Namespace is set to
+// "*", services from all namespaces will be returned.
+func (s *ConsulOnePointSevenNodeServicesClient) NodeServicesWithTag(
+	client *api.Client,
+	tag string,
+	nodeName string,
+	opts *api.QueryOptions) ([]ConsulService, *api.QueryMeta, error) {
+	if opts == nil {
+		opts = &api.QueryOptions{}
+	}
+	opts.Filter = fmt.Sprintf("\"%s\" in Tags", tag)
+	nodeCatalog, meta, err := client.Catalog().NodeServiceList(nodeName, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	var svcs []ConsulService
+	// seenServices is used to ensure the svcs list is unique. Its keys are
+	// <service name>/<namespace>.
+	seenSvcs := make(map[string]bool)
+	for _, svcInstance := range nodeCatalog.Services {
+		svcName := svcInstance.Service
+		key := fmt.Sprintf("%s/%s", svcName, svcInstance.Namespace)
+		if _, ok := seenSvcs[key]; !ok {
+			svcs = append(svcs, ConsulService{
+				Namespace: svcInstance.Namespace,
+				Name:      svcName,
+			})
+			seenSvcs[key] = true
+		}
+	}
+	return svcs, meta, nil
+}

--- a/catalog/to-consul/consul_node_services_client_ent_test.go
+++ b/catalog/to-consul/consul_node_services_client_ent_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Test the Consul 1.7 client against Consul Enterprise.
-func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
+func TestConsulNamespacesNodeServicesClient_NodeServices(t *testing.T) {
 	t.Parallel()
 	cases := map[string]struct {
 		ConsulServices []api.CatalogRegistration
@@ -48,10 +48,10 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 			},
 			Exp: nil,
 		},
-		"service on k8s node but without tag": {
+		"service on k8s node without any tags": {
 			ConsulServices: []api.CatalogRegistration{
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id",
@@ -62,10 +62,24 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 			},
 			Exp: nil,
 		},
+		"service on k8s node without k8s tag": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    ConsulSyncNodeName,
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    []string{"not-k8s", "foo"},
+					},
+				},
+			},
+			Exp: nil,
+		},
 		"service on k8s node with k8s tag": {
 			ConsulServices: []api.CatalogRegistration{
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id",
@@ -84,7 +98,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 		"multiple services": {
 			ConsulServices: []api.CatalogRegistration{
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc1-id",
@@ -93,7 +107,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc2-id2",
@@ -116,7 +130,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 		"multiple service instances": {
 			ConsulServices: []api.CatalogRegistration{
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id1",
@@ -125,7 +139,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id2",
@@ -144,7 +158,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 		"services across multiple namespaces": {
 			ConsulServices: []api.CatalogRegistration{
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id1",
@@ -153,7 +167,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:        "svc-ns-id",
@@ -177,7 +191,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 		"services with same name across multiple namespaces": {
 			ConsulServices: []api.CatalogRegistration{
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id",
@@ -186,7 +200,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:        "svc-id",
@@ -210,7 +224,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 		"multiple services across multiple namespaces": {
 			ConsulServices: []api.CatalogRegistration{
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id1",
@@ -219,7 +233,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc-id2",
@@ -228,7 +242,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:        "svc-id1",
@@ -238,7 +252,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:        "svc-id2",
@@ -248,7 +262,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc2-id1",
@@ -257,7 +271,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:      "svc2-id2",
@@ -266,7 +280,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:        "svc2-id1",
@@ -276,7 +290,7 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 					},
 				},
 				{
-					Node:    "k8s-sync",
+					Node:    ConsulSyncNodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						ID:        "svc2-id2",
@@ -308,6 +322,9 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 	}
 
 	for name, c := range cases {
+		if name != "multiple services across multiple namespaces" {
+			continue
+		}
 		t.Run(name, func(tt *testing.T) {
 			require := require.New(tt)
 			svr, err := testutil.NewTestServerT(tt)
@@ -329,8 +346,10 @@ func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
 				require.NoError(err)
 			}
 
-			client := ConsulOnePointSevenNodeServicesClient{}
-			svcs, _, err := client.NodeServicesWithTag(consulClient, "k8s", "k8s-sync", &api.QueryOptions{
+			client := ConsulNamespacesNodeServicesClient{
+				Client: consulClient,
+			}
+			svcs, _, err := client.NodeServices("k8s", ConsulSyncNodeName, api.QueryOptions{
 				Namespace: "*",
 			})
 			require.NoError(err)

--- a/catalog/to-consul/consul_node_services_client_ent_test.go
+++ b/catalog/to-consul/consul_node_services_client_ent_test.go
@@ -1,0 +1,343 @@
+// +build enterprise
+
+package catalog
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// Test the Consul 1.7 client against Consul Enterprise.
+func TestConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		ConsulServices []api.CatalogRegistration
+		Exp            []ConsulService
+	}{
+		"no services": {
+			ConsulServices: nil,
+			Exp:            nil,
+		},
+		"no services on k8s node": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "not-k8s",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+					},
+				},
+			},
+			Exp: nil,
+		},
+		"service with k8s tag on different node": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "not-k8s",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: nil,
+		},
+		"service on k8s node but without tag": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    nil,
+					},
+				},
+			},
+			Exp: nil,
+		},
+		"service on k8s node with k8s tag": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "default",
+					Name:      "svc",
+				},
+			},
+		},
+		"multiple services": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc1-id",
+						Service: "svc1",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc2-id2",
+						Service: "svc2",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "default",
+					Name:      "svc1",
+				},
+				{
+					Namespace: "default",
+					Name:      "svc2",
+				},
+			},
+		},
+		"multiple service instances": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id1",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id2",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "default",
+					Name:      "svc",
+				},
+			},
+		},
+		"services across multiple namespaces": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id1",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:        "svc-ns-id",
+						Service:   "svc-ns",
+						Tags:      []string{"k8s"},
+						Namespace: "ns",
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "default",
+					Name:      "svc",
+				},
+				{
+					Namespace: "ns",
+					Name:      "svc-ns",
+				},
+			},
+		},
+		"services with same name across multiple namespaces": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:        "svc-id",
+						Service:   "svc",
+						Tags:      []string{"k8s"},
+						Namespace: "ns",
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "default",
+					Name:      "svc",
+				},
+				{
+					Namespace: "ns",
+					Name:      "svc",
+				},
+			},
+		},
+		"multiple services across multiple namespaces": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id1",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id2",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:        "svc-id1",
+						Service:   "svc",
+						Tags:      []string{"k8s"},
+						Namespace: "ns",
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:        "svc-id2",
+						Service:   "svc",
+						Tags:      []string{"k8s"},
+						Namespace: "ns",
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc2-id1",
+						Service: "svc2",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc2-id2",
+						Service: "svc2",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:        "svc2-id1",
+						Service:   "svc2",
+						Tags:      []string{"k8s"},
+						Namespace: "ns",
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:        "svc2-id2",
+						Service:   "svc2",
+						Tags:      []string{"k8s"},
+						Namespace: "ns",
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "default",
+					Name:      "svc",
+				},
+				{
+					Namespace: "default",
+					Name:      "svc2",
+				},
+				{
+					Namespace: "ns",
+					Name:      "svc",
+				},
+				{
+					Namespace: "ns",
+					Name:      "svc2",
+				},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(tt *testing.T) {
+			require := require.New(tt)
+			svr, err := testutil.NewTestServerT(tt)
+			require.NoError(err)
+			defer svr.Stop()
+
+			consulClient, err := api.NewClient(&api.Config{
+				Address: svr.HTTPAddr,
+			})
+			require.NoError(err)
+			for _, registration := range c.ConsulServices {
+				if registration.Service.Namespace != "" && registration.Service.Namespace != "default" {
+					_, _, err = consulClient.Namespaces().Create(&api.Namespace{
+						Name: registration.Service.Namespace,
+					}, nil)
+					require.NoError(err)
+				}
+				_, err = consulClient.Catalog().Register(&registration, nil)
+				require.NoError(err)
+			}
+
+			client := ConsulOnePointSevenNodeServicesClient{}
+			svcs, _, err := client.NodeServicesWithTag(consulClient, "k8s", "k8s-sync", &api.QueryOptions{
+				Namespace: "*",
+			})
+			require.NoError(err)
+			require.Len(svcs, len(c.Exp))
+			for _, expSvc := range c.Exp {
+				require.Contains(svcs, expSvc)
+			}
+		})
+	}
+}

--- a/catalog/to-consul/consul_node_services_client_test.go
+++ b/catalog/to-consul/consul_node_services_client_test.go
@@ -1,0 +1,168 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreConsulOnePointSevenClient_NodeServicesWithTag(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		ConsulServices []api.CatalogRegistration
+		Exp            []ConsulService
+	}{
+		"no services": {
+			ConsulServices: nil,
+			Exp:            nil,
+		},
+		"no services on k8s node": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "not-k8s",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+					},
+				},
+			},
+			Exp: nil,
+		},
+		"service with k8s tag on different node": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "not-k8s",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: nil,
+		},
+		"service on k8s node but without tag": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    nil,
+					},
+				},
+			},
+			Exp: nil,
+		},
+		"service on k8s node with k8s tag": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "",
+					Name:      "svc",
+				},
+			},
+		},
+		"multiple services": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc1-id",
+						Service: "svc1",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc2-id2",
+						Service: "svc2",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "",
+					Name:      "svc1",
+				},
+				{
+					Namespace: "",
+					Name:      "svc2",
+				},
+			},
+		},
+		"multiple service instances": {
+			ConsulServices: []api.CatalogRegistration{
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id1",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+				{
+					Node:    "k8s-sync",
+					Address: "127.0.0.1",
+					Service: &api.AgentService{
+						ID:      "svc-id2",
+						Service: "svc",
+						Tags:    []string{"k8s"},
+					},
+				},
+			},
+			Exp: []ConsulService{
+				{
+					Namespace: "",
+					Name:      "svc",
+				},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(tt *testing.T) {
+			require := require.New(tt)
+			svr, err := testutil.NewTestServerT(tt)
+			require.NoError(err)
+			defer svr.Stop()
+
+			consulClient, err := api.NewClient(&api.Config{
+				Address: svr.HTTPAddr,
+			})
+			require.NoError(err)
+			for _, registration := range c.ConsulServices {
+				_, err = consulClient.Catalog().Register(&registration, nil)
+				require.NoError(err)
+			}
+
+			client := ConsulPreOnePointSevenNodeServicesClient{}
+			svcs, _, err := client.NodeServicesWithTag(consulClient, "k8s", "k8s-sync", nil)
+			require.NoError(err)
+			require.Len(svcs, len(c.Exp))
+			for _, expSvc := range c.Exp {
+				require.Contains(svcs, expSvc)
+			}
+		})
+	}
+}

--- a/catalog/to-consul/syncer.go
+++ b/catalog/to-consul/syncer.go
@@ -165,7 +165,7 @@ func (s *ConsulSyncer) watchReapableServices(ctx context.Context) {
 		var meta *api.QueryMeta
 		err := backoff.Retry(func() error {
 			var err error
-			services, meta, err = s.ConsulNodeServicesClient.NodeServicesWithTag(s.Client, s.ConsulK8STag, ConsulSyncNodeName, opts)
+			services, meta, err = s.ConsulNodeServicesClient.NodeServices(s.ConsulK8STag, ConsulSyncNodeName, *opts)
 			return err
 		}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
 

--- a/catalog/to-consul/syncer_ent_test.go
+++ b/catalog/to-consul/syncer_ent_test.go
@@ -23,7 +23,9 @@ func TestConsulSyncer_ConsulNamespaces(t *testing.T) {
 
 	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
 		s.EnableNamespaces = true
-		s.ConsulNodeServicesClient = &ConsulOnePointSevenNodeServicesClient{}
+		s.ConsulNodeServicesClient = &ConsulNamespacesNodeServicesClient{
+			Client: client,
+		}
 	})
 	defer closer()
 
@@ -70,7 +72,9 @@ func TestConsulSyncer_ReapConsulNamespace(t *testing.T) {
 
 	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
 		s.EnableNamespaces = true
-		s.ConsulNodeServicesClient = &ConsulOnePointSevenNodeServicesClient{}
+		s.ConsulNodeServicesClient = &ConsulNamespacesNodeServicesClient{
+			Client: client,
+		}
 	})
 	defer closer()
 
@@ -133,7 +137,9 @@ func TestConsulSyncer_reapServiceInstanceNamespacesEnabled(t *testing.T) {
 	})
 	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
 		s.EnableNamespaces = true
-		s.ConsulNodeServicesClient = &ConsulOnePointSevenNodeServicesClient{}
+		s.ConsulNodeServicesClient = &ConsulNamespacesNodeServicesClient{
+			Client: client,
+		}
 	})
 	defer closer()
 

--- a/catalog/to-consul/syncer_ent_test.go
+++ b/catalog/to-consul/syncer_ent_test.go
@@ -23,6 +23,7 @@ func TestConsulSyncer_ConsulNamespaces(t *testing.T) {
 
 	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
 		s.EnableNamespaces = true
+		s.ConsulNodeServicesClient = &ConsulOnePointSevenNodeServicesClient{}
 	})
 	defer closer()
 
@@ -69,6 +70,7 @@ func TestConsulSyncer_ReapConsulNamespace(t *testing.T) {
 
 	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
 		s.EnableNamespaces = true
+		s.ConsulNodeServicesClient = &ConsulOnePointSevenNodeServicesClient{}
 	})
 	defer closer()
 
@@ -131,6 +133,7 @@ func TestConsulSyncer_reapServiceInstanceNamespacesEnabled(t *testing.T) {
 	})
 	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
 		s.EnableNamespaces = true
+		s.ConsulNodeServicesClient = &ConsulOnePointSevenNodeServicesClient{}
 	})
 	defer closer()
 

--- a/catalog/to-consul/syncer_test.go
+++ b/catalog/to-consul/syncer_test.go
@@ -217,12 +217,14 @@ func testConsulSyncer(client *api.Client) (*ConsulSyncer, func()) {
 // prior to starting via the configurator method.
 func testConsulSyncerWithConfig(client *api.Client, configurator func(*ConsulSyncer)) (*ConsulSyncer, func()) {
 	s := &ConsulSyncer{
-		Client:                   client,
-		Log:                      hclog.Default(),
-		SyncPeriod:               200 * time.Millisecond,
-		ServicePollPeriod:        50 * time.Millisecond,
-		ConsulK8STag:             TestConsulK8STag,
-		ConsulNodeServicesClient: &ConsulPreOnePointSevenNodeServicesClient{},
+		Client:            client,
+		Log:               hclog.Default(),
+		SyncPeriod:        200 * time.Millisecond,
+		ServicePollPeriod: 50 * time.Millisecond,
+		ConsulK8STag:      TestConsulK8STag,
+		ConsulNodeServicesClient: &ConsulPreNamespacesNodeServicesClient{
+			Client: client,
+		},
 	}
 	configurator(s)
 	s.init()

--- a/catalog/to-consul/syncer_test.go
+++ b/catalog/to-consul/syncer_test.go
@@ -217,11 +217,12 @@ func testConsulSyncer(client *api.Client) (*ConsulSyncer, func()) {
 // prior to starting via the configurator method.
 func testConsulSyncerWithConfig(client *api.Client, configurator func(*ConsulSyncer)) (*ConsulSyncer, func()) {
 	s := &ConsulSyncer{
-		Client:            client,
-		Log:               hclog.Default(),
-		SyncPeriod:        200 * time.Millisecond,
-		ServicePollPeriod: 50 * time.Millisecond,
-		ConsulK8STag:      TestConsulK8STag,
+		Client:                   client,
+		Log:                      hclog.Default(),
+		SyncPeriod:               200 * time.Millisecond,
+		ServicePollPeriod:        50 * time.Millisecond,
+		ConsulK8STag:             TestConsulK8STag,
+		ConsulNodeServicesClient: &ConsulPreOnePointSevenNodeServicesClient{},
 	}
 	configurator(s)
 	s.init()

--- a/subcommand/sync-catalog/command.go
+++ b/subcommand/sync-catalog/command.go
@@ -224,9 +224,13 @@ func (c *Command) Run(args []string) int {
 		// enabled we use a client that queries the older API endpoint.
 		var svcsClient catalogtoconsul.ConsulNodeServicesClient
 		if c.flagEnableNamespaces {
-			svcsClient = &catalogtoconsul.ConsulOnePointSevenNodeServicesClient{}
+			svcsClient = &catalogtoconsul.ConsulNamespacesNodeServicesClient{
+				Client: c.consulClient,
+			}
 		} else {
-			svcsClient = &catalogtoconsul.ConsulPreOnePointSevenNodeServicesClient{}
+			svcsClient = &catalogtoconsul.ConsulPreNamespacesNodeServicesClient{
+				Client: c.consulClient,
+			}
 		}
 		// Build the Consul sync and start it
 		syncer := &catalogtoconsul.ConsulSyncer{


### PR DESCRIPTION
If namespaces are not enabled, use a Consul catalog API that is
available in older Consul versions instead of the API that's only
available in Consul 1.7+.

Design decisions:
* I've only implemented the adapter for the `NodeServiceList` endpoint rather than for the whole consul client API. This means `Syncer` needs both `ConsulClient` and `ConsulNodeServiceListClient` but it reduces the amount of code required vs needing to wrap the whole API of `ConsulClient`.
* Previously (before namespaces) the code used the `/catalog/services` endpoint to return just service names and then it filtered on those with the tag `k8s`. It never checked if those services were registered to the `k8s-sync` node. Rather than going back to that API, I've switched it to the `/catalog/node/:node_id` endpoint. I made this change because it matches what the namespaces code is doing by hitting the `/catalog/node-services/:node_id` endpoint. This makes the adapter easier to understand since it's adapting "list services for a node" instead of "list services for a node if namespaces, else list all services regardless of node". It is also backwards compatible because the only node the sync process ever registered services on is `k8s-sync`.
* Rather than having `ConsulClient` be a field in the adapting client, I'm making it part of the function signature. I made this decision because I liked that the Syncer was using the same underlying Consul client for all its calls. If it redefined its own `ConsulClient` field (it doesn't right now), then the clients would be out of sync if the adapting client had its own.
* I've changed the implementation of the namespaces-aware client to add a filter on tags. This filtering was originally being done in code but it seems better to use the proper API capabilities for this.

Manual Testing:
1. Consul OSS 1.6.3 - Use code before change, create a service manually with tag "k8s", see that it **does not** get deleted. This is because the catalog list call is failing and so we never populate the list of services to delete.
1. Consul OSS 1.6.3 - Use code after change, create a service manually with tag "k8s" on node k8s-sync, see that is deleted (proving that the bug is fixed)
1. Consul OSS 1.7.0 - Run with namespaces disabled, manually create a service with tag k8s on node k8s-sync, see that it is deleted.
1. Consul Enterprise 1.7.0 - Run with namespaces enabled syncing to one namespace. Change config to mirroring. See that services in old namespace are deleted.