### PR TITLE
Increase connect-inject initContainer resource request and limit

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -11,11 +11,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+// The init container is bounded in memory usage by the size of the consul binary,
+// So we will match the memory limit/requests to the size of the consul binary
+// This has the added effect of modifying the connect-inject pod resource requirements
+// if/when it becomes larger than the pod resources
 const (
 	initContainerCPULimit      = "50m"
 	initContainerCPURequest    = "50m"
-	initContainerMemoryLimit   = "25Mi"
-	initContainerMemoryRequest = "25Mi"
+	initContainerMemoryLimit   = "110Mi"
+	initContainerMemoryRequest = "110Mi"
 )
 
 type initContainerCommandData struct {

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -19,7 +19,7 @@ const (
 	initContainerCPULimit      = "50m"
 	initContainerCPURequest    = "50m"
 	initContainerMemoryLimit   = "125Mi"
-	initContainerMemoryRequest = "125Mi"
+	initContainerMemoryRequest = "25Mi"
 )
 
 type initContainerCommandData struct {

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -12,7 +12,7 @@ import (
 )
 
 // The init container is bounded in memory usage by the size of the consul binary,
-// So we will match the memory limit/requests to the size of the consul binary
+// So we will match the memory limit to the size of the consul binary plus 7Mi for safety buffer
 // This has the added effect of modifying the connect-inject pod resource requirements
 // if/when it becomes larger than the pod resources
 const (

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -18,8 +18,8 @@ import (
 const (
 	initContainerCPULimit      = "50m"
 	initContainerCPURequest    = "50m"
-	initContainerMemoryLimit   = "110Mi"
-	initContainerMemoryRequest = "110Mi"
+	initContainerMemoryLimit   = "125Mi"
+	initContainerMemoryRequest = "125Mi"
 )
 
 type initContainerCommandData struct {

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -11,10 +11,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-// The init container is bounded in memory usage by the size of the consul binary,
-// So we will match the memory limit to the size of the consul binary plus 7Mi for safety buffer
-// This has the added effect of modifying the connect-inject pod resource requirements
-// if/when it becomes larger than the pod resources
+// The init container is bound in memory use by the size of the consul binary as it has
+// to copy it to a shared volume, this can eat up page cache during cp which could be equal
+// to the size of the consul binary. Instead we will set the initContainerMemoryLimit
+// to approx the size of the consul binary which is about 118Mi. Setting the Limit but not the
+// initContainerMemoryRequest so that we do not modify the resource requests of the pod
+// and potentially affect scheduling.
 const (
 	initContainerCPULimit      = "50m"
 	initContainerCPURequest    = "50m"


### PR DESCRIPTION
Currently the initContainer for connect-inject has a resource limit of 25Mi, this was introduced as a feature in the 0.16.0 release.
As part of it's runtime the initContainer issues a `cp` of the consul binary (100Mi+). Normally this is fine but it is possible to get into a situation where the host is under resource pressure and enough dirty pages from the `cp` operation accumulate in memory such that an OOM is triggered.
The initContainer is short lived and we just need it to run, so increase the resource limit to the size of the consul binary.
This resolves  #283 