### PR TITLE
add lint-consul-retry tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,13 @@ jobs:
             fi
       - run: go vet ./...
 
+  # lint consul tests
+  lint-consul-retry:
+    executor: go
+    steps:
+      - checkout
+      - run: go get -u github.com/hashicorp/lint-consul-retry && lint-consul-retry
+
   test:
     executor: go
     environment:
@@ -120,12 +127,15 @@ workflows:
   test-and-build:
     jobs:
       - go-fmt-and-vet
+      - lint-consul-retry
       - test:
           requires:
             - go-fmt-and-vet
+            - lint-consul-retry
       - test_enterprise:
           requires:
             - go-fmt-and-vet
+            - lint-consul-retry
       - build-distros:
           requires:
             - test


### PR DESCRIPTION
This PR adds `lint-consul-retry` which checks to make sure `retry.Run` runs on `retry.R` rather than `testing.T`.