### PR TITLE
add namespace_prefix to acls rule for connect inject

### DIFF
--- a/subcommand/server-acl-init/rules.go
+++ b/subcommand/server-acl-init/rules.go
@@ -217,17 +217,14 @@ node_prefix "" {
 }
 {{- if .EnableNamespaces }}
 namespace_prefix "" {
+{{- end }}
   service_prefix "" {
     policy = "write"
   }
-}
-{{- else }}
-service_prefix "" {
-  policy = "write"
+{{- if .EnableNamespaces }}
 }
 {{- end }}
-{{- end }}
-`
+{{- end }}`
 	return c.renderRules(injectRulesTpl)
 }
 

--- a/subcommand/server-acl-init/rules.go
+++ b/subcommand/server-acl-init/rules.go
@@ -212,12 +212,18 @@ func (c *Command) injectRules() (string, error) {
 operator = "write"
 {{- end }}
 {{- if .EnableHealthChecks }}
+{{- if .EnableNamespaces }}
+namespace_prefix "" {
+{{- end }}
   node_prefix "" {
      policy = "write"
   }
   service_prefix "" {
      policy = "write"
   }
+{{- if .EnableNamespaces }}
+}
+{{- end }}
 {{- end }}
 `
 	return c.renderRules(injectRulesTpl)

--- a/subcommand/server-acl-init/rules.go
+++ b/subcommand/server-acl-init/rules.go
@@ -212,16 +212,18 @@ func (c *Command) injectRules() (string, error) {
 operator = "write"
 {{- end }}
 {{- if .EnableHealthChecks }}
+node_prefix "" {
+  policy = "write"
+}
 {{- if .EnableNamespaces }}
 namespace_prefix "" {
-{{- end }}
-  node_prefix "" {
-     policy = "write"
-  }
   service_prefix "" {
-     policy = "write"
+    policy = "write"
   }
-{{- if .EnableNamespaces }}
+}
+{{- else }}
+service_prefix "" {
+  policy = "write"
 }
 {{- end }}
 {{- end }}

--- a/subcommand/server-acl-init/rules_test.go
+++ b/subcommand/server-acl-init/rules_test.go
@@ -531,12 +531,14 @@ operator = "write"`,
 			true,
 			`
 operator = "write"
+namespace_prefix "" {
   node_prefix "" {
      policy = "write"
   }
   service_prefix "" {
      policy = "write"
-  }`,
+  }
+}`,
 		},
 	}
 

--- a/subcommand/server-acl-init/rules_test.go
+++ b/subcommand/server-acl-init/rules_test.go
@@ -518,12 +518,12 @@ operator = "write"`,
 			false,
 			true,
 			`
-  node_prefix "" {
-     policy = "write"
-  }
-  service_prefix "" {
-     policy = "write"
-  }`,
+node_prefix "" {
+  policy = "write"
+}
+service_prefix "" {
+  policy = "write"
+}`,
 		},
 		{
 			"Namespaces are enabled, health checks controller enabled",
@@ -531,12 +531,12 @@ operator = "write"`,
 			true,
 			`
 operator = "write"
+node_prefix "" {
+  policy = "write"
+}
 namespace_prefix "" {
-  node_prefix "" {
-     policy = "write"
-  }
   service_prefix "" {
-     policy = "write"
+    policy = "write"
   }
 }`,
 		},

--- a/subcommand/server-acl-init/rules_test.go
+++ b/subcommand/server-acl-init/rules_test.go
@@ -521,9 +521,9 @@ operator = "write"`,
 node_prefix "" {
   policy = "write"
 }
-service_prefix "" {
-  policy = "write"
-}`,
+  service_prefix "" {
+    policy = "write"
+  }`,
 		},
 		{
 			"Namespaces are enabled, health checks controller enabled",


### PR DESCRIPTION
Changes proposed in this PR:
- update the ACL rules for connect-inject when health checks are enabled alongside namespaces and update the unit tests to reflect this.
NOTE: dependency on the following PR to be merged first #376 

How I've tested this PR:
unit-testing

How I expect reviewers to test this PR:
run the unit tests
it should be sufficient to test with ACLs+namespaces+mirroring enabled against consul-ent.
acceptance test coverage will be added to consul-helm


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
