### PR TITLE
Update lifecycle sidecar memory limit flag default value

### DIFF
--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -141,7 +141,7 @@ func (c *Command) init() {
 	c.flagSet.StringVar(&c.flagLifecycleSidecarCPURequest, "lifecycle-sidecar-cpu-request", "20m", "Lifecycle sidecar CPU request.")
 	c.flagSet.StringVar(&c.flagLifecycleSidecarCPULimit, "lifecycle-sidecar-cpu-limit", "20m", "Lifecycle sidecar CPU limit.")
 	c.flagSet.StringVar(&c.flagLifecycleSidecarMemoryRequest, "lifecycle-sidecar-memory-request", "25Mi", "Lifecycle sidecar memory request.")
-	c.flagSet.StringVar(&c.flagLifecycleSidecarMemoryLimit, "lifecycle-sidecar-memory-limit", "25Mi", "Lifecycle sidecar memory limit.")
+	c.flagSet.StringVar(&c.flagLifecycleSidecarMemoryLimit, "lifecycle-sidecar-memory-limit", "50Mi", "Lifecycle sidecar memory limit.")
 
 	c.http = &flags.HTTPFlags{}
 	flags.Merge(c.flagSet, c.http.Flags())

--- a/subcommand/inject-connect/command_test.go
+++ b/subcommand/inject-connect/command_test.go
@@ -143,5 +143,5 @@ func TestRun_ResourceLimitDefaults(t *testing.T) {
 	require.Equal(t, cmd.flagLifecycleSidecarCPURequest, "20m")
 	require.Equal(t, cmd.flagLifecycleSidecarCPULimit, "20m")
 	require.Equal(t, cmd.flagLifecycleSidecarMemoryRequest, "25Mi")
-	require.Equal(t, cmd.flagLifecycleSidecarMemoryLimit, "25Mi")
+	require.Equal(t, cmd.flagLifecycleSidecarMemoryLimit, "50Mi")
 }


### PR DESCRIPTION
Changes proposed in this PR:
- Update lifecycle sidecar memory limit flag default value to 50Mi

How I've tested this PR:
Updated default value test.

How I expect reviewers to test this PR:
Verify the test functions as expected, includes the updated value and passes.

Checklist:
- [ x ] Tests added
- [ N/A ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
