### PR TITLE
Fail sync if consul delete returns an error

### DIFF
--- a/api/v1alpha1/proxydefaults_types.go
+++ b/api/v1alpha1/proxydefaults_types.go
@@ -25,6 +25,7 @@ const (
 
 // ProxyDefaults is the Schema for the proxydefaults API
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
 type ProxyDefaults struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -20,6 +20,7 @@ const (
 
 // ServiceDefaults is the Schema for the servicedefaults API
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
 type ServiceDefaults struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/serviceintentions_types.go
+++ b/api/v1alpha1/serviceintentions_types.go
@@ -72,6 +72,7 @@ type IntentionAction string
 
 // ServiceIntentions is the Schema for the serviceintentions API
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
 type ServiceIntentions struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -248,7 +248,7 @@ type ServiceResolverFailover struct {
 	ServiceSubset string `json:"serviceSubset,omitempty"`
 	// Namespace is the namespace to resolve the requested service from to form
 	// the failover group of instances. If empty the current namespace is used.
-	Namespace string `json:"namespaces,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
 	// Datacenters is a fixed list of datacenters to try during failover.
 	Datacenters []string `json:"datacenters,omitempty"`
 }

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -22,6 +22,7 @@ const ServiceResolverKubeKind string = "serviceresolver"
 
 // ServiceResolver is the Schema for the serviceresolvers API
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
 type ServiceResolver struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/servicerouter_types.go
+++ b/api/v1alpha1/servicerouter_types.go
@@ -271,6 +271,7 @@ func (in *ServiceRouteDestination) toConsul() *capi.ServiceRouteDestination {
 
 // ServiceRouter is the Schema for the servicerouters API
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
 type ServiceRouter struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/servicesplitter_types.go
+++ b/api/v1alpha1/servicesplitter_types.go
@@ -20,6 +20,7 @@ import (
 
 // ServiceSplitter is the Schema for the servicesplitters API
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
 type ServiceSplitter struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/consul.hashicorp.com_proxydefaults.yaml
+++ b/config/crd/bases/consul.hashicorp.com_proxydefaults.yaml
@@ -13,6 +13,10 @@ spec:
     description: The sync status of the resource with Consul
     name: Synced
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The age of the resource
+    name: Age
+    type: date
   group: consul.hashicorp.com
   names:
     kind: ProxyDefaults

--- a/config/crd/bases/consul.hashicorp.com_servicedefaults.yaml
+++ b/config/crd/bases/consul.hashicorp.com_servicedefaults.yaml
@@ -13,6 +13,10 @@ spec:
     description: The sync status of the resource with Consul
     name: Synced
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The age of the resource
+    name: Age
+    type: date
   group: consul.hashicorp.com
   names:
     kind: ServiceDefaults

--- a/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
+++ b/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
@@ -13,6 +13,10 @@ spec:
     description: The sync status of the resource with Consul
     name: Synced
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The age of the resource
+    name: Age
+    type: date
   group: consul.hashicorp.com
   names:
     kind: ServiceIntentions

--- a/config/crd/bases/consul.hashicorp.com_serviceresolvers.yaml
+++ b/config/crd/bases/consul.hashicorp.com_serviceresolvers.yaml
@@ -56,7 +56,7 @@ spec:
                     items:
                       type: string
                     type: array
-                  namespaces:
+                  namespace:
                     description: Namespace is the namespace to resolve the requested service from to form the failover group of instances. If empty the current namespace is used.
                     type: string
                   service:

--- a/config/crd/bases/consul.hashicorp.com_serviceresolvers.yaml
+++ b/config/crd/bases/consul.hashicorp.com_serviceresolvers.yaml
@@ -13,6 +13,10 @@ spec:
     description: The sync status of the resource with Consul
     name: Synced
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The age of the resource
+    name: Age
+    type: date
   group: consul.hashicorp.com
   names:
     kind: ServiceResolver

--- a/config/crd/bases/consul.hashicorp.com_servicerouters.yaml
+++ b/config/crd/bases/consul.hashicorp.com_servicerouters.yaml
@@ -13,6 +13,10 @@ spec:
     description: The sync status of the resource with Consul
     name: Synced
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The age of the resource
+    name: Age
+    type: date
   group: consul.hashicorp.com
   names:
     kind: ServiceRouter

--- a/config/crd/bases/consul.hashicorp.com_servicesplitters.yaml
+++ b/config/crd/bases/consul.hashicorp.com_servicesplitters.yaml
@@ -13,6 +13,10 @@ spec:
     description: The sync status of the resource with Consul
     name: Synced
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The age of the resource
+    name: Age
+    type: date
   group: consul.hashicorp.com
   names:
     kind: ServiceSplitter

--- a/controller/configentry_controller.go
+++ b/controller/configentry_controller.go
@@ -126,7 +126,8 @@ func (r *ConfigEntryController) ReconcileEntry(
 						Namespace: r.consulNamespace(configEntry.ConsulMirroringNS(), configEntry.ConsulGlobalResource()),
 					})
 					if err != nil {
-						return ctrl.Result{}, fmt.Errorf("deleting config entry from consul: %w", err)
+						return r.syncFailed(ctx, logger, crdCtrl, configEntry, ConsulAgentError,
+							fmt.Errorf("deleting config entry from consul: %w", err))
 					}
 					logger.Info("deletion from Consul successful")
 				} else {

--- a/controller/configentry_controller_test.go
+++ b/controller/configentry_controller_test.go
@@ -2161,7 +2161,7 @@ func TestConfigEntryControllers_updatesStatusWhenDeleteFails(t *testing.T) {
 	err = client.Get(ctx, defaultsNamespacedName, defaults)
 	require.NoError(t, err)
 
-	// Update service-default with deletion timestamp so that it attempts deletion on reconcile.
+	// Update service-defaults with deletion timestamp so that it attempts deletion on reconcile.
 	defaults.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 	err = client.Update(ctx, defaults)
 	require.NoError(t, err)

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/consul/api v1.4.1-0.20201007080954-aa0f5ff839c5 h1:mHgaDaPdf0z3UG3G2UpCINFMRKhzi1DLNoOp6sIQWnU=
 github.com/hashicorp/consul/api v1.4.1-0.20201007080954-aa0f5ff839c5/go.mod h1:1NSuaUUkFaJzMasbfq/11wKYWSR67Xn6r2DXKhuDNFg=
-github.com/hashicorp/consul/api v1.6.0 h1:SZB2hQW8AcTOpfDmiVblQbijxzsRuiyy0JpHfabvHio=
-github.com/hashicorp/consul/api v1.6.0/go.mod h1:1NSuaUUkFaJzMasbfq/11wKYWSR67Xn6r2DXKhuDNFg=
 github.com/hashicorp/consul/sdk v0.4.1-0.20201006182405-a2a8e9c7839a h1:yclqizoDCodLeiAUg1Siaodz3hvIBxzH8A2GnjY74EU=
 github.com/hashicorp/consul/sdk v0.4.1-0.20201006182405-a2a8e9c7839a/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=


### PR DESCRIPTION
Changes proposed in this PR:
- In case consul fails while attempting to delete a config entry, update the sync value to being failed. This can happen when there are other config entries that depend on the config entry being deleted. For example, a service-defaults entry being deleted before service-splitter/service-router/service-resolver entries that depend on the service-defaults.
- Add Age column to CRD printer columns

How I've tested this PR: Deployed it in local cluster and viewed the changes. Wasn't sure what a failing test case would look like for this particular error so I would like some feedback on that. Maybe just a standalone test for service-defaults with service splitters? Most of the existing tests test every config entry but that assertion will probably not be the case here.


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
