### PR TITLE
Always update auth method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ executors:
       - image: circleci/golang:1.13
     environment:
       - TEST_RESULTS: /tmp/test-results # path to where test results are saved
-      - CONSUL_VERSION: 1.7.0 # Consul's OSS version to use in tests
-      - CONSUL_ENT_VERSION: 1.7.0+ent # Consul's enterprise version to use in tests
+      - CONSUL_VERSION: 1.8.0 # Consul's OSS version to use in tests
+      - CONSUL_ENT_VERSION: 1.8.0+ent # Consul's enterprise version to use in tests
 
 jobs:
   go-fmt-and-vet:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ executors:
       - image: circleci/golang:1.13
     environment:
       - TEST_RESULTS: /tmp/test-results # path to where test results are saved
-      - CONSUL_VERSION: 1.8.0 # Consul's OSS version to use in tests
-      - CONSUL_ENT_VERSION: 1.8.0+ent # Consul's enterprise version to use in tests
+      - CONSUL_VERSION: 1.7.0 # Consul's OSS version to use in tests
+      - CONSUL_ENT_VERSION: 1.7.0+ent # Consul's enterprise version to use in tests
 
 jobs:
   go-fmt-and-vet:

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -136,7 +136,7 @@ func (c *Command) init() {
 			"default namespace, specify the value in the form <GatewayName>.<ConsulNamespace>.")
 
 	c.flags.Var((*flags.AppendSliceValue)(&c.flagServerAddresses), "server-address",
-		"The IP, DNS name or the cloud auto-join string of the Consul server(s). If providing IPs or DNS names, may be specified multiple times."+
+		"The IP, DNS name or the cloud auto-join string of the Consul server(s). If providing IPs or DNS names, may be specified multiple times. "+
 			"At least one value is required.")
 	c.flags.UintVar(&c.flagServerPort, "server-port", 8500, "The HTTP or HTTPS port of the Consul server. Defaults to 8500.")
 	c.flags.StringVar(&c.flagConsulCACert, "consul-ca-cert", "",

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -819,6 +819,7 @@ func TestRun_ConnectInjectAuthMethodUpdates(t *testing.T) {
 
 	// Overwrite the default kubernetes api, service account token and CA cert
 	kubernetesHost := "https://kubernetes.example.com"
+	// This token is the base64 encoded example token from jwt.io
 	serviceAccountToken = "ZXlKaGJHY2lPaUpJVXpJMU5pSXNJblI1Y0NJNklrcFhWQ0o5LmV5SnpkV0lpT2lJeE1qTTBOVFkzT0Rrd0lpd2libUZ0WlNJNklrcHZhRzRnUkc5bElpd2lhV0YwSWpveE5URTJNak01TURJeWZRLlNmbEt4d1JKU01lS0tGMlFUNGZ3cE1lSmYzNlBPazZ5SlZfYWRRc3N3NWM="
 	serviceAccountCACert = base64.StdEncoding.EncodeToString([]byte(caCertPem))
 
@@ -1847,7 +1848,7 @@ func generateServerCerts(t *testing.T) (string, string, string, func()) {
 // CA Cert and JWT token.
 func setUpK8sServiceAccount(t *testing.T, k8s *fake.Clientset) (string, string) {
 	// Create ServiceAccount for the kubernetes auth method if it doesn't exist,
-	// and update do nothing.
+	// otherwise, do nothing.
 	serviceAccountName := resourcePrefix + "-connect-injector-authmethod-svc-account"
 	sa, _ := k8s.CoreV1().ServiceAccounts(ns).Get(serviceAccountName, metav1.GetOptions{})
 	if sa == nil {

--- a/subcommand/server-acl-init/connect_inject.go
+++ b/subcommand/server-acl-init/connect_inject.go
@@ -9,6 +9,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// We use the default Kubernetes service as the default host
+// for the auth method created in Consul.
+// This is recommended as described here:
+// https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
 const defaultKubernetesHost = "https://kubernetes.default.svc"
 
 // configureConnectInject sets up auth methods so that connect injection will

--- a/subcommand/server-acl-init/connect_inject.go
+++ b/subcommand/server-acl-init/connect_inject.go
@@ -9,83 +9,58 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const defaultKubernetesHost = "https://kubernetes.default.svc"
+
 // configureConnectInject sets up auth methods so that connect injection will
 // work.
 func (c *Command) configureConnectInject(consulClient *api.Client) error {
 
 	authMethodName := c.withPrefix("k8s-auth-method")
 
-	// If not running namespaces, check if there's already an auth method.
-	// This means no changes need to be made to it. Binding rules should
-	// still be checked in case a user has updated their config.
-	var createAuthMethod bool
-	if !c.flagEnableNamespaces {
-		// Check if an auth method exists with the given name
-		err := c.untilSucceeds(fmt.Sprintf("checking if %s auth method exists", authMethodName),
-			func() error {
-				am, _, err := consulClient.ACL().AuthMethodRead(authMethodName, &api.QueryOptions{})
-				// This call returns nil if an AuthMethod does
-				// not exist with that name. This means we will
-				// need to create one.
-				if err == nil && am == nil {
-					createAuthMethod = true
-				}
+	// Create the auth method template. This requires calls to the
+	// kubernetes environment.
+	authMethodTmpl, err := c.createAuthMethodTmpl(authMethodName)
+	if err != nil {
+		return err
+	}
+
+	// Set up the auth method in the specific namespace if not mirroring.
+	// If namespaces and mirroring are enabled, this is not necessary because
+	// the auth method will fall back to being created in the Consul `default`
+	// namespace automatically, as is necessary for mirroring.
+	// Note: if the config changes, an auth method will be created in the
+	// correct namespace, but the old auth method will not be removed.
+	writeOptions := api.WriteOptions{}
+	if c.flagEnableNamespaces && !c.flagEnableInjectK8SNSMirroring {
+		writeOptions.Namespace = c.flagConsulInjectDestinationNamespace
+
+		if c.flagConsulInjectDestinationNamespace != consulDefaultNamespace {
+			// If not the default namespace, check if it exists, creating it
+			// if necessary. The Consul namespace must exist for the AuthMethod
+			// to be created there.
+			err = c.untilSucceeds(fmt.Sprintf("checking or creating namespace %s",
+				c.flagConsulInjectDestinationNamespace),
+				func() error {
+					err := c.checkAndCreateNamespace(c.flagConsulInjectDestinationNamespace, consulClient)
+					return err
+				})
+			if err != nil {
 				return err
-			})
-		if err != nil {
-			return err
+			}
 		}
 	}
 
-	// If namespaces are enabled, a namespace configuration change may need
-	// the auth method to be updated (as with a different mirroring prefix)
-	// or a new auth method created (if a new destination namespace is specified).
-	if c.flagEnableNamespaces || createAuthMethod {
-		// Create the auth method template. This requires calls to the
-		// kubernetes environment.
-		authMethodTmpl, err := c.createAuthMethodTmpl(authMethodName)
-		if err != nil {
+	err = c.untilSucceeds(fmt.Sprintf("creating auth method %s", authMethodTmpl.Name),
+		func() error {
+			var err error
+			// `AuthMethodCreate` will also be able to update an existing
+			// AuthMethod based on the name provided. This means that any
+			// configuration changes will correctly update the AuthMethod.
+			_, _, err = consulClient.ACL().AuthMethodCreate(&authMethodTmpl, &writeOptions)
 			return err
-		}
-
-		// Set up the auth method in the specific namespace if not mirroring
-		// If namespaces and mirroring are enabled, this is not necessary because
-		// the auth method will fall back to being created in the Consul `default`
-		// namespace automatically, as is necessary for mirroring.
-		// Note: if the config changes, an auth method will be created in the
-		// correct namespace, but the old auth method will not be removed.
-		writeOptions := api.WriteOptions{}
-		if c.flagEnableNamespaces && !c.flagEnableInjectK8SNSMirroring {
-			writeOptions.Namespace = c.flagConsulInjectDestinationNamespace
-
-			if c.flagConsulInjectDestinationNamespace != consulDefaultNamespace {
-				// If not the default namespace, check if it exists, creating it
-				// if necessary. The Consul namespace must exist for the AuthMethod
-				// to be created there.
-				err = c.untilSucceeds(fmt.Sprintf("checking or creating namespace %s",
-					c.flagConsulInjectDestinationNamespace),
-					func() error {
-						err := c.checkAndCreateNamespace(c.flagConsulInjectDestinationNamespace, consulClient)
-						return err
-					})
-				if err != nil {
-					return err
-				}
-			}
-		}
-
-		err = c.untilSucceeds(fmt.Sprintf("creating auth method %s", authMethodTmpl.Name),
-			func() error {
-				var err error
-				// `AuthMethodCreate` will also be able to update an existing
-				// AuthMethod based on the name provided. This means that any namespace
-				// configuration changes will correctly update the AuthMethod.
-				_, _, err = consulClient.ACL().AuthMethodCreate(&authMethodTmpl, &writeOptions)
-				return err
-			})
-		if err != nil {
-			return err
-		}
+		})
+	if err != nil {
+		return err
 	}
 
 	// Create the binding rule.
@@ -110,7 +85,7 @@ func (c *Command) configureConnectInject(consulClient *api.Client) error {
 	}
 
 	var existingRules []*api.ACLBindingRule
-	err := c.untilSucceeds(fmt.Sprintf("listing binding rules for auth method %s", authMethodName),
+	err = c.untilSucceeds(fmt.Sprintf("listing binding rules for auth method %s", authMethodName),
 		func() error {
 			var err error
 			existingRules, _, err = consulClient.ACL().BindingRuleList(authMethodName, &queryOptions)
@@ -186,7 +161,7 @@ func (c *Command) createAuthMethodTmpl(authMethodName string) (api.ACLAuthMethod
 		return api.ACLAuthMethod{}, err
 	}
 
-	kubernetesHost := "https://kubernetes.default.svc"
+	kubernetesHost := defaultKubernetesHost
 
 	// Check if custom auth method Host and CACert are provided
 	if c.flagInjectAuthMethodHost != "" {


### PR DESCRIPTION
Previously, we would only update auth method in Consul
if Consul namespaces are enabled. This was necessary to make sure
that if namespace configuration changes, it is reflected in the auth method.

However, running Consul servers externally is another use case why it's important
to update the auth method. That is because if you run a Helm install, then uninstall
and install again, the auth method saved in Consul is out-of-date:
the service account JWT token saved in the auth method refers to the service account token
that has been deleted from Kubernetes when you ran helm uninstall.

This change proposes to always update the auth method to solve for the
external servers use case.