### PR TITLE
Replace reflect.DeepEqual with gocmp.Equal

### DIFF
--- a/api/v1alpha1/proxydefaults_types.go
+++ b/api/v1alpha1/proxydefaults_types.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/consul/api"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
@@ -123,15 +125,16 @@ func (in *ProxyDefaults) ToConsul() api.ConfigEntry {
 }
 
 func (in *ProxyDefaults) MatchesConsul(candidate api.ConfigEntry) bool {
-	proxyDefCand, ok := candidate.(*capi.ProxyConfigEntry)
+	configEntry, ok := candidate.(*capi.ProxyConfigEntry)
 	if !ok {
 		return false
 	}
-	proxyDefCand.Namespace = ""
-	proxyDefCand.CreateIndex = 0
-	proxyDefCand.ModifyIndex = 0
+	// Zero out fields from consul that we don't want to compare on.
+	configEntry.Namespace = ""
+	configEntry.CreateIndex = 0
+	configEntry.ModifyIndex = 0
 
-	return reflect.DeepEqual(in.ToConsul(), proxyDefCand)
+	return cmp.Equal(in.ToConsul(), configEntry, cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
 }
 
 func (in *ProxyDefaults) Validate() error {

--- a/api/v1alpha1/proxydefaults_types.go
+++ b/api/v1alpha1/proxydefaults_types.go
@@ -156,19 +156,6 @@ func (in *ProxyDefaults) Validate() error {
 	return nil
 }
 
-// matchesConfig compares the values of the config on the spec and that on the
-// the consul proxy-default and returns true if they match and false otherwise.
-func (in *ProxyDefaults) matchesConfig(config map[string]interface{}) bool {
-	if in.Spec.Config == nil || config == nil {
-		return in.Spec.Config == nil && config == nil
-	}
-	var inConfig map[string]interface{}
-	if err := json.Unmarshal(in.Spec.Config, &inConfig); err != nil {
-		return false
-	}
-	return cmp.Equal(inConfig, config)
-}
-
 // convertConfig converts the config of type json.RawMessage which is stored
 // by the resource into type map[string]interface{} which is saved by the
 // consul API.

--- a/api/v1alpha1/proxydefaults_types.go
+++ b/api/v1alpha1/proxydefaults_types.go
@@ -128,12 +128,7 @@ func (in *ProxyDefaults) MatchesConsul(candidate api.ConfigEntry) bool {
 	if !ok {
 		return false
 	}
-	// Zero out fields from consul that we don't want to compare on.
-	configEntry.Namespace = ""
-	configEntry.CreateIndex = 0
-	configEntry.ModifyIndex = 0
-
-	return cmp.Equal(in.ToConsul(), configEntry, cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
+	return cmp.Equal(in.ToConsul(), configEntry, cmpopts.IgnoreFields(capi.ProxyConfigEntry{}, "Namespace", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
 }
 
 func (in *ProxyDefaults) Validate() error {

--- a/api/v1alpha1/proxydefaults_types.go
+++ b/api/v1alpha1/proxydefaults_types.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -167,7 +166,7 @@ func (in *ProxyDefaults) matchesConfig(config map[string]interface{}) bool {
 	if err := json.Unmarshal(in.Spec.Config, &inConfig); err != nil {
 		return false
 	}
-	return reflect.DeepEqual(inConfig, config)
+	return cmp.Equal(inConfig, config)
 }
 
 // convertConfig converts the config of type json.RawMessage which is stored

--- a/api/v1alpha1/proxydefaults_types_test.go
+++ b/api/v1alpha1/proxydefaults_types_test.go
@@ -15,10 +15,11 @@ import (
 // Test MatchesConsul for cases that should return true.
 func TestProxyDefaults_MatchesConsul(t *testing.T) {
 	cases := map[string]struct {
-		Ours   ProxyDefaults
-		Theirs *capi.ProxyConfigEntry
+		Ours    ProxyDefaults
+		Theirs  capi.ConfigEntry
+		Matches bool
 	}{
-		"empty fields": {
+		"empty fields matches": {
 			Ours: ProxyDefaults{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: common.Global,
@@ -26,11 +27,15 @@ func TestProxyDefaults_MatchesConsul(t *testing.T) {
 				Spec: ProxyDefaultsSpec{},
 			},
 			Theirs: &capi.ProxyConfigEntry{
-				Name: common.Global,
-				Kind: capi.ProxyDefaults,
+				Name:        common.Global,
+				Kind:        capi.ProxyDefaults,
+				Namespace:   "default",
+				CreateIndex: 1,
+				ModifyIndex: 2,
 			},
+			Matches: true,
 		},
-		"all fields set": {
+		"all fields set matches": {
 			Ours: ProxyDefaults{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: common.Global,
@@ -86,11 +91,25 @@ func TestProxyDefaults_MatchesConsul(t *testing.T) {
 					},
 				},
 			},
+			Matches: true,
+		},
+		"mismatched types does not match": {
+			Ours: ProxyDefaults{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: common.Global,
+				},
+				Spec: ProxyDefaultsSpec{},
+			},
+			Theirs: &capi.ServiceConfigEntry{
+				Name: common.Global,
+				Kind: capi.ProxyDefaults,
+			},
+			Matches: false,
 		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			require.True(t, c.Ours.MatchesConsul(c.Theirs))
+			require.Equal(t, c.Ours.MatchesConsul(c.Theirs), c.Matches)
 		})
 	}
 }

--- a/api/v1alpha1/proxydefaults_types_test.go
+++ b/api/v1alpha1/proxydefaults_types_test.go
@@ -109,7 +109,7 @@ func TestProxyDefaults_MatchesConsul(t *testing.T) {
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, c.Ours.MatchesConsul(c.Theirs), c.Matches)
+			require.Equal(t, c.Matches, c.Ours.MatchesConsul(c.Theirs))
 		})
 	}
 }

--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -159,12 +159,7 @@ func (in *ServiceDefaults) MatchesConsul(candidate capi.ConfigEntry) bool {
 	if !ok {
 		return false
 	}
-	// Zero out fields from consul that we don't want to compare on.
-	configEntry.Namespace = ""
-	configEntry.CreateIndex = 0
-	configEntry.ModifyIndex = 0
-
-	return cmp.Equal(in.ToConsul(), configEntry, cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
+	return cmp.Equal(in.ToConsul(), configEntry, cmpopts.IgnoreFields(capi.ServiceConfigEntry{}, "Namespace", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
 }
 
 // ExposeConfig describes HTTP paths to expose through Envoy outside of Connect.

--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -193,35 +193,6 @@ type ExposePath struct {
 	Protocol string `json:"protocol,omitempty"`
 }
 
-// matches returns true if the expose config of the entry is the same as the struct
-func (e ExposeConfig) matches(expose capi.ExposeConfig) bool {
-	if e.Checks != expose.Checks {
-		return false
-	}
-
-	if len(e.Paths) != len(expose.Paths) {
-		return false
-	}
-
-	for _, path := range e.Paths {
-		found := false
-		for _, entryPath := range expose.Paths {
-			if path.Protocol == entryPath.Protocol &&
-				path.Path == entryPath.Path &&
-				path.ListenerPort == entryPath.ListenerPort &&
-				path.LocalPathPort == entryPath.LocalPathPort {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			return false
-		}
-	}
-	return true
-}
-
 // toConsul returns the ExposeConfig for the entry
 func (e ExposeConfig) toConsul() capi.ExposeConfig {
 	var paths []capi.ExposePath

--- a/api/v1alpha1/servicedefaults_types_test.go
+++ b/api/v1alpha1/servicedefaults_types_test.go
@@ -384,7 +384,7 @@ func TestServiceDefaults_MatchesConsul(t *testing.T) {
 
 	for name, testCase := range cases {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, testCase.internal.MatchesConsul(testCase.consul), testCase.matches)
+			require.Equal(t, testCase.matches, testCase.internal.MatchesConsul(testCase.consul))
 		})
 	}
 }

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -109,16 +111,16 @@ func (in *ServiceResolver) ToConsul() capi.ConfigEntry {
 }
 
 func (in *ServiceResolver) MatchesConsul(candidate capi.ConfigEntry) bool {
-	serviceResolverCandidate, ok := candidate.(*capi.ServiceResolverConfigEntry)
+	configEntry, ok := candidate.(*capi.ServiceResolverConfigEntry)
 	if !ok {
 		return false
 	}
 	// Zero out fields from consul that we don't want to compare on.
-	serviceResolverCandidate.Namespace = ""
-	serviceResolverCandidate.ModifyIndex = 0
-	serviceResolverCandidate.CreateIndex = 0
+	configEntry.Namespace = ""
+	configEntry.ModifyIndex = 0
+	configEntry.CreateIndex = 0
 
-	return reflect.DeepEqual(in.ToConsul(), serviceResolverCandidate)
+	return cmp.Equal(in.ToConsul(), configEntry, cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
 }
 
 func (in *ServiceResolver) Validate() error {

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -2,7 +2,6 @@ package v1alpha1
 
 import (
 	"encoding/json"
-	"reflect"
 	"sort"
 	"time"
 
@@ -466,7 +465,7 @@ func (in ServiceResolverFailover) matchesConsul(candidate capi.ServiceResolverFa
 	return in.Service == candidate.Service &&
 		in.ServiceSubset == candidate.ServiceSubset &&
 		in.Namespace == candidate.Namespace &&
-		reflect.DeepEqual(in.Datacenters, candidate.Datacenters)
+		cmp.Equal(in.Datacenters, candidate.Datacenters)
 }
 
 func (in *LoadBalancer) toConsul() *capi.LoadBalancer {

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -114,12 +114,7 @@ func (in *ServiceResolver) MatchesConsul(candidate capi.ConfigEntry) bool {
 	if !ok {
 		return false
 	}
-	// Zero out fields from consul that we don't want to compare on.
-	configEntry.Namespace = ""
-	configEntry.ModifyIndex = 0
-	configEntry.CreateIndex = 0
-
-	return cmp.Equal(in.ToConsul(), configEntry, cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
+	return cmp.Equal(in.ToConsul(), configEntry, cmpopts.IgnoreFields(capi.ServiceResolverConfigEntry{}, "Namespace", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
 }
 
 func (in *ServiceResolver) Validate() error {

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -373,32 +373,11 @@ func (in ServiceResolverSubsetMap) toConsul() map[string]capi.ServiceResolverSub
 	return m
 }
 
-func (in ServiceResolverSubsetMap) matchesConsul(candidate map[string]capi.ServiceResolverSubset) bool {
-	if len(in) != len(candidate) {
-		return false
-	}
-
-	for thisKey, thisVal := range in {
-		candidateVal, ok := candidate[thisKey]
-		if !ok {
-			return false
-		}
-		if !thisVal.matchesConsul(candidateVal) {
-			return false
-		}
-	}
-	return true
-}
-
 func (in ServiceResolverSubset) toConsul() capi.ServiceResolverSubset {
 	return capi.ServiceResolverSubset{
 		Filter:      in.Filter,
 		OnlyPassing: in.OnlyPassing,
 	}
-}
-
-func (in ServiceResolverSubset) matchesConsul(candidate capi.ServiceResolverSubset) bool {
-	return in.OnlyPassing == candidate.OnlyPassing && in.Filter == candidate.Filter
 }
 
 func (in *ServiceResolverRedirect) toConsul() *capi.ServiceResolverRedirect {
@@ -413,16 +392,6 @@ func (in *ServiceResolverRedirect) toConsul() *capi.ServiceResolverRedirect {
 	}
 }
 
-func (in *ServiceResolverRedirect) matchesConsul(candidate *capi.ServiceResolverRedirect) bool {
-	if in == nil || candidate == nil {
-		return in == nil && candidate == nil
-	}
-	return in.Service == candidate.Service &&
-		in.ServiceSubset == candidate.ServiceSubset &&
-		in.Namespace == candidate.Namespace &&
-		in.Datacenter == candidate.Datacenter
-}
-
 func (in ServiceResolverFailoverMap) toConsul() map[string]capi.ServiceResolverFailover {
 	if in == nil {
 		return nil
@@ -434,24 +403,6 @@ func (in ServiceResolverFailoverMap) toConsul() map[string]capi.ServiceResolverF
 	return m
 }
 
-func (in ServiceResolverFailoverMap) matchesConsul(candidate map[string]capi.ServiceResolverFailover) bool {
-	if len(in) != len(candidate) {
-		return false
-	}
-
-	for thisKey, thisVal := range in {
-		candidateVal, ok := candidate[thisKey]
-		if !ok {
-			return false
-		}
-
-		if !thisVal.matchesConsul(candidateVal) {
-			return false
-		}
-	}
-	return true
-}
-
 func (in ServiceResolverFailover) toConsul() capi.ServiceResolverFailover {
 	return capi.ServiceResolverFailover{
 		Service:       in.Service,
@@ -459,13 +410,6 @@ func (in ServiceResolverFailover) toConsul() capi.ServiceResolverFailover {
 		Namespace:     in.Namespace,
 		Datacenters:   in.Datacenters,
 	}
-}
-
-func (in ServiceResolverFailover) matchesConsul(candidate capi.ServiceResolverFailover) bool {
-	return in.Service == candidate.Service &&
-		in.ServiceSubset == candidate.ServiceSubset &&
-		in.Namespace == candidate.Namespace &&
-		cmp.Equal(in.Datacenters, candidate.Datacenters)
 }
 
 func (in *LoadBalancer) toConsul() *capi.LoadBalancer {

--- a/api/v1alpha1/serviceresolver_types_test.go
+++ b/api/v1alpha1/serviceresolver_types_test.go
@@ -175,7 +175,7 @@ func TestServiceResolver_MatchesConsul(t *testing.T) {
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, c.Ours.MatchesConsul(c.Theirs), c.Matches)
+			require.Equal(t, c.Matches, c.Ours.MatchesConsul(c.Theirs))
 		})
 	}
 }

--- a/api/v1alpha1/serviceresolver_types_test.go
+++ b/api/v1alpha1/serviceresolver_types_test.go
@@ -12,10 +12,11 @@ import (
 
 func TestServiceResolver_MatchesConsul(t *testing.T) {
 	cases := map[string]struct {
-		Ours   ServiceResolver
-		Theirs *capi.ServiceResolverConfigEntry
+		Ours    ServiceResolver
+		Theirs  capi.ConfigEntry
+		Matches bool
 	}{
-		"empty fields": {
+		"empty fields matches": {
 			Ours: ServiceResolver{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "name",
@@ -23,11 +24,15 @@ func TestServiceResolver_MatchesConsul(t *testing.T) {
 				Spec: ServiceResolverSpec{},
 			},
 			Theirs: &capi.ServiceResolverConfigEntry{
-				Name: "name",
-				Kind: capi.ServiceResolver,
+				Name:        "name",
+				Kind:        capi.ServiceResolver,
+				Namespace:   "foobar",
+				CreateIndex: 1,
+				ModifyIndex: 2,
 			},
+			Matches: true,
 		},
-		"all fields set": {
+		"all fields set matches": {
 			Ours: ServiceResolver{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "name",
@@ -149,11 +154,28 @@ func TestServiceResolver_MatchesConsul(t *testing.T) {
 					},
 				},
 			},
+			Matches: true,
+		},
+		"different types does not match": {
+			Ours: ServiceResolver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+				},
+				Spec: ServiceResolverSpec{},
+			},
+			Theirs: &capi.ProxyConfigEntry{
+				Name:        "name",
+				Kind:        capi.ServiceResolver,
+				Namespace:   "foobar",
+				CreateIndex: 1,
+				ModifyIndex: 2,
+			},
+			Matches: false,
 		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			require.True(t, c.Ours.MatchesConsul(c.Theirs))
+			require.Equal(t, c.Ours.MatchesConsul(c.Theirs), c.Matches)
 		})
 	}
 }

--- a/api/v1alpha1/servicerouter_types.go
+++ b/api/v1alpha1/servicerouter_types.go
@@ -362,12 +362,7 @@ func (in *ServiceRouter) MatchesConsul(candidate capi.ConfigEntry) bool {
 	if !ok {
 		return false
 	}
-	// Zero out fields from consul that we don't want to compare on.
-	configEntry.Namespace = ""
-	configEntry.ModifyIndex = 0
-	configEntry.CreateIndex = 0
-
-	return cmp.Equal(in.ToConsul(), configEntry, cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
+	return cmp.Equal(in.ToConsul(), configEntry, cmpopts.IgnoreFields(capi.ServiceRouterConfigEntry{}, "Namespace", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
 }
 
 func (in *ServiceRouter) Validate() error {

--- a/api/v1alpha1/servicerouter_types.go
+++ b/api/v1alpha1/servicerouter_types.go
@@ -2,9 +2,10 @@ package v1alpha1
 
 import (
 	"encoding/json"
-	"reflect"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -365,7 +366,8 @@ func (in *ServiceRouter) MatchesConsul(candidate capi.ConfigEntry) bool {
 	configEntry.Namespace = ""
 	configEntry.ModifyIndex = 0
 	configEntry.CreateIndex = 0
-	return reflect.DeepEqual(in.ToConsul(), configEntry)
+
+	return cmp.Equal(in.ToConsul(), configEntry, cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
 }
 
 func (in *ServiceRouter) Validate() error {

--- a/api/v1alpha1/servicerouter_types_test.go
+++ b/api/v1alpha1/servicerouter_types_test.go
@@ -148,7 +148,7 @@ func TestServiceRouter_MatchesConsul(t *testing.T) {
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, c.Ours.MatchesConsul(c.Theirs), c.Matches)
+			require.Equal(t, c.Matches, c.Ours.MatchesConsul(c.Theirs))
 		})
 	}
 }

--- a/api/v1alpha1/servicerouter_types_test.go
+++ b/api/v1alpha1/servicerouter_types_test.go
@@ -10,13 +10,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Test MatchesConsul for cases that should return true.
-func TestServiceRouter_MatchesConsulTrue(t *testing.T) {
+// Test MatchesConsul.
+func TestServiceRouter_MatchesConsul(t *testing.T) {
 	cases := map[string]struct {
-		Ours   ServiceRouter
-		Theirs *capi.ServiceRouterConfigEntry
+		Ours    ServiceRouter
+		Theirs  capi.ConfigEntry
+		Matches bool
 	}{
-		"empty fields": {
+		"empty fields matches": {
 			Ours: ServiceRouter{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "name",
@@ -30,8 +31,9 @@ func TestServiceRouter_MatchesConsulTrue(t *testing.T) {
 				CreateIndex: 1,
 				ModifyIndex: 2,
 			},
+			Matches: true,
 		},
-		"all fields set": {
+		"all fields set matches": {
 			Ours: ServiceRouter{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "name",
@@ -125,49 +127,28 @@ func TestServiceRouter_MatchesConsulTrue(t *testing.T) {
 					},
 				},
 			},
+			Matches: true,
 		},
-	}
-	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
-			require.True(t, c.Ours.MatchesConsul(c.Theirs))
-		})
-	}
-}
-
-// Test MatchesConsul for cases that should return false.
-func TestServiceRouter_MatchesConsulFalse(t *testing.T) {
-	cases := map[string]struct {
-		Ours   ServiceRouter
-		Theirs capi.ConfigEntry
-	}{
-		"different type": {
+		"mismatched type does not match": {
 			Ours: ServiceRouter{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "name",
 				},
 				Spec: ServiceRouterSpec{},
 			},
-			Theirs: &capi.ServiceConfigEntry{
-				Name: "name",
-				Kind: capi.ServiceRouter,
+			Theirs: &capi.ProxyConfigEntry{
+				Kind:        capi.ServiceRouter,
+				Name:        "name",
+				Namespace:   "namespace",
+				CreateIndex: 1,
+				ModifyIndex: 2,
 			},
-		},
-		"different name": {
-			Ours: ServiceRouter{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "name",
-				},
-				Spec: ServiceRouterSpec{},
-			},
-			Theirs: &capi.ServiceRouterConfigEntry{
-				Name: "other_name",
-				Kind: capi.ServiceRouter,
-			},
+			Matches: false,
 		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			require.False(t, c.Ours.MatchesConsul(c.Theirs))
+			require.Equal(t, c.Ours.MatchesConsul(c.Theirs), c.Matches)
 		})
 	}
 }

--- a/api/v1alpha1/servicesplitter_types.go
+++ b/api/v1alpha1/servicesplitter_types.go
@@ -3,8 +3,9 @@ package v1alpha1
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/consul-k8s/api/common"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
@@ -137,11 +138,12 @@ func (in *ServiceSplitter) MatchesConsul(candidate capi.ConfigEntry) bool {
 	if !ok {
 		return false
 	}
+	// Zero out fields from consul that we don't want to compare on.
 	serviceSplitterCandidate.Namespace = ""
 	serviceSplitterCandidate.CreateIndex = 0
 	serviceSplitterCandidate.ModifyIndex = 0
 
-	return reflect.DeepEqual(in.ToConsul(), candidate)
+	return cmp.Equal(in.ToConsul(), candidate, cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
 }
 
 func (in *ServiceSplitter) Validate() error {

--- a/api/v1alpha1/servicesplitter_types.go
+++ b/api/v1alpha1/servicesplitter_types.go
@@ -134,16 +134,16 @@ func (in *ServiceSplitter) ToConsul() capi.ConfigEntry {
 }
 
 func (in *ServiceSplitter) MatchesConsul(candidate capi.ConfigEntry) bool {
-	serviceSplitterCandidate, ok := candidate.(*capi.ServiceSplitterConfigEntry)
+	configEntry, ok := candidate.(*capi.ServiceSplitterConfigEntry)
 	if !ok {
 		return false
 	}
 	// Zero out fields from consul that we don't want to compare on.
-	serviceSplitterCandidate.Namespace = ""
-	serviceSplitterCandidate.CreateIndex = 0
-	serviceSplitterCandidate.ModifyIndex = 0
+	configEntry.Namespace = ""
+	configEntry.CreateIndex = 0
+	configEntry.ModifyIndex = 0
 
-	return cmp.Equal(in.ToConsul(), candidate, cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
+	return cmp.Equal(in.ToConsul(), configEntry, cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
 }
 
 func (in *ServiceSplitter) Validate() error {

--- a/api/v1alpha1/servicesplitter_types.go
+++ b/api/v1alpha1/servicesplitter_types.go
@@ -138,12 +138,7 @@ func (in *ServiceSplitter) MatchesConsul(candidate capi.ConfigEntry) bool {
 	if !ok {
 		return false
 	}
-	// Zero out fields from consul that we don't want to compare on.
-	configEntry.Namespace = ""
-	configEntry.CreateIndex = 0
-	configEntry.ModifyIndex = 0
-
-	return cmp.Equal(in.ToConsul(), configEntry, cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
+	return cmp.Equal(in.ToConsul(), configEntry, cmpopts.IgnoreFields(capi.ServiceSplitterConfigEntry{}, "Namespace", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
 }
 
 func (in *ServiceSplitter) Validate() error {

--- a/api/v1alpha1/servicesplitter_types_test.go
+++ b/api/v1alpha1/servicesplitter_types_test.go
@@ -81,7 +81,7 @@ func TestServiceSplitter_MatchesConsul(t *testing.T) {
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, c.Ours.MatchesConsul(c.Theirs), c.Matches)
+			require.Equal(t, c.Matches, c.Ours.MatchesConsul(c.Theirs))
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/deckarep/golang-set v1.7.1
 	github.com/digitalocean/godo v1.10.0 // indirect
 	github.com/go-logr/logr v0.1.0
+	github.com/google/go-cmp v0.4.0
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/consul/api v1.4.1-0.20200924193849-85d223b73c1d
 	github.com/hashicorp/consul/sdk v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -773,6 +773,7 @@ gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/main.go
+++ b/main.go
@@ -4,8 +4,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/hashicorp/consul-k8s/version"
 	"github.com/mitchellh/cli"
+
+	"github.com/hashicorp/consul-k8s/version"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -4,9 +4,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/mitchellh/cli"
-
 	"github.com/hashicorp/consul-k8s/version"
+	"github.com/mitchellh/cli"
 )
 
 func main() {


### PR DESCRIPTION
- go-cmp has a more robust library for compares as it allows ignoring
  unexported fields.
- Refactored the MatchesConsul tests for serviceDefaults to resemble other MatchesConsul tests

How I've tested this PR:
- existing tests for MatchesConsul continue to pass.

How I expect reviewers to test this PR:
- this is a refactor so existing tests passing should imply it was successful.

