### PR TITLE
Trim spaces before checking if an upstream is a prepared query

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -116,7 +116,7 @@ func (h *Handler) containerInit(pod *corev1.Pod, k8sNamespace string) (corev1.Co
 
 			var datacenter, service_name, prepared_query, namespace string
 			var port int32
-			if parts[0] == "prepared_query" {
+			if strings.TrimSpace(parts[0]) == "prepared_query" {
 				port, _ = portValue(pod, strings.TrimSpace(parts[2]))
 				prepared_query = strings.TrimSpace(parts[1])
 			} else {

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -164,6 +164,35 @@ services {
 		},
 
 		{
+			"Multiple upstream services",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				pod.Annotations[annotationUpstreams] = "db:1234, db:2345, db:3456"
+				return pod
+			},
+			`proxy {
+    destination_service_name = "web"
+    destination_service_id = "${SERVICE_ID}"
+    upstreams {
+      destination_type = "service" 
+      destination_name = "db"
+      local_bind_port = 1234
+    }
+    upstreams {
+      destination_type = "service" 
+      destination_name = "db"
+      local_bind_port = 2345
+    }
+    upstreams {
+      destination_type = "service" 
+      destination_name = "db"
+      local_bind_port = 3456
+    }
+  }`,
+			"",
+		},
+
+		{
 			"Upstream datacenter specified",
 			func(pod *corev1.Pod) *corev1.Pod {
 				pod.Annotations[annotationService] = "web"
@@ -208,6 +237,35 @@ services {
       destination_type = "prepared_query" 
       destination_name = "handle"
       local_bind_port = 1234
+    }
+  }`,
+			"",
+		},
+
+		{
+			"Upstream prepared queries and non-query",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				pod.Annotations[annotationUpstreams] = "prepared_query:handle:8200, servicename:8201, prepared_query:6687bd19-5654-76be-d764:8202"
+				return pod
+			},
+			`proxy {
+    destination_service_name = "web"
+    destination_service_id = "${SERVICE_ID}"
+    upstreams {
+      destination_type = "prepared_query" 
+      destination_name = "handle"
+      local_bind_port = 8200
+    }
+    upstreams {
+      destination_type = "service" 
+      destination_name = "servicename"
+      local_bind_port = 8201
+    }
+    upstreams {
+      destination_type = "prepared_query" 
+      destination_name = "6687bd19-5654-76be-d764"
+      local_bind_port = 8202
     }
   }`,
 			"",


### PR DESCRIPTION
Fixes #224.

If a user puts spaces between their upstreams in the annotation,
the first section of a prepared query later in the list shows up
as ` prepared_query`. We were doing a direct comparison of this
value with `prepared_query`, which is incorrect. This change trims
the spaces on the first part of an upstream before checking its type.

Adds several different tests to verify the behavior with multiple
upstreams defined.