### PR TITLE
Feature/name k8s node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## UNRELEASED
 
+IMPROVEMENTS:
+
+* Add an ability to configure the synthetic Consul node name where catalog sync registers services. [[GH-312](https://github.com/hashicorp/consul-k8s/pull/312)]
+  * Sync: Add `-consul-node-name` flag to the `sync-catalog` command to configure the Consul node name for syncing services to Consul.
+  * ACLs: Add `-sync-consul-node-name` flag to the server-acl-init command so that it can create correct policy for the sync catalog.
+
 ## 0.18.1 (August 10, 2020)
 
 BUG FIXES:

--- a/catalog/to-consul/resource.go
+++ b/catalog/to-consul/resource.go
@@ -332,7 +332,7 @@ func (t *ServiceResource) generateRegistrations(key string) {
 	// shallow copied for each instance.
 	baseNode := consulapi.CatalogRegistration{
 		SkipNodeUpdate: true,
-		Node:           ConsulSyncNodeName,
+		Node:           t.Syncer.Node(),
 		Address:        "127.0.0.1",
 		NodeMeta: map[string]string{
 			ConsulSourceKey: ConsulSourceValue,

--- a/catalog/to-consul/resource.go
+++ b/catalog/to-consul/resource.go
@@ -332,7 +332,7 @@ func (t *ServiceResource) generateRegistrations(key string) {
 	// shallow copied for each instance.
 	baseNode := consulapi.CatalogRegistration{
 		SkipNodeUpdate: true,
-		Node:           t.Syncer.Node(),
+		Node:           t.Syncer.ConsulNode(),
 		Address:        "127.0.0.1",
 		NodeMeta: map[string]string{
 			ConsulSourceKey: ConsulSourceValue,

--- a/catalog/to-consul/resource.go
+++ b/catalog/to-consul/resource.go
@@ -115,6 +115,9 @@ type ServiceResource struct {
 	// `k8s-default` namespace.
 	K8SNSMirroringPrefix string
 
+	// The Consul node name to register service with.
+	ConsulNodeName string
+
 	// serviceLock must be held for any read/write to these maps.
 	serviceLock sync.RWMutex
 
@@ -332,7 +335,7 @@ func (t *ServiceResource) generateRegistrations(key string) {
 	// shallow copied for each instance.
 	baseNode := consulapi.CatalogRegistration{
 		SkipNodeUpdate: true,
-		Node:           t.Syncer.ConsulNode(),
+		Node:           t.ConsulNodeName,
 		Address:        "127.0.0.1",
 		NodeMeta: map[string]string{
 			ConsulSourceKey: ConsulSourceValue,

--- a/catalog/to-consul/resource_test.go
+++ b/catalog/to-consul/resource_test.go
@@ -27,7 +27,7 @@ func init() {
 func TestServiceResource_createDelete(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -55,7 +55,7 @@ func TestServiceResource_createDelete(t *testing.T) {
 func TestServiceResource_defaultEnable(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -80,7 +80,7 @@ func TestServiceResource_defaultEnable(t *testing.T) {
 func TestServiceResource_defaultEnableDisable(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -106,7 +106,7 @@ func TestServiceResource_defaultEnableDisable(t *testing.T) {
 func TestServiceResource_defaultDisable(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ExplicitEnable = true
 
@@ -132,7 +132,7 @@ func TestServiceResource_defaultDisable(t *testing.T) {
 func TestServiceResource_defaultDisableEnable(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ExplicitEnable = true
 
@@ -159,7 +159,7 @@ func TestServiceResource_defaultDisableEnable(t *testing.T) {
 func TestServiceResource_changeSyncToFalse(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ExplicitEnable = true
 
@@ -200,7 +200,7 @@ func TestServiceResource_changeSyncToFalse(t *testing.T) {
 func TestServiceResource_addK8SNamespace(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.AddK8SNamespaceSuffix = true
 
@@ -228,7 +228,7 @@ func TestServiceResource_addK8SNamespace(t *testing.T) {
 func TestServiceResource_addK8SNamespaceWithPrefix(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.AddK8SNamespaceSuffix = true
 	serviceResource.ConsulServicePrefix = "prefix"
@@ -257,7 +257,7 @@ func TestServiceResource_addK8SNamespaceWithPrefix(t *testing.T) {
 func TestServiceResource_addK8SNamespaceWithNameAnnotation(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.AddK8SNamespaceSuffix = true
 
@@ -285,7 +285,7 @@ func TestServiceResource_addK8SNamespaceWithNameAnnotation(t *testing.T) {
 func TestServiceResource_externalIP(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -315,7 +315,7 @@ func TestServiceResource_externalIP(t *testing.T) {
 func TestServiceResource_externalIPPrefix(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ConsulServicePrefix = "prefix"
 
@@ -346,7 +346,7 @@ func TestServiceResource_externalIPPrefix(t *testing.T) {
 func TestServiceResource_lb(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -373,7 +373,7 @@ func TestServiceResource_lb(t *testing.T) {
 func TestServiceResource_lbPrefix(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ConsulServicePrefix = "prefix"
 
@@ -402,7 +402,7 @@ func TestServiceResource_lbPrefix(t *testing.T) {
 func TestServiceResource_lbMultiEndpoint(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -436,7 +436,7 @@ func TestServiceResource_lbMultiEndpoint(t *testing.T) {
 func TestServiceResource_lbAnnotatedName(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -463,7 +463,7 @@ func TestServiceResource_lbAnnotatedName(t *testing.T) {
 func TestServiceResource_lbPort(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -495,7 +495,7 @@ func TestServiceResource_lbPort(t *testing.T) {
 func TestServiceResource_lbAnnotatedPort(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -528,7 +528,7 @@ func TestServiceResource_lbAnnotatedPort(t *testing.T) {
 func TestServiceResource_lbAnnotatedTags(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ConsulK8STag = TestConsulK8STag
 
@@ -556,7 +556,7 @@ func TestServiceResource_lbAnnotatedTags(t *testing.T) {
 func TestServiceResource_lbAnnotatedMeta(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -583,7 +583,7 @@ func TestServiceResource_lbAnnotatedMeta(t *testing.T) {
 func TestServiceResource_lbRegisterEndpoints(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.LoadBalancerEndpointsSync = true
 
@@ -637,7 +637,7 @@ func TestServiceResource_lbRegisterEndpoints(t *testing.T) {
 // Test that the proper registrations are generated for a NodePort type.
 func TestServiceResource_nodePort(t *testing.T) {
 	t.Parallel()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	client := fake.NewSimpleClientset()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.NodePortSync = ExternalOnly
@@ -677,7 +677,7 @@ func TestServiceResource_nodePort(t *testing.T) {
 func TestServiceResource_nodePortPrefix(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.NodePortSync = ExternalOnly
 	serviceResource.ConsulServicePrefix = "prefix"
@@ -718,7 +718,7 @@ func TestServiceResource_nodePortPrefix(t *testing.T) {
 func TestServiceResource_nodePort_singleEndpoint(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.NodePortSync = ExternalOnly
 
@@ -773,7 +773,7 @@ func TestServiceResource_nodePort_singleEndpoint(t *testing.T) {
 func TestServiceResource_nodePortAnnotatedPort(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.NodePortSync = ExternalOnly
 
@@ -813,7 +813,7 @@ func TestServiceResource_nodePortAnnotatedPort(t *testing.T) {
 func TestServiceResource_nodePortUnnamedPort(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.NodePortSync = ExternalOnly
 
@@ -858,7 +858,7 @@ func TestServiceResource_nodePortUnnamedPort(t *testing.T) {
 func TestServiceResource_nodePort_internalOnlySync(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.NodePortSync = InternalOnly
 
@@ -898,7 +898,7 @@ func TestServiceResource_nodePort_internalOnlySync(t *testing.T) {
 func TestServiceResource_nodePort_externalFirstSync(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.NodePortSync = ExternalFirst
 
@@ -945,7 +945,7 @@ func TestServiceResource_nodePort_externalFirstSync(t *testing.T) {
 func TestServiceResource_clusterIP(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = true
 
@@ -981,7 +981,7 @@ func TestServiceResource_clusterIP(t *testing.T) {
 func TestServiceResource_clusterIPPrefix(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = true
 	serviceResource.ConsulServicePrefix = "prefix"
@@ -1019,7 +1019,7 @@ func TestServiceResource_clusterIPPrefix(t *testing.T) {
 func TestServiceResource_clusterIPAnnotatedPortName(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = true
 
@@ -1057,7 +1057,7 @@ func TestServiceResource_clusterIPAnnotatedPortName(t *testing.T) {
 func TestServiceResource_clusterIPAnnotatedPortNumber(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = true
 
@@ -1094,7 +1094,7 @@ func TestServiceResource_clusterIPAnnotatedPortNumber(t *testing.T) {
 func TestServiceResource_clusterIPUnnamedPorts(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = true
 
@@ -1135,7 +1135,7 @@ func TestServiceResource_clusterIPUnnamedPorts(t *testing.T) {
 func TestServiceResource_clusterIPSyncDisabled(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = false
 
@@ -1164,7 +1164,7 @@ func TestServiceResource_clusterIPSyncDisabled(t *testing.T) {
 func TestServiceResource_clusterIPAllNamespaces(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	testNamespace := "test_namespace"
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = true
@@ -1201,7 +1201,7 @@ func TestServiceResource_clusterIPAllNamespaces(t *testing.T) {
 func TestServiceResource_clusterIPTargetPortNamed(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = true
 
@@ -1282,7 +1282,7 @@ func TestServiceResource_AllowDenyNamespaces(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(tt *testing.T) {
 			client := fake.NewSimpleClientset()
-			syncer := &TestSyncer{}
+			syncer := NewTestSyncer()
 			serviceResource := defaultServiceResource(client, syncer)
 			serviceResource.AllowK8sNamespacesSet = c.AllowList
 			serviceResource.DenyK8sNamespacesSet = c.DenyList
@@ -1333,7 +1333,7 @@ func TestServiceResource_singleDestNamespace(t *testing.T) {
 	for _, consulDestNamespace := range consulDestNamespaces {
 		t.Run(consulDestNamespace, func(tt *testing.T) {
 			client := fake.NewSimpleClientset()
-			syncer := &TestSyncer{}
+			syncer := NewTestSyncer()
 			serviceResource := defaultServiceResource(client, syncer)
 			serviceResource.ConsulDestinationNamespace = consulDestNamespace
 			serviceResource.EnableNamespaces = true
@@ -1358,7 +1358,7 @@ func TestServiceResource_singleDestNamespace(t *testing.T) {
 func TestServiceResource_MirroredNamespace(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.EnableK8SNSMirroring = true
 	serviceResource.EnableNamespaces = true
@@ -1393,7 +1393,7 @@ func TestServiceResource_MirroredNamespace(t *testing.T) {
 func TestServiceResource_MirroredPrefixNamespace(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := &TestSyncer{}
+	syncer := NewTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.EnableK8SNSMirroring = true
 	serviceResource.EnableNamespaces = true

--- a/catalog/to-consul/resource_test.go
+++ b/catalog/to-consul/resource_test.go
@@ -27,7 +27,7 @@ func init() {
 func TestServiceResource_createDelete(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -55,7 +55,7 @@ func TestServiceResource_createDelete(t *testing.T) {
 func TestServiceResource_defaultEnable(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -80,7 +80,7 @@ func TestServiceResource_defaultEnable(t *testing.T) {
 func TestServiceResource_defaultEnableDisable(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -106,7 +106,7 @@ func TestServiceResource_defaultEnableDisable(t *testing.T) {
 func TestServiceResource_defaultDisable(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ExplicitEnable = true
 
@@ -132,7 +132,7 @@ func TestServiceResource_defaultDisable(t *testing.T) {
 func TestServiceResource_defaultDisableEnable(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ExplicitEnable = true
 
@@ -159,7 +159,7 @@ func TestServiceResource_defaultDisableEnable(t *testing.T) {
 func TestServiceResource_changeSyncToFalse(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ExplicitEnable = true
 
@@ -200,7 +200,7 @@ func TestServiceResource_changeSyncToFalse(t *testing.T) {
 func TestServiceResource_addK8SNamespace(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.AddK8SNamespaceSuffix = true
 
@@ -228,7 +228,7 @@ func TestServiceResource_addK8SNamespace(t *testing.T) {
 func TestServiceResource_addK8SNamespaceWithPrefix(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.AddK8SNamespaceSuffix = true
 	serviceResource.ConsulServicePrefix = "prefix"
@@ -257,7 +257,7 @@ func TestServiceResource_addK8SNamespaceWithPrefix(t *testing.T) {
 func TestServiceResource_addK8SNamespaceWithNameAnnotation(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.AddK8SNamespaceSuffix = true
 
@@ -285,7 +285,7 @@ func TestServiceResource_addK8SNamespaceWithNameAnnotation(t *testing.T) {
 func TestServiceResource_externalIP(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -315,7 +315,7 @@ func TestServiceResource_externalIP(t *testing.T) {
 func TestServiceResource_externalIPPrefix(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ConsulServicePrefix = "prefix"
 
@@ -346,7 +346,7 @@ func TestServiceResource_externalIPPrefix(t *testing.T) {
 func TestServiceResource_lb(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -373,7 +373,7 @@ func TestServiceResource_lb(t *testing.T) {
 func TestServiceResource_lbPrefix(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ConsulServicePrefix = "prefix"
 
@@ -402,7 +402,7 @@ func TestServiceResource_lbPrefix(t *testing.T) {
 func TestServiceResource_lbMultiEndpoint(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -436,7 +436,7 @@ func TestServiceResource_lbMultiEndpoint(t *testing.T) {
 func TestServiceResource_lbAnnotatedName(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -463,7 +463,7 @@ func TestServiceResource_lbAnnotatedName(t *testing.T) {
 func TestServiceResource_lbPort(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -495,7 +495,7 @@ func TestServiceResource_lbPort(t *testing.T) {
 func TestServiceResource_lbAnnotatedPort(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -528,7 +528,7 @@ func TestServiceResource_lbAnnotatedPort(t *testing.T) {
 func TestServiceResource_lbAnnotatedTags(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ConsulK8STag = TestConsulK8STag
 
@@ -556,7 +556,7 @@ func TestServiceResource_lbAnnotatedTags(t *testing.T) {
 func TestServiceResource_lbAnnotatedMeta(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 
 	// Start the controller
@@ -583,7 +583,7 @@ func TestServiceResource_lbAnnotatedMeta(t *testing.T) {
 func TestServiceResource_lbRegisterEndpoints(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.LoadBalancerEndpointsSync = true
 
@@ -637,7 +637,7 @@ func TestServiceResource_lbRegisterEndpoints(t *testing.T) {
 // Test that the proper registrations are generated for a NodePort type.
 func TestServiceResource_nodePort(t *testing.T) {
 	t.Parallel()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	client := fake.NewSimpleClientset()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.NodePortSync = ExternalOnly
@@ -677,7 +677,7 @@ func TestServiceResource_nodePort(t *testing.T) {
 func TestServiceResource_nodePortPrefix(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.NodePortSync = ExternalOnly
 	serviceResource.ConsulServicePrefix = "prefix"
@@ -718,7 +718,7 @@ func TestServiceResource_nodePortPrefix(t *testing.T) {
 func TestServiceResource_nodePort_singleEndpoint(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.NodePortSync = ExternalOnly
 
@@ -773,7 +773,7 @@ func TestServiceResource_nodePort_singleEndpoint(t *testing.T) {
 func TestServiceResource_nodePortAnnotatedPort(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.NodePortSync = ExternalOnly
 
@@ -813,7 +813,7 @@ func TestServiceResource_nodePortAnnotatedPort(t *testing.T) {
 func TestServiceResource_nodePortUnnamedPort(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.NodePortSync = ExternalOnly
 
@@ -858,7 +858,7 @@ func TestServiceResource_nodePortUnnamedPort(t *testing.T) {
 func TestServiceResource_nodePort_internalOnlySync(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.NodePortSync = InternalOnly
 
@@ -898,7 +898,7 @@ func TestServiceResource_nodePort_internalOnlySync(t *testing.T) {
 func TestServiceResource_nodePort_externalFirstSync(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.NodePortSync = ExternalFirst
 
@@ -945,7 +945,7 @@ func TestServiceResource_nodePort_externalFirstSync(t *testing.T) {
 func TestServiceResource_clusterIP(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = true
 
@@ -981,7 +981,7 @@ func TestServiceResource_clusterIP(t *testing.T) {
 func TestServiceResource_clusterIPPrefix(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = true
 	serviceResource.ConsulServicePrefix = "prefix"
@@ -1019,7 +1019,7 @@ func TestServiceResource_clusterIPPrefix(t *testing.T) {
 func TestServiceResource_clusterIPAnnotatedPortName(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = true
 
@@ -1057,7 +1057,7 @@ func TestServiceResource_clusterIPAnnotatedPortName(t *testing.T) {
 func TestServiceResource_clusterIPAnnotatedPortNumber(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = true
 
@@ -1094,7 +1094,7 @@ func TestServiceResource_clusterIPAnnotatedPortNumber(t *testing.T) {
 func TestServiceResource_clusterIPUnnamedPorts(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = true
 
@@ -1135,7 +1135,7 @@ func TestServiceResource_clusterIPUnnamedPorts(t *testing.T) {
 func TestServiceResource_clusterIPSyncDisabled(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = false
 
@@ -1164,7 +1164,7 @@ func TestServiceResource_clusterIPSyncDisabled(t *testing.T) {
 func TestServiceResource_clusterIPAllNamespaces(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	testNamespace := "test_namespace"
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = true
@@ -1201,7 +1201,7 @@ func TestServiceResource_clusterIPAllNamespaces(t *testing.T) {
 func TestServiceResource_clusterIPTargetPortNamed(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.ClusterIPSync = true
 
@@ -1282,7 +1282,7 @@ func TestServiceResource_AllowDenyNamespaces(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(tt *testing.T) {
 			client := fake.NewSimpleClientset()
-			syncer := NewTestSyncer()
+			syncer := newTestSyncer()
 			serviceResource := defaultServiceResource(client, syncer)
 			serviceResource.AllowK8sNamespacesSet = c.AllowList
 			serviceResource.DenyK8sNamespacesSet = c.DenyList
@@ -1333,7 +1333,7 @@ func TestServiceResource_singleDestNamespace(t *testing.T) {
 	for _, consulDestNamespace := range consulDestNamespaces {
 		t.Run(consulDestNamespace, func(tt *testing.T) {
 			client := fake.NewSimpleClientset()
-			syncer := NewTestSyncer()
+			syncer := newTestSyncer()
 			serviceResource := defaultServiceResource(client, syncer)
 			serviceResource.ConsulDestinationNamespace = consulDestNamespace
 			serviceResource.EnableNamespaces = true
@@ -1358,7 +1358,7 @@ func TestServiceResource_singleDestNamespace(t *testing.T) {
 func TestServiceResource_MirroredNamespace(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.EnableK8SNSMirroring = true
 	serviceResource.EnableNamespaces = true
@@ -1393,7 +1393,7 @@ func TestServiceResource_MirroredNamespace(t *testing.T) {
 func TestServiceResource_MirroredPrefixNamespace(t *testing.T) {
 	t.Parallel()
 	client := fake.NewSimpleClientset()
-	syncer := NewTestSyncer()
+	syncer := newTestSyncer()
 	serviceResource := defaultServiceResource(client, syncer)
 	serviceResource.EnableK8SNSMirroring = true
 	serviceResource.EnableNamespaces = true

--- a/catalog/to-consul/syncer.go
+++ b/catalog/to-consul/syncer.go
@@ -28,10 +28,6 @@ const (
 type Syncer interface {
 	// Sync is called to sync the full set of registrations.
 	Sync([]*api.CatalogRegistration)
-
-	// ConsulNode returns the name of the Consul node where services
-	// will be synced.
-	ConsulNode() string
 }
 
 // ConsulSyncer is a Syncer that takes the set of registrations and
@@ -69,7 +65,7 @@ type ConsulSyncer struct {
 	// ConsulK8STag is the tag value for services registered.
 	ConsulK8STag string
 
-	// The Consul node name to register for this syncer.
+	// The Consul node name to register services with.
 	ConsulNodeName string
 
 	// ConsulNodeServicesClient is used to list services for a node. We use a
@@ -99,10 +95,6 @@ type ConsulSyncer struct {
 	// watchers is all namespaces mapped to a map of Consul service
 	// names mapped to a cancel function for watcher routines
 	watchers map[string]map[string]context.CancelFunc
-}
-
-func (s *ConsulSyncer) ConsulNode() string {
-	return s.ConsulNodeName
 }
 
 // Sync implements Syncer
@@ -196,7 +188,7 @@ func (s *ConsulSyncer) watchReapableServices(ctx context.Context) {
 		var meta *api.QueryMeta
 		err := backoff.Retry(func() error {
 			var err error
-			services, meta, err = s.ConsulNodeServicesClient.NodeServices(s.ConsulK8STag, s.ConsulNode(), *opts)
+			services, meta, err = s.ConsulNodeServicesClient.NodeServices(s.ConsulK8STag, s.ConsulNodeName, *opts)
 			return err
 		}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
 

--- a/catalog/to-consul/syncer.go
+++ b/catalog/to-consul/syncer.go
@@ -32,6 +32,7 @@ const (
 type Syncer interface {
 	// Sync is called to sync the full set of registrations.
 	Sync([]*api.CatalogRegistration)
+	Node() string
 }
 
 // ConsulSyncer is a Syncer that takes the set of registrations and
@@ -69,6 +70,9 @@ type ConsulSyncer struct {
 	// ConsulK8STag is the tag value for services registered.
 	ConsulK8STag string
 
+	// The Consul node name to register for this syncer.
+	NodeName string
+
 	// ConsulNodeServicesClient is used to list services for a node. We use a
 	// separate client for this API call that handles older version of Consul.
 	ConsulNodeServicesClient ConsulNodeServicesClient
@@ -96,6 +100,10 @@ type ConsulSyncer struct {
 	// watchers is all namespaces mapped to a map of Consul service
 	// names mapped to a cancel function for watcher routines
 	watchers map[string]map[string]context.CancelFunc
+}
+
+func (s *ConsulSyncer) Node() string {
+	return s.NodeName
 }
 
 // Sync implements Syncer

--- a/catalog/to-consul/syncer_test.go
+++ b/catalog/to-consul/syncer_test.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -64,61 +65,67 @@ func TestConsulSyncer_register(t *testing.T) {
 // Test that the syncer reaps individual invalid service instances.
 func TestConsulSyncer_reapServiceInstance(t *testing.T) {
 	t.Parallel()
-	require := require.New(t)
 
-	// Set up server, client, syncer
-	a, err := testutil.NewTestServerConfigT(t, nil)
-	require.NoError(err)
-	defer a.Stop()
+	for _, node := range []string{ConsulSyncNodeName, "test-node"} {
+		name := fmt.Sprintf("consul node name: %s", node)
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
 
-	client, err := api.NewClient(&api.Config{
-		Address: a.HTTPAddr,
-	})
-	require.NoError(err)
+			// Set up server, client, syncer
+			a, err := testutil.NewTestServerConfigT(t, nil)
+			require.NoError(err)
+			defer a.Stop()
 
-	s, closer := testConsulSyncer(client)
-	defer closer()
+			client, err := api.NewClient(&api.Config{
+				Address: a.HTTPAddr,
+			})
+			require.NoError(err)
 
-	// Sync
-	s.Sync([]*api.CatalogRegistration{
-		testRegistration(ConsulSyncNodeName, "bar", "default"),
-	})
+			s, closer := testConsulSyncer(client)
+			defer closer()
 
-	// Wait for the first service
-	retry.Run(t, func(r *retry.R) {
-		services, _, err := client.Catalog().Service("bar", "", nil)
-		if err != nil {
-			r.Fatalf("err: %s", err)
-		}
-		if len(services) != 1 {
-			r.Fatal("service not found or too many")
-		}
-	})
+			// Sync
+			s.Sync([]*api.CatalogRegistration{
+				testRegistration(node, "bar", "default"),
+			})
 
-	// Create an invalid service directly in Consul
-	svc := testRegistration(ConsulSyncNodeName, "bar", "default")
-	svc.Service.ID = serviceID("k8s-sync", "bar2")
-	_, err = client.Catalog().Register(svc, nil)
-	require.NoError(err)
+			// Wait for the first service
+			retry.Run(t, func(r *retry.R) {
+				services, _, err := client.Catalog().Service("bar", "", nil)
+				if err != nil {
+					r.Fatalf("err: %s", err)
+				}
+				if len(services) != 1 {
+					r.Fatal("service not found or too many")
+				}
+			})
 
-	// Valid service should exist
-	var service *api.CatalogService
-	retry.Run(t, func(r *retry.R) {
-		services, _, err := client.Catalog().Service("bar", "", nil)
-		if err != nil {
-			r.Fatalf("err: %s", err)
-		}
-		if len(services) != 1 {
-			r.Fatal("service not found or too many")
-		}
-		service = services[0]
-	})
+			// Create an invalid service directly in Consul
+			svc := testRegistration(node, "bar", "default")
+			svc.Service.ID = serviceID(node, "bar2")
+			_, err = client.Catalog().Register(svc, nil)
+			require.NoError(err)
 
-	// Verify the settings
-	require.Equal(serviceID("k8s-sync", "bar"), service.ServiceID)
-	require.Equal("k8s-sync", service.Node)
-	require.Equal("bar", service.ServiceName)
-	require.Equal("127.0.0.1", service.Address)
+			// Valid service should exist
+			var service *api.CatalogService
+			retry.Run(t, func(r *retry.R) {
+				services, _, err := client.Catalog().Service("bar", "", nil)
+				if err != nil {
+					r.Fatalf("err: %s", err)
+				}
+				if len(services) != 1 {
+					r.Fatal("service not found or too many")
+				}
+				service = services[0]
+			})
+
+			// Verify the settings
+			require.Equal(serviceID(node, "bar"), service.ServiceID)
+			require.Equal(node, service.Node)
+			require.Equal("bar", service.ServiceName)
+			require.Equal("127.0.0.1", service.Address)
+		})
+	}
 }
 
 // Test that the syncer reaps services not registered by us that are tagged

--- a/catalog/to-consul/syncer_test.go
+++ b/catalog/to-consul/syncer_test.go
@@ -14,6 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	// ConsulSyncNodeName is the name of the node in Consul that we register
+	// services on. It's not a real node backed by a Consul agent.
+	ConsulSyncNodeName = "k8s-sync"
+)
+
 func TestConsulSyncer_register(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
@@ -282,6 +288,7 @@ func testConsulSyncerWithConfig(client *api.Client, configurator func(*ConsulSyn
 		SyncPeriod:        200 * time.Millisecond,
 		ServicePollPeriod: 50 * time.Millisecond,
 		ConsulK8STag:      TestConsulK8STag,
+		ConsulNodeName:    ConsulSyncNodeName,
 		ConsulNodeServicesClient: &PreNamespacesNodeServicesClient{
 			Client: client,
 		},

--- a/catalog/to-consul/testing.go
+++ b/catalog/to-consul/testing.go
@@ -10,25 +10,25 @@ const (
 	TestConsulK8STag = "k8s"
 )
 
-// TestSyncer implements Syncer for tests, giving easy access to the
+// testSyncer implements Syncer for tests, giving easy access to the
 // set of registrations.
-type TestSyncer struct {
+type testSyncer struct {
 	sync.Mutex     // Lock should be held while accessing Registrations
 	Registrations  []*api.CatalogRegistration
 	ConsulNodeName string // Consul node name to register for this syncer
 }
 
-func (s *TestSyncer) ConsulNode() string {
+func (s *testSyncer) ConsulNode() string {
 	return s.ConsulNodeName
 }
 
 // Sync implements Syncer
-func (s *TestSyncer) Sync(rs []*api.CatalogRegistration) {
+func (s *testSyncer) Sync(rs []*api.CatalogRegistration) {
 	s.Lock()
 	defer s.Unlock()
 	s.Registrations = rs
 }
 
-func NewTestSyncer() *TestSyncer {
-	return &TestSyncer{ConsulNodeName: "k8s-sync"}
+func newTestSyncer() *testSyncer {
+	return &testSyncer{ConsulNodeName: "k8s-sync"}
 }

--- a/catalog/to-consul/testing.go
+++ b/catalog/to-consul/testing.go
@@ -15,6 +15,12 @@ const (
 type TestSyncer struct {
 	sync.Mutex    // Lock should be held while accessing Registrations
 	Registrations []*api.CatalogRegistration
+	// The Consul node name to register for this syncer.
+	NodeName string
+}
+
+func (s *TestSyncer) Node() string {
+	return s.NodeName
 }
 
 // Sync implements Syncer
@@ -22,4 +28,8 @@ func (s *TestSyncer) Sync(rs []*api.CatalogRegistration) {
 	s.Lock()
 	defer s.Unlock()
 	s.Registrations = rs
+}
+
+func NewTestSyncer() *TestSyncer {
+	return &TestSyncer{NodeName: "k8s-sync"}
 }

--- a/catalog/to-consul/testing.go
+++ b/catalog/to-consul/testing.go
@@ -13,13 +13,8 @@ const (
 // testSyncer implements Syncer for tests, giving easy access to the
 // set of registrations.
 type testSyncer struct {
-	sync.Mutex     // Lock should be held while accessing Registrations
-	Registrations  []*api.CatalogRegistration
-	ConsulNodeName string // Consul node name to register for this syncer
-}
-
-func (s *testSyncer) ConsulNode() string {
-	return s.ConsulNodeName
+	sync.Mutex    // Lock should be held while accessing Registrations
+	Registrations []*api.CatalogRegistration
 }
 
 // Sync implements Syncer
@@ -30,5 +25,5 @@ func (s *testSyncer) Sync(rs []*api.CatalogRegistration) {
 }
 
 func newTestSyncer() *testSyncer {
-	return &testSyncer{ConsulNodeName: "k8s-sync"}
+	return &testSyncer{}
 }

--- a/catalog/to-consul/testing.go
+++ b/catalog/to-consul/testing.go
@@ -13,14 +13,13 @@ const (
 // TestSyncer implements Syncer for tests, giving easy access to the
 // set of registrations.
 type TestSyncer struct {
-	sync.Mutex    // Lock should be held while accessing Registrations
-	Registrations []*api.CatalogRegistration
-	// The Consul node name to register for this syncer.
-	NodeName string
+	sync.Mutex     // Lock should be held while accessing Registrations
+	Registrations  []*api.CatalogRegistration
+	ConsulNodeName string // Consul node name to register for this syncer
 }
 
-func (s *TestSyncer) Node() string {
-	return s.NodeName
+func (s *TestSyncer) ConsulNode() string {
+	return s.ConsulNodeName
 }
 
 // Sync implements Syncer
@@ -31,5 +30,5 @@ func (s *TestSyncer) Sync(rs []*api.CatalogRegistration) {
 }
 
 func NewTestSyncer() *TestSyncer {
-	return &TestSyncer{NodeName: "k8s-sync"}
+	return &TestSyncer{ConsulNodeName: "k8s-sync"}
 }

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -38,7 +39,8 @@ type Command struct {
 
 	flagCreateClientToken bool
 
-	flagCreateSyncToken bool
+	flagCreateSyncToken    bool
+	flagSyncConsulNodeName string
 
 	flagCreateInjectToken      bool
 	flagCreateInjectAuthMethod bool
@@ -105,8 +107,12 @@ func (c *Command) init() {
 		"Toggle for updating the anonymous token to allow DNS queries to work")
 	c.flags.BoolVar(&c.flagCreateClientToken, "create-client-token", true,
 		"Toggle for creating a client agent token. Default is true.")
+
 	c.flags.BoolVar(&c.flagCreateSyncToken, "create-sync-token", false,
 		"Toggle for creating a catalog sync token.")
+	c.flags.StringVar(&c.flagSyncConsulNodeName, "sync-consul-node-name", "k8s-sync",
+		"The Consul node name to register for catalog sync. Defaults to k8s-sync. To be discoverable "+
+			"via DNS, the name should only contain alpha-numerics and dashes.")
 
 	c.flags.BoolVar(&c.flagCreateInjectToken, "create-inject-namespace-token", false,
 		"Toggle for creating a connect injector token. Only required when namespaces are enabled.")
@@ -210,12 +216,10 @@ func (c *Command) Run(args []string) int {
 		c.UI.Error("Should have no non-flag arguments.")
 		return 1
 	}
-	if len(c.flagServerAddresses) == 0 {
-		c.UI.Error("-server-address must be set at least once")
-		return 1
-	}
-	if c.flagResourcePrefix == "" {
-		c.UI.Error("-resource-prefix must be set")
+
+	// Validate flags
+	if err := c.validateFlags(); err != nil {
+		c.UI.Error(err.Error())
 		return 1
 	}
 
@@ -749,6 +753,39 @@ func (c *Command) createAnonymousPolicy() bool {
 			// token. Cross-dc API calls are needed by the Connect proxies to talk
 			// cross-dc.
 			(c.flagCreateInjectAuthMethod && c.flagCreateACLReplicationToken))
+}
+
+func (c *Command) validateFlags() error {
+	if len(c.flagServerAddresses) == 0 {
+		return errors.New("-server-address must be set at least once")
+	}
+
+	if c.flagResourcePrefix == "" {
+		return errors.New("-resource-prefix must be set")
+	}
+
+	// For the Consul node name to be discoverable via DNS, it must contain only
+	// dashes and alphanumeric characters. Length is also constrained.
+	// These restrictions match those defined in Consul's agent definition.
+	var InvalidDnsRe = regexp.MustCompile(`[^A-Za-z0-9\\-]+`)
+	const MaxDNSLabelLength = 63
+
+	if InvalidDnsRe.MatchString(c.flagSyncConsulNodeName) {
+		return fmt.Errorf("Node name will not be discoverable "+
+			"via DNS due to invalid characters. Valid characters include "+
+			"all alpha-numerics and dashes. sync-consul-node-name=%s",
+			c.flagSyncConsulNodeName,
+		)
+	}
+	if len(c.flagSyncConsulNodeName) > MaxDNSLabelLength {
+		return fmt.Errorf("Node name will not be discoverable "+
+			"via DNS due to it being too long. Valid lengths are between "+
+			"1 and 63 bytes. sync-consul-node-name=%s",
+			c.flagSyncConsulNodeName,
+		)
+	}
+
+	return nil
 }
 
 const consulDefaultNamespace = "default"

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -767,20 +767,20 @@ func (c *Command) validateFlags() error {
 	// For the Consul node name to be discoverable via DNS, it must contain only
 	// dashes and alphanumeric characters. Length is also constrained.
 	// These restrictions match those defined in Consul's agent definition.
-	var InvalidDnsRe = regexp.MustCompile(`[^A-Za-z0-9\\-]+`)
-	const MaxDNSLabelLength = 63
+	var invalidDnsRe = regexp.MustCompile(`[^A-Za-z0-9\\-]+`)
+	const maxDNSLabelLength = 63
 
-	if InvalidDnsRe.MatchString(c.flagSyncConsulNodeName) {
-		return fmt.Errorf("Node name will not be discoverable "+
+	if invalidDnsRe.MatchString(c.flagSyncConsulNodeName) {
+		return fmt.Errorf("-sync-consul-node-name=%s is invalid: node name will not be discoverable "+
 			"via DNS due to invalid characters. Valid characters include "+
-			"all alpha-numerics and dashes. sync-consul-node-name=%s",
+			"all alpha-numerics and dashes",
 			c.flagSyncConsulNodeName,
 		)
 	}
-	if len(c.flagSyncConsulNodeName) > MaxDNSLabelLength {
-		return fmt.Errorf("Node name will not be discoverable "+
+	if len(c.flagSyncConsulNodeName) > maxDNSLabelLength {
+		return fmt.Errorf("-sync-consul-node-name=%s is invalid: node name will not be discoverable "+
 			"via DNS due to it being too long. Valid lengths are between "+
-			"1 and 63 bytes. sync-consul-node-name=%s",
+			"1 and 63 bytes",
 			c.flagSyncConsulNodeName,
 		)
 	}

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -56,6 +56,24 @@ func TestRun_FlagValidation(t *testing.T) {
 			Flags:  []string{"-bootstrap-token-file=/notexist", "-server-address=localhost", "-resource-prefix=prefix"},
 			ExpErr: "Unable to read bootstrap token from file \"/notexist\": open /notexist: no such file or directory",
 		},
+		{
+			Flags: []string{
+				"-server-address=localhost",
+				"-resource-prefix=prefix",
+				"-sync-consul-node-name=Speci@l_Chars",
+			},
+			ExpErr: "Node name will not be discoverable via DNS due to invalid characters. Valid characters include " +
+				"all alpha-numerics and dashes. sync-consul-node-name=Speci@l_Chars",
+		},
+		{
+			Flags: []string{
+				"-server-address=localhost",
+				"-resource-prefix=prefix",
+				"-sync-consul-node-name=5r9OPGfSRXUdGzNjBdAwmhCBrzHDNYs4XjZVR4wp7lSLIzqwS0ta51nBLIN0TMPV-too-long",
+			},
+			ExpErr: "Node name will not be discoverable via DNS due to it being too long. Valid lengths are between " +
+				"1 and 63 bytes. sync-consul-node-name=5r9OPGfSRXUdGzNjBdAwmhCBrzHDNYs4XjZVR4wp7lSLIzqwS0ta51nBLIN0TMPV-too-long",
+		},
 	}
 
 	for _, c := range cases {
@@ -930,6 +948,84 @@ func TestRun_BindingRuleUpdates(t *testing.T) {
 		require.Equal(api.BindingRuleBindTypeService, actRule.BindType)
 		require.Equal("${serviceaccount.name}", actRule.BindName)
 		require.Equal("serviceaccount.name!=changed", actRule.Selector)
+	}
+}
+
+// Test that the catalog sync policy is updated if the Consul node name changes.
+func TestRun_SyncPolicyUpdates(t *testing.T) {
+	t.Parallel()
+	k8s, testSvr := completeSetup(t)
+	setUpK8sServiceAccount(t, k8s)
+	defer testSvr.Stop()
+	require := require.New(t)
+
+	ui := cli.NewMockUi()
+	commonArgs := []string{
+		"-resource-prefix=" + resourcePrefix,
+		"-k8s-namespace=" + ns,
+		"-server-address", strings.Split(testSvr.HTTPAddr, ":")[0],
+		"-server-port", strings.Split(testSvr.HTTPAddr, ":")[1],
+		"-create-sync-token",
+	}
+	firstRunArgs := append(commonArgs,
+		"-sync-consul-node-name=k8s-sync",
+	)
+	// Our second run, we change the binding rule selector.
+	secondRunArgs := append(commonArgs,
+		"-sync-consul-node-name=new-node-name",
+	)
+
+	// Run the command first to populate the sync policy.
+	cmd := Command{
+		UI:        ui,
+		clientset: k8s,
+	}
+	responseCode := cmd.Run(firstRunArgs)
+	require.Equal(0, responseCode, ui.ErrorWriter.String())
+
+	// Create consul client
+	bootToken := getBootToken(t, k8s, resourcePrefix, ns)
+	consul, err := api.NewClient(&api.Config{
+		Address: testSvr.HTTPAddr,
+		Token:   bootToken,
+	})
+	require.NoError(err)
+
+	// Get and check the sync policy details
+	firstPolicies, _, err := consul.ACL().PolicyList(nil)
+	require.NoError(err)
+
+	for _, p := range firstPolicies {
+		if p.Name == "catalog-sync-token" {
+			policy, _, err := consul.ACL().PolicyRead(p.ID, nil)
+			require.NoError(err)
+
+			// Check the node name in the policy
+			require.Contains(policy.Rules, "k8s-sync")
+		}
+	}
+
+	// Re-run the command with a new Consul node name. The sync policy should be updated.
+	// NOTE: We're redefining the command so that the old flag values are reset.
+	cmd = Command{
+		UI:        ui,
+		clientset: k8s,
+	}
+	responseCode = cmd.Run(secondRunArgs)
+	require.Equal(0, responseCode, ui.ErrorWriter.String())
+
+	// Get and check the sync policy details
+	secondPolicies, _, err := consul.ACL().PolicyList(nil)
+	require.NoError(err)
+
+	for _, p := range secondPolicies {
+		if p.Name == "catalog-sync-token" {
+			policy, _, err := consul.ACL().PolicyRead(p.ID, nil)
+			require.NoError(err)
+
+			// Check the node name in the policy
+			require.Contains(policy.Rules, "new-node-name")
+		}
 	}
 }
 

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -62,8 +62,8 @@ func TestRun_FlagValidation(t *testing.T) {
 				"-resource-prefix=prefix",
 				"-sync-consul-node-name=Speci@l_Chars",
 			},
-			ExpErr: "Node name will not be discoverable via DNS due to invalid characters. Valid characters include " +
-				"all alpha-numerics and dashes. sync-consul-node-name=Speci@l_Chars",
+			ExpErr: "-sync-consul-node-name=Speci@l_Chars is invalid: node name will not be discoverable " +
+				"via DNS due to invalid characters. Valid characters include all alpha-numerics and dashes",
 		},
 		{
 			Flags: []string{
@@ -71,8 +71,8 @@ func TestRun_FlagValidation(t *testing.T) {
 				"-resource-prefix=prefix",
 				"-sync-consul-node-name=5r9OPGfSRXUdGzNjBdAwmhCBrzHDNYs4XjZVR4wp7lSLIzqwS0ta51nBLIN0TMPV-too-long",
 			},
-			ExpErr: "Node name will not be discoverable via DNS due to it being too long. Valid lengths are between " +
-				"1 and 63 bytes. sync-consul-node-name=5r9OPGfSRXUdGzNjBdAwmhCBrzHDNYs4XjZVR4wp7lSLIzqwS0ta51nBLIN0TMPV-too-long",
+			ExpErr: "-sync-consul-node-name=5r9OPGfSRXUdGzNjBdAwmhCBrzHDNYs4XjZVR4wp7lSLIzqwS0ta51nBLIN0TMPV-too-long is invalid: node name will not be discoverable " +
+				"via DNS due to it being too long. Valid lengths are between 1 and 63 bytes",
 		},
 	}
 
@@ -895,7 +895,7 @@ func TestRun_BindingRuleUpdates(t *testing.T) {
 	firstRunArgs := append(commonArgs,
 		"-acl-binding-rule-selector=serviceaccount.name!=default",
 	)
-	// Our second run, we change the binding rule selector.
+	// On the second run, we change the binding rule selector.
 	secondRunArgs := append(commonArgs,
 		"-acl-binding-rule-selector=serviceaccount.name!=changed",
 	)
@@ -955,7 +955,6 @@ func TestRun_BindingRuleUpdates(t *testing.T) {
 func TestRun_SyncPolicyUpdates(t *testing.T) {
 	t.Parallel()
 	k8s, testSvr := completeSetup(t)
-	setUpK8sServiceAccount(t, k8s)
 	defer testSvr.Stop()
 	require := require.New(t)
 
@@ -970,7 +969,7 @@ func TestRun_SyncPolicyUpdates(t *testing.T) {
 	firstRunArgs := append(commonArgs,
 		"-sync-consul-node-name=k8s-sync",
 	)
-	// Our second run, we change the binding rule selector.
+	// On the second run, we change the sync node name.
 	secondRunArgs := append(commonArgs,
 		"-sync-consul-node-name=new-node-name",
 	)

--- a/subcommand/server-acl-init/create_or_update.go
+++ b/subcommand/server-acl-init/create_or_update.go
@@ -108,7 +108,7 @@ func (c *Command) createOrUpdateACLPolicy(policy api.ACLPolicy, consulClient *ap
 	// settings, the policies associated with their ACL tokens will need to be
 	// updated to be namespace aware.
 	// Allowing the Consul node name to be configurable also requires any sync
-	// token to be updated in case the node name has changed.
+	// policy to be updated in case the node name has changed.
 	if isPolicyExistsErr(err, policy.Name) {
 		if c.flagEnableNamespaces || c.flagCreateSyncToken {
 			c.log.Info(fmt.Sprintf("Policy %q already exists, updating", policy.Name))

--- a/subcommand/server-acl-init/create_or_update.go
+++ b/subcommand/server-acl-init/create_or_update.go
@@ -107,8 +107,10 @@ func (c *Command) createOrUpdateACLPolicy(policy api.ACLPolicy, consulClient *ap
 	// Consul version with namespace support or changes any of their namespace
 	// settings, the policies associated with their ACL tokens will need to be
 	// updated to be namespace aware.
+	// Allowing the Consul node name to be configurable also requires any sync
+	// token to be updated in case the node name has changed.
 	if isPolicyExistsErr(err, policy.Name) {
-		if c.flagEnableNamespaces {
+		if c.flagEnableNamespaces || c.flagCreateSyncToken {
 			c.log.Info(fmt.Sprintf("Policy %q already exists, updating", policy.Name))
 
 			// The policy ID is required in any PolicyUpdate call, so first we need to

--- a/subcommand/server-acl-init/rules.go
+++ b/subcommand/server-acl-init/rules.go
@@ -11,6 +11,7 @@ type rulesData struct {
 	ConsulSyncDestinationNamespace string
 	EnableSyncK8SNSMirroring       bool
 	SyncK8SNSMirroringPrefix       string
+	SyncConsulNodeName             string
 }
 
 type gatewayRulesData struct {
@@ -174,7 +175,7 @@ namespace "{{ .GatewayNamespace }}" {
 
 func (c *Command) syncRules() (string, error) {
 	syncRulesTpl := `
-  node "k8s-sync" {
+  node "{{ .SyncConsulNodeName }}" {
     policy = "write"
   }
 {{- if .EnableNamespaces }}
@@ -246,6 +247,7 @@ func (c *Command) rulesData() rulesData {
 		ConsulSyncDestinationNamespace: c.flagConsulSyncDestinationNamespace,
 		EnableSyncK8SNSMirroring:       c.flagEnableSyncK8SNSMirroring,
 		SyncK8SNSMirroringPrefix:       c.flagSyncK8SNSMirroringPrefix,
+		SyncConsulNodeName:             c.flagSyncConsulNodeName,
 	}
 }
 

--- a/subcommand/server-acl-init/rules_test.go
+++ b/subcommand/server-acl-init/rules_test.go
@@ -314,6 +314,7 @@ func TestSyncRules(t *testing.T) {
 		ConsulSyncDestinationNamespace string
 		EnableSyncK8SNSMirroring       bool
 		SyncK8SNSMirroringPrefix       string
+		SyncConsulNodeName             string
 		Expected                       string
 	}{
 		{
@@ -322,7 +323,25 @@ func TestSyncRules(t *testing.T) {
 			"sync-namespace",
 			true,
 			"prefix-",
+			"k8s-sync",
 			`node "k8s-sync" {
+    policy = "write"
+  }
+  node_prefix "" {
+    policy = "read"
+  }
+  service_prefix "" {
+    policy = "write"
+  }`,
+		},
+		{
+			"Namespaces are disabled, non-default node name",
+			false,
+			"sync-namespace",
+			true,
+			"prefix-",
+			"new-node-name",
+			`node "new-node-name" {
     policy = "write"
   }
   node_prefix "" {
@@ -338,7 +357,28 @@ func TestSyncRules(t *testing.T) {
 			"sync-namespace",
 			false,
 			"prefix-",
+			"k8s-sync",
 			`node "k8s-sync" {
+    policy = "write"
+  }
+operator = "write"
+namespace "sync-namespace" {
+  node_prefix "" {
+    policy = "read"
+  }
+  service_prefix "" {
+    policy = "write"
+  }
+}`,
+		},
+		{
+			"Namespaces are enabled, mirroring disabled, non-default node name",
+			true,
+			"sync-namespace",
+			false,
+			"prefix-",
+			"new-node-name",
+			`node "new-node-name" {
     policy = "write"
   }
 operator = "write"
@@ -357,7 +397,28 @@ namespace "sync-namespace" {
 			"sync-namespace",
 			true,
 			"",
+			"k8s-sync",
 			`node "k8s-sync" {
+    policy = "write"
+  }
+operator = "write"
+namespace_prefix "" {
+  node_prefix "" {
+    policy = "read"
+  }
+  service_prefix "" {
+    policy = "write"
+  }
+}`,
+		},
+		{
+			"Namespaces are enabled, mirroring enabled, prefix empty, non-default node name",
+			true,
+			"sync-namespace",
+			true,
+			"",
+			"new-node-name",
+			`node "new-node-name" {
     policy = "write"
   }
 operator = "write"
@@ -376,7 +437,28 @@ namespace_prefix "" {
 			"sync-namespace",
 			true,
 			"prefix-",
+			"k8s-sync",
 			`node "k8s-sync" {
+    policy = "write"
+  }
+operator = "write"
+namespace_prefix "prefix-" {
+  node_prefix "" {
+    policy = "read"
+  }
+  service_prefix "" {
+    policy = "write"
+  }
+}`,
+		},
+		{
+			"Namespaces are enabled, mirroring enabled, prefix defined, non-default node name",
+			true,
+			"sync-namespace",
+			true,
+			"prefix-",
+			"new-node-name",
+			`node "new-node-name" {
     policy = "write"
   }
 operator = "write"
@@ -400,6 +482,7 @@ namespace_prefix "prefix-" {
 				flagConsulSyncDestinationNamespace: tt.ConsulSyncDestinationNamespace,
 				flagEnableSyncK8SNSMirroring:       tt.EnableSyncK8SNSMirroring,
 				flagSyncK8SNSMirroringPrefix:       tt.SyncK8SNSMirroringPrefix,
+				flagSyncConsulNodeName:             tt.SyncConsulNodeName,
 			}
 
 			syncRules, err := cmd.syncRules()

--- a/subcommand/sync-catalog/command.go
+++ b/subcommand/sync-catalog/command.go
@@ -48,6 +48,7 @@ type Command struct {
 	flagNodePortSyncType      string
 	flagAddK8SNamespaceSuffix bool
 	flagLogLevel              string
+	flagNodeName              string
 
 	// Flags to support namespaces
 	flagEnableNamespaces           bool     // Use namespacing on all components
@@ -131,6 +132,8 @@ func (c *Command) init() {
 	c.flags.StringVar(&c.flagCrossNamespaceACLPolicy, "consul-cross-namespace-acl-policy", "",
 		"[Enterprise Only] Name of the ACL policy to attach to all created Consul namespaces to allow service "+
 			"discovery across Consul namespaces. Only necessary if ACLs are enabled.")
+	c.flags.StringVar(&c.flagNodeName, "node-name", "k8s-sync",
+		"The Consul node name to register for k8s-sync. Defaults to k8s-sync.")
 
 	c.http = &flags.HTTPFlags{}
 	c.k8s = &flags.K8SFlags{}
@@ -244,6 +247,7 @@ func (c *Command) Run(args []string) int {
 			ServicePollPeriod:        c.flagConsulWritePeriod * 2,
 			ConsulK8STag:             c.flagConsulK8STag,
 			ConsulNodeServicesClient: svcsClient,
+			NodeName:                 c.flagNodeName,
 		}
 		go syncer.Run(ctx)
 

--- a/subcommand/sync-catalog/command.go
+++ b/subcommand/sync-catalog/command.go
@@ -280,6 +280,7 @@ func (c *Command) Run(args []string) int {
 				ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
 				EnableK8SNSMirroring:       c.flagEnableK8SNSMirroring,
 				K8SNSMirroringPrefix:       c.flagK8SNSMirroringPrefix,
+				ConsulNodeName:             c.flagConsulNodeName,
 			},
 		}
 
@@ -392,20 +393,18 @@ func (c *Command) validateFlags() error {
 	// For the Consul node name to be discoverable via DNS, it must contain only
 	// dashes and alphanumeric characters. Length is also constrained.
 	// These restrictions match those defined in Consul's agent definition.
-	var InvalidDnsRe = regexp.MustCompile(`[^A-Za-z0-9\\-]+`)
-	const MaxDNSLabelLength = 63
+	var invalidDnsRe = regexp.MustCompile(`[^A-Za-z0-9\\-]+`)
+	const maxDNSLabelLength = 63
 
-	if InvalidDnsRe.MatchString(c.flagConsulNodeName) {
-		return fmt.Errorf("Node name will not be discoverable "+
-			"via DNS due to invalid characters. Valid characters include "+
-			"all alpha-numerics and dashes. consul-node-name=%s",
+	if invalidDnsRe.MatchString(c.flagConsulNodeName) {
+		return fmt.Errorf("-consul-node-name=%s is invalid: node name will not be discoverable "+
+			"via DNS due to invalid characters. Valid characters include all alpha-numerics and dashes",
 			c.flagConsulNodeName,
 		)
 	}
-	if len(c.flagConsulNodeName) > MaxDNSLabelLength {
-		return fmt.Errorf("Node name will not be discoverable "+
-			"via DNS due to it being too long. Valid lengths are between "+
-			"1 and 63 bytes. consul-node-name=%s",
+	if len(c.flagConsulNodeName) > maxDNSLabelLength {
+		return fmt.Errorf("-consul-node-name=%s is invalid: node name will not be discoverable "+
+			"via DNS due to it being too long. Valid lengths are between 1 and 63 bytes",
 			c.flagConsulNodeName,
 		)
 	}

--- a/subcommand/sync-catalog/command_test.go
+++ b/subcommand/sync-catalog/command_test.go
@@ -26,13 +26,13 @@ func TestRun_FlagValidation(t *testing.T) {
 	}{
 		{
 			Flags: []string{"-consul-node-name=Speci@l_Chars"},
-			ExpErr: "Node name will not be discoverable via DNS due to invalid characters. Valid characters include " +
-				"all alpha-numerics and dashes. consul-node-name=Speci@l_Chars",
+			ExpErr: "-consul-node-name=Speci@l_Chars is invalid: node name will not be discoverable " +
+				"via DNS due to invalid characters. Valid characters include all alpha-numerics and dashes",
 		},
 		{
 			Flags: []string{"-consul-node-name=5r9OPGfSRXUdGzNjBdAwmhCBrzHDNYs4XjZVR4wp7lSLIzqwS0ta51nBLIN0TMPV-too-long"},
-			ExpErr: "Node name will not be discoverable via DNS due to it being too long. Valid lengths are between " +
-				"1 and 63 bytes. consul-node-name=5r9OPGfSRXUdGzNjBdAwmhCBrzHDNYs4XjZVR4wp7lSLIzqwS0ta51nBLIN0TMPV-too-long",
+			ExpErr: "-consul-node-name=5r9OPGfSRXUdGzNjBdAwmhCBrzHDNYs4XjZVR4wp7lSLIzqwS0ta51nBLIN0TMPV-too-long is invalid: node name will not be discoverable " +
+				"via DNS due to it being too long. Valid lengths are between 1 and 63 bytes",
 		},
 	}
 

--- a/subcommand/sync-catalog/command_test.go
+++ b/subcommand/sync-catalog/command_test.go
@@ -16,6 +16,39 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+// Test flag validation
+func TestRun_FlagValidation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Flags  []string
+		ExpErr string
+	}{
+		{
+			Flags: []string{"-consul-node-name=Speci@l_Chars"},
+			ExpErr: "Node name will not be discoverable via DNS due to invalid characters. Valid characters include " +
+				"all alpha-numerics and dashes. consul-node-name=Speci@l_Chars",
+		},
+		{
+			Flags: []string{"-consul-node-name=5r9OPGfSRXUdGzNjBdAwmhCBrzHDNYs4XjZVR4wp7lSLIzqwS0ta51nBLIN0TMPV-too-long"},
+			ExpErr: "Node name will not be discoverable via DNS due to it being too long. Valid lengths are between " +
+				"1 and 63 bytes. consul-node-name=5r9OPGfSRXUdGzNjBdAwmhCBrzHDNYs4XjZVR4wp7lSLIzqwS0ta51nBLIN0TMPV-too-long",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.ExpErr, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI: ui,
+			}
+			responseCode := cmd.Run(c.Flags)
+			require.Equal(t, 1, responseCode, ui.ErrorWriter.String())
+			require.Contains(t, ui.ErrorWriter.String(), c.ExpErr)
+		})
+	}
+}
+
 // Test that the default consul service is synced to k8s
 func TestRun_Defaults_SyncsConsulServiceToK8s(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Update of PR #103. 

Changes proposed in this PR:
- Be able to configure the synthetic Consul node name where catalog sync registers services.

How I've tested this PR:
Using consul-helm [#580](https://github.com/hashicorp/consul-helm/pull/580), I deployed with catalog sync enabled by default.

How I expect reviewers to test this PR:
Similarly.

Checklist:
 :ballot_box_with_check: Tests added
 :ballot_box_with_check: CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
      -> to be added when the PR exists to link to
