### PR TITLE
Connect: only look for service account secrets when creating/updating auth method

### DIFF
--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -1890,7 +1890,7 @@ func setUpK8sServiceAccount(t *testing.T, k8s *fake.Clientset) (string, string) 
 	sa, _ := k8s.CoreV1().ServiceAccounts(ns).Get(context.Background(), serviceAccountName, metav1.GetOptions{})
 	if sa == nil {
 		// Create a service account that references two secrets.
-		// The second secret is mimicing the behavior on Openshift,
+		// The second secret is mimicking the behavior on Openshift,
 		// where two secrets are injected: one with SA token and one with docker config.
 		_, err := k8s.CoreV1().ServiceAccounts(ns).Create(
 			context.Background(),

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -1889,6 +1889,9 @@ func setUpK8sServiceAccount(t *testing.T, k8s *fake.Clientset) (string, string) 
 	serviceAccountName := resourcePrefix + "-connect-injector-authmethod-svc-account"
 	sa, _ := k8s.CoreV1().ServiceAccounts(ns).Get(context.Background(), serviceAccountName, metav1.GetOptions{})
 	if sa == nil {
+		// Create a service account that references two secrets.
+		// The second secret is mimicing the behavior on Openshift,
+		// where two secrets are injected: one with SA token and one with docker config.
 		_, err := k8s.CoreV1().ServiceAccounts(ns).Create(
 			context.Background(),
 			&v1.ServiceAccount{

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -88,6 +88,7 @@ func TestRun_Defaults(t *testing.T) {
 		clientset: k8s,
 	}
 	args := []string{
+		"-timeout=1m",
 		"-k8s-namespace=" + ns,
 		"-server-address", strings.Split(testSvr.HTTPAddr, ":")[0],
 		"-server-port", strings.Split(testSvr.HTTPAddr, ":")[1],
@@ -233,6 +234,7 @@ func TestRun_TokensPrimaryDC(t *testing.T) {
 			}
 			cmd.init()
 			cmdArgs := append([]string{
+				"-timeout=1m",
 				"-k8s-namespace=" + ns,
 				"-server-address", strings.Split(testSvr.HTTPAddr, ":")[0],
 				"-server-port", strings.Split(testSvr.HTTPAddr, ":")[1],
@@ -389,6 +391,7 @@ func TestRun_TokensReplicatedDC(t *testing.T) {
 			}
 			cmd.init()
 			cmdArgs := append([]string{
+				"-timeout=1m",
 				"-k8s-namespace=" + ns,
 				"-acl-replication-token-file", tokenFile,
 				"-server-address", strings.Split(secondaryAddr, ":")[0],
@@ -516,6 +519,7 @@ func TestRun_TokensWithProvidedBootstrapToken(t *testing.T) {
 				clientset: k8s,
 			}
 			cmdArgs := append([]string{
+				"-timeout=1m",
 				"-k8s-namespace", ns,
 				"-bootstrap-token-file", tokenFile,
 				"-server-address", strings.Split(testAgent.HTTPAddr, ":")[0],
@@ -624,6 +628,7 @@ func TestRun_AnonymousTokenPolicy(t *testing.T) {
 			}
 			cmd.init()
 			cmdArgs := append([]string{
+				"-timeout=1m",
 				"-resource-prefix=" + resourcePrefix,
 				"-k8s-namespace=" + ns,
 				"-server-address", strings.Split(consulHTTPAddr, ":")[0],
@@ -718,6 +723,7 @@ func TestRun_ConnectInjectAuthMethod(t *testing.T) {
 			cmd.init()
 			bindingRuleSelector := "serviceaccount.name!=default"
 			cmdArgs := []string{
+				"-timeout=1m",
 				"-resource-prefix=" + resourcePrefix,
 				"-k8s-namespace=" + ns,
 				"-server-address", strings.Split(testSvr.HTTPAddr, ":")[0],
@@ -788,6 +794,7 @@ func TestRun_ConnectInjectAuthMethodUpdates(t *testing.T) {
 
 	// First, create an auth method using the defaults
 	responseCode := cmd.Run([]string{
+		"-timeout=1m",
 		"-resource-prefix=" + resourcePrefix,
 		"-k8s-namespace=" + ns,
 		"-server-address", strings.Split(testSvr.HTTPAddr, ":")[0],
@@ -830,6 +837,7 @@ func TestRun_ConnectInjectAuthMethodUpdates(t *testing.T) {
 
 	// Run command again
 	responseCode = cmd.Run([]string{
+		"-timeout=1m",
 		"-resource-prefix=" + resourcePrefix,
 		"-k8s-namespace=" + ns,
 		"-server-address", strings.Split(testSvr.HTTPAddr, ":")[0],
@@ -954,6 +962,7 @@ func TestRun_DelayedServers(t *testing.T) {
 	var responseCode int
 	go func() {
 		responseCode = cmd.Run([]string{
+			"-timeout=1m",
 			"-resource-prefix=" + resourcePrefix,
 			"-k8s-namespace=" + ns,
 			"-server-address=127.0.0.1",
@@ -1075,6 +1084,7 @@ func TestRun_NoLeader(t *testing.T) {
 	var responseCode int
 	go func() {
 		responseCode = cmd.Run([]string{
+			"-timeout=1m",
 			"-resource-prefix=" + resourcePrefix,
 			"-k8s-namespace=" + ns,
 			"-server-address=" + serverURL.Hostname(),
@@ -1185,6 +1195,7 @@ func TestRun_ClientTokensRetry(t *testing.T) {
 		clientset: k8s,
 	}
 	responseCode := cmd.Run([]string{
+		"-timeout=1m",
 		"-resource-prefix=" + resourcePrefix,
 		"-k8s-namespace=" + ns,
 		"-server-address=" + serverURL.Hostname(),
@@ -1285,6 +1296,7 @@ func TestRun_AlreadyBootstrapped(t *testing.T) {
 	}
 
 	responseCode := cmd.Run([]string{
+		"-timeout=500ms",
 		"-resource-prefix=" + resourcePrefix,
 		"-k8s-namespace=" + ns,
 		"-server-address=" + serverURL.Hostname(),
@@ -1366,6 +1378,7 @@ func TestRun_SkipBootstrapping_WhenBootstrapTokenIsProvided(t *testing.T) {
 	}
 
 	responseCode := cmd.Run([]string{
+		"-timeout=500ms",
 		"-resource-prefix=" + resourcePrefix,
 		"-k8s-namespace=" + ns,
 		"-server-address=" + serverURL.Hostname(),
@@ -1398,10 +1411,10 @@ func TestRun_Timeout(t *testing.T) {
 	}
 
 	responseCode := cmd.Run([]string{
+		"-timeout=500ms",
 		"-resource-prefix=" + resourcePrefix,
 		"-k8s-namespace=" + ns,
 		"-server-address=foo",
-		"-timeout=500ms",
 	})
 	require.Equal(1, responseCode, ui.ErrorWriter.String())
 }
@@ -1434,6 +1447,7 @@ func TestRun_HTTPS(t *testing.T) {
 	}
 
 	responseCode := cmd.Run([]string{
+		"-timeout=1m",
 		"-resource-prefix=" + resourcePrefix,
 		"-k8s-namespace=" + ns,
 		"-use-https",
@@ -1472,6 +1486,7 @@ func TestRun_ACLReplicationTokenValid(t *testing.T) {
 	}
 	secondaryCmd.init()
 	secondaryCmdArgs := []string{
+		"-timeout=1m",
 		"-k8s-namespace=" + ns,
 		"-server-address", strings.Split(secondaryAddr, ":")[0],
 		"-server-port", strings.Split(secondaryAddr, ":")[1],
@@ -1526,6 +1541,7 @@ func TestRun_AnonPolicy_IgnoredWithReplication(t *testing.T) {
 			}
 			cmd.init()
 			cmdArgs := append([]string{
+				"-timeout=1m",
 				"-k8s-namespace=" + ns,
 				"-acl-replication-token-file", tokenFile,
 				"-server-address", strings.Split(serverAddr, ":")[0],
@@ -1572,6 +1588,7 @@ func TestRun_CloudAutoJoin(t *testing.T) {
 		providers: map[string]discover.Provider{"mock": provider},
 	}
 	args := []string{
+		"-timeout=1m",
 		"-k8s-namespace=" + ns,
 		"-resource-prefix=" + resourcePrefix,
 		"-server-address", "provider=mock",
@@ -1641,6 +1658,7 @@ func TestRun_GatewayErrors(t *testing.T) {
 				clientset: k8s,
 			}
 			cmdArgs := []string{
+				"-timeout=500ms",
 				"-resource-prefix=" + resourcePrefix,
 				"-k8s-namespace=" + ns,
 				"-server-address", strings.Split(testSvr.HTTPAddr, ":")[0],
@@ -1879,6 +1897,9 @@ func setUpK8sServiceAccount(t *testing.T, k8s *fake.Clientset) (string, string) 
 				},
 				Secrets: []v1.ObjectReference{
 					{
+						Name: resourcePrefix + "-some-other-secret",
+					},
+					{
 						Name: resourcePrefix + "-connect-injector-authmethod-svc-account",
 					},
 				},
@@ -1903,8 +1924,26 @@ func setUpK8sServiceAccount(t *testing.T, k8s *fake.Clientset) (string, string) 
 			"ca.crt": caCertBytes,
 			"token":  tokenBytes,
 		},
+		Type: v1.SecretTypeServiceAccountToken,
 	}
-	existingSecret, _ := k8s.CoreV1().Secrets(ns).Get(context.Background(), secretName, metav1.GetOptions{})
+	createOrUpdateSecret(t, k8s, secret)
+
+	// Create the second secret of a different type
+	otherSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resourcePrefix + "-some-other-secret",
+		},
+		Data: map[string][]byte{},
+		Type: v1.SecretTypeDockercfg,
+	}
+	createOrUpdateSecret(t, k8s, otherSecret)
+
+	return string(caCertBytes), string(tokenBytes)
+}
+
+func createOrUpdateSecret(t *testing.T, k8s *fake.Clientset, secret *v1.Secret) {
+	existingSecret, _ := k8s.CoreV1().Secrets(ns).Get(context.Background(), secret.Name, metav1.GetOptions{})
+	var err error
 	if existingSecret == nil {
 		_, err = k8s.CoreV1().Secrets(ns).Create(context.Background(), secret, metav1.CreateOptions{})
 		require.NoError(t, err)
@@ -1912,8 +1951,6 @@ func setUpK8sServiceAccount(t *testing.T, k8s *fake.Clientset) (string, string) 
 		_, err = k8s.CoreV1().Secrets(ns).Update(context.Background(), secret, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	}
-
-	return string(caCertBytes), string(tokenBytes)
 }
 
 // policyExists asserts that policy with name exists. Returns the policy

--- a/subcommand/server-acl-init/connect_inject.go
+++ b/subcommand/server-acl-init/connect_inject.go
@@ -163,7 +163,7 @@ func (c *Command) createAuthMethodTmpl(authMethodName string) (api.ACLAuthMethod
 				secret, err = c.clientset.CoreV1().Secrets(c.flagK8sNamespace).Get(context.TODO(), secretRef.Name, metav1.GetOptions{})
 				return err
 			})
-		if secret.Type == apiv1.SecretTypeServiceAccountToken {
+		if secret != nil && secret.Type == apiv1.SecretTypeServiceAccountToken {
 			saSecret = secret
 			break
 		}
@@ -171,6 +171,8 @@ func (c *Command) createAuthMethodTmpl(authMethodName string) (api.ACLAuthMethod
 	if err != nil {
 		return api.ACLAuthMethod{}, err
 	}
+	// This is very unlikely to happen because Kubernetes ensure that there is always
+	// a secret of type ServiceAccountToken.
 	if saSecret == nil {
 		return api.ACLAuthMethod{},
 			fmt.Errorf("found no secret of type 'kubernetes.io/service-account-token' associated with the %s service account", saName)

--- a/subcommand/server-acl-init/connect_inject_test.go
+++ b/subcommand/server-acl-init/connect_inject_test.go
@@ -1,0 +1,66 @@
+package serveraclinit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// Test that createAuthMethodTmpl returns an error when
+// it cannot find a secret of type kubernetes.io/service-account-token
+// associated with the service account.
+// Note we are only testing this special error case here because we cannot assert on log output
+// from the command.
+// Also note that the remainder of this function is tested in the command_test.go.
+func TestCommand_createAuthMethodTmpl_SecretNotFound(t *testing.T) {
+	k8s := fake.NewSimpleClientset()
+
+	cmd := &Command{
+		flagK8sNamespace:   ns,
+		flagResourcePrefix: resourcePrefix,
+		clientset:          k8s,
+		log:                hclog.New(nil),
+		cmdTimeout:         context.TODO(),
+	}
+
+	serviceAccountName := resourcePrefix + "-connect-injector-authmethod-svc-account"
+	secretName := resourcePrefix + "-connect-injector-authmethod-svc-account"
+
+	// Create a service account referencing secretName
+	sa, _ := k8s.CoreV1().ServiceAccounts(ns).Get(context.Background(), serviceAccountName, metav1.GetOptions{})
+	if sa == nil {
+		_, err := k8s.CoreV1().ServiceAccounts(ns).Create(
+			context.Background(),
+			&v1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: serviceAccountName,
+				},
+				Secrets: []v1.ObjectReference{
+					{
+						Name: secretName,
+					},
+				},
+			},
+			metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	// Create a secret of non service-account-token type (we're using the opaque type).
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: secretName,
+		},
+		Data: map[string][]byte{},
+		Type: v1.SecretTypeOpaque,
+	}
+	_, err := k8s.CoreV1().Secrets(ns).Create(context.TODO(), secret, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = cmd.createAuthMethodTmpl("test")
+	require.EqualError(t, err, "found no secret of type 'kubernetes.io/service-account-token' associated with the release-name-consul-connect-injector-authmethod-svc-account service account")
+}


### PR DESCRIPTION
### Changes proposed in this PR:
Kubernetes service account could have multiple secrets associated with it.
Previously, we were only looking at the first secret in the list and using
that secret to create or update the auth method in Consul.
However, on some platforms the service account may contain other types of secrets.
Specifically, in the case of Openshift, there are two secrets: one for the service account token
and the other for docker config credentials. This second secret gets injected automatically by Openshift.

This PR changes our implementation to use the first secret of type kubernetes.io/service-account-token.

### How I've tested this PR:
Created a docker image (`ishustava/consul-k8s-dev:09-04-2020-5e7491d`) and ran connect acceptance tests with it on openshift.

### How I expect reviewers to test this PR:
No infrastructure tests required from the reviewers at this point. We can rely on helm acceptance tests to make sure we didn't break anything.

### Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
