### PR TITLE
Update policies for namespaces

### DIFF
--- a/subcommand/server-acl-init/rules.go
+++ b/subcommand/server-acl-init/rules.go
@@ -148,15 +148,13 @@ namespace "{{ .ConsulSyncDestinationNamespace }}" {
 	return c.renderRules(syncRulesTpl)
 }
 
-// This should only be set when namespaces are enabled.
 func (c *Command) injectRules() (string, error) {
-	// The Connect injector only needs permissions to create namespaces
+	// The Connect injector only needs permissions to create namespaces.
 	injectRulesTpl := `
 {{- if .EnableNamespaces }}
 operator = "write"
 {{- end }}
 `
-
 	return c.renderRules(injectRulesTpl)
 }
 
@@ -174,12 +172,12 @@ operator = "write"
 agent_prefix "" {
   policy = "read"
 }
+node_prefix "" {
+  policy = "write"
+}
 {{- if .EnableNamespaces }}
 namespace_prefix "" {
 {{- end }}
-  node_prefix "" {
-    policy = "write"
-  }
   service_prefix "" {
     policy = "read"
     intentions = "read"

--- a/subcommand/server-acl-init/rules_test.go
+++ b/subcommand/server-acl-init/rules_test.go
@@ -312,9 +312,9 @@ operator = "write"
 agent_prefix "" {
   policy = "read"
 }
-  node_prefix "" {
-    policy = "write"
-  }
+node_prefix "" {
+  policy = "write"
+}
   service_prefix "" {
     policy = "read"
     intentions = "read"
@@ -328,10 +328,10 @@ operator = "write"
 agent_prefix "" {
   policy = "read"
 }
+node_prefix "" {
+  policy = "write"
+}
 namespace_prefix "" {
-  node_prefix "" {
-    policy = "write"
-  }
   service_prefix "" {
     policy = "read"
     intentions = "read"


### PR DESCRIPTION
* node:write needs to be in the default namespace since nodes aren't
namespaced
* connect inject and catalog sync need global acl tokens and policies when namespaces are enabled because a global token is required to create namespaces