### PR TITLE
Support resource settings

### DIFF
--- a/connect-inject/envoy_sidecar.go
+++ b/connect-inject/envoy_sidecar.go
@@ -2,6 +2,7 @@ package connectinject
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -12,7 +13,6 @@ import (
 type sidecarContainerCommandData struct {
 	AuthMethod      string
 	ConsulNamespace string
-	Resources corev1.ResourceRequirements
 }
 
 func (h *Handler) envoySidecar(pod *corev1.Pod, k8sNamespace string) (corev1.Container, error) {
@@ -21,24 +21,16 @@ func (h *Handler) envoySidecar(pod *corev1.Pod, k8sNamespace string) (corev1.Con
 		ConsulNamespace: h.consulNamespace(k8sNamespace),
 	}
 
-	if h.Resources {
-		templateData.Resources = corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse(h.CPULimit),
-				corev1.ResourceMemory: resource.MustParse(h.MemoryLimit),
-			},
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse(h.CPULimit),
-				corev1.ResourceMemory: resource.MustParse(h.MemoryLimit),
-			},
-		}
-	}
-
 	// Render the command
 	var buf bytes.Buffer
 	tpl := template.Must(template.New("root").Parse(strings.TrimSpace(
 		sidecarPreStopCommandTpl)))
 	err := tpl.Execute(&buf, &templateData)
+	if err != nil {
+		return corev1.Container{}, err
+	}
+
+	resources, err := h.envoySidecarResources(pod)
 	if err != nil {
 		return corev1.Container{}, err
 	}
@@ -54,7 +46,7 @@ func (h *Handler) envoySidecar(pod *corev1.Pod, k8sNamespace string) (corev1.Con
 				},
 			},
 		},
-		Resources: templateData.Resources,
+		Resources: resources,
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      volumeName,
@@ -95,6 +87,72 @@ func (h *Handler) envoySidecar(pod *corev1.Pod, k8sNamespace string) (corev1.Con
 		})
 	}
 	return container, nil
+}
+
+func (h *Handler) envoySidecarResources(pod *corev1.Pod) (corev1.ResourceRequirements, error) {
+	resources := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{},
+		Requests: corev1.ResourceList{},
+	}
+	// zeroQuantity is used for comparison to see if a quantity was explicitly
+	// set.
+	var zeroQuantity resource.Quantity
+
+	// NOTE: We only want to set the limit/request if the default or annotation
+	// was explicitly set. If it's not explicitly set, it will be the zero value
+	// which would show up in the pod spec as being explicitly set to zero if we
+	// set that key, e.g. "cpu" to zero.
+	// We want it to not show up in the pod spec at all if if it's not explicitly
+	// set so that users aren't wondering why it's set to 0 when they didn't specify
+	// a request/limit. If they have explicitly set it to 0 then it will be set
+	// to 0 in the pod spec because we're doing a comparison to the zero-valued
+	// struct.
+
+	// CPU Limit.
+	if anno, ok := pod.Annotations[annotationSidecarProxyCPULimit]; ok {
+		cpuLimit, err := resource.ParseQuantity(anno)
+		if err != nil {
+			return corev1.ResourceRequirements{}, fmt.Errorf("parsing annotation %s:%q: %s", annotationSidecarProxyCPULimit, anno, err)
+		}
+		resources.Limits[corev1.ResourceCPU] = cpuLimit
+	} else if h.DefaultProxyCPULimit != zeroQuantity {
+		resources.Limits[corev1.ResourceCPU] = h.DefaultProxyCPULimit
+	}
+
+	// CPU Request.
+	if anno, ok := pod.Annotations[annotationSidecarProxyCPURequest]; ok {
+		cpuRequest, err := resource.ParseQuantity(anno)
+		if err != nil {
+			return corev1.ResourceRequirements{}, fmt.Errorf("parsing annotation %s:%q: %s", annotationSidecarProxyCPURequest, anno, err)
+		}
+		resources.Requests[corev1.ResourceCPU] = cpuRequest
+	} else if h.DefaultProxyCPURequest != zeroQuantity {
+		resources.Requests[corev1.ResourceCPU] = h.DefaultProxyCPURequest
+	}
+
+	// Memory Limit.
+	if anno, ok := pod.Annotations[annotationSidecarProxyMemoryLimit]; ok {
+		memoryLimit, err := resource.ParseQuantity(anno)
+		if err != nil {
+			return corev1.ResourceRequirements{}, fmt.Errorf("parsing annotation %s:%q: %s", annotationSidecarProxyMemoryLimit, anno, err)
+		}
+		resources.Limits[corev1.ResourceMemory] = memoryLimit
+	} else if h.DefaultProxyMemoryLimit != zeroQuantity {
+		resources.Limits[corev1.ResourceMemory] = h.DefaultProxyMemoryLimit
+	}
+
+	// Memory Request.
+	if anno, ok := pod.Annotations[annotationSidecarProxyMemoryRequest]; ok {
+		memoryRequest, err := resource.ParseQuantity(anno)
+		if err != nil {
+			return corev1.ResourceRequirements{}, fmt.Errorf("parsing annotation %s:%q: %s", annotationSidecarProxyMemoryRequest, anno, err)
+		}
+		resources.Requests[corev1.ResourceMemory] = memoryRequest
+	} else if h.DefaultProxyMemoryRequest != zeroQuantity {
+		resources.Requests[corev1.ResourceMemory] = h.DefaultProxyMemoryRequest
+	}
+
+	return resources, nil
 }
 
 const sidecarPreStopCommandTpl = `

--- a/connect-inject/envoy_sidecar_test.go
+++ b/connect-inject/envoy_sidecar_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -202,4 +203,183 @@ func TestHandlerEnvoySidecar_NamespacesAndAuthMethod(t *testing.T) {
   /consul/connect-inject/service.hcl
 && /consul/connect-inject/consul logout \
   -token-file="/consul/connect-inject/acl-token"`)
+}
+
+func TestHandlerEnvoySidecar_Resources(t *testing.T) {
+	mem1 := resource.MustParse("100Mi")
+	mem2 := resource.MustParse("200Mi")
+	cpu1 := resource.MustParse("100m")
+	cpu2 := resource.MustParse("200m")
+	zero := resource.MustParse("0")
+
+	cases := map[string]struct {
+		handler      Handler
+		annotations  map[string]string
+		expResources corev1.ResourceRequirements
+		expErr       string
+	}{
+		"no defaults, no annotations": {
+			handler:     Handler{},
+			annotations: nil,
+			expResources: corev1.ResourceRequirements{
+				Limits:   corev1.ResourceList{},
+				Requests: corev1.ResourceList{},
+			},
+		},
+		"all defaults, no annotations": {
+			handler: Handler{
+				DefaultProxyCPURequest:    cpu1,
+				DefaultProxyCPULimit:      cpu2,
+				DefaultProxyMemoryRequest: mem1,
+				DefaultProxyMemoryLimit:   mem2,
+			},
+			annotations: nil,
+			expResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    cpu2,
+					corev1.ResourceMemory: mem2,
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    cpu1,
+					corev1.ResourceMemory: mem1,
+				},
+			},
+		},
+		"no defaults, all annotations": {
+			handler: Handler{},
+			annotations: map[string]string{
+				annotationSidecarProxyCPURequest:    "100m",
+				annotationSidecarProxyMemoryRequest: "100Mi",
+				annotationSidecarProxyCPULimit:      "200m",
+				annotationSidecarProxyMemoryLimit:   "200Mi",
+			},
+			expResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    cpu2,
+					corev1.ResourceMemory: mem2,
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    cpu1,
+					corev1.ResourceMemory: mem1,
+				},
+			},
+		},
+		"annotations override defaults": {
+			handler: Handler{
+				DefaultProxyCPURequest:    zero,
+				DefaultProxyCPULimit:      zero,
+				DefaultProxyMemoryRequest: zero,
+				DefaultProxyMemoryLimit:   zero,
+			},
+			annotations: map[string]string{
+				annotationSidecarProxyCPURequest:    "100m",
+				annotationSidecarProxyMemoryRequest: "100Mi",
+				annotationSidecarProxyCPULimit:      "200m",
+				annotationSidecarProxyMemoryLimit:   "200Mi",
+			},
+			expResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    cpu2,
+					corev1.ResourceMemory: mem2,
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    cpu1,
+					corev1.ResourceMemory: mem1,
+				},
+			},
+		},
+		"defaults set to zero, no annotations": {
+			handler: Handler{
+				DefaultProxyCPURequest:    zero,
+				DefaultProxyCPULimit:      zero,
+				DefaultProxyMemoryRequest: zero,
+				DefaultProxyMemoryLimit:   zero,
+			},
+			annotations: nil,
+			expResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    zero,
+					corev1.ResourceMemory: zero,
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    zero,
+					corev1.ResourceMemory: zero,
+				},
+			},
+		},
+		"annotations set to 0": {
+			handler: Handler{},
+			annotations: map[string]string{
+				annotationSidecarProxyCPURequest:    "0",
+				annotationSidecarProxyMemoryRequest: "0",
+				annotationSidecarProxyCPULimit:      "0",
+				annotationSidecarProxyMemoryLimit:   "0",
+			},
+			expResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    zero,
+					corev1.ResourceMemory: zero,
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    zero,
+					corev1.ResourceMemory: zero,
+				},
+			},
+		},
+		"invalid cpu request": {
+			handler: Handler{},
+			annotations: map[string]string{
+				annotationSidecarProxyCPURequest: "invalid",
+			},
+			expErr: "parsing annotation consul.hashicorp.com/sidecar-proxy-cpu-request:\"invalid\": quantities must match the regular expression",
+		},
+		"invalid cpu limit": {
+			handler: Handler{},
+			annotations: map[string]string{
+				annotationSidecarProxyCPULimit: "invalid",
+			},
+			expErr: "parsing annotation consul.hashicorp.com/sidecar-proxy-cpu-limit:\"invalid\": quantities must match the regular expression",
+		},
+		"invalid memory request": {
+			handler: Handler{},
+			annotations: map[string]string{
+				annotationSidecarProxyMemoryRequest: "invalid",
+			},
+			expErr: "parsing annotation consul.hashicorp.com/sidecar-proxy-memory-request:\"invalid\": quantities must match the regular expression",
+		},
+		"invalid memory limit": {
+			handler: Handler{},
+			annotations: map[string]string{
+				annotationSidecarProxyMemoryLimit: "invalid",
+			},
+			expErr: "parsing annotation consul.hashicorp.com/sidecar-proxy-memory-limit:\"invalid\": quantities must match the regular expression",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(tt *testing.T) {
+			require := require.New(tt)
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: c.annotations,
+				},
+
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "web",
+						},
+					},
+				},
+			}
+			container, err := c.handler.envoySidecar(pod, k8sNamespace)
+			if c.expErr != "" {
+				require.NotNil(err)
+				require.Contains(err.Error(), c.expErr)
+			} else {
+				require.NoError(err)
+				require.Equal(c.expResources, container.Resources)
+			}
+		})
+	}
 }

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -163,6 +163,20 @@ type Handler struct {
 	// Only necessary if ACLs are enabled.
 	CrossNamespaceACLPolicy string
 
+	// Resources checks if cpu and memory resources for sidecar pods and
+	// init containers should be set. If this is false, no resources
+	// will be set.
+	Resources bool
+	// CPULimit sets cpu limit for pods
+	CPULimit string
+	// MemoryLimit sets memory limit for pods
+	MemoryLimit string
+	// CPURequest sets cpu requests for pods
+	CPURequest string
+	// MemoryRequest sets memory requests for pods
+	MemoryRequest string
+
+
 	// Log
 	Log hclog.Logger
 }

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattbaird/jsonpatch"
 	"k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -76,6 +77,11 @@ const (
 	// consul-k8s lifecycle-sidecar command. This flag controls how often the
 	// service is synced (i.e. re-registered) with the local agent.
 	annotationSyncPeriod = "consul.hashicorp.com/connect-sync-period"
+
+	annotationSidecarProxyCPULimit      = "consul.hashicorp.com/sidecar-proxy-cpu-limit"
+	annotationSidecarProxyCPURequest    = "consul.hashicorp.com/sidecar-proxy-cpu-request"
+	annotationSidecarProxyMemoryLimit   = "consul.hashicorp.com/sidecar-proxy-memory-limit"
+	annotationSidecarProxyMemoryRequest = "consul.hashicorp.com/sidecar-proxy-memory-request"
 )
 
 var (
@@ -163,19 +169,11 @@ type Handler struct {
 	// Only necessary if ACLs are enabled.
 	CrossNamespaceACLPolicy string
 
-	// Resources checks if cpu and memory resources for sidecar pods and
-	// init containers should be set. If this is false, no resources
-	// will be set.
-	Resources bool
-	// CPULimit sets cpu limit for pods
-	CPULimit string
-	// MemoryLimit sets memory limit for pods
-	MemoryLimit string
-	// CPURequest sets cpu requests for pods
-	CPURequest string
-	// MemoryRequest sets memory requests for pods
-	MemoryRequest string
-
+	// Default resource settings for sidecar proxies.
+	DefaultProxyCPURequest    resource.Quantity
+	DefaultProxyCPULimit      resource.Quantity
+	DefaultProxyMemoryRequest resource.Quantity
+	DefaultProxyMemoryLimit   resource.Quantity
 
 	// Log
 	Log hclog.Logger

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -337,6 +337,39 @@ func TestHandlerHandle(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			"enable resources",
+			Handler{Resources: true, CPULimit: "1", MemoryLimit: "100Mi", CPURequest: "1", MemoryRequest: "100Mi", Log: hclog.Default().Named("handler")},
+			v1beta1.AdmissionRequest{
+				Object: encodeRaw(t, &corev1.Pod{
+					Spec: basicSpec,
+				}),
+			},
+			"",
+			[]jsonpatch.JsonPatchOperation{
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/volumes",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/-",
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationStatus),
+				},
+			},
+		},
 	}
 
 	for _, tt := range cases {

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -337,39 +337,6 @@ func TestHandlerHandle(t *testing.T) {
 				},
 			},
 		},
-
-		{
-			"enable resources",
-			Handler{Resources: true, CPULimit: "1", MemoryLimit: "100Mi", CPURequest: "1", MemoryRequest: "100Mi", Log: hclog.Default().Named("handler")},
-			v1beta1.AdmissionRequest{
-				Object: encodeRaw(t, &corev1.Pod{
-					Spec: basicSpec,
-				}),
-			},
-			"",
-			[]jsonpatch.JsonPatchOperation{
-				{
-					Operation: "add",
-					Path:      "/metadata/annotations",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationStatus),
-				},
-			},
-		},
 	}
 
 	for _, tt := range cases {

--- a/connect-inject/lifecycle_sidecar.go
+++ b/connect-inject/lifecycle_sidecar.go
@@ -2,7 +2,16 @@ package connectinject
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"strings"
+)
+
+const (
+	lifecycleContainerCPULimit      = "10m"
+	lifecycleContainerCPURequest    = "10m"
+	lifecycleContainerMemoryLimit   = "25Mi"
+	lifecycleContainerMemoryRequest = "25Mi"
 )
 
 func (h *Handler) lifecycleSidecar(pod *corev1.Pod) corev1.Container {
@@ -52,6 +61,17 @@ func (h *Handler) lifecycleSidecar(pod *corev1.Pod) corev1.Container {
 			})
 	}
 
+	resources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(lifecycleContainerCPULimit),
+			corev1.ResourceMemory: resource.MustParse(lifecycleContainerMemoryLimit),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(lifecycleContainerCPURequest),
+			corev1.ResourceMemory: resource.MustParse(lifecycleContainerMemoryRequest),
+		},
+	}
+
 	return corev1.Container{
 		Name:  "consul-connect-lifecycle-sidecar",
 		Image: h.ImageConsulK8S,
@@ -62,6 +82,7 @@ func (h *Handler) lifecycleSidecar(pod *corev1.Pod) corev1.Container {
 				MountPath: "/consul/connect-inject",
 			},
 		},
-		Command: command,
+		Command:   command,
+		Resources: resources,
 	}
 }

--- a/connect-inject/lifecycle_sidecar_test.go
+++ b/connect-inject/lifecycle_sidecar_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 )
@@ -52,6 +53,16 @@ func TestLifecycleSidecar_Default(t *testing.T) {
 			"consul-k8s", "lifecycle-sidecar",
 			"-service-config", "/consul/connect-inject/service.hcl",
 			"-consul-binary", "/consul/connect-inject/consul",
+		},
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(lifecycleContainerCPULimit),
+				corev1.ResourceMemory: resource.MustParse(lifecycleContainerMemoryLimit),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(lifecycleContainerCPURequest),
+				corev1.ResourceMemory: resource.MustParse(lifecycleContainerMemoryRequest),
+			},
 		},
 	}, container)
 }
@@ -159,6 +170,16 @@ func TestLifecycleSidecar_TLS(t *testing.T) {
 			"consul-k8s", "lifecycle-sidecar",
 			"-service-config", "/consul/connect-inject/service.hcl",
 			"-consul-binary", "/consul/connect-inject/consul",
+		},
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(lifecycleContainerCPULimit),
+				corev1.ResourceMemory: resource.MustParse(lifecycleContainerMemoryLimit),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(lifecycleContainerCPURequest),
+				corev1.ResourceMemory: resource.MustParse(lifecycleContainerMemoryRequest),
+			},
 		},
 	}, container)
 }

--- a/go.sum
+++ b/go.sum
@@ -476,6 +476,7 @@ k8s.io/api v0.0.0-20190325185214-7544f9db76f6/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j
 k8s.io/apimachinery v0.0.0-20180821005732-488889b0007f/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/apimachinery v0.0.0-20190223001710-c182ff3b9841 h1:Q4RZrHNtlC/mSdC1sTrcZ5RchC/9vxLVj57pWiCBKv4=
 k8s.io/apimachinery v0.0.0-20190223001710-c182ff3b9841/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/apimachinery v0.0.0-20190620073744-d16981aedf33 h1:Lkd+QNFOB3DqrDyWo796aodJgFJautn/M+t9IGearPc=
 k8s.io/client-go v8.0.0+incompatible h1:tTI4hRmb1DRMl4fG6Vclfdi6nTM82oIrTT7HfitmxC4=
 k8s.io/client-go v8.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c h1:3KSCztE7gPitlZmWbNwue/2U0YruD65DqX3INopDAQM=

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -49,6 +49,12 @@ type Command struct {
 	flagDefaultProtocol      string // Default protocol for use with central config
 	flagConsulCACert         string // [Deprecated] Path to CA Certificate to use when communicating with Consul clients
 
+	flagResources       bool   // True to enable resources for init and sidecar pods
+	flagCPULimit        string // CPU Limits
+	flagMemoryLimit     string // Memory Limits
+	flagCPURequest      string // CPU Requests
+	flagMemoryRequest   string // Memory Limits
+
 	// Flags to support namespaces
 	flagEnableNamespaces           bool     // Use namespacing on all components
 	flagConsulDestinationNamespace string   // Consul namespace to register everything if not mirroring
@@ -116,6 +122,12 @@ func (c *Command) init() {
 	flags.Merge(c.flagSet, c.http.ClientFlags())
 	flags.Merge(c.flagSet, c.http.ServerFlags())
 
+	c.flagSet.BoolVar(&c.flagResources, "enable-resources", false,
+		"Enable to set custom resources for init and sidecar pods")
+	c.flagSet.StringVar(&c.flagCPULimit, "cpu-limit", "", "CPU Limits for init and sidecar pods")
+	c.flagSet.StringVar(&c.flagMemoryLimit, "memory-limit", "", "Memory Limits for init and sidecar pods")
+	c.flagSet.StringVar(&c.flagCPURequest, "cpu-request", "", "CPU Requests for init and sidecar pods")
+	c.flagSet.StringVar(&c.flagMemoryRequest, "memory-request", "", "Memory Requests for init and sidecar pods")
 	c.help = flags.Usage(help, c.flagSet)
 }
 
@@ -216,6 +228,10 @@ func (c *Command) Run(args []string) int {
 		WriteServiceDefaults:       c.flagWriteServiceDefaults,
 		DefaultProtocol:            c.flagDefaultProtocol,
 		ConsulCACert:               string(consulCACert),
+		CPULimit:          c.flagCPULimit,
+		MemoryLimit:       c.flagMemoryLimit,
+		CPURequest:        c.flagCPURequest,
+		MemoryRequest:     c.flagMemoryRequest,
 		EnableNamespaces:           c.flagEnableNamespaces,
 		AllowK8sNamespacesSet:      allowSet,
 		DenyK8sNamespacesSet:       denySet,

--- a/subcommand/inject-connect/command_test.go
+++ b/subcommand/inject-connect/command_test.go
@@ -22,6 +22,36 @@ func TestRun_FlagValidation(t *testing.T) {
 			flags:  []string{"-consul-k8s-image", "foo", "-ca-file", "bar"},
 			expErr: "Error reading Consul's CA cert file \"bar\"",
 		},
+		{
+			flags:  []string{"-consul-k8s-image", "foo", "-default-sidecar-proxy-cpu-limit=unparseable"},
+			expErr: "-default-sidecar-proxy-cpu-limit is invalid",
+		},
+		{
+			flags:  []string{"-consul-k8s-image", "foo", "-default-sidecar-proxy-cpu-request=unparseable"},
+			expErr: "-default-sidecar-proxy-cpu-request is invalid",
+		},
+		{
+			flags:  []string{"-consul-k8s-image", "foo", "-default-sidecar-proxy-memory-limit=unparseable"},
+			expErr: "-default-sidecar-proxy-memory-limit is invalid",
+		},
+		{
+			flags:  []string{"-consul-k8s-image", "foo", "-default-sidecar-proxy-memory-request=unparseable"},
+			expErr: "-default-sidecar-proxy-memory-request is invalid",
+		},
+		{
+			flags: []string{"-consul-k8s-image", "foo",
+				"-default-sidecar-proxy-memory-request=50Mi",
+				"-default-sidecar-proxy-memory-limit=25Mi",
+			},
+			expErr: "request must be <= limit: -default-sidecar-proxy-memory-request value of \"50Mi\" is greater than the -default-sidecar-proxy-memory-limit value of \"25Mi\"",
+		},
+		{
+			flags: []string{"-consul-k8s-image", "foo",
+				"-default-sidecar-proxy-cpu-request=50m",
+				"-default-sidecar-proxy-cpu-limit=25m",
+			},
+			expErr: "request must be <= limit: -default-sidecar-proxy-cpu-request value of \"50m\" is greater than the -default-sidecar-proxy-cpu-limit value of \"25m\"",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
* Set resource settings for init and lifecycle containers. These are set by default and not overridable. They're set by default to avoid needing a separate flag to turn them on. This is safe because they're set to more than double observed resource requirements so users that don't need resource settings won't be affected. They're not exposed for overriding because they won't change based on use-case, i.e. a service with a lot of throughput may need to customize its envoy proxy cpu/memory however the init container and lifecycle sidecar will need the same cpu/memory as all the other connect pods since they're doing the same job.
* Allow setting resource settings for envoy sidecar via default settings passed in through Helm chart values that will apply to all pods, overridable by annotations on injected pods.
* Flags:
  * `-default-sidecar-proxy-cpu-limit`
  * `-default-sidecar-proxy-cpu-request`
  * `-default-sidecar-proxy-memory-limit`
  * `-default-sidecar-proxy-memory-request`
* Annotations:
  * `consul.hashicorp.com/sidecar-proxy-cpu-limit`
  * `consul.hashicorp.com/sidecar-proxy-cpu-request`
  * `consul.hashicorp.com/sidecar-proxy-memory-limit`
  * `consul.hashicorp.com/sidecar-proxy-memory-request`

See https://github.com/hashicorp/consul-helm/pull/470 for testing.

Refactors @wuvs work from https://github.com/hashicorp/consul-k8s/pull/109.