### PR TITLE
Pass down path through validators

### DIFF
--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -1,7 +1,6 @@
 package v1alpha1
 
 import (
-	"fmt"
 	"reflect"
 	"sort"
 	"time"
@@ -112,6 +111,7 @@ func (in *ServiceResolver) MatchesConsul(candidate capi.ConfigEntry) bool {
 
 func (in *ServiceResolver) Validate() error {
 	var errs field.ErrorList
+	path := field.NewPath("spec")
 
 	// Iterate through failover map keys in sorted order so tests are
 	// deterministic.
@@ -122,7 +122,7 @@ func (in *ServiceResolver) Validate() error {
 	sort.Strings(keys)
 	for _, k := range keys {
 		f := in.Spec.Failover[k]
-		if err := f.validate(k); err != nil {
+		if err := f.validate(path.Child("failover").Key(k)); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -132,9 +132,8 @@ func (in *ServiceResolver) Validate() error {
 		in.Name(), errs)
 }
 
-func (in *ServiceResolverFailover) validate(key string) *field.Error {
+func (in *ServiceResolverFailover) validate(path *field.Path) *field.Error {
 	if in.Service == "" && in.ServiceSubset == "" && in.Namespace == "" && len(in.Datacenters) == 0 {
-		path := field.NewPath("spec").Child(fmt.Sprintf("failover[%s]", key))
 		// NOTE: We're passing "{}" here as our value because we know that the
 		// error is we have an empty object.
 		return field.Invalid(path, "{}",

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -52,10 +52,10 @@ func (m MeshGatewayConfig) toConsul() capi.MeshGatewayConfig {
 	}
 }
 
-func (m MeshGatewayConfig) validate() *field.Error {
+func (m MeshGatewayConfig) validate(path *field.Path) *field.Error {
 	modes := []string{"remote", "local", "none", ""}
 	if !sliceContains(modes, m.Mode) {
-		return field.Invalid(field.NewPath("spec").Child("meshGateway").Child("mode"), m.Mode, notInSliceMessage(modes))
+		return field.Invalid(path.Child("mode"), m.Mode, notInSliceMessage(modes))
 	}
 	return nil
 }


### PR DESCRIPTION
- Pass the path down to the validation methods so they don't need to know
where in the struct they are placed.
- Also use .Index() and .Key() instead of fmt.Sprintf to indicate where
in a slice/map we are.
