### PR TITLE
Support external servers

### DIFF
--- a/helper/go-discover/discover.go
+++ b/helper/go-discover/discover.go
@@ -1,0 +1,61 @@
+package godiscover
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/consul-k8s/version"
+	"github.com/hashicorp/go-discover"
+	discoverk8s "github.com/hashicorp/go-discover/provider/k8s"
+	"github.com/hashicorp/go-hclog"
+)
+
+// ConsulServerAddresses uses go-discover to discover Consul servers
+// provided by the 'discoverString' and returns them.
+func ConsulServerAddresses(discoverString string, providers map[string]discover.Provider, logger hclog.Logger) ([]string, error) {
+	// If it's a cloud-auto join string, discover server addresses through the cloud provider.
+	// This code was adapted from
+	// https://github.com/hashicorp/consul/blob/c5fe112e59f6e8b03159ec8f2dbe7f4a026ce823/agent/retry_join.go#L55-L89.
+	disco, err := newDiscover(providers)
+	if err != nil {
+		return nil, err
+	}
+	logger.Debug("using cloud auto-join", "server-addr", discoverString)
+	servers, err := disco.Addrs(discoverString, logger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	// check if we discovered any servers
+	if len(servers) == 0 {
+		return nil, fmt.Errorf("could not discover any Consul servers with %q", discoverString)
+	}
+
+	logger.Debug("discovered servers", "servers", strings.Join(servers, " "))
+
+	return servers, nil
+}
+
+// newDiscover initializes the new Discover object
+// set up with all predefined providers, as well as
+// the k8s provider.
+// This code was adapted from
+// https://github.com/hashicorp/consul/blob/c5fe112e59f6e8b03159ec8f2dbe7f4a026ce823/agent/retry_join.go#L42-L53
+func newDiscover(providers map[string]discover.Provider) (*discover.Discover, error) {
+	if providers == nil {
+		providers = make(map[string]discover.Provider)
+	}
+
+	for k, v := range discover.Providers {
+		providers[k] = v
+	}
+	providers["k8s"] = &discoverk8s.Provider{}
+
+	userAgent := fmt.Sprintf("consul-k8s/%s (https://www.consul.io/)", version.GetHumanVersion())
+	return discover.New(
+		discover.WithUserAgent(userAgent),
+		discover.WithProviders(providers),
+	)
+}

--- a/helper/go-discover/discover_test.go
+++ b/helper/go-discover/discover_test.go
@@ -1,0 +1,70 @@
+package godiscover
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/consul-k8s/helper/go-discover/mocks"
+	"github.com/hashicorp/go-discover"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsulServerAddresses(t *testing.T) {
+	logger := hclog.New(nil)
+
+	tests := []struct {
+		name            string
+		discoverString  string
+		want            []string
+		wantErr         bool
+		errMessage      string
+		wantProviderErr bool
+	}{
+		{
+			"Gets addresses from the provider",
+			"provider=mock",
+			[]string{"1.1.1.1", "2.2.2.2"},
+			false,
+			"",
+			false,
+		},
+		{
+			"Errors when no addresses were discovered",
+			"provider=mock",
+			nil,
+			true,
+			"could not discover any Consul servers with \"provider=mock\"",
+			false,
+		},
+		{
+			"Errors when the the provider errors",
+			"provider=mock",
+			nil,
+			true,
+			"provider error",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := mocks.MockProvider{}
+			providers := map[string]discover.Provider{
+				"mock": &provider,
+			}
+			if tt.wantProviderErr {
+				provider.On("Addrs", mock.Anything, mock.Anything).Return(nil, errors.New(tt.errMessage))
+			} else {
+				provider.On("Addrs", mock.Anything, mock.Anything).Return(tt.want, nil)
+			}
+			got, err := ConsulServerAddresses(tt.discoverString, providers, logger)
+			if !tt.wantErr {
+				require.Equal(t, tt.want, got)
+			} else {
+				require.Error(t, err)
+				require.EqualError(t, err, tt.errMessage)
+			}
+		})
+	}
+}

--- a/helper/go-discover/mocks/mock_provider.go
+++ b/helper/go-discover/mocks/mock_provider.go
@@ -1,0 +1,24 @@
+package mocks
+
+import (
+	"log"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockProvider struct {
+	mock.Mock
+}
+
+func (m *MockProvider) Addrs(args map[string]string, l *log.Logger) ([]string, error) {
+	retVal := m.Called(args, l)
+	addresses := retVal.Get(0)
+	if addresses != nil {
+		return addresses.([]string), nil
+	}
+	return nil, retVal.Error(1)
+}
+
+func (m *MockProvider) Help() string {
+	return "mock-provider help"
+}

--- a/subcommand/server-acl-init/anonymous_token.go
+++ b/subcommand/server-acl-init/anonymous_token.go
@@ -9,7 +9,7 @@ import (
 func (c *Command) configureAnonymousPolicy(consulClient *api.Client) error {
 	anonRules, err := c.anonymousTokenRules()
 	if err != nil {
-		c.Log.Error("Error templating anonymous token rules", "err", err)
+		c.log.Error("Error templating anonymous token rules", "err", err)
 		return err
 	}
 

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -114,7 +114,7 @@ func (c *Command) init() {
 		"Toggle for creating a connect inject auth method. Deprecated: use -create-inject-auth-method instead.")
 	c.flags.StringVar(&c.flagInjectAuthMethodHost, "inject-auth-method-host", "",
 		"Kubernetes Host config parameter for the auth method."+
-			"If not provided, the default cluster Kuberentes service will be used.")
+			"If not provided, the default cluster Kubernetes service will be used.")
 	c.flags.StringVar(&c.flagInjectAuthMethodCACert, "inject-auth-method-ca-cert", "",
 		"Base64-encoded PEM-encoded CA Certificate for the auth method."+
 			"If not provided, the CA cert from the service account for this auth method will be used.")

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -33,15 +33,23 @@ type Command struct {
 	flagResourcePrefix string
 	flagK8sNamespace   string
 
-	flagAllowDNS                 bool
-	flagCreateClientToken        bool
-	flagCreateSyncToken          bool
-	flagCreateInjectToken        bool
-	flagCreateInjectAuthMethod   bool
-	flagBindingRuleSelector      string
-	flagCreateEntLicenseToken    bool
+	flagAllowDNS bool
+
+	flagCreateClientToken bool
+
+	flagCreateSyncToken bool
+
+	flagCreateInjectToken      bool
+	flagCreateInjectAuthMethod bool
+	flagInjectAuthMethodHost   string
+	flagInjectAuthMethodCACert string
+	flagBindingRuleSelector    string
+
+	flagCreateEntLicenseToken bool
+
 	flagCreateSnapshotAgentToken bool
-	flagCreateMeshGatewayToken   bool
+
+	flagCreateMeshGatewayToken bool
 
 	// Flags to configure Consul connection
 	flagServerAddresses     []string
@@ -97,14 +105,22 @@ func (c *Command) init() {
 		"Toggle for creating a client agent token. Default is true.")
 	c.flags.BoolVar(&c.flagCreateSyncToken, "create-sync-token", false,
 		"Toggle for creating a catalog sync token.")
+
 	c.flags.BoolVar(&c.flagCreateInjectToken, "create-inject-namespace-token", false,
 		"Toggle for creating a connect injector token. Only required when namespaces are enabled.")
 	c.flags.BoolVar(&c.flagCreateInjectAuthMethod, "create-inject-auth-method", false,
 		"Toggle for creating a connect inject auth method.")
 	c.flags.BoolVar(&c.flagCreateInjectAuthMethod, "create-inject-token", false,
 		"Toggle for creating a connect inject auth method. Deprecated: use -create-inject-auth-method instead.")
+	c.flags.StringVar(&c.flagInjectAuthMethodHost, "inject-auth-method-host", "",
+		"Kubernetes Host config parameter for the auth method."+
+			"If not provided, the default cluster Kuberentes service will be used.")
+	c.flags.StringVar(&c.flagInjectAuthMethodCACert, "inject-auth-method-ca-cert", "",
+		"Base64-encoded PEM-encoded CA Certificate for the auth method."+
+			"If not provided, the CA cert from the service account for this auth method will be used.")
 	c.flags.StringVar(&c.flagBindingRuleSelector, "acl-binding-rule-selector", "",
 		"Selector string for connectInject ACL Binding Rule.")
+
 	c.flags.BoolVar(&c.flagCreateEntLicenseToken, "create-enterprise-license-token", false,
 		"Toggle for creating a token for the enterprise license job.")
 	c.flags.BoolVar(&c.flagCreateSnapshotAgentToken, "create-snapshot-agent-token", false,

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -296,7 +296,7 @@ func (c *Command) Run(args []string) int {
 		// since they will be performing replication.
 		// We can use the replication token as our bootstrap token because it
 		// has permissions to create policies and tokens.
-		c.log.Info("ACL replication is enabled so skipping ACL bootstrapping")
+		c.log.Info("ACL replication is enabled so skipping Consul server ACL bootstrapping")
 		bootstrapToken = aclReplicationToken
 	} else {
 		// Check if we've already been bootstrapped.

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -42,7 +42,6 @@ type Command struct {
 	flagCreateInjectToken      bool
 	flagCreateInjectAuthMethod bool
 	flagInjectAuthMethodHost   string
-	flagInjectAuthMethodCACert string
 	flagBindingRuleSelector    string
 
 	flagCreateEntLicenseToken bool
@@ -115,9 +114,6 @@ func (c *Command) init() {
 	c.flags.StringVar(&c.flagInjectAuthMethodHost, "inject-auth-method-host", "",
 		"Kubernetes Host config parameter for the auth method."+
 			"If not provided, the default cluster Kubernetes service will be used.")
-	c.flags.StringVar(&c.flagInjectAuthMethodCACert, "inject-auth-method-ca-cert", "",
-		"Base64-encoded PEM-encoded CA Certificate for the auth method."+
-			"If not provided, the CA cert from the service account for this auth method will be used.")
 	c.flags.StringVar(&c.flagBindingRuleSelector, "acl-binding-rule-selector", "",
 		"Selector string for connectInject ACL Binding Rule.")
 

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -43,7 +43,7 @@ type Command struct {
 	flagCreateSnapshotAgentToken bool
 	flagCreateMeshGatewayToken   bool
 
-	// Flags to configure Consul client
+	// Flags to configure Consul connection
 	flagServerAddresses     []string
 	flagServerPort          uint
 	flagConsulCACert        string

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -289,7 +289,7 @@ func (c *Command) Run(args []string) int {
 	if c.flagBootstrapTokenFile != "" {
 		// If bootstrap token is provided, we skip server bootstrapping and use
 		// the provided token to create policies and tokens for the rest of the components.
-		c.log.Info("Bootstrap token is provided so skipping ACL bootstrapping")
+		c.log.Info("Bootstrap token is provided so skipping Consul server ACL bootstrapping")
 		bootstrapToken = providedBootstrapToken
 	} else if c.flagACLReplicationTokenFile != "" {
 		// If ACL replication is enabled, we don't need to ACL bootstrap the servers

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -104,16 +104,16 @@ func (c *Command) init() {
 	c.flags.BoolVar(&c.flagCreateInjectAuthMethod, "create-inject-token", false,
 		"Toggle for creating a connect inject auth method. Deprecated: use -create-inject-auth-method instead.")
 	c.flags.StringVar(&c.flagBindingRuleSelector, "acl-binding-rule-selector", "",
-		"Selector string for connectInject ACL Binding Rule")
+		"Selector string for connectInject ACL Binding Rule.")
 	c.flags.BoolVar(&c.flagCreateEntLicenseToken, "create-enterprise-license-token", false,
 		"Toggle for creating a token for the enterprise license job.")
 	c.flags.BoolVar(&c.flagCreateSnapshotAgentToken, "create-snapshot-agent-token", false,
 		"[Enterprise Only] Toggle for creating a token for the Consul snapshot agent deployment.")
 	c.flags.BoolVar(&c.flagCreateMeshGatewayToken, "create-mesh-gateway-token", false,
-		"Toggle for creating a token for a Connect mesh gateway")
+		"Toggle for creating a token for a Connect mesh gateway.")
 
 	c.flags.Var((*flags.AppendSliceValue)(&c.flagServerAddresses), "server-address",
-		"The IP, DNS name or the cloud auto-join string of the Consul server(s), may be provided multiple times."+
+		"The IP, DNS name or the cloud auto-join string of the Consul server(s). If providing IPs or DNS names, may be specified multiple times."+
 			"At least one value is required.")
 	c.flags.UintVar(&c.flagServerPort, "server-port", 8500, "The HTTP or HTTPS port of the Consul server. Defaults to 8500.")
 	c.flags.StringVar(&c.flagConsulCACert, "consul-ca-cert", "",
@@ -143,7 +143,7 @@ func (c *Command) init() {
 			"if mirroring is enabled.")
 
 	c.flags.BoolVar(&c.flagCreateACLReplicationToken, "create-acl-replication-token", false,
-		"Toggle for creating a token for ACL replication between datacenters")
+		"Toggle for creating a token for ACL replication between datacenters.")
 	c.flags.StringVar(&c.flagACLReplicationTokenFile, "acl-replication-token-file", "",
 		"Path to file containing ACL token to be used for ACL replication. If set, ACL replication is enabled.")
 
@@ -244,7 +244,7 @@ func (c *Command) Run(args []string) int {
 
 	serverAddresses := c.flagServerAddresses
 	// Check if the provided addresses contain a cloud-auto join string.
-	// If yes, call go-discover to discover addresses of the Consul servers.
+	// If yes, call godiscover to discover addresses of the Consul servers.
 	if len(c.flagServerAddresses) == 1 && strings.Contains(c.flagServerAddresses[0], "provider=") {
 		var err error
 		serverAddresses, err = godiscover.ConsulServerAddresses(c.flagServerAddresses[0], c.providers, c.log)

--- a/subcommand/server-acl-init/command_ent_test.go
+++ b/subcommand/server-acl-init/command_ent_test.go
@@ -68,7 +68,7 @@ func TestRun_ConnectInject_SingleDestinationNamespace(t *testing.T) {
 			require.NoError(err)
 			require.NotNil(actMethod)
 			require.Equal("kubernetes", actMethod.Type)
-			require.Equal("Kubernetes AuthMethod", actMethod.Description)
+			require.Equal("Kubernetes Auth Method", actMethod.Description)
 			require.NotContains(actMethod.Config, "MapNamespaces")
 			require.NotContains(actMethod.Config, "ConsulNamespacePrefix")
 
@@ -181,7 +181,7 @@ func TestRun_ConnectInject_NamespaceMirroring(t *testing.T) {
 			require.NoError(err)
 			require.NotNil(method, authMethodName+" not found")
 			require.Equal("kubernetes", method.Type)
-			require.Equal("Kubernetes AuthMethod", method.Description)
+			require.Equal("Kubernetes Auth Method", method.Description)
 			require.Contains(method.Config, "MapNamespaces")
 			require.Contains(method.Config, "ConsulNamespacePrefix")
 			require.Equal(true, method.Config["MapNamespaces"])

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -618,7 +618,7 @@ func TestRun_ConnectInjectAuthMethod(t *testing.T) {
 				&api.QueryOptions{Token: bootToken})
 			require.NoError(err)
 			require.Contains(authMethod.Config, "Host")
-			require.Equal(authMethod.Config["Host"], "https://1.2.3.4:443")
+			require.Equal(authMethod.Config["Host"], "https://kubernetes.default.svc")
 			require.Contains(authMethod.Config, "CACert")
 			require.Equal(authMethod.Config["CACert"], caCert)
 			require.Contains(authMethod.Config, "ServiceAccountJWT")

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -1153,6 +1153,8 @@ func TestRun_AnonPolicy_IgnoredWithReplication(t *testing.T) {
 				"-server-address", strings.Split(serverAddr, ":")[0],
 				"-server-port", strings.Split(serverAddr, ":")[1],
 				"-resource-prefix=" + resourcePrefix,
+				"-server-address", strings.Split(serverAddr, ":")[0],
+				"-server-port", strings.Split(serverAddr, ":")[1],
 			}, flag)
 			responseCode := cmd.Run(cmdArgs)
 			require.Equal(t, 0, responseCode, ui.ErrorWriter.String())

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -573,10 +573,6 @@ func TestRun_AnonymousTokenPolicy(t *testing.T) {
 func TestRun_ConnectInjectAuthMethod(t *testing.T) {
 	t.Parallel()
 
-	// Generate CA
-	_, _, caCertPem, _, err := cert.GenerateCA("Kubernetes CA - Test")
-	require.NoError(t, err)
-
 	cases := map[string]struct {
 		flags          []string
 		expectedHost   string
@@ -596,23 +592,6 @@ func TestRun_ConnectInjectAuthMethod(t *testing.T) {
 				"-inject-auth-method-host=https://my-kube.com",
 			},
 			expectedHost: "https://my-kube.com",
-		},
-		"-inject-auth-method-ca-cert flag": {
-			flags: []string{
-				"-create-inject-auth-method",
-				"-inject-auth-method-ca-cert=" + base64.StdEncoding.EncodeToString([]byte(caCertPem)),
-			},
-			expectedHost:   "https://kubernetes.default.svc",
-			expectedCACert: caCertPem,
-		},
-		"-inject-auth-method-host and -inject-auth-method-ca-cert flags": {
-			flags: []string{
-				"-create-inject-auth-method",
-				"-inject-auth-method-host=https://my-kube.com",
-				"-inject-auth-method-ca-cert=" + base64.StdEncoding.EncodeToString([]byte(caCertPem)),
-			},
-			expectedHost:   "https://my-kube.com",
-			expectedCACert: caCertPem,
 		},
 	}
 	for testName, c := range cases {
@@ -1360,8 +1339,6 @@ func TestRun_AnonPolicy_IgnoredWithReplication(t *testing.T) {
 				"-server-address", strings.Split(serverAddr, ":")[0],
 				"-server-port", strings.Split(serverAddr, ":")[1],
 				"-resource-prefix=" + resourcePrefix,
-				"-server-address", strings.Split(serverAddr, ":")[0],
-				"-server-port", strings.Split(serverAddr, ":")[1],
 			}, flag)
 			responseCode := cmd.Run(cmdArgs)
 			require.Equal(t, 0, responseCode, ui.ErrorWriter.String())

--- a/subcommand/server-acl-init/connect_inject.go
+++ b/subcommand/server-acl-init/connect_inject.go
@@ -1,7 +1,6 @@
 package serveraclinit
 
 import (
-	"encoding/base64"
 	"errors"
 	"fmt"
 
@@ -188,18 +187,10 @@ func (c *Command) createAuthMethodTmpl(authMethodName string) (api.ACLAuthMethod
 	}
 
 	kubernetesHost := "https://kubernetes.default.svc"
-	kubernetesCACert := string(saSecret.Data["ca.crt"])
 
 	// Check if custom auth method Host and CACert are provided
 	if c.flagInjectAuthMethodHost != "" {
 		kubernetesHost = c.flagInjectAuthMethodHost
-	}
-	if c.flagInjectAuthMethodCACert != "" {
-		kubernetesCACertBytes, err := base64.StdEncoding.DecodeString(c.flagInjectAuthMethodCACert)
-		if err != nil {
-			return api.ACLAuthMethod{}, err
-		}
-		kubernetesCACert = string(kubernetesCACertBytes)
 	}
 
 	// Now we're ready to set up Consul's auth method.
@@ -209,7 +200,7 @@ func (c *Command) createAuthMethodTmpl(authMethodName string) (api.ACLAuthMethod
 		Type:        "kubernetes",
 		Config: map[string]interface{}{
 			"Host":              kubernetesHost,
-			"CACert":            kubernetesCACert,
+			"CACert":            string(saSecret.Data["ca.crt"]),
 			"ServiceAccountJWT": string(saSecret.Data["token"]),
 		},
 	}

--- a/subcommand/server-acl-init/connect_inject.go
+++ b/subcommand/server-acl-init/connect_inject.go
@@ -157,21 +157,10 @@ func (c *Command) configureConnectInject(consulClient *api.Client) error {
 }
 
 func (c *Command) createAuthMethodTmpl(authMethodName string) (api.ACLAuthMethod, error) {
-	var kubeSvc *apiv1.Service
-	err := c.untilSucceeds("getting kubernetes service IP",
-		func() error {
-			var err error
-			kubeSvc, err = c.clientset.CoreV1().Services("default").Get("kubernetes", metav1.GetOptions{})
-			return err
-		})
-	if err != nil {
-		return api.ACLAuthMethod{}, err
-	}
-
 	// Get the Secret name for the auth method ServiceAccount.
 	var authMethodServiceAccount *apiv1.ServiceAccount
 	saName := c.withPrefix("connect-injector-authmethod-svc-account")
-	err = c.untilSucceeds(fmt.Sprintf("getting %s ServiceAccount", saName),
+	err := c.untilSucceeds(fmt.Sprintf("getting %s ServiceAccount", saName),
 		func() error {
 			var err error
 			authMethodServiceAccount, err = c.clientset.CoreV1().ServiceAccounts(c.flagK8sNamespace).Get(saName, metav1.GetOptions{})
@@ -203,7 +192,7 @@ func (c *Command) createAuthMethodTmpl(authMethodName string) (api.ACLAuthMethod
 		Description: "Kubernetes AuthMethod",
 		Type:        "kubernetes",
 		Config: map[string]interface{}{
-			"Host":              fmt.Sprintf("https://%s:443", kubeSvc.Spec.ClusterIP),
+			"Host":              "https://kubernetes.default.svc",
 			"CACert":            string(saSecret.Data["ca.crt"]),
 			"ServiceAccountJWT": string(saSecret.Data["token"]),
 		},

--- a/subcommand/server-acl-init/create_or_update.go
+++ b/subcommand/server-acl-init/create_or_update.go
@@ -58,7 +58,7 @@ func (c *Command) createACL(name, rules string, localToken bool, dc string, cons
 	secretName := c.withPrefix(name + "-acl-token")
 	_, err = c.clientset.CoreV1().Secrets(c.flagK8sNamespace).Get(secretName, metav1.GetOptions{})
 	if err == nil {
-		c.Log.Info(fmt.Sprintf("Secret %q already exists", secretName))
+		c.log.Info(fmt.Sprintf("Secret %q already exists", secretName))
 		return nil
 	}
 
@@ -107,7 +107,7 @@ func (c *Command) createOrUpdateACLPolicy(policy api.ACLPolicy, consulClient *ap
 	// updated to be namespace aware.
 	if isPolicyExistsErr(err, policy.Name) {
 		if c.flagEnableNamespaces {
-			c.Log.Info(fmt.Sprintf("Policy %q already exists, updating", policy.Name))
+			c.log.Info(fmt.Sprintf("Policy %q already exists, updating", policy.Name))
 
 			// The policy ID is required in any PolicyUpdate call, so first we need to
 			// get the existing policy to extract its ID.
@@ -134,7 +134,7 @@ func (c *Command) createOrUpdateACLPolicy(policy api.ACLPolicy, consulClient *ap
 			_, _, err = consulClient.ACL().PolicyUpdate(&policy, &api.WriteOptions{})
 			return err
 		} else {
-			c.Log.Info(fmt.Sprintf("Policy %q already exists, skipping update", policy.Name))
+			c.log.Info(fmt.Sprintf("Policy %q already exists, skipping update", policy.Name))
 			return nil
 		}
 	}
@@ -169,7 +169,7 @@ func (c *Command) checkAndCreateNamespace(ns string, consulClient *api.Client) e
 		if err != nil {
 			return err
 		}
-		c.Log.Info("created consul namespace", "name", consulNamespace.Name)
+		c.log.Info("created consul namespace", "name", consulNamespace.Name)
 	}
 
 	return nil

--- a/subcommand/sync-catalog/command_ent_test.go
+++ b/subcommand/sync-catalog/command_ent_test.go
@@ -723,8 +723,6 @@ func TestRun_ToConsulNamespacesACLs(t *testing.T) {
 }
 
 // Set up test consul agent and fake kubernetes cluster client
-// todo: use this setup method everywhere. The old one (completeSetup) uses
-// the test agent instead of the testserver.
 func completeSetupEnterprise(t *testing.T) (*fake.Clientset, *testutil.TestServer) {
 	k8s := fake.NewSimpleClientset()
 	svr, err := testutil.NewTestServerT(t)


### PR DESCRIPTION
This PR proposes the following changes to support external servers:
1. Add a `bootstrap-token-file` flag to support "already-bootstrapped" external servers. This could also work for folks that want to do ACL bootstrapping themselves on the external server and just provide a bootstrap token so that the rest of tokens and policies for consul-k8s are set up. Some use-cases in hashicorp/consul-helm#413.
1. `-server-address` flag now supports cloud auto-join strings. This is similar to how `get-consul-client-ca` command behaves. Cloud auto-join support here was added for consistency.
1. `-inject-auth-method-host` and `-inject-auth-method-ca-cert` to allow configuring custom auth method parameters. This is needed because during the login workflow, consul servers are talking to the Kubernetes API to verify the JWT token. When Consul servers are external to the Kubernetes cluster, we can't make assumptions about where the kube API server is running and so we have to ask for this information from the user.