### PR TITLE
Support Consul namespaces for service-intentions

### DIFF
--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -227,7 +227,7 @@ func (e ExposeConfig) validate(path *field.Path) []*field.Error {
 				pathCfg.Path,
 				`must begin with a '/'`))
 		}
-		if !sliceContains(protocols, pathCfg.Protocol) {
+		if pathCfg.Protocol != "" && !sliceContains(protocols, pathCfg.Protocol) {
 			errs = append(errs, field.Invalid(
 				indexPath.Child("protocol"),
 				pathCfg.Protocol,

--- a/api/v1alpha1/servicedefaults_types_test.go
+++ b/api/v1alpha1/servicedefaults_types_test.go
@@ -223,6 +223,17 @@ func TestServiceDefaults_Validate(t *testing.T) {
 					MeshGateway: MeshGatewayConfig{
 						Mode: "remote",
 					},
+					Expose: ExposeConfig{
+						Checks: false,
+						Paths: []ExposePath{
+							{
+								ListenerPort:  100,
+								Path:          "/bar",
+								LocalPathPort: 1000,
+								Protocol:      "",
+							},
+						},
+					},
 				},
 			},
 			expectedErrMsg: "",

--- a/api/v1alpha1/serviceintentions_types.go
+++ b/api/v1alpha1/serviceintentions_types.go
@@ -298,13 +298,19 @@ func (in *IntentionHTTPPermission) validate(path *field.Path) field.ErrorList {
 }
 
 // Default sets zero value fields on this object to their defaults.
-func (in *ServiceIntentions) Default() {
-	if in.Spec.Destination.Namespace == "" {
-		in.Spec.Destination.Namespace = in.Namespace
-	}
-	for _, source := range in.Spec.Sources {
-		if source.Namespace == "" {
-			source.Namespace = in.Namespace
+func (in *ServiceIntentions) Default(consulNamespacesEnabled bool) {
+	// If namespaces are enabled we want to set all the namespace fields to their
+	// defaults. If namespaces are not enabled (i.e. OSS) we don't set any
+	// namespace fields because this would cause errors
+	// making API calls (because namespace fields can't be set in OSS).
+	if consulNamespacesEnabled {
+		if in.Spec.Destination.Namespace == "" {
+			in.Spec.Destination.Namespace = in.Namespace
+		}
+		for _, source := range in.Spec.Sources {
+			if source.Namespace == "" {
+				source.Namespace = in.Namespace
+			}
 		}
 	}
 }

--- a/api/v1alpha1/serviceintentions_types.go
+++ b/api/v1alpha1/serviceintentions_types.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/consul-k8s/api/common"
+	"github.com/hashicorp/consul-k8s/namespaces"
 	"github.com/hashicorp/consul/api"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
@@ -153,10 +154,11 @@ func (in *ServiceIntentions) SyncedConditionStatus() corev1.ConditionStatus {
 
 func (in *ServiceIntentions) ToConsul(datacenter string) api.ConfigEntry {
 	return &capi.ServiceIntentionsConfigEntry{
-		Kind:    in.ConsulKind(),
-		Name:    in.Spec.Destination.Name,
-		Sources: in.Spec.Sources.toConsul(),
-		Meta:    meta(datacenter),
+		Kind:      in.ConsulKind(),
+		Name:      in.Spec.Destination.Name,
+		Namespace: in.Spec.Destination.Namespace,
+		Sources:   in.Spec.Sources.toConsul(),
+		Meta:      meta(datacenter),
 	}
 }
 
@@ -297,22 +299,41 @@ func (in *IntentionHTTPPermission) validate(path *field.Path) field.ErrorList {
 	return errs
 }
 
-// Default sets zero value fields on this object to their defaults.
-func (in *ServiceIntentions) Default(consulNamespacesEnabled bool) {
-	// If namespaces are enabled we want to set all the namespace fields to their
-	// defaults. If namespaces are not enabled (i.e. OSS) we don't set any
+// Default sets the namespace field on spec.destination to their default values if namespaces are enabled.
+func (in *ServiceIntentions) Default(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
+	// If namespaces are enabled we want to set the destination namespace field to it's
+	// default. If namespaces are not enabled (i.e. OSS) we don't set the
 	// namespace fields because this would cause errors
 	// making API calls (because namespace fields can't be set in OSS).
 	if consulNamespacesEnabled {
+		namespace := namespaces.ConsulNamespace(in.Namespace, consulNamespacesEnabled, destinationNamespace, mirroring, prefix)
 		if in.Spec.Destination.Namespace == "" {
-			in.Spec.Destination.Namespace = in.Namespace
+			in.Spec.Destination.Namespace = namespace
 		}
-		for _, source := range in.Spec.Sources {
-			if source.Namespace == "" {
-				source.Namespace = in.Namespace
+	}
+}
+
+// ValidateNamespaces returns an error if spec.destination.namespace or spec.sources[i].namespace
+// is set but namespaces are disabled.
+func (in *ServiceIntentions) ValidateNamespaces(namespacesEnabled bool) error {
+	var errs field.ErrorList
+	path := field.NewPath("spec")
+	if !namespacesEnabled {
+		if in.Spec.Destination.Namespace != "" {
+			errs = append(errs, field.Invalid(path.Child("destination").Child("namespace"), in.Spec.Destination.Namespace, `consul namespaces must be enabled to set destination.namespace`))
+		}
+		for i, source := range in.Spec.Sources {
+			if source.Namespace != "" {
+				errs = append(errs, field.Invalid(path.Child("sources").Index(i).Child("namespace"), source.Namespace, `consul namespaces must be enabled to set source.namespace`))
 			}
 		}
 	}
+	if len(errs) > 0 {
+		return apierrors.NewInvalid(
+			schema.GroupKind{Group: ConsulHashicorpGroup, Kind: common.ServiceIntentions},
+			in.KubernetesName(), errs)
+	}
+	return nil
 }
 
 func (in IntentionAction) validate(path *field.Path) *field.Error {

--- a/api/v1alpha1/serviceintentions_types.go
+++ b/api/v1alpha1/serviceintentions_types.go
@@ -251,6 +251,9 @@ func (in *ServiceIntentions) MatchesConsul(candidate api.ConfigEntry) bool {
 func (in *ServiceIntentions) Validate() error {
 	var errs field.ErrorList
 	path := field.NewPath("spec")
+	if len(in.Spec.Sources) == 0 {
+		errs = append(errs, field.Required(path.Child("sources"), `at least one source must be specified`))
+	}
 	for i, source := range in.Spec.Sources {
 		if len(source.Permissions) > 0 && source.Action != "" {
 			asJSON, _ := json.Marshal(source)

--- a/api/v1alpha1/serviceintentions_types_test.go
+++ b/api/v1alpha1/serviceintentions_types_test.go
@@ -1,7 +1,6 @@
 package v1alpha1
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -199,7 +198,8 @@ func TestServiceIntentions_ToConsul(t *testing.T) {
 				},
 				Spec: ServiceIntentionsSpec{
 					Destination: Destination{
-						Name: "svc-name",
+						Name:      "svc-name",
+						Namespace: "dest-ns",
 					},
 					Sources: []*SourceIntention{
 						{
@@ -248,8 +248,9 @@ func TestServiceIntentions_ToConsul(t *testing.T) {
 				},
 			},
 			Exp: &capi.ServiceIntentionsConfigEntry{
-				Kind: capi.ServiceIntentions,
-				Name: "svc-name",
+				Kind:      capi.ServiceIntentions,
+				Name:      "svc-name",
+				Namespace: "dest-ns",
 				Sources: []*capi.SourceIntention{
 					{
 						Name:        "svc1",
@@ -458,205 +459,79 @@ func TestServiceIntentions_ObjectMeta(t *testing.T) {
 	require.Equal(t, meta, serviceResolver.GetObjectMeta())
 }
 
-// Test defaulting behavior for both OSS and enterprise.
+// Test defaulting behavior when namespaces are enabled as well as disabled.
 func TestServiceIntentions_Default(t *testing.T) {
-	cases := map[string]struct {
-		input  *ServiceIntentions
-		output *ServiceIntentions
+	namespaceConfig := map[string]struct {
+		enabled              bool
+		destinationNamespace string
+		mirroring            bool
+		prefix               string
+		sourceNamespace      string
+		expectedDestination  string
 	}{
-		"destination.namespace blank, meta.namespace default": {
-			input: &ServiceIntentions{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "default",
-				},
-				Spec: ServiceIntentionsSpec{
-					Destination: Destination{
-						Name: "bar",
-					},
-				},
-			},
-			output: &ServiceIntentions{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "default",
-				},
-				Spec: ServiceIntentionsSpec{
-					Destination: Destination{
-						Name:      "bar",
-						Namespace: "default",
-					},
-				},
-			},
+		"disabled": {
+			enabled:              false,
+			destinationNamespace: "",
+			mirroring:            false,
+			prefix:               "",
+			sourceNamespace:      "bar",
+			expectedDestination:  "",
 		},
-		"destination.namespace blank, meta.namespace foobar": {
-			input: &ServiceIntentions{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "foobar",
-				},
-				Spec: ServiceIntentionsSpec{
-					Destination: Destination{
-						Name: "bar",
-					},
-				},
-			},
-			output: &ServiceIntentions{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "foobar",
-				},
-				Spec: ServiceIntentionsSpec{
-					Destination: Destination{
-						Name:      "bar",
-						Namespace: "foobar",
-					},
-				},
-			},
+		"destinationNS": {
+			enabled:              true,
+			destinationNamespace: "foo",
+			mirroring:            false,
+			prefix:               "",
+			sourceNamespace:      "bar",
+			expectedDestination:  "foo",
 		},
-		"sources.namespace blank, meta.namespace default": {
-			input: &ServiceIntentions{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "default",
-				},
-				Spec: ServiceIntentionsSpec{
-					Destination: Destination{
-						Name:      "bar",
-						Namespace: "foo",
-					},
-					Sources: SourceIntentions{
-						{
-							Name:   "baz",
-							Action: "allow",
-						},
-					},
-				},
-			},
-			output: &ServiceIntentions{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "default",
-				},
-				Spec: ServiceIntentionsSpec{
-					Destination: Destination{
-						Name:      "bar",
-						Namespace: "foo",
-					},
-					Sources: SourceIntentions{
-						{
-							Name:      "baz",
-							Action:    "allow",
-							Namespace: "default",
-						},
-					},
-				},
-			},
+		"mirroringEnabledWithoutPrefix": {
+			enabled:              true,
+			destinationNamespace: "",
+			mirroring:            true,
+			prefix:               "",
+			sourceNamespace:      "bar",
+			expectedDestination:  "bar",
 		},
-		"sources.namespace blank, meta.namespace foobar": {
-			input: &ServiceIntentions{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "foobar",
-				},
-				Spec: ServiceIntentionsSpec{
-					Destination: Destination{
-						Name:      "bar",
-						Namespace: "foo",
-					},
-					Sources: SourceIntentions{
-						{
-							Name:   "baz",
-							Action: "allow",
-						},
-					},
-				},
-			},
-			output: &ServiceIntentions{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "foobar",
-				},
-				Spec: ServiceIntentionsSpec{
-					Destination: Destination{
-						Name:      "bar",
-						Namespace: "foo",
-					},
-					Sources: SourceIntentions{
-						{
-							Name:      "baz",
-							Action:    "allow",
-							Namespace: "foobar",
-						},
-					},
-				},
-			},
-		},
-		"only populated blank namespaces": {
-			input: &ServiceIntentions{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "foobar",
-				},
-				Spec: ServiceIntentionsSpec{
-					Destination: Destination{
-						Name:      "bar",
-						Namespace: "foo",
-					},
-					Sources: SourceIntentions{
-						{
-							Name:   "baz",
-							Action: "allow",
-						},
-						{
-							Name:      "baz2",
-							Action:    "allow",
-							Namespace: "another-namespace",
-						},
-					},
-				},
-			},
-			output: &ServiceIntentions{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "foobar",
-				},
-				Spec: ServiceIntentionsSpec{
-					Destination: Destination{
-						Name:      "bar",
-						Namespace: "foo",
-					},
-					Sources: SourceIntentions{
-						{
-							Name:      "baz",
-							Action:    "allow",
-							Namespace: "foobar",
-						},
-						{
-							Name:      "baz2",
-							Action:    "allow",
-							Namespace: "another-namespace",
-						},
-					},
-				},
-			},
+		"mirroringWithPrefix": {
+			enabled:              true,
+			destinationNamespace: "",
+			mirroring:            true,
+			prefix:               "ns-",
+			sourceNamespace:      "bar",
+			expectedDestination:  "ns-bar",
 		},
 	}
-	for name, testCase := range cases {
-		// We also test with consul namespaces enabled/disabled. When disabled,
-		// the input shouldn't change since we don't set any namespace defaults
-		// in OSS.
-		for _, namespacesEnabled := range []bool{false, true} {
-			testName := fmt.Sprintf("%s namespaces=%t", name, namespacesEnabled)
-			t.Run(testName, func(t *testing.T) {
-				testCase.input.Default(namespacesEnabled)
-				if namespacesEnabled {
-					require.True(t, cmp.Equal(testCase.input, testCase.output))
-				} else {
-					require.True(t, cmp.Equal(testCase.input, testCase.input))
-				}
-			})
+
+	for name, s := range namespaceConfig {
+		input := &ServiceIntentions{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: s.sourceNamespace,
+			},
+			Spec: ServiceIntentionsSpec{
+				Destination: Destination{
+					Name: "bar",
+				},
+			},
 		}
+		output := &ServiceIntentions{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: s.sourceNamespace,
+			},
+			Spec: ServiceIntentionsSpec{
+				Destination: Destination{
+					Name:      "bar",
+					Namespace: s.expectedDestination,
+				},
+			},
+		}
+
+		t.Run(name, func(t *testing.T) {
+			input.Default(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
+			require.True(t, cmp.Equal(input, output))
+		})
 	}
 }
 
@@ -859,6 +734,303 @@ func TestServiceIntentions_Validate(t *testing.T) {
 	for name, testCase := range cases {
 		t.Run(name, func(t *testing.T) {
 			err := testCase.input.Validate()
+			if testCase.expectedErrMsg != "" {
+				require.EqualError(t, err, testCase.expectedErrMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestServiceIntentions_ValidateNamespaces(t *testing.T) {
+	cases := map[string]struct {
+		namespacesEnabled bool
+		input             *ServiceIntentions
+		expectedErrMsg    string
+	}{
+		"enabled: valid": {
+			true,
+			&ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: Destination{
+						Name:      "dest-service",
+						Namespace: "namespace",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:      "web",
+							Namespace: "web",
+							Action:    "allow",
+						},
+						{
+							Name:      "db",
+							Namespace: "db",
+							Action:    "deny",
+						},
+						{
+							Name:      "bar",
+							Namespace: "bar",
+							Permissions: IntentionPermissions{
+								{
+									Action: "allow",
+									HTTP: &IntentionHTTPPermission{
+										PathExact:  "/foo",
+										PathPrefix: "/bar",
+										PathRegex:  "/baz",
+										Header: IntentionHTTPHeaderPermissions{
+											{
+												Name:    "header",
+												Present: true,
+												Exact:   "exact",
+												Prefix:  "prefix",
+												Suffix:  "suffix",
+												Regex:   "regex",
+												Invert:  true,
+											},
+										},
+										Methods: []string{
+											"GET",
+											"PUT",
+										},
+									},
+								},
+							},
+							Description: "an L7 config",
+						},
+					},
+				},
+			},
+			"",
+		},
+		"disabled: destination namespace specified": {
+			false,
+			&ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: Destination{
+						Name:      "dest-service",
+						Namespace: "foo",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:   "web",
+							Action: "allow",
+						},
+						{
+							Name:   "db",
+							Action: "deny",
+						},
+						{
+							Name: "bar",
+							Permissions: IntentionPermissions{
+								{
+									Action: "allow",
+									HTTP: &IntentionHTTPPermission{
+										PathExact:  "/foo",
+										PathPrefix: "/bar",
+										PathRegex:  "/baz",
+										Header: IntentionHTTPHeaderPermissions{
+											{
+												Name:    "header",
+												Present: true,
+												Exact:   "exact",
+												Prefix:  "prefix",
+												Suffix:  "suffix",
+												Regex:   "regex",
+												Invert:  true,
+											},
+										},
+										Methods: []string{
+											"GET",
+											"PUT",
+										},
+									},
+								},
+							},
+							Description: "an L7 config",
+						},
+					},
+				},
+			},
+			`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.destination.namespace: Invalid value: "foo": consul namespaces must be enabled to set destination.namespace`,
+		},
+		"disabled: single source namespace specified": {
+			false,
+			&ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: Destination{
+						Name: "dest-service",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:      "web",
+							Action:    "allow",
+							Namespace: "bar",
+						},
+						{
+							Name:   "db",
+							Action: "deny",
+						},
+						{
+							Name: "bar",
+							Permissions: IntentionPermissions{
+								{
+									Action: "allow",
+									HTTP: &IntentionHTTPPermission{
+										PathExact:  "/foo",
+										PathPrefix: "/bar",
+										PathRegex:  "/baz",
+										Header: IntentionHTTPHeaderPermissions{
+											{
+												Name:    "header",
+												Present: true,
+												Exact:   "exact",
+												Prefix:  "prefix",
+												Suffix:  "suffix",
+												Regex:   "regex",
+												Invert:  true,
+											},
+										},
+										Methods: []string{
+											"GET",
+											"PUT",
+										},
+									},
+								},
+							},
+							Description: "an L7 config",
+						},
+					},
+				},
+			},
+			`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].namespace: Invalid value: "bar": consul namespaces must be enabled to set source.namespace`,
+		},
+		"disabled: multiple source namespace specified": {
+			false,
+			&ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: Destination{
+						Name: "dest-service",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:      "web",
+							Action:    "allow",
+							Namespace: "bar",
+						},
+						{
+							Name:      "db",
+							Action:    "deny",
+							Namespace: "baz",
+						},
+						{
+							Name:      "bar",
+							Namespace: "baz",
+							Permissions: IntentionPermissions{
+								{
+									Action: "allow",
+									HTTP: &IntentionHTTPPermission{
+										PathExact:  "/foo",
+										PathPrefix: "/bar",
+										PathRegex:  "/baz",
+										Header: IntentionHTTPHeaderPermissions{
+											{
+												Name:    "header",
+												Present: true,
+												Exact:   "exact",
+												Prefix:  "prefix",
+												Suffix:  "suffix",
+												Regex:   "regex",
+												Invert:  true,
+											},
+										},
+										Methods: []string{
+											"GET",
+											"PUT",
+										},
+									},
+								},
+							},
+							Description: "an L7 config",
+						},
+					},
+				},
+			},
+			`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: [spec.sources[0].namespace: Invalid value: "bar": consul namespaces must be enabled to set source.namespace, spec.sources[1].namespace: Invalid value: "baz": consul namespaces must be enabled to set source.namespace, spec.sources[2].namespace: Invalid value: "baz": consul namespaces must be enabled to set source.namespace]`,
+		},
+		"disabled: multiple source and destination namespace specified": {
+			false,
+			&ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: Destination{
+						Name:      "dest-service",
+						Namespace: "foo",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:      "web",
+							Action:    "allow",
+							Namespace: "bar",
+						},
+						{
+							Name:      "db",
+							Action:    "deny",
+							Namespace: "baz",
+						},
+						{
+							Name:      "bar",
+							Namespace: "baz",
+							Permissions: IntentionPermissions{
+								{
+									Action: "allow",
+									HTTP: &IntentionHTTPPermission{
+										PathExact:  "/foo",
+										PathPrefix: "/bar",
+										PathRegex:  "/baz",
+										Header: IntentionHTTPHeaderPermissions{
+											{
+												Name:    "header",
+												Present: true,
+												Exact:   "exact",
+												Prefix:  "prefix",
+												Suffix:  "suffix",
+												Regex:   "regex",
+												Invert:  true,
+											},
+										},
+										Methods: []string{
+											"GET",
+											"PUT",
+										},
+									},
+								},
+							},
+							Description: "an L7 config",
+						},
+					},
+				},
+			},
+			`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: [spec.destination.namespace: Invalid value: "foo": consul namespaces must be enabled to set destination.namespace, spec.sources[0].namespace: Invalid value: "bar": consul namespaces must be enabled to set source.namespace, spec.sources[1].namespace: Invalid value: "baz": consul namespaces must be enabled to set source.namespace, spec.sources[2].namespace: Invalid value: "baz": consul namespaces must be enabled to set source.namespace]`,
+		},
+	}
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := testCase.input.ValidateNamespaces(testCase.namespacesEnabled)
 			if testCase.expectedErrMsg != "" {
 				require.EqualError(t, err, testCase.expectedErrMsg)
 			} else {

--- a/api/v1alpha1/serviceintentions_types_test.go
+++ b/api/v1alpha1/serviceintentions_types_test.go
@@ -466,7 +466,6 @@ func TestServiceIntentions_Default(t *testing.T) {
 		destinationNamespace string
 		mirroring            bool
 		prefix               string
-		sourceNamespace      string
 		expectedDestination  string
 	}{
 		"disabled": {
@@ -474,7 +473,6 @@ func TestServiceIntentions_Default(t *testing.T) {
 			destinationNamespace: "",
 			mirroring:            false,
 			prefix:               "",
-			sourceNamespace:      "bar",
 			expectedDestination:  "",
 		},
 		"destinationNS": {
@@ -482,7 +480,6 @@ func TestServiceIntentions_Default(t *testing.T) {
 			destinationNamespace: "foo",
 			mirroring:            false,
 			prefix:               "",
-			sourceNamespace:      "bar",
 			expectedDestination:  "foo",
 		},
 		"mirroringEnabledWithoutPrefix": {
@@ -490,7 +487,6 @@ func TestServiceIntentions_Default(t *testing.T) {
 			destinationNamespace: "",
 			mirroring:            true,
 			prefix:               "",
-			sourceNamespace:      "bar",
 			expectedDestination:  "bar",
 		},
 		"mirroringWithPrefix": {
@@ -498,7 +494,6 @@ func TestServiceIntentions_Default(t *testing.T) {
 			destinationNamespace: "",
 			mirroring:            true,
 			prefix:               "ns-",
-			sourceNamespace:      "bar",
 			expectedDestination:  "ns-bar",
 		},
 	}
@@ -507,7 +502,7 @@ func TestServiceIntentions_Default(t *testing.T) {
 		input := &ServiceIntentions{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
-				Namespace: s.sourceNamespace,
+				Namespace: "bar",
 			},
 			Spec: ServiceIntentionsSpec{
 				Destination: Destination{
@@ -518,7 +513,7 @@ func TestServiceIntentions_Default(t *testing.T) {
 		output := &ServiceIntentions{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
-				Namespace: s.sourceNamespace,
+				Namespace: "bar",
 			},
 			Spec: ServiceIntentionsSpec{
 				Destination: Destination{

--- a/api/v1alpha1/serviceintentions_types_test.go
+++ b/api/v1alpha1/serviceintentions_types_test.go
@@ -596,6 +596,21 @@ func TestServiceIntentions_Validate(t *testing.T) {
 			},
 			"",
 		},
+		"no sources": {
+			&ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: Destination{
+						Name:      "dest-service",
+						Namespace: "namespace",
+					},
+					Sources: SourceIntentions{},
+				},
+			},
+			`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources: Required value: at least one source must be specified`,
+		},
 		"invalid action": {
 			&ServiceIntentions{
 				ObjectMeta: metav1.ObjectMeta{

--- a/api/v1alpha1/serviceintentions_webhook_test.go
+++ b/api/v1alpha1/serviceintentions_webhook_test.go
@@ -37,6 +37,13 @@ func TestHandle_ServiceIntentions_Create(t *testing.T) {
 						Name:      "foo",
 						Namespace: "bar",
 					},
+					Sources: SourceIntentions{
+						{
+							Name:      "bar",
+							Namespace: "foo",
+							Action:    "allow",
+						},
+					},
 				},
 			},
 			expAllow: true,
@@ -76,6 +83,13 @@ func TestHandle_ServiceIntentions_Create(t *testing.T) {
 						Name:      "foo",
 						Namespace: "bar",
 					},
+					Sources: SourceIntentions{
+						{
+							Name:      "bar",
+							Namespace: "foo",
+							Action:    "allow",
+						},
+					},
 				},
 			}},
 			newResource: &ServiceIntentions{
@@ -86,6 +100,13 @@ func TestHandle_ServiceIntentions_Create(t *testing.T) {
 					Destination: Destination{
 						Name:      "foo",
 						Namespace: "bar",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:      "bar",
+							Namespace: "foo",
+							Action:    "allow",
+						},
 					},
 				},
 			},
@@ -103,6 +124,13 @@ func TestHandle_ServiceIntentions_Create(t *testing.T) {
 						Name:      "foo",
 						Namespace: "bar",
 					},
+					Sources: SourceIntentions{
+						{
+							Name:      "bar",
+							Namespace: "foo",
+							Action:    "allow",
+						},
+					},
 				},
 			}},
 			newResource: &ServiceIntentions{
@@ -113,6 +141,13 @@ func TestHandle_ServiceIntentions_Create(t *testing.T) {
 					Destination: Destination{
 						Name:      "foo",
 						Namespace: "baz",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:      "bar",
+							Namespace: "foo",
+							Action:    "allow",
+						},
 					},
 				},
 			},
@@ -130,6 +165,13 @@ func TestHandle_ServiceIntentions_Create(t *testing.T) {
 						Name:      "foo",
 						Namespace: "bar",
 					},
+					Sources: SourceIntentions{
+						{
+							Name:      "bar",
+							Namespace: "foo",
+							Action:    "allow",
+						},
+					},
 				},
 			}},
 			newResource: &ServiceIntentions{
@@ -140,6 +182,13 @@ func TestHandle_ServiceIntentions_Create(t *testing.T) {
 					Destination: Destination{
 						Name:      "foo",
 						Namespace: "baz",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:      "bar",
+							Namespace: "foo",
+							Action:    "allow",
+						},
 					},
 				},
 			},
@@ -156,6 +205,13 @@ func TestHandle_ServiceIntentions_Create(t *testing.T) {
 					Destination: Destination{
 						Name: "foo",
 					},
+					Sources: SourceIntentions{
+						{
+							Name:      "bar",
+							Namespace: "foo",
+							Action:    "allow",
+						},
+					},
 				},
 			}},
 			newResource: &ServiceIntentions{
@@ -165,6 +221,13 @@ func TestHandle_ServiceIntentions_Create(t *testing.T) {
 				Spec: ServiceIntentionsSpec{
 					Destination: Destination{
 						Name: "foo",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:      "bar",
+							Namespace: "foo",
+							Action:    "allow",
+						},
 					},
 				},
 			},
@@ -444,6 +507,13 @@ func TestHandle_ServiceIntentions_Patches(t *testing.T) {
 				Spec: ServiceIntentionsSpec{
 					Destination: Destination{
 						Name: "foo",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:      "bar",
+							Namespace: "foo",
+							Action:    "allow",
+						},
 					},
 				},
 			},

--- a/controller/configentry_controller_ent_test.go
+++ b/controller/configentry_controller_ent_test.go
@@ -156,7 +156,7 @@ func TestConfigEntryController_createsConfigEntry_consulNamespaces(tt *testing.T
 					Spec: v1alpha1.ServiceIntentionsSpec{
 						Destination: v1alpha1.Destination{
 							Name:      "test",
-							Namespace: c.SourceKubeNS,
+							Namespace: c.ExpConsulNS,
 						},
 						Sources: v1alpha1.SourceIntentions{
 							&v1alpha1.SourceIntention{
@@ -404,7 +404,7 @@ func TestConfigEntryController_updatesConfigEntry_consulNamespaces(tt *testing.T
 					Spec: v1alpha1.ServiceIntentionsSpec{
 						Destination: v1alpha1.Destination{
 							Name:      "foo",
-							Namespace: c.SourceKubeNS,
+							Namespace: c.ExpConsulNS,
 						},
 						Sources: v1alpha1.SourceIntentions{
 							&v1alpha1.SourceIntention{
@@ -669,7 +669,7 @@ func TestConfigEntryController_deletesConfigEntry_consulNamespaces(tt *testing.T
 					Spec: v1alpha1.ServiceIntentionsSpec{
 						Destination: v1alpha1.Destination{
 							Name:      "test",
-							Namespace: c.SourceKubeNS,
+							Namespace: c.ExpConsulNS,
 						},
 						Sources: v1alpha1.SourceIntentions{
 							&v1alpha1.SourceIntention{

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.0.1
 	google.golang.org/api v0.9.0 // indirect
 	google.golang.org/appengine v1.6.0 // indirect
 	k8s.io/api v0.18.6

--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -248,11 +248,13 @@ func (c *Command) Run(args []string) int {
 			}})
 		mgr.GetWebhookServer().Register("/mutate-v1alpha1-serviceintentions",
 			&webhook.Admission{Handler: &v1alpha1.ServiceIntentionsWebhook{
-				Client:                 mgr.GetClient(),
-				ConsulClient:           consulClient,
-				Logger:                 ctrl.Log.WithName("webhooks").WithName(common.ServiceIntentions),
-				EnableConsulNamespaces: c.flagEnableNamespaces,
-				EnableNSMirroring:      c.flagEnableNSMirroring,
+				Client:                     mgr.GetClient(),
+				ConsulClient:               consulClient,
+				Logger:                     ctrl.Log.WithName("webhooks").WithName(common.ServiceIntentions),
+				EnableConsulNamespaces:     c.flagEnableNamespaces,
+				EnableNSMirroring:          c.flagEnableNSMirroring,
+				ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
+				NSMirroringPrefix:          c.flagNSMirroringPrefix,
 			}})
 	}
 	// +kubebuilder:scaffold:builder


### PR DESCRIPTION
Changes proposed in this PR:
- Fix support for service-intentions and Consul enterprise. Previously the defaults we were setting for the namespace fields weren't getting applied to the object in the webhook because we weren't returning any patches. When the entry got into the controller, its destination.namespace field was `""`.  We would then attempt to create a namespace with name `""` which would fail. In addition, if the namespace creation didn't error out, we would create the config entry in the namespace `"default"` instead of what we wanted to be the default namespace (e.g. if mirroring we wanted the namespace to equal the kube namespace).

- In this PR, we reject requests that have source.namespace or destination.namespace specified and consul namespaces are disabled.

- Additionally, if a destination namespace is explicitly specified, and namespaces are enabled, we create the service intention in the specified destination namespace.

- In case the destination namespace is not specified and namespaces are enabled, we use our existing logic to determine the consul namespace, depending on mirroring, mirror-prefix and destination consul namespace values.

- This PR allows validates that atleast one source value is set on an intention.
- It also ensures that exposePaths.protocol does not fail is `""` is set as it's value as that defaulting is managed by Consul.
How I've tested this PR:
- Acceptance tests are passing https://github.com/hashicorp/consul-helm/pull/645 using this image. Previously they were failing for Consul enterprise.

Closes https://github.com/hashicorp/consul-k8s/issues/367

How I expect reviewers to test this PR:
- code, review acceptance tests

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
