### PR TITLE
Add get-consul-client-ca command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -5,6 +5,7 @@ import (
 
 	cmdACLInit "github.com/hashicorp/consul-k8s/subcommand/acl-init"
 	cmdDeleteCompletedJob "github.com/hashicorp/consul-k8s/subcommand/delete-completed-job"
+	cmdGetConsulClientCA "github.com/hashicorp/consul-k8s/subcommand/get-consul-client-ca"
 	cmdInjectConnect "github.com/hashicorp/consul-k8s/subcommand/inject-connect"
 	cmdLifecycleSidecar "github.com/hashicorp/consul-k8s/subcommand/lifecycle-sidecar"
 	cmdServerACLInit "github.com/hashicorp/consul-k8s/subcommand/server-acl-init"
@@ -43,6 +44,10 @@ func init() {
 
 		"delete-completed-job": func() (cli.Command, error) {
 			return &cmdDeleteCompletedJob.Command{UI: ui}, nil
+		},
+
+		"get-consul-client-ca": func() (cli.Command, error) {
+			return &cmdGetConsulClientCA.Command{UI: ui}, nil
 		},
 
 		"version": func() (cli.Command, error) {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hashicorp/consul v1.7.1
 	github.com/hashicorp/consul/api v1.4.0
 	github.com/hashicorp/consul/sdk v0.4.0
+	github.com/hashicorp/go-discover v0.0.0-20191202160150-7ec2cfbda7a2
 	github.com/hashicorp/go-hclog v0.12.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/golang-lru v0.5.3 // indirect

--- a/helper/cert/source_gen.go
+++ b/helper/cert/source_gen.go
@@ -1,20 +1,9 @@
 package cert
 
 import (
-	"bytes"
 	"context"
 	"crypto"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/sha256"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
-	"fmt"
-	"math/big"
-	"net"
-	"strings"
 	"sync"
 	"time"
 )
@@ -40,7 +29,7 @@ type GenSource struct {
 	ExpiryWithin time.Duration
 
 	mu             sync.Mutex
-	caCert         []byte
+	caCert         string
 	caCertTemplate *x509.Certificate
 	caSigner       crypto.Signer
 }
@@ -57,15 +46,14 @@ func (s *GenSource) Certificate(ctx context.Context, last *Bundle) (Bundle, erro
 			return result, err
 		}
 	}
-
 	// Set the CA cert
-	result.CACert = s.caCert
+	result.CACert = []byte(s.caCert)
 
 	// If we have a prior cert, we wait for getting near to the expiry
 	// (within 30 minutes arbitrarily chosen).
 	if last != nil {
 		// We have a prior certificate, let's parse it to get the expiry
-		cert, err := parseCert(last.Cert)
+		cert, err := ParseCert(last.Cert)
 		if err != nil {
 			return result, err
 		}
@@ -88,7 +76,7 @@ func (s *GenSource) Certificate(ctx context.Context, last *Bundle) (Bundle, erro
 	}
 
 	// Generate cert, set it on the result, and return
-	cert, key, err := s.generateCert()
+	cert, key, err := GenerateCert(s.Name+" Service", s.expiry(), s.caCertTemplate, s.caSigner, s.Hosts)
 	if err == nil {
 		result.Cert = []byte(cert)
 		result.Key = []byte(key)
@@ -114,162 +102,15 @@ func (s *GenSource) expiryWithin() time.Duration {
 	return time.Duration(float64(s.expiry()) * 0.10)
 }
 
-func (s *GenSource) generateCert() (string, string, error) {
-	// Create the private key we'll use for this leaf cert.
-	signer, keyPEM, err := s.privateKey()
-	if err != nil {
-		return "", "", err
-	}
-
-	// The serial number for the cert
-	sn, err := serialNumber()
-	if err != nil {
-		return "", "", err
-	}
-
-	// Create the leaf cert
-	template := x509.Certificate{
-		SerialNumber:          sn,
-		Subject:               pkix.Name{CommonName: s.Name + " Service"},
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		NotAfter:              time.Now().Add(s.expiry()),
-		NotBefore:             time.Now().Add(-1 * time.Minute),
-	}
-	for _, h := range s.Hosts {
-		if ip := net.ParseIP(h); ip != nil {
-			template.IPAddresses = append(template.IPAddresses, ip)
-		} else {
-			template.DNSNames = append(template.DNSNames, h)
-		}
-	}
-
-	bs, err := x509.CreateCertificate(
-		rand.Reader, &template, s.caCertTemplate, signer.Public(), s.caSigner)
-	if err != nil {
-		return "", "", err
-	}
-	var buf bytes.Buffer
-	err = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: bs})
-	if err != nil {
-		return "", "", err
-	}
-
-	return buf.String(), keyPEM, nil
-}
-
 func (s *GenSource) generateCA() error {
-	// Create the private key we'll use for this CA cert.
-	signer, _, err := s.privateKey()
+	// generate the CA
+	signer, _, caCertPem, caCertTemplate, err := GenerateCA(s.Name + " CA")
 	if err != nil {
 		return err
 	}
 	s.caSigner = signer
-
-	// The serial number for the cert
-	sn, err := serialNumber()
-	if err != nil {
-		return err
-	}
-
-	signerKeyId, err := keyId(signer.Public())
-	if err != nil {
-		return err
-	}
-
-	// Create the CA cert
-	template := x509.Certificate{
-		SerialNumber:          sn,
-		Subject:               pkix.Name{CommonName: s.Name + " CA"},
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		IsCA:                  true,
-		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
-		NotBefore:             time.Now().Add(-1 * time.Minute),
-		AuthorityKeyId:        signerKeyId,
-		SubjectKeyId:          signerKeyId,
-	}
-
-	bs, err := x509.CreateCertificate(
-		rand.Reader, &template, &template, signer.Public(), signer)
-	if err != nil {
-		return err
-	}
-
-	var buf bytes.Buffer
-	err = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: bs})
-	if err != nil {
-		return err
-	}
-
-	s.caCert = buf.Bytes()
-	s.caCertTemplate = &template
+	s.caCert = caCertPem
+	s.caCertTemplate = caCertTemplate
 
 	return nil
-}
-
-// privateKey returns a new ECDSA-based private key. Both a crypto.Signer
-// and the key in PEM format are returned.
-func (s *GenSource) privateKey() (crypto.Signer, string, error) {
-	pk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		return nil, "", err
-	}
-
-	bs, err := x509.MarshalECPrivateKey(pk)
-	if err != nil {
-		return nil, "", err
-	}
-
-	var buf bytes.Buffer
-	err = pem.Encode(&buf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: bs})
-	if err != nil {
-		return nil, "", err
-	}
-
-	return pk, buf.String(), nil
-}
-
-// serialNumber generates a new random serial number.
-func serialNumber() (*big.Int, error) {
-	return rand.Int(rand.Reader, (&big.Int{}).Exp(big.NewInt(2), big.NewInt(159), nil))
-}
-
-// keyId returns a x509 KeyId from the given signing key. The key must be
-// an *ecdsa.PublicKey currently, but may support more types in the future.
-func keyId(raw interface{}) ([]byte, error) {
-	switch raw.(type) {
-	case *ecdsa.PublicKey:
-	default:
-		return nil, fmt.Errorf("invalid key type: %T", raw)
-	}
-
-	// This is not standard; RFC allows any unique identifier as long as they
-	// match in subject/authority chains but suggests specific hashing of DER
-	// bytes of public key including DER tags.
-	bs, err := x509.MarshalPKIXPublicKey(raw)
-	if err != nil {
-		return nil, err
-	}
-
-	// String formatted
-	kID := sha256.Sum256(bs)
-	return []byte(strings.Replace(fmt.Sprintf("% x", kID), " ", ":", -1)), nil
-}
-
-// parseCert parses the x509 certificate from a PEM-encoded value.
-func parseCert(pemValue []byte) (*x509.Certificate, error) {
-	// The _ result below is not an error but the remaining PEM bytes.
-	block, _ := pem.Decode(pemValue)
-	if block == nil {
-		return nil, fmt.Errorf("no PEM-encoded data found")
-	}
-
-	if block.Type != "CERTIFICATE" {
-		return nil, fmt.Errorf("first PEM-block should be CERTIFICATE type")
-	}
-
-	return x509.ParseCertificate(block.Bytes)
 }

--- a/helper/cert/source_gen_test.go
+++ b/helper/cert/source_gen_test.go
@@ -112,7 +112,7 @@ func testBundleVerify(t *testing.T, bundle *Bundle) {
 	cmd := exec.Command(
 		"openssl", "verify", "-verbose", "-CAfile", "ca.pem", "leaf.pem")
 	cmd.Dir = td
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	t.Log(string(output))
 	require.NoError(err)
 }

--- a/helper/cert/tls_util.go
+++ b/helper/cert/tls_util.go
@@ -1,0 +1,192 @@
+package cert
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"strings"
+	"time"
+)
+
+// GenerateCA generates a CA with the provided
+// common name valid for 10 years. It returns the private key as
+// a crypto.Signer and a PEM string and certificate
+// as a *x509.Certificate and a PEM string or an error.
+func GenerateCA(commonName string) (
+	signer crypto.Signer,
+	keyPem string,
+	caCertPem string,
+	caCertTemplate *x509.Certificate,
+	err error) {
+	// Create the private key we'll use for this CA cert.
+	signer, keyPem, err = privateKey()
+	if err != nil {
+		return
+	}
+
+	// The serial number for the cert
+	sn, err := serialNumber()
+	if err != nil {
+		return
+	}
+
+	signerKeyId, err := keyId(signer.Public())
+	if err != nil {
+		return
+	}
+
+	// Create the CA cert
+	caCertTemplate = &x509.Certificate{
+		SerialNumber:          sn,
+		Subject:               pkix.Name{CommonName: commonName},
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:                  true,
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		NotBefore:             time.Now().Add(-1 * time.Minute),
+		AuthorityKeyId:        signerKeyId,
+		SubjectKeyId:          signerKeyId,
+	}
+
+	bs, err := x509.CreateCertificate(
+		rand.Reader, caCertTemplate, caCertTemplate, signer.Public(), signer)
+	if err != nil {
+		return
+	}
+
+	var buf bytes.Buffer
+	err = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: bs})
+	if err != nil {
+		return
+	}
+	caCertPem = buf.String()
+
+	return
+}
+
+// GenerateCert generates a leaf certificate
+// with the given common name, expiry, hosts as SANs,
+// and CA. It returns a PEM encoded certificate
+// and private key of the generated certificate or an error.
+func GenerateCert(
+	commonName string,
+	expiry time.Duration,
+	caCert *x509.Certificate,
+	caCertSigner crypto.Signer,
+	hosts []string) (string, string, error) {
+	// Create the private key we'll use for this leaf cert.
+	signer, keyPEM, err := privateKey()
+	if err != nil {
+		return "", "", err
+	}
+
+	// The serial number for the cert
+	sn, err := serialNumber()
+	if err != nil {
+		return "", "", err
+	}
+
+	// Create the leaf cert
+	template := x509.Certificate{
+		SerialNumber:          sn,
+		Subject:               pkix.Name{CommonName: commonName},
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		NotAfter:              time.Now().Add(expiry),
+		NotBefore:             time.Now().Add(-1 * time.Minute),
+	}
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+	bs, err := x509.CreateCertificate(
+		rand.Reader, &template, caCert, signer.Public(), caCertSigner)
+	if err != nil {
+		return "", "", err
+	}
+	var buf bytes.Buffer
+	err = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: bs})
+	if err != nil {
+		return "", "", err
+	}
+
+	return buf.String(), keyPEM, nil
+}
+
+// ParseCert parses the x509 certificate from a PEM-encoded value.
+func ParseCert(pemValue []byte) (*x509.Certificate, error) {
+	// The _ result below is not an error but the remaining PEM bytes.
+	block, _ := pem.Decode(pemValue)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM-encoded data found")
+	}
+
+	if block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("first PEM-block should be CERTIFICATE type")
+	}
+
+	return x509.ParseCertificate(block.Bytes)
+}
+
+// privateKey returns a new ECDSA-based private key. Both a crypto.Signer
+// and the key in PEM format are returned.
+func privateKey() (crypto.Signer, string, error) {
+	pk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, "", err
+	}
+
+	bs, err := x509.MarshalECPrivateKey(pk)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var buf bytes.Buffer
+	err = pem.Encode(&buf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: bs})
+	if err != nil {
+		return nil, "", err
+	}
+
+	return pk, buf.String(), nil
+}
+
+// serialNumber generates a new random serial number.
+func serialNumber() (*big.Int, error) {
+	return rand.Int(rand.Reader, (&big.Int{}).Exp(big.NewInt(2), big.NewInt(159), nil))
+}
+
+// keyId returns a x509 keyId from the given signing key. The key must be
+// an *ecdsa.PublicKey currently, but may support more types in the future.
+func keyId(raw interface{}) ([]byte, error) {
+	switch raw.(type) {
+	case *ecdsa.PublicKey:
+	default:
+		return nil, fmt.Errorf("invalid key type: %T", raw)
+	}
+
+	// This is not standard; RFC allows any unique identifier as long as they
+	// match in subject/authority chains but suggests specific hashing of DER
+	// bytes of public key including DER tags.
+	bs, err := x509.MarshalPKIXPublicKey(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	// String formatted
+	kID := sha256.Sum256(bs)
+	return []byte(strings.Replace(fmt.Sprintf("% x", kID), " ", ":", -1)), nil
+}

--- a/subcommand/get-consul-client-ca/command.go
+++ b/subcommand/get-consul-client-ca/command.go
@@ -1,0 +1,157 @@
+package getconsulclientca
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/command/flags"
+	"github.com/hashicorp/go-hclog"
+	"github.com/mitchellh/cli"
+)
+
+type Command struct {
+	UI cli.Ui
+
+	flags *flag.FlagSet
+
+	flagOutputFile    string
+	flagHttpAddr      string
+	flagCAFile        string
+	flagTLSServerName string
+	flagLogLevel      string
+
+	once sync.Once
+	help string
+}
+
+func (c *Command) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.StringVar(&c.flagOutputFile, "output-file", "",
+		"The path to the file where to put the Consul client's CA certificate.")
+	c.flags.StringVar(&c.flagHttpAddr, "http-addr", "",
+		"The HTTP address of the Consul server. This can also be provided via the CONSUL_HTTP_ADDR environment variable.")
+	c.flags.StringVar(&c.flagCAFile, "ca-file", "",
+		"The path to the CA file to use when making requests to the Consul server. This can also be provided via the CONSUL_CACERT environment variable")
+	c.flags.StringVar(&c.flagTLSServerName, "tls-server-name", "",
+		"The server name to set as the SNI header when sending HTTPS requests to Consul. This can also be provided via the CONSUL_TLS_SERVER_NAME environment variable.")
+	c.flags.StringVar(&c.flagLogLevel, "log-level", "info",
+		"Log verbosity level. Supported values (in order of detail) are \"trace\", "+
+			"\"debug\", \"info\", \"warn\", and \"error\".")
+
+	c.help = flags.Usage(help, c.flags)
+}
+
+func (c *Command) Run(args []string) int {
+	c.once.Do(c.init)
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+	if len(c.flags.Args()) > 0 {
+		c.UI.Error(fmt.Sprintf("Should have no non-flag arguments."))
+		return 1
+	}
+
+	if c.flagOutputFile == "" {
+		c.UI.Error(fmt.Sprintf("-output-file must be set"))
+		return 1
+	}
+
+	// create Consul client
+	consulClient, err := c.consulClient()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error initializing Consul client: %s", err))
+		return 1
+	}
+
+	// create a logger
+	level := hclog.LevelFromString(c.flagLogLevel)
+	if level == hclog.NoLevel {
+		c.UI.Error(fmt.Sprintf("Unknown log level: %s", c.flagLogLevel))
+		return 1
+	}
+	logger := hclog.New(&hclog.LoggerOptions{
+		Level:  level,
+		Output: os.Stderr,
+	})
+
+	// Get the active CA root from Consul
+	// Wait until it gets a successful response
+	var activeRoot string
+	for activeRoot == "" {
+		caRoots, _, err := consulClient.Agent().ConnectCARoots(nil)
+		if err != nil {
+			logger.Info("Error retrieving CA roots from Consul", "err", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		activeRoot, err = c.getActiveRoot(caRoots)
+		if err != nil {
+			logger.Info("Could not get an active root", "err", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+	}
+
+	err = ioutil.WriteFile(c.flagOutputFile, []byte(activeRoot), 0644)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error writing CA file: %s", err))
+		return 1
+	}
+
+	return 0
+}
+
+func (c *Command) consulClient() (*api.Client, error) {
+	cfg := api.DefaultConfig()
+	if c.flagHttpAddr != "" {
+		cfg.Address = c.flagHttpAddr
+	}
+	if c.flagCAFile != "" {
+		cfg.TLSConfig.CAFile = c.flagCAFile
+	}
+	if c.flagTLSServerName != "" {
+		cfg.TLSConfig.Address = c.flagTLSServerName
+	}
+
+	return api.NewClient(cfg)
+}
+
+func (c *Command) getActiveRoot(roots *api.CARootList) (string, error) {
+	if roots == nil {
+		return "", fmt.Errorf("ca roots is nil")
+	}
+	if roots.Roots == nil {
+		return "", fmt.Errorf("ca roots is nil")
+	}
+	if len(roots.Roots) == 0 {
+		return "", fmt.Errorf("the list of root CAs is empty")
+	}
+
+	for _, root := range roots.Roots {
+		if root.Active {
+			return root.RootCertPEM, nil
+		}
+	}
+	return "", fmt.Errorf("none of the roots were active")
+}
+
+func (c *Command) Synopsis() string { return synopsis }
+func (c *Command) Help() string {
+	c.once.Do(c.init)
+	return c.help
+}
+
+const synopsis = "Retrieve Consul client CA if using auto-encrypt feature."
+const help = `
+Usage: consul-k8s get-consul-client-ca [options]
+
+  Retrieve Consul client CA certificate by continuously polling
+  Consul servers and save it at the provided file location.
+
+`

--- a/subcommand/get-consul-client-ca/command.go
+++ b/subcommand/get-consul-client-ca/command.go
@@ -190,7 +190,7 @@ func (c *Command) consulServerAddr(logger hclog.Logger) (string, error) {
 			return "", fmt.Errorf("could not discover any Consul servers with %q", c.flagServerAddr)
 		}
 
-		logger.Debug("discovered servers", strings.Join(servers, " "))
+		logger.Debug("discovered servers", "servers", strings.Join(servers, " "))
 
 		// Pick the first server from the list,
 		// ignoring the port since we need to use HTTP API

--- a/subcommand/get-consul-client-ca/command_test.go
+++ b/subcommand/get-consul-client-ca/command_test.go
@@ -1,0 +1,239 @@
+package getconsulclientca
+
+import (
+	"crypto"
+	"fmt"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/freeport"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/consul/tlsutil"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun_FlagsValidation(t *testing.T) {
+	t.Parallel()
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI: ui,
+	}
+
+	exitCode := cmd.Run([]string{
+		"-output-file", "",
+	})
+	require.Equal(t, 1, exitCode)
+	require.Contains(t, ui.ErrorWriter.String(), "-output-file must be set")
+}
+
+// Test that in the happy case scenario
+// we retrieve the CA from Consul and
+// write it to a file
+func TestRun(t *testing.T) {
+	t.Parallel()
+	outputFile, err := ioutil.TempFile("", "ca")
+	require.NoError(t, err)
+
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI: ui,
+	}
+
+	// start the test server
+	a, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
+		c.Connect = map[string]interface{}{
+			"enabled": true,
+		}
+	})
+	require.NoError(t, err)
+	defer a.Stop()
+
+	// run the command
+	exitCode := cmd.Run([]string{
+		"-http-addr", a.HTTPAddr,
+		"-output-file", outputFile.Name(),
+	})
+	require.Equal(t, 0, exitCode)
+
+	client, err := api.NewClient(&api.Config{
+		Address: a.HTTPAddr,
+	})
+	require.NoError(t, err)
+
+	// get the actual root ca cert from consul
+	roots, _, err := client.Agent().ConnectCARoots(nil)
+	require.NoError(t, err)
+	require.NotNil(t, roots)
+	require.NotNil(t, roots.Roots)
+	require.Len(t, roots.Roots, 1)
+	require.True(t, roots.Roots[0].Active)
+	expectedCARoot := roots.Roots[0].RootCertPEM
+
+	// read the file contents
+	actualCARoot, err := ioutil.ReadFile(outputFile.Name())
+	require.NoError(t, err)
+	require.Equal(t, expectedCARoot, string(actualCARoot))
+}
+
+// Test that if the Consul server is not available at first,
+// we continue to poll it until it comes up.
+func TestRun_ConsulServerAvailableLater(t *testing.T) {
+	t.Parallel()
+	outputFile, err := ioutil.TempFile("", "ca")
+	require.NoError(t, err)
+
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI: ui,
+	}
+
+	randomPorts := freeport.MustTake(6)
+
+	// Start the command asynchronously
+	exitCode := -1
+	go func() {
+		exitCode = cmd.Run([]string{
+			"-http-addr", fmt.Sprintf("http://127.0.0.1:%d", randomPorts[1]),
+			"-output-file", outputFile.Name(),
+		})
+		require.Equal(t, 0, exitCode)
+	}()
+
+	// start the test server
+	time.Sleep(500 * time.Millisecond)
+	a, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
+		c.Ports = &testutil.TestPortConfig{
+			DNS:     randomPorts[0],
+			HTTP:    randomPorts[1],
+			HTTPS:   randomPorts[2],
+			SerfLan: randomPorts[3],
+			SerfWan: randomPorts[4],
+			Server:  randomPorts[5],
+		}
+		c.Connect = map[string]interface{}{
+			"enabled": true,
+		}
+	})
+	require.NoError(t, err)
+	defer a.Stop()
+
+	// wait for command to exit
+	retry.Run(t, func(r *retry.R) {
+		require.Equal(r, 0, exitCode)
+	})
+
+	client, err := api.NewClient(&api.Config{
+		Address: a.HTTPAddr,
+	})
+	require.NoError(t, err)
+
+	// get the actual ca cert from consul
+	var expectedCARoot string
+	timer := &retry.Timer{Timeout: 500 * time.Millisecond, Wait: 100 * time.Millisecond}
+	retry.RunWith(timer, t, func(r *retry.R) {
+		roots, _, err := client.Agent().ConnectCARoots(nil)
+		require.NoError(r, err)
+		require.NotNil(r, roots)
+		require.NotNil(r, roots.Roots)
+		require.Len(r, roots.Roots, 1)
+		require.True(r, roots.Roots[0].Active)
+		expectedCARoot = roots.Roots[0].RootCertPEM
+	})
+
+	// check that the file contents match the actual CA
+	actualCARoot, err := ioutil.ReadFile(outputFile.Name())
+	require.NoError(t, err)
+	require.Equal(t, expectedCARoot, string(actualCARoot))
+}
+
+// Test that the command checks for the active root CA
+// and only writes the active one to the output file, ignoring
+// the inactive one.
+func TestRun_GetsOnlyActiveRoot(t *testing.T) {
+	t.Parallel()
+	outputFile, err := ioutil.TempFile("", "ca")
+	require.NoError(t, err)
+
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI: ui,
+	}
+
+	// start test server
+	a, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
+		c.Connect = map[string]interface{}{
+			"enabled": true,
+		}
+	})
+	require.NoError(t, err)
+	defer a.Stop()
+
+	client, err := api.NewClient(&api.Config{
+		Address: a.HTTPAddr,
+	})
+	require.NoError(t, err)
+
+	// generate a new CA
+	ca, key := generateCA(t)
+
+	// set it as an active CA in Consul
+	retry.Run(t, func(r *retry.R) {
+		_, err = client.Connect().CASetConfig(&api.CAConfig{
+			Provider: "consul",
+			Config: map[string]interface{}{
+				"RootCert":   ca,
+				"PrivateKey": key,
+			},
+		}, nil)
+		require.NoError(r, err)
+	})
+
+	exitCode := cmd.Run([]string{
+		"-http-addr", a.HTTPAddr,
+		"-output-file", outputFile.Name(),
+	})
+	require.Equal(t, 0, exitCode)
+
+	// get the actual ca cert from consul
+	var expectedCARoot string
+	retry.Run(t, func(r *retry.R) {
+		roots, _, err := client.Agent().ConnectCARoots(nil)
+		require.NoError(r, err)
+		require.NotNil(r, roots)
+		require.NotNil(r, roots.Roots)
+		require.Len(r, roots.Roots, 2)
+		if roots.Roots[0].Active {
+			expectedCARoot = roots.Roots[0].RootCertPEM
+		} else {
+			expectedCARoot = roots.Roots[1].RootCertPEM
+		}
+	})
+
+	// read the file contents
+	actualCARoot, err := ioutil.ReadFile(outputFile.Name())
+	require.NoError(t, err)
+	require.Equal(t, expectedCARoot, string(actualCARoot))
+}
+
+// generateCA generates Consul CA
+// and returns cert and key as pem strings.
+func generateCA(t *testing.T) (caPem, keyPem string) {
+	require := require.New(t)
+
+	sn, err := tlsutil.GenerateSerialNumber()
+	require.NoError(err)
+
+	var signer crypto.Signer
+	signer, keyPem, err = tlsutil.GeneratePrivateKey()
+	require.NoError(err)
+
+	constraints := []string{"consul", "localhost"}
+	caPem, err = tlsutil.GenerateCA(signer, sn, 1, constraints)
+	require.NoError(err)
+
+	return
+}

--- a/subcommand/get-consul-client-ca/command_test.go
+++ b/subcommand/get-consul-client-ca/command_test.go
@@ -163,6 +163,11 @@ func TestRun_ConsulServerAvailableLater(t *testing.T) {
 		})
 		require.NoError(t, err)
 	}()
+	defer func() {
+		if a != nil {
+			a.Stop()
+		}
+	}()
 
 	exitCode := cmd.Run([]string{
 		"-server-addr", "localhost",
@@ -171,12 +176,6 @@ func TestRun_ConsulServerAvailableLater(t *testing.T) {
 		"-output-file", outputFile.Name(),
 	})
 	require.Equal(t, 0, exitCode)
-
-	// make sure a has been initialized by the time we call Stop()
-	retry.Run(t, func(r *retry.R) {
-		require.NotNil(r, a)
-	})
-	defer a.Stop()
 
 	client, err := api.NewClient(&api.Config{
 		Address: a.HTTPSAddr,

--- a/subcommand/lifecycle-sidecar/command_test.go
+++ b/subcommand/lifecycle-sidecar/command_test.go
@@ -161,10 +161,14 @@ func TestRun_ServicesRegistration_ConsulDown(t *testing.T) {
 	cmd := Command{
 		UI: ui,
 	}
-	randomPort := freeport.MustTake(1)[0]
+
+	// we need to reserve all 6 ports to avoid potential
+	// port collisions with other tests
+	randomPorts := freeport.MustTake(6)
+
 	// Run async because we need to kill it when the test is over.
 	exitChan := runCommandAsynchronously(&cmd, []string{
-		"-http-addr", fmt.Sprintf("127.0.0.1:%d", randomPort),
+		"-http-addr", fmt.Sprintf("127.0.0.1:%d", randomPorts[1]),
 		"-service-config", configFile,
 		"-sync-period", "100ms",
 	})
@@ -174,7 +178,12 @@ func TestRun_ServicesRegistration_ConsulDown(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 	a, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 		c.Ports = &testutil.TestPortConfig{
-			HTTP: randomPort,
+			DNS:     randomPorts[0],
+			HTTP:    randomPorts[1],
+			HTTPS:   randomPorts[2],
+			SerfLan: randomPorts[3],
+			SerfWan: randomPorts[4],
+			Server:  randomPorts[5],
 		}
 	})
 	require.NoError(t, err)

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -1,12 +1,10 @@
 package serveraclinit
 
 import (
-	"crypto/x509"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,10 +13,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul-k8s/helper/cert"
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/hashicorp/consul/tlsutil"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
 	appv1 "k8s.io/api/apps/v1"
@@ -1397,34 +1395,21 @@ func generateServerCerts(t *testing.T) (string, string, string, func()) {
 	require.NoError(err)
 
 	// Generate CA
-	sn, err := tlsutil.GenerateSerialNumber()
-	require.NoError(err)
-
-	s, _, err := tlsutil.GeneratePrivateKey()
-	require.NoError(err)
-
-	constraints := []string{"consul", "localhost"}
-	ca, err := tlsutil.GenerateCA(s, sn, 1, constraints)
+	signer, _, caCertPem, caCertTemplate, err := cert.GenerateCA("Consul Agent CA - Test")
 	require.NoError(err)
 
 	// Generate Server Cert
-	name := fmt.Sprintf("server.%s.%s", "dc1", "consul")
-	DNSNames := []string{name, "localhost"}
-	IPAddresses := []net.IP{net.ParseIP("127.0.0.1")}
-	extKeyUsage := []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
-
-	sn, err = tlsutil.GenerateSerialNumber()
-	require.NoError(err)
-
-	pub, priv, err := tlsutil.GenerateCert(s, ca, sn, name, 1, DNSNames, IPAddresses, extKeyUsage)
+	name := "server.dc1.consul"
+	hosts := []string{name, "localhost", "127.0.0.1"}
+	certPem, keyPem, err := cert.GenerateCert(name, 1*time.Hour, caCertTemplate, signer, hosts)
 	require.NoError(err)
 
 	// Write certs and key to files
-	_, err = caFile.WriteString(ca)
+	_, err = caFile.WriteString(caCertPem)
 	require.NoError(err)
-	_, err = certFile.WriteString(pub)
+	_, err = certFile.WriteString(certPem)
 	require.NoError(err)
-	_, err = certKeyFile.WriteString(priv)
+	_, err = certKeyFile.WriteString(keyPem)
 	require.NoError(err)
 
 	cleanupFunc := func() {


### PR DESCRIPTION
When auto-encrypt is enabled, we need to retrieve Consul client CA from the Consul servers.

This command calls the `/agent/connect/ca/roots` endpoint, finds the currently active root CA, and writes it to the provided output file location.

This command allows you to provide a cloud-join string instead of the server address and this command will discover the servers. This allows us to re-use the `client.join` value in the Helm chart without requiring operators to provide the address of the server in addition to the join value.