### PR TITLE
De-duplicate error logs

### DIFF
--- a/connect-inject/health_check_resource.go
+++ b/connect-inject/health_check_resource.go
@@ -210,8 +210,7 @@ func (h *HealthCheckResource) registerConsulHealthCheck(client *api.Client, cons
 		},
 	})
 	if err != nil {
-		h.Log.Error("unable to register health check with Consul from k8s", "err", err)
-		return err
+		return fmt.Errorf("registering health check for service %q: %s", serviceID, err)
 	}
 	return nil
 }
@@ -221,8 +220,7 @@ func (h *HealthCheckResource) getServiceCheck(client *api.Client, healthCheckID 
 	filter := fmt.Sprintf("CheckID == `%s`", healthCheckID)
 	checks, err := client.Agent().ChecksWithFilter(filter)
 	if err != nil {
-		h.Log.Error("unable to get agent health check", "checkID", healthCheckID, "filter", filter, "err", err)
-		return nil, err
+		return nil, fmt.Errorf("getting check %q: %s", healthCheckID, err)
 	}
 	// This will be nil (does not exist) or an actual check.
 	return checks[healthCheckID], nil


### PR DESCRIPTION
Stop errors being logged multiple times. See full example log below.

In two locations we were logging the error twice:
```
2020-10-30T21:47:26.653Z [ERROR] healthCheckResource: unable to get agent health check: <err>"
2020-10-30T21:47:26.653Z [ERROR] healthCheckResource: unable to update pod: err="unable to get agent health checks: <err>"
```

```
2020-10-30T21:47:26.653Z [ERROR] healthCheckResource: unable to get agent health check: <err>"
2020-10-30T21:47:26.653Z [ERROR] healthCheckResource: unable to update pod: err="unable to get agent health checks: <err>"
```

Instead we are now returning an error from those inner locations because we know our caller will log it.

In addition, I've changed the language slightly from "error doing an action" to "doing an action" since we know it's an error already because it's logged at error level. This stops the logs from stuttering: "unable to update pod: unable to get agent health check..." => "unable to update pod: getting agent health check: GET /hi EOF" 


<details><summary>Real log example</summary>

```
Listening on ":8080"...
2020/10/30 21:47:26 http: TLS handshake error from 10.4.2.1:48944: No certificate available.
Updated certificate bundle received. Updating certs...
2020-10-30T21:47:26.653Z [ERROR] healthCheckResource: unable to get agent health check: checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl filter="CheckID == `default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl`" err="Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:26.653Z [ERROR] healthCheckResource: unable to update pod: err="unable to get agent health checks: serviceID=static-client-658fd8b7f9-t9tzh-static-client, checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl, Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:26.940Z [ERROR] healthCheckResource: unable to get agent health check: checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl filter="CheckID == `default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl`" err="Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:26.941Z [ERROR] healthCheckResource: unable to update pod: err="unable to get agent health checks: serviceID=static-client-658fd8b7f9-t9tzh-static-client, checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl, Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:26.941Z [ERROR] healthCheckController: failed processing item, retrying: key=default/static-client-658fd8b7f9-t9tzh error="unable to get agent health checks: serviceID=static-client-658fd8b7f9-t9tzh-static-client, checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl, Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:26.944Z [ERROR] healthCheckResource: unable to get agent health check: checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl filter="CheckID == `default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl`" err="Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:26.946Z [ERROR] healthCheckResource: unable to update pod: err="unable to get agent health checks: serviceID=static-client-658fd8b7f9-t9tzh-static-client, checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl, Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:26.946Z [ERROR] healthCheckController: failed processing item, retrying: key=default/static-client-658fd8b7f9-t9tzh error="unable to get agent health checks: serviceID=static-client-658fd8b7f9-t9tzh-static-client, checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl, Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:26.946Z [ERROR] healthCheckResource: unable to get agent health check: checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl filter="CheckID == `default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl`" err="Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:26.952Z [ERROR] healthCheckResource: unable to update pod: err="unable to get agent health checks: serviceID=static-client-658fd8b7f9-t9tzh-static-client, checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl, Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:26.952Z [ERROR] healthCheckController: failed processing item, retrying: key=default/static-client-658fd8b7f9-t9tzh error="unable to get agent health checks: serviceID=static-client-658fd8b7f9-t9tzh-static-client, checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl, Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:27.043Z [ERROR] healthCheckResource: unable to get agent health check: checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl filter="CheckID == `default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl`" err="Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:27.043Z [ERROR] healthCheckResource: unable to update pod: err="unable to get agent health checks: serviceID=static-client-658fd8b7f9-t9tzh-static-client, checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl, Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:27.043Z [ERROR] healthCheckController: failed processing item, retrying: key=default/static-client-658fd8b7f9-t9tzh error="unable to get agent health checks: serviceID=static-client-658fd8b7f9-t9tzh-static-client, checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl, Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:27.084Z [ERROR] healthCheckResource: unable to get agent health check: checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl filter="CheckID == `default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl`" err="Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:27.084Z [ERROR] healthCheckResource: unable to update pod: err="unable to get agent health checks: serviceID=static-client-658fd8b7f9-t9tzh-static-client, checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl, Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:27.084Z [ERROR] healthCheckController: failed processing item, retrying: key=default/static-client-658fd8b7f9-t9tzh error="unable to get agent health checks: serviceID=static-client-658fd8b7f9-t9tzh-static-client, checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl, Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:27.170Z [ERROR] healthCheckResource: unable to get agent health check: checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl filter="CheckID == `default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl`" err="Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:27.170Z [ERROR] healthCheckResource: unable to update pod: err="unable to get agent health checks: serviceID=static-client-658fd8b7f9-t9tzh-static-client, checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl, Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
2020-10-30T21:47:27.170Z [ERROR] healthCheckController: failed processing item, no more retries: key=default/static-client-658fd8b7f9-t9tzh error="unable to get agent health checks: serviceID=static-client-658fd8b7f9-t9tzh-static-client, checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl, Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused"
E1030 21:47:27.170720       1 controller.go:190] unable to get agent health checks: serviceID=static-client-658fd8b7f9-t9tzh-static-client, checkID=default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl, Get "https://10.128.0.68:8501/v1/agent/checks?filter=CheckID+%3D%3D+%60default_static-client-658fd8b7f9-t9tzh-static-client_kubernetes-health-check-ttl%60": dial tcp 10.128.0.68:8501: connect: connection refused
2020-10-30T21:48:09.292Z [INFO]  handler: Request received: Method=POST URL=/mutate?timeout=10s
2020-10-30T21:48:22.111Z [INFO]  handler: Request received: Method=POST URL=/mutate?timeout=10s
2020-10-30T21:49:07.294Z [ERROR] healthCheckResource: unable to register health check with Consul from k8s: err="Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.294Z [ERROR] healthCheckResource: unable to update pod: err="unable to register health check: Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.294Z [ERROR] healthCheckController: failed processing item, retrying: key=default/static-server-75657fccd-zncfr error="unable to register health check: Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.303Z [ERROR] healthCheckResource: unable to register health check with Consul from k8s: err="Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.303Z [ERROR] healthCheckResource: unable to update pod: err="unable to register health check: Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.303Z [ERROR] healthCheckController: failed processing item, retrying: key=default/static-server-75657fccd-zncfr error="unable to register health check: Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.344Z [ERROR] healthCheckResource: unable to register health check with Consul from k8s: err="Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.344Z [ERROR] healthCheckResource: unable to update pod: err="unable to register health check: Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.344Z [ERROR] healthCheckController: failed processing item, retrying: key=default/static-server-75657fccd-zncfr error="unable to register health check: Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.369Z [ERROR] healthCheckResource: unable to register health check with Consul from k8s: err="Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.369Z [ERROR] healthCheckResource: unable to update pod: err="unable to register health check: Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.369Z [ERROR] healthCheckController: failed processing item, retrying: key=default/static-server-75657fccd-zncfr error="unable to register health check: Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.443Z [ERROR] healthCheckResource: unable to register health check with Consul from k8s: err="Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.443Z [ERROR] healthCheckResource: unable to update pod: err="unable to register health check: Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.443Z [ERROR] healthCheckController: failed processing item, retrying: key=default/static-server-75657fccd-zncfr error="unable to register health check: Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.529Z [ERROR] healthCheckResource: unable to register health check with Consul from k8s: err="Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.530Z [ERROR] healthCheckResource: unable to update pod: err="unable to register health check: Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
2020-10-30T21:49:07.530Z [ERROR] healthCheckController: failed processing item, no more retries: key=default/static-server-75657fccd-zncfr error="unable to register health check: Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)"
E1030 21:49:07.530378       1 controller.go:190] unable to register health check: Unexpected response code: 500 (ServiceID "default/static-server-75657fccd-zncfr-static-server" does not exist)
```
</details>