### PR TITLE
Base the dev docker image on the release image

### DIFF
--- a/build-support/docker/Dev.dockerfile
+++ b/build-support/docker/Dev.dockerfile
@@ -1,2 +1,2 @@
-FROM consul:latest
+FROM hashicorp/consul-k8s:latest
 COPY pkg/bin/linux_amd64/consul-k8s /bin


### PR DESCRIPTION
To ensure that the dev docker image is the same as the release image
base it off of the latest consul-k8s image and just replace the binary.