### PR TITLE
Ensure system recovers quickly from failures or drift in state

### DIFF
--- a/subcommand/webhook-cert-manager/command.go
+++ b/subcommand/webhook-cert-manager/command.go
@@ -187,9 +187,9 @@ func (c *Command) certWatcher(ctx context.Context, ch <-chan cert.MetaBundle, cl
 
 		case <-time.After(defaultRetryDuration):
 			// This forces the mutating ctrlWebhook config to remain updated
-			// fairly quickly. helm upgrades will rewrite the contents of the
+			// fairly quickly. Helm upgrades will rewrite the contents of the
 			// CA bundle which will not be in sync with the certs in the system.
-			// This fast reconcile ensure the system recovers fairly quickly in case
+			// This fast reconcile ensures the system recovers fairly quickly in case
 			// the secret or MWC gets deleted or reset.
 
 		case <-ctx.Done():

--- a/subcommand/webhook-cert-manager/command.go
+++ b/subcommand/webhook-cert-manager/command.go
@@ -290,13 +290,12 @@ func (c *Command) updateWebhookConfig(ctx context.Context, metaBundle cert.MetaB
 }
 
 func (c *Command) webhookUpdated(ctx context.Context, bundle cert.MetaBundle, clientset kubernetes.Interface) bool {
-	value := base64.StdEncoding.EncodeToString(bundle.CACert)
 	webhookCfg, err := clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, bundle.WebhookConfigName, metav1.GetOptions{})
 	if err != nil {
 		return false
 	}
 	for _, webhook := range webhookCfg.Webhooks {
-		if !bytes.Equal(webhook.ClientConfig.CABundle, []byte(value)) {
+		if !bytes.Equal(webhook.ClientConfig.CABundle, bundle.CACert) {
 			return false
 		}
 	}

--- a/subcommand/webhook-cert-manager/command_test.go
+++ b/subcommand/webhook-cert-manager/command_test.go
@@ -369,27 +369,27 @@ func TestCertWatcher(t *testing.T) {
 	defer stopCommand(t, &cmd, exitCh)
 
 	ctx := context.Background()
-	// This first sleep is required to ensure the command had completed validating that the MWC does exist in the cluster
-	// It ensures the MWC is absent when the server actually attempts to update it with a bundle.
-	time.Sleep(1 * time.Millisecond)
-	err = k8s.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(ctx, webhookName, metav1.DeleteOptions{})
-	require.NoError(t, err)
-
-	// This sleep ensures the cluster attempts to try updating the MWC every second and fails before we re-create it in the cluster.
-	time.Sleep(100 * time.Millisecond)
-	_, err = k8s.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(ctx, webhook, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	// If this test passes, it implies that the system has recovered before a new certificate is available
-	// or its default retry timer of 30 minutes has forced the reconcile.
 	timer := &retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}
 	retry.RunWith(timer, t, func(r *retry.R) {
-		webhookConfig1, err := k8s.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, webhookName, metav1.GetOptions{})
+		webhookConfig, err := k8s.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, webhookName, metav1.GetOptions{})
 		require.NoError(r, err)
-		require.NotEqual(r, webhookConfig1.Webhooks[0].ClientConfig.CABundle, "")
+		//Verify that the CA cert has been initally set on the MWC
+		require.True(r, len(webhookConfig.Webhooks[0].ClientConfig.CABundle) > 800)
+	})
+	// Update the CA bundle on the MWC to `""` to replicate a helm upgrade
+	webhook.Webhooks[0].ClientConfig.CABundle = []byte("")
+	_, err = k8s.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Update(ctx, webhook, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// If this test passes, it implies that the system has recovered from the MWC
+	// getting updated to have the correct CA withing a reasonable time window
+	timer = &retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}
+	retry.RunWith(timer, t, func(r *retry.R) {
+		webhookConfig, err := k8s.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, webhookName, metav1.GetOptions{})
+		require.NoError(r, err)
 		// This verifies that the MWC is populated with a valid certificate which has a
-		// a len of 800 chars. But the length is not deterministic because it is encoded.
-		require.True(r, len(webhookConfig1.Webhooks[0].ClientConfig.CABundle) > 800)
+		// a len of at least 800 chars. But the length is not deterministic because it is encoded.
+		require.True(r, len(webhookConfig.Webhooks[0].ClientConfig.CABundle) > 800)
 	})
 }
 

--- a/subcommand/webhook-cert-manager/command_test.go
+++ b/subcommand/webhook-cert-manager/command_test.go
@@ -382,7 +382,7 @@ func TestCertWatcher(t *testing.T) {
 	require.NoError(t, err)
 
 	// If this test passes, it implies that the system has recovered from the MWC
-	// getting updated to have the correct CA withing a reasonable time window
+	// getting updated to have the correct CA within a reasonable time window
 	timer = &retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}
 	retry.RunWith(timer, t, func(r *retry.R) {
 		webhookConfig, err := k8s.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, webhookName, metav1.GetOptions{})

--- a/subcommand/webhook-cert-manager/mocks/mocks.go
+++ b/subcommand/webhook-cert-manager/mocks/mocks.go
@@ -1,0 +1,23 @@
+package mocks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/consul-k8s/helper/cert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockCertSource struct {
+	mock.Mock
+}
+
+func (m *MockCertSource) Certificate(_ context.Context, _ *cert.Bundle) (cert.Bundle, error) {
+	result := cert.Bundle{
+		Cert:   []byte(fmt.Sprintf("certificate-string-%d", time.Now().Unix())),
+		Key:    []byte(fmt.Sprintf("private-key-string-%d", time.Now().Unix())),
+		CACert: []byte(fmt.Sprintf("ca-certificate-string-%d", time.Now().Unix())),
+	}
+	return result, nil
+}


### PR DESCRIPTION
Changes proposed in this PR:
- helm upgrades will cause the caBundle to get reset on the mutating webhooks. By "reconciling" the state of the system every second, we ensure the drift in this state has a minimal impact on the uptime of the system. it will now verify that the certificates as well as the CA bundle are "correct" every second and update them if they arent.

- this will also ensure any edits made to the secret or the webhook configuration, which could lead to downtime in the system, are recovered from within a second.

How I've tested this PR:
- helm installed consul with the image.
- performed a helm upgrade once the system had reached a stable state.
- attempted the creation of a service default and it did not throw an x509 error.

How I expect reviewers to test this PR:
- `kubectl edit` the secret with the certificate and/or the MWC for the webhook certs. The system should recover within a few seconds and the webhook and the webhook configuration should be able to communicate with each other successfully.

Image for testing: 
`ashwinvenkatesh/consul-k8s:webhook-certs@sha256:25b85fd6ccbe7e141cd1541264c40cb15f28c1ba815a4df58c6a3949b583e91f`

Checklist:
- [x] Tests added