### PR TITLE
Add missing additional columns

### DIFF
--- a/api/v1alpha1/serviceintentions_types.go
+++ b/api/v1alpha1/serviceintentions_types.go
@@ -71,6 +71,7 @@ type IntentionAction string
 // +kubebuilder:subresource:status
 
 // ServiceIntentions is the Schema for the serviceintentions API
+// +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
 type ServiceIntentions struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/servicesplitter_types.go
+++ b/api/v1alpha1/servicesplitter_types.go
@@ -19,6 +19,7 @@ import (
 // +kubebuilder:subresource:status
 
 // ServiceSplitter is the Schema for the servicesplitters API
+// +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
 type ServiceSplitter struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
+++ b/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
@@ -8,6 +8,11 @@ metadata:
   creationTimestamp: null
   name: serviceintentions.consul.hashicorp.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Synced")].status
+    description: The sync status of the resource with Consul
+    name: Synced
+    type: string
   group: consul.hashicorp.com
   names:
     kind: ServiceIntentions

--- a/config/crd/bases/consul.hashicorp.com_servicesplitters.yaml
+++ b/config/crd/bases/consul.hashicorp.com_servicesplitters.yaml
@@ -8,6 +8,11 @@ metadata:
   creationTimestamp: null
   name: servicesplitters.consul.hashicorp.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Synced")].status
+    description: The sync status of the resource with Consul
+    name: Synced
+    type: string
   group: consul.hashicorp.com
   names:
     kind: ServiceSplitter

--- a/go.sum
+++ b/go.sum
@@ -302,6 +302,7 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgx v3.3.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=


### PR DESCRIPTION
Missing from service-intentions and splitter but on the rest

These show up on
```
$ k get servicesplitter
NAME   AGE
foo    7s
$ k get servicedefaults
NAME                     SYNCED
foo                      True
```