### PR TITLE
Fix bug where preStop hook was malformed

### DIFF
--- a/connect-inject/envoy_sidecar.go
+++ b/connect-inject/envoy_sidecar.go
@@ -92,7 +92,7 @@ const sidecarPreStopCommandTpl = `
   /consul/connect-inject/service.hcl
 
 {{- if .AuthMethod }}
-&& /consul/connect-inject/consul logout \
+/consul/connect-inject/consul logout \
   -token-file="/consul/connect-inject/acl-token"
 {{- end}}
 `

--- a/connect-inject/envoy_sidecar_test.go
+++ b/connect-inject/envoy_sidecar_test.go
@@ -89,7 +89,7 @@ func TestHandlerEnvoySidecar_AuthMethod(t *testing.T) {
 	require.Equal(preStopCommand, `/bin/sh -ec /consul/connect-inject/consul services deregister \
   -token-file="/consul/connect-inject/acl-token" \
   /consul/connect-inject/service.hcl
-&& /consul/connect-inject/consul logout \
+/consul/connect-inject/consul logout \
   -token-file="/consul/connect-inject/acl-token"`)
 }
 
@@ -200,6 +200,6 @@ func TestHandlerEnvoySidecar_NamespacesAndAuthMethod(t *testing.T) {
   -token-file="/consul/connect-inject/acl-token" \
   -namespace="k8snamespace" \
   /consul/connect-inject/service.hcl
-&& /consul/connect-inject/consul logout \
+/consul/connect-inject/consul logout \
   -token-file="/consul/connect-inject/acl-token"`)
 }


### PR DESCRIPTION
The previous preStop hook would fail with
  ```
  /bin/sh: syntax error: unexpected \"&&\"\n"
  ```
When acls were turned on. This would cause consul logout to not execute
and leave ACL tokens forever. This fix removes the && that was causing
the syntax issue. Since the prestop hook is executed in sh -ec, the -e
will cause the command to exit if any of the commands fail so && is not
necessary.

Testing: Create a connect-injected pod with ACLs on. Delete it, look at `kubectl get events`. You should see an error from the hook like shown in the issue. Now use `lkysow/consul-k8s-dev:may26-prestop`, there will be no error.

Fixes https://github.com/hashicorp/consul-k8s/issues/265