### PR TITLE
push latest image for crd-controller-base branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,9 @@ ci.dev-docker:
 ifeq ($(CIRCLE_BRANCH), master)
 	@docker tag $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT) $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
 	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
+ifeq ($(CIRCLE_BRANCH), crd-controller-base)
+	@docker tag $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT) $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):crd-controller-base-latest
+	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):crd-controller-base-latest
 endif
 
 .PHONY: all bin clean dev dist docker-images go-build-image test tools ci.dev-docker


### PR DESCRIPTION
Changes proposed in this PR:
- In addition to `git rev-parse --short HEAD` commit hash docker images, this PR will push a `consul-k8s:crd-controller-base-latest` tag that gets updated on every new commit to the `crd-controller-base` branch 