### PR TITLE
Add -create-controller-token flag

### DIFF
--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -45,6 +45,8 @@ type Command struct {
 	flagInjectAuthMethodHost   string
 	flagBindingRuleSelector    string
 
+	flagCreateControllerToken bool
+
 	flagCreateEntLicenseToken bool
 
 	flagCreateSnapshotAgentToken bool
@@ -119,6 +121,9 @@ func (c *Command) init() {
 			"If not provided, the default cluster Kubernetes service will be used.")
 	c.flags.StringVar(&c.flagBindingRuleSelector, "acl-binding-rule-selector", "",
 		"Selector string for connectInject ACL Binding Rule.")
+
+	c.flags.BoolVar(&c.flagCreateControllerToken, "create-controller-token", false,
+		"Toggle for creating a token for the controller.")
 
 	c.flags.BoolVar(&c.flagCreateEntLicenseToken, "create-enterprise-license-token", false,
 		"Toggle for creating a token for the enterprise license job.")
@@ -630,6 +635,19 @@ func (c *Command) Run(args []string) int {
 		// Policy must be global because it replicates from the primary DC
 		// and so the primary DC needs to be able to accept the token.
 		err = c.createGlobalACL(common.ACLReplicationTokenName, rules, consulDC, consulClient)
+		if err != nil {
+			c.log.Error(err.Error())
+			return 1
+		}
+	}
+
+	if c.flagCreateControllerToken {
+		rules, err := c.controllerRules()
+		if err != nil {
+			c.log.Error("Error templating controller token rules", "err", err)
+			return 1
+		}
+		err = c.createLocalACL("controller", rules, consulDC, consulClient)
 		if err != nil {
 			c.log.Error(err.Error())
 			return 1

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -218,6 +218,14 @@ func TestRun_TokensPrimaryDC(t *testing.T) {
 			SecretNames: []string{resourcePrefix + "-acl-replication-acl-token"},
 			LocalToken:  false,
 		},
+		{
+			TestName:    "Controller token",
+			TokenFlags:  []string{"-create-controller-token"},
+			PolicyNames: []string{"controller-token"},
+			PolicyDCs:   []string{"dc1"},
+			SecretNames: []string{resourcePrefix + "-controller-acl-token"},
+			LocalToken:  true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.TestName, func(t *testing.T) {

--- a/subcommand/server-acl-init/rules.go
+++ b/subcommand/server-acl-init/rules.go
@@ -240,6 +240,20 @@ namespace_prefix "" {
 	return c.renderRules(aclReplicationRulesTpl)
 }
 
+// todo: implement namespaces support.
+func (c *Command) controllerRules() (string, error) {
+	controllerRules := `
+operator = "write"
+node_prefix "" {
+  policy = "write"
+}
+service_prefix "" {
+  policy = "write"
+}
+`
+	return c.renderRules(controllerRules)
+}
+
 func (c *Command) rulesData() rulesData {
 	return rulesData{
 		EnableNamespaces:               c.flagEnableNamespaces,

--- a/subcommand/server-acl-init/rules_test.go
+++ b/subcommand/server-acl-init/rules_test.go
@@ -499,3 +499,49 @@ namespace_prefix "" {
 		})
 	}
 }
+
+func TestControllerRules(t *testing.T) {
+	cases := []struct {
+		Name             string
+		EnableNamespaces bool
+		Expected         string
+	}{
+		{
+			"Namespaces are disabled",
+			false,
+			`operator = "write"
+node_prefix "" {
+  policy = "write"
+}
+service_prefix "" {
+  policy = "write"
+}`,
+		},
+		{
+			"Namespaces are enabled",
+			true,
+			`operator = "write"
+node_prefix "" {
+  policy = "write"
+}
+service_prefix "" {
+  policy = "write"
+}`,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			require := require.New(t)
+
+			cmd := Command{
+				flagEnableNamespaces: tt.EnableNamespaces,
+			}
+
+			rules, err := cmd.controllerRules()
+
+			require.NoError(err)
+			require.Equal(tt.Expected, rules)
+		})
+	}
+}


### PR DESCRIPTION
Will create an ACL token for controller. No Consul Enterprise support
right now.

How I've tested this PR:
- Check out this branch: https://github.com/hashicorp/consul-helm/pull/587 and follow the instructions there

How I expect reviewers to test this PR:
- ☝️ 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (not applicable)
