### PR TITLE
Dont attempt to create '*' namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ BUG FIXES:
 * CRDs: validate custom resources can only set namespace fields if Consul namespaces are enabled [[GH-375](https://github.com/hashicorp/consul-k8s/pull/375)]
 * CRDs: Ensure ACL token is global so that secondary DCs can manage custom resources.
   Without this fix, controllers running in secondary datacenters would get ACL errors. [[GH-369](https://github.com/hashicorp/consul-k8s/pull/369)]
+* CRDs: do not attempt to create a `*` namespace when service intentions specify `*` as destination.namespace. [[GH-382](https://github.com/hashicorp/consul-k8s/pull/382)]
 
 ## 0.19.0 (October 12, 2020)
 

--- a/namespaces/namespaces.go
+++ b/namespaces/namespaces.go
@@ -8,10 +8,15 @@ import (
 	capi "github.com/hashicorp/consul/api"
 )
 
+const WildcardNamespace string = "*"
+
 // EnsureExists ensures a Consul namespace with name ns exists. If it doesn't,
 // it will create it and set crossNSACLPolicy as a policy default.
 // Boolean return value indicates if the namespace was created by this call.
 func EnsureExists(client *capi.Client, ns string, crossNSAClPolicy string) (bool, error) {
+	if ns == WildcardNamespace {
+		return false, nil
+	}
 	// Check if the Consul namespace exists.
 	namespaceInfo, _, err := client.Namespaces().Read(ns, nil)
 	if err != nil {

--- a/namespaces/namespaces_test.go
+++ b/namespaces/namespaces_test.go
@@ -71,44 +71,9 @@ func TestEnsureExists_AlreadyExists(tt *testing.T) {
 
 // Test that if the namespace already exists the function succeeds.
 func TestEnsureExists_WildcardNamespace_AlreadyExists(tt *testing.T) {
-	for _, c := range []struct {
-		ACLsEnabled bool
-	}{
-		{
-			ACLsEnabled: true,
-		},
-		{
-			ACLsEnabled: false,
-		},
-	} {
-		tt.Run(fmt.Sprintf("acls: %t", c.ACLsEnabled), func(t *testing.T) {
-			req := require.New(t)
-			ns := WildcardNamespace
-			masterToken := "master"
-
-			consul, err := testutil.NewTestServerConfigT(t, func(cfg *testutil.TestServerConfig) {
-				cfg.ACL.Enabled = c.ACLsEnabled
-				cfg.ACL.DefaultPolicy = "deny"
-				cfg.ACL.Tokens.Master = masterToken
-			})
-			req.NoError(err)
-			defer consul.Stop()
-			consulClient, err := capi.NewClient(&capi.Config{
-				Address: consul.HTTPAddr,
-				Token:   masterToken,
-			})
-			req.NoError(err)
-
-			// We do not create the namespace explicitly as the '*' namespace already exists.
-			var crossNSPolicy string
-			if c.ACLsEnabled {
-				crossNSPolicy = "cross-ns-policy"
-			}
-			created, err := EnsureExists(consulClient, ns, crossNSPolicy)
-			req.NoError(err)
-			require.False(t, created)
-		})
-	}
+	created, err := EnsureExists(nil, WildcardNamespace, "")
+	require.NoError(tt, err)
+	require.False(tt, created)
 }
 
 // Test that it creates the namespace if it doesn't exist.

--- a/namespaces/namespaces_test.go
+++ b/namespaces/namespaces_test.go
@@ -69,6 +69,48 @@ func TestEnsureExists_AlreadyExists(tt *testing.T) {
 	}
 }
 
+// Test that if the namespace already exists the function succeeds.
+func TestEnsureExists_WildcardNamespace_AlreadyExists(tt *testing.T) {
+	for _, c := range []struct {
+		ACLsEnabled bool
+	}{
+		{
+			ACLsEnabled: true,
+		},
+		{
+			ACLsEnabled: false,
+		},
+	} {
+		tt.Run(fmt.Sprintf("acls: %t", c.ACLsEnabled), func(t *testing.T) {
+			req := require.New(t)
+			ns := WildcardNamespace
+			masterToken := "master"
+
+			consul, err := testutil.NewTestServerConfigT(t, func(cfg *testutil.TestServerConfig) {
+				cfg.ACL.Enabled = c.ACLsEnabled
+				cfg.ACL.DefaultPolicy = "deny"
+				cfg.ACL.Tokens.Master = masterToken
+			})
+			req.NoError(err)
+			defer consul.Stop()
+			consulClient, err := capi.NewClient(&capi.Config{
+				Address: consul.HTTPAddr,
+				Token:   masterToken,
+			})
+			req.NoError(err)
+
+			// We do not create the namespace explicitly as the '*' namespace already exists.
+			var crossNSPolicy string
+			if c.ACLsEnabled {
+				crossNSPolicy = "cross-ns-policy"
+			}
+			created, err := EnsureExists(consulClient, ns, crossNSPolicy)
+			req.NoError(err)
+			require.False(t, created)
+		})
+	}
+}
+
 // Test that it creates the namespace if it doesn't exist.
 func TestEnsureExists_CreatesNS(tt *testing.T) {
 	for _, c := range []struct {


### PR DESCRIPTION
Changes proposed in this PR:
- Do not attempt to create a wildcard namespace when verifying if it exists
Interestingly, the consul API does not return `*` namespace in a get request. This leads to us attempting to create the namespace when `*` is provided as a destination namespace for service intentions. This PR ensures we do not attempt to create the namespace when provided.

How I've tested this PR:
- Unit tests
- Created an image which i deployed with consul-helm and tried to create a service intention where the destination intention was "*"

How I expect reviewers to test this PR:
- Code Review

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
