### PR TITLE
Add new load-balancer-address command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -7,6 +7,7 @@ import (
 	cmdDeleteCompletedJob "github.com/hashicorp/consul-k8s/subcommand/delete-completed-job"
 	cmdInjectConnect "github.com/hashicorp/consul-k8s/subcommand/inject-connect"
 	cmdLifecycleSidecar "github.com/hashicorp/consul-k8s/subcommand/lifecycle-sidecar"
+	cmdLoadBalancerAddress "github.com/hashicorp/consul-k8s/subcommand/load-balancer-address"
 	cmdServerACLInit "github.com/hashicorp/consul-k8s/subcommand/server-acl-init"
 	cmdSyncCatalog "github.com/hashicorp/consul-k8s/subcommand/sync-catalog"
 	cmdVersion "github.com/hashicorp/consul-k8s/subcommand/version"
@@ -43,6 +44,10 @@ func init() {
 
 		"delete-completed-job": func() (cli.Command, error) {
 			return &cmdDeleteCompletedJob.Command{UI: ui}, nil
+		},
+
+		"load-balancer-address": func() (cli.Command, error) {
+			return &cmdLoadBalancerAddress.Command{UI: ui}, nil
 		},
 
 		"version": func() (cli.Command, error) {

--- a/subcommand/load-balancer-address/command.go
+++ b/subcommand/load-balancer-address/command.go
@@ -1,0 +1,156 @@
+package loadbalanceraddress
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/hashicorp/consul-k8s/subcommand"
+	k8sflags "github.com/hashicorp/consul-k8s/subcommand/flags"
+	"github.com/hashicorp/consul/command/flags"
+	"github.com/hashicorp/go-hclog"
+	"github.com/mitchellh/cli"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Command struct {
+	UI cli.Ui
+
+	flags    *flag.FlagSet
+	k8sFlags *k8sflags.K8SFlags
+
+	flagNamespace   string
+	flagServiceName string
+	flagOutputFile  string
+
+	retryDuration time.Duration
+	k8sClient     kubernetes.Interface
+	once          sync.Once
+	help          string
+}
+
+func (c *Command) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.StringVar(&c.flagNamespace, "k8s-namespace", "",
+		"Kubernetes namespace where service is created")
+	c.flags.StringVar(&c.flagServiceName, "name", "",
+		"Name of the service")
+	c.flags.StringVar(&c.flagOutputFile, "output-file", "",
+		"Path to file to write load balancer address")
+
+	c.k8sFlags = &k8sflags.K8SFlags{}
+	flags.Merge(c.flags, c.k8sFlags.Flags())
+	c.help = flags.Usage(help, c.flags)
+}
+
+// Run waits until a Kubernetes service has an ingress address and then writes
+// it to an output file.
+func (c *Command) Run(args []string) int {
+	c.once.Do(c.init)
+	if err := c.validateFlags(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	if c.k8sClient == nil {
+		config, err := subcommand.K8SConfig(c.k8sFlags.KubeConfig())
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error retrieving Kubernetes auth: %s", err))
+			return 1
+		}
+		c.k8sClient, err = kubernetes.NewForConfig(config)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error initializing Kubernetes client: %s", err))
+			return 1
+		}
+	}
+	if c.retryDuration == 0 {
+		c.retryDuration = 1 * time.Second
+	}
+	log := hclog.New(&hclog.LoggerOptions{
+		Level:  hclog.Info,
+		Output: os.Stderr,
+	})
+
+	// Run until we get an address from the service.
+	var address string
+	backoff.Retry(withErrLogger(log, func() error {
+		svc, err := c.k8sClient.CoreV1().Services(c.flagNamespace).Get(c.flagServiceName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("getting service %s: %s", c.flagServiceName, err)
+		}
+		for _, ingr := range svc.Status.LoadBalancer.Ingress {
+			if ingr.IP != "" {
+				address = ingr.IP
+				return nil
+			} else if ingr.Hostname != "" {
+				address = ingr.Hostname
+				return nil
+			}
+		}
+		return fmt.Errorf("service %s has no ingress IP or hostname", c.flagServiceName)
+	}), backoff.NewConstantBackOff(c.retryDuration))
+
+	// Write the address to file.
+	err := ioutil.WriteFile(c.flagOutputFile, []byte(address), 0600)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Unable to write address to file: %s", err))
+		return 1
+	}
+
+	c.UI.Info(fmt.Sprintf("Address %q written to %s successfully", address, c.flagOutputFile))
+	return 0
+}
+
+func (c *Command) validateFlags(args []string) error {
+	if err := c.flags.Parse(args); err != nil {
+		return err
+	}
+	if len(c.flags.Args()) > 0 {
+		return errors.New("should have no non-flag arguments")
+	}
+	if c.flagNamespace == "" {
+		return errors.New("-k8s-namespace must be set")
+	}
+	if c.flagServiceName == "" {
+		return errors.New("-name must be set")
+	}
+	if c.flagOutputFile == "" {
+		return errors.New("-output-file must be set")
+	}
+	return nil
+}
+
+// withErrLogger runs op and logs if op returns an error.
+// It returns the result of op.
+func withErrLogger(log hclog.Logger, op func() error) func() error {
+	return func() error {
+		err := op()
+		if err != nil {
+			log.Error(err.Error())
+		}
+		return err
+	}
+}
+
+func (c *Command) Synopsis() string { return synopsis }
+func (c *Command) Help() string {
+	c.once.Do(c.init)
+	return c.help
+}
+
+const synopsis = "Output Kubernetes LoadBalancer service ingress address to file"
+const help = `
+Usage: consul-k8s load-balancer-address [options]
+
+  Waits until the Kubernetes service specified by -name in namespace
+  -k8s-namespace is created and has an ingress address. Then writes the
+  address to -output-file.
+
+`

--- a/subcommand/load-balancer-address/command_test.go
+++ b/subcommand/load-balancer-address/command_test.go
@@ -1,0 +1,259 @@
+package loadbalanceraddress
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// Test that flags are validated.
+func TestRun_FlagValidation(t *testing.T) {
+	cases := []struct {
+		Flags  []string
+		ExpErr string
+	}{
+		{
+			Flags:  []string{},
+			ExpErr: "-k8s-namespace must be set",
+		},
+		{
+			Flags:  []string{"-k8s-namespace=default"},
+			ExpErr: "-name must be set",
+		},
+		{
+			Flags:  []string{"-k8s-namespace=default", "-name=name"},
+			ExpErr: "-output-file must be set",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.ExpErr, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI: ui,
+			}
+			responseCode := cmd.Run(c.Flags)
+			require.Equal(t, 1, responseCode, ui.ErrorWriter.String())
+			require.Contains(t, ui.ErrorWriter.String(), c.ExpErr)
+		})
+	}
+}
+
+// Test that if the file can't be written to we return an error.
+func TestRun_UnableToWriteToFile(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	k8sNS := "default"
+	svcName := "service-name"
+	expAddress := "1.2.3.4"
+
+	// Create the service.
+	k8s := fake.NewSimpleClientset()
+	_, err := k8s.CoreV1().Services(k8sNS).Create(kubeSvc(svcName, expAddress, ""))
+	require.NoError(err)
+
+	// Run command with an unwriteable file.
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI:        ui,
+		k8sClient: k8s,
+	}
+	responseCode := cmd.Run([]string{
+		"-k8s-namespace", k8sNS,
+		"-name", svcName,
+		"-output-file", "/this/filepath/does/not/exist",
+	})
+	require.Equal(1, responseCode, ui.ErrorWriter.String())
+	require.Contains(ui.ErrorWriter.String(),
+		"Unable to write address to file: open /this/filepath/does/not/exist: no such file or directory")
+}
+
+// Test running with different permutations of ingress.
+func TestRun_LoadBalancerIngressPermutations(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	cases := map[string]struct {
+		Ingress    []v1.LoadBalancerIngress
+		ExpAddress string
+	}{
+		"ip": {
+			Ingress: []v1.LoadBalancerIngress{
+				{
+					IP: "1.2.3.4",
+				},
+			},
+			ExpAddress: "1.2.3.4",
+		},
+		"hostname": {
+			Ingress: []v1.LoadBalancerIngress{
+				{
+					Hostname: "example.com",
+				},
+			},
+			ExpAddress: "example.com",
+		},
+		"empty first ingress": {
+			Ingress: []v1.LoadBalancerIngress{
+				{},
+				{
+					IP: "1.2.3.4",
+				},
+			},
+			ExpAddress: "1.2.3.4",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			k8sNS := "default"
+			svcName := "service-name"
+
+			// Create the service.
+			k8s := fake.NewSimpleClientset()
+			svc := &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: svcName,
+				},
+				Status: v1.ServiceStatus{
+					LoadBalancer: v1.LoadBalancerStatus{
+						Ingress: c.Ingress,
+					},
+				},
+			}
+			_, err := k8s.CoreV1().Services(k8sNS).Create(svc)
+			require.NoError(err)
+
+			// Run command.
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI:        ui,
+				k8sClient: k8s,
+			}
+			tmpDir, err := ioutil.TempDir("", "")
+			require.NoError(err)
+			defer os.RemoveAll(tmpDir)
+			outputFile := filepath.Join(tmpDir, "address.txt")
+
+			responseCode := cmd.Run([]string{
+				"-k8s-namespace", k8sNS,
+				"-name", svcName,
+				"-output-file", outputFile,
+			})
+			require.Equal(0, responseCode, ui.ErrorWriter.String())
+			actAddressBytes, err := ioutil.ReadFile(outputFile)
+			require.NoError(err)
+			require.Equal(c.ExpAddress, string(actAddressBytes))
+
+		})
+	}
+}
+
+// Test that we write the address to file successfully, even when we have to retry
+// looking up the service. This mimics what happens in Kubernetes when a
+// service gets an ingress address after a cloud provider provisions a
+// load balancer.
+func TestRun_FileWrittenAfterRetry(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		// InitialService controls whether a service with that name will have
+		// already been created. The service won't have an address yet.
+		InitialService bool
+		// UpdateDelay controls how long we wait before updating the service
+		// with the UpdateIP address. NOTE: the retry duration for this
+		// test is set to 10ms.
+		UpdateDelay time.Duration
+	}{
+		"initial service exists": {
+			InitialService: true,
+			UpdateDelay:    50 * time.Millisecond,
+		},
+		"initial service does not exist, immediate update": {
+			InitialService: false,
+			UpdateDelay:    0,
+		},
+		"initial service does not exist, 50ms delay": {
+			InitialService: false,
+			UpdateDelay:    50 * time.Millisecond,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			k8sNS := "default"
+			svcName := "service-name"
+			ip := "1.2.3.4"
+			k8s := fake.NewSimpleClientset()
+
+			if c.InitialService {
+				_, err := k8s.CoreV1().Services(k8sNS).Create(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: svcName,
+					},
+				})
+				require.NoError(t, err)
+			}
+
+			// Create/update the service after delay.
+			go func() {
+				time.Sleep(c.UpdateDelay)
+				svc := kubeSvc(svcName, ip, "")
+				var err error
+				if c.InitialService {
+					_, err = k8s.CoreV1().Services(k8sNS).Update(svc)
+				} else {
+					_, err = k8s.CoreV1().Services(k8sNS).Create(svc)
+				}
+				require.NoError(t, err)
+			}()
+
+			// Run command.
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI:            ui,
+				k8sClient:     k8s,
+				retryDuration: 10 * time.Millisecond,
+			}
+			tmpDir, err := ioutil.TempDir("", "")
+			require.NoError(t, err)
+			defer os.RemoveAll(tmpDir)
+			outputFile := filepath.Join(tmpDir, "address.txt")
+
+			responseCode := cmd.Run([]string{
+				"-k8s-namespace", k8sNS,
+				"-name", svcName,
+				"-output-file", outputFile,
+			})
+			require.Equal(t, 0, responseCode, ui.ErrorWriter.String())
+			actAddressBytes, err := ioutil.ReadFile(outputFile)
+			require.NoError(t, err)
+			require.Equal(t, ip, string(actAddressBytes))
+		})
+	}
+}
+
+func kubeSvc(name string, ip string, hostname string) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{
+						IP:       ip,
+						Hostname: hostname,
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Command usage:
```
  consul-k8s load-balancer-address \
    -k8s-namespace default \
    -name my-service-name \
    -output-file address.txt
```

The command will run in a retry loop until the service has been assigned
an ingress IP or hostname. It will then write that address to file.

The command will be used in the helm chart in the init container for the mesh-gateway.