### PR TITLE
Fix test configuration race.

### DIFF
--- a/catalog/to-consul/syncer_test.go
+++ b/catalog/to-consul/syncer_test.go
@@ -167,10 +167,11 @@ func TestConsulSyncer_noReapingUntilInitialSync(t *testing.T) {
 		Address: a.HTTPAddr,
 	})
 	require.NoError(t, err)
-	s, closer := testConsulSyncer(client)
-	// Set the sync period to 5ms so we know it will have run at least once
-	// after we wait 100ms.
-	s.SyncPeriod = 5 * time.Millisecond
+	s, closer := testConsulSyncerWithConfig(client, func(s *ConsulSyncer) {
+		// Set the sync period to 5ms so we know it will have run at least once
+		// after we wait 100ms.
+		s.SyncPeriod = 5 * time.Millisecond
+	})
 	defer closer()
 
 	// Create a service directly in Consul. Since it was created on the


### PR DESCRIPTION
Needed to set the config in the closure instead of after the syncer
started. (https://github.com/hashicorp/consul-k8s/pull/208#discussion_r389070766)