### PR TITLE
Implement webhook support for consul ent

### DIFF
--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -146,9 +146,21 @@ func (c *Command) Run(args []string) int {
 		// Note: The path here should be identical to the one on the kubebuilder
 		// annotation in each webhook file.
 		mgr.GetWebhookServer().Register("/mutate-v1alpha1-servicedefaults",
-			&webhook.Admission{Handler: v1alpha1.NewServiceDefaultsValidator(mgr.GetClient(), consulClient, ctrl.Log.WithName("webhooks").WithName("ServiceDefaults"))})
+			&webhook.Admission{Handler: &v1alpha1.ServiceDefaultsValidator{
+				Client:                 mgr.GetClient(),
+				ConsulClient:           consulClient,
+				Logger:                 ctrl.Log.WithName("webhooks").WithName("servicedefaults"),
+				EnableConsulNamespaces: c.flagEnableNamespaces,
+				EnableNSMirroring:      c.flagEnableNSMirroring,
+			}})
 		mgr.GetWebhookServer().Register("/mutate-v1alpha1-serviceresolver",
-			&webhook.Admission{Handler: v1alpha1.NewServiceResolverValidator(mgr.GetClient(), consulClient, ctrl.Log.WithName("webhooks").WithName("ServiceResolver"))})
+			&webhook.Admission{Handler: &v1alpha1.ServiceResolverValidator{
+				Client:                 mgr.GetClient(),
+				ConsulClient:           consulClient,
+				Logger:                 ctrl.Log.WithName("webhooks").WithName("serviceresolver"),
+				EnableConsulNamespaces: c.flagEnableNamespaces,
+				EnableNSMirroring:      c.flagEnableNSMirroring,
+			}})
 	}
 	// +kubebuilder:scaffold:builder
 


### PR DESCRIPTION
- if running ent and namespace mirroring is enabled then allow multiple
resources with the same name across namespaces.
- make Validator structs public and remove constructors

How I've tested this PR:
- I haven't

Checklist:
- [x] Tests added

Not sure if we should make this a struct like we did for `ConfigEntryController` and set the EnableNamespaces and EnableNSMirroring as fields.
