### PR TITLE
Allow init and lifecycle containers resource limits to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+IMPROVEMENTS:
+
+* Connect: Add resource request and limit flags for the injected init and lifecycle sidecar containers [[GH-298](https://github.com/hashicorp/consul-k8s/pull/298)].
+
 BUG FIXES:
 
 * Connect: Respect allow/deny list flags when namespaces are disabled. [[GH-296](https://github.com/hashicorp/consul-k8s/issues/296)]

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -1488,7 +1488,18 @@ export CONSUL_GRPC_ADDR="${HOST_IP}:8502"`)
 
 func TestHandlerContainerInit_Resources(t *testing.T) {
 	require := require.New(t)
-	h := Handler{}
+	h := Handler{
+		InitContainerResources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("20m"),
+				corev1.ResourceMemory: resource.MustParse("25Mi"),
+			},
+		},
+	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -1508,12 +1519,12 @@ func TestHandlerContainerInit_Resources(t *testing.T) {
 	require.NoError(err)
 	require.Equal(corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(initContainerCPULimit),
-			corev1.ResourceMemory: resource.MustParse(initContainerMemoryLimit),
+			corev1.ResourceCPU:    resource.MustParse("20m"),
+			corev1.ResourceMemory: resource.MustParse("25Mi"),
 		},
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(initContainerCPURequest),
-			corev1.ResourceMemory: resource.MustParse(initContainerMemoryRequest),
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+			corev1.ResourceMemory: resource.MustParse("10Mi"),
 		},
 	}, container.Resources)
 }

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -78,6 +78,7 @@ const (
 	// service is synced (i.e. re-registered) with the local agent.
 	annotationSyncPeriod = "consul.hashicorp.com/connect-sync-period"
 
+	// annotations for sidecar proxy resource limits
 	annotationSidecarProxyCPULimit      = "consul.hashicorp.com/sidecar-proxy-cpu-limit"
 	annotationSidecarProxyCPURequest    = "consul.hashicorp.com/sidecar-proxy-cpu-request"
 	annotationSidecarProxyMemoryLimit   = "consul.hashicorp.com/sidecar-proxy-memory-limit"
@@ -169,11 +170,20 @@ type Handler struct {
 	// Only necessary if ACLs are enabled.
 	CrossNamespaceACLPolicy string
 
-	// Default resource settings for sidecar proxies.
+	// Default resource settings for sidecar proxies. Some of these
+	// fields may be empty.
 	DefaultProxyCPURequest    resource.Quantity
 	DefaultProxyCPULimit      resource.Quantity
 	DefaultProxyMemoryRequest resource.Quantity
 	DefaultProxyMemoryLimit   resource.Quantity
+
+	// Resource settings for init container. All of these fields
+	// will be populated by the defaults provided in the initial flags.
+	InitContainerResources corev1.ResourceRequirements
+
+	// Resource settings for lifecycle sidecar. All of these fields
+	// will be populated by the defaults provided in the initial flags.
+	LifecycleSidecarResources corev1.ResourceRequirements
 
 	// Log
 	Log hclog.Logger

--- a/connect-inject/lifecycle_sidecar.go
+++ b/connect-inject/lifecycle_sidecar.go
@@ -1,17 +1,9 @@
 package connectinject
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	"strings"
-)
 
-const (
-	lifecycleContainerCPULimit      = "20m"
-	lifecycleContainerCPURequest    = "20m"
-	lifecycleContainerMemoryLimit   = "25Mi"
-	lifecycleContainerMemoryRequest = "25Mi"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func (h *Handler) lifecycleSidecar(pod *corev1.Pod) corev1.Container {
@@ -61,17 +53,6 @@ func (h *Handler) lifecycleSidecar(pod *corev1.Pod) corev1.Container {
 			})
 	}
 
-	resources := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(lifecycleContainerCPULimit),
-			corev1.ResourceMemory: resource.MustParse(lifecycleContainerMemoryLimit),
-		},
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(lifecycleContainerCPURequest),
-			corev1.ResourceMemory: resource.MustParse(lifecycleContainerMemoryRequest),
-		},
-	}
-
 	return corev1.Container{
 		Name:  "consul-connect-lifecycle-sidecar",
 		Image: h.ImageConsulK8S,
@@ -83,6 +64,6 @@ func (h *Handler) lifecycleSidecar(pod *corev1.Pod) corev1.Container {
 			},
 		},
 		Command:   command,
-		Resources: resources,
+		Resources: h.LifecycleSidecarResources,
 	}
 }

--- a/subcommand/inject-connect/command_test.go
+++ b/subcommand/inject-connect/command_test.go
@@ -52,6 +52,66 @@ func TestRun_FlagValidation(t *testing.T) {
 			},
 			expErr: "request must be <= limit: -default-sidecar-proxy-cpu-request value of \"50m\" is greater than the -default-sidecar-proxy-cpu-limit value of \"25m\"",
 		},
+		{
+			flags:  []string{"-consul-k8s-image", "foo", "-init-container-cpu-limit=unparseable"},
+			expErr: "-init-container-cpu-limit 'unparseable' is invalid",
+		},
+		{
+			flags:  []string{"-consul-k8s-image", "foo", "-init-container-cpu-request=unparseable"},
+			expErr: "-init-container-cpu-request 'unparseable' is invalid",
+		},
+		{
+			flags:  []string{"-consul-k8s-image", "foo", "-init-container-memory-limit=unparseable"},
+			expErr: "-init-container-memory-limit 'unparseable' is invalid",
+		},
+		{
+			flags:  []string{"-consul-k8s-image", "foo", "-init-container-memory-request=unparseable"},
+			expErr: "-init-container-memory-request 'unparseable' is invalid",
+		},
+		{
+			flags: []string{"-consul-k8s-image", "foo",
+				"-init-container-memory-request=50Mi",
+				"-init-container-memory-limit=25Mi",
+			},
+			expErr: "request must be <= limit: -init-container-memory-request value of \"50Mi\" is greater than the -init-container-memory-limit value of \"25Mi\"",
+		},
+		{
+			flags: []string{"-consul-k8s-image", "foo",
+				"-init-container-cpu-request=50m",
+				"-init-container-cpu-limit=25m",
+			},
+			expErr: "request must be <= limit: -init-container-cpu-request value of \"50m\" is greater than the -init-container-cpu-limit value of \"25m\"",
+		},
+		{
+			flags:  []string{"-consul-k8s-image", "foo", "-lifecycle-sidecar-cpu-limit=unparseable"},
+			expErr: "-lifecycle-sidecar-cpu-limit 'unparseable' is invalid",
+		},
+		{
+			flags:  []string{"-consul-k8s-image", "foo", "-lifecycle-sidecar-cpu-request=unparseable"},
+			expErr: "-lifecycle-sidecar-cpu-request 'unparseable' is invalid",
+		},
+		{
+			flags:  []string{"-consul-k8s-image", "foo", "-lifecycle-sidecar-memory-limit=unparseable"},
+			expErr: "-lifecycle-sidecar-memory-limit 'unparseable' is invalid",
+		},
+		{
+			flags:  []string{"-consul-k8s-image", "foo", "-lifecycle-sidecar-memory-request=unparseable"},
+			expErr: "-lifecycle-sidecar-memory-request 'unparseable' is invalid",
+		},
+		{
+			flags: []string{"-consul-k8s-image", "foo",
+				"-lifecycle-sidecar-memory-request=50Mi",
+				"-lifecycle-sidecar-memory-limit=25Mi",
+			},
+			expErr: "request must be <= limit: -lifecycle-sidecar-memory-request value of \"50Mi\" is greater than the -lifecycle-sidecar-memory-limit value of \"25Mi\"",
+		},
+		{
+			flags: []string{"-consul-k8s-image", "foo",
+				"-lifecycle-sidecar-cpu-request=50m",
+				"-lifecycle-sidecar-cpu-limit=25m",
+			},
+			expErr: "request must be <= limit: -lifecycle-sidecar-cpu-request value of \"50m\" is greater than the -lifecycle-sidecar-cpu-limit value of \"25m\"",
+		},
 	}
 
 	for _, c := range cases {
@@ -67,4 +127,21 @@ func TestRun_FlagValidation(t *testing.T) {
 			require.Contains(t, ui.ErrorWriter.String(), c.expErr)
 		})
 	}
+}
+
+func TestRun_ResourceLimitDefaults(t *testing.T) {
+	cmd := Command{}
+	cmd.init()
+
+	// Init container defaults
+	require.Equal(t, cmd.flagInitContainerCPURequest, "50m")
+	require.Equal(t, cmd.flagInitContainerCPULimit, "50m")
+	require.Equal(t, cmd.flagInitContainerMemoryRequest, "25Mi")
+	require.Equal(t, cmd.flagInitContainerMemoryLimit, "150Mi")
+
+	// Lifecycle sidecar container defaults
+	require.Equal(t, cmd.flagLifecycleSidecarCPURequest, "20m")
+	require.Equal(t, cmd.flagLifecycleSidecarCPULimit, "20m")
+	require.Equal(t, cmd.flagLifecycleSidecarMemoryRequest, "25Mi")
+	require.Equal(t, cmd.flagLifecycleSidecarMemoryLimit, "25Mi")
 }


### PR DESCRIPTION
Updates the work done in #289.

Changes proposed in this PR:
- Adds resource request and limit flags for both the injected init and lifecycle sidecar containers

How I've tested this PR:
Added and updated tests for the functionality. Changed default values to unique values and deployed to a cluster, verifying that they were applied and in the correct place.

How I expect reviewers to test this PR:
Verify the tests function as expected and include all the relevant cases. Deploy the connect injector using the new flags and verify that any injected pods include the provided values.

Checklist:
- [ x ] Tests added
- [ x ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
