### PR TITLE
Add -create-acl-replication-token flag

### DIFF
--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -201,6 +201,20 @@ func TestRun_Tokens(t *testing.T) {
 			TokenName:          "mesh-gateway",
 			SecretName:         "my-prefix-mesh-gateway-acl-token",
 		},
+		"acl-replication token -release-name": {
+			TokenFlag:          "-create-acl-replication-token",
+			ResourcePrefixFlag: "",
+			ReleaseNameFlag:    "release-name",
+			TokenName:          "acl-replication",
+			SecretName:         "release-name-consul-acl-replication-acl-token",
+		},
+		"acl-replication token -resource-prefix": {
+			TokenFlag:          "-create-acl-replication-token",
+			ResourcePrefixFlag: "my-prefix",
+			ReleaseNameFlag:    "release-name",
+			TokenName:          "acl-replication",
+			SecretName:         "my-prefix-acl-replication-acl-token",
+		},
 	}
 	for testName, c := range cases {
 		t.Run(testName, func(t *testing.T) {

--- a/subcommand/server-acl-init/rules_test.go
+++ b/subcommand/server-acl-init/rules_test.go
@@ -297,3 +297,52 @@ operator = "write"`,
 		})
 	}
 }
+
+func TestReplicationTokenRules(t *testing.T) {
+	cases := []struct {
+		Name             string
+		EnableNamespaces bool
+		Expected         string
+	}{
+		{
+			"Namespaces are disabled",
+			false,
+			`acl = "write"
+operator = "write"
+  node_prefix "" {
+    policy = "write"
+  }
+  service_prefix "" {
+    policy = "read"
+    intentions = "read"
+  }`,
+		},
+		{
+			"Namespaces are enabled",
+			true,
+			`acl = "write"
+operator = "write"
+namespace_prefix "" {
+  node_prefix "" {
+    policy = "write"
+  }
+  service_prefix "" {
+    policy = "read"
+    intentions = "read"
+  }
+}`,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			require := require.New(t)
+			cmd := Command{
+				flagEnableNamespaces: tt.EnableNamespaces,
+			}
+			replicationTokenRules, err := cmd.aclReplicationRules()
+			require.NoError(err)
+			require.Equal(tt.Expected, replicationTokenRules)
+		})
+	}
+}


### PR DESCRIPTION
The ACL replication token is used for ACL replication between Consul
datacenters.