### PR TITLE
Change perms from 0400 to 0600 for acl-token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BUG FIXES:
 
 * Connect: Fix upstream annotation parsing when multiple prepared queries are separated by spaces [[GH-224](https://github.com/hashicorp/consul-k8s/issues/224)]
+* ACLs: Fix bug with `acl-init -token-sink-file` where running the command twice would fail [[GH-248](https://github.com/hashicorp/consul-k8s/pull/248)]
 
 ## 0.13.0 (April 06, 2020)
 

--- a/subcommand/acl-init/command.go
+++ b/subcommand/acl-init/command.go
@@ -104,7 +104,9 @@ func (c *Command) Run(args []string) int {
 			return 1
 		}
 
-		// Write the data out as a file
+		// Write the data out as a file.
+		// Must be 0644 because this is written by the consul-k8s user but needs
+		// to be readable by the consul user.
 		err = ioutil.WriteFile(filepath.Join(c.flagACLDir, "acl-config.json"), buf.Bytes(), 0644)
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error writing config file: %s", err))
@@ -113,7 +115,9 @@ func (c *Command) Run(args []string) int {
 	}
 
 	if c.flagTokenSinkFile != "" {
-		err := ioutil.WriteFile(c.flagTokenSinkFile, []byte(secret), 0400)
+		// Must be 0600 in case this command is re-run. In that case we need
+		// to have permissions to overwrite our file.
+		err := ioutil.WriteFile(c.flagTokenSinkFile, []byte(secret), 0600)
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error writing token to file %q: %s", c.flagTokenSinkFile, err))
 			return 1

--- a/subcommand/acl-init/command_test.go
+++ b/subcommand/acl-init/command_test.go
@@ -87,7 +87,7 @@ func TestRun_TokenSinkFileErr(t *testing.T) {
 }
 
 // Test that if the command is run twice it succeeds. This test is the result
-// of a bug that we discovered where the command failed on second runs because
+// of a bug that we discovered where the command failed on subsequent runs because
 // the token file only had read permissions (0400).
 func TestRun_TokenSinkFileTwice(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
If the acl-init command is re-run, it needs to be able to overwrite the
previously written acl-token file.

In some testing, the `service-init` init container has later commands fail. Then Kubernetes restarts the init container and it continuously fails with the error:
```
Error writing token to file "/consul/service/acl-token": open /consul/service/acl-token: permission denied
```
because that file has already been written but it has 0400 permissions so can't be overwritten.

To reproduce, edit `mesh-gateway-deployment`:
```
                ls -la /consul/service
                {{- if (or .Values.global.acls.manageSystemACLs .Values.global.bootstrapACLs) }}
                consul-k8s acl-init \
                  -secret-name="{{ template "consul.fullname" . }}-mesh-gateway-acl-token" \
                  -k8s-namespace={{ .Release.Namespace }} \
                  -token-sink-file=/consul/service/acl-token
                {{ end }}
                exit 1
```

The first run-through will write the token. Subsequent run throughs will always fail.