### PR TITLE
Use metadata field from configEntry

### DIFF
--- a/api/common/common.go
+++ b/api/common/common.go
@@ -10,4 +10,8 @@ const (
 
 	Global                 string = "global"
 	DefaultConsulNamespace string = "default"
+
+	SourceKey     string = "external-source"
+	DatacenterKey string = "consul.hashicorp.com/source-datacenter"
+	SourceValue   string = "kubernetes"
 )

--- a/api/common/configentry.go
+++ b/api/common/configentry.go
@@ -40,7 +40,7 @@ type ConfigEntryResource interface {
 	// ToConsul converts the resource to the corresponding Consul API definition.
 	// Its return type is the generic ConfigEntry but a specific config entry
 	// type should be constructed e.g. ServiceConfigEntry.
-	ToConsul() api.ConfigEntry
+	ToConsul(datacenter string) api.ConfigEntry
 	// MatchesConsul returns true if the resource has the same fields as the Consul
 	// config entry.
 	MatchesConsul(candidate api.ConfigEntry) bool

--- a/api/common/configentry_webhook_test.go
+++ b/api/common/configentry_webhook_test.go
@@ -181,7 +181,7 @@ func (in *mockConfigEntry) SyncedConditionStatus() corev1.ConditionStatus {
 	return corev1.ConditionTrue
 }
 
-func (in *mockConfigEntry) ToConsul() capi.ConfigEntry {
+func (in *mockConfigEntry) ToConsul(string) capi.ConfigEntry {
 	return &capi.ServiceConfigEntry{}
 }
 

--- a/api/v1alpha1/proxydefaults_types.go
+++ b/api/v1alpha1/proxydefaults_types.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/consul-k8s/api/common"
 	"github.com/hashicorp/consul/api"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
@@ -121,10 +120,7 @@ func (in *ProxyDefaults) ToConsul(datacenter string) capi.ConfigEntry {
 		MeshGateway: in.Spec.MeshGateway.toConsul(),
 		Expose:      in.Spec.Expose.toConsul(),
 		Config:      consulConfig,
-		Meta: map[string]string{
-			common.SourceKey:     common.SourceValue,
-			common.DatacenterKey: datacenter,
-		},
+		Meta:        getMeta(datacenter),
 	}
 }
 

--- a/api/v1alpha1/proxydefaults_types.go
+++ b/api/v1alpha1/proxydefaults_types.go
@@ -120,7 +120,7 @@ func (in *ProxyDefaults) ToConsul(datacenter string) capi.ConfigEntry {
 		MeshGateway: in.Spec.MeshGateway.toConsul(),
 		Expose:      in.Spec.Expose.toConsul(),
 		Config:      consulConfig,
-		Meta:        getMeta(datacenter),
+		Meta:        meta(datacenter),
 	}
 }
 

--- a/api/v1alpha1/proxydefaults_types_test.go
+++ b/api/v1alpha1/proxydefaults_types_test.go
@@ -32,6 +32,10 @@ func TestProxyDefaults_MatchesConsul(t *testing.T) {
 				Namespace:   "default",
 				CreateIndex: 1,
 				ModifyIndex: 2,
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
+				},
 			},
 			Matches: true,
 		},
@@ -129,6 +133,10 @@ func TestProxyDefaults_ToConsul(t *testing.T) {
 			Exp: &capi.ProxyConfigEntry{
 				Name: "name",
 				Kind: capi.ProxyDefaults,
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
+				},
 			},
 		},
 		"every field set": {
@@ -187,12 +195,16 @@ func TestProxyDefaults_ToConsul(t *testing.T) {
 						},
 					},
 				},
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
+				},
 			},
 		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			act := c.Ours.ToConsul()
+			act := c.Ours.ToConsul("datacenter")
 			resolver, ok := act.(*capi.ProxyConfigEntry)
 			require.True(t, ok, "could not cast")
 			require.Equal(t, c.Exp, resolver)

--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/consul-k8s/api/common"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -131,10 +130,7 @@ func (in *ServiceDefaults) ToConsul(datacenter string) capi.ConfigEntry {
 		MeshGateway: in.Spec.MeshGateway.toConsul(),
 		Expose:      in.Spec.Expose.toConsul(),
 		ExternalSNI: in.Spec.ExternalSNI,
-		Meta: map[string]string{
-			common.SourceKey:     common.SourceValue,
-			common.DatacenterKey: datacenter,
-		},
+		Meta:        getMeta(datacenter),
 	}
 }
 

--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -130,7 +130,7 @@ func (in *ServiceDefaults) ToConsul(datacenter string) capi.ConfigEntry {
 		MeshGateway: in.Spec.MeshGateway.toConsul(),
 		Expose:      in.Spec.Expose.toConsul(),
 		ExternalSNI: in.Spec.ExternalSNI,
-		Meta:        getMeta(datacenter),
+		Meta:        meta(datacenter),
 	}
 }
 

--- a/api/v1alpha1/servicedefaults_types_test.go
+++ b/api/v1alpha1/servicedefaults_types_test.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
+	"github.com/hashicorp/consul-k8s/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -14,265 +15,80 @@ func TestServiceDefaults_ToConsul(t *testing.T) {
 		input    *ServiceDefaults
 		expected *capi.ServiceConfigEntry
 	}{
-		"kind:service-defaults": {
-			&ServiceDefaults{},
-			&capi.ServiceConfigEntry{
-				Kind: capi.ServiceDefaults,
-			},
-		},
-		"name:resource-name": {
+		"empty fields": {
 			&ServiceDefaults{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "resource-name",
+					Name: "foo",
 				},
+				Spec: ServiceDefaultsSpec{},
 			},
 			&capi.ServiceConfigEntry{
+				Name: "foo",
 				Kind: capi.ServiceDefaults,
-				Name: "resource-name",
-			},
-		},
-		"protocol:http": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					Protocol: "http",
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
 				},
 			},
-			&capi.ServiceConfigEntry{
-				Kind:     capi.ServiceDefaults,
-				Protocol: "http",
-			},
 		},
-		"protocol:https": {
+		"every field set": {
 			&ServiceDefaults{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
 				Spec: ServiceDefaultsSpec{
 					Protocol: "https",
-				},
-			},
-			&capi.ServiceConfigEntry{
-				Kind:     capi.ServiceDefaults,
-				Protocol: "https",
-			},
-		},
-		"protocol:''": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					Protocol: "",
-				},
-			},
-			&capi.ServiceConfigEntry{
-				Kind:     capi.ServiceDefaults,
-				Protocol: "",
-			},
-		},
-		"mode:unsupported": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					MeshGateway: MeshGatewayConfig{
-						Mode: "unsupported",
-					},
-				},
-			},
-			&capi.ServiceConfigEntry{
-				Kind: capi.ServiceDefaults,
-				MeshGateway: capi.MeshGatewayConfig{
-					Mode: capi.MeshGatewayModeDefault,
-				},
-			},
-		},
-		"mode:local": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
 					MeshGateway: MeshGatewayConfig{
 						Mode: "local",
 					},
-				},
-			},
-			&capi.ServiceConfigEntry{
-				Kind: capi.ServiceDefaults,
-				MeshGateway: capi.MeshGatewayConfig{
-					Mode: capi.MeshGatewayModeLocal,
-				},
-			},
-		},
-		"mode:remote": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					MeshGateway: MeshGatewayConfig{
-						Mode: "remote",
-					},
-				},
-			},
-			&capi.ServiceConfigEntry{
-				Kind: capi.ServiceDefaults,
-				MeshGateway: capi.MeshGatewayConfig{
-					Mode: capi.MeshGatewayModeRemote,
-				},
-			},
-		},
-		"mode:none": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					MeshGateway: MeshGatewayConfig{
-						Mode: "none",
-					},
-				},
-			},
-			&capi.ServiceConfigEntry{
-				Kind: capi.ServiceDefaults,
-				MeshGateway: capi.MeshGatewayConfig{
-					Mode: capi.MeshGatewayModeNone,
-				},
-			},
-		},
-		"mode:default": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					MeshGateway: MeshGatewayConfig{
-						Mode: "default",
-					},
-				},
-			},
-			&capi.ServiceConfigEntry{
-				Kind: capi.ServiceDefaults,
-				MeshGateway: capi.MeshGatewayConfig{
-					Mode: capi.MeshGatewayModeDefault,
-				},
-			},
-		},
-		"mode:''": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					MeshGateway: MeshGatewayConfig{
-						Mode: "",
-					},
-				},
-			},
-			&capi.ServiceConfigEntry{
-				Kind: capi.ServiceDefaults,
-				MeshGateway: capi.MeshGatewayConfig{
-					Mode: capi.MeshGatewayModeDefault,
-				},
-			},
-		},
-		"externalSNI:test-external-sni": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					ExternalSNI: "test-external-sni",
-				},
-			},
-			&capi.ServiceConfigEntry{
-				Kind:        capi.ServiceDefaults,
-				ExternalSNI: "test-external-sni",
-			},
-		},
-		"externalSNI:''": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					ExternalSNI: "",
-				},
-			},
-			&capi.ServiceConfigEntry{
-				Kind:        capi.ServiceDefaults,
-				ExternalSNI: "",
-			},
-		},
-		"expose.checks:false": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					Expose: ExposeConfig{
-						Checks: false,
-					},
-				},
-			},
-			&capi.ServiceConfigEntry{
-				Kind: capi.ServiceDefaults,
-				Expose: capi.ExposeConfig{
-					Checks: false,
-				},
-			},
-		},
-		"expose.checks:true": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
 					Expose: ExposeConfig{
 						Checks: true,
-					},
-				},
-			},
-			&capi.ServiceConfigEntry{
-				Kind: capi.ServiceDefaults,
-				Expose: capi.ExposeConfig{
-					Checks: true,
-				},
-			},
-		},
-		"expose.paths:single": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					Expose: ExposeConfig{
 						Paths: []ExposePath{
 							{
 								ListenerPort:  80,
-								Path:          "/test/path",
-								LocalPathPort: 42,
-								Protocol:      "tcp",
-							},
-						},
-					},
-				},
-			},
-			&capi.ServiceConfigEntry{
-				Kind: capi.ServiceDefaults,
-				Expose: capi.ExposeConfig{
-					Paths: []capi.ExposePath{
-						{
-							ListenerPort:  80,
-							Path:          "/test/path",
-							LocalPathPort: 42,
-							Protocol:      "tcp",
-						},
-					},
-				},
-			},
-		},
-		"expose.paths:multiple": {
-			&ServiceDefaults{
-				Spec: ServiceDefaultsSpec{
-					Expose: ExposeConfig{
-						Paths: []ExposePath{
-							{
-								ListenerPort:  80,
-								Path:          "/test/path",
-								LocalPathPort: 42,
+								Path:          "/path",
+								LocalPathPort: 9000,
 								Protocol:      "tcp",
 							},
 							{
 								ListenerPort:  8080,
-								Path:          "/root/test/path",
-								LocalPathPort: 4201,
-								Protocol:      "https",
+								Path:          "/another-path",
+								LocalPathPort: 9091,
+								Protocol:      "http2",
 							},
 						},
 					},
+					ExternalSNI: "external-sni",
 				},
 			},
 			&capi.ServiceConfigEntry{
-				Kind: capi.ServiceDefaults,
+				Kind:     capi.ServiceDefaults,
+				Name:     "foo",
+				Protocol: "https",
+				MeshGateway: capi.MeshGatewayConfig{
+					Mode: capi.MeshGatewayModeLocal,
+				},
 				Expose: capi.ExposeConfig{
+					Checks: true,
 					Paths: []capi.ExposePath{
 						{
 							ListenerPort:  80,
-							Path:          "/test/path",
-							LocalPathPort: 42,
+							Path:          "/path",
+							LocalPathPort: 9000,
 							Protocol:      "tcp",
 						},
 						{
 							ListenerPort:  8080,
-							Path:          "/root/test/path",
-							LocalPathPort: 4201,
-							Protocol:      "https",
+							Path:          "/another-path",
+							LocalPathPort: 9091,
+							Protocol:      "http2",
 						},
 					},
+				},
+				ExternalSNI: "external-sni",
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
 				},
 			},
 		},
@@ -280,7 +96,7 @@ func TestServiceDefaults_ToConsul(t *testing.T) {
 
 	for name, testCase := range cases {
 		t.Run(name, func(t *testing.T) {
-			output := testCase.input.ToConsul()
+			output := testCase.input.ToConsul("datacenter")
 			require.Equal(t, testCase.expected, output)
 		})
 	}
@@ -305,6 +121,10 @@ func TestServiceDefaults_MatchesConsul(t *testing.T) {
 				Namespace:   "namespace",
 				CreateIndex: 1,
 				ModifyIndex: 2,
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
+				},
 			},
 			true,
 		},

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -106,7 +106,7 @@ func (in *ServiceResolver) ToConsul(datacenter string) capi.ConfigEntry {
 		Failover:       in.Spec.Failover.toConsul(),
 		ConnectTimeout: in.Spec.ConnectTimeout,
 		LoadBalancer:   in.Spec.LoadBalancer.toConsul(),
-		Meta:           getMeta(datacenter),
+		Meta:           meta(datacenter),
 	}
 }
 

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/consul-k8s/api/common"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -107,10 +106,7 @@ func (in *ServiceResolver) ToConsul(datacenter string) capi.ConfigEntry {
 		Failover:       in.Spec.Failover.toConsul(),
 		ConnectTimeout: in.Spec.ConnectTimeout,
 		LoadBalancer:   in.Spec.LoadBalancer.toConsul(),
-		Meta: map[string]string{
-			common.SourceKey:     common.SourceValue,
-			common.DatacenterKey: datacenter,
-		},
+		Meta:           getMeta(datacenter),
 	}
 }
 

--- a/api/v1alpha1/serviceresolver_types_test.go
+++ b/api/v1alpha1/serviceresolver_types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul-k8s/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +30,10 @@ func TestServiceResolver_MatchesConsul(t *testing.T) {
 				Namespace:   "foobar",
 				CreateIndex: 1,
 				ModifyIndex: 2,
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
+				},
 			},
 			Matches: true,
 		},
@@ -195,6 +200,10 @@ func TestServiceResolver_ToConsul(t *testing.T) {
 			Exp: &capi.ServiceResolverConfigEntry{
 				Name: "name",
 				Kind: capi.ServiceResolver,
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
+				},
 			},
 		},
 		"every field set": {
@@ -318,12 +327,16 @@ func TestServiceResolver_ToConsul(t *testing.T) {
 						},
 					},
 				},
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
+				},
 			},
 		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			act := c.Ours.ToConsul()
+			act := c.Ours.ToConsul("datacenter")
 			serviceResolver, ok := act.(*capi.ServiceResolverConfigEntry)
 			require.True(t, ok, "could not cast")
 			require.Equal(t, c.Exp, serviceResolver)

--- a/api/v1alpha1/servicerouter_types.go
+++ b/api/v1alpha1/servicerouter_types.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/consul-k8s/api/common"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -355,10 +354,7 @@ func (in *ServiceRouter) ToConsul(datacenter string) capi.ConfigEntry {
 		Kind:   in.ConsulKind(),
 		Name:   in.Name(),
 		Routes: routes,
-		Meta: map[string]string{
-			common.SourceKey:     common.SourceValue,
-			common.DatacenterKey: datacenter,
-		},
+		Meta:   getMeta(datacenter),
 	}
 }
 

--- a/api/v1alpha1/servicerouter_types.go
+++ b/api/v1alpha1/servicerouter_types.go
@@ -354,7 +354,7 @@ func (in *ServiceRouter) ToConsul(datacenter string) capi.ConfigEntry {
 		Kind:   in.ConsulKind(),
 		Name:   in.Name(),
 		Routes: routes,
-		Meta:   getMeta(datacenter),
+		Meta:   meta(datacenter),
 	}
 }
 

--- a/api/v1alpha1/servicerouter_types_test.go
+++ b/api/v1alpha1/servicerouter_types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul-k8s/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +31,10 @@ func TestServiceRouter_MatchesConsul(t *testing.T) {
 				Namespace:   "namespace",
 				CreateIndex: 1,
 				ModifyIndex: 2,
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
+				},
 			},
 			Matches: true,
 		},
@@ -168,6 +173,10 @@ func TestServiceRouter_ToConsul(t *testing.T) {
 			Exp: &capi.ServiceRouterConfigEntry{
 				Name: "name",
 				Kind: capi.ServiceRouter,
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
+				},
 			},
 		},
 		"every field set": {
@@ -263,12 +272,16 @@ func TestServiceRouter_ToConsul(t *testing.T) {
 						},
 					},
 				},
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
+				},
 			},
 		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			act := c.Ours.ToConsul()
+			act := c.Ours.ToConsul("datacenter")
 			ServiceRouter, ok := act.(*capi.ServiceRouterConfigEntry)
 			require.True(t, ok, "could not cast")
 			require.Equal(t, c.Exp, ServiceRouter)

--- a/api/v1alpha1/servicesplitter_types.go
+++ b/api/v1alpha1/servicesplitter_types.go
@@ -130,7 +130,7 @@ func (in *ServiceSplitter) ToConsul(datacenter string) capi.ConfigEntry {
 		Kind:   in.ConsulKind(),
 		Name:   in.Name(),
 		Splits: in.Spec.Splits.toConsul(),
-		Meta:   getMeta(datacenter),
+		Meta:   meta(datacenter),
 	}
 }
 

--- a/api/v1alpha1/servicesplitter_types.go
+++ b/api/v1alpha1/servicesplitter_types.go
@@ -130,10 +130,7 @@ func (in *ServiceSplitter) ToConsul(datacenter string) capi.ConfigEntry {
 		Kind:   in.ConsulKind(),
 		Name:   in.Name(),
 		Splits: in.Spec.Splits.toConsul(),
-		Meta: map[string]string{
-			common.SourceKey:     common.SourceValue,
-			common.DatacenterKey: datacenter,
-		},
+		Meta:   getMeta(datacenter),
 	}
 }
 

--- a/api/v1alpha1/servicesplitter_types.go
+++ b/api/v1alpha1/servicesplitter_types.go
@@ -125,11 +125,15 @@ func (in *ServiceSplitter) SyncedConditionStatus() corev1.ConditionStatus {
 	return condition.Status
 }
 
-func (in *ServiceSplitter) ToConsul() capi.ConfigEntry {
+func (in *ServiceSplitter) ToConsul(datacenter string) capi.ConfigEntry {
 	return &capi.ServiceSplitterConfigEntry{
 		Kind:   in.ConsulKind(),
 		Name:   in.Name(),
 		Splits: in.Spec.Splits.toConsul(),
+		Meta: map[string]string{
+			common.SourceKey:     common.SourceValue,
+			common.DatacenterKey: datacenter,
+		},
 	}
 }
 
@@ -138,7 +142,8 @@ func (in *ServiceSplitter) MatchesConsul(candidate capi.ConfigEntry) bool {
 	if !ok {
 		return false
 	}
-	return cmp.Equal(in.ToConsul(), configEntry, cmpopts.IgnoreFields(capi.ServiceSplitterConfigEntry{}, "Namespace", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
+	// No datacenter is passed to ToConsul as we ignore the Meta field when checking for equality.
+	return cmp.Equal(in.ToConsul(""), configEntry, cmpopts.IgnoreFields(capi.ServiceSplitterConfigEntry{}, "Namespace", "Meta", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
 }
 
 func (in *ServiceSplitter) Validate() error {

--- a/api/v1alpha1/servicesplitter_types_test.go
+++ b/api/v1alpha1/servicesplitter_types_test.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
+	"github.com/hashicorp/consul-k8s/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +30,10 @@ func TestServiceSplitter_MatchesConsul(t *testing.T) {
 				Namespace:   "namespace",
 				CreateIndex: 1,
 				ModifyIndex: 2,
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
+				},
 			},
 			Matches: true,
 		},
@@ -101,6 +106,10 @@ func TestServiceSplitter_ToConsul(t *testing.T) {
 			Exp: &capi.ServiceSplitterConfigEntry{
 				Name: "name",
 				Kind: capi.ServiceSplitter,
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
+				},
 			},
 		},
 		"every field set": {
@@ -130,12 +139,16 @@ func TestServiceSplitter_ToConsul(t *testing.T) {
 						Namespace:     "baz",
 					},
 				},
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
+				},
 			},
 		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			act := c.Ours.ToConsul()
+			act := c.Ours.ToConsul("datacenter")
 			ServiceSplitter, ok := act.(*capi.ServiceSplitterConfigEntry)
 			require.True(t, ok, "could not cast")
 			require.Equal(t, c.Exp, ServiceSplitter)

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -78,7 +78,7 @@ func invalidPathPrefix(path string) bool {
 	return path != "" && !strings.HasPrefix(path, "/")
 }
 
-func getMeta(datacenter string) map[string]string {
+func meta(datacenter string) map[string]string {
 	return map[string]string{
 		common.SourceKey:     common.SourceValue,
 		common.DatacenterKey: datacenter,

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/consul-k8s/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -75,4 +76,11 @@ func sliceContains(slice []string, entry string) bool {
 
 func invalidPathPrefix(path string) bool {
 	return path != "" && !strings.HasPrefix(path, "/")
+}
+
+func getMeta(datacenter string) map[string]string {
+	return map[string]string{
+		common.SourceKey:     common.SourceValue,
+		common.DatacenterKey: datacenter,
+	}
 }

--- a/controller/configentry_controller.go
+++ b/controller/configentry_controller.go
@@ -189,9 +189,9 @@ func (r *ConfigEntryController) ReconcileEntry(
 
 	// Check if the config entry is managed by our datacenter.
 	// Do not process resource if the entry was not created within our datacenter
-	// as it was created in a different cluster within the federation.
+	// as it was created in a different cluster which will be managing that config entry.
 	if entry.GetMeta()[common.DatacenterKey] != r.DatacenterName {
-		return r.syncFailed(ctx, logger, crdCtrl, configEntry, ExternallyManagedConfigError, errors.New(fmt.Sprintf("config entry managed in different datacenter: %s", entry.GetMeta()[common.DatacenterKey])))
+		return r.syncFailed(ctx, logger, crdCtrl, configEntry, ExternallyManagedConfigError, fmt.Errorf("config entry managed in different datacenter: %q", entry.GetMeta()[common.DatacenterKey]))
 	}
 
 	if !configEntry.MatchesConsul(entry) {

--- a/controller/configentry_controller.go
+++ b/controller/configentry_controller.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 

--- a/controller/configentry_controller_test.go
+++ b/controller/configentry_controller_test.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const DatacenterName = "datacenter"
+
 type testReconciler interface {
 	Reconcile(req ctrl.Request) (ctrl.Result, error)
 }
@@ -55,7 +57,8 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -84,7 +87,8 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -113,7 +117,8 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -155,7 +160,8 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -193,7 +199,8 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -284,7 +291,8 @@ func TestConfigEntryControllers_updatesConfigEntry(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -317,7 +325,8 @@ func TestConfigEntryControllers_updatesConfigEntry(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -350,7 +359,8 @@ func TestConfigEntryControllers_updatesConfigEntry(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -397,7 +407,8 @@ func TestConfigEntryControllers_updatesConfigEntry(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -453,7 +464,8 @@ func TestConfigEntryControllers_updatesConfigEntry(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -496,7 +508,7 @@ func TestConfigEntryControllers_updatesConfigEntry(t *testing.T) {
 			// We haven't run reconcile yet so we must create the config entry
 			// in Consul ourselves.
 			{
-				written, _, err := consulClient.ConfigEntries().Set(c.configEntryResource.ToConsul(), nil)
+				written, _, err := consulClient.ConfigEntries().Set(c.configEntryResource.ToConsul(DatacenterName), nil)
 				req.NoError(err)
 				req.True(written)
 			}
@@ -562,7 +574,8 @@ func TestConfigEntryControllers_deletesConfigEntry(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -588,7 +601,8 @@ func TestConfigEntryControllers_deletesConfigEntry(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -614,7 +628,8 @@ func TestConfigEntryControllers_deletesConfigEntry(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -654,7 +669,8 @@ func TestConfigEntryControllers_deletesConfigEntry(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -689,7 +705,8 @@ func TestConfigEntryControllers_deletesConfigEntry(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -722,7 +739,7 @@ func TestConfigEntryControllers_deletesConfigEntry(t *testing.T) {
 			// We haven't run reconcile yet so we must create the config entry
 			// in Consul ourselves.
 			{
-				written, _, err := consulClient.ConfigEntries().Set(c.configEntryResourceWithDeletion.ToConsul(), nil)
+				written, _, err := consulClient.ConfigEntries().Set(c.configEntryResourceWithDeletion.ToConsul(DatacenterName), nil)
 				req.NoError(err)
 				req.True(written)
 			}
@@ -776,7 +793,8 @@ func TestConfigEntryControllers_errorUpdatesSyncStatus(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -800,7 +818,8 @@ func TestConfigEntryControllers_errorUpdatesSyncStatus(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -824,7 +843,8 @@ func TestConfigEntryControllers_errorUpdatesSyncStatus(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -854,7 +874,8 @@ func TestConfigEntryControllers_errorUpdatesSyncStatus(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -941,7 +962,8 @@ func TestConfigEntryControllers_setsSyncedToTrue(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -973,7 +995,8 @@ func TestConfigEntryControllers_setsSyncedToTrue(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -1005,7 +1028,8 @@ func TestConfigEntryControllers_setsSyncedToTrue(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -1048,7 +1072,8 @@ func TestConfigEntryControllers_setsSyncedToTrue(t *testing.T) {
 					Client: client,
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
-						ConsulClient: consulClient,
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
 					},
 				}
 			},
@@ -1083,7 +1108,7 @@ func TestConfigEntryControllers_setsSyncedToTrue(t *testing.T) {
 
 			// Create the resource in Consul to mimic that it was created
 			// successfully (but its status hasn't been updated).
-			_, _, err = consulClient.ConfigEntries().Set(c.configEntryResource.ToConsul(), nil)
+			_, _, err = consulClient.ConfigEntries().Set(c.configEntryResource.ToConsul(DatacenterName), nil)
 			require.NoError(t, err)
 
 			r := c.reconciler(client, consulClient, logrtest.TestLogger{T: t})
@@ -1101,6 +1126,231 @@ func TestConfigEntryControllers_setsSyncedToTrue(t *testing.T) {
 			err = client.Get(ctx, namespacedName, c.configEntryResource)
 			req.NoError(err)
 			req.Equal(corev1.ConditionTrue, c.configEntryResource.SyncedConditionStatus())
+		})
+	}
+}
+
+// Test that if the config entry exists in Consul but is not managed by the
+// controller, deleting the resource does not delete the Consul config entry
+func TestConfigEntryControllers_doesNotDeleteUnownedConfig(t *testing.T) {
+	t.Parallel()
+	kubeNS := "default"
+
+	cases := []struct {
+		kubeKind                        string
+		consulKind                      string
+		consulPrereq                    []capi.ConfigEntry
+		configEntryResourceWithDeletion common.ConfigEntryResource
+		reconciler                      func(client.Client, *capi.Client, logr.Logger) testReconciler
+	}{
+		{
+			kubeKind:   "ServiceDefaults",
+			consulKind: capi.ServiceDefaults,
+			configEntryResourceWithDeletion: &v1alpha1.ServiceDefaults{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "foo",
+					Namespace:         kubeNS,
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{FinalizerName},
+				},
+				Spec: v1alpha1.ServiceDefaultsSpec{
+					Protocol: "http",
+				},
+			},
+			reconciler: func(client client.Client, consulClient *capi.Client, logger logr.Logger) testReconciler {
+				return &ServiceDefaultsController{
+					Client: client,
+					Log:    logger,
+					ConfigEntryController: &ConfigEntryController{
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
+					},
+				}
+			},
+		},
+		{
+			kubeKind:   "ServiceResolver",
+			consulKind: capi.ServiceResolver,
+			configEntryResourceWithDeletion: &v1alpha1.ServiceResolver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "foo",
+					Namespace:         kubeNS,
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{FinalizerName},
+				},
+				Spec: v1alpha1.ServiceResolverSpec{
+					Redirect: &v1alpha1.ServiceResolverRedirect{
+						Service: "redirect",
+					},
+				},
+			},
+			reconciler: func(client client.Client, consulClient *capi.Client, logger logr.Logger) testReconciler {
+				return &ServiceResolverController{
+					Client: client,
+					Log:    logger,
+					ConfigEntryController: &ConfigEntryController{
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
+					},
+				}
+			},
+		},
+		{
+			kubeKind:   "ProxyDefaults",
+			consulKind: capi.ProxyDefaults,
+			configEntryResourceWithDeletion: &v1alpha1.ProxyDefaults{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              common.Global,
+					Namespace:         kubeNS,
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{FinalizerName},
+				},
+				Spec: v1alpha1.ProxyDefaultsSpec{
+					MeshGateway: v1alpha1.MeshGatewayConfig{
+						Mode: "remote",
+					},
+				},
+			},
+			reconciler: func(client client.Client, consulClient *capi.Client, logger logr.Logger) testReconciler {
+				return &ProxyDefaultsController{
+					Client: client,
+					Log:    logger,
+					ConfigEntryController: &ConfigEntryController{
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
+					},
+				}
+			},
+		},
+		{
+			kubeKind:   "ServiceRouter",
+			consulKind: capi.ServiceRouter,
+			consulPrereq: []capi.ConfigEntry{
+				&capi.ServiceConfigEntry{
+					Kind:     capi.ServiceDefaults,
+					Name:     "foo",
+					Protocol: "http",
+				},
+			},
+			configEntryResourceWithDeletion: &v1alpha1.ServiceRouter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "foo",
+					Namespace:         kubeNS,
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{FinalizerName},
+				},
+				Spec: v1alpha1.ServiceRouterSpec{
+					Routes: []v1alpha1.ServiceRoute{
+						{
+							Match: &v1alpha1.ServiceRouteMatch{
+								HTTP: &v1alpha1.ServiceRouteHTTPMatch{
+									PathPrefix: "/admin",
+								},
+							},
+						},
+					},
+				},
+			},
+
+			reconciler: func(client client.Client, consulClient *capi.Client, logger logr.Logger) testReconciler {
+				return &ServiceRouterController{
+					Client: client,
+					Log:    logger,
+					ConfigEntryController: &ConfigEntryController{
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
+					},
+				}
+			},
+		},
+		{
+			kubeKind:   "ServiceSplitter",
+			consulKind: capi.ServiceSplitter,
+			consulPrereq: []capi.ConfigEntry{
+				&capi.ServiceConfigEntry{
+					Kind:     capi.ServiceDefaults,
+					Name:     "foo",
+					Protocol: "http",
+				},
+			},
+			configEntryResourceWithDeletion: &v1alpha1.ServiceSplitter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "foo",
+					Namespace:         kubeNS,
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{FinalizerName},
+				},
+				Spec: v1alpha1.ServiceSplitterSpec{
+					Splits: []v1alpha1.ServiceSplit{
+						{
+							Weight: 100,
+						},
+					},
+				},
+			},
+			reconciler: func(client client.Client, consulClient *capi.Client, logger logr.Logger) testReconciler {
+				return &ServiceSplitterController{
+					Client: client,
+					Log:    logger,
+					ConfigEntryController: &ConfigEntryController{
+						ConsulClient:   consulClient,
+						DatacenterName: DatacenterName,
+					},
+				}
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.kubeKind, func(t *testing.T) {
+			req := require.New(t)
+
+			s := runtime.NewScheme()
+			s.AddKnownTypes(v1alpha1.GroupVersion, c.configEntryResourceWithDeletion)
+			client := fake.NewFakeClientWithScheme(s, c.configEntryResourceWithDeletion)
+
+			consul, err := testutil.NewTestServerConfigT(t, nil)
+			req.NoError(err)
+			defer consul.Stop()
+			consulClient, err := capi.NewClient(&capi.Config{
+				Address: consul.HTTPAddr,
+			})
+			req.NoError(err)
+
+			// Create any prereqs.
+			for _, configEntry := range c.consulPrereq {
+				written, _, err := consulClient.ConfigEntries().Set(configEntry, nil)
+				req.NoError(err)
+				req.True(written)
+			}
+
+			// We haven't run reconcile yet so we must create the config entry
+			// in Consul ourselves.
+			{
+				// Create the resource with differnt datacenter on metadata
+				written, _, err := consulClient.ConfigEntries().Set(c.configEntryResourceWithDeletion.ToConsul("different-datacenter"), nil)
+				req.NoError(err)
+				req.True(written)
+			}
+
+			// Now run reconcile. It's marked for deletion so this should delete the kubernetes resource
+			// but not the consul config entry.
+			{
+				namespacedName := types.NamespacedName{
+					Namespace: kubeNS,
+					Name:      c.configEntryResourceWithDeletion.Name(),
+				}
+				r := c.reconciler(client, consulClient, logrtest.TestLogger{T: t})
+				resp, err := r.Reconcile(ctrl.Request{
+					NamespacedName: namespacedName,
+				})
+				req.NoError(err)
+				req.False(resp.Requeue)
+
+				entry, _, err := consulClient.ConfigEntries().Get(c.consulKind, c.configEntryResourceWithDeletion.Name(), nil)
+				req.NoError(err)
+				req.Equal(entry.GetMeta()[common.DatacenterKey], "different-datacenter")
+			}
 		})
 	}
 }

--- a/controller/configentry_controller_test.go
+++ b/controller/configentry_controller_test.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-const DatacenterName = "datacenter"
+const datacenterName = "datacenter"
 
 type testReconciler interface {
 	Reconcile(req ctrl.Request) (ctrl.Result, error)
@@ -58,7 +58,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -88,7 +88,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -118,7 +118,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -161,7 +161,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -200,7 +200,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -292,7 +292,7 @@ func TestConfigEntryControllers_updatesConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -326,7 +326,7 @@ func TestConfigEntryControllers_updatesConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -360,7 +360,7 @@ func TestConfigEntryControllers_updatesConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -408,7 +408,7 @@ func TestConfigEntryControllers_updatesConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -465,7 +465,7 @@ func TestConfigEntryControllers_updatesConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -508,7 +508,7 @@ func TestConfigEntryControllers_updatesConfigEntry(t *testing.T) {
 			// We haven't run reconcile yet so we must create the config entry
 			// in Consul ourselves.
 			{
-				written, _, err := consulClient.ConfigEntries().Set(c.configEntryResource.ToConsul(DatacenterName), nil)
+				written, _, err := consulClient.ConfigEntries().Set(c.configEntryResource.ToConsul(datacenterName), nil)
 				req.NoError(err)
 				req.True(written)
 			}
@@ -575,7 +575,7 @@ func TestConfigEntryControllers_deletesConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -602,7 +602,7 @@ func TestConfigEntryControllers_deletesConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -629,7 +629,7 @@ func TestConfigEntryControllers_deletesConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -670,7 +670,7 @@ func TestConfigEntryControllers_deletesConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -706,7 +706,7 @@ func TestConfigEntryControllers_deletesConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -739,7 +739,7 @@ func TestConfigEntryControllers_deletesConfigEntry(t *testing.T) {
 			// We haven't run reconcile yet so we must create the config entry
 			// in Consul ourselves.
 			{
-				written, _, err := consulClient.ConfigEntries().Set(c.configEntryResourceWithDeletion.ToConsul(DatacenterName), nil)
+				written, _, err := consulClient.ConfigEntries().Set(c.configEntryResourceWithDeletion.ToConsul(datacenterName), nil)
 				req.NoError(err)
 				req.True(written)
 			}
@@ -794,7 +794,7 @@ func TestConfigEntryControllers_errorUpdatesSyncStatus(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -819,7 +819,7 @@ func TestConfigEntryControllers_errorUpdatesSyncStatus(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -844,7 +844,7 @@ func TestConfigEntryControllers_errorUpdatesSyncStatus(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -875,7 +875,7 @@ func TestConfigEntryControllers_errorUpdatesSyncStatus(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -963,7 +963,7 @@ func TestConfigEntryControllers_setsSyncedToTrue(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -996,7 +996,7 @@ func TestConfigEntryControllers_setsSyncedToTrue(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -1029,7 +1029,7 @@ func TestConfigEntryControllers_setsSyncedToTrue(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -1073,7 +1073,7 @@ func TestConfigEntryControllers_setsSyncedToTrue(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -1108,7 +1108,7 @@ func TestConfigEntryControllers_setsSyncedToTrue(t *testing.T) {
 
 			// Create the resource in Consul to mimic that it was created
 			// successfully (but its status hasn't been updated).
-			_, _, err = consulClient.ConfigEntries().Set(c.configEntryResource.ToConsul(DatacenterName), nil)
+			_, _, err = consulClient.ConfigEntries().Set(c.configEntryResource.ToConsul(datacenterName), nil)
 			require.NoError(t, err)
 
 			r := c.reconciler(client, consulClient, logrtest.TestLogger{T: t})
@@ -1161,7 +1161,7 @@ func TestConfigEntryControllers_doesNotCreateUnownedConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -1186,7 +1186,7 @@ func TestConfigEntryControllers_doesNotCreateUnownedConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -1211,7 +1211,7 @@ func TestConfigEntryControllers_doesNotCreateUnownedConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -1250,7 +1250,7 @@ func TestConfigEntryControllers_doesNotCreateUnownedConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -1288,7 +1288,7 @@ func TestConfigEntryControllers_doesNotCreateUnownedConfigEntry(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -1342,7 +1342,7 @@ func TestConfigEntryControllers_doesNotCreateUnownedConfigEntry(t *testing.T) {
 				resp, err := r.Reconcile(ctrl.Request{
 					NamespacedName: namespacedName,
 				})
-				req.EqualError(err, "config entry managed in different datacenter: different-datacenter")
+				req.EqualError(err, "config entry managed in different datacenter: \"different-datacenter\"")
 				req.False(resp.Requeue)
 
 				// Now check that the object in Consul is as expected.
@@ -1356,7 +1356,7 @@ func TestConfigEntryControllers_doesNotCreateUnownedConfigEntry(t *testing.T) {
 				status, reason, errMsg := c.configEntryResource.SyncedCondition()
 				req.Equal(corev1.ConditionFalse, status)
 				req.Equal("ExternallyManagedConfigError", reason)
-				req.Equal(errMsg, "config entry managed in different datacenter: different-datacenter")
+				req.Equal(errMsg, "config entry managed in different datacenter: \"different-datacenter\"")
 			}
 		})
 	}
@@ -1396,7 +1396,7 @@ func TestConfigEntryControllers_doesNotDeleteUnownedConfig(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -1428,7 +1428,7 @@ func TestConfigEntryControllers_doesNotDeleteUnownedConfig(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -1460,7 +1460,7 @@ func TestConfigEntryControllers_doesNotDeleteUnownedConfig(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -1505,7 +1505,7 @@ func TestConfigEntryControllers_doesNotDeleteUnownedConfig(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},
@@ -1546,7 +1546,7 @@ func TestConfigEntryControllers_doesNotDeleteUnownedConfig(t *testing.T) {
 					Log:    logger,
 					ConfigEntryController: &ConfigEntryController{
 						ConsulClient:   consulClient,
-						DatacenterName: DatacenterName,
+						DatacenterName: datacenterName,
 					},
 				}
 			},

--- a/controller/configentry_controller_test.go
+++ b/controller/configentry_controller_test.go
@@ -1327,7 +1327,7 @@ func TestConfigEntryControllers_doesNotCreateUnownedConfigEntry(t *testing.T) {
 				req.True(written)
 			}
 
-			// Now run reconcile which should update the entry in Consul.
+			// Now run reconcile which should **not** update the entry in Consul.
 			{
 				namespacedName := types.NamespacedName{
 					Namespace: kubeNS,

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.4.0
 	github.com/google/go-querystring v1.0.0 // indirect
-	github.com/hashicorp/consul/api v1.4.1-0.20200924193849-85d223b73c1d
+	github.com/hashicorp/consul/api v1.4.1-0.20200930131338-207491eaa7c3
 	github.com/hashicorp/consul/sdk v0.6.0
 	github.com/hashicorp/go-discover v0.0.0-20200812215701-c4b85f6ed31f
 	github.com/hashicorp/go-hclog v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
-github.com/hashicorp/consul/api v1.4.1-0.20200924193849-85d223b73c1d h1:iBze2PVwt9XRSpLmiefQmy3ZG0aAZkgzx8pZN5zgiOY=
-github.com/hashicorp/consul/api v1.4.1-0.20200924193849-85d223b73c1d/go.mod h1:1NSuaUUkFaJzMasbfq/11wKYWSR67Xn6r2DXKhuDNFg=
+github.com/hashicorp/consul/api v1.4.1-0.20200930131338-207491eaa7c3 h1:+4bVPIxGKrBTt6urzF70HM3mdkS2EUC/6IR7vLABFWM=
+github.com/hashicorp/consul/api v1.4.1-0.20200930131338-207491eaa7c3/go.mod h1:1NSuaUUkFaJzMasbfq/11wKYWSR67Xn6r2DXKhuDNFg=
 github.com/hashicorp/consul/sdk v0.6.0 h1:FfhMEkwvQl57CildXJyGHnwGGM4HMODGyfjGwNM1Vdw=
 github.com/hashicorp/consul/sdk v0.6.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=

--- a/main.go
+++ b/main.go
@@ -4,8 +4,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/hashicorp/consul-k8s/version"
 	"github.com/mitchellh/cli"
+
+	"github.com/hashicorp/consul-k8s/version"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -4,9 +4,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/mitchellh/cli"
-
 	"github.com/hashicorp/consul-k8s/version"
+	"github.com/mitchellh/cli"
 )
 
 func main() {

--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -28,6 +28,7 @@ type Command struct {
 	flagWebhookTLSCertDir    string
 	flagEnableLeaderElection bool
 	flagEnableWebhooks       bool
+	flagDatacenterName       string
 
 	// Flags to support Consul Enterprise namespaces.
 	flagEnableNamespaces           bool
@@ -56,6 +57,8 @@ func (c *Command) init() {
 	c.flagSet.BoolVar(&c.flagEnableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	c.flagSet.StringVar(&c.flagDatacenterName, "datacenter-name", "",
+		"Name of the Consul datacenter the controller is operating in. This is added as metadata on managed custom resources.")
 	c.flagSet.BoolVar(&c.flagEnableNamespaces, "enable-namespaces", false,
 		"[Enterprise Only] Enables Consul Enterprise namespaces, in either a single Consul namespace or mirrored.")
 	c.flagSet.StringVar(&c.flagConsulDestinationNamespace, "consul-destination-namespace", "default",
@@ -93,6 +96,10 @@ func (c *Command) Run(args []string) int {
 		c.UI.Error("Invalid arguments: -webhook-tls-cert-dir must be set")
 		return 1
 	}
+	if c.flagDatacenterName == "" {
+		c.UI.Error("Invalid arguments: -datacenter-name must be set")
+		return 1
+	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:           scheme,
@@ -113,6 +120,7 @@ func (c *Command) Run(args []string) int {
 
 	configEntryReconciler := &controller.ConfigEntryController{
 		ConsulClient:               consulClient,
+		DatacenterName:             c.flagDatacenterName,
 		EnableConsulNamespaces:     c.flagEnableNamespaces,
 		ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
 		EnableNSMirroring:          c.flagEnableNSMirroring,

--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -28,7 +28,7 @@ type Command struct {
 	flagWebhookTLSCertDir    string
 	flagEnableLeaderElection bool
 	flagEnableWebhooks       bool
-	flagDatacenterName       string
+	flagDatacenter           string
 
 	// Flags to support Consul Enterprise namespaces.
 	flagEnableNamespaces           bool
@@ -57,7 +57,7 @@ func (c *Command) init() {
 	c.flagSet.BoolVar(&c.flagEnableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	c.flagSet.StringVar(&c.flagDatacenterName, "datacenter-name", "",
+	c.flagSet.StringVar(&c.flagDatacenter, "datacenter", "",
 		"Name of the Consul datacenter the controller is operating in. This is added as metadata on managed custom resources.")
 	c.flagSet.BoolVar(&c.flagEnableNamespaces, "enable-namespaces", false,
 		"[Enterprise Only] Enables Consul Enterprise namespaces, in either a single Consul namespace or mirrored.")
@@ -96,8 +96,8 @@ func (c *Command) Run(args []string) int {
 		c.UI.Error("Invalid arguments: -webhook-tls-cert-dir must be set")
 		return 1
 	}
-	if c.flagDatacenterName == "" {
-		c.UI.Error("Invalid arguments: -datacenter-name must be set")
+	if c.flagDatacenter == "" {
+		c.UI.Error("Invalid arguments: -datacenter must be set")
 		return 1
 	}
 
@@ -120,7 +120,7 @@ func (c *Command) Run(args []string) int {
 
 	configEntryReconciler := &controller.ConfigEntryController{
 		ConsulClient:               consulClient,
-		DatacenterName:             c.flagDatacenterName,
+		DatacenterName:             c.flagDatacenter,
 		EnableConsulNamespaces:     c.flagEnableNamespaces,
 		ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
 		EnableNSMirroring:          c.flagEnableNSMirroring,

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -18,6 +18,14 @@ func TestRun_FlagValidation(t *testing.T) {
 			flags:  nil,
 			expErr: "-webhook-tls-cert-dir must be set",
 		},
+		{
+			flags:  []string{"-datacenter-name", "foo"},
+			expErr: "-webhook-tls-cert-dir must be set",
+		},
+		{
+			flags:  []string{"-webhook-tls-cert-dir", "/foo"},
+			expErr: "-datacenter-name must be set",
+		},
 	}
 
 	for _, c := range cases {

--- a/subcommand/controller/command_test.go
+++ b/subcommand/controller/command_test.go
@@ -19,12 +19,12 @@ func TestRun_FlagValidation(t *testing.T) {
 			expErr: "-webhook-tls-cert-dir must be set",
 		},
 		{
-			flags:  []string{"-datacenter-name", "foo"},
+			flags:  []string{"-datacenter", "foo"},
 			expErr: "-webhook-tls-cert-dir must be set",
 		},
 		{
 			flags:  []string{"-webhook-tls-cert-dir", "/foo"},
-			expErr: "-datacenter-name must be set",
+			expErr: "-datacenter must be set",
 		},
 	}
 


### PR DESCRIPTION
This will determine if the resource is managed from outside the current cluster

Changes proposed in this PR:
- Add flag `datacenter` that is a required flag for the controller for startup. This string will be used in the meta() field of the config entries managed by Consul
- Add datacenter specific metadata on the Config Entry Meta field before creating the resource in Consul.
This field will be ignore when checking for equality between resources with `cmp.Equal()`.
- A config entry will only be update/deleted from Consul if the metadata on it indicates that it was created in the datacenter the controller is running in.

How I've tested this PR:
- Adding additional acceptance tests to validate this behavior.

How I expect reviewers to test this PR:
- Ideally, one should be able to use the consul CLI to create config entries an installed Consul. These will not have the meta information set on them. Attempting to create a Custom Resource that shares that same name should lead the the resource getting accepted by the cluster, but will fail reconcile and its status should mention that the sync has failed with a reason indicating the Config is managed externally.
- Deleting this resource will not have the side-effect of deleting the Config Entry from Consul.

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
