### PR TITLE
add ACL support for health checks controller

### DIFF
--- a/subcommand/inject-connect/command_test.go
+++ b/subcommand/inject-connect/command_test.go
@@ -117,7 +117,7 @@ func TestRun_FlagValidation(t *testing.T) {
 			expErr: "request must be <= limit: -lifecycle-sidecar-cpu-request value of \"50m\" is greater than the -lifecycle-sidecar-cpu-limit value of \"25m\"",
 		},
 		{
-			flags: []string{"-consul-k8s-image", "kschoche/consul-k8s-dev",
+			flags: []string{"-consul-k8s-image", "hashicorpdev/consul-k8s:latest",
 				"-enable-health-checks-controller=true"},
 			expErr: "CONSUL_HTTP_ADDR is not specified",
 		},

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -42,10 +42,10 @@ type Command struct {
 	flagCreateSyncToken    bool
 	flagSyncConsulNodeName string
 
-	flagCreateInjectToken      bool
-	flagCreateInjectAuthMethod bool
-	flagInjectAuthMethodHost   string
-	flagBindingRuleSelector    string
+	flagAddInjectNamespaceRules bool
+	flagCreateInjectAuthMethod  bool
+	flagInjectAuthMethodHost    string
+	flagBindingRuleSelector     string
 
 	flagCreateControllerToken bool
 
@@ -81,7 +81,7 @@ type Command struct {
 	flagBootstrapTokenFile string
 
 	// Flag for health check connect-inject rules
-	flagEnableHealthChecksController bool
+	flagAddInjectHealthChecksRules bool
 
 	flagLogLevel string
 	flagTimeout  time.Duration
@@ -119,7 +119,7 @@ func (c *Command) init() {
 		"The Consul node name to register for catalog sync. Defaults to k8s-sync. To be discoverable "+
 			"via DNS, the name should only contain alpha-numerics and dashes.")
 
-	c.flags.BoolVar(&c.flagCreateInjectToken, "create-inject-namespace-token", false,
+	c.flags.BoolVar(&c.flagAddInjectNamespaceRules, "create-inject-namespace-token", false,
 		"Toggle for creating a connect injector token. Only required when namespaces are enabled.")
 	c.flags.BoolVar(&c.flagCreateInjectAuthMethod, "create-inject-auth-method", false,
 		"Toggle for creating a connect inject auth method.")
@@ -188,7 +188,7 @@ func (c *Command) init() {
 		"Path to file containing ACL token for creating policies and tokens. This token must have 'acl:write' permissions."+
 			"When provided, servers will not be bootstrapped and their policies and tokens will not be updated.")
 
-	c.flags.BoolVar(&c.flagEnableHealthChecksController, "enable-health-checks-controller", false,
+	c.flags.BoolVar(&c.flagAddInjectHealthChecksRules, "add-inject-health-checks-rules", false,
 		"Creates health check controller ACL rules.")
 
 	c.flags.DurationVar(&c.flagTimeout, "timeout", 10*time.Minute,
@@ -463,7 +463,8 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
-	if c.flagCreateInjectToken || c.flagEnableHealthChecksController {
+	// Add rules for connect inject based on whether namespaces are enabled or health checks, or both.
+	if c.flagAddInjectNamespaceRules || c.flagAddInjectHealthChecksRules {
 		injectRules, err := c.injectRules()
 		if err != nil {
 			c.log.Error("Error templating inject rules", "err", err)

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -80,7 +80,7 @@ type Command struct {
 	// Flag to support a custom bootstrap token
 	flagBootstrapTokenFile string
 
-	// Health checks controller is enabled.
+	// Flag to indicate that the health checks controller is enabled.
 	flagEnableHealthChecks bool
 
 	flagLogLevel string
@@ -131,7 +131,7 @@ func (c *Command) init() {
 	c.flags.BoolVar(&c.flagCreateInjectToken, "create-inject-auth-method", false,
 		"Toggle for creating a connect inject auth method. Deprecated: use -create-inject-token instead.")
 	c.flags.BoolVar(&c.flagCreateInjectToken, "create-inject-token", false,
-		"Toggle for creating a connect inject auth method.")
+		"Toggle for creating a connect inject auth method and an ACL token. The ACL token will only be created if either of the -enable-namespaces or -enable-health-checks flags is set.")
 	c.flags.StringVar(&c.flagInjectAuthMethodHost, "inject-auth-method-host", "",
 		"Kubernetes Host config parameter for the auth method."+
 			"If not provided, the default cluster Kubernetes service will be used.")
@@ -196,7 +196,7 @@ func (c *Command) init() {
 			"When provided, servers will not be bootstrapped and their policies and tokens will not be updated.")
 
 	c.flags.BoolVar(&c.flagEnableHealthChecks, "enable-health-checks", false,
-		"Toggle for creating health check controller token.")
+		"Toggle for adding ACL rules for the health check controller to the connect ACL token. Requires -create-inject-token to be also be set.")
 
 	c.flags.DurationVar(&c.flagTimeout, "timeout", 10*time.Minute,
 		"How long we'll try to bootstrap ACLs for before timing out, e.g. 1ms, 2s, 3m")

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -190,7 +190,7 @@ func (c *Command) init() {
 		"Path to file containing ACL token for creating policies and tokens. This token must have 'acl:write' permissions."+
 			"When provided, servers will not be bootstrapped and their policies and tokens will not be updated.")
 
-	c.flags.BoolVar(&c.flagAddInjectHealthChecksRules, "add-inject-health-checks-rules", false,
+	c.flags.BoolVar(&c.flagAddInjectHealthChecksRules, "enable-health-checks", false,
 		"Creates health check controller ACL rules.")
 
 	c.flags.DurationVar(&c.flagTimeout, "timeout", 10*time.Minute,

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -471,7 +471,7 @@ func (c *Command) Run(args []string) int {
 	}
 
 	if c.flagCreateInjectToken {
-		err := c.configureConnectInject(consulClient)
+		err := c.configureConnectInjectAuthMethod(consulClient)
 		if err != nil {
 			c.log.Error(err.Error())
 			return 1

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -80,6 +80,9 @@ type Command struct {
 	// Flag to support a custom bootstrap token
 	flagBootstrapTokenFile string
 
+	// Flag for health check connect-inject rules
+	flagEnableHealthChecksController bool
+
 	flagLogLevel string
 	flagTimeout  time.Duration
 
@@ -184,6 +187,9 @@ func (c *Command) init() {
 	c.flags.StringVar(&c.flagBootstrapTokenFile, "bootstrap-token-file", "",
 		"Path to file containing ACL token for creating policies and tokens. This token must have 'acl:write' permissions."+
 			"When provided, servers will not be bootstrapped and their policies and tokens will not be updated.")
+
+	c.flags.BoolVar(&c.flagEnableHealthChecksController, "enable-health-checks-controller", false,
+		"Creates health check controller ACL rules.")
 
 	c.flags.DurationVar(&c.flagTimeout, "timeout", 10*time.Minute,
 		"How long we'll try to bootstrap ACLs for before timing out, e.g. 1ms, 2s, 3m")
@@ -457,7 +463,7 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
-	if c.flagCreateInjectToken {
+	if c.flagCreateInjectToken || c.flagEnableHealthChecksController {
 		injectRules, err := c.injectRules()
 		if err != nil {
 			c.log.Error("Error templating inject rules", "err", err)

--- a/subcommand/server-acl-init/command_ent_test.go
+++ b/subcommand/server-acl-init/command_ent_test.go
@@ -668,6 +668,13 @@ func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
 			SecretNames: []string{resourcePrefix + "-acl-replication-acl-token"},
 			LocalToken:  false,
 		},
+		"inject token with namespaces (deprecated)": {
+			TokenFlags:  []string{"-create-inject-auth-method", "-enable-namespaces"},
+			PolicyNames: []string{"connect-inject-token"},
+			PolicyDCs:   nil,
+			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
+			LocalToken:  false,
+		},
 		"inject token with namespaces": {
 			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces"},
 			PolicyNames: []string{"connect-inject-token"},

--- a/subcommand/server-acl-init/command_ent_test.go
+++ b/subcommand/server-acl-init/command_ent_test.go
@@ -682,7 +682,7 @@ func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
 			LocalToken:  false,
 		},
-		"inject token with health checks": {
+		"inject token with health checks and namespaces": {
 			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces", "-enable-health-checks"},
 			PolicyNames: []string{"connect-inject-token"},
 			PolicyDCs:   nil,

--- a/subcommand/server-acl-init/command_ent_test.go
+++ b/subcommand/server-acl-init/command_ent_test.go
@@ -1,8 +1,9 @@
+// +build enterprise
+
 package serveraclinit
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -16,105 +17,100 @@ import (
 
 // Test the auth method and acl binding rule created when namespaces are enabled
 // and there's a single consul destination namespace.
-func TestRun_ConnectInject_SingleDestinationNamespace(tt *testing.T) {
-	tt.Parallel()
+func TestRun_ConnectInject_SingleDestinationNamespace(t *testing.T) {
+	t.Parallel()
 
-	cases := []string{"-create-inject-auth-method", "-create-inject-token"}
-	for _, flag := range cases {
-		tt.Run(flag, func(t *testing.T) {
-			consulDestNamespaces := []string{"default", "destination"}
-			for _, consulDestNamespace := range consulDestNamespaces {
-				t.Run(consulDestNamespace, func(tt *testing.T) {
-					k8s, testAgent := completeEnterpriseSetup(tt)
-					defer testAgent.Stop()
-					setUpK8sServiceAccount(tt, k8s, ns)
-					require := require.New(tt)
+	consulDestNamespaces := []string{"default", "destination"}
+	for _, consulDestNamespace := range consulDestNamespaces {
+		t.Run(consulDestNamespace, func(tt *testing.T) {
+			k8s, testAgent := completeEnterpriseSetup(tt)
+			defer testAgent.Stop()
+			setUpK8sServiceAccount(tt, k8s, ns)
+			require := require.New(tt)
 
-					ui := cli.NewMockUi()
-					cmd := Command{
-						UI:        ui,
-						clientset: k8s,
-					}
-					cmd.init()
-					args := []string{
-						"-server-address=" + strings.Split(testAgent.HTTPAddr, ":")[0],
-						"-server-port=" + strings.Split(testAgent.HTTPAddr, ":")[1],
-						"-resource-prefix=" + resourcePrefix,
-						"-k8s-namespace=" + ns,
-						flag,
-						"-enable-namespaces",
-						"-consul-inject-destination-namespace", consulDestNamespace,
-						"-acl-binding-rule-selector=serviceaccount.name!=default",
-					}
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI:        ui,
+				clientset: k8s,
+			}
+			cmd.init()
+			args := []string{
+				"-server-address=" + strings.Split(testAgent.HTTPAddr, ":")[0],
+				"-server-port=" + strings.Split(testAgent.HTTPAddr, ":")[1],
+				"-resource-prefix=" + resourcePrefix,
+				"-k8s-namespace=" + ns,
+				"-create-inject-token",
+				"-enable-namespaces",
+				"-consul-inject-destination-namespace", consulDestNamespace,
+				"-acl-binding-rule-selector=serviceaccount.name!=default",
+			}
 
-					responseCode := cmd.Run(args)
-					require.Equal(0, responseCode, ui.ErrorWriter.String())
+			responseCode := cmd.Run(args)
+			require.Equal(0, responseCode, ui.ErrorWriter.String())
 
-					bootToken := getBootToken(t, k8s, resourcePrefix, ns)
-					consul, err := api.NewClient(&api.Config{
-						Address: testAgent.HTTPAddr,
-						Token:   bootToken,
-					})
-					require.NoError(err)
+			bootToken := getBootToken(t, k8s, resourcePrefix, ns)
+			consul, err := api.NewClient(&api.Config{
+				Address: testAgent.HTTPAddr,
+				Token:   bootToken,
+			})
+			require.NoError(err)
 
-					// Ensure there's only one auth method.
-					namespaceQuery := &api.QueryOptions{
-						Namespace: consulDestNamespace,
-					}
-					methods, _, err := consul.ACL().AuthMethodList(namespaceQuery)
-					require.NoError(err)
-					require.Len(methods, 1)
+			// Ensure there's only one auth method.
+			namespaceQuery := &api.QueryOptions{
+				Namespace: consulDestNamespace,
+			}
+			methods, _, err := consul.ACL().AuthMethodList(namespaceQuery)
+			require.NoError(err)
+			require.Len(methods, 1)
 
-					// Check the ACL auth method is created in the expected namespace.
-					authMethodName := resourcePrefix + "-k8s-auth-method"
-					actMethod, _, err := consul.ACL().AuthMethodRead(authMethodName, namespaceQuery)
-					require.NoError(err)
-					require.NotNil(actMethod)
-					require.Equal("kubernetes", actMethod.Type)
-					require.Equal("Kubernetes Auth Method", actMethod.Description)
-					require.NotContains(actMethod.Config, "MapNamespaces")
-					require.NotContains(actMethod.Config, "ConsulNamespacePrefix")
+			// Check the ACL auth method is created in the expected namespace.
+			authMethodName := resourcePrefix + "-k8s-auth-method"
+			actMethod, _, err := consul.ACL().AuthMethodRead(authMethodName, namespaceQuery)
+			require.NoError(err)
+			require.NotNil(actMethod)
+			require.Equal("kubernetes", actMethod.Type)
+			require.Equal("Kubernetes Auth Method", actMethod.Description)
+			require.NotContains(actMethod.Config, "MapNamespaces")
+			require.NotContains(actMethod.Config, "ConsulNamespacePrefix")
 
-					// Check the binding rule is as expected.
-					rules, _, err := consul.ACL().BindingRuleList(authMethodName, namespaceQuery)
-					require.NoError(err)
-					require.Len(rules, 1)
-					actRule, _, err := consul.ACL().BindingRuleRead(rules[0].ID, namespaceQuery)
-					require.NoError(err)
-					require.NotNil(actRule)
-					require.Equal("Kubernetes binding rule", actRule.Description)
-					require.Equal(api.BindingRuleBindTypeService, actRule.BindType)
-					require.Equal("${serviceaccount.name}", actRule.BindName)
-					require.Equal("serviceaccount.name!=default", actRule.Selector)
+			// Check the binding rule is as expected.
+			rules, _, err := consul.ACL().BindingRuleList(authMethodName, namespaceQuery)
+			require.NoError(err)
+			require.Len(rules, 1)
+			actRule, _, err := consul.ACL().BindingRuleRead(rules[0].ID, namespaceQuery)
+			require.NoError(err)
+			require.NotNil(actRule)
+			require.Equal("Kubernetes binding rule", actRule.Description)
+			require.Equal(api.BindingRuleBindTypeService, actRule.BindType)
+			require.Equal("${serviceaccount.name}", actRule.BindName)
+			require.Equal("serviceaccount.name!=default", actRule.Selector)
 
-					// Check that the default namespace got an attached ACL policy
-					defNamespace, _, err := consul.Namespaces().Read("default", &api.QueryOptions{})
-					require.NoError(err)
-					require.NotNil(defNamespace)
-					require.NotNil(defNamespace.ACLs)
-					require.Len(defNamespace.ACLs.PolicyDefaults, 1)
-					require.Equal("cross-namespace-policy", defNamespace.ACLs.PolicyDefaults[0].Name)
+			// Check that the default namespace got an attached ACL policy
+			defNamespace, _, err := consul.Namespaces().Read("default", &api.QueryOptions{})
+			require.NoError(err)
+			require.NotNil(defNamespace)
+			require.NotNil(defNamespace.ACLs)
+			require.Len(defNamespace.ACLs.PolicyDefaults, 1)
+			require.Equal("cross-namespace-policy", defNamespace.ACLs.PolicyDefaults[0].Name)
 
-					if consulDestNamespace != "default" {
-						// Check that only one namespace was created besides the
-						// already existing `default` namespace
-						namespaces, _, err := consul.Namespaces().List(&api.QueryOptions{})
-						require.NoError(err)
-						require.Len(namespaces, 2)
+			if consulDestNamespace != "default" {
+				// Check that only one namespace was created besides the
+				// already existing `default` namespace
+				namespaces, _, err := consul.Namespaces().List(&api.QueryOptions{})
+				require.NoError(err)
+				require.Len(namespaces, 2)
 
-						// Check the created namespace properties
-						actNamespace, _, err := consul.Namespaces().Read(consulDestNamespace, &api.QueryOptions{})
-						require.NoError(err)
-						require.NotNil(actNamespace)
-						require.Equal(consulDestNamespace, actNamespace.Name)
-						require.Equal("Auto-generated by consul-k8s", actNamespace.Description)
-						require.NotNil(actNamespace.ACLs)
-						require.Len(actNamespace.ACLs.PolicyDefaults, 1)
-						require.Equal("cross-namespace-policy", actNamespace.ACLs.PolicyDefaults[0].Name)
-						require.Contains(actNamespace.Meta, "external-source")
-						require.Equal("kubernetes", actNamespace.Meta["external-source"])
-					}
-				})
+				// Check the created namespace properties
+				actNamespace, _, err := consul.Namespaces().Read(consulDestNamespace, &api.QueryOptions{})
+				require.NoError(err)
+				require.NotNil(actNamespace)
+				require.Equal(consulDestNamespace, actNamespace.Name)
+				require.Equal("Auto-generated by consul-k8s", actNamespace.Description)
+				require.NotNil(actNamespace.ACLs)
+				require.Len(actNamespace.ACLs.PolicyDefaults, 1)
+				require.Equal("cross-namespace-policy", actNamespace.ACLs.PolicyDefaults[0].Name)
+				require.Contains(actNamespace.Meta, "external-source")
+				require.Equal("kubernetes", actNamespace.Meta["external-source"])
 			}
 		})
 	}
@@ -125,7 +121,6 @@ func TestRun_ConnectInject_SingleDestinationNamespace(tt *testing.T) {
 func TestRun_ConnectInject_NamespaceMirroring(tt *testing.T) {
 	tt.Parallel()
 
-	flagcases := []string{"-create-inject-auth-method", "-create-inject-token"}
 	cases := map[string]struct {
 		MirroringPrefix string
 		ExtraFlags      []string
@@ -146,79 +141,75 @@ func TestRun_ConnectInject_NamespaceMirroring(tt *testing.T) {
 		},
 	}
 
-	for _, flag := range flagcases {
-		tt.Run(flag, func(t *testing.T) {
-			for name, c := range cases {
-				t.Run(name, func(tt *testing.T) {
-					k8s, testAgent := completeEnterpriseSetup(t)
-					defer testAgent.Stop()
-					setUpK8sServiceAccount(tt, k8s, ns)
-					require := require.New(tt)
+	for name, c := range cases {
+		tt.Run(name, func(t *testing.T) {
+			k8s, testAgent := completeEnterpriseSetup(t)
+			defer testAgent.Stop()
+			setUpK8sServiceAccount(t, k8s, ns)
+			require := require.New(t)
 
-					ui := cli.NewMockUi()
-					cmd := Command{
-						UI:        ui,
-						clientset: k8s,
-					}
-					cmd.init()
-					args := []string{
-						"-server-address=" + strings.Split(testAgent.HTTPAddr, ":")[0],
-						"-server-port=" + strings.Split(testAgent.HTTPAddr, ":")[1],
-						"-resource-prefix=" + resourcePrefix,
-						"-k8s-namespace=" + ns,
-						flag,
-						"-enable-namespaces",
-						"-enable-inject-k8s-namespace-mirroring",
-						"-inject-k8s-namespace-mirroring-prefix", c.MirroringPrefix,
-						"-acl-binding-rule-selector=serviceaccount.name!=default",
-					}
-					args = append(args, c.ExtraFlags...)
-					responseCode := cmd.Run(args)
-					require.Equal(0, responseCode, ui.ErrorWriter.String())
-
-					bootToken := getBootToken(t, k8s, resourcePrefix, ns)
-					consul, err := api.NewClient(&api.Config{
-						Address: testAgent.HTTPAddr,
-						Token:   bootToken,
-					})
-					require.NoError(err)
-
-					// Check the ACL auth method is as expected.
-					authMethodName := resourcePrefix + "-k8s-auth-method"
-					method, _, err := consul.ACL().AuthMethodRead(authMethodName, nil)
-					require.NoError(err)
-					require.NotNil(method, authMethodName+" not found")
-					require.Equal("kubernetes", method.Type)
-					require.Equal("Kubernetes Auth Method", method.Description)
-					require.Contains(method.Config, "MapNamespaces")
-					require.Contains(method.Config, "ConsulNamespacePrefix")
-					require.Equal(true, method.Config["MapNamespaces"])
-					require.Equal(c.MirroringPrefix, method.Config["ConsulNamespacePrefix"])
-
-					// Check the binding rule is as expected.
-					rules, _, err := consul.ACL().BindingRuleList(authMethodName, nil)
-					require.NoError(err)
-					require.Len(rules, 1)
-					actRule, _, err := consul.ACL().BindingRuleRead(rules[0].ID, nil)
-					require.NoError(err)
-					require.NotNil(actRule)
-					require.Equal("Kubernetes binding rule", actRule.Description)
-					require.Equal(api.BindingRuleBindTypeService, actRule.BindType)
-					require.Equal("${serviceaccount.name}", actRule.BindName)
-					require.Equal("serviceaccount.name!=default", actRule.Selector)
-				})
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI:        ui,
+				clientset: k8s,
 			}
+			cmd.init()
+			args := []string{
+				"-server-address=" + strings.Split(testAgent.HTTPAddr, ":")[0],
+				"-server-port=" + strings.Split(testAgent.HTTPAddr, ":")[1],
+				"-resource-prefix=" + resourcePrefix,
+				"-k8s-namespace=" + ns,
+				"-create-inject-token",
+				"-enable-namespaces",
+				"-enable-inject-k8s-namespace-mirroring",
+				"-inject-k8s-namespace-mirroring-prefix", c.MirroringPrefix,
+				"-acl-binding-rule-selector=serviceaccount.name!=default",
+			}
+			args = append(args, c.ExtraFlags...)
+			responseCode := cmd.Run(args)
+			require.Equal(0, responseCode, ui.ErrorWriter.String())
+
+			bootToken := getBootToken(t, k8s, resourcePrefix, ns)
+			consul, err := api.NewClient(&api.Config{
+				Address: testAgent.HTTPAddr,
+				Token:   bootToken,
+			})
+			require.NoError(err)
+
+			// Check the ACL auth method is as expected.
+			authMethodName := resourcePrefix + "-k8s-auth-method"
+			method, _, err := consul.ACL().AuthMethodRead(authMethodName, nil)
+			require.NoError(err)
+			require.NotNil(method, authMethodName+" not found")
+			require.Equal("kubernetes", method.Type)
+			require.Equal("Kubernetes Auth Method", method.Description)
+			require.Contains(method.Config, "MapNamespaces")
+			require.Contains(method.Config, "ConsulNamespacePrefix")
+			require.Equal(true, method.Config["MapNamespaces"])
+			require.Equal(c.MirroringPrefix, method.Config["ConsulNamespacePrefix"])
+
+			// Check the binding rule is as expected.
+			rules, _, err := consul.ACL().BindingRuleList(authMethodName, nil)
+			require.NoError(err)
+			require.Len(rules, 1)
+			actRule, _, err := consul.ACL().BindingRuleRead(rules[0].ID, nil)
+			require.NoError(err)
+			require.NotNil(actRule)
+			require.Equal("Kubernetes binding rule", actRule.Description)
+			require.Equal(api.BindingRuleBindTypeService, actRule.BindType)
+			require.Equal("${serviceaccount.name}", actRule.BindName)
+			require.Equal("serviceaccount.name!=default", actRule.Selector)
 		})
 	}
 }
 
 // Test that ACL policies get updated if namespaces config changes.
-func TestRun_ACLPolicyUpdates(t *testing.T) {
-	t.Parallel()
+func TestRun_ACLPolicyUpdates(tt *testing.T) {
+	tt.Parallel()
 
 	k8sNamespaceFlags := []string{"default", "other"}
 	for _, k8sNamespaceFlag := range k8sNamespaceFlags {
-		t.Run(k8sNamespaceFlag, func(t *testing.T) {
+		tt.Run(k8sNamespaceFlag, func(t *testing.T) {
 			k8s, testAgent := completeEnterpriseSetup(t)
 			setUpK8sServiceAccount(t, k8s, k8sNamespaceFlag)
 			defer testAgent.Stop()
@@ -265,12 +256,10 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 			require.NoError(err)
 
 			// Check that the expected policies were created.
-			// TODO: I think this was an invalid test
 			firstRunExpectedPolicies := []string{
 				"anonymous-token-policy",
 				"client-token",
 				"catalog-sync-token",
-				//				"connect-inject-token",
 				"mesh-gateway-token",
 				"client-snapshot-agent-token",
 				"enterprise-license-token",
@@ -415,22 +404,9 @@ func TestRun_ConnectInject_Updates(t *testing.T) {
 			AuthMethodExpectedNamespacePrefixConfig: "prefix-",
 			BindingRuleExpectedNS:                   "default",
 		},
-		"no ns => single dest ns (deprecated)": {
-			FirstRunArgs: nil,
-			SecondRunArgs: []string{
-				"-create-inject-auth-method",
-				"-enable-namespaces",
-				"-consul-inject-destination-namespace=dest",
-			},
-			AuthMethodExpectedNS:                    "dest",
-			AuthMethodExpectMapNamespacesConfig:     false,
-			AuthMethodExpectedNamespacePrefixConfig: "",
-			BindingRuleExpectedNS:                   "dest",
-		},
 		"no ns => single dest ns": {
 			FirstRunArgs: nil,
 			SecondRunArgs: []string{
-				"-create-inject-token",
 				"-enable-namespaces",
 				"-consul-inject-destination-namespace=dest",
 			},
@@ -442,13 +418,11 @@ func TestRun_ConnectInject_Updates(t *testing.T) {
 		"mirroring ns => single dest ns": {
 			FirstRunArgs: []string{
 				"-enable-namespaces",
-				"-create-inject-token",
 				"-enable-inject-k8s-namespace-mirroring",
 				"-inject-k8s-namespace-mirroring-prefix=prefix-",
 			},
 			SecondRunArgs: []string{
 				"-enable-namespaces",
-				"-create-inject-token",
 				"-consul-inject-destination-namespace=dest",
 			},
 			AuthMethodExpectedNS:                    "dest",
@@ -458,13 +432,11 @@ func TestRun_ConnectInject_Updates(t *testing.T) {
 		},
 		"single dest ns => mirroring ns": {
 			FirstRunArgs: []string{
-				"-create-inject-token",
 				"-enable-namespaces",
 				"-consul-inject-destination-namespace=dest",
 			},
 			SecondRunArgs: []string{
 				"-enable-namespaces",
-				"-create-inject-token",
 				"-enable-inject-k8s-namespace-mirroring",
 				"-inject-k8s-namespace-mirroring-prefix=prefix-",
 			},
@@ -475,14 +447,12 @@ func TestRun_ConnectInject_Updates(t *testing.T) {
 		},
 		"mirroring ns (no prefix) => mirroring ns (no prefix)": {
 			FirstRunArgs: []string{
-				"-create-inject-token",
 				"-enable-namespaces",
 				"-enable-inject-k8s-namespace-mirroring",
 				"-inject-k8s-namespace-mirroring-prefix=",
 			},
 			SecondRunArgs: []string{
 				"-enable-namespaces",
-				"-create-inject-token",
 				"-enable-inject-k8s-namespace-mirroring",
 				"-inject-k8s-namespace-mirroring-prefix=",
 			},
@@ -493,13 +463,11 @@ func TestRun_ConnectInject_Updates(t *testing.T) {
 		},
 		"mirroring ns => mirroring ns (same prefix)": {
 			FirstRunArgs: []string{
-				"-create-inject-token",
 				"-enable-namespaces",
 				"-enable-inject-k8s-namespace-mirroring",
 				"-inject-k8s-namespace-mirroring-prefix=prefix-",
 			},
 			SecondRunArgs: []string{
-				"-create-inject-token",
 				"-enable-namespaces",
 				"-enable-inject-k8s-namespace-mirroring",
 				"-inject-k8s-namespace-mirroring-prefix=prefix-",
@@ -511,13 +479,11 @@ func TestRun_ConnectInject_Updates(t *testing.T) {
 		},
 		"mirroring ns (no prefix) => mirroring ns (prefix)": {
 			FirstRunArgs: []string{
-				"-create-inject-token",
 				"-enable-namespaces",
 				"-enable-inject-k8s-namespace-mirroring",
 				"-inject-k8s-namespace-mirroring-prefix=",
 			},
 			SecondRunArgs: []string{
-				"-create-inject-token",
 				"-enable-namespaces",
 				"-enable-inject-k8s-namespace-mirroring",
 				"-inject-k8s-namespace-mirroring-prefix=prefix-",
@@ -530,13 +496,11 @@ func TestRun_ConnectInject_Updates(t *testing.T) {
 		"mirroring ns (prefix) => mirroring ns (no prefix)": {
 			FirstRunArgs: []string{
 				"-enable-namespaces",
-				"-create-inject-token",
 				"-enable-inject-k8s-namespace-mirroring",
 				"-inject-k8s-namespace-mirroring-prefix=prefix-",
 			},
 			SecondRunArgs: []string{
 				"-enable-namespaces",
-				"-create-inject-token",
 				"-enable-inject-k8s-namespace-mirroring",
 				"-inject-k8s-namespace-mirroring-prefix=",
 			},
@@ -547,83 +511,80 @@ func TestRun_ConnectInject_Updates(t *testing.T) {
 		},
 	}
 
-	tokenflags := []string{"-create-inject-auth-method", "-create-inject-token"}
-	for _, flag := range tokenflags {
-		for name, c := range cases {
-			t.Run(fmt.Sprintf("%v-%v", name, flag), func(tt *testing.T) {
-				require := require.New(tt)
-				k8s, testAgent := completeEnterpriseSetup(tt)
-				defer testAgent.Stop()
-				setUpK8sServiceAccount(tt, k8s, ns)
+	for name, c := range cases {
+		t.Run(name, func(tt *testing.T) {
+			require := require.New(tt)
+			k8s, testAgent := completeEnterpriseSetup(tt)
+			defer testAgent.Stop()
+			setUpK8sServiceAccount(tt, k8s, ns)
 
-				ui := cli.NewMockUi()
-				defaultArgs := []string{
-					"-server-address=" + strings.Split(testAgent.HTTPAddr, ":")[0],
-					"-server-port=" + strings.Split(testAgent.HTTPAddr, ":")[1],
-					"-resource-prefix=" + resourcePrefix,
-					"-k8s-namespace=" + ns,
-					flag,
-				}
+			ui := cli.NewMockUi()
+			defaultArgs := []string{
+				"-server-address=" + strings.Split(testAgent.HTTPAddr, ":")[0],
+				"-server-port=" + strings.Split(testAgent.HTTPAddr, ":")[1],
+				"-resource-prefix=" + resourcePrefix,
+				"-k8s-namespace=" + ns,
+				"-create-inject-token",
+			}
 
-				// First run. NOTE: we don't assert anything here since we've
-				// tested these results in other tests. What we care about here
-				// is the result after the second run.
-				cmd := Command{
-					UI:        ui,
-					clientset: k8s,
-				}
-				responseCode := cmd.Run(append(defaultArgs, c.FirstRunArgs...))
-				require.Equal(0, responseCode, ui.ErrorWriter.String())
+			// First run. NOTE: we don't assert anything here since we've
+			// tested these results in other tests. What we care about here
+			// is the result after the second run.
+			cmd := Command{
+				UI:        ui,
+				clientset: k8s,
+			}
+			responseCode := cmd.Run(append(defaultArgs, c.FirstRunArgs...))
+			require.Equal(0, responseCode, ui.ErrorWriter.String())
 
-				// Second run.
-				// NOTE: We're redefining the command so that the old flag values are
-				// reset.
-				cmd = Command{
-					UI:        ui,
-					clientset: k8s,
-				}
-				responseCode = cmd.Run(append(defaultArgs, c.SecondRunArgs...))
-				require.Equal(0, responseCode, ui.ErrorWriter.String())
+			// Second run.
+			// NOTE: We're redefining the command so that the old flag values are
+			// reset.
+			cmd = Command{
+				UI:        ui,
+				clientset: k8s,
+			}
+			responseCode = cmd.Run(append(defaultArgs, c.SecondRunArgs...))
+			require.Equal(0, responseCode, ui.ErrorWriter.String())
 
-				// Now check that everything is as expected.
-				bootToken := getBootToken(t, k8s, resourcePrefix, ns)
-				consul, err := api.NewClient(&api.Config{
-					Address: testAgent.HTTPAddr,
-					Token:   bootToken,
-				})
-				require.NoError(err)
-
-				// Check the ACL auth method is as expected.
-				authMethodName := resourcePrefix + "-k8s-auth-method"
-				method, _, err := consul.ACL().AuthMethodRead(authMethodName, &api.QueryOptions{
-					Namespace: c.AuthMethodExpectedNS,
-				})
-				require.NoError(err)
-				require.NotNil(method, authMethodName+" not found")
-				if c.AuthMethodExpectMapNamespacesConfig {
-					require.Contains(method.Config, "MapNamespaces")
-					require.Contains(method.Config, "ConsulNamespacePrefix")
-					require.Equal(true, method.Config["MapNamespaces"])
-					require.Equal(c.AuthMethodExpectedNamespacePrefixConfig, method.Config["ConsulNamespacePrefix"])
-				} else {
-					require.NotContains(method.Config, "MapNamespaces")
-					require.NotContains(method.Config, "ConsulNamespacePrefix")
-				}
-
-				// Check the binding rule is as expected.
-				rules, _, err := consul.ACL().BindingRuleList(authMethodName, &api.QueryOptions{
-					Namespace: c.BindingRuleExpectedNS,
-				})
-				require.NoError(err)
-				require.Len(rules, 1)
+			// Now check that everything is as expected.
+			bootToken := getBootToken(tt, k8s, resourcePrefix, ns)
+			consul, err := api.NewClient(&api.Config{
+				Address: testAgent.HTTPAddr,
+				Token:   bootToken,
 			})
-		}
+			require.NoError(err)
+
+			// Check the ACL auth method is as expected.
+			authMethodName := resourcePrefix + "-k8s-auth-method"
+			method, _, err := consul.ACL().AuthMethodRead(authMethodName, &api.QueryOptions{
+				Namespace: c.AuthMethodExpectedNS,
+			})
+			require.NoError(err)
+			require.NotNil(method, authMethodName+" not found")
+			if c.AuthMethodExpectMapNamespacesConfig {
+				require.Contains(method.Config, "MapNamespaces")
+				require.Contains(method.Config, "ConsulNamespacePrefix")
+				require.Equal(true, method.Config["MapNamespaces"])
+				require.Equal(c.AuthMethodExpectedNamespacePrefixConfig, method.Config["ConsulNamespacePrefix"])
+			} else {
+				require.NotContains(method.Config, "MapNamespaces")
+				require.NotContains(method.Config, "ConsulNamespacePrefix")
+			}
+
+			// Check the binding rule is as expected.
+			rules, _, err := consul.ACL().BindingRuleList(authMethodName, &api.QueryOptions{
+				Namespace: c.BindingRuleExpectedNS,
+			})
+			require.NoError(err)
+			require.Len(rules, 1)
+		})
 	}
 }
 
 // Test the tokens and policies that are created when namespaces is enabled.
-func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
-	t.Parallel()
+func TestRun_TokensWithNamespacesEnabled(tt *testing.T) {
+	tt.Parallel()
 
 	cases := map[string]struct {
 		TokenFlags  []string
@@ -644,13 +605,6 @@ func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
 			PolicyNames: []string{"catalog-sync-token"},
 			PolicyDCs:   nil,
 			SecretNames: []string{resourcePrefix + "-catalog-sync-acl-token"},
-			LocalToken:  false,
-		},
-		"connect-inject-namespace token (deprecated)": {
-			TokenFlags:  []string{"-create-inject-namespace-token", "-enable-namespaces"},
-			PolicyNames: []string{"connect-inject-token"},
-			PolicyDCs:   nil,
-			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
 			LocalToken:  false,
 		},
 		"connect-inject-token": {
@@ -714,9 +668,23 @@ func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
 			SecretNames: []string{resourcePrefix + "-acl-replication-acl-token"},
 			LocalToken:  false,
 		},
+		"inject token with namespaces": {
+			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces"},
+			PolicyNames: []string{"connect-inject-token"},
+			PolicyDCs:   nil,
+			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
+			LocalToken:  false,
+		},
+		"inject token with health checks": {
+			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces", "-enable-health-checks"},
+			PolicyNames: []string{"connect-inject-token"},
+			PolicyDCs:   nil,
+			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
+			LocalToken:  false,
+		},
 	}
 	for testName, c := range cases {
-		t.Run(testName, func(t *testing.T) {
+		tt.Run(testName, func(t *testing.T) {
 			k8s, testSvr := completeEnterpriseSetup(t)
 			setUpK8sServiceAccount(t, k8s, ns)
 			defer testSvr.Stop()
@@ -782,8 +750,8 @@ func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
 }
 
 // Test the parsing the namespace from gateway names
-func TestRun_GatewayNamespaceParsing(t *testing.T) {
-	t.Parallel()
+func TestRun_GatewayNamespaceParsing(tt *testing.T) {
+	tt.Parallel()
 
 	cases := []struct {
 		TestName         string
@@ -947,7 +915,7 @@ namespace "namespace2" {
 		},
 	}
 	for _, c := range cases {
-		t.Run(c.TestName, func(t *testing.T) {
+		tt.Run(c.TestName, func(t *testing.T) {
 			k8s, testSvr := completeEnterpriseSetup(t)
 			defer testSvr.Stop()
 			require := require.New(t)

--- a/subcommand/server-acl-init/command_ent_test.go
+++ b/subcommand/server-acl-init/command_ent_test.go
@@ -118,8 +118,8 @@ func TestRun_ConnectInject_SingleDestinationNamespace(t *testing.T) {
 
 // Test the auth method and acl binding rule created when namespaces are enabled
 // and we're mirroring namespaces.
-func TestRun_ConnectInject_NamespaceMirroring(tt *testing.T) {
-	tt.Parallel()
+func TestRun_ConnectInject_NamespaceMirroring(t *testing.T) {
+	t.Parallel()
 
 	cases := map[string]struct {
 		MirroringPrefix string
@@ -142,11 +142,11 @@ func TestRun_ConnectInject_NamespaceMirroring(tt *testing.T) {
 	}
 
 	for name, c := range cases {
-		tt.Run(name, func(t *testing.T) {
-			k8s, testAgent := completeEnterpriseSetup(t)
+		t.Run(name, func(tt *testing.T) {
+			k8s, testAgent := completeEnterpriseSetup(tt)
 			defer testAgent.Stop()
-			setUpK8sServiceAccount(t, k8s, ns)
-			require := require.New(t)
+			setUpK8sServiceAccount(tt, k8s, ns)
+			require := require.New(tt)
 
 			ui := cli.NewMockUi()
 			cmd := Command{
@@ -169,7 +169,7 @@ func TestRun_ConnectInject_NamespaceMirroring(tt *testing.T) {
 			responseCode := cmd.Run(args)
 			require.Equal(0, responseCode, ui.ErrorWriter.String())
 
-			bootToken := getBootToken(t, k8s, resourcePrefix, ns)
+			bootToken := getBootToken(tt, k8s, resourcePrefix, ns)
 			consul, err := api.NewClient(&api.Config{
 				Address: testAgent.HTTPAddr,
 				Token:   bootToken,
@@ -204,12 +204,12 @@ func TestRun_ConnectInject_NamespaceMirroring(tt *testing.T) {
 }
 
 // Test that ACL policies get updated if namespaces config changes.
-func TestRun_ACLPolicyUpdates(tt *testing.T) {
-	tt.Parallel()
+func TestRun_ACLPolicyUpdates(t *testing.T) {
+	t.Parallel()
 
 	k8sNamespaceFlags := []string{"default", "other"}
 	for _, k8sNamespaceFlag := range k8sNamespaceFlags {
-		tt.Run(k8sNamespaceFlag, func(t *testing.T) {
+		t.Run(k8sNamespaceFlag, func(t *testing.T) {
 			k8s, testAgent := completeEnterpriseSetup(t)
 			setUpK8sServiceAccount(t, k8s, k8sNamespaceFlag)
 			defer testAgent.Stop()
@@ -583,8 +583,8 @@ func TestRun_ConnectInject_Updates(t *testing.T) {
 }
 
 // Test the tokens and policies that are created when namespaces is enabled.
-func TestRun_TokensWithNamespacesEnabled(tt *testing.T) {
-	tt.Parallel()
+func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
+	t.Parallel()
 
 	cases := map[string]struct {
 		TokenFlags  []string
@@ -684,7 +684,7 @@ func TestRun_TokensWithNamespacesEnabled(tt *testing.T) {
 		},
 	}
 	for testName, c := range cases {
-		tt.Run(testName, func(t *testing.T) {
+		t.Run(testName, func(t *testing.T) {
 			k8s, testSvr := completeEnterpriseSetup(t)
 			setUpK8sServiceAccount(t, k8s, ns)
 			defer testSvr.Stop()
@@ -750,8 +750,8 @@ func TestRun_TokensWithNamespacesEnabled(tt *testing.T) {
 }
 
 // Test the parsing the namespace from gateway names
-func TestRun_GatewayNamespaceParsing(tt *testing.T) {
-	tt.Parallel()
+func TestRun_GatewayNamespaceParsing(t *testing.T) {
+	t.Parallel()
 
 	cases := []struct {
 		TestName         string
@@ -915,7 +915,7 @@ namespace "namespace2" {
 		},
 	}
 	for _, c := range cases {
-		tt.Run(c.TestName, func(t *testing.T) {
+		t.Run(c.TestName, func(t *testing.T) {
 			k8s, testSvr := completeEnterpriseSetup(t)
 			defer testSvr.Stop()
 			require := require.New(t)

--- a/subcommand/server-acl-init/command_ent_test.go
+++ b/subcommand/server-acl-init/command_ent_test.go
@@ -669,14 +669,7 @@ func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
 			LocalToken:  false,
 		},
 		"inject token with namespaces (deprecated)": {
-			TokenFlags:  []string{"-create-inject-auth-method", "-enable-namespaces"},
-			PolicyNames: []string{"connect-inject-token"},
-			PolicyDCs:   nil,
-			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
-			LocalToken:  false,
-		},
-		"inject token with namespaces": {
-			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces"},
+			TokenFlags:  []string{"-create-inject-auth-method", "-enable-namespaces", "-create-inject-namespace-token"},
 			PolicyNames: []string{"connect-inject-token"},
 			PolicyDCs:   nil,
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -33,8 +33,8 @@ import (
 var ns = "default"
 var resourcePrefix = "release-name-consul"
 
-func TestRun_FlagValidation(tt *testing.T) {
-	tt.Parallel()
+func TestRun_FlagValidation(t *testing.T) {
+	t.Parallel()
 
 	cases := []struct {
 		Flags  []string
@@ -77,7 +77,7 @@ func TestRun_FlagValidation(tt *testing.T) {
 	}
 
 	for _, c := range cases {
-		tt.Run(c.ExpErr, func(t *testing.T) {
+		t.Run(c.ExpErr, func(t *testing.T) {
 			ui := cli.NewMockUi()
 			cmd := Command{
 				UI: ui,
@@ -142,8 +142,8 @@ func TestRun_Defaults(t *testing.T) {
 
 // Test the different flags that should create tokens and save them as
 // Kubernetes secrets.
-func TestRun_TokensPrimaryDC(tt *testing.T) {
-	tt.Parallel()
+func TestRun_TokensPrimaryDC(t *testing.T) {
+	t.Parallel()
 
 	cases := []struct {
 		TestName    string
@@ -247,7 +247,7 @@ func TestRun_TokensPrimaryDC(tt *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		tt.Run(c.TestName, func(t *testing.T) {
+		t.Run(c.TestName, func(t *testing.T) {
 			k8s, testSvr := completeSetup(t)
 			setUpK8sServiceAccount(t, k8s, ns)
 			defer testSvr.Stop()
@@ -313,8 +313,8 @@ func TestRun_TokensPrimaryDC(tt *testing.T) {
 }
 
 // Test creating each token type when replication is enabled.
-func TestRun_TokensReplicatedDC(tt *testing.T) {
-	tt.Parallel()
+func TestRun_TokensReplicatedDC(t *testing.T) {
+	t.Parallel()
 
 	cases := []struct {
 		TestName    string
@@ -402,7 +402,7 @@ func TestRun_TokensReplicatedDC(tt *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		tt.Run(c.TestName, func(t *testing.T) {
+		t.Run(c.TestName, func(t *testing.T) {
 			bootToken := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 			tokenFile, fileCleanup := writeTempFile(t, bootToken)
 			defer fileCleanup()
@@ -455,8 +455,8 @@ func TestRun_TokensReplicatedDC(tt *testing.T) {
 }
 
 // Test creating each token type when the bootstrap token is provided.
-func TestRun_TokensWithProvidedBootstrapToken(tt *testing.T) {
-	tt.Parallel()
+func TestRun_TokensWithProvidedBootstrapToken(t *testing.T) {
+	t.Parallel()
 
 	cases := []struct {
 		TestName    string
@@ -532,7 +532,7 @@ func TestRun_TokensWithProvidedBootstrapToken(tt *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		tt.Run(c.TestName, func(t *testing.T) {
+		t.Run(c.TestName, func(t *testing.T) {
 			bootToken := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 			tokenFile, fileCleanup := writeTempFile(t, bootToken)
 			defer fileCleanup()
@@ -589,8 +589,8 @@ func TestRun_TokensWithProvidedBootstrapToken(tt *testing.T) {
 
 // Test the conditions under which we should create the anonymous token
 // policy.
-func TestRun_AnonymousTokenPolicy(tt *testing.T) {
-	tt.Parallel()
+func TestRun_AnonymousTokenPolicy(t *testing.T) {
+	t.Parallel()
 
 	cases := map[string]struct {
 		Flags              []string
@@ -639,7 +639,7 @@ func TestRun_AnonymousTokenPolicy(tt *testing.T) {
 		},
 	}
 	for name, c := range cases {
-		tt.Run(name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			flags := c.Flags
 			var k8s *fake.Clientset
 			var consulHTTPAddr string
@@ -727,8 +727,8 @@ func TestRun_AnonymousTokenPolicy(tt *testing.T) {
 	}
 }
 
-func TestRun_ConnectInjectAuthMethod(tt *testing.T) {
-	tt.Parallel()
+func TestRun_ConnectInjectAuthMethod(t *testing.T) {
+	t.Parallel()
 
 	cases := map[string]struct {
 		flags        []string
@@ -758,7 +758,7 @@ func TestRun_ConnectInjectAuthMethod(tt *testing.T) {
 		},
 	}
 	for testName, c := range cases {
-		tt.Run(testName, func(t *testing.T) {
+		t.Run(testName, func(t *testing.T) {
 
 			k8s, testSvr := completeSetup(t)
 			defer testSvr.Stop()
@@ -1663,11 +1663,11 @@ func TestRun_ACLReplicationTokenValid(t *testing.T) {
 }
 
 // Test that if acl replication is enabled, we don't create an anonymous token policy.
-func TestRun_AnonPolicy_IgnoredWithReplication(tt *testing.T) {
+func TestRun_AnonPolicy_IgnoredWithReplication(t *testing.T) {
 	// The anonymous policy is configured when one of these flags is set.
 	cases := []string{"-allow-dns", "-create-inject-auth-method"}
 	for _, flag := range cases {
-		tt.Run(flag, func(t *testing.T) {
+		t.Run(flag, func(t *testing.T) {
 			bootToken := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 			tokenFile, fileCleanup := writeTempFile(t, bootToken)
 			defer fileCleanup()
@@ -1761,8 +1761,8 @@ func TestRun_CloudAutoJoin(t *testing.T) {
 	require.Len(agentPolicy.Datacenters, 0)
 }
 
-func TestRun_GatewayErrors(tt *testing.T) {
-	tt.Parallel()
+func TestRun_GatewayErrors(t *testing.T) {
+	t.Parallel()
 
 	cases := map[string]struct {
 		flags []string
@@ -1787,11 +1787,11 @@ func TestRun_GatewayErrors(tt *testing.T) {
 		},
 	}
 	for testName, c := range cases {
-		tt.Run(testName, func(t *testing.T) {
+		t.Run(testName, func(tt *testing.T) {
 
-			k8s, testSvr := completeSetup(t)
+			k8s, testSvr := completeSetup(tt)
 			defer testSvr.Stop()
-			require := require.New(t)
+			require := require.New(tt)
 
 			// Run the command.
 			ui := cli.NewMockUi()

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -170,12 +170,20 @@ func TestRun_TokensPrimaryDC(t *testing.T) {
 			LocalToken:  true,
 		},
 		{
-			TestName:    "Inject namespace token",
-			TokenFlags:  []string{"-create-inject-namespace-token"},
+			TestName:    "Inject token (deprecated)",
+			TokenFlags:  []string{"-create-inject-namespace-token", "-enable-namespaces"},
 			PolicyNames: []string{"connect-inject-token"},
-			PolicyDCs:   []string{"dc1"},
+			PolicyDCs:   nil,
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
-			LocalToken:  true,
+			LocalToken:  false,
+		},
+		{
+			TestName:    "Inject token with namespaces",
+			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces"},
+			PolicyNames: []string{"connect-inject-token"},
+			PolicyDCs:   nil,
+			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
+			LocalToken:  false,
 		},
 		{
 			TestName:    "Enterprise license token",
@@ -247,7 +255,7 @@ func TestRun_TokensPrimaryDC(t *testing.T) {
 		},
 		{
 			TestName:    "Health Checks ACL token",
-			TokenFlags:  []string{"-add-inject-health-checks-rules"},
+			TokenFlags:  []string{"-create-inject-token", "-add-inject-health-checks-rules"},
 			PolicyNames: []string{"connect-inject-token"},
 			PolicyDCs:   []string{"dc1"},
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
@@ -255,16 +263,17 @@ func TestRun_TokensPrimaryDC(t *testing.T) {
 		},
 		{
 			TestName:    "Health Checks ACL token with namespaces enabled",
-			TokenFlags:  []string{"-add-inject-health-checks-rules", "-create-inject-namespace-token"},
+			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces", "-add-inject-health-checks-rules"},
 			PolicyNames: []string{"connect-inject-token"},
-			PolicyDCs:   []string{"dc1"},
+			PolicyDCs:   nil,
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
-			LocalToken:  true,
+			LocalToken:  false,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.TestName, func(t *testing.T) {
 			k8s, testSvr := completeSetup(t)
+			setUpK8sServiceAccount(t, k8s)
 			defer testSvr.Stop()
 			require := require.New(t)
 
@@ -356,12 +365,20 @@ func TestRun_TokensReplicatedDC(t *testing.T) {
 			LocalToken:  true,
 		},
 		{
-			TestName:    "Inject namespace token",
-			TokenFlags:  []string{"-create-inject-namespace-token"},
+			TestName:    "Inject namespace token (deprecated)",
+			TokenFlags:  []string{"-create-inject-namespace-token", "-enable-namespaces"},
 			PolicyNames: []string{"connect-inject-token-dc2"},
-			PolicyDCs:   []string{"dc2"},
+			PolicyDCs:   nil,
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
-			LocalToken:  true,
+			LocalToken:  false,
+		},
+		{
+			TestName:    "Inject namespace token with namespaces",
+			TokenFlags:  []string{"-enable-namespaces", "-create-inject-token"},
+			PolicyNames: []string{"connect-inject-token-dc2"},
+			PolicyDCs:   nil,
+			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
+			LocalToken:  false,
 		},
 		{
 			TestName:    "Enterprise license token",
@@ -415,6 +432,22 @@ func TestRun_TokensReplicatedDC(t *testing.T) {
 				resourcePrefix + "-another-gateway-terminating-gateway-acl-token"},
 			LocalToken: true,
 		},
+		{
+			TestName:    "Health Checks ACL token",
+			TokenFlags:  []string{"-create-inject-token", "-add-inject-health-checks-rules"},
+			PolicyNames: []string{"connect-inject-token-dc2"},
+			PolicyDCs:   []string{"dc2"},
+			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
+			LocalToken:  true,
+		},
+		{
+			TestName:    "Health Checks ACL token with namespaces enabled",
+			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces", "-add-inject-health-checks-rules"},
+			PolicyNames: []string{"connect-inject-token-dc2"},
+			PolicyDCs:   nil,
+			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
+			LocalToken:  false,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.TestName, func(t *testing.T) {
@@ -423,6 +456,7 @@ func TestRun_TokensReplicatedDC(t *testing.T) {
 			defer fileCleanup()
 
 			k8s, consul, secondaryAddr, cleanup := mockReplicatedSetup(t, bootToken)
+			setUpK8sServiceAccount(t, k8s)
 			defer cleanup()
 
 			// Run the command.
@@ -491,8 +525,14 @@ func TestRun_TokensWithProvidedBootstrapToken(t *testing.T) {
 			SecretNames: []string{resourcePrefix + "-catalog-sync-acl-token"},
 		},
 		{
-			TestName:    "Inject token",
-			TokenFlags:  []string{"-create-inject-namespace-token"},
+			TestName:    "Inject token (deprecated)",
+			TokenFlags:  []string{"-create-inject-namespace-token", "-enable-namespaces"},
+			PolicyNames: []string{"connect-inject-token"},
+			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
+		},
+		{
+			TestName:    "Inject token with namespaces",
+			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces"},
 			PolicyNames: []string{"connect-inject-token"},
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
 		},
@@ -544,6 +584,18 @@ func TestRun_TokensWithProvidedBootstrapToken(t *testing.T) {
 			PolicyNames: []string{"acl-replication-token"},
 			SecretNames: []string{resourcePrefix + "-acl-replication-acl-token"},
 		},
+		{
+			TestName:    "Health Checks ACL token",
+			TokenFlags:  []string{"-create-inject-token", "-add-inject-health-checks-rules"},
+			PolicyNames: []string{"connect-inject-token"},
+			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
+		},
+		{
+			TestName:    "Health Checks ACL token with namespaces enabled",
+			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces", "-add-inject-health-checks-rules"},
+			PolicyNames: []string{"connect-inject-token"},
+			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.TestName, func(t *testing.T) {
@@ -552,6 +604,7 @@ func TestRun_TokensWithProvidedBootstrapToken(t *testing.T) {
 			defer fileCleanup()
 
 			k8s, testAgent := completeBootstrappedSetup(t, bootToken)
+			setUpK8sServiceAccount(t, k8s)
 			defer testAgent.Stop()
 
 			// Run the command.
@@ -620,18 +673,33 @@ func TestRun_AnonymousTokenPolicy(t *testing.T) {
 			SecondaryDC:        true,
 			ExpAnonymousPolicy: false,
 		},
-		"auth method, primary dc, no replication": {
+		"auth method, primary dc, no replication (deprecated)": {
 			Flags:              []string{"-create-inject-auth-method"},
 			SecondaryDC:        false,
 			ExpAnonymousPolicy: false,
 		},
-		"auth method, primary dc, with replication": {
+		"auth method, primary dc, with replication (deprecated)": {
 			Flags:              []string{"-create-inject-auth-method", "-create-acl-replication-token"},
 			SecondaryDC:        false,
 			ExpAnonymousPolicy: true,
 		},
-		"auth method, secondary dc": {
+		"auth method, secondary dc (deprecated)": {
 			Flags:              []string{"-create-inject-auth-method"},
+			SecondaryDC:        true,
+			ExpAnonymousPolicy: false,
+		},
+		"auth method, primary dc, no replication": {
+			Flags:              []string{"-create-inject-token"},
+			SecondaryDC:        false,
+			ExpAnonymousPolicy: false,
+		},
+		"auth method, primary dc, with replication": {
+			Flags:              []string{"-create-inject-token", "-create-acl-replication-token"},
+			SecondaryDC:        false,
+			ExpAnonymousPolicy: true,
+		},
+		"auth method, secondary dc": {
+			Flags:              []string{"-create-inject-token"},
 			SecondaryDC:        true,
 			ExpAnonymousPolicy: false,
 		},
@@ -740,9 +808,16 @@ func TestRun_ConnectInjectAuthMethod(t *testing.T) {
 			flags:        []string{"-create-inject-auth-method"},
 			expectedHost: "https://kubernetes.default.svc",
 		},
-		"-inject-auth-method-host flag": {
+		"-inject-auth-method-host flag (deprecated)": {
 			flags: []string{
 				"-create-inject-auth-method",
+				"-inject-auth-method-host=https://my-kube.com",
+			},
+			expectedHost: "https://my-kube.com",
+		},
+		"-inject-auth-method-host flag": {
+			flags: []string{
+				"-create-inject-token",
 				"-inject-auth-method-host=https://my-kube.com",
 			},
 			expectedHost: "https://my-kube.com",
@@ -818,168 +893,181 @@ func TestRun_ConnectInjectAuthMethod(t *testing.T) {
 
 // Test that when we provide a different k8s auth method parameters,
 // the auth method is updated.
-func TestRun_ConnectInjectAuthMethodUpdates(t *testing.T) {
-	t.Parallel()
+func TestRun_ConnectInjectAuthMethodUpdates(tt *testing.T) {
+	tt.Parallel()
 
-	k8s, testSvr := completeSetup(t)
-	defer testSvr.Stop()
-	caCert, jwtToken := setUpK8sServiceAccount(t, k8s)
-	require := require.New(t)
+	cases := []string{"-create-inject-auth-method", "-create-inject-token"}
 
-	ui := cli.NewMockUi()
-	cmd := Command{
-		UI:        ui,
-		clientset: k8s,
+	for _, flag := range cases {
+		tt.Run(flag, func(t *testing.T) {
+
+			k8s, testSvr := completeSetup(t)
+			defer testSvr.Stop()
+			caCert, jwtToken := setUpK8sServiceAccount(t, k8s)
+			require := require.New(t)
+
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI:        ui,
+				clientset: k8s,
+			}
+
+			bindingRuleSelector := "serviceaccount.name!=default"
+
+			// First, create an auth method using the defaults
+			responseCode := cmd.Run([]string{
+				"-timeout=1m",
+				"-resource-prefix=" + resourcePrefix,
+				"-k8s-namespace=" + ns,
+				"-server-address", strings.Split(testSvr.HTTPAddr, ":")[0],
+				"-server-port", strings.Split(testSvr.HTTPAddr, ":")[1],
+				flag,
+				"-acl-binding-rule-selector=" + bindingRuleSelector,
+			})
+			require.Equal(0, responseCode, ui.ErrorWriter.String())
+
+			// Check that the auth method was created.
+			bootToken := getBootToken(t, k8s, resourcePrefix, ns)
+			consul, err := api.NewClient(&api.Config{
+				Address: testSvr.HTTPAddr,
+			})
+			require.NoError(err)
+			authMethodName := resourcePrefix + "-k8s-auth-method"
+			authMethod, _, err := consul.ACL().AuthMethodRead(authMethodName,
+				&api.QueryOptions{Token: bootToken})
+			require.NoError(err)
+			require.NotNil(authMethod)
+			require.Contains(authMethod.Config, "Host")
+			require.Equal(authMethod.Config["Host"], defaultKubernetesHost)
+			require.Contains(authMethod.Config, "CACert")
+			require.Equal(authMethod.Config["CACert"], caCert)
+			require.Contains(authMethod.Config, "ServiceAccountJWT")
+			require.Equal(authMethod.Config["ServiceAccountJWT"], jwtToken)
+
+			// Generate a new CA certificate
+			_, _, caCertPem, _, err := cert.GenerateCA("kubernetes")
+			require.NoError(err)
+
+			// Overwrite the default kubernetes api, service account token and CA cert
+			kubernetesHost := "https://kubernetes.example.com"
+			// This token is the base64 encoded example token from jwt.io
+			serviceAccountToken = "ZXlKaGJHY2lPaUpJVXpJMU5pSXNJblI1Y0NJNklrcFhWQ0o5LmV5SnpkV0lpT2lJeE1qTTBOVFkzT0Rrd0lpd2libUZ0WlNJNklrcHZhRzRnUkc5bElpd2lhV0YwSWpveE5URTJNak01TURJeWZRLlNmbEt4d1JKU01lS0tGMlFUNGZ3cE1lSmYzNlBPazZ5SlZfYWRRc3N3NWM="
+			serviceAccountCACert = base64.StdEncoding.EncodeToString([]byte(caCertPem))
+
+			// Create a new service account
+			updatedCACert, updatedJWTToken := setUpK8sServiceAccount(t, k8s)
+
+			// Run command again
+			responseCode = cmd.Run([]string{
+				"-timeout=1m",
+				"-resource-prefix=" + resourcePrefix,
+				"-k8s-namespace=" + ns,
+				"-server-address", strings.Split(testSvr.HTTPAddr, ":")[0],
+				"-server-port", strings.Split(testSvr.HTTPAddr, ":")[1],
+				"-acl-binding-rule-selector=" + bindingRuleSelector,
+				flag,
+				"-inject-auth-method-host=" + kubernetesHost,
+			})
+			require.Equal(0, responseCode, ui.ErrorWriter.String())
+
+			// Check that the auth method has been updated
+			authMethod, _, err = consul.ACL().AuthMethodRead(authMethodName,
+				&api.QueryOptions{Token: bootToken})
+			require.NoError(err)
+			require.NotNil(authMethod)
+			require.Contains(authMethod.Config, "Host")
+			require.Equal(authMethod.Config["Host"], kubernetesHost)
+			require.Contains(authMethod.Config, "CACert")
+			require.Equal(authMethod.Config["CACert"], updatedCACert)
+			require.Contains(authMethod.Config, "ServiceAccountJWT")
+			require.Equal(authMethod.Config["ServiceAccountJWT"], updatedJWTToken)
+		})
 	}
-
-	bindingRuleSelector := "serviceaccount.name!=default"
-
-	// First, create an auth method using the defaults
-	responseCode := cmd.Run([]string{
-		"-timeout=1m",
-		"-resource-prefix=" + resourcePrefix,
-		"-k8s-namespace=" + ns,
-		"-server-address", strings.Split(testSvr.HTTPAddr, ":")[0],
-		"-server-port", strings.Split(testSvr.HTTPAddr, ":")[1],
-		"-create-inject-auth-method",
-		"-acl-binding-rule-selector=" + bindingRuleSelector,
-	})
-	require.Equal(0, responseCode, ui.ErrorWriter.String())
-
-	// Check that the auth method was created.
-	bootToken := getBootToken(t, k8s, resourcePrefix, ns)
-	consul, err := api.NewClient(&api.Config{
-		Address: testSvr.HTTPAddr,
-	})
-	require.NoError(err)
-	authMethodName := resourcePrefix + "-k8s-auth-method"
-	authMethod, _, err := consul.ACL().AuthMethodRead(authMethodName,
-		&api.QueryOptions{Token: bootToken})
-	require.NoError(err)
-	require.NotNil(authMethod)
-	require.Contains(authMethod.Config, "Host")
-	require.Equal(authMethod.Config["Host"], defaultKubernetesHost)
-	require.Contains(authMethod.Config, "CACert")
-	require.Equal(authMethod.Config["CACert"], caCert)
-	require.Contains(authMethod.Config, "ServiceAccountJWT")
-	require.Equal(authMethod.Config["ServiceAccountJWT"], jwtToken)
-
-	// Generate a new CA certificate
-	_, _, caCertPem, _, err := cert.GenerateCA("kubernetes")
-	require.NoError(err)
-
-	// Overwrite the default kubernetes api, service account token and CA cert
-	kubernetesHost := "https://kubernetes.example.com"
-	// This token is the base64 encoded example token from jwt.io
-	serviceAccountToken = "ZXlKaGJHY2lPaUpJVXpJMU5pSXNJblI1Y0NJNklrcFhWQ0o5LmV5SnpkV0lpT2lJeE1qTTBOVFkzT0Rrd0lpd2libUZ0WlNJNklrcHZhRzRnUkc5bElpd2lhV0YwSWpveE5URTJNak01TURJeWZRLlNmbEt4d1JKU01lS0tGMlFUNGZ3cE1lSmYzNlBPazZ5SlZfYWRRc3N3NWM="
-	serviceAccountCACert = base64.StdEncoding.EncodeToString([]byte(caCertPem))
-
-	// Create a new service account
-	updatedCACert, updatedJWTToken := setUpK8sServiceAccount(t, k8s)
-
-	// Run command again
-	responseCode = cmd.Run([]string{
-		"-timeout=1m",
-		"-resource-prefix=" + resourcePrefix,
-		"-k8s-namespace=" + ns,
-		"-server-address", strings.Split(testSvr.HTTPAddr, ":")[0],
-		"-server-port", strings.Split(testSvr.HTTPAddr, ":")[1],
-		"-acl-binding-rule-selector=" + bindingRuleSelector,
-		"-create-inject-auth-method",
-		"-inject-auth-method-host=" + kubernetesHost,
-	})
-	require.Equal(0, responseCode, ui.ErrorWriter.String())
-
-	// Check that the auth method has been updated
-	authMethod, _, err = consul.ACL().AuthMethodRead(authMethodName,
-		&api.QueryOptions{Token: bootToken})
-	require.NoError(err)
-	require.NotNil(authMethod)
-	require.Contains(authMethod.Config, "Host")
-	require.Equal(authMethod.Config["Host"], kubernetesHost)
-	require.Contains(authMethod.Config, "CACert")
-	require.Equal(authMethod.Config["CACert"], updatedCACert)
-	require.Contains(authMethod.Config, "ServiceAccountJWT")
-	require.Equal(authMethod.Config["ServiceAccountJWT"], updatedJWTToken)
 }
 
 // Test that ACL binding rules are updated if the rule selector changes.
-func TestRun_BindingRuleUpdates(t *testing.T) {
-	t.Parallel()
-	k8s, testSvr := completeSetup(t)
-	setUpK8sServiceAccount(t, k8s)
-	defer testSvr.Stop()
-	require := require.New(t)
+func TestRun_BindingRuleUpdates(tt *testing.T) {
+	tt.Parallel()
+	cases := []string{"-create-inject-auth-method", "-create-inject-token"}
 
-	consul, err := api.NewClient(&api.Config{
-		Address: testSvr.HTTPAddr,
-	})
-	require.NoError(err)
+	for _, flag := range cases {
+		tt.Run(flag, func(t *testing.T) {
+			k8s, testSvr := completeSetup(t)
+			setUpK8sServiceAccount(t, k8s)
+			defer testSvr.Stop()
+			require := require.New(t)
 
-	ui := cli.NewMockUi()
-	commonArgs := []string{
-		"-resource-prefix=" + resourcePrefix,
-		"-k8s-namespace=" + ns,
-		"-server-address", strings.Split(testSvr.HTTPAddr, ":")[0],
-		"-server-port", strings.Split(testSvr.HTTPAddr, ":")[1],
-		"-create-inject-auth-method",
-	}
-	firstRunArgs := append(commonArgs,
-		"-acl-binding-rule-selector=serviceaccount.name!=default",
-	)
-	// On the second run, we change the binding rule selector.
-	secondRunArgs := append(commonArgs,
-		"-acl-binding-rule-selector=serviceaccount.name!=changed",
-	)
+			consul, err := api.NewClient(&api.Config{
+				Address: testSvr.HTTPAddr,
+			})
+			require.NoError(err)
 
-	// Run the command first to populate the binding rule.
-	cmd := Command{
-		UI:        ui,
-		clientset: k8s,
-	}
-	responseCode := cmd.Run(firstRunArgs)
-	require.Equal(0, responseCode, ui.ErrorWriter.String())
+			ui := cli.NewMockUi()
+			commonArgs := []string{
+				"-resource-prefix=" + resourcePrefix,
+				"-k8s-namespace=" + ns,
+				"-server-address", strings.Split(testSvr.HTTPAddr, ":")[0],
+				"-server-port", strings.Split(testSvr.HTTPAddr, ":")[1],
+				flag,
+			}
+			firstRunArgs := append(commonArgs,
+				"-acl-binding-rule-selector=serviceaccount.name!=default",
+			)
+			// On the second run, we change the binding rule selector.
+			secondRunArgs := append(commonArgs,
+				"-acl-binding-rule-selector=serviceaccount.name!=changed",
+			)
 
-	// Validate the binding rule.
-	{
-		queryOpts := &api.QueryOptions{Token: getBootToken(t, k8s, resourcePrefix, ns)}
-		authMethodName := resourcePrefix + "-k8s-auth-method"
-		rules, _, err := consul.ACL().BindingRuleList(authMethodName, queryOpts)
-		require.NoError(err)
-		require.Len(rules, 1)
-		actRule, _, err := consul.ACL().BindingRuleRead(rules[0].ID, queryOpts)
-		require.NoError(err)
-		require.NotNil(actRule)
-		require.Equal("Kubernetes binding rule", actRule.Description)
-		require.Equal(api.BindingRuleBindTypeService, actRule.BindType)
-		require.Equal("${serviceaccount.name}", actRule.BindName)
-		require.Equal("serviceaccount.name!=default", actRule.Selector)
-	}
+			// Run the command first to populate the binding rule.
+			cmd := Command{
+				UI:        ui,
+				clientset: k8s,
+			}
+			responseCode := cmd.Run(firstRunArgs)
+			require.Equal(0, responseCode, ui.ErrorWriter.String())
 
-	// Re-run the command with namespace flags. The policies should be updated.
-	// NOTE: We're redefining the command so that the old flag values are
-	// reset.
-	cmd = Command{
-		UI:        ui,
-		clientset: k8s,
-	}
-	responseCode = cmd.Run(secondRunArgs)
-	require.Equal(0, responseCode, ui.ErrorWriter.String())
+			// Validate the binding rule.
+			{
+				queryOpts := &api.QueryOptions{Token: getBootToken(t, k8s, resourcePrefix, ns)}
+				authMethodName := resourcePrefix + "-k8s-auth-method"
+				rules, _, err := consul.ACL().BindingRuleList(authMethodName, queryOpts)
+				require.NoError(err)
+				require.Len(rules, 1)
+				actRule, _, err := consul.ACL().BindingRuleRead(rules[0].ID, queryOpts)
+				require.NoError(err)
+				require.NotNil(actRule)
+				require.Equal("Kubernetes binding rule", actRule.Description)
+				require.Equal(api.BindingRuleBindTypeService, actRule.BindType)
+				require.Equal("${serviceaccount.name}", actRule.BindName)
+				require.Equal("serviceaccount.name!=default", actRule.Selector)
+			}
 
-	// Check the binding rule is changed expected.
-	{
-		queryOpts := &api.QueryOptions{Token: getBootToken(t, k8s, resourcePrefix, ns)}
-		authMethodName := resourcePrefix + "-k8s-auth-method"
-		rules, _, err := consul.ACL().BindingRuleList(authMethodName, queryOpts)
-		require.NoError(err)
-		require.Len(rules, 1)
-		actRule, _, err := consul.ACL().BindingRuleRead(rules[0].ID, queryOpts)
-		require.NoError(err)
-		require.NotNil(actRule)
-		require.Equal("Kubernetes binding rule", actRule.Description)
-		require.Equal(api.BindingRuleBindTypeService, actRule.BindType)
-		require.Equal("${serviceaccount.name}", actRule.BindName)
-		require.Equal("serviceaccount.name!=changed", actRule.Selector)
+			// Re-run the command with namespace flags. The policies should be updated.
+			// NOTE: We're redefining the command so that the old flag values are
+			// reset.
+			cmd = Command{
+				UI:        ui,
+				clientset: k8s,
+			}
+			responseCode = cmd.Run(secondRunArgs)
+			require.Equal(0, responseCode, ui.ErrorWriter.String())
+
+			// Check the binding rule is changed expected.
+			{
+				queryOpts := &api.QueryOptions{Token: getBootToken(t, k8s, resourcePrefix, ns)}
+				authMethodName := resourcePrefix + "-k8s-auth-method"
+				rules, _, err := consul.ACL().BindingRuleList(authMethodName, queryOpts)
+				require.NoError(err)
+				require.Len(rules, 1)
+				actRule, _, err := consul.ACL().BindingRuleRead(rules[0].ID, queryOpts)
+				require.NoError(err)
+				require.NotNil(actRule)
+				require.Equal("Kubernetes binding rule", actRule.Description)
+				require.Equal(api.BindingRuleBindTypeService, actRule.BindType)
+				require.Equal("${serviceaccount.name}", actRule.BindName)
+				require.Equal("serviceaccount.name!=changed", actRule.Selector)
+			}
+		})
 	}
 }
 

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -255,7 +255,7 @@ func TestRun_TokensPrimaryDC(t *testing.T) {
 		},
 		{
 			TestName:    "Health Checks ACL token",
-			TokenFlags:  []string{"-create-inject-token", "-add-inject-health-checks-rules"},
+			TokenFlags:  []string{"-create-inject-token", "-enable-health-checks"},
 			PolicyNames: []string{"connect-inject-token"},
 			PolicyDCs:   []string{"dc1"},
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
@@ -263,7 +263,7 @@ func TestRun_TokensPrimaryDC(t *testing.T) {
 		},
 		{
 			TestName:    "Health Checks ACL token with namespaces enabled",
-			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces", "-add-inject-health-checks-rules"},
+			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces", "-enable-health-checks"},
 			PolicyNames: []string{"connect-inject-token"},
 			PolicyDCs:   nil,
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
@@ -434,7 +434,7 @@ func TestRun_TokensReplicatedDC(t *testing.T) {
 		},
 		{
 			TestName:    "Health Checks ACL token",
-			TokenFlags:  []string{"-create-inject-token", "-add-inject-health-checks-rules"},
+			TokenFlags:  []string{"-create-inject-token", "-enable-health-checks"},
 			PolicyNames: []string{"connect-inject-token-dc2"},
 			PolicyDCs:   []string{"dc2"},
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
@@ -442,7 +442,7 @@ func TestRun_TokensReplicatedDC(t *testing.T) {
 		},
 		{
 			TestName:    "Health Checks ACL token with namespaces enabled",
-			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces", "-add-inject-health-checks-rules"},
+			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces", "-enable-health-checks"},
 			PolicyNames: []string{"connect-inject-token-dc2"},
 			PolicyDCs:   nil,
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
@@ -586,13 +586,13 @@ func TestRun_TokensWithProvidedBootstrapToken(t *testing.T) {
 		},
 		{
 			TestName:    "Health Checks ACL token",
-			TokenFlags:  []string{"-create-inject-token", "-add-inject-health-checks-rules"},
+			TokenFlags:  []string{"-create-inject-token", "-enable-health-checks"},
 			PolicyNames: []string{"connect-inject-token"},
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
 		},
 		{
 			TestName:    "Health Checks ACL token with namespaces enabled",
-			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces", "-add-inject-health-checks-rules"},
+			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces", "-enable-health-checks"},
 			PolicyNames: []string{"connect-inject-token"},
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
 		},

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -33,8 +33,8 @@ import (
 var ns = "default"
 var resourcePrefix = "release-name-consul"
 
-func TestRun_FlagValidation(t *testing.T) {
-	t.Parallel()
+func TestRun_FlagValidation(tt *testing.T) {
+	tt.Parallel()
 
 	cases := []struct {
 		Flags  []string
@@ -77,7 +77,7 @@ func TestRun_FlagValidation(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		t.Run(c.ExpErr, func(t *testing.T) {
+		tt.Run(c.ExpErr, func(t *testing.T) {
 			ui := cli.NewMockUi()
 			cmd := Command{
 				UI: ui,
@@ -142,8 +142,8 @@ func TestRun_Defaults(t *testing.T) {
 
 // Test the different flags that should create tokens and save them as
 // Kubernetes secrets.
-func TestRun_TokensPrimaryDC(t *testing.T) {
-	t.Parallel()
+func TestRun_TokensPrimaryDC(tt *testing.T) {
+	tt.Parallel()
 
 	cases := []struct {
 		TestName    string
@@ -168,22 +168,6 @@ func TestRun_TokensPrimaryDC(t *testing.T) {
 			PolicyDCs:   []string{"dc1"},
 			SecretNames: []string{resourcePrefix + "-catalog-sync-acl-token"},
 			LocalToken:  true,
-		},
-		{
-			TestName:    "Inject token (deprecated)",
-			TokenFlags:  []string{"-create-inject-namespace-token", "-enable-namespaces"},
-			PolicyNames: []string{"connect-inject-token"},
-			PolicyDCs:   nil,
-			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
-			LocalToken:  false,
-		},
-		{
-			TestName:    "Inject token with namespaces",
-			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces"},
-			PolicyNames: []string{"connect-inject-token"},
-			PolicyDCs:   nil,
-			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
-			LocalToken:  false,
 		},
 		{
 			TestName:    "Enterprise license token",
@@ -261,17 +245,9 @@ func TestRun_TokensPrimaryDC(t *testing.T) {
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
 			LocalToken:  true,
 		},
-		{
-			TestName:    "Health Checks ACL token with namespaces enabled",
-			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces", "-enable-health-checks"},
-			PolicyNames: []string{"connect-inject-token"},
-			PolicyDCs:   nil,
-			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
-			LocalToken:  false,
-		},
 	}
 	for _, c := range cases {
-		t.Run(c.TestName, func(t *testing.T) {
+		tt.Run(c.TestName, func(t *testing.T) {
 			k8s, testSvr := completeSetup(t)
 			setUpK8sServiceAccount(t, k8s, ns)
 			defer testSvr.Stop()
@@ -337,8 +313,8 @@ func TestRun_TokensPrimaryDC(t *testing.T) {
 }
 
 // Test creating each token type when replication is enabled.
-func TestRun_TokensReplicatedDC(t *testing.T) {
-	t.Parallel()
+func TestRun_TokensReplicatedDC(tt *testing.T) {
+	tt.Parallel()
 
 	cases := []struct {
 		TestName    string
@@ -363,22 +339,6 @@ func TestRun_TokensReplicatedDC(t *testing.T) {
 			PolicyDCs:   []string{"dc2"},
 			SecretNames: []string{resourcePrefix + "-catalog-sync-acl-token"},
 			LocalToken:  true,
-		},
-		{
-			TestName:    "Inject namespace token (deprecated)",
-			TokenFlags:  []string{"-create-inject-namespace-token", "-enable-namespaces"},
-			PolicyNames: []string{"connect-inject-token-dc2"},
-			PolicyDCs:   nil,
-			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
-			LocalToken:  false,
-		},
-		{
-			TestName:    "Inject namespace token with namespaces",
-			TokenFlags:  []string{"-enable-namespaces", "-create-inject-token"},
-			PolicyNames: []string{"connect-inject-token-dc2"},
-			PolicyDCs:   nil,
-			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
-			LocalToken:  false,
 		},
 		{
 			TestName:    "Enterprise license token",
@@ -440,17 +400,9 @@ func TestRun_TokensReplicatedDC(t *testing.T) {
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
 			LocalToken:  true,
 		},
-		{
-			TestName:    "Health Checks ACL token with namespaces enabled",
-			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces", "-enable-health-checks"},
-			PolicyNames: []string{"connect-inject-token-dc2"},
-			PolicyDCs:   nil,
-			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
-			LocalToken:  false,
-		},
 	}
 	for _, c := range cases {
-		t.Run(c.TestName, func(t *testing.T) {
+		tt.Run(c.TestName, func(t *testing.T) {
 			bootToken := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 			tokenFile, fileCleanup := writeTempFile(t, bootToken)
 			defer fileCleanup()
@@ -503,8 +455,8 @@ func TestRun_TokensReplicatedDC(t *testing.T) {
 }
 
 // Test creating each token type when the bootstrap token is provided.
-func TestRun_TokensWithProvidedBootstrapToken(t *testing.T) {
-	t.Parallel()
+func TestRun_TokensWithProvidedBootstrapToken(tt *testing.T) {
+	tt.Parallel()
 
 	cases := []struct {
 		TestName    string
@@ -523,18 +475,6 @@ func TestRun_TokensWithProvidedBootstrapToken(t *testing.T) {
 			TokenFlags:  []string{"-create-sync-token"},
 			PolicyNames: []string{"catalog-sync-token"},
 			SecretNames: []string{resourcePrefix + "-catalog-sync-acl-token"},
-		},
-		{
-			TestName:    "Inject token (deprecated)",
-			TokenFlags:  []string{"-create-inject-namespace-token", "-enable-namespaces"},
-			PolicyNames: []string{"connect-inject-token"},
-			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
-		},
-		{
-			TestName:    "Inject token with namespaces",
-			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces"},
-			PolicyNames: []string{"connect-inject-token"},
-			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
 		},
 		{
 			TestName:    "Enterprise license token",
@@ -590,15 +530,9 @@ func TestRun_TokensWithProvidedBootstrapToken(t *testing.T) {
 			PolicyNames: []string{"connect-inject-token"},
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
 		},
-		{
-			TestName:    "Health Checks ACL token with namespaces enabled",
-			TokenFlags:  []string{"-create-inject-token", "-enable-namespaces", "-enable-health-checks"},
-			PolicyNames: []string{"connect-inject-token"},
-			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
-		},
 	}
 	for _, c := range cases {
-		t.Run(c.TestName, func(t *testing.T) {
+		tt.Run(c.TestName, func(t *testing.T) {
 			bootToken := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 			tokenFile, fileCleanup := writeTempFile(t, bootToken)
 			defer fileCleanup()
@@ -655,8 +589,8 @@ func TestRun_TokensWithProvidedBootstrapToken(t *testing.T) {
 
 // Test the conditions under which we should create the anonymous token
 // policy.
-func TestRun_AnonymousTokenPolicy(t *testing.T) {
-	t.Parallel()
+func TestRun_AnonymousTokenPolicy(tt *testing.T) {
+	tt.Parallel()
 
 	cases := map[string]struct {
 		Flags              []string
@@ -705,7 +639,7 @@ func TestRun_AnonymousTokenPolicy(t *testing.T) {
 		},
 	}
 	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
+		tt.Run(name, func(t *testing.T) {
 			flags := c.Flags
 			var k8s *fake.Clientset
 			var consulHTTPAddr string
@@ -793,8 +727,8 @@ func TestRun_AnonymousTokenPolicy(t *testing.T) {
 	}
 }
 
-func TestRun_ConnectInjectAuthMethod(t *testing.T) {
-	t.Parallel()
+func TestRun_ConnectInjectAuthMethod(tt *testing.T) {
+	tt.Parallel()
 
 	cases := map[string]struct {
 		flags        []string
@@ -824,12 +758,12 @@ func TestRun_ConnectInjectAuthMethod(t *testing.T) {
 		},
 	}
 	for testName, c := range cases {
-		t.Run(testName, func(tt *testing.T) {
+		tt.Run(testName, func(t *testing.T) {
 
-			k8s, testSvr := completeSetup(tt)
+			k8s, testSvr := completeSetup(t)
 			defer testSvr.Stop()
-			caCert, jwtToken := setUpK8sServiceAccount(tt, k8s, ns)
-			require := require.New(tt)
+			caCert, jwtToken := setUpK8sServiceAccount(t, k8s, ns)
+			require := require.New(t)
 
 			// Run the command.
 			ui := cli.NewMockUi()
@@ -896,8 +830,8 @@ func TestRun_ConnectInjectAuthMethod(t *testing.T) {
 func TestRun_ConnectInjectAuthMethodUpdates(tt *testing.T) {
 	tt.Parallel()
 
+	// Test with deprecated -create-inject-auth-method flag.
 	cases := []string{"-create-inject-auth-method", "-create-inject-token"}
-
 	for _, flag := range cases {
 		tt.Run(flag, func(t *testing.T) {
 
@@ -988,8 +922,9 @@ func TestRun_ConnectInjectAuthMethodUpdates(tt *testing.T) {
 // Test that ACL binding rules are updated if the rule selector changes.
 func TestRun_BindingRuleUpdates(tt *testing.T) {
 	tt.Parallel()
-	cases := []string{"-create-inject-auth-method", "-create-inject-token"}
 
+	// Test with deprecated -create-inject-auth-method flag.
+	cases := []string{"-create-inject-auth-method", "-create-inject-token"}
 	for _, flag := range cases {
 		tt.Run(flag, func(t *testing.T) {
 			k8s, testSvr := completeSetup(t)
@@ -1728,11 +1663,11 @@ func TestRun_ACLReplicationTokenValid(t *testing.T) {
 }
 
 // Test that if acl replication is enabled, we don't create an anonymous token policy.
-func TestRun_AnonPolicy_IgnoredWithReplication(t *testing.T) {
+func TestRun_AnonPolicy_IgnoredWithReplication(tt *testing.T) {
 	// The anonymous policy is configured when one of these flags is set.
 	cases := []string{"-allow-dns", "-create-inject-auth-method"}
 	for _, flag := range cases {
-		t.Run(flag, func(t *testing.T) {
+		tt.Run(flag, func(t *testing.T) {
 			bootToken := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 			tokenFile, fileCleanup := writeTempFile(t, bootToken)
 			defer fileCleanup()
@@ -1826,8 +1761,8 @@ func TestRun_CloudAutoJoin(t *testing.T) {
 	require.Len(agentPolicy.Datacenters, 0)
 }
 
-func TestRun_GatewayErrors(t *testing.T) {
-	t.Parallel()
+func TestRun_GatewayErrors(tt *testing.T) {
+	tt.Parallel()
 
 	cases := map[string]struct {
 		flags []string
@@ -1852,11 +1787,11 @@ func TestRun_GatewayErrors(t *testing.T) {
 		},
 	}
 	for testName, c := range cases {
-		t.Run(testName, func(tt *testing.T) {
+		tt.Run(testName, func(t *testing.T) {
 
-			k8s, testSvr := completeSetup(tt)
+			k8s, testSvr := completeSetup(t)
 			defer testSvr.Stop()
-			require := require.New(tt)
+			require := require.New(t)
 
 			// Run the command.
 			ui := cli.NewMockUi()

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -247,7 +247,15 @@ func TestRun_TokensPrimaryDC(t *testing.T) {
 		},
 		{
 			TestName:    "Health Checks ACL token",
-			TokenFlags:  []string{"-enable-health-checks-controller"},
+			TokenFlags:  []string{"-add-inject-health-checks-rules"},
+			PolicyNames: []string{"connect-inject-token"},
+			PolicyDCs:   []string{"dc1"},
+			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
+			LocalToken:  true,
+		},
+		{
+			TestName:    "Health Checks ACL token with namespaces enabled",
+			TokenFlags:  []string{"-add-inject-health-checks-rules", "-create-inject-namespace-token"},
 			PolicyNames: []string{"connect-inject-token"},
 			PolicyDCs:   []string{"dc1"},
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -245,6 +245,14 @@ func TestRun_TokensPrimaryDC(t *testing.T) {
 			SecretNames: []string{resourcePrefix + "-controller-acl-token"},
 			LocalToken:  true,
 		},
+		{
+			TestName:    "Health Checks ACL token",
+			TokenFlags:  []string{"-enable-health-checks-controller"},
+			PolicyNames: []string{"connect-inject-token"},
+			PolicyDCs:   []string{"dc1"},
+			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
+			LocalToken:  true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.TestName, func(t *testing.T) {

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -827,13 +827,13 @@ func TestRun_ConnectInjectAuthMethod(t *testing.T) {
 
 // Test that when we provide a different k8s auth method parameters,
 // the auth method is updated.
-func TestRun_ConnectInjectAuthMethodUpdates(tt *testing.T) {
-	tt.Parallel()
+func TestRun_ConnectInjectAuthMethodUpdates(t *testing.T) {
+	t.Parallel()
 
 	// Test with deprecated -create-inject-auth-method flag.
 	cases := []string{"-create-inject-auth-method", "-create-inject-token"}
 	for _, flag := range cases {
-		tt.Run(flag, func(t *testing.T) {
+		t.Run(flag, func(t *testing.T) {
 
 			k8s, testSvr := completeSetup(t)
 			defer testSvr.Stop()

--- a/subcommand/server-acl-init/connect_inject.go
+++ b/subcommand/server-acl-init/connect_inject.go
@@ -19,7 +19,7 @@ const defaultKubernetesHost = "https://kubernetes.default.svc"
 
 // configureConnectInject sets up auth methods so that connect injection will
 // work.
-func (c *Command) configureConnectInject(consulClient *api.Client) error {
+func (c *Command) configureConnectInjectAuthMethod(consulClient *api.Client) error {
 
 	authMethodName := c.withPrefix("k8s-auth-method")
 

--- a/subcommand/server-acl-init/rules.go
+++ b/subcommand/server-acl-init/rules.go
@@ -7,14 +7,15 @@ import (
 )
 
 type rulesData struct {
-	EnableNamespaces        bool
-	SyncConsulDestNS        string
-	SyncEnableNSMirroring   bool
-	SyncNSMirroringPrefix   string
-	InjectConsulDestNS      string
-	InjectEnableNSMirroring bool
-	InjectNSMirroringPrefix string
-	SyncConsulNodeName      string
+	EnableNamespaces             bool
+	SyncConsulDestNS             string
+	SyncEnableNSMirroring        bool
+	SyncNSMirroringPrefix        string
+	InjectConsulDestNS           string
+	InjectEnableNSMirroring      bool
+	InjectNSMirroringPrefix      string
+	SyncConsulNodeName           string
+	EnableHealthChecksController bool
 }
 
 type gatewayRulesData struct {
@@ -204,10 +205,24 @@ namespace "{{ .SyncConsulDestNS }}" {
 }
 
 func (c *Command) injectRules() (string, error) {
-	// The Connect injector only needs permissions to create namespaces.
+	// The Connect injector needs permissions to create namespaces and create/update service checks.
 	injectRulesTpl := `
 {{- if .EnableNamespaces }}
 operator = "write"
+{{- end }}
+{{- if .EnableHealthChecksController }}
+{{- if .EnableNamespaces }}
+namespace_prefix "" {
+{{- end }}
+  node_prefix "" {
+     policy = "write"
+  }
+  service_prefix "" {
+     policy = "write"
+  }
+{{- if .EnableNamespaces }}
+}
+{{- end }}
 {{- end }}
 `
 	return c.renderRules(injectRulesTpl)
@@ -267,14 +282,15 @@ namespace "{{ .InjectConsulDestNS }}" {
 
 func (c *Command) rulesData() rulesData {
 	return rulesData{
-		EnableNamespaces:        c.flagEnableNamespaces,
-		SyncConsulDestNS:        c.flagConsulSyncDestinationNamespace,
-		SyncEnableNSMirroring:   c.flagEnableSyncK8SNSMirroring,
-		SyncNSMirroringPrefix:   c.flagSyncK8SNSMirroringPrefix,
-		InjectConsulDestNS:      c.flagConsulInjectDestinationNamespace,
-		InjectEnableNSMirroring: c.flagEnableInjectK8SNSMirroring,
-		InjectNSMirroringPrefix: c.flagInjectK8SNSMirroringPrefix,
-		SyncConsulNodeName:      c.flagSyncConsulNodeName,
+		EnableNamespaces:             c.flagEnableNamespaces,
+		SyncConsulDestNS:             c.flagConsulSyncDestinationNamespace,
+		SyncEnableNSMirroring:        c.flagEnableSyncK8SNSMirroring,
+		SyncNSMirroringPrefix:        c.flagSyncK8SNSMirroringPrefix,
+		InjectConsulDestNS:           c.flagConsulInjectDestinationNamespace,
+		InjectEnableNSMirroring:      c.flagEnableInjectK8SNSMirroring,
+		InjectNSMirroringPrefix:      c.flagInjectK8SNSMirroringPrefix,
+		SyncConsulNodeName:           c.flagSyncConsulNodeName,
+		EnableHealthChecksController: c.flagEnableHealthChecksController,
 	}
 }
 

--- a/subcommand/server-acl-init/rules.go
+++ b/subcommand/server-acl-init/rules.go
@@ -285,7 +285,7 @@ func (c *Command) rulesData() rulesData {
 		InjectEnableNSMirroring: c.flagEnableInjectK8SNSMirroring,
 		InjectNSMirroringPrefix: c.flagInjectK8SNSMirroringPrefix,
 		SyncConsulNodeName:      c.flagSyncConsulNodeName,
-		EnableHealthChecks:      c.flagAddInjectHealthChecksRules,
+		EnableHealthChecks:      c.flagEnableHealthChecks,
 	}
 }
 

--- a/subcommand/server-acl-init/rules.go
+++ b/subcommand/server-acl-init/rules.go
@@ -7,15 +7,15 @@ import (
 )
 
 type rulesData struct {
-	EnableNamespaces             bool
-	SyncConsulDestNS             string
-	SyncEnableNSMirroring        bool
-	SyncNSMirroringPrefix        string
-	InjectConsulDestNS           string
-	InjectEnableNSMirroring      bool
-	InjectNSMirroringPrefix      string
-	SyncConsulNodeName           string
-	EnableHealthChecksController bool
+	EnableNamespaces        bool
+	SyncConsulDestNS        string
+	SyncEnableNSMirroring   bool
+	SyncNSMirroringPrefix   string
+	InjectConsulDestNS      string
+	InjectEnableNSMirroring bool
+	InjectNSMirroringPrefix string
+	SyncConsulNodeName      string
+	EnableHealthChecks      bool
 }
 
 type gatewayRulesData struct {
@@ -211,7 +211,7 @@ func (c *Command) injectRules() (string, error) {
 {{- if .EnableNamespaces }}
 operator = "write"
 {{- end }}
-{{- if .EnableHealthChecksController }}
+{{- if .EnableHealthChecks }}
   node_prefix "" {
      policy = "write"
   }
@@ -277,15 +277,15 @@ namespace "{{ .InjectConsulDestNS }}" {
 
 func (c *Command) rulesData() rulesData {
 	return rulesData{
-		EnableNamespaces:             c.flagEnableNamespaces,
-		SyncConsulDestNS:             c.flagConsulSyncDestinationNamespace,
-		SyncEnableNSMirroring:        c.flagEnableSyncK8SNSMirroring,
-		SyncNSMirroringPrefix:        c.flagSyncK8SNSMirroringPrefix,
-		InjectConsulDestNS:           c.flagConsulInjectDestinationNamespace,
-		InjectEnableNSMirroring:      c.flagEnableInjectK8SNSMirroring,
-		InjectNSMirroringPrefix:      c.flagInjectK8SNSMirroringPrefix,
-		SyncConsulNodeName:           c.flagSyncConsulNodeName,
-		EnableHealthChecksController: c.flagAddInjectHealthChecksRules,
+		EnableNamespaces:        c.flagEnableNamespaces,
+		SyncConsulDestNS:        c.flagConsulSyncDestinationNamespace,
+		SyncEnableNSMirroring:   c.flagEnableSyncK8SNSMirroring,
+		SyncNSMirroringPrefix:   c.flagSyncK8SNSMirroringPrefix,
+		InjectConsulDestNS:      c.flagConsulInjectDestinationNamespace,
+		InjectEnableNSMirroring: c.flagEnableInjectK8SNSMirroring,
+		InjectNSMirroringPrefix: c.flagInjectK8SNSMirroringPrefix,
+		SyncConsulNodeName:      c.flagSyncConsulNodeName,
+		EnableHealthChecks:      c.flagAddInjectHealthChecksRules,
 	}
 }
 

--- a/subcommand/server-acl-init/rules.go
+++ b/subcommand/server-acl-init/rules.go
@@ -205,24 +205,19 @@ namespace "{{ .SyncConsulDestNS }}" {
 }
 
 func (c *Command) injectRules() (string, error) {
-	// The Connect injector needs permissions to create namespaces and create/update service checks.
+	// The Connect injector needs permissions to create namespaces when namespaces are enabled
+	// and also create/update service checks when health checks are enabled.
 	injectRulesTpl := `
 {{- if .EnableNamespaces }}
 operator = "write"
 {{- end }}
 {{- if .EnableHealthChecksController }}
-{{- if .EnableNamespaces }}
-namespace_prefix "" {
-{{- end }}
   node_prefix "" {
      policy = "write"
   }
   service_prefix "" {
      policy = "write"
   }
-{{- if .EnableNamespaces }}
-}
-{{- end }}
 {{- end }}
 `
 	return c.renderRules(injectRulesTpl)
@@ -290,7 +285,7 @@ func (c *Command) rulesData() rulesData {
 		InjectEnableNSMirroring:      c.flagEnableInjectK8SNSMirroring,
 		InjectNSMirroringPrefix:      c.flagInjectK8SNSMirroringPrefix,
 		SyncConsulNodeName:           c.flagSyncConsulNodeName,
-		EnableHealthChecksController: c.flagEnableHealthChecksController,
+		EnableHealthChecksController: c.flagAddInjectHealthChecksRules,
 	}
 }
 

--- a/subcommand/server-acl-init/rules_test.go
+++ b/subcommand/server-acl-init/rules_test.go
@@ -495,20 +495,50 @@ namespace_prefix "prefix-" {
 
 func TestInjectRules(t *testing.T) {
 	cases := []struct {
-		Name             string
-		EnableNamespaces bool
-		Expected         string
+		Name               string
+		EnableNamespaces   bool
+		EnableHealthChecks bool
+		Expected           string
 	}{
 		{
-			"Namespaces are disabled",
+			"Namespaces are disabled, health checks controller disabled",
+			false,
 			false,
 			"",
 		},
 		{
-			"Namespaces are enabled",
+			"Namespaces are enabled, health checks controller disabled",
 			true,
+			false,
 			`
 operator = "write"`,
+		},
+		{
+			"Namespaces are disabled, health checks controller enabled",
+			false,
+			true,
+			`
+  node_prefix "" {
+     policy = "write"
+  }
+  service_prefix "" {
+     policy = "write"
+  }`,
+		},
+		{
+			"Namespaces are enabled, health checks controller enabled",
+			true,
+			true,
+			`
+operator = "write"
+namespace_prefix "" {
+  node_prefix "" {
+     policy = "write"
+  }
+  service_prefix "" {
+     policy = "write"
+  }
+}`,
 		},
 	}
 
@@ -517,7 +547,8 @@ operator = "write"`,
 			require := require.New(t)
 
 			cmd := Command{
-				flagEnableNamespaces: tt.EnableNamespaces,
+				flagEnableNamespaces:             tt.EnableNamespaces,
+				flagEnableHealthChecksController: tt.EnableHealthChecks,
 			}
 
 			injectorRules, err := cmd.injectRules()

--- a/subcommand/server-acl-init/rules_test.go
+++ b/subcommand/server-acl-init/rules_test.go
@@ -531,14 +531,12 @@ operator = "write"`,
 			true,
 			`
 operator = "write"
-namespace_prefix "" {
   node_prefix "" {
      policy = "write"
   }
   service_prefix "" {
      policy = "write"
-  }
-}`,
+  }`,
 		},
 	}
 
@@ -547,8 +545,8 @@ namespace_prefix "" {
 			require := require.New(t)
 
 			cmd := Command{
-				flagEnableNamespaces:             tt.EnableNamespaces,
-				flagEnableHealthChecksController: tt.EnableHealthChecks,
+				flagEnableNamespaces:           tt.EnableNamespaces,
+				flagAddInjectHealthChecksRules: tt.EnableHealthChecks,
 			}
 
 			injectorRules, err := cmd.injectRules()

--- a/subcommand/server-acl-init/rules_test.go
+++ b/subcommand/server-acl-init/rules_test.go
@@ -545,8 +545,8 @@ operator = "write"
 			require := require.New(t)
 
 			cmd := Command{
-				flagEnableNamespaces:           tt.EnableNamespaces,
-				flagAddInjectHealthChecksRules: tt.EnableHealthChecks,
+				flagEnableNamespaces:   tt.EnableNamespaces,
+				flagEnableHealthChecks: tt.EnableHealthChecks,
 			}
 
 			injectorRules, err := cmd.injectRules()


### PR DESCRIPTION
Changes proposed in this PR:
- server-acl-init will now add additional rules for the connect-inject-webhook when ACLs and health checks are enabled.
- deprecate `-create-inject-auth-method`
- deprecate `-create-inject-namespace-token`. This flag was always passed when `-enable-namespaces` was true so now we just look at`-enable-namespaces` and `-create-inject-token`
- undeprecate `-create-inject-token`. This will always be passed by helm if connect inject is enabled.
- move all namespaced server-acl-init/command_test.go tests that used `-create-inject-namespace-token` from oss to ent as these are now invalid for oss (they always were but they got away with being in oss because they weren't passing `-enable-namespaces`
- tests to validate backwards compatibility are added and coverage for new flags.

How I've tested this PR:
unit tests + some manual testing of the command flags

How I expect reviewers to test this PR:
run the unit tests and try out the full stack by grabbing
https://github.com/hashicorp/consul-helm/pull/665

This table summarizes what helm would pass with versions <= 0.25.0 (old) and > 0.25.0 (new):

|     | Enable Namespaces | Enable Healthchecks | Flags Passed                                                                   | Auth Method | Token | Global Token |
|-----|-------------------|---------------------|--------------------------------------------------------------------------------|-------------|-------|--------------|
| Old |       FALSE       | N/A                 | -create-inject-auth-method                                                     | Yes         | No    | N/A          |
|     |        TRUE       | N/A                 | -create-inject-auth-method, -enable-namespaces, -create-inject-namespace-token | Yes         | Yes   | Yes          |
|     |                   |                     |                                                                                |             |       |              |
| New |       FALSE       |        FALSE        | -create-inject-token                                                           | Yes         | No    | N/A          |
|     |        TRUE       |        FALSE        | -create-inject-token, -enable-namespaces                                       | Yes         | Yes   | Yes          |
|     |        TRUE       |         TRUE        | -create-inject-token, -enable-namespaces, -enable-healthchecks                 | Yes         | Yes   | Yes          |
|     |       FALSE       |         TRUE        | -create-inject-token, -enable-healthchecks                                     | Yes         | Yes   | No           |

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added - this will be part of the full health checks changelog entry
