### PR TITLE
Inject-connect command: deprecate the -consul-ca-cert flag

### DIFF
--- a/subcommand/inject-connect/command_test.go
+++ b/subcommand/inject-connect/command_test.go
@@ -1,31 +1,40 @@
 package connectinject
 
 import (
+	"testing"
+
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
-	"testing"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestRun_FlagValidation(t *testing.T) {
 	cases := []struct {
-		Flags  []string
-		ExpErr string
+		name   string
+		flags  []string
+		expErr string
 	}{
 		{
-			Flags:  []string{},
-			ExpErr: "-consul-k8s-image must be set",
+			flags:  []string{},
+			expErr: "-consul-k8s-image must be set",
+		},
+		{
+			flags:  []string{"-consul-k8s-image", "foo", "-ca-file", "bar"},
+			expErr: "Error reading Consul's CA cert file \"bar\"",
 		},
 	}
 
 	for _, c := range cases {
-		t.Run(c.ExpErr, func(t *testing.T) {
+		t.Run(c.expErr, func(t *testing.T) {
+			k8sClient := fake.NewSimpleClientset()
 			ui := cli.NewMockUi()
 			cmd := Command{
-				UI: ui,
+				UI:        ui,
+				clientset: k8sClient,
 			}
-			code := cmd.Run([]string{})
+			code := cmd.Run(c.flags)
 			require.Equal(t, 1, code)
-			require.Contains(t, ui.ErrorWriter.String(), c.ExpErr)
+			require.Contains(t, ui.ErrorWriter.String(), c.expErr)
 		})
 	}
 }


### PR DESCRIPTION
Now that the inject-connect command has Consul's HTTP flags, we should use only one flag to control TLS communications with the local agents.

Currently, we set both flags. The `-consul-ca-cert` flag sets the CA cert for the init container, the envoy proxy sidecar, and the lifecycle sidecar, and they use that CA to talk to their local agent.

The `-ca-file` flag controls the CA cert that is used by the handler to talk to its local agent (this happens only if namespaces are enabled).

Although these agents could be on different hosts, the CA that singed their certificates must be the same, so there is no need to have two different flags.