### PR TITLE
top level build was failing due to missing bin extension for windows

### DIFF
--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -280,7 +280,13 @@ function build_consul_local {
             then
                GOBIN_EXTRA="${os}_${arch}/"
             fi
-            CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go install -ldflags "${GOLDFLAGS}" -tags "${GOTAGS}" && cp "${MAIN_GOPATH}/bin/${GOBIN_EXTRA}"/consul-k8s "${outdir}/consul-k8s"
+            if test "${os}" == "windows"
+            then
+              OS_BIN_EXTENSION=".exe"
+            else
+              OS_BIN_EXTENSION=""
+            fi
+            CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go install -ldflags "${GOLDFLAGS}" -tags "${GOTAGS}" && cp "${MAIN_GOPATH}/bin/${GOBIN_EXTRA}"/consul-k8s${OS_BIN_EXTENSION} "${outdir}/consul-k8s"
             if test $? -ne 0
             then
                err "ERROR: Failed to build Consul for ${osarch}"


### PR DESCRIPTION
Top level build `make all` was failing due to file extensions for windows.
This change checks if we need to modify binary extension at build time and appends to the binary if necessary.
```
 consul-k8s % make
==> Building Consul - OSes: solaris darwin freebsd linux windows, Architectures: 386 amd64 arm arm64
Building sequentially with go install
--->   solaris/amd64
<snip>
--->   windows/386
cp: /Users/kyle/go/bin/windows_386//consul-k8s: No such file or directory
ERROR: Failed to build Consul for windows/386
make: *** [bin] Error 1
```
