### PR TITLE
Update resources for lifecycle sidecar and init container for connect-inject

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -13,7 +13,7 @@ import (
 
 // The init container is bound in memory usage by the size of the consul binary
 // as it issues a cpu of the binary to a shared volume. The limit is set to be
-// slightly larger than the binary to ensure we dont get OOM killed during the cp.
+// slightly larger than the binary to ensure we don't get OOM killed during the cp.
 const (
 	initContainerCPULimit      = "50m"
 	initContainerCPURequest    = "50m"

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -11,10 +11,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+// The init container is bound in memory usage by the size of the consul binary
+// as it issues a cpu of the binary to a shared volume. The limit is set to be
+// slightly larger than the binary to ensure we dont get OOM killed during the cp.
 const (
 	initContainerCPULimit      = "50m"
 	initContainerCPURequest    = "50m"
-	initContainerMemoryLimit   = "125Mi"
+	initContainerMemoryLimit   = "150Mi"
 	initContainerMemoryRequest = "25Mi"
 )
 

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -14,7 +14,7 @@ import (
 const (
 	initContainerCPULimit      = "50m"
 	initContainerCPURequest    = "50m"
-	initContainerMemoryLimit   = "25Mi"
+	initContainerMemoryLimit   = "125Mi"
 	initContainerMemoryRequest = "25Mi"
 )
 

--- a/connect-inject/lifecycle_sidecar.go
+++ b/connect-inject/lifecycle_sidecar.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	lifecycleContainerCPULimit      = "10m"
-	lifecycleContainerCPURequest    = "10m"
+	lifecycleContainerCPULimit      = "20m"
+	lifecycleContainerCPURequest    = "20m"
 	lifecycleContainerMemoryLimit   = "25Mi"
 	lifecycleContainerMemoryRequest = "25Mi"
 )


### PR DESCRIPTION
Currently the initContainer for connect-inject has a resource limit of 25Mi, this was introduced as a feature in the 0.16.0 release.
As part of it's runtime the initContainer issues a cp of the consul binary (100Mi+). Normally this is fine but it is possible to get into a situation where the host is under resource pressure and enough dirty pages from the cp operation accumulate in memory such that an OOM is triggered.
The initContainer is short lived and we just need it to run, so increase the resource limit to the size of the consul binary.
Likewise the lifecycle sidecar's settings were set too low, we double the cpu resources to alleviate cpu constraints.

This resolves #283