### PR TITLE
Ci/add dev docker publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,17 @@ jobs:
       - store_artifacts:
           path: /tmp/test-results
 
-  build-distros:
+  build-distro: # defines a parameterized job
+    description: A job that will build the os/arch distro set by XC_OS and XC_ARCH
+    parameters:
+      OS:
+        description: What OSes to build
+        default: ""
+        type: string
+      ARCH:
+        description: What architectures to build
+        default: ""
+        type: string
     executor: go
     environment:
       GOXPARALLEL: 2 # CircleCI containers are 2 CPU x 4GB RAM
@@ -114,10 +124,7 @@ jobs:
       - restore_cache:
           keys:
             - consul-k8s-modcache-v1-{{ checksum "go.mod" }}
-
-      - run: make tools
-      - run: ./build-support/scripts/build-local.sh
-
+      - run: XC_OS=<< parameters.OS >> XC_ARCH=<< parameters.ARCH >> ./build-support/scripts/build-local.sh
       # persist to downstream job
       - persist_to_workspace:
           root: .
@@ -152,11 +159,28 @@ workflows:
           requires:
             - go-fmt-and-vet
             - lint-consul-retry
-      - build-distros:
+      - build-distro:
+          OS: "darwin freebsd linux windows"
+          ARCH: "386"
+          name: build-distros-386
+          requires:
+            - test
+            - test_enterprise
+      - build-distro:
+          OS: "darwin freebsd linux solaris windows"
+          ARCH: "amd64"
+          name: build-distros-amd64
+          requires:
+            - test
+            - test_enterprise
+      - build-distro:
+          OS: "linux"
+          ARCH: "arm arm64"
+          name: build-distros-arm-arm64
           requires:
             - test
             - test_enterprise
       - dev-upload-docker:
           context: consul-ci
           requires:
-            - build-distros
+            - build-distros-amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,9 +118,25 @@ jobs:
       - run: make tools
       - run: ./build-support/scripts/build-local.sh
 
+      # persist to downstream job
+      - persist_to_workspace:
+          root: .
+          paths:
+            - pkg/bin
       # save dev build to CircleCI
       - store_artifacts:
           path: ./pkg/bin
+
+  # upload dev docker image
+  dev-upload-docker:
+    executor: go
+    steps:
+      - checkout
+      # get consul-k8s binary
+      - attach_workspace:
+          at: .
+      - setup_remote_docker
+      - run: make ci.dev-docker
 
 workflows:
   version: 2
@@ -140,3 +156,7 @@ workflows:
           requires:
             - test
             - test_enterprise
+      - dev-upload-docker:
+          context: consul-ci
+          requires:
+            - build-distros

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
       - restore_cache:
           keys:
             - consul-k8s-modcache-v1-{{ checksum "go.mod" }}
-      - run: XC_OS=<< parameters.OS >> XC_ARCH=<< parameters.ARCH >> ./build-support/scripts/build-local.sh
+      - run: XC_OS="<< parameters.OS >>" XC_ARCH="<< parameters.ARCH >>" ./build-support/scripts/build-local.sh
       # persist to downstream job
       - persist_to_workspace:
           root: .

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ export GOTAGS
 ################
 CI_DEV_DOCKER_NAMESPACE?=hashicorpdev
 CI_DEV_DOCKER_IMAGE_NAME?=consul-k8s
-CI_DEV_DOCKER_WORKDIR?=pkg/bin/linux_amd64/
+CI_DEV_DOCKER_WORKDIR?=.
 CONSUL_K8S_IMAGE_VERSION?=latest
 ################
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ export GOTAGS
 ################
 CI_DEV_DOCKER_NAMESPACE?=hashicorpdev
 CI_DEV_DOCKER_IMAGE_NAME?=consul-k8s
-CI_DEV_DOCKER_WORKDIR?=bin/
+CI_DEV_DOCKER_WORKDIR?=pkg/bin/linux_amd64/
 CONSUL_K8S_IMAGE_VERSION?=latest
 ################
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,17 @@ export GIT_DESCRIBE
 export GOLDFLAGS
 export GOTAGS
 
+
+
+################
+# CI Variables #
+################
+CI_DEV_DOCKER_NAMESPACE?=hashicorpdev
+CI_DEV_DOCKER_IMAGE_NAME?=consul-k8s
+CI_DEV_DOCKER_WORKDIR?=bin/
+CONSUL_K8S_IMAGE_VERSION?=latest
+################
+
 DIST_TAG?=1
 DIST_BUILD?=1
 DIST_SIGN?=1
@@ -118,4 +129,24 @@ clean:
 		$(CURDIR)/pkg
 
 
-.PHONY: all bin clean dev dist docker-images go-build-image test tools
+# In CircleCI, the linux binary will be attached from a previous step at pkg/bin/linux_amd64/. This make target
+# should only run in CI and not locally.
+ci.dev-docker:
+	@echo "Pulling consul-k8s container image - $(CONSUL_K8S_IMAGE_VERSION)"
+	@docker pull hashicorp/$(CI_DEV_DOCKER_IMAGE_NAME):$(CONSUL_K8S_IMAGE_VERSION) >/dev/null
+	@echo "Building consul-k8s Development container - $(CI_DEV_DOCKER_IMAGE_NAME)"
+	@docker build -t '$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT)' \
+	--build-arg CONSUL_K8S_IMAGE_VERSION=$(CONSUL_K8S_IMAGE_VERSION) \
+	--label COMMIT_SHA=$(CIRCLE_SHA1) \
+	--label PULL_REQUEST=$(CIRCLE_PULL_REQUEST) \
+	--label CIRCLE_BUILD_URL=$(CIRCLE_BUILD_URL) \
+	$(CI_DEV_DOCKER_WORKDIR) -f $(CURDIR)/build-support/docker/Dev.dockerfile
+	@echo $(DOCKER_PASS) | docker login -u="$(DOCKER_USER)" --password-stdin
+	@echo "Pushing dev image to: https://cloud.docker.com/u/$(CI_DEV_DOCKER_NAMESPACE)/repository/docker/$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME)"
+	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT)
+ifeq ($(CIRCLE_BRANCH), master)
+	@docker tag $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT) $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
+	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
+endif
+
+.PHONY: all bin clean dev dist docker-images go-build-image test tools ci.dev-docker


### PR DESCRIPTION
This PR publishes a docker image to https://hub.docker.com/repository/docker/hashicorpdev/consul-k8s/ for every commit. Every commit will publish a tag corresponding to its short ref. Any commit to master will also update the `latest` tag. 

To pull the latest commit of consul-k8s you can do: `docker pull hashicorpdev/consul-k8s:latest` 

To pull a specific commit of consul-k8s that you have pushed to CI: `docker pull hashicorpdev/consul-k8s:$(git rev-parse --short HEAD)` this is because the short ref is not guaranteed to be a specific length (generally 7 characters) due to collisions. Ex: the latest commit on this PR is here: https://hub.docker.com/layers/hashicorpdev/consul-k8s/93e4c97/images/sha256-1d4eb0bd0d403f557e4aa509cede8237d9d7911cce5dd6a7b9c1697e96060e6c?context=repo

I have also split out the distro builds to make them run faster, so now they run in < 3 min across 3 containers instead of < 6 mins in one container. 