### PR TITLE
Add defaults and validation for ServiceDefaults

### DIFF
--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -180,9 +180,7 @@ func (e ExposeConfig) validate() []*field.Error {
 		if path.Path != "" && !strings.HasPrefix(path.Path, "/") {
 			errs = append(errs, field.Invalid(field.NewPath("spec").Child("expose").Child(fmt.Sprintf("paths[%d]", i)).Child("path"), path.Path, `must begin with a '/'`))
 		}
-		if sliceContains(protocols, path.Protocol) {
-			continue
-		} else {
+		if !sliceContains(protocols, path.Protocol) {
 			errs = append(errs, field.Invalid(field.NewPath("spec").Child("expose").Child(fmt.Sprintf("paths[%d]", i)).Child("protocol"), path.Protocol, notInSliceMessage(protocols)))
 		}
 	}

--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -175,15 +175,15 @@ func (e ExposeConfig) toConsul() capi.ExposeConfig {
 
 func (e ExposeConfig) validate() []*field.Error {
 	var errs field.ErrorList
+	protocols := []string{"http", "http2"}
 	for i, path := range e.Paths {
 		if path.Path != "" && !strings.HasPrefix(path.Path, "/") {
 			errs = append(errs, field.Invalid(field.NewPath("spec").Child("expose").Child(fmt.Sprintf("paths[%d]", i)).Child("path"), path.Path, `must begin with a '/'`))
 		}
-		switch path.Protocol {
-		case "http", "http2":
+		if sliceContains(protocols, path.Protocol) {
 			continue
-		default:
-			errs = append(errs, field.Invalid(field.NewPath("spec").Child("expose").Child(fmt.Sprintf("paths[%d]", i)).Child("protocol"), path.Protocol, `must be one of "http" or "http2"`))
+		} else {
+			errs = append(errs, field.Invalid(field.NewPath("spec").Child("expose").Child(fmt.Sprintf("paths[%d]", i)).Child("protocol"), path.Protocol, notInSliceMessage(protocols)))
 		}
 	}
 	return errs

--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -78,13 +78,8 @@ func (in *ServiceDefaults) MatchesConsul(entry *capi.ServiceConfigEntry) bool {
 		in.Spec.ExternalSNI == entry.ExternalSNI
 }
 
-func (in *ServiceDefaults) Default() {
-	if in.Spec.Protocol == "" {
-		in.Spec.Protocol = "tcp"
-	}
-	in.Spec.Expose.defaultConfig()
-}
-
+// Validate validates the fields provided in the spec of the ServiceDefaults and
+// returns an error which lists all invalid fields in the resource spec.
 func (in *ServiceDefaults) Validate() error {
 	var allErrs field.ErrorList
 	if err := in.Spec.MeshGateway.validate(); err != nil {
@@ -174,18 +169,10 @@ func (e ExposeConfig) toConsul() capi.ExposeConfig {
 	}
 }
 
-func (e *ExposeConfig) defaultConfig() {
-	for i, path := range e.Paths {
-		if path.Protocol == "" {
-			e.Paths[i].Protocol = "http"
-		}
-	}
-}
-
 func (e ExposeConfig) validate() []*field.Error {
 	var errs field.ErrorList
 	for i, path := range e.Paths {
-		if !strings.HasPrefix(path.Path, "/") {
+		if path.Path != "" && !strings.HasPrefix(path.Path, "/") {
 			errs = append(errs, field.Invalid(field.NewPath("spec").Child("expose").Child(fmt.Sprintf("paths[%d]", i)).Child("path"), path.Path, `must begin with a '/'`))
 		}
 		switch path.Protocol {

--- a/api/v1alpha1/servicedefaults_types_test.go
+++ b/api/v1alpha1/servicedefaults_types_test.go
@@ -671,7 +671,7 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			`ServiceDefaults.consul.hashicorp.com "my-service" is invalid: spec.meshGateway.mode: Invalid value: "foobar": must be one of "remote", "local", "none" or ""`,
+			`servicedefaults.consul.hashicorp.com "my-service" is invalid: spec.meshGateway.mode: Invalid value: "foobar": must be one of "remote", "local", "none" or ""`,
 		},
 		"expose.paths[].protocol": {
 			&ServiceDefaults{
@@ -689,7 +689,7 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			`ServiceDefaults.consul.hashicorp.com "my-service" is invalid: spec.expose.paths[0].protocol: Invalid value: "invalid-protocol": must be one of "http" or "http2"`,
+			`servicedefaults.consul.hashicorp.com "my-service" is invalid: spec.expose.paths[0].protocol: Invalid value: "invalid-protocol": must be one of "http" or "http2"`,
 		},
 		"expose.paths[].path": {
 			&ServiceDefaults{
@@ -707,7 +707,7 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			`ServiceDefaults.consul.hashicorp.com "my-service" is invalid: spec.expose.paths[0].path: Invalid value: "invalid-path": must begin with a '/'`,
+			`servicedefaults.consul.hashicorp.com "my-service" is invalid: spec.expose.paths[0].path: Invalid value: "invalid-path": must begin with a '/'`,
 		},
 		"multi-error": {
 			&ServiceDefaults{
@@ -728,7 +728,7 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			`ServiceDefaults.consul.hashicorp.com "my-service" is invalid: [spec.meshGateway.mode: Invalid value: "invalid-mode": must be one of "remote", "local", "none" or "", spec.expose.paths[0].path: Invalid value: "invalid-path": must begin with a '/', spec.expose.paths[0].protocol: Invalid value: "invalid-protocol": must be one of "http" or "http2"]`,
+			`servicedefaults.consul.hashicorp.com "my-service" is invalid: [spec.meshGateway.mode: Invalid value: "invalid-mode": must be one of "remote", "local", "none" or "", spec.expose.paths[0].path: Invalid value: "invalid-path": must begin with a '/', spec.expose.paths[0].protocol: Invalid value: "invalid-protocol": must be one of "http" or "http2"]`,
 		},
 	}
 

--- a/api/v1alpha1/servicedefaults_types_test.go
+++ b/api/v1alpha1/servicedefaults_types_test.go
@@ -671,7 +671,7 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			`servicedefaults.consul.hashicorp.com "my-service" is invalid: spec.meshGateway.mode: Invalid value: "foobar": must be one of "remote", "local", "none" or ""`,
+			`servicedefaults.consul.hashicorp.com "my-service" is invalid: spec.meshGateway.mode: Invalid value: "foobar": must be one of "remote", "local", "none", ""`,
 		},
 		"expose.paths[].protocol": {
 			&ServiceDefaults{
@@ -689,7 +689,7 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			`servicedefaults.consul.hashicorp.com "my-service" is invalid: spec.expose.paths[0].protocol: Invalid value: "invalid-protocol": must be one of "http" or "http2"`,
+			`servicedefaults.consul.hashicorp.com "my-service" is invalid: spec.expose.paths[0].protocol: Invalid value: "invalid-protocol": must be one of "http", "http2"`,
 		},
 		"expose.paths[].path": {
 			&ServiceDefaults{
@@ -728,7 +728,7 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			`servicedefaults.consul.hashicorp.com "my-service" is invalid: [spec.meshGateway.mode: Invalid value: "invalid-mode": must be one of "remote", "local", "none" or "", spec.expose.paths[0].path: Invalid value: "invalid-path": must begin with a '/', spec.expose.paths[0].protocol: Invalid value: "invalid-protocol": must be one of "http" or "http2"]`,
+			`servicedefaults.consul.hashicorp.com "my-service" is invalid: [spec.meshGateway.mode: Invalid value: "invalid-mode": must be one of "remote", "local", "none", "", spec.expose.paths[0].path: Invalid value: "invalid-path": must begin with a '/', spec.expose.paths[0].protocol: Invalid value: "invalid-protocol": must be one of "http", "http2"]`,
 		},
 	}
 

--- a/api/v1alpha1/servicedefaults_types_test.go
+++ b/api/v1alpha1/servicedefaults_types_test.go
@@ -724,7 +724,64 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			`ServiceDefaults.consul.hashicorp.com "my-service" is invalid: spec.meshGateway.mode: Invalid value: "foobar": must be on of "remote", "local", "none" or ""`,
+			`ServiceDefaults.consul.hashicorp.com "my-service" is invalid: spec.meshGateway.mode: Invalid value: "foobar": must be one of "remote", "local", "none" or ""`,
+		},
+		"expose.paths[].protocol": {
+			&ServiceDefaults{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-service",
+				},
+				Spec: ServiceDefaultsSpec{
+					Expose: ExposeConfig{
+						Paths: []ExposePath{
+							{
+								Protocol: "invalid-protocol",
+								Path:     "/valid-path",
+							},
+						},
+					},
+				},
+			},
+			`ServiceDefaults.consul.hashicorp.com "my-service" is invalid: spec.expose.paths[0].protocol: Invalid value: "invalid-protocol": must be one of "http" or "http2"`,
+		},
+		"expose.paths[].path": {
+			&ServiceDefaults{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-service",
+				},
+				Spec: ServiceDefaultsSpec{
+					Expose: ExposeConfig{
+						Paths: []ExposePath{
+							{
+								Protocol: "http",
+								Path:     "invalid-path",
+							},
+						},
+					},
+				},
+			},
+			`ServiceDefaults.consul.hashicorp.com "my-service" is invalid: spec.expose.paths[0].path: Invalid value: "invalid-path": must begin with a '/'`,
+		},
+		"multi-error": {
+			&ServiceDefaults{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-service",
+				},
+				Spec: ServiceDefaultsSpec{
+					MeshGateway: MeshGatewayConfig{
+						Mode: "invalid-mode",
+					},
+					Expose: ExposeConfig{
+						Paths: []ExposePath{
+							{
+								Protocol: "invalid-protocol",
+								Path:     "invalid-path",
+							},
+						},
+					},
+				},
+			},
+			`ServiceDefaults.consul.hashicorp.com "my-service" is invalid: [spec.meshGateway.mode: Invalid value: "invalid-mode": must be one of "remote", "local", "none" or "", spec.expose.paths[0].path: Invalid value: "invalid-path": must begin with a '/', spec.expose.paths[0].protocol: Invalid value: "invalid-protocol": must be one of "http" or "http2"]`,
 		},
 	}
 

--- a/api/v1alpha1/servicedefaults_types_test.go
+++ b/api/v1alpha1/servicedefaults_types_test.go
@@ -655,59 +655,6 @@ func TestMatchesConsul(t *testing.T) {
 	}
 }
 
-func TestDefault(t *testing.T) {
-	cases := map[string]struct {
-		input    *ServiceDefaults
-		expected *ServiceDefaults
-	}{
-		"protocol": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					Protocol: "",
-				},
-			},
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					Protocol: "tcp",
-				},
-			},
-		},
-		"expose.path.protocol": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					Protocol: "tcp",
-					Expose: ExposeConfig{
-						Paths: []ExposePath{
-							{
-								Protocol: "",
-							},
-						},
-					},
-				},
-			},
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					Protocol: "tcp",
-					Expose: ExposeConfig{
-						Paths: []ExposePath{
-							{
-								Protocol: "http",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for name, testCase := range cases {
-		t.Run(name, func(t *testing.T) {
-			testCase.input.Default()
-			require.Equal(t, testCase.expected, testCase.input)
-		})
-	}
-}
-
 func TestValidate(t *testing.T) {
 	cases := map[string]struct {
 		input          *ServiceDefaults

--- a/api/v1alpha1/servicedefaults_webhook.go
+++ b/api/v1alpha1/servicedefaults_webhook.go
@@ -50,6 +50,10 @@ func (v *serviceDefaultsValidator) Handle(ctx context.Context, req admission.Req
 			}
 		}
 	}
+	svcDefaults.Default()
+	if err := svcDefaults.Validate(); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
 	return admission.Allowed("Valid Service Defaults Request")
 }
 

--- a/api/v1alpha1/servicedefaults_webhook.go
+++ b/api/v1alpha1/servicedefaults_webhook.go
@@ -50,7 +50,6 @@ func (v *serviceDefaultsValidator) Handle(ctx context.Context, req admission.Req
 			}
 		}
 	}
-	svcDefaults.Default()
 	if err := svcDefaults.Validate(); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	capi "github.com/hashicorp/consul/api"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 type MeshGatewayMode string
@@ -45,5 +46,14 @@ func (m MeshGatewayConfig) toConsul() capi.MeshGatewayConfig {
 		return capi.MeshGatewayConfig{
 			Mode: capi.MeshGatewayModeDefault,
 		}
+	}
+}
+
+func (m MeshGatewayConfig) validate() *field.Error {
+	switch m.Mode {
+	case "", "local", "remote", "none":
+		return nil
+	default:
+		return field.Invalid(field.NewPath("spec").Child("meshGateway").Child("mode"), m.Mode, `must be one of "remote", "local", "none" or ""`)
 	}
 }

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	capi "github.com/hashicorp/consul/api"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -50,10 +52,28 @@ func (m MeshGatewayConfig) toConsul() capi.MeshGatewayConfig {
 }
 
 func (m MeshGatewayConfig) validate() *field.Error {
-	switch m.Mode {
-	case "", "local", "remote", "none":
+	modes := []string{"remote", "local", "none", ""}
+	if sliceContains(modes, m.Mode) {
 		return nil
-	default:
-		return field.Invalid(field.NewPath("spec").Child("meshGateway").Child("mode"), m.Mode, `must be one of "remote", "local", "none" or ""`)
+	} else {
+		return field.Invalid(field.NewPath("spec").Child("meshGateway").Child("mode"), m.Mode, notInSliceMessage(modes))
 	}
+}
+
+func notInSliceMessage(slice []string) string {
+	message := ""
+	for _, s := range slice {
+		message = fmt.Sprintf(`%s, "%s"`, message, s)
+	}
+	runes := []rune(message)
+	return fmt.Sprintf(`must be one of %s`, string(runes[2:]))
+}
+
+func sliceContains(slice []string, entry string) bool {
+	for _, s := range slice {
+		if entry == s {
+			return true
+		}
+	}
+	return false
 }

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"strings"
 
 	capi "github.com/hashicorp/consul/api"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -53,20 +54,14 @@ func (m MeshGatewayConfig) toConsul() capi.MeshGatewayConfig {
 
 func (m MeshGatewayConfig) validate() *field.Error {
 	modes := []string{"remote", "local", "none", ""}
-	if sliceContains(modes, m.Mode) {
-		return nil
-	} else {
+	if !sliceContains(modes, m.Mode) {
 		return field.Invalid(field.NewPath("spec").Child("meshGateway").Child("mode"), m.Mode, notInSliceMessage(modes))
 	}
+	return nil
 }
 
 func notInSliceMessage(slice []string) string {
-	message := ""
-	for _, s := range slice {
-		message = fmt.Sprintf(`%s, "%s"`, message, s)
-	}
-	runes := []rune(message)
-	return fmt.Sprintf(`must be one of %s`, string(runes[2:]))
+	return fmt.Sprintf(`must be one of "%s"`, strings.Join(slice, `", "`))
 }
 
 func sliceContains(slice []string, entry string) bool {


### PR DESCRIPTION
Changes proposed in this PR:

Add defaulting and validation for ServiceDefaults

Checklist:
- [x] Tests added

How I tested the PR:
• Used the image `ashwinvenkatesh/consul-k8s:validation` to deploy consul via helm with the controller enabled.
• Tried creating service default resource with
  • Invalid mesh gateway mode
  • Invalid expose path protocol (not in "http" and "http2") and path value (not prefixed by "/")
This led to webhook errors which indicated the invalid fields
  • Combinations of various invalid values for the above fields
This led to webhook errors that listed every single invalid field

How I expect people to test the PR:

• You can retry the above scenarios with multiple invalid values to verify every invalid value is mentioned in the returned error from the webhook.