### PR TITLE
Validate CR namespaces based on consul namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 * Federation: ensure replication ACL token can replicate policies and tokens in Consul namespaces other than `default` (Consul-enterprise only). [[GH-364](https://github.com/hashicorp/consul-k8s/issues/364)]
+* CRDs: validate custom resources can only set namespace fields if Consul namespaces are enabled [[GH-375](https://github.com/hashicorp/consul-k8s/pull/375)]
 
 ## 0.19.0 (October 12, 2020)
 

--- a/api/common/configentry.go
+++ b/api/common/configentry.go
@@ -56,5 +56,5 @@ type ConfigEntryResource interface {
 	// DeepCopyObject should be implemented by the generated code.
 	DeepCopyObject() runtime.Object
 	// Validate returns an error if the resource is invalid.
-	Validate() error
+	Validate(namespacesEnabled bool) error
 }

--- a/api/common/configentry_webhook.go
+++ b/api/common/configentry_webhook.go
@@ -53,7 +53,7 @@ func ValidateConfigEntry(
 			}
 		}
 	}
-	if err := cfgEntry.Validate(); err != nil {
+	if err := cfgEntry.Validate(enableConsulNamespaces); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	return admission.Allowed(fmt.Sprintf("valid %s request", cfgEntry.KubeKind()))

--- a/api/common/configentry_webhook_test.go
+++ b/api/common/configentry_webhook_test.go
@@ -193,7 +193,7 @@ func (in *mockConfigEntry) ToConsul(string) capi.ConfigEntry {
 	return &capi.ServiceConfigEntry{}
 }
 
-func (in *mockConfigEntry) Validate() error {
+func (in *mockConfigEntry) Validate(bool) error {
 	if !in.Valid {
 		return errors.New("invalid")
 	}

--- a/api/v1alpha1/proxydefaults_types.go
+++ b/api/v1alpha1/proxydefaults_types.go
@@ -143,7 +143,7 @@ func (in *ProxyDefaults) MatchesConsul(candidate api.ConfigEntry) bool {
 	return cmp.Equal(in.ToConsul(""), configEntry, cmpopts.IgnoreFields(capi.ProxyConfigEntry{}, "Namespace", "Meta", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
 }
 
-func (in *ProxyDefaults) Validate() error {
+func (in *ProxyDefaults) Validate(namespacesEnabled bool) error {
 	var allErrs field.ErrorList
 	path := field.NewPath("spec")
 

--- a/api/v1alpha1/proxydefaults_webhook.go
+++ b/api/v1alpha1/proxydefaults_webhook.go
@@ -61,7 +61,7 @@ func (v *ProxyDefaultsWebhook) Handle(ctx context.Context, req admission.Request
 		}
 	}
 
-	if err := proxyDefaults.Validate(); err != nil {
+	if err := proxyDefaults.Validate(v.EnableConsulNamespaces); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	return admission.Allowed(fmt.Sprintf("valid %s request", proxyDefaults.KubeKind()))

--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -141,7 +141,7 @@ func (in *ServiceDefaults) ToConsul(datacenter string) capi.ConfigEntry {
 
 // Validate validates the fields provided in the spec of the ServiceDefaults and
 // returns an error which lists all invalid fields in the resource spec.
-func (in *ServiceDefaults) Validate() error {
+func (in *ServiceDefaults) Validate(namespacesEnabled bool) error {
 	var allErrs field.ErrorList
 	path := field.NewPath("spec")
 

--- a/api/v1alpha1/servicedefaults_types_test.go
+++ b/api/v1alpha1/servicedefaults_types_test.go
@@ -312,7 +312,7 @@ func TestServiceDefaults_Validate(t *testing.T) {
 
 	for name, testCase := range cases {
 		t.Run(name, func(t *testing.T) {
-			err := testCase.input.Validate()
+			err := testCase.input.Validate(false)
 			if testCase.expectedErrMsg != "" {
 				require.EqualError(t, err, testCase.expectedErrMsg)
 			} else {

--- a/api/v1alpha1/serviceintentions_types.go
+++ b/api/v1alpha1/serviceintentions_types.go
@@ -248,7 +248,7 @@ func (in *ServiceIntentions) MatchesConsul(candidate api.ConfigEntry) bool {
 	)
 }
 
-func (in *ServiceIntentions) Validate() error {
+func (in *ServiceIntentions) Validate(namespacesEnabled bool) error {
 	var errs field.ErrorList
 	path := field.NewPath("spec")
 	if len(in.Spec.Sources) == 0 {
@@ -268,6 +268,9 @@ func (in *ServiceIntentions) Validate() error {
 			}
 		}
 	}
+
+	errs = append(errs, in.validateNamespaces(namespacesEnabled)...)
+
 	if len(errs) > 0 {
 		return apierrors.NewInvalid(
 			schema.GroupKind{Group: ConsulHashicorpGroup, Kind: common.ServiceIntentions},
@@ -316,9 +319,7 @@ func (in *ServiceIntentions) Default(consulNamespacesEnabled bool, destinationNa
 	}
 }
 
-// ValidateNamespaces returns an error if spec.destination.namespace or spec.sources[i].namespace
-// is set but namespaces are disabled.
-func (in *ServiceIntentions) ValidateNamespaces(namespacesEnabled bool) error {
+func (in *ServiceIntentions) validateNamespaces(namespacesEnabled bool) field.ErrorList {
 	var errs field.ErrorList
 	path := field.NewPath("spec")
 	if !namespacesEnabled {
@@ -331,12 +332,7 @@ func (in *ServiceIntentions) ValidateNamespaces(namespacesEnabled bool) error {
 			}
 		}
 	}
-	if len(errs) > 0 {
-		return apierrors.NewInvalid(
-			schema.GroupKind{Group: ConsulHashicorpGroup, Kind: common.ServiceIntentions},
-			in.KubernetesName(), errs)
-	}
-	return nil
+	return errs
 }
 
 func (in IntentionAction) validate(path *field.Path) *field.Error {

--- a/api/v1alpha1/serviceintentions_types.go
+++ b/api/v1alpha1/serviceintentions_types.go
@@ -324,11 +324,11 @@ func (in *ServiceIntentions) validateNamespaces(namespacesEnabled bool) field.Er
 	path := field.NewPath("spec")
 	if !namespacesEnabled {
 		if in.Spec.Destination.Namespace != "" {
-			errs = append(errs, field.Invalid(path.Child("destination").Child("namespace"), in.Spec.Destination.Namespace, `consul namespaces must be enabled to set destination.namespace`))
+			errs = append(errs, field.Invalid(path.Child("destination").Child("namespace"), in.Spec.Destination.Namespace, `Consul Enterprise namespaces must be enabled to set destination.namespace`))
 		}
 		for i, source := range in.Spec.Sources {
 			if source.Namespace != "" {
-				errs = append(errs, field.Invalid(path.Child("sources").Index(i).Child("namespace"), source.Namespace, `consul namespaces must be enabled to set source.namespace`))
+				errs = append(errs, field.Invalid(path.Child("sources").Index(i).Child("namespace"), source.Namespace, `Consul Enterprise namespaces must be enabled to set source.namespace`))
 			}
 		}
 	}

--- a/api/v1alpha1/serviceintentions_webhook.go
+++ b/api/v1alpha1/serviceintentions_webhook.go
@@ -89,12 +89,8 @@ func (v *ServiceIntentionsWebhook) Handle(ctx context.Context, req admission.Req
 		}
 	}
 
-	if err := svcIntentions.Validate(); err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-
 	// ServiceIntentions are invalid if destination namespaces or source namespaces are set when Consul Namespaces are not enabled.
-	if err := svcIntentions.ValidateNamespaces(v.EnableConsulNamespaces); err != nil {
+	if err := svcIntentions.Validate(v.EnableConsulNamespaces); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 

--- a/api/v1alpha1/serviceintentions_webhook_test.go
+++ b/api/v1alpha1/serviceintentions_webhook_test.go
@@ -496,7 +496,7 @@ func TestHandle_ServiceIntentions_Patches(t *testing.T) {
 				},
 			},
 			expPatches: []jsonpatch.Operation{},
-			errMsg:     `serviceintentions.consul.hashicorp.com "foo-intention" is invalid: [spec.destination.namespace: Invalid value: "bar": consul namespaces must be enabled to set destination.namespace, spec.sources[0].namespace: Invalid value: "baz": consul namespaces must be enabled to set source.namespace]`,
+			errMsg:     `serviceintentions.consul.hashicorp.com "foo-intention" is invalid: [spec.destination.namespace: Invalid value: "bar": Consul Enterprise namespaces must be enabled to set destination.namespace, spec.sources[0].namespace: Invalid value: "baz": Consul Enterprise namespaces must be enabled to set source.namespace]`,
 		},
 		"destination.namespace empty": {
 			newResource: &ServiceIntentions{
@@ -577,7 +577,7 @@ func TestHandle_ServiceIntentions_Patches(t *testing.T) {
 				},
 			},
 			expPatches: []jsonpatch.Operation{},
-			errMsg:     `serviceintentions.consul.hashicorp.com "foo-intention" is invalid: spec.destination.namespace: Invalid value: "bar": consul namespaces must be enabled to set destination.namespace`,
+			errMsg:     `serviceintentions.consul.hashicorp.com "foo-intention" is invalid: spec.destination.namespace: Invalid value: "bar": Consul Enterprise namespaces must be enabled to set destination.namespace`,
 		},
 	}
 	for name, c := range cases {

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -155,12 +155,12 @@ func (in *ServiceResolver) validateNamespaces(namespacesEnabled bool) field.Erro
 	if !namespacesEnabled {
 		if in.Spec.Redirect != nil {
 			if in.Spec.Redirect.Namespace != "" {
-				errs = append(errs, field.Invalid(path.Child("redirect").Child("namespace"), in.Spec.Redirect.Namespace, `consul namespaces must be enabled to set redirect.namespace`))
+				errs = append(errs, field.Invalid(path.Child("redirect").Child("namespace"), in.Spec.Redirect.Namespace, `Consul Enterprise namespaces must be enabled to set redirect.namespace`))
 			}
 		}
 		for k, v := range in.Spec.Failover {
 			if v.Namespace != "" {
-				errs = append(errs, field.Invalid(path.Child("failover").Key(k).Child("namespace"), v.Namespace, `consul namespaces must be enabled to set failover.namespace`))
+				errs = append(errs, field.Invalid(path.Child("failover").Key(k).Child("namespace"), v.Namespace, `Consul Enterprise namespaces must be enabled to set failover.namespace`))
 			}
 		}
 

--- a/api/v1alpha1/serviceresolver_types_test.go
+++ b/api/v1alpha1/serviceresolver_types_test.go
@@ -445,10 +445,32 @@ func TestServiceResolver_ObjectMeta(t *testing.T) {
 
 func TestServiceResolver_Validate(t *testing.T) {
 	cases := map[string]struct {
-		input          *ServiceResolver
-		expectedErrMsg string
+		input             *ServiceResolver
+		namespacesEnabled bool
+		expectedErrMsgs   []string
 	}{
-		"valid": {
+		"namespaces enabled: valid": {
+			input: &ServiceResolver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: ServiceResolverSpec{
+					Redirect: &ServiceResolverRedirect{
+						Service:   "bar",
+						Namespace: "namespace-a",
+					},
+					Failover: map[string]ServiceResolverFailover{
+						"failA": {
+							Service:   "baz",
+							Namespace: "namespace-b",
+						},
+					},
+				},
+			},
+			namespacesEnabled: true,
+			expectedErrMsgs:   nil,
+		},
+		"namespaces disabled: valid": {
 			input: &ServiceResolver{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -457,9 +479,15 @@ func TestServiceResolver_Validate(t *testing.T) {
 					Redirect: &ServiceResolverRedirect{
 						Service: "bar",
 					},
+					Failover: map[string]ServiceResolverFailover{
+						"failA": {
+							Service: "baz",
+						},
+					},
 				},
 			},
-			expectedErrMsg: "",
+			namespacesEnabled: false,
+			expectedErrMsgs:   nil,
 		},
 		"failover service, servicesubset, namespace, datacenters empty": {
 			input: &ServiceResolver{
@@ -483,7 +511,11 @@ func TestServiceResolver_Validate(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: "serviceresolver.consul.hashicorp.com \"foo\" is invalid: [spec.failover[failA]: Invalid value: \"{}\": service, serviceSubset, namespace and datacenters cannot all be empty at once, spec.failover[failB]: Invalid value: \"{}\": service, serviceSubset, namespace and datacenters cannot all be empty at once]",
+			namespacesEnabled: false,
+			expectedErrMsgs: []string{
+				"spec.failover[failA]: Invalid value: \"{}\": service, serviceSubset, namespace and datacenters cannot all be empty at once",
+				"spec.failover[failB]: Invalid value: \"{}\": service, serviceSubset, namespace and datacenters cannot all be empty at once",
+			},
 		},
 		"hashPolicy.field invalid": {
 			input: &ServiceResolver{
@@ -500,7 +532,10 @@ func TestServiceResolver_Validate(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: `serviceresolver.consul.hashicorp.com "foo" is invalid: spec.loadBalancer.hashPolicies[0].field: Invalid value: "invalid": must be one of "header", "cookie", "query_parameter"`,
+			namespacesEnabled: false,
+			expectedErrMsgs: []string{
+				`serviceresolver.consul.hashicorp.com "foo" is invalid: spec.loadBalancer.hashPolicies[0].field: Invalid value: "invalid": must be one of "header", "cookie", "query_parameter"`,
+			},
 		},
 		"hashPolicy sourceIP and field set": {
 			input: &ServiceResolver{
@@ -518,7 +553,10 @@ func TestServiceResolver_Validate(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: `serviceresolver.consul.hashicorp.com "foo" is invalid: spec.loadBalancer.hashPolicies[0]: Invalid value: "{\"field\":\"header\",\"sourceIP\":true}": cannot set both field and sourceIP`,
+			namespacesEnabled: false,
+			expectedErrMsgs: []string{
+				`serviceresolver.consul.hashicorp.com "foo" is invalid: spec.loadBalancer.hashPolicies[0]: Invalid value: "{\"field\":\"header\",\"sourceIP\":true}": cannot set both field and sourceIP`,
+			},
 		},
 		"cookieConfig session and ttl set": {
 			input: &ServiceResolver{
@@ -539,14 +577,76 @@ func TestServiceResolver_Validate(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: `serviceresolver.consul.hashicorp.com "foo" is invalid: spec.loadBalancer.hashPolicies[0].cookieConfig: Invalid value: "{\"session\":true,\"ttl\":100}": cannot set both session and ttl`,
+			namespacesEnabled: false,
+			expectedErrMsgs: []string{
+				`serviceresolver.consul.hashicorp.com "foo" is invalid: spec.loadBalancer.hashPolicies[0].cookieConfig: Invalid value: "{\"session\":true,\"ttl\":100}": cannot set both session and ttl`,
+			},
+		},
+		"namespaces disabled: redirect namespace specified": {
+			input: &ServiceResolver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: ServiceResolverSpec{
+					Redirect: &ServiceResolverRedirect{
+						Namespace: "namespace-a",
+					},
+				},
+			},
+			namespacesEnabled: false,
+			expectedErrMsgs: []string{
+				"serviceresolver.consul.hashicorp.com \"foo\" is invalid: spec.redirect.namespace: Invalid value: \"namespace-a\": Consul Enterprise namespaces must be enabled to set redirect.namespace",
+			},
+		},
+		"namespaces disabled: single failover namespace specified": {
+			input: &ServiceResolver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: ServiceResolverSpec{
+					Failover: map[string]ServiceResolverFailover{
+						"failA": {
+							Namespace: "namespace-a",
+						},
+					},
+				},
+			},
+			expectedErrMsgs: []string{
+				"serviceresolver.consul.hashicorp.com \"foo\" is invalid: spec.failover[failA].namespace: Invalid value: \"namespace-a\": Consul Enterprise namespaces must be enabled to set failover.namespace",
+			},
+			namespacesEnabled: false,
+		},
+		"namespaces disabled: multiple failover namespaces specified": {
+			input: &ServiceResolver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: ServiceResolverSpec{
+					Failover: map[string]ServiceResolverFailover{
+						"failA": {
+							Namespace: "namespace-a",
+						},
+						"failB": {
+							Namespace: "namespace-b",
+						},
+					},
+				},
+			},
+			namespacesEnabled: false,
+			expectedErrMsgs: []string{
+				"spec.failover[failA].namespace: Invalid value: \"namespace-a\": Consul Enterprise namespaces must be enabled to set failover.namespace",
+				"spec.failover[failB].namespace: Invalid value: \"namespace-b\": Consul Enterprise namespaces must be enabled to set failover.namespace",
+			},
 		},
 	}
 	for name, testCase := range cases {
 		t.Run(name, func(t *testing.T) {
-			err := testCase.input.Validate()
-			if testCase.expectedErrMsg != "" {
-				require.EqualError(t, err, testCase.expectedErrMsg)
+			err := testCase.input.Validate(testCase.namespacesEnabled)
+			if len(testCase.expectedErrMsgs) != 0 {
+				require.Error(t, err)
+				for _, s := range testCase.expectedErrMsgs {
+					require.Contains(t, err.Error(), s)
+				}
 			} else {
 				require.NoError(t, err)
 			}

--- a/api/v1alpha1/servicerouter_types.go
+++ b/api/v1alpha1/servicerouter_types.go
@@ -402,7 +402,7 @@ func (in *ServiceRouter) validateNamespaces(namespacesEnabled bool) field.ErrorL
 		for i, r := range in.Spec.Routes {
 			if r.Destination != nil {
 				if r.Destination.Namespace != "" {
-					errs = append(errs, field.Invalid(path.Child("routes").Index(i).Child("destination").Child("namespace"), r.Destination.Namespace, `consul namespaces must be enabled to set destination.namespace`))
+					errs = append(errs, field.Invalid(path.Child("routes").Index(i).Child("destination").Child("namespace"), r.Destination.Namespace, `Consul Enterprise namespaces must be enabled to set destination.namespace`))
 				}
 			}
 		}

--- a/api/v1alpha1/servicesplitter_types.go
+++ b/api/v1alpha1/servicesplitter_types.go
@@ -172,7 +172,7 @@ func (in *ServiceSplitter) validateNamespaces(namespacesEnabled bool) field.Erro
 	if !namespacesEnabled {
 		for i, s := range in.Spec.Splits {
 			if s.Namespace != "" {
-				errs = append(errs, field.Invalid(path.Child("splits").Index(i).Child("namespace"), s.Namespace, `consul namespaces must be enabled to set split.namespace`))
+				errs = append(errs, field.Invalid(path.Child("splits").Index(i).Child("namespace"), s.Namespace, `Consul Enterprise namespaces must be enabled to set split.namespace`))
 			}
 
 		}


### PR DESCRIPTION
ServiceRouters, ServiceResolvers, ServiceSplitters, and
ServiceIntentions should only have namespaces set in their spec when
consul namespaces are enabled. When consul namespaces are disabled, the
webhook now returns a validation error if these CRs have a namespace.

Previously, users could apply CRs with namespaces set even when consul
namespaces are disabled, causing them to think the namespaces might be
having an effect when they are not.

Co-authored-by: Ashwin Venkatesh <ashwin@hashicorp.com>

How I've tested this PR:
- ran unit tests (`make test`)
- ran acceptance tests in consul-helm using `gcr.io/nitya-293720/consul-k8s-dev@sha256:80044a89e92a32dc782117b7bc9626f8aebecf2b5253a6996d141969ef81bf7b`
- deployed consul-k8s with image `gcr.io/nitya-293720/consul-k8s-dev@sha256:80044a89e92a32dc782117b7bc9626f8aebecf2b5253a6996d141969ef81bf7b` and applied the following ServiceIntention, ServiceResolver, ServiceRouter, ServiceSplitter with namespaces and verified I saw the right errors in each case. 

```
apiVersion: consul.hashicorp.com/v1alpha1
kind: ServiceIntentions
metadata:
  name: intentions
spec:
  destination:
    name: svc1
    namespace: C
  sources:
  - name: svc2
    namespace: A
    action: allow
  - name: svc3
    namespace: B
    permissions:
    - action: allow
      http:
        methods:
        - GET
        - PUT
        pathExact: "/foo"
---
apiVersion: consul.hashicorp.com/v1alpha1
kind: ServiceResolver
metadata:
  name: resolver
spec:
  redirect:
    service: bar
    namespace: A
  failover:
    failA:
      namespace: B
---
apiVersion: consul.hashicorp.com/v1alpha1
kind: ServiceRouter
metadata:
  name: router
spec:
  routes:
    - destination:
        namespace: A
      match:
        http:
          pathPrefix: "/foo"
---
apiVersion: consul.hashicorp.com/v1alpha1
kind: ServiceSplitter
metadata:
  name: splitter
spec:
  splits:
  - namespace: A
    weight: 100
  - namespace: B
    weight: 100
```

Sample Error from ServiceIntention:
```
Error from server: error when creating "serviceintention.yaml": admission webhook "mutate-serviceintentions.consul.hashicorp.com" denied the request: serviceintentions.consul.hashicorp.com "intentions" is invalid: [spec.destination.namespace: Invalid value: "C": consul namespaces must be enabled to set destination.namespace, spec.sources[0].namespace: Invalid value: "A": consul namespaces must be enabled to set source.namespace, spec.sources[1].namespace: Invalid value: "B": consul namespaces must be enabled to set source.namespace]
```

How I expect reviewers to test this PR:
- code review

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
