### PR TITLE
Support split weights that have a value of 0

### DIFF
--- a/api/v1alpha1/servicesplitter_types.go
+++ b/api/v1alpha1/servicesplitter_types.go
@@ -179,8 +179,8 @@ func (in ServiceSplits) validate(path *field.Path) field.ErrorList {
 }
 
 func (in ServiceSplit) validate(path *field.Path) *field.Error {
-	// Validate that the weight value is between 0.01 and 100.
-	if in.Weight > 100 || in.Weight < 0.01 {
+	// Validate that the weight value is between 0.01 and 100 but allow a weight to be 0.
+	if in.Weight != 0 && (in.Weight > 100 || in.Weight < 0.01) {
 		return field.Invalid(path, in.Weight, "weight must be a percentage between 0.01 and 100")
 	}
 

--- a/api/v1alpha1/servicesplitter_types_test.go
+++ b/api/v1alpha1/servicesplitter_types_test.go
@@ -261,6 +261,30 @@ func TestServiceSplitter_Validate(t *testing.T) {
 				},
 			},
 		},
+
+		"valid - splits with 0 weight": {
+			input: &ServiceSplitter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: ServiceSplitterSpec{
+					Splits: []ServiceSplit{
+						{
+							Weight: 50.0,
+						},
+						{
+							Weight: 50,
+						},
+						{
+							Weight: 0.0,
+						},
+						{
+							Weight: 0,
+						},
+					},
+				},
+			},
+		},
 		"sum of weights must be 100": {
 			input: &ServiceSplitter{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Changes proposed in this PR:
- Add support for service splits having 0 weight

How I've tested this PR: unit tests, Cody tested an image with this fix which worked for his demo

How I expect reviewers to test this PR: Try creating a service split that has 0 weight. The webhook should not prevent the resource from getting created.


Checklist:
- [x] Tests added
