### PR TITLE
Don't set envoy flag `--max-obj-name-len`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## UNRELEASED
 
+BREAKING CHANGES:
+* Connect: No longer set `--max-obj-name-len` flag when executing `envoy`. This flag
+  was [deprecated](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.11.0#deprecated)
+  in Envoy 1.11.0 and had no effect from then onwards. With Envoy >= 1.15.0 setting
+  this flag will result in an error, hence why we're removing it. [[GH-350](https://github.com/hashicorp/consul-k8s/pull/350)]
+
+  If you are running any Envoy version >= 1.11.0 this change will have no effect. If you
+  are running an Envoy version < 1.11.0 then you must upgrade Envoy to a newer
+  version. This can be done by setting the `global.imageEnvoy` key in the
+  Consul Helm chart.
+
 IMPROVEMENTS:
 
 * Add an ability to configure the synthetic Consul node name where catalog sync registers services. [[GH-312](https://github.com/hashicorp/consul-k8s/pull/312)]

--- a/connect-inject/envoy_sidecar.go
+++ b/connect-inject/envoy_sidecar.go
@@ -66,7 +66,6 @@ func (h *Handler) envoySidecar(pod *corev1.Pod, k8sNamespace string) (corev1.Con
 		},
 		Command: []string{
 			"envoy",
-			"--max-obj-name-len", "256",
 			"--config-path", "/consul/connect-inject/envoy-bootstrap.yaml",
 		},
 	}

--- a/connect-inject/envoy_sidecar_test.go
+++ b/connect-inject/envoy_sidecar_test.go
@@ -32,7 +32,6 @@ func TestHandlerEnvoySidecar(t *testing.T) {
 	require.NoError(err)
 	require.Equal(container.Command, []string{
 		"envoy",
-		"--max-obj-name-len", "256",
 		"--config-path", "/consul/connect-inject/envoy-bootstrap.yaml",
 	})
 


### PR DESCRIPTION
This flag was deprecated and ignored in Envoy 1.11 and will result
in an error for Envoy 1.15.

How I've tested this PR:
* Run with `ghcr.io/lkysow/consul-k8s-dev:oct06-envoy` against envoy versions 1.14.4, 1.13.4, 1.12.6, 1.11.2

How I expect reviewers to test this PR:
* You can see here (https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.11.0#deprecated) that the flag is deprecated so unless you want to, there's no need to test it yourself that connect still works.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
