### PR TITLE
fail if service name != service account name

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -81,6 +81,12 @@ func (h *Handler) containerInit(pod *corev1.Pod, k8sNamespace string) (corev1.Co
 		panic("No service found. This should be impossible since we default it.")
 	}
 
+	// When ACLs are enabled, the ACL token returned from `consul login` is only
+	// valid for a service with the same name as the ServiceAccountName.
+	if data.AuthMethod != "" && data.ServiceName != pod.Spec.ServiceAccountName {
+		return corev1.Container{}, fmt.Errorf("serviceAccountName %q does not match service name %q", pod.Spec.ServiceAccountName, data.ServiceName)
+	}
+
 	// If a port is specified, then we determine the value of that port
 	// and register that port for the host service.
 	if raw, ok := pod.Annotations[annotationPort]; ok && raw != "" {


### PR DESCRIPTION
This check only occurs when ACLs are enable with connectInject.

Tested that it only performs this check when ACLs are enabled. Screenshot of error when incorrect pod config is applied

Closes #237 

Signed-off-by: Ashwin Venkatesh <ashwin@hashicorp.com>

<img width="3339" alt="Screen Shot 2020-06-19 at 10 54 48 AM" src="https://user-images.githubusercontent.com/26226763/85150799-feb20a80-b220-11ea-94c5-5b6710b3d36c.png">
