### PR TITLE
Update ACLs for consul ent and controller

### DIFF
--- a/subcommand/server-acl-init/rules.go
+++ b/subcommand/server-acl-init/rules.go
@@ -7,10 +7,13 @@ import (
 )
 
 type rulesData struct {
-	EnableNamespaces               bool
-	ConsulSyncDestinationNamespace string
-	EnableSyncK8SNSMirroring       bool
-	SyncK8SNSMirroringPrefix       string
+	EnableNamespaces        bool
+	SyncConsulDestNS        string
+	SyncEnableNSMirroring   bool
+	SyncNSMirroringPrefix   string
+	InjectConsulDestNS      string
+	InjectEnableNSMirroring bool
+	InjectNSMirroringPrefix string
 }
 
 type gatewayRulesData struct {
@@ -179,10 +182,10 @@ func (c *Command) syncRules() (string, error) {
   }
 {{- if .EnableNamespaces }}
 operator = "write"
-{{- if .EnableSyncK8SNSMirroring }}
-namespace_prefix "{{ .SyncK8SNSMirroringPrefix }}" {
+{{- if .SyncEnableNSMirroring }}
+namespace_prefix "{{ .SyncNSMirroringPrefix }}" {
 {{- else }}
-namespace "{{ .ConsulSyncDestinationNamespace }}" {
+namespace "{{ .SyncConsulDestNS }}" {
 {{- end }}
 {{- end }}
   node_prefix "" {
@@ -240,26 +243,37 @@ namespace_prefix "" {
 	return c.renderRules(aclReplicationRulesTpl)
 }
 
-// todo: implement namespaces support.
 func (c *Command) controllerRules() (string, error) {
 	controllerRules := `
 operator = "write"
-node_prefix "" {
-  policy = "write"
+{{- if .EnableNamespaces }}
+{{- if .InjectEnableNSMirroring }}
+namespace_prefix "{{ .InjectNSMirroringPrefix }}" {
+{{- else }}
+namespace "{{ .InjectConsulDestNS }}" {
+{{- end }}
+  service_prefix "" {
+    policy = "write"
+  }
 }
+{{- else }}
 service_prefix "" {
   policy = "write"
 }
+{{- end }}
 `
 	return c.renderRules(controllerRules)
 }
 
 func (c *Command) rulesData() rulesData {
 	return rulesData{
-		EnableNamespaces:               c.flagEnableNamespaces,
-		ConsulSyncDestinationNamespace: c.flagConsulSyncDestinationNamespace,
-		EnableSyncK8SNSMirroring:       c.flagEnableSyncK8SNSMirroring,
-		SyncK8SNSMirroringPrefix:       c.flagSyncK8SNSMirroringPrefix,
+		EnableNamespaces:        c.flagEnableNamespaces,
+		SyncConsulDestNS:        c.flagConsulSyncDestinationNamespace,
+		SyncEnableNSMirroring:   c.flagEnableSyncK8SNSMirroring,
+		SyncNSMirroringPrefix:   c.flagSyncK8SNSMirroringPrefix,
+		InjectConsulDestNS:      c.flagConsulInjectDestinationNamespace,
+		InjectEnableNSMirroring: c.flagEnableInjectK8SNSMirroring,
+		InjectNSMirroringPrefix: c.flagInjectK8SNSMirroringPrefix,
 	}
 }
 

--- a/subcommand/server-acl-init/rules.go
+++ b/subcommand/server-acl-init/rules.go
@@ -252,13 +252,11 @@ namespace_prefix "{{ .InjectNSMirroringPrefix }}" {
 {{- else }}
 namespace "{{ .InjectConsulDestNS }}" {
 {{- end }}
+{{- end }}
   service_prefix "" {
     policy = "write"
   }
-}
-{{- else }}
-service_prefix "" {
-  policy = "write"
+{{- if .EnableNamespaces }}
 }
 {{- end }}
 `

--- a/subcommand/server-acl-init/rules_test.go
+++ b/subcommand/server-acl-init/rules_test.go
@@ -513,9 +513,9 @@ func TestControllerRules(t *testing.T) {
 			Name:             "namespaces=disabled",
 			EnableNamespaces: false,
 			Expected: `operator = "write"
-service_prefix "" {
-  policy = "write"
-}`,
+  service_prefix "" {
+    policy = "write"
+  }`,
 		},
 		{
 			Name:             "namespaces=enabled, consulDestNS=consul",

--- a/subcommand/server-acl-init/rules_test.go
+++ b/subcommand/server-acl-init/rules_test.go
@@ -504,28 +504,51 @@ func TestControllerRules(t *testing.T) {
 	cases := []struct {
 		Name             string
 		EnableNamespaces bool
+		DestConsulNS     string
+		Mirroring        bool
+		MirroringPrefix  string
 		Expected         string
 	}{
 		{
-			"Namespaces are disabled",
-			false,
-			`operator = "write"
-node_prefix "" {
-  policy = "write"
-}
+			Name:             "namespaces=disabled",
+			EnableNamespaces: false,
+			Expected: `operator = "write"
 service_prefix "" {
   policy = "write"
 }`,
 		},
 		{
-			"Namespaces are enabled",
-			true,
-			`operator = "write"
-node_prefix "" {
-  policy = "write"
-}
-service_prefix "" {
-  policy = "write"
+			Name:             "namespaces=enabled, consulDestNS=consul",
+			EnableNamespaces: true,
+			DestConsulNS:     "consul",
+			Expected: `operator = "write"
+namespace "consul" {
+  service_prefix "" {
+    policy = "write"
+  }
+}`,
+		},
+		{
+			Name:             "namespaces=enabled, mirroring=true",
+			EnableNamespaces: true,
+			Mirroring:        true,
+			Expected: `operator = "write"
+namespace_prefix "" {
+  service_prefix "" {
+    policy = "write"
+  }
+}`,
+		},
+		{
+			Name:             "namespaces=enabled, mirroring=true, mirroringPrefix=prefix-",
+			EnableNamespaces: true,
+			Mirroring:        true,
+			MirroringPrefix:  "prefix-",
+			Expected: `operator = "write"
+namespace_prefix "prefix-" {
+  service_prefix "" {
+    policy = "write"
+  }
 }`,
 		},
 	}
@@ -535,7 +558,10 @@ service_prefix "" {
 			require := require.New(t)
 
 			cmd := Command{
-				flagEnableNamespaces: tt.EnableNamespaces,
+				flagEnableNamespaces:                 tt.EnableNamespaces,
+				flagConsulInjectDestinationNamespace: tt.DestConsulNS,
+				flagEnableInjectK8SNSMirroring:       tt.Mirroring,
+				flagInjectK8SNSMirroringPrefix:       tt.MirroringPrefix,
 			}
 
 			rules, err := cmd.controllerRules()


### PR DESCRIPTION
Changes proposed in this PR:
- Companion to https://github.com/hashicorp/consul-k8s/pull/323. This updates the ACL token we create to make it work for consul enterprise namespaces.

How I've tested this PR: Ran the acceptance tests from https://github.com/hashicorp/consul-helm/pull/601 which tests with secure installation and a Docker image made with a merge of this branch and https://github.com/hashicorp/consul-k8s/pull/323.

How I expect reviewers to test this PR: You could run the acceptance tests yourselves or review the ones I wrote and see that CI/CD passes for them.

Checklist:
- [x] Tests added
