### PR TITLE
Remove test agent from sync tests

### DIFF
--- a/catalog/to-consul/syncer_ent_test.go
+++ b/catalog/to-consul/syncer_ent_test.go
@@ -14,9 +14,11 @@ import (
 // Test that the syncer registers services in Consul namespaces.
 func TestConsulSyncer_ConsulNamespaces(t *testing.T) {
 	t.Parallel()
+
 	a, err := testutil.NewTestServerT(t)
 	require.NoError(t, err)
 	defer a.Stop()
+
 	client, err := api.NewClient(&api.Config{
 		Address: a.HTTPAddr,
 	})
@@ -63,9 +65,11 @@ func TestConsulSyncer_ConsulNamespaces(t *testing.T) {
 // across all Consul namespaces.
 func TestConsulSyncer_ReapConsulNamespace(t *testing.T) {
 	t.Parallel()
+
 	a, err := testutil.NewTestServerT(t)
 	require.NoError(t, err)
 	defer a.Stop()
+
 	client, err := api.NewClient(&api.Config{
 		Address: a.HTTPAddr,
 	})
@@ -130,9 +134,11 @@ func TestConsulSyncer_ReapConsulNamespace(t *testing.T) {
 // namespaces are enabled.
 func TestConsulSyncer_reapServiceInstanceNamespacesEnabled(t *testing.T) {
 	t.Parallel()
+
 	a, err := testutil.NewTestServerT(t)
 	require.NoError(t, err)
 	defer a.Stop()
+
 	client, err := api.NewClient(&api.Config{
 		Address: a.HTTPAddr,
 	})

--- a/catalog/to-k8s/source_test.go
+++ b/catalog/to-k8s/source_test.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 
 	toconsul "github.com/hashicorp/consul-k8s/catalog/to-consul"
-	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 )
@@ -19,20 +18,25 @@ func TestSource_initServices(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	a := agent.NewTestAgent(t, t.Name(), ``)
-	defer a.Shutdown()
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
-	client := a.Client()
+	// Set up server, client
+	a, err := testutil.NewTestServerT(t)
+	require.NoError(err)
+	defer a.Stop()
+
+	client, err := api.NewClient(&api.Config{
+		Address: a.HTTPAddr,
+	})
+	require.NoError(err)
 
 	// Create services before the source is running
-	_, err := client.Catalog().Register(testRegistration("hostA", "svcA", nil), nil)
+	_, err = client.Catalog().Register(testRegistration("hostA", "svcA", nil), nil)
 	require.NoError(err)
 	_, err = client.Catalog().Register(testRegistration("hostB", "svcA", nil), nil)
 	require.NoError(err)
 	_, err = client.Catalog().Register(testRegistration("hostB", "svcB", nil), nil)
 	require.NoError(err)
 
-	_, sink, closer := testSource(t, client)
+	_, sink, closer := testSource(client)
 	defer closer()
 
 	var actual map[string]string
@@ -40,7 +44,7 @@ func TestSource_initServices(t *testing.T) {
 		sink.Lock()
 		defer sink.Unlock()
 		actual = sink.Services
-		if len(actual) == 0 {
+		if len(actual) != 3 {
 			r.Fatal("services not found")
 		}
 	})
@@ -58,17 +62,23 @@ func TestSource_prefix(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	a := agent.NewTestAgent(t, t.Name(), ``)
-	defer a.Shutdown()
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
-	client := a.Client()
+	// Set up server, client
+	a, err := testutil.NewTestServerT(t)
+	require.NoError(err)
+	defer a.Stop()
 
-	src, sink, closer := testSource(t, client)
-	src.Prefix = "foo-" // This is a race, we should fix this, but test only
+	client, err := api.NewClient(&api.Config{
+		Address: a.HTTPAddr,
+	})
+	require.NoError(err)
+
+	_, sink, closer := testSourceWithConfig(client, func(s *Source) {
+		s.Prefix = "foo-"
+	})
 	defer closer()
 
 	// Create services before the source is running
-	_, err := client.Catalog().Register(testRegistration("hostA", "svcA", nil), nil)
+	_, err = client.Catalog().Register(testRegistration("hostA", "svcA", nil), nil)
 	require.NoError(err)
 	_, err = client.Catalog().Register(testRegistration("hostB", "svcA", nil), nil)
 	require.NoError(err)
@@ -98,20 +108,25 @@ func TestSource_ignoreK8S(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	a := agent.NewTestAgent(t, t.Name(), ``)
-	defer a.Shutdown()
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
-	client := a.Client()
+	// Set up server, client
+	a, err := testutil.NewTestServerT(t)
+	require.NoError(err)
+	defer a.Stop()
+
+	client, err := api.NewClient(&api.Config{
+		Address: a.HTTPAddr,
+	})
+	require.NoError(err)
 
 	// Create services before the source is running
-	_, err := client.Catalog().Register(testRegistration("hostA", "svcA", nil), nil)
+	_, err = client.Catalog().Register(testRegistration("hostA", "svcA", nil), nil)
 	require.NoError(err)
 	_, err = client.Catalog().Register(testRegistration("hostB", "svcA", nil), nil)
 	require.NoError(err)
 	_, err = client.Catalog().Register(testRegistration("hostB", "svcB", []string{toconsul.TestConsulK8STag}), nil)
 	require.NoError(err)
 
-	_, sink, closer := testSource(t, client)
+	_, sink, closer := testSource(client)
 	defer closer()
 
 	var actual map[string]string
@@ -119,7 +134,7 @@ func TestSource_ignoreK8S(t *testing.T) {
 		sink.Lock()
 		defer sink.Unlock()
 		actual = sink.Services
-		if len(actual) == 0 {
+		if len(actual) != 2 {
 			r.Fatal("services not found")
 		}
 	})
@@ -133,23 +148,29 @@ func TestSource_ignoreK8S(t *testing.T) {
 
 // Test that the source deletes services properly.
 func TestSource_deleteService(t *testing.T) {
-	t.Parallel()
+	// Unable to be run in parallel with other tests that
+	// check for the existence of `consul.service.test`
 	require := require.New(t)
 
-	a := agent.NewTestAgent(t, t.Name(), ``)
-	defer a.Shutdown()
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
-	client := a.Client()
+	// Set up server, client
+	a, err := testutil.NewTestServerT(t)
+	require.NoError(err)
+	defer a.Stop()
+
+	client, err := api.NewClient(&api.Config{
+		Address: a.HTTPAddr,
+	})
+	require.NoError(err)
 
 	// Create services before the source is running
-	_, err := client.Catalog().Register(testRegistration("hostA", "svcA", nil), nil)
+	_, err = client.Catalog().Register(testRegistration("hostA", "svcA", nil), nil)
 	require.NoError(err)
 	_, err = client.Catalog().Register(testRegistration("hostB", "svcA", nil), nil)
 	require.NoError(err)
 	_, err = client.Catalog().Register(testRegistration("hostB", "svcB", nil), nil)
 	require.NoError(err)
 
-	_, sink, closer := testSource(t, client)
+	_, sink, closer := testSource(client)
 	defer closer()
 
 	var actual map[string]string
@@ -157,7 +178,7 @@ func TestSource_deleteService(t *testing.T) {
 		sink.Lock()
 		defer sink.Unlock()
 		actual = sink.Services
-		if len(actual) == 0 {
+		if len(actual) != 3 {
 			r.Fatal("services not found")
 		}
 	})
@@ -192,20 +213,25 @@ func TestSource_deleteServiceInstance(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	a := agent.NewTestAgent(t, t.Name(), ``)
-	defer a.Shutdown()
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
-	client := a.Client()
+	// Set up server, client
+	a, err := testutil.NewTestServerT(t)
+	require.NoError(err)
+	defer a.Stop()
+
+	client, err := api.NewClient(&api.Config{
+		Address: a.HTTPAddr,
+	})
+	require.NoError(err)
 
 	// Create services before the source is running
-	_, err := client.Catalog().Register(testRegistration("hostA", "svcA", nil), nil)
+	_, err = client.Catalog().Register(testRegistration("hostA", "svcA", nil), nil)
 	require.NoError(err)
 	_, err = client.Catalog().Register(testRegistration("hostB", "svcA", nil), nil)
 	require.NoError(err)
 	_, err = client.Catalog().Register(testRegistration("hostB", "svcB", nil), nil)
 	require.NoError(err)
 
-	_, sink, closer := testSource(t, client)
+	_, sink, closer := testSource(client)
 	defer closer()
 
 	var actual map[string]string
@@ -213,7 +239,7 @@ func TestSource_deleteServiceInstance(t *testing.T) {
 		sink.Lock()
 		defer sink.Unlock()
 		actual = sink.Services
-		if len(actual) == 0 {
+		if len(actual) != 3 {
 			r.Fatal("services not found")
 		}
 	})
@@ -233,7 +259,7 @@ func TestSource_deleteServiceInstance(t *testing.T) {
 	})
 }
 
-// testRegistration creates a Consul test registration.
+// testRegistration creates a Consul test registration
 func testRegistration(node, service string, tags []string) *api.CatalogRegistration {
 	return &api.CatalogRegistration{
 		Node:    node,
@@ -245,8 +271,14 @@ func testRegistration(node, service string, tags []string) *api.CatalogRegistrat
 	}
 }
 
-// testSource creates a Source and Sink for testing.
-func testSource(t *testing.T, client *api.Client) (*Source, *TestSink, func()) {
+// testSource creates a Source and Sink for testing
+func testSource(client *api.Client) (*Source, *TestSink, func()) {
+	return testSourceWithConfig(client, func(source *Source) {})
+}
+
+// testSourceWithConfig starts a Source that can be configured
+// prior to starting via the configurator method
+func testSourceWithConfig(client *api.Client, configurator func(*Source)) (*Source, *TestSink, func()) {
 	sink := &TestSink{}
 	s := &Source{
 		Client:       client,
@@ -255,6 +287,7 @@ func testSource(t *testing.T, client *api.Client) (*Source, *TestSink, func()) {
 		Log:          hclog.Default(),
 		ConsulK8STag: toconsul.TestConsulK8STag,
 	}
+	configurator(s)
 
 	ctx, cancelF := context.WithCancel(context.Background())
 	doneCh := make(chan struct{})

--- a/subcommand/sync-catalog/command_ent_test.go
+++ b/subcommand/sync-catalog/command_ent_test.go
@@ -42,13 +42,13 @@ func TestRun_ToConsulSingleDestinationNamespace(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.Name, func(tt *testing.T) {
-			k8s, testAgent := completeSetupEnterprise(tt)
-			defer testAgent.Stop()
+			k8s, testServer := completeSetupEnterprise(tt)
+			defer testServer.Stop()
 
 			// Run the command.
 			ui := cli.NewMockUi()
 			consulClient, err := api.NewClient(&api.Config{
-				Address: testAgent.HTTPAddr,
+				Address: testServer.HTTPAddr,
 			})
 			require.NoError(tt, err)
 
@@ -177,13 +177,13 @@ func TestRun_ToConsulMirroringNamespaces(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(tt *testing.T) {
-			k8s, testAgent := completeSetupEnterprise(tt)
-			defer testAgent.Stop()
+			k8s, testServer := completeSetupEnterprise(tt)
+			defer testServer.Stop()
 
 			// Run the command.
 			ui := cli.NewMockUi()
 			consulClient, err := api.NewClient(&api.Config{
-				Address: testAgent.HTTPAddr,
+				Address: testServer.HTTPAddr,
 			})
 			require.NoError(tt, err)
 
@@ -448,11 +448,11 @@ func TestRun_ToConsulChangingNamespaceFlags(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(tt *testing.T) {
-			k8s, testAgent := completeSetupEnterprise(tt)
-			defer testAgent.Stop()
+			k8s, testServer := completeSetupEnterprise(tt)
+			defer testServer.Stop()
 			ui := cli.NewMockUi()
 			consulClient, err := api.NewClient(&api.Config{
-				Address: testAgent.HTTPAddr,
+				Address: testServer.HTTPAddr,
 			})
 			require.NoError(tt, err)
 


### PR DESCRIPTION
Removes the TestAgent that was imported from OSS Consul. Instead,
makes use of the Consul TestServer that is part of the sdk.