### PR TITLE
fix connect-inject handler tests

### DIFF
--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -361,7 +361,9 @@ func (h *Handler) Mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespon
 	// Add Pod label for health checks
 	patches = append(patches, updateLabels(
 		pod.Labels,
-		map[string]string{labelInject: "true"})...)
+		map[string]string{
+			labelInject: "injected",
+		})...)
 
 	// Generate the patch
 	var patch []byte

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -109,6 +109,10 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationStatus),
 				},
+				{
+					Operation: "add",
+					Path:      "/metadata/labels",
+				},
 			},
 		},
 
@@ -122,6 +126,9 @@ func TestHandlerHandle(t *testing.T) {
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"testLabel": "123",
+						},
 						Annotations: map[string]string{
 							annotationUpstreams: "echo:1234,db:1234",
 						},
@@ -171,6 +178,10 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationStatus),
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/labels/" + escapeJSONPointer(labelInject),
 				},
 			},
 		},
@@ -241,6 +252,10 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationStatus),
 				},
+				{
+					Operation: "add",
+					Path:      "/metadata/labels",
+				},
 			},
 		},
 
@@ -285,6 +300,10 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationStatus),
 				},
+				{
+					Operation: "add",
+					Path:      "/metadata/labels",
+				},
 			},
 		},
 
@@ -328,6 +347,10 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationStatus),
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/labels",
 				},
 			},
 		},
@@ -375,6 +398,10 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationStatus),
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/labels",
 				},
 			},
 		},


### PR DESCRIPTION
This is the first of a few PRs that fix consul-k8s tests

How I've tested this PR:
run connect-inject/handler_test.go

How I expect reviewers to test this PR:
run connect-inject/handler_test.go


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
