### PR TITLE
Fix race condition in lifecycle-sidecar tests

### DIFF
--- a/subcommand/lifecycle-sidecar/command_test.go
+++ b/subcommand/lifecycle-sidecar/command_test.go
@@ -254,6 +254,11 @@ func TestRun_ConsulCommandFlags(t *testing.T) {
 // Note that it's the responsibility of the caller to terminate the command by calling stopCommand,
 // otherwise it can run forever.
 func runCommandAsynchronously(cmd *Command, args []string) chan int {
+	// We have to run cmd.init() to ensure that the channel the command is
+	// using to watch for os interrupts is initialized. If we don't do this,
+	// then if stopCommand is called immediately, it will block forever
+	// because it calls interrupt() which will attempt to send on a nil channel.
+	cmd.init()
 	exitChan := make(chan int, 1)
 	go func() {
 		exitChan <- cmd.Run(args)


### PR DESCRIPTION
Similar to the fix made for the sync catalog command, ensure that there
is no race condition between starting the command and setting an
interrupt. This race condition is triggered if the goroutine that calls
Run() runs after stopCommand() is run. In this case, the channel that
listens for a SIGTERM signal has not been initialized and so stopCommand
hangs forever writing to a nil channel.