### PR TITLE
[inject-connect] Add possibility to override the init container template

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -185,6 +185,12 @@ func (h *Handler) containerInit(pod *corev1.Pod, k8sNamespace string) (corev1.Co
 		volMounts = append(volMounts, saTokenVolumeMount)
 	}
 
+	// Get the command template
+	initContainerCommandTpl := defaultInitContainerCommandTpl
+	if h.InitContainerCommandTpl != "" {
+		initContainerCommandTpl = h.InitContainerCommandTpl
+	}
+
 	// Render the command
 	var buf bytes.Buffer
 	tpl := template.Must(template.New("root").Parse(strings.TrimSpace(
@@ -242,7 +248,7 @@ func (h *Handler) containerInit(pod *corev1.Pod, k8sNamespace string) (corev1.Co
 // Note: the order of the services in the service.hcl file is important,
 // and the connect-proxy service should come after the "main" service
 // because its alias health check depends on the main service to exist.
-const initContainerCommandTpl = `
+const defaultInitContainerCommandTpl = `
 {{- if .ConsulCACert}}
 export CONSUL_HTTP_ADDR="https://${HOST_IP}:8501"
 export CONSUL_GRPC_ADDR="https://${HOST_IP}:8502"

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -144,6 +144,10 @@ type Handler struct {
 	// If not set, will use HTTP.
 	ConsulCACert string
 
+	// Template content that will be use to generate
+	// the init container command for consul connect injection
+	InitContainerCommandTpl string
+
 	// EnableNamespaces indicates that a user is running Consul Enterprise
 	// with version 1.7+ which is namespace aware. It enables Consul namespaces,
 	// with injection into either a single Consul namespace or mirrored from


### PR DESCRIPTION
Changes proposed in this PR:
- Add an option to pass a custom template for the init container command

How I've tested this PR:
I have this patch running on my consul-k8s deployment :)

How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
