### PR TITLE
connect: register the service before the proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 BUG FIXES:
 
 * Connect: Reduce downtime caused by an alias health check of the sidecar proxy not being healthy for up to 1 minute
-  when a Connect-enabled service is restarted [[GH-305](https://github.com/hashicorp/consul-k8s/pull/305)].
+  when a Connect-enabled service is restarted. Note that this fix reverts the behavior of Consul Connect to the behavior
+  it had before consul-k8s `v0.16.0` and Consul `v1.8.x`, where Consul can route to potentially unhealthy instances of a service
+  because we don't respect Kubernetes readiness/liveness checks yet. Please follow [GH-155](https://github.com/hashicorp/consul-k8s/issues/155)
+  for updates on that feature. [[GH-305](https://github.com/hashicorp/consul-k8s/pull/305)]
 
 ## 0.18.0 (July 30, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## UNRELEASED
 
+BUG FIXES:
+
+* Connect: Reduce downtime caused by an alias health check of the sidecar proxy not being healthy for up to 1 minute
+  when a Connect-enabled service is restarted [[GH-305](https://github.com/hashicorp/consul-k8s/pull/305)].
+
 ## 0.18.0 (July 30, 2020)
 
 IMPROVEMENTS:

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -57,6 +57,16 @@ export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 # the preStop hook can access it to deregister the service.
 cat <<EOF >/consul/connect-inject/service.hcl
 services {
+  id   = "${SERVICE_ID}"
+  name = "web"
+  address = "${POD_IP}"
+  port = 0
+  meta = {
+    pod-name = "${POD_NAME}"
+  }
+}
+
+services {
   id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
@@ -83,16 +93,6 @@ services {
     alias_service = "${SERVICE_ID}"
   }
 }
-
-services {
-  id   = "${SERVICE_ID}"
-  name = "web"
-  address = "${POD_IP}"
-  port = 0
-  meta = {
-    pod-name = "${POD_NAME}"
-  }
-}
 EOF
 
 /bin/consul services register \
@@ -116,6 +116,16 @@ cp /bin/consul /consul/connect-inject/consul`,
 				return pod
 			},
 			`services {
+  id   = "${SERVICE_ID}"
+  name = "web"
+  address = "${POD_IP}"
+  port = 1234
+  meta = {
+    pod-name = "${POD_NAME}"
+  }
+}
+
+services {
   id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
@@ -144,16 +154,7 @@ cp /bin/consul /consul/connect-inject/consul`,
     alias_service = "${SERVICE_ID}"
   }
 }
-
-services {
-  id   = "${SERVICE_ID}"
-  name = "web"
-  address = "${POD_IP}"
-  port = 1234
-  meta = {
-    pod-name = "${POD_NAME}"
-  }
-}`,
+`,
 			"",
 		},
 
@@ -293,6 +294,17 @@ services {
 				return pod
 			},
 			`services {
+  id   = "${SERVICE_ID}"
+  name = "web"
+  address = "${POD_IP}"
+  port = 1234
+  tags = ["abc"]
+  meta = {
+    pod-name = "${POD_NAME}"
+  }
+}
+
+services {
   id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
@@ -320,17 +332,6 @@ services {
   checks {
     name = "Destination Alias"
     alias_service = "${SERVICE_ID}"
-  }
-}
-
-services {
-  id   = "${SERVICE_ID}"
-  name = "web"
-  address = "${POD_IP}"
-  port = 1234
-  tags = ["abc"]
-  meta = {
-    pod-name = "${POD_NAME}"
   }
 }`,
 			"",
@@ -345,6 +346,17 @@ services {
 				return pod
 			},
 			`services {
+  id   = "${SERVICE_ID}"
+  name = "web"
+  address = "${POD_IP}"
+  port = 1234
+  tags = ["abc","123"]
+  meta = {
+    pod-name = "${POD_NAME}"
+  }
+}
+
+services {
   id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
@@ -372,17 +384,6 @@ services {
   checks {
     name = "Destination Alias"
     alias_service = "${SERVICE_ID}"
-  }
-}
-
-services {
-  id   = "${SERVICE_ID}"
-  name = "web"
-  address = "${POD_IP}"
-  port = 1234
-  tags = ["abc","123"]
-  meta = {
-    pod-name = "${POD_NAME}"
   }
 }`,
 			"",
@@ -397,6 +398,17 @@ services {
 				return pod
 			},
 			`services {
+  id   = "${SERVICE_ID}"
+  name = "web"
+  address = "${POD_IP}"
+  port = 1234
+  tags = ["abc","123"]
+  meta = {
+    pod-name = "${POD_NAME}"
+  }
+}
+
+services {
   id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
@@ -424,17 +436,6 @@ services {
   checks {
     name = "Destination Alias"
     alias_service = "${SERVICE_ID}"
-  }
-}
-
-services {
-  id   = "${SERVICE_ID}"
-  name = "web"
-  address = "${POD_IP}"
-  port = 1234
-  tags = ["abc","123"]
-  meta = {
-    pod-name = "${POD_NAME}"
   }
 }`,
 			"",
@@ -450,6 +451,17 @@ services {
 				return pod
 			},
 			`services {
+  id   = "${SERVICE_ID}"
+  name = "web"
+  address = "${POD_IP}"
+  port = 1234
+  tags = ["abc","123","abc","123","def","456"]
+  meta = {
+    pod-name = "${POD_NAME}"
+  }
+}
+
+services {
   id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
@@ -477,17 +489,6 @@ services {
   checks {
     name = "Destination Alias"
     alias_service = "${SERVICE_ID}"
-  }
-}
-
-services {
-  id   = "${SERVICE_ID}"
-  name = "web"
-  address = "${POD_IP}"
-  port = 1234
-  tags = ["abc","123","abc","123","def","456"]
-  meta = {
-    pod-name = "${POD_NAME}"
   }
 }`,
 			"",
@@ -512,6 +513,18 @@ services {
 				return pod
 			},
 			`services {
+  id   = "${SERVICE_ID}"
+  name = "web"
+  address = "${POD_IP}"
+  port = 1234
+  meta = {
+    name = "abc"
+    version = "2"
+    pod-name = "${POD_NAME}"
+  }
+}
+
+services {
   id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
@@ -540,18 +553,6 @@ services {
   checks {
     name = "Destination Alias"
     alias_service = "${SERVICE_ID}"
-  }
-}
-
-services {
-  id   = "${SERVICE_ID}"
-  name = "web"
-  address = "${POD_IP}"
-  port = 1234
-  meta = {
-    name = "abc"
-    version = "2"
-    pod-name = "${POD_NAME}"
   }
 }`,
 			"",
@@ -659,6 +660,17 @@ export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 # the preStop hook can access it to deregister the service.
 cat <<EOF >/consul/connect-inject/service.hcl
 services {
+  id   = "${SERVICE_ID}"
+  name = "web"
+  address = "${POD_IP}"
+  port = 0
+  namespace = "default"
+  meta = {
+    pod-name = "${POD_NAME}"
+  }
+}
+
+services {
   id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
@@ -684,17 +696,6 @@ services {
   checks {
     name = "Destination Alias"
     alias_service = "${SERVICE_ID}"
-  }
-}
-
-services {
-  id   = "${SERVICE_ID}"
-  name = "web"
-  address = "${POD_IP}"
-  port = 0
-  namespace = "default"
-  meta = {
-    pod-name = "${POD_NAME}"
   }
 }
 EOF
@@ -733,6 +734,17 @@ export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 # the preStop hook can access it to deregister the service.
 cat <<EOF >/consul/connect-inject/service.hcl
 services {
+  id   = "${SERVICE_ID}"
+  name = "web"
+  address = "${POD_IP}"
+  port = 0
+  namespace = "non-default"
+  meta = {
+    pod-name = "${POD_NAME}"
+  }
+}
+
+services {
   id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
@@ -758,17 +770,6 @@ services {
   checks {
     name = "Destination Alias"
     alias_service = "${SERVICE_ID}"
-  }
-}
-
-services {
-  id   = "${SERVICE_ID}"
-  name = "web"
-  address = "${POD_IP}"
-  port = 0
-  namespace = "non-default"
-  meta = {
-    pod-name = "${POD_NAME}"
   }
 }
 EOF
@@ -808,6 +809,17 @@ export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 # the preStop hook can access it to deregister the service.
 cat <<EOF >/consul/connect-inject/service.hcl
 services {
+  id   = "${SERVICE_ID}"
+  name = "web"
+  address = "${POD_IP}"
+  port = 0
+  namespace = "non-default"
+  meta = {
+    pod-name = "${POD_NAME}"
+  }
+}
+
+services {
   id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
@@ -833,17 +845,6 @@ services {
   checks {
     name = "Destination Alias"
     alias_service = "${SERVICE_ID}"
-  }
-}
-
-services {
-  id   = "${SERVICE_ID}"
-  name = "web"
-  address = "${POD_IP}"
-  port = 0
-  namespace = "non-default"
-  meta = {
-    pod-name = "${POD_NAME}"
   }
 }
 EOF
@@ -892,6 +893,17 @@ export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 # the preStop hook can access it to deregister the service.
 cat <<EOF >/consul/connect-inject/service.hcl
 services {
+  id   = "${SERVICE_ID}"
+  name = "web"
+  address = "${POD_IP}"
+  port = 0
+  namespace = "k8snamespace"
+  meta = {
+    pod-name = "${POD_NAME}"
+  }
+}
+
+services {
   id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
@@ -917,17 +929,6 @@ services {
   checks {
     name = "Destination Alias"
     alias_service = "${SERVICE_ID}"
-  }
-}
-
-services {
-  id   = "${SERVICE_ID}"
-  name = "web"
-  address = "${POD_IP}"
-  port = 0
-  namespace = "k8snamespace"
-  meta = {
-    pod-name = "${POD_NAME}"
   }
 }
 EOF
@@ -976,6 +977,17 @@ export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 # the preStop hook can access it to deregister the service.
 cat <<EOF >/consul/connect-inject/service.hcl
 services {
+  id   = "${SERVICE_ID}"
+  name = "web"
+  address = "${POD_IP}"
+  port = 0
+  namespace = "non-default"
+  meta = {
+    pod-name = "${POD_NAME}"
+  }
+}
+
+services {
   id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
@@ -1001,17 +1013,6 @@ services {
   checks {
     name = "Destination Alias"
     alias_service = "${SERVICE_ID}"
-  }
-}
-
-services {
-  id   = "${SERVICE_ID}"
-  name = "web"
-  address = "${POD_IP}"
-  port = 0
-  namespace = "non-default"
-  meta = {
-    pod-name = "${POD_NAME}"
   }
 }
 EOF
@@ -1064,6 +1065,17 @@ export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 # the preStop hook can access it to deregister the service.
 cat <<EOF >/consul/connect-inject/service.hcl
 services {
+  id   = "${SERVICE_ID}"
+  name = "web"
+  address = "${POD_IP}"
+  port = 0
+  namespace = "k8snamespace"
+  meta = {
+    pod-name = "${POD_NAME}"
+  }
+}
+
+services {
   id   = "${PROXY_SERVICE_ID}"
   name = "web-sidecar-proxy"
   kind = "connect-proxy"
@@ -1089,17 +1101,6 @@ services {
   checks {
     name = "Destination Alias"
     alias_service = "${SERVICE_ID}"
-  }
-}
-
-services {
-  id   = "${SERVICE_ID}"
-  name = "web"
-  address = "${POD_IP}"
-  port = 0
-  namespace = "k8snamespace"
-  meta = {
-    pod-name = "${POD_NAME}"
   }
 }
 EOF


### PR DESCRIPTION
Because the proxy service registers an alias health check that points to the service ID of the main service and we're registering the proxy service before the main service, the alias check starts out as red
because at that time the service doesn't yet exist. Consul runs this check every minute, and so this will become green only after one minute.

This is particularly bad in a case when a service is restarted either due to scheduled or unscheduled maintenance. For example, when you have deployment and you trigger a re-deploy (kubectl rollout restart), kubernetes by default will do a rolling deploy, where it won't terminate the old instance until the new one comes up and is healthy. But Consul will take an additional minute or so to mark this service as healthy, causing downtime, where either no downtime or minimal downtime should be experienced.

### Changes proposed in this PR:

Switch the order of how services are registered with Consul, with the main service registered first and the proxy service after.

### Steps to reproduce and test
1. Deploy the latest helm chart with connect enabled 
   ```shell
    helm install consul --set global.name=consul --set connectInject.enabled=true --set server.replicas=1 --set server.bootstrapExpect=1 hashicorp/consul
   ```
1. Create static-server and static-client deployments. 
    ```shell
     kubectl apply -f https://raw.githubusercontent.com/hashicorp/consul-helm/acceptance-tests-base/test/acceptance/tests/connect/fixtures/static-server.yaml
     kubectl apply -f https://raw.githubusercontent.com/hashicorp/consul-helm/acceptance-tests-base/test/acceptance/tests/connect/fixtures/static-client.yaml
    ```
1. Exec into the static client pod and run the following loop (it should print "hello world" every second):
   ```
    $ kubectl exec -it static-client-758b47746d-r5rll /bin/sh
    kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl kubectl exec [POD] -- [COMMAND] instead.
    Defaulting container name to static-client.
    Use 'kubectl describe pod/static-client-758b47746d-r5rll -n default' to see all of the containers in this pod.
    # while true; do echo "$(date) $(curl -sS http://localhost:1234)"; sleep 1; done
    ```
1. Restart the static-server deployment and observe about 1 minute of downtime in the logs from the while loop above.
    ```
     kubectl rollout restart deploy/static-server
    ```

To fix, upgrade to the image built from this PR and run helm upgrade:
```
helm upgrade consul --set global.name=consul --set global.imageK8S=hashicorpdev/consul-k8s:f817303 --set connectInject.enabled=true --set server.replicas=1 --set server.bootstrapExpect=1 hashicorp/consul
```
Once the connect injector becomes healthy, restart the static-server deployment again (step 4 above). You should either see no or 1-2 errors (i.e. 1-2 seconds of downtime) printed from the while loop running in the static-client container.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
