### PR TITLE
Fix bug with defining connect healthcheck

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -323,7 +323,7 @@ services {
 
   checks {
     name = "Destination Alias"
-    alias_service = "{{ .ServiceName }}"
+    alias_service = "${SERVICE_ID}"
   }
 }
 

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -77,7 +77,7 @@ services {
 
   checks {
     name = "Destination Alias"
-    alias_service = "web"
+    alias_service = "${SERVICE_ID}"
   }
 }
 
@@ -132,7 +132,7 @@ cp /bin/consul /consul/connect-inject/consul`,
 
   checks {
     name = "Destination Alias"
-    alias_service = "web"
+    alias_service = "${SERVICE_ID}"
   }
 }
 
@@ -304,7 +304,7 @@ services {
 
   checks {
     name = "Destination Alias"
-    alias_service = "web"
+    alias_service = "${SERVICE_ID}"
   }
 }
 
@@ -350,7 +350,7 @@ services {
 
   checks {
     name = "Destination Alias"
-    alias_service = "web"
+    alias_service = "${SERVICE_ID}"
   }
 }
 
@@ -396,7 +396,7 @@ services {
 
   checks {
     name = "Destination Alias"
-    alias_service = "web"
+    alias_service = "${SERVICE_ID}"
   }
 }
 
@@ -443,7 +443,7 @@ services {
 
   checks {
     name = "Destination Alias"
-    alias_service = "web"
+    alias_service = "${SERVICE_ID}"
   }
 }
 
@@ -502,7 +502,7 @@ services {
 
   checks {
     name = "Destination Alias"
-    alias_service = "web"
+    alias_service = "${SERVICE_ID}"
   }
 }
 
@@ -635,7 +635,7 @@ services {
 
   checks {
     name = "Destination Alias"
-    alias_service = "web"
+    alias_service = "${SERVICE_ID}"
   }
 }
 
@@ -703,7 +703,7 @@ services {
 
   checks {
     name = "Destination Alias"
-    alias_service = "web"
+    alias_service = "${SERVICE_ID}"
   }
 }
 
@@ -772,7 +772,7 @@ services {
 
   checks {
     name = "Destination Alias"
-    alias_service = "web"
+    alias_service = "${SERVICE_ID}"
   }
 }
 
@@ -850,7 +850,7 @@ services {
 
   checks {
     name = "Destination Alias"
-    alias_service = "web"
+    alias_service = "${SERVICE_ID}"
   }
 }
 
@@ -928,7 +928,7 @@ services {
 
   checks {
     name = "Destination Alias"
-    alias_service = "web"
+    alias_service = "${SERVICE_ID}"
   }
 }
 
@@ -1010,7 +1010,7 @@ services {
 
   checks {
     name = "Destination Alias"
-    alias_service = "web"
+    alias_service = "${SERVICE_ID}"
   }
 }
 


### PR DESCRIPTION
Previously we were setting the alias_service field of alias checks to
the service name instead of the service id. This check would then pass
because Consul would consider an alias for a non-existent service id to
be okay. With https://github.com/hashicorp/consul/pull/7384, now the
check will fail if the service id doesn't exist and so those connect
services will be considered unhealthy and be unroutable.