### PR TITLE
Replication token needs acl write on all ns's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UNRELEASED
 
+BUG FIXES:
+* Federation: ensure replication ACL token can replicate policies and tokens in Consul namespaces other than `default` (Consul-enterprise only). [[GH-364](https://github.com/hashicorp/consul-k8s/issues/364)]
+
 ## 0.19.0 (October 12, 2020)
 
 FEATURES:

--- a/subcommand/server-acl-init/rules.go
+++ b/subcommand/server-acl-init/rules.go
@@ -222,7 +222,6 @@ func (c *Command) aclReplicationRules() (string, error) {
 	// datacenters during federation since in order to start ACL replication,
 	// we need a token with both replication and agent permissions.
 	aclReplicationRulesTpl := `
-acl = "write"
 operator = "write"
 agent_prefix "" {
   policy = "read"
@@ -233,6 +232,7 @@ node_prefix "" {
 {{- if .EnableNamespaces }}
 namespace_prefix "" {
 {{- end }}
+  acl = "write"
   service_prefix "" {
     policy = "read"
     intentions = "read"

--- a/subcommand/server-acl-init/rules_test.go
+++ b/subcommand/server-acl-init/rules_test.go
@@ -537,14 +537,14 @@ func TestReplicationTokenRules(t *testing.T) {
 		{
 			"Namespaces are disabled",
 			false,
-			`acl = "write"
-operator = "write"
+			`operator = "write"
 agent_prefix "" {
   policy = "read"
 }
 node_prefix "" {
   policy = "write"
 }
+  acl = "write"
   service_prefix "" {
     policy = "read"
     intentions = "read"
@@ -553,8 +553,7 @@ node_prefix "" {
 		{
 			"Namespaces are enabled",
 			true,
-			`acl = "write"
-operator = "write"
+			`operator = "write"
 agent_prefix "" {
   policy = "read"
 }
@@ -562,6 +561,7 @@ node_prefix "" {
   policy = "write"
 }
 namespace_prefix "" {
+  acl = "write"
   service_prefix "" {
     policy = "read"
     intentions = "read"


### PR DESCRIPTION
If namespaces are enabled, the replication token will need to be able to
replicate all tokens and policies from all namespaces. Without this
functionality, users won't be able to use namespaced
tokens/policies/roles in secondary datacenters (since they won't be
replicated).

Fixes https://github.com/hashicorp/consul-k8s/issues/364

How I've tested this PR:
* Federated two clusters with ACLs enabled
* Created a namespace `luke`
* Created a policy and token in namespace `luke`:
    ```hcl
    acl = "read"
    ```
* On secondary DC, exec'd into server and ran:
    ```bash
    curl -H "X-Consul-Token: 5207f7dd-cfb0-7d7f-b0a5-964295bcb3a1" -k https://localhost:8501/v1/acl/token/self
    ACL not found
    ```
* Modified replication ACL policy to have `namespace_prefix ""`
* Confirmed that (after a 5m delay) that the API call worked

How I expect reviewers to test this PR:
* code review

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
