### PR TITLE
add support of consul namespaces to health checks

### DIFF
--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -88,8 +88,7 @@ const (
 	// injected is used as the annotation value for annotationInjected
 	injected = "injected"
 
-	// annotationConsulDestinationNamespace is the Consul namespace the service is registered into.
-
+	// annotationConsulNamespace is the Consul namespace the service is registered into.
 	annotationConsulNamespace = "consul.hashicorp.com/consul-namespace"
 )
 

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -88,8 +88,9 @@ const (
 	// injected is used as the annotation value for annotationInjected
 	injected = "injected"
 
-	// annotationConsulDestinationNamespace is the configured Consul destination namespace
-	annotationConsulDestinationNamespace = "consul.hashicorp.com/consul-destination-namespace"
+	// annotationConsulDestinationNamespace is the Consul namespace the service is registered into.
+
+	annotationConsulNamespace = "consul.hashicorp.com/consul-namespace"
 )
 
 var (

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -364,12 +364,12 @@ func (h *Handler) Mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespon
 			labelInject: injected,
 		})...)
 
-	// Consul-ENT only : Add the Consul destination namespace as an annotation to the pod.
+	// Consul-ENT only: Add the Consul destination namespace as an annotation to the pod.
 	if h.EnableNamespaces {
 		patches = append(patches, updateAnnotation(
 			pod.Annotations,
 			map[string]string{
-				annotationConsulDestinationNamespace: h.consulNamespace(req.Namespace),
+				annotationConsulNamespace: h.consulNamespace(req.Namespace),
 			})...)
 	}
 

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -365,7 +365,7 @@ func (h *Handler) Mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespon
 		})...)
 
 	// Consul-ENT only : Add the Consul destination namespace as an annotation to the pod.
-	if h.EnableNamespaces && h.EnableK8SNSMirroring {
+	if h.EnableNamespaces {
 		patches = append(patches, updateAnnotation(
 			pod.Annotations,
 			map[string]string{

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -87,6 +87,9 @@ const (
 
 	// injected is used as the annotation value for annotationInjected
 	injected = "injected"
+
+	// annotationConsulDestinationNamespace is the configured Consul destination namespace
+	annotationConsulDestinationNamespace = "consul.hashicorp.com/consul-destination-namespace"
 )
 
 var (
@@ -359,6 +362,15 @@ func (h *Handler) Mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespon
 		map[string]string{
 			labelInject: injected,
 		})...)
+
+	// Consul-ENT only : Add the Consul destination namespace as an annotation to the pod.
+	if h.EnableNamespaces && h.EnableK8SNSMirroring {
+		patches = append(patches, updateAnnotation(
+			pod.Annotations,
+			map[string]string{
+				annotationConsulDestinationNamespace: h.consulNamespace(req.Namespace),
+			})...)
+	}
 
 	// Generate the patch
 	var patch []byte

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -402,58 +402,6 @@ func TestHandlerHandle(t *testing.T) {
 				},
 			},
 		},
-		{
-			"consul destination namespace annotation is set",
-			Handler{
-				Log:                        hclog.Default().Named("handler"),
-				AllowK8sNamespacesSet:      mapset.NewSetWith("*"),
-				DenyK8sNamespacesSet:       mapset.NewSet(),
-				ConsulDestinationNamespace: "abcd",
-				EnableK8SNSMirroring:       true,
-				EnableNamespaces:           true,
-			},
-			v1beta1.AdmissionRequest{
-				Object: encodeRaw(t, &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{},
-					Spec:       basicSpec,
-				}),
-			},
-			"",
-			[]jsonpatch.JsonPatchOperation{
-				{
-					Operation: "add",
-					Path:      "/metadata/annotations",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/volumes",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/initContainers",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/-",
-				},
-				{
-					Operation: "add",
-					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationStatus),
-				},
-				{
-					Operation: "add",
-					Path:      "/metadata/labels/",
-				},
-				{
-					Operation: "add",
-					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationConsulDestinationNamespace),
-				},
-			},
-		},
 	}
 
 	for _, tt := range cases {

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -403,21 +403,19 @@ func TestHandlerHandle(t *testing.T) {
 			},
 		},
 		{
-			"pod with existing label",
+			"consul destination namespace annotation is set",
 			Handler{
-				Log:                   hclog.Default().Named("handler"),
-				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
-				DenyK8sNamespacesSet:  mapset.NewSet(),
+				Log:                        hclog.Default().Named("handler"),
+				AllowK8sNamespacesSet:      mapset.NewSetWith("*"),
+				DenyK8sNamespacesSet:       mapset.NewSet(),
+				ConsulDestinationNamespace: "abcd",
+				EnableK8SNSMirroring:       true,
+				EnableNamespaces:           true,
 			},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							"testLabel": "123",
-						},
-					},
-
-					Spec: basicSpec,
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec:       basicSpec,
 				}),
 			},
 			"",
@@ -448,7 +446,11 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
-					Path:      "/metadata/labels/" + escapeJSONPointer(labelInject),
+					Path:      "/metadata/labels/",
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationConsulDestinationNamespace),
 				},
 			},
 		},

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set"
 	"github.com/hashicorp/go-hclog"
 	"github.com/mattbaird/jsonpatch"
 	"github.com/stretchr/testify/require"
@@ -399,6 +399,57 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/labels",
+				},
+			},
+		},
+
+		{
+			"pod with existing label",
+			Handler{
+				Log:                   hclog.Default().Named("handler"),
+				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
+				DenyK8sNamespacesSet:  mapset.NewSet(),
+			},
+			v1beta1.AdmissionRequest{
+				Object: encodeRaw(t, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"testLabel": "123",
+						},
+					},
+
+					Spec: basicSpec,
+				}),
+			},
+			"",
+			[]jsonpatch.JsonPatchOperation{
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/volumes",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/-",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/-",
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationStatus),
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/labels/" + escapeJSONPointer(labelInject),
 				},
 			},
 		},

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	mapset "github.com/deckarep/golang-set"
+	"github.com/deckarep/golang-set"
 	"github.com/hashicorp/go-hclog"
 	"github.com/mattbaird/jsonpatch"
 	"github.com/stretchr/testify/require"

--- a/connect-inject/health_check_resource.go
+++ b/connect-inject/health_check_resource.go
@@ -163,7 +163,7 @@ func (h *HealthCheckResource) reconcilePod(pod *corev1.Pod) error {
 	if serviceCheck == nil {
 		// Create a new health check.
 		h.Log.Debug("registering new health check", "name", pod.Name, "id", healthCheckID)
-		err = h.registerConsulHealthCheck(client, pod, healthCheckID, serviceID, status)
+		err = h.registerConsulHealthCheck(client, healthCheckID, serviceID, status)
 		if err != nil {
 			return fmt.Errorf("unable to register health check: %s", err)
 		}
@@ -192,7 +192,7 @@ func (h *HealthCheckResource) updateConsulHealthCheckStatus(client *api.Client, 
 // registerConsulHealthCheck registers a TTL health check for the service on this Agent.
 // The Agent is local to the Pod which has a kubernetes health check.
 // This has the effect of marking the service instance healthy/unhealthy for Consul service mesh traffic.
-func (h *HealthCheckResource) registerConsulHealthCheck(client *api.Client, pod *corev1.Pod, consulHealthCheckID, serviceID, status string) error {
+func (h *HealthCheckResource) registerConsulHealthCheck(client *api.Client, consulHealthCheckID, serviceID, status string) error {
 	h.Log.Debug("registering Consul health check", "id", consulHealthCheckID, "serviceID", serviceID)
 
 	// Create a TTL health check in Consul associated with this service and pod.
@@ -208,8 +208,6 @@ func (h *HealthCheckResource) registerConsulHealthCheck(client *api.Client, pod 
 			SuccessBeforePassing:   1,
 			FailuresBeforeCritical: 1,
 		},
-		// For Consul-ENT only. In OSS this will be set to "" which has no effect.
-		Namespace: pod.Annotations[annotationConsulDestinationNamespace],
 	})
 	if err != nil {
 		h.Log.Error("unable to register health check with Consul from k8s", "err", err)
@@ -255,8 +253,8 @@ func (h *HealthCheckResource) getConsulClient(pod *corev1.Pod) (*api.Client, err
 	newAddr := fmt.Sprintf("%s://%s:%s", h.ConsulUrl.Scheme, pod.Status.HostIP, h.ConsulUrl.Port())
 	localConfig := api.DefaultConfig()
 	localConfig.Address = newAddr
-	if pod.Annotations[annotationConsulDestinationNamespace] != "" {
-		localConfig.Namespace = pod.Annotations[annotationConsulDestinationNamespace]
+	if pod.Annotations[annotationConsulNamespace] != "" {
+		localConfig.Namespace = pod.Annotations[annotationConsulNamespace]
 	}
 	localClient, err := api.NewClient(localConfig)
 	if err != nil {

--- a/connect-inject/health_check_resource.go
+++ b/connect-inject/health_check_resource.go
@@ -208,7 +208,7 @@ func (h *HealthCheckResource) registerConsulHealthCheck(client *api.Client, pod 
 			SuccessBeforePassing:   1,
 			FailuresBeforeCritical: 1,
 		},
-		// For Consul-ENT only, this will be omitted for OSS, aka ""
+		// For Consul-ENT only. In OSS this will be set to "" which has no effect.
 		Namespace: pod.Annotations[annotationConsulDestinationNamespace],
 	})
 	if err != nil {

--- a/connect-inject/health_check_resource_ent_test.go
+++ b/connect-inject/health_check_resource_ent_test.go
@@ -1,5 +1,6 @@
 package connectinject
 
+/*
 import (
 	"context"
 	"fmt"
@@ -76,3 +77,5 @@ func TestUpsert_ABCPodWithNoServiceReturnsError(t *testing.T) {
 	err := resource.Upsert("", pod)
 	require.Contains(err.Error(), "test-pod-test-service\" does not exist)")
 }
+
+*/

--- a/connect-inject/health_check_resource_ent_test.go
+++ b/connect-inject/health_check_resource_ent_test.go
@@ -40,7 +40,7 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 		{
 			Name:                 "reconcilePod will create check and set passed",
 			PreCreateHealthCheck: false,
-			InitialState:         api.HealthPassing,
+			InitialState:         "", // only used when precreating a health check
 			Pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testPodName,
@@ -75,7 +75,7 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 		{
 			Name:                 "reconcilePod will create check and set failed",
 			PreCreateHealthCheck: false,
-			InitialState:         api.HealthPassing,
+			InitialState:         "", // only used when precreating a health check
 			Pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testPodName,

--- a/connect-inject/health_check_resource_ent_test.go
+++ b/connect-inject/health_check_resource_ent_test.go
@@ -183,7 +183,7 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 			"",
 		},
 		{
-			"precreacte failed check, no pod changes results in no healthcheck changes",
+			"precreate failed check, no pod changes results in no healthcheck changes",
 			true,
 			api.HealthCritical,
 			&corev1.Pod{

--- a/connect-inject/health_check_resource_ent_test.go
+++ b/connect-inject/health_check_resource_ent_test.go
@@ -1,0 +1,78 @@
+package connectinject
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/freeport"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestUpsert_ABCPodWithNoServiceReturnsError(t *testing.T) {
+	t.Parallel()
+	t.Run("test-consul-dest-namespace", func(t *testing.T) {
+		var err error
+		require := require.New(t)
+		// Get a server, client, and handler.
+		server, client, resource := testServerAgentResourceAndController(t, tt.Pod)
+		defer server.Stop()
+		// Register the service with Consul.
+		server.AddService(t, testServiceNameReg, api.HealthPassing, nil)
+		// Register the health check if this is not an object create path.
+		registerHealthCheck(t, client, tt.InitialState)
+		// Upsert and Reconcile both use reconcilePod to reconcile a pod.
+		err = resource.reconcilePod(tt.Pod)
+		// If we're expecting any error from reconcilePod.
+		if tt.Err != "" {
+			// used in the cases where we're expecting an error from
+			// the controller/handler, in which case do not check agent
+			// checks as they're not relevant/created.
+			require.Error(err, tt.Err)
+			return
+		}
+		require.NoError(err)
+		// Get the agent checks if they were registered.
+		actual := getConsulAgentChecks(t, client)
+		require.True(cmp.Equal(actual, tt.Expected, cmpopts.IgnoreFields(api.AgentCheck{}, ignoredFields...)))
+	})
+
+	t.Parallel()
+	require := require.New(t)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPodName,
+			Namespace: "default",
+			Labels:    map[string]string{labelInject: "true"},
+			Annotations: map[string]string{
+				annotationStatus:  injected,
+				annotationService: testServiceNameAnnotation,
+			},
+		},
+		Spec: testPodSpec,
+		Status: corev1.PodStatus{
+			HostIP: "127.0.0.1",
+			Phase:  corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	server, _, resource := testServerAgentResourceAndController(t, pod)
+	defer server.Stop()
+	// Start Upsert, it will attempt to reconcile the Pod but the service doesnt exist in Consul so will fail.
+	err := resource.Upsert("", pod)
+	require.Contains(err.Error(), "test-pod-test-service\" does not exist)")
+}

--- a/connect-inject/health_check_resource_ent_test.go
+++ b/connect-inject/health_check_resource_ent_test.go
@@ -28,6 +28,7 @@ var testPodWithNamespace = corev1.Pod{
 	Spec: corev1.PodSpec{},
 }
 
+// Test that when consulNamespaces are enabled, the health check is registered in the right namespace.
 func TestReconcilePodWithNamespace(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -218,9 +219,11 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 			// Get a server, client, and handler.
 			server, client, resource := testServerAgentResourceAndControllerWithConsulNS(t, tt.Pod, testNamespace)
 			defer server.Stop()
-			// Register the service with Consul.
+			// Create the namespace in Consul.
 			_, _, err := client.Namespaces().Create(&api.Namespace{Name: testNamespace}, nil)
 			require.NoError(err)
+
+                       // Register the service with Consul.
 			err = client.Agent().ServiceRegister(&api.AgentServiceRegistration{
 				ID:        testServiceNameReg,
 				Name:      testServiceNameAnnotation,

--- a/connect-inject/health_check_resource_ent_test.go
+++ b/connect-inject/health_check_resource_ent_test.go
@@ -1,81 +1,338 @@
+// +build enterprise
+
 package connectinject
 
-/*
 import (
-	"context"
-	"fmt"
-	"net/url"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/freeport"
-	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestUpsert_ABCPodWithNoServiceReturnsError(t *testing.T) {
-	t.Parallel()
-	t.Run("test-consul-dest-namespace", func(t *testing.T) {
-		var err error
-		require := require.New(t)
-		// Get a server, client, and handler.
-		server, client, resource := testServerAgentResourceAndController(t, tt.Pod)
-		defer server.Stop()
-		// Register the service with Consul.
-		server.AddService(t, testServiceNameReg, api.HealthPassing, nil)
-		// Register the health check if this is not an object create path.
-		registerHealthCheck(t, client, tt.InitialState)
-		// Upsert and Reconcile both use reconcilePod to reconcile a pod.
-		err = resource.reconcilePod(tt.Pod)
-		// If we're expecting any error from reconcilePod.
-		if tt.Err != "" {
-			// used in the cases where we're expecting an error from
-			// the controller/handler, in which case do not check agent
-			// checks as they're not relevant/created.
-			require.Error(err, tt.Err)
-			return
-		}
-		require.NoError(err)
-		// Get the agent checks if they were registered.
-		actual := getConsulAgentChecks(t, client)
-		require.True(cmp.Equal(actual, tt.Expected, cmpopts.IgnoreFields(api.AgentCheck{}, ignoredFields...)))
-	})
+const (
+	testNamespace = "testNamesapce"
+	testName      = "testName"
+)
 
-	t.Parallel()
-	require := require.New(t)
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testPodName,
-			Namespace: "default",
-			Labels:    map[string]string{labelInject: "true"},
-			Annotations: map[string]string{
-				annotationStatus:  injected,
-				annotationService: testServiceNameAnnotation,
-			},
-		},
-		Spec: testPodSpec,
-		Status: corev1.PodStatus{
-			HostIP: "127.0.0.1",
-			Phase:  corev1.PodRunning,
-			Conditions: []corev1.PodCondition{{
-				Type:   corev1.PodReady,
-				Status: corev1.ConditionTrue,
-			}},
-		},
-	}
-	server, _, resource := testServerAgentResourceAndController(t, pod)
-	defer server.Stop()
-	// Start Upsert, it will attempt to reconcile the Pod but the service doesnt exist in Consul so will fail.
-	err := resource.Upsert("", pod)
-	require.Contains(err.Error(), "test-pod-test-service\" does not exist)")
+var testPodWithNamespace = corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: testNamespace,
+		Name:      testName,
+	},
+	Spec: corev1.PodSpec{},
 }
 
-*/
+func TestReconcilePodWithNamespace(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		Name                 string
+		PreCreateHealthCheck bool
+		InitialState         string
+		Pod                  *corev1.Pod
+		Expected             *api.AgentCheck
+		Err                  string
+	}{
+		{
+			"reconcilePod will create check and set passed",
+			false,
+			api.HealthPassing,
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testPodName,
+					Namespace: testNamespace,
+					Labels:    map[string]string{labelInject: "true"},
+					Annotations: map[string]string{
+						annotationStatus:                     injected,
+						annotationService:                    testServiceNameAnnotation,
+						annotationConsulDestinationNamespace: testNamespace,
+					},
+				},
+				Spec: testPodSpec,
+				Status: corev1.PodStatus{
+					HostIP: "127.0.0.1",
+					Phase:  corev1.PodRunning,
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			&api.AgentCheck{
+				CheckID: testHealthCheckID,
+				Status:  api.HealthPassing,
+				Notes:   "",
+				Output:  kubernetesSuccessReasonMsg,
+				Type:    ttl,
+				Name:    name,
+			},
+			"",
+		},
+		{
+			"reconcilePod will create check and set failed",
+			false,
+			api.HealthPassing,
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testPodName,
+					Namespace: testNamespace,
+					Labels:    map[string]string{labelInject: "true"},
+					Annotations: map[string]string{
+						annotationStatus:                     injected,
+						annotationService:                    testServiceNameAnnotation,
+						annotationConsulDestinationNamespace: testNamespace,
+					},
+				},
+				Spec: testPodSpec,
+				Status: corev1.PodStatus{
+					HostIP: "127.0.0.1",
+					Phase:  corev1.PodRunning,
+					Conditions: []corev1.PodCondition{{
+						Type:    corev1.PodReady,
+						Status:  corev1.ConditionFalse,
+						Message: testFailureMessage,
+					}},
+				},
+			},
+			&api.AgentCheck{
+				CheckID: testHealthCheckID,
+				Status:  api.HealthCritical,
+				Notes:   "",
+				Output:  testFailureMessage,
+				Type:    ttl,
+				Name:    name,
+			},
+			"",
+		},
+		{
+			"precreate a passing pod and change to failed",
+			true,
+			api.HealthPassing,
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testPodName,
+					Namespace: testNamespace,
+					Labels:    map[string]string{labelInject: "true"},
+					Annotations: map[string]string{
+						annotationStatus:                     injected,
+						annotationService:                    testServiceNameAnnotation,
+						annotationConsulDestinationNamespace: testNamespace,
+					},
+				},
+				Spec: testPodSpec,
+				Status: corev1.PodStatus{
+					HostIP: "127.0.0.1",
+					Phase:  corev1.PodRunning,
+					Conditions: []corev1.PodCondition{{
+						Type:    corev1.PodReady,
+						Status:  corev1.ConditionFalse,
+						Message: testFailureMessage,
+					}},
+				},
+			},
+			&api.AgentCheck{
+				CheckID: testHealthCheckID,
+				Status:  api.HealthCritical,
+				Output:  testFailureMessage,
+				Type:    ttl,
+				Name:    name,
+			},
+			"",
+		},
+		{
+			"precreate failed pod and change to passing",
+			true,
+			api.HealthCritical,
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testPodName,
+					Namespace: testNamespace,
+					Labels:    map[string]string{labelInject: "true"},
+					Annotations: map[string]string{
+						annotationStatus:                     injected,
+						annotationService:                    testServiceNameAnnotation,
+						annotationConsulDestinationNamespace: testNamespace,
+					},
+				},
+				Spec: testPodSpec,
+				Status: corev1.PodStatus{
+					HostIP: "127.0.0.1",
+					Phase:  corev1.PodRunning,
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			&api.AgentCheck{
+				CheckID: testHealthCheckID,
+				Status:  api.HealthPassing,
+				Output:  testCheckNotesPassing,
+				Type:    ttl,
+				Name:    name,
+			},
+			"",
+		},
+		{
+			"precreacte failed check, no pod changes results in no healthcheck changes",
+			true,
+			api.HealthCritical,
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testPodName,
+					Namespace: testNamespace,
+					Labels:    map[string]string{labelInject: "true"},
+					Annotations: map[string]string{
+						annotationStatus:                     injected,
+						annotationService:                    testServiceNameAnnotation,
+						annotationConsulDestinationNamespace: testNamespace,
+					},
+				},
+				Spec: testPodSpec,
+				Status: corev1.PodStatus{
+					HostIP: "127.0.0.1",
+					Phase:  corev1.PodRunning,
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionFalse,
+					}},
+				},
+			},
+			&api.AgentCheck{
+				CheckID: testHealthCheckID,
+				Status:  api.HealthCritical,
+				Output:  "", // when there is no change in status, Consul doesnt set the Output field
+				Type:    ttl,
+				Name:    name,
+			},
+			"",
+		},
+		{
+			"PodNotRunning will be ignored for processing",
+			false,
+			"",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testPodName,
+					Namespace: testNamespace,
+					Labels:    map[string]string{labelInject: "true"},
+					Annotations: map[string]string{
+						annotationStatus:                     injected,
+						annotationService:                    testServiceNameAnnotation,
+						annotationConsulDestinationNamespace: testNamespace,
+					},
+				},
+				Spec: testPodSpec,
+				Status: corev1.PodStatus{
+					HostIP: "127.0.0.1",
+					Phase:  corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			nil,
+			"",
+		},
+		{
+			"PodRunning no annotations will be ignored for processing",
+			false,
+			"",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testPodName,
+					Namespace: testNamespace,
+					Labels:    map[string]string{labelInject: "true"},
+				},
+				Spec: testPodSpec,
+				Status: corev1.PodStatus{
+					HostIP: "127.0.0.1",
+					Phase:  corev1.PodRunning,
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			nil,
+			"",
+		},
+		{
+			"PodRunning no Ready Status will be ignored for processing",
+			false,
+			"",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testPodName,
+					Namespace: testNamespace,
+					Labels:    map[string]string{labelInject: "true"},
+				},
+				Spec: testPodSpec,
+				Status: corev1.PodStatus{
+					HostIP: "127.0.0.1",
+					Phase:  corev1.PodRunning,
+				},
+			},
+			nil,
+			"",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			var err error
+			registration := api.CatalogRegistration{
+				//			ID:      testServiceNameReg,
+				Node:    "test-k8s",
+				Address: "127.0.0.1",
+				Service: &api.AgentService{
+					ID:        testServiceNameAnnotation,
+					Service:   testServiceNameAnnotation,
+					Namespace: testNamespace,
+					Tags:      nil,
+				},
+			}
+			require := require.New(t)
+			// Get a server, client, and handler.
+			server, client, resource := testServerAgentResourceAndController(t, tt.Pod)
+			defer server.Stop()
+			// Register the service with Consul.
+			_, _, err = client.Namespaces().Create(&api.Namespace{Name: testNamespace}, nil)
+			require.NoError(err)
+			_, err = client.Catalog().Register(&registration, nil)
+			require.NoError(err)
+
+			services, _, err := client.Catalog().Services(&api.QueryOptions{})
+			for x, _ := range services {
+				t.Logf("========= %v ", x)
+			}
+			require.NoError(err)
+			cats, _, err := client.Catalog().Service(testServiceNameReg, "", &api.QueryOptions{})
+			for _, x := range cats {
+				t.Logf("======== id: %v, sid: %v, ns: %v, sname: %v", x.ID, x.ServiceID, x.Namespace, x.ServiceName)
+			}
+			require.NoError(err)
+			if tt.PreCreateHealthCheck {
+				// Register the health check if this is not an object create path.
+				registerHealthCheck(t, client, tt.Pod, tt.InitialState)
+			}
+			// Upsert and Reconcile both use reconcilePod to reconcile a pod.
+			err = resource.reconcilePod(tt.Pod)
+			// If we're expecting any error from reconcilePod.
+			if tt.Err != "" {
+				// used in the cases where we're expecting an error from
+				// the controller/handler, in which case do not check agent
+				// checks as they're not relevant/created.
+				require.Error(err, tt.Err)
+				return
+			}
+			require.NoError(err)
+			// Get the agent checks if they were registered.
+			actual := getConsulAgentChecks(t, client)
+			require.True(cmp.Equal(actual, tt.Expected, cmpopts.IgnoreFields(api.AgentCheck{}, ignoredFields...)))
+		})
+	}
+}

--- a/connect-inject/health_check_resource_ent_test.go
+++ b/connect-inject/health_check_resource_ent_test.go
@@ -223,7 +223,7 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 			_, _, err := client.Namespaces().Create(&api.Namespace{Name: testNamespace}, nil)
 			require.NoError(err)
 
-                       // Register the service with Consul.
+			// Register the service with Consul.
 			err = client.Agent().ServiceRegister(&api.AgentServiceRegistration{
 				ID:        testServiceNameReg,
 				Name:      testServiceNameAnnotation,

--- a/connect-inject/health_check_resource_ent_test.go
+++ b/connect-inject/health_check_resource_ent_test.go
@@ -36,21 +36,20 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 		InitialState         string
 		Pod                  *corev1.Pod
 		Expected             *api.AgentCheck
-		Err                  string
 	}{
 		{
-			"reconcilePod will create check and set passed",
-			false,
-			api.HealthPassing,
-			&corev1.Pod{
+			Name:                 "reconcilePod will create check and set passed",
+			PreCreateHealthCheck: false,
+			InitialState:         api.HealthPassing,
+			Pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testPodName,
 					Namespace: testNamespace,
 					Labels:    map[string]string{labelInject: "true"},
 					Annotations: map[string]string{
-						annotationStatus:                     injected,
-						annotationService:                    testServiceNameAnnotation,
-						annotationConsulDestinationNamespace: testNamespace,
+						annotationStatus:          injected,
+						annotationService:         testServiceNameAnnotation,
+						annotationConsulNamespace: testNamespace,
 					},
 				},
 				Spec: testPodSpec,
@@ -63,7 +62,7 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 					}},
 				},
 			},
-			&api.AgentCheck{
+			Expected: &api.AgentCheck{
 				CheckID:   testNamespacedHealthCheckID,
 				Status:    api.HealthPassing,
 				Notes:     "",
@@ -72,21 +71,20 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 				Name:      name,
 				Namespace: testNamespace,
 			},
-			"",
 		},
 		{
-			"reconcilePod will create check and set failed",
-			false,
-			api.HealthPassing,
-			&corev1.Pod{
+			Name:                 "reconcilePod will create check and set failed",
+			PreCreateHealthCheck: false,
+			InitialState:         api.HealthPassing,
+			Pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testPodName,
 					Namespace: testNamespace,
 					Labels:    map[string]string{labelInject: "true"},
 					Annotations: map[string]string{
-						annotationStatus:                     injected,
-						annotationService:                    testServiceNameAnnotation,
-						annotationConsulDestinationNamespace: testNamespace,
+						annotationStatus:          injected,
+						annotationService:         testServiceNameAnnotation,
+						annotationConsulNamespace: testNamespace,
 					},
 				},
 				Spec: testPodSpec,
@@ -100,7 +98,7 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 					}},
 				},
 			},
-			&api.AgentCheck{
+			Expected: &api.AgentCheck{
 				CheckID:   testNamespacedHealthCheckID,
 				Status:    api.HealthCritical,
 				Notes:     "",
@@ -109,21 +107,20 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 				Name:      name,
 				Namespace: testNamespace,
 			},
-			"",
 		},
 		{
-			"precreate a passing pod and change to failed",
-			true,
-			api.HealthPassing,
-			&corev1.Pod{
+			Name:                 "precreate a passing pod and change to failed",
+			PreCreateHealthCheck: true,
+			InitialState:         api.HealthPassing,
+			Pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testPodName,
 					Namespace: testNamespace,
 					Labels:    map[string]string{labelInject: "true"},
 					Annotations: map[string]string{
-						annotationStatus:                     injected,
-						annotationService:                    testServiceNameAnnotation,
-						annotationConsulDestinationNamespace: testNamespace,
+						annotationStatus:          injected,
+						annotationService:         testServiceNameAnnotation,
+						annotationConsulNamespace: testNamespace,
 					},
 				},
 				Spec: testPodSpec,
@@ -137,7 +134,7 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 					}},
 				},
 			},
-			&api.AgentCheck{
+			Expected: &api.AgentCheck{
 				CheckID:   testNamespacedHealthCheckID,
 				Status:    api.HealthCritical,
 				Output:    testFailureMessage,
@@ -145,21 +142,20 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 				Name:      name,
 				Namespace: testNamespace,
 			},
-			"",
 		},
 		{
-			"precreate failed pod and change to passing",
-			true,
-			api.HealthCritical,
-			&corev1.Pod{
+			Name:                 "precreate failed pod and change to passing",
+			PreCreateHealthCheck: true,
+			InitialState:         api.HealthCritical,
+			Pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testPodName,
 					Namespace: testNamespace,
 					Labels:    map[string]string{labelInject: "true"},
 					Annotations: map[string]string{
-						annotationStatus:                     injected,
-						annotationService:                    testServiceNameAnnotation,
-						annotationConsulDestinationNamespace: testNamespace,
+						annotationStatus:          injected,
+						annotationService:         testServiceNameAnnotation,
+						annotationConsulNamespace: testNamespace,
 					},
 				},
 				Spec: testPodSpec,
@@ -172,7 +168,7 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 					}},
 				},
 			},
-			&api.AgentCheck{
+			Expected: &api.AgentCheck{
 				CheckID:   testNamespacedHealthCheckID,
 				Status:    api.HealthPassing,
 				Output:    testCheckNotesPassing,
@@ -180,21 +176,20 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 				Name:      name,
 				Namespace: testNamespace,
 			},
-			"",
 		},
 		{
-			"precreate failed check, no pod changes results in no healthcheck changes",
-			true,
-			api.HealthCritical,
-			&corev1.Pod{
+			Name:                 "precreate failed check, no pod changes results in no health check changes",
+			PreCreateHealthCheck: true,
+			InitialState:         api.HealthCritical,
+			Pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testPodName,
 					Namespace: testNamespace,
 					Labels:    map[string]string{labelInject: "true"},
 					Annotations: map[string]string{
-						annotationStatus:                     injected,
-						annotationService:                    testServiceNameAnnotation,
-						annotationConsulDestinationNamespace: testNamespace,
+						annotationStatus:          injected,
+						annotationService:         testServiceNameAnnotation,
+						annotationConsulNamespace: testNamespace,
 					},
 				},
 				Spec: testPodSpec,
@@ -207,7 +202,7 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 					}},
 				},
 			},
-			&api.AgentCheck{
+			Expected: &api.AgentCheck{
 				CheckID:   testNamespacedHealthCheckID,
 				Status:    api.HealthCritical,
 				Output:    "", // when there is no change in status, Consul doesnt set the Output field
@@ -215,88 +210,16 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 				Name:      name,
 				Namespace: testNamespace,
 			},
-			"",
-		},
-		{
-			"PodNotRunning will be ignored for processing",
-			false,
-			"",
-			&corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testPodName,
-					Namespace: testNamespace,
-					Labels:    map[string]string{labelInject: "true"},
-					Annotations: map[string]string{
-						annotationStatus:                     injected,
-						annotationService:                    testServiceNameAnnotation,
-						annotationConsulDestinationNamespace: testNamespace,
-					},
-				},
-				Spec: testPodSpec,
-				Status: corev1.PodStatus{
-					HostIP: "127.0.0.1",
-					Phase:  corev1.PodPending,
-					Conditions: []corev1.PodCondition{{
-						Type:   corev1.PodReady,
-						Status: corev1.ConditionTrue,
-					}},
-				},
-			},
-			nil,
-			"",
-		},
-		{
-			"PodRunning no annotations will be ignored for processing",
-			false,
-			"",
-			&corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testPodName,
-					Namespace: testNamespace,
-					Labels:    map[string]string{labelInject: "true"},
-				},
-				Spec: testPodSpec,
-				Status: corev1.PodStatus{
-					HostIP: "127.0.0.1",
-					Phase:  corev1.PodRunning,
-					Conditions: []corev1.PodCondition{{
-						Type:   corev1.PodReady,
-						Status: corev1.ConditionTrue,
-					}},
-				},
-			},
-			nil,
-			"",
-		},
-		{
-			"PodRunning no Ready Status will be ignored for processing",
-			false,
-			"",
-			&corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testPodName,
-					Namespace: testNamespace,
-					Labels:    map[string]string{labelInject: "true"},
-				},
-				Spec: testPodSpec,
-				Status: corev1.PodStatus{
-					HostIP: "127.0.0.1",
-					Phase:  corev1.PodRunning,
-				},
-			},
-			nil,
-			"",
 		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
-			var err error
 			require := require.New(t)
 			// Get a server, client, and handler.
-			server, client, resource := testServerAgentResourceAndController(t, tt.Pod)
+			server, client, resource := testServerAgentResourceAndControllerWithConsulNS(t, tt.Pod, testNamespace)
 			defer server.Stop()
 			// Register the service with Consul.
-			_, _, err = client.Namespaces().Create(&api.Namespace{Name: testNamespace}, nil)
+			_, _, err := client.Namespaces().Create(&api.Namespace{Name: testNamespace}, nil)
 			require.NoError(err)
 			err = client.Agent().ServiceRegister(&api.AgentServiceRegistration{
 				ID:        testServiceNameReg,
@@ -306,18 +229,10 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 			require.NoError(err)
 			if tt.PreCreateHealthCheck {
 				// Register the health check if this is not an object create path.
-				registerHealthCheck(t, client, tt.Pod, tt.InitialState)
+				registerHealthCheck(t, client, tt.InitialState)
 			}
 			// Upsert and Reconcile both use reconcilePod to reconcile a pod.
 			err = resource.reconcilePod(tt.Pod)
-			// If we're expecting any error from reconcilePod.
-			if tt.Err != "" {
-				// used in the cases where we're expecting an error from
-				// the controller/handler, in which case do not check agent
-				// checks as they're not relevant/created.
-				require.Error(err, tt.Err)
-				return
-			}
 			require.NoError(err)
 			// Get the agent checks if they were registered.
 			actual := getConsulAgentChecks(t, client, testNamespacedHealthCheckID)

--- a/connect-inject/health_check_resource_test.go
+++ b/connect-inject/health_check_resource_test.go
@@ -214,7 +214,7 @@ func TestReconcilePod(t *testing.T) {
 			"",
 		},
 		{
-			"precreacte failed check, no pod changes results in no healthcheck changes",
+			"precreate failed check, no pod changes results in no healthcheck changes",
 			true,
 			api.HealthCritical,
 			&corev1.Pod{


### PR DESCRIPTION
[Consul-ENT only]

Changes proposed in this PR:
- connect-inject now adds a new annotation when Mutate is called "consul.hashicorp.com/consul-destination-namespace" when namespaces and mirroring are enabled.
- health checks are created in namespaces if they are supported+used
- existing unit tests are modified a bit to be able to re-use code between oss and consul-ent

How I've tested this PR:
unit tests have been added for the patch functionality as well as health checks resource.

How I expect reviewers to test this PR:
Unit tests.
Alternatively running and end to end test manually by:
1. deploying with consul-helm consul-ent, along with 
```
global:
  imageK8S: kschoche/consul-k8s-dev
  enableConsulNamespaces: true
  name: consul
  image: hashicorp/consul-enterprise:1.9.0-ent-beta1
  tls:
    enabled: true
server:
  enterpriseLicense:
    secretName: 'ent-license'
    secretKey: 'key'
connectInject:
  healthChecks:
    enabled: true
  enabled: true
  consulNamespaces:
    mirroringK8S: true
```
2. Deploy a connect-injected application with k8s readiness probes into a k8s namespace


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
