### PR TITLE
increase cpu request/limits for lifecycle sidecar

### DIFF
--- a/connect-inject/lifecycle_sidecar.go
+++ b/connect-inject/lifecycle_sidecar.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	lifecycleContainerCPULimit      = "10m"
-	lifecycleContainerCPURequest    = "10m"
+	lifecycleContainerCPULimit      = "20m"
+	lifecycleContainerCPURequest    = "20m"
 	lifecycleContainerMemoryLimit   = "25Mi"
 	lifecycleContainerMemoryRequest = "25Mi"
 )


### PR DESCRIPTION
With the current CPU resource limits set to 10m we're noticing high cpu usage in the lifecycle sidecar.
Setting this value to 20m instead shows more stable usage during testing.