### PR TITLE
Set failing check when pod is not yet running

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -10,6 +10,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const InjectInitContainerName = "consul-connect-inject-init"
+
 type initContainerCommandData struct {
 	ServiceName      string
 	ProxyServiceName string
@@ -193,7 +195,7 @@ func (h *Handler) containerInit(pod *corev1.Pod, k8sNamespace string) (corev1.Co
 	}
 
 	return corev1.Container{
-		Name:  "consul-connect-inject-init",
+		Name:  InjectInitContainerName,
 		Image: h.ImageConsul,
 		Env: []corev1.EnvVar{
 			{

--- a/connect-inject/health_check_resource_ent_test.go
+++ b/connect-inject/health_check_resource_ent_test.go
@@ -58,8 +58,9 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 				},
 				Spec: testPodSpec,
 				Status: corev1.PodStatus{
-					HostIP: "127.0.0.1",
-					Phase:  corev1.PodRunning,
+					HostIP:                "127.0.0.1",
+					Phase:                 corev1.PodRunning,
+					InitContainerStatuses: completedInjectInitContainer,
 					Conditions: []corev1.PodCondition{{
 						Type:   corev1.PodReady,
 						Status: corev1.ConditionTrue,
@@ -93,8 +94,9 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 				},
 				Spec: testPodSpec,
 				Status: corev1.PodStatus{
-					HostIP: "127.0.0.1",
-					Phase:  corev1.PodRunning,
+					HostIP:                "127.0.0.1",
+					Phase:                 corev1.PodRunning,
+					InitContainerStatuses: completedInjectInitContainer,
 					Conditions: []corev1.PodCondition{{
 						Type:    corev1.PodReady,
 						Status:  corev1.ConditionFalse,
@@ -129,8 +131,9 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 				},
 				Spec: testPodSpec,
 				Status: corev1.PodStatus{
-					HostIP: "127.0.0.1",
-					Phase:  corev1.PodRunning,
+					HostIP:                "127.0.0.1",
+					Phase:                 corev1.PodRunning,
+					InitContainerStatuses: completedInjectInitContainer,
 					Conditions: []corev1.PodCondition{{
 						Type:    corev1.PodReady,
 						Status:  corev1.ConditionFalse,
@@ -164,8 +167,9 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 				},
 				Spec: testPodSpec,
 				Status: corev1.PodStatus{
-					HostIP: "127.0.0.1",
-					Phase:  corev1.PodRunning,
+					HostIP:                "127.0.0.1",
+					Phase:                 corev1.PodRunning,
+					InitContainerStatuses: completedInjectInitContainer,
 					Conditions: []corev1.PodCondition{{
 						Type:   corev1.PodReady,
 						Status: corev1.ConditionTrue,
@@ -198,8 +202,9 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 				},
 				Spec: testPodSpec,
 				Status: corev1.PodStatus{
-					HostIP: "127.0.0.1",
-					Phase:  corev1.PodRunning,
+					HostIP:                "127.0.0.1",
+					Phase:                 corev1.PodRunning,
+					InitContainerStatuses: completedInjectInitContainer,
 					Conditions: []corev1.PodCondition{{
 						Type:   corev1.PodReady,
 						Status: corev1.ConditionFalse,
@@ -232,8 +237,9 @@ func TestReconcilePodWithNamespace(t *testing.T) {
 				},
 				Spec: testPodSpec,
 				Status: corev1.PodStatus{
-					HostIP: "127.0.0.1",
-					Phase:  corev1.PodRunning,
+					HostIP:                "127.0.0.1",
+					Phase:                 corev1.PodRunning,
+					InitContainerStatuses: completedInjectInitContainer,
 					Conditions: []corev1.PodCondition{{
 						Type:   corev1.PodReady,
 						Status: corev1.ConditionTrue,


### PR DESCRIPTION
Once the inject init container completes, the service instance is
registered with Consul. We want to immediately register a failing health
check at this time, otherwise the pod will receive traffic even though
its readiness check hasn't passed and its non-init containers might not
even be running yet.

How I expect reviewers to test this PR:
* To test in a cluster, use Helm:
  ```yaml
  global:
    name: consul
    imageK8S: ghcr.io/lkysow/consul-k8s-dev:nov04-early-reg3
  connectInject:
    enabled: true
    healthChecks:
      enabled: true
  server:
    replicas: 1
    bootstrapExpect: 1
  ```
* Then create a Pod that will never start up. The below pod uses an invald image which can never be pulled.

  ```yaml
  apiVersion: v1
  kind: ServiceAccount
  metadata:
    name: static-client
  ---
  apiVersion: v1
  kind: Pod
  metadata:
    name: static-client
    annotations:
      "consul.hashicorp.com/connect-inject": "true"
      "consul.hashicorp.com/connect-service-upstreams": "static-server:1234"
  spec:
    containers:
      - name: static-client
        image: tutum/l:latest
        command: [ "/bin/sh", "-c", "--" ]
        args: [ "while true; do sleep 30; done;" ]
        ports:
          - containerPort: 8080
            name: http
    serviceAccountName: static-client
  ```
* Notice that the health check is created and its output set to "Pod is pending"

Checklist:
- [x] Tests added
