### PR TITLE
server-acl-init: Add -server-address and -server-port

### DIFF
--- a/subcommand/server-acl-init/command_ent_test.go
+++ b/subcommand/server-acl-init/command_ent_test.go
@@ -63,7 +63,7 @@ func TestRun_ConnectInject_SingleDestinationNamespace(t *testing.T) {
 			require.Len(methods, 1)
 
 			// Check the ACL auth method is created in the expected namespace.
-			authMethodName := releaseName + "-consul-k8s-auth-method"
+			authMethodName := resourcePrefix + "-k8s-auth-method"
 			actMethod, _, err := consul.ACL().AuthMethodRead(authMethodName, namespaceQuery)
 			require.NoError(err)
 			require.NotNil(actMethod)
@@ -176,7 +176,7 @@ func TestRun_ConnectInject_NamespaceMirroring(t *testing.T) {
 			require.NoError(err)
 
 			// Check the ACL auth method is as expected.
-			authMethodName := releaseName + "-consul-k8s-auth-method"
+			authMethodName := resourcePrefix + "-k8s-auth-method"
 			method, _, err := consul.ACL().AuthMethodRead(authMethodName, nil)
 			require.NoError(err)
 			require.NotNil(method, authMethodName+" not found")
@@ -544,7 +544,7 @@ func TestRun_ConnectInject_Updates(t *testing.T) {
 			require.NoError(err)
 
 			// Check the ACL auth method is as expected.
-			authMethodName := releaseName + "-consul-k8s-auth-method"
+			authMethodName := resourcePrefix + "-k8s-auth-method"
 			method, _, err := consul.ACL().AuthMethodRead(authMethodName, &api.QueryOptions{
 				Namespace: c.AuthMethodExpectedNS,
 			})

--- a/subcommand/server-acl-init/command_ent_test.go
+++ b/subcommand/server-acl-init/command_ent_test.go
@@ -3,6 +3,7 @@
 package serveraclinit
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/api"
@@ -21,7 +22,7 @@ func TestRun_ConnectInject_SingleDestinationNamespace(t *testing.T) {
 	consulDestNamespaces := []string{"default", "destination"}
 	for _, consulDestNamespace := range consulDestNamespaces {
 		t.Run(consulDestNamespace, func(tt *testing.T) {
-			k8s, testAgent := completeEnterpriseSetup(tt, resourcePrefix, ns)
+			k8s, testAgent := completeEnterpriseSetup(tt)
 			defer testAgent.Stop()
 			setUpK8sServiceAccount(tt, k8s)
 			require := require.New(tt)
@@ -33,10 +34,10 @@ func TestRun_ConnectInject_SingleDestinationNamespace(t *testing.T) {
 			}
 			cmd.init()
 			args := []string{
-				"-server-label-selector=component=server,app=consul,release=" + releaseName,
+				"-server-address=" + strings.Split(testAgent.HTTPAddr, ":")[0],
+				"-server-port=" + strings.Split(testAgent.HTTPAddr, ":")[1],
 				"-resource-prefix=" + resourcePrefix,
 				"-k8s-namespace=" + ns,
-				"-expected-replicas=1",
 				"-create-inject-auth-method",
 				"-enable-namespaces",
 				"-consul-inject-destination-namespace", consulDestNamespace,
@@ -141,7 +142,7 @@ func TestRun_ConnectInject_NamespaceMirroring(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(tt *testing.T) {
-			k8s, testAgent := completeEnterpriseSetup(t, resourcePrefix, ns)
+			k8s, testAgent := completeEnterpriseSetup(t)
 			defer testAgent.Stop()
 			setUpK8sServiceAccount(tt, k8s)
 			require := require.New(tt)
@@ -153,10 +154,10 @@ func TestRun_ConnectInject_NamespaceMirroring(t *testing.T) {
 			}
 			cmd.init()
 			args := []string{
-				"-server-label-selector=component=server,app=consul,release=" + releaseName,
+				"-server-address=" + strings.Split(testAgent.HTTPAddr, ":")[0],
+				"-server-port=" + strings.Split(testAgent.HTTPAddr, ":")[1],
 				"-resource-prefix=" + resourcePrefix,
 				"-k8s-namespace=" + ns,
-				"-expected-replicas=1",
 				"-create-inject-auth-method",
 				"-enable-namespaces",
 				"-enable-inject-k8s-namespace-mirroring",
@@ -208,13 +209,14 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 	k8sNamespaceFlags := []string{"default", "other"}
 	for _, k8sNamespaceFlag := range k8sNamespaceFlags {
 		t.Run(k8sNamespaceFlag, func(t *testing.T) {
-			k8s, testAgent := completeEnterpriseSetup(t, resourcePrefix, k8sNamespaceFlag)
+			k8s, testAgent := completeEnterpriseSetup(t)
 			defer testAgent.Stop()
 			require := require.New(t)
 
 			ui := cli.NewMockUi()
 			firstRunArgs := []string{
-				"-server-label-selector=component=server,app=consul,release=" + releaseName,
+				"-server-address=" + strings.Split(testAgent.HTTPAddr, ":")[0],
+				"-server-port=" + strings.Split(testAgent.HTTPAddr, ":")[1],
 				"-resource-prefix=" + resourcePrefix,
 				"-k8s-namespace", k8sNamespaceFlag,
 				"-create-client-token",
@@ -224,7 +226,6 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 				"-create-inject-namespace-token",
 				"-create-snapshot-agent-token",
 				"-create-enterprise-license-token",
-				"-expected-replicas=1",
 			}
 			// Our second run, we're going to update from namespaces disabled to
 			// namespaces enabled with a single destination ns.
@@ -501,16 +502,16 @@ func TestRun_ConnectInject_Updates(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(tt *testing.T) {
 			require := require.New(tt)
-			k8s, testAgent := completeEnterpriseSetup(tt, resourcePrefix, ns)
+			k8s, testAgent := completeEnterpriseSetup(tt)
 			defer testAgent.Stop()
 			setUpK8sServiceAccount(tt, k8s)
 
 			ui := cli.NewMockUi()
 			defaultArgs := []string{
-				"-server-label-selector=component=server,app=consul,release=" + releaseName,
+				"-server-address=" + strings.Split(testAgent.HTTPAddr, ":")[0],
+				"-server-port=" + strings.Split(testAgent.HTTPAddr, ":")[1],
 				"-resource-prefix=" + resourcePrefix,
 				"-k8s-namespace=" + ns,
-				"-expected-replicas=1",
 				"-create-inject-auth-method",
 			}
 
@@ -632,7 +633,7 @@ func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
 	}
 	for testName, c := range cases {
 		t.Run(testName, func(t *testing.T) {
-			k8s, testSvr := completeEnterpriseSetup(t, resourcePrefix, ns)
+			k8s, testSvr := completeEnterpriseSetup(t)
 			defer testSvr.Stop()
 			require := require.New(t)
 
@@ -644,10 +645,10 @@ func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
 			}
 			cmd.init()
 			cmdArgs := []string{
-				"-server-label-selector=component=server,app=consul,release=" + releaseName,
+				"-server-address", strings.Split(testSvr.HTTPAddr, ":")[0],
+				"-server-port", strings.Split(testSvr.HTTPAddr, ":")[1],
 				"-resource-prefix=" + resourcePrefix,
 				"-k8s-namespace=" + ns,
-				"-expected-replicas=1",
 				"-enable-namespaces",
 				c.TokenFlag,
 			}
@@ -693,15 +694,13 @@ func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
 }
 
 // Set up test consul agent and kubernetes cluster.
-func completeEnterpriseSetup(t *testing.T, prefix string, k8sNamespace string) (*fake.Clientset, *testutil.TestServer) {
+func completeEnterpriseSetup(t *testing.T) (*fake.Clientset, *testutil.TestServer) {
 	k8s := fake.NewSimpleClientset()
 
 	svr, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 		c.ACL.Enabled = true
 	})
 	require.NoError(t, err)
-
-	createTestK8SResources(t, k8s, svr.HTTPAddr, prefix, "http", k8sNamespace)
 
 	return k8s, svr
 }

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -1211,7 +1211,7 @@ func mockReplicatedSetup(t *testing.T, bootToken string) (*fake.Clientset, *api.
 // command to set up replication. Otherwise it will do it through config.
 // Returns the Kubernetes client for the secondary DC,
 // a Consul API client initialized for the secondary DC,
-// ACL replication token, the address of the secondary Consul server, and a
+// the address of the secondary Consul server, ACL replication token, and a
 // cleanup function that should be called at the end of the test that cleans
 // up resources.
 func replicatedSetup(t *testing.T, bootToken string) (*fake.Clientset, *api.Client, string, string, func()) {

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -638,7 +638,7 @@ func TestRun_DelayedServers(t *testing.T) {
 	}
 
 	// Start the command before the server is up.
-	// Run in a goroutine so we can create the Pods asynchronously
+	// Run in a goroutine so we can start the server asynchronously
 	done := make(chan bool)
 	var responseCode int
 	go func() {
@@ -865,7 +865,6 @@ func TestRun_ClientTokensRetry(t *testing.T) {
 	}))
 	defer consulServer.Close()
 
-	// Create the Server Pods.
 	serverURL, err := url.Parse(consulServer.URL)
 	require.NoError(err)
 
@@ -951,7 +950,6 @@ func TestRun_AlreadyBootstrapped(t *testing.T) {
 	}))
 	defer consulServer.Close()
 
-	// Create the Server Pods.
 	serverURL, err := url.Parse(consulServer.URL)
 	require.NoError(err)
 

--- a/subcommand/server-acl-init/servers.go
+++ b/subcommand/server-acl-init/servers.go
@@ -10,76 +10,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// podAddr is a convenience struct for passing around pod names and
-// addresses for Consul servers.
-type podAddr struct {
-	// Name is the name of the pod.
-	Name string
-	// Addr is in the form "<ip>:<port>".
-	Addr string
-}
-
-// getConsulServers returns n Consul server pods with their http addresses.
-// If there are less server pods than 'n' then the function will wait.
-func (c *Command) getConsulServers(n int, scheme string) ([]podAddr, error) {
-	var serverPods *apiv1.PodList
-	err := c.untilSucceeds("discovering Consul server pods",
-		func() error {
-			var err error
-			serverPods, err = c.clientset.CoreV1().Pods(c.flagK8sNamespace).List(metav1.ListOptions{LabelSelector: c.flagServerLabelSelector})
-			if err != nil {
-				return err
-			}
-
-			if len(serverPods.Items) == 0 {
-				return fmt.Errorf("no server pods with labels %q found", c.flagServerLabelSelector)
-			}
-
-			if len(serverPods.Items) < n {
-				return fmt.Errorf("found %d servers, require %d", len(serverPods.Items), n)
-			}
-
-			for _, pod := range serverPods.Items {
-				if pod.Status.PodIP == "" {
-					return fmt.Errorf("pod %s has no IP", pod.Name)
-				}
-			}
-			return nil
-		})
-	if err != nil {
-		return nil, err
-	}
-
-	var podAddrs []podAddr
-	for _, pod := range serverPods.Items {
-		var httpPort int32
-		for _, p := range pod.Spec.Containers[0].Ports {
-			if p.Name == scheme {
-				httpPort = p.ContainerPort
-			}
-		}
-		if httpPort == 0 {
-			return nil, fmt.Errorf("pod %s has no port labeled '%s'", pod.Name, scheme)
-		}
-		addr := fmt.Sprintf("%s:%d", pod.Status.PodIP, httpPort)
-		podAddrs = append(podAddrs, podAddr{
-			Name: pod.Name,
-			Addr: addr,
-		})
-	}
-	return podAddrs, nil
-}
-
 // bootstrapServers bootstraps ACLs and ensures each server has an ACL token.
 func (c *Command) bootstrapServers(bootTokenSecretName, scheme string) (string, error) {
-	serverPods, err := c.getConsulServers(c.flagReplicas, scheme)
-	if err != nil {
-		return "", err
-	}
-	c.Log.Info(fmt.Sprintf("Found %d Consul server Pods", len(serverPods)))
-
-	// Pick the first pod to connect to for bootstrapping and set up connection.
-	firstServerAddr := serverPods[0].Addr
+	// Pick the first server address to connect to for bootstrapping and set up connection.
+	firstServerAddr := fmt.Sprintf("%s:%d", c.flagServerHosts[0], c.flagServerPort)
 	consulClient, err := api.NewClient(&api.Config{
 		Address: firstServerAddr,
 		Scheme:  scheme,
@@ -159,7 +93,7 @@ func (c *Command) bootstrapServers(bootTokenSecretName, scheme string) (string, 
 	}
 
 	// Create new tokens for each server and apply them.
-	if err := c.setServerTokens(consulClient, serverPods, string(bootstrapToken), scheme); err != nil {
+	if err := c.setServerTokens(consulClient, string(bootstrapToken), scheme); err != nil {
 		return "", err
 	}
 	return string(bootstrapToken), nil
@@ -167,40 +101,20 @@ func (c *Command) bootstrapServers(bootTokenSecretName, scheme string) (string, 
 
 // setServerTokens creates policies and associated ACL token for each server
 // and then provides the token to the server.
-func (c *Command) setServerTokens(consulClient *api.Client,
-	serverPods []podAddr, bootstrapToken, scheme string) error {
-
+func (c *Command) setServerTokens(consulClient *api.Client, bootstrapToken, scheme string) error {
 	agentPolicy, err := c.setServerPolicy(consulClient)
 	if err != nil {
 		return err
 	}
 
 	// Create agent token for each server agent.
-	var serverTokens []api.ACLToken
-	for _, pod := range serverPods {
+	for _, host := range c.flagServerHosts {
 		var token *api.ACLToken
-		err := c.untilSucceeds(fmt.Sprintf("creating server token for %s - PUT /v1/acl/token", pod.Name),
-			func() error {
-				tokenReq := api.ACLToken{
-					Description: fmt.Sprintf("Server Token for %s", pod.Name),
-					Policies:    []*api.ACLTokenPolicyLink{{Name: agentPolicy.Name}},
-				}
-				var err error
-				token, _, err = consulClient.ACL().TokenCreate(&tokenReq, nil)
-				return err
-			})
-		if err != nil {
-			return err
-		}
-		serverTokens = append(serverTokens, *token)
-	}
 
-	// Pass out agent tokens to servers.
-	for i, pod := range serverPods {
 		// We create a new client for each server because we need to call each
 		// server specifically.
 		serverClient, err := api.NewClient(&api.Config{
-			Address: pod.Addr,
+			Address: fmt.Sprintf("%s:%d", host, c.flagServerPort),
 			Scheme:  scheme,
 			Token:   bootstrapToken,
 			TLSConfig: api.TLSConfig{
@@ -208,21 +122,34 @@ func (c *Command) setServerTokens(consulClient *api.Client,
 				CAFile:  c.flagConsulCACert,
 			},
 		})
-		if err != nil {
-			return fmt.Errorf(" creating Consul client for address %q: %s", pod.Addr, err)
-		}
-		podName := pod.Name
 
-		// Update token.
-		err = c.untilSucceeds(fmt.Sprintf("updating server token for %s - PUT /v1/agent/token/agent", podName),
+		// Create token for the server
+		err = c.untilSucceeds(fmt.Sprintf("creating server token for %s - PUT /v1/acl/token", host),
 			func() error {
-				_, err := serverClient.Agent().UpdateAgentACLToken(serverTokens[i].SecretID, nil)
+				tokenReq := api.ACLToken{
+					Description: fmt.Sprintf("Server Token for %s", host),
+					Policies:    []*api.ACLTokenPolicyLink{{Name: agentPolicy.Name}},
+				}
+				var err error
+				token, _, err = serverClient.ACL().TokenCreate(&tokenReq, nil)
+				return err
+			})
+		if err != nil {
+			return err
+		}
+
+		// Pass out agent tokens to servers.
+		// Update token.
+		err = c.untilSucceeds(fmt.Sprintf("updating server token for %s - PUT /v1/agent/token/agent", host),
+			func() error {
+				_, err := serverClient.Agent().UpdateAgentACLToken(token.SecretID, nil)
 				return err
 			})
 		if err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 

--- a/subcommand/server-acl-init/servers.go
+++ b/subcommand/server-acl-init/servers.go
@@ -13,7 +13,7 @@ import (
 // bootstrapServers bootstraps ACLs and ensures each server has an ACL token.
 func (c *Command) bootstrapServers(bootTokenSecretName, scheme string) (string, error) {
 	// Pick the first server address to connect to for bootstrapping and set up connection.
-	firstServerAddr := fmt.Sprintf("%s:%d", c.flagServerHosts[0], c.flagServerPort)
+	firstServerAddr := fmt.Sprintf("%s:%d", c.flagServerAddresses[0], c.flagServerPort)
 	consulClient, err := api.NewClient(&api.Config{
 		Address: firstServerAddr,
 		Scheme:  scheme,
@@ -108,7 +108,7 @@ func (c *Command) setServerTokens(consulClient *api.Client, bootstrapToken, sche
 	}
 
 	// Create agent token for each server agent.
-	for _, host := range c.flagServerHosts {
+	for _, host := range c.flagServerAddresses {
 		var token *api.ACLToken
 
 		// We create a new client for each server because we need to call each


### PR DESCRIPTION
This PR proposes to change the server-acl-init command to use user-provided server-address and server-port instead of discovering servers' Pod IPs and ports via Kubernetes API.

## Why 
Currently, the `server-acl-init` command knows a lot about how the servers are deployed. It makes some assumptions about the resource names of the stateful set and uses Kubernetes API as its discovery mechanism for server addresses. This creates a fair amount of extra logic to correctly discover the server IPs and ports. In addition, we have some logic that checks if the stateful set rollout is currently in progress and waits until it's complete. The Statefulset logic was added specifically to prevent a situation when we would discover the IPs of the servers right before Kubernetes would kill and restart the container, causing its IP to change and the `server-acl-init` job to run forever trying to talk to the pod IP that no longer exists.

This PR was motivated by the idea that we don't really need to use Kube API to discover the IPs of the servers. Kubernetes already has a built-in mechanism for discovering IPs of the stateful set because each pod in a stateful set has a ["well-known" DNS name](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id). Using these DNS names would allow us to not only simplify the logic of this command but also avoid potential edge cases where the pod IP we've discovered has changed while the job is running. Additionally, this would allow us to eventually run this command against external servers.

## Summary of the Changes
### Command Flags
* ❗️ ❗️ **[Breaking change]** Add the required `-server-address` command flag
* Add `-server-port` command flag and default it to `8500`.
* ❗️ ❗️ **[Breaking change]** Remove `-expected-replicas`, `-release-name` (already deprecated), and `-server-label-selector` flags because we no longer need them.

### Other changes
* Because we're requiring server addresses be provided, we're removing the logic that checks whether stateful set rollout is in progress. In the case when the server addresses are DNS names of the stateful set, the reasons for this logic go away since even if pod IPs change, the Kube DNS should handle that for us.

## Testing
All testing was done on AKS with the `ishustava/consul-k8s-dev:04-07-2020-497214b` image (or equivalent).
Cases tested:
- Clean install
- Upgrade of servers
- Upgrade when there's a config change causing an update to ACL policies
- Upgrade of servers when servers were in an unhealthy state (split-brain)

## Feedback
I'm looking for feedback in the following areas:
- Am I missing any test cases?
- Flag names

