### PR TITLE
Use global token for controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 BUG FIXES:
 * Federation: ensure replication ACL token can replicate policies and tokens in Consul namespaces other than `default` (Consul-enterprise only). [[GH-364](https://github.com/hashicorp/consul-k8s/issues/364)]
 * CRDs: validate custom resources can only set namespace fields if Consul namespaces are enabled [[GH-375](https://github.com/hashicorp/consul-k8s/pull/375)]
+* CRDs: Ensure ACL token is global so that secondary DCs can manage custom resources.
+  Without this fix, controllers running in secondary datacenters would get ACL errors. [[GH-369](https://github.com/hashicorp/consul-k8s/pull/369)]
 
 ## 0.19.0 (October 12, 2020)
 

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -666,7 +666,10 @@ func (c *Command) Run(args []string) int {
 			c.log.Error("Error templating controller token rules", "err", err)
 			return 1
 		}
-		err = c.createLocalACL("controller", rules, consulDC, consulClient)
+		// Controller token must be global because config entry writes all
+		// go to the primary datacenter. This means secondary datacenters need
+		// a token that is known by the primary datacenters.
+		err = c.createGlobalACL("controller", rules, consulDC, consulClient)
 		if err != nil {
 			c.log.Error(err.Error())
 			return 1

--- a/subcommand/server-acl-init/command_ent_test.go
+++ b/subcommand/server-acl-init/command_ent_test.go
@@ -232,6 +232,7 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 				"-ingress-gateway-name=anothergw",
 				"-terminating-gateway-name=gw",
 				"-terminating-gateway-name=anothergw",
+				"-create-controller-token",
 			}
 			// Our second run, we're going to update from namespaces disabled to
 			// namespaces enabled with a single destination ns.
@@ -267,6 +268,7 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 				"anothergw-ingress-gateway-token",
 				"gw-terminating-gateway-token",
 				"anothergw-terminating-gateway-token",
+				"controller-token",
 			}
 			policies, _, err := consul.ACL().PolicyList(nil)
 			require.NoError(err)
@@ -318,6 +320,7 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 				"anothergw-ingress-gateway-token",
 				"gw-terminating-gateway-token",
 				"anothergw-terminating-gateway-token",
+				"controller-token",
 			}
 			policies, _, err = consul.ACL().PolicyList(nil)
 			require.NoError(err)
@@ -680,6 +683,13 @@ func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
 			PolicyNames: []string{"connect-inject-token"},
 			PolicyDCs:   nil,
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
+			LocalToken:  false,
+		},
+		"controller token": {
+			TokenFlags:  []string{"-create-controller-token"},
+			PolicyNames: []string{"controller-token"},
+			PolicyDCs:   nil,
+			SecretNames: []string{resourcePrefix + "-controller-acl-token"},
 			LocalToken:  false,
 		},
 	}

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -233,9 +233,9 @@ func TestRun_TokensPrimaryDC(t *testing.T) {
 			TestName:    "Controller token",
 			TokenFlags:  []string{"-create-controller-token"},
 			PolicyNames: []string{"controller-token"},
-			PolicyDCs:   []string{"dc1"},
+			PolicyDCs:   nil,
 			SecretNames: []string{resourcePrefix + "-controller-acl-token"},
-			LocalToken:  true,
+			LocalToken:  false,
 		},
 		{
 			TestName:    "Health Checks ACL token",
@@ -400,6 +400,14 @@ func TestRun_TokensReplicatedDC(t *testing.T) {
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
 			LocalToken:  true,
 		},
+		{
+			TestName:    "Controller token",
+			TokenFlags:  []string{"-create-controller-token"},
+			PolicyNames: []string{"controller-token-dc2"},
+			PolicyDCs:   nil,
+			SecretNames: []string{resourcePrefix + "-controller-acl-token"},
+			LocalToken:  false,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.TestName, func(t *testing.T) {
@@ -529,6 +537,12 @@ func TestRun_TokensWithProvidedBootstrapToken(t *testing.T) {
 			TokenFlags:  []string{"-create-inject-token", "-enable-health-checks"},
 			PolicyNames: []string{"connect-inject-token"},
 			SecretNames: []string{resourcePrefix + "-connect-inject-acl-token"},
+		},
+		{
+			TestName:    "Controller token",
+			TokenFlags:  []string{"-create-controller-token"},
+			PolicyNames: []string{"controller-token"},
+			SecretNames: []string{resourcePrefix + "-controller-acl-token"},
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
Controller token must be global because config entries are global and therefore all writes/reads
go to the primary datacenter. This means secondary datacenters need
a token that is known by the primary datacenters, i.e. a global token.

How I've tested this PR:
* federated two dcs using consul k8s image `ghcr.io/lkysow/consul-k8s-dev:oct29`
* created servicedefaults in secondary dc
    ```
    cat <<EOF | kubectl apply -f -
    apiVersion: consul.hashicorp.com/v1alpha1
    kind: ServiceDefaults
    metadata:
      name: api
    spec:
      protocol: http
    EOF
    servicedefaults.consul.hashicorp.com/api created

    k get servicedefaults
    NAME   SYNCED
    api    True
    ```

How I expect reviewers to test this PR:
* code review

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
