### PR TITLE
Don't deregister checks on stopped pods

### DIFF
--- a/connect-inject/health_check_resource.go
+++ b/connect-inject/health_check_resource.go
@@ -172,7 +172,7 @@ func (h *HealthCheckResource) reconcilePod(pod *corev1.Pod) error {
 		h.Log.Debug("registering new health check", "name", pod.Name, "id", healthCheckID)
 		err = h.registerConsulHealthCheck(client, healthCheckID, serviceID, status)
 		if errors.Is(err, ServiceNotFoundErr) {
-			h.Log.Warn("skipping registration because service not registered with Consul-this may be because the pod is shutting down", "serviceID", serviceID)
+			h.Log.Warn("skipping registration because service not registered with Consul - this may be because the pod is shutting down", "serviceID", serviceID)
 			return nil
 		} else if err != nil {
 			return fmt.Errorf("unable to register health check: %s", err)

--- a/connect-inject/health_check_resource_test.go
+++ b/connect-inject/health_check_resource_test.go
@@ -377,7 +377,9 @@ func TestReconcilePod(t *testing.T) {
 	}
 }
 
-func TestUpsert_PodWithNoServiceReturnsError(t *testing.T) {
+// Test that when we call upsert and the service hasn't been registered
+// in Consul yet, we don't return an error.
+func TestUpsert_PodWithNoService(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	pod := &corev1.Pod{
@@ -403,9 +405,8 @@ func TestUpsert_PodWithNoServiceReturnsError(t *testing.T) {
 	}
 	server, _, resource := testServerAgentResourceAndController(t, pod)
 	defer server.Stop()
-	// Start Upsert, it will attempt to reconcile the Pod but the service doesnt exist in Consul so will fail.
 	err := resource.Upsert("", pod)
-	require.Contains(err.Error(), "test-pod-test-service\" does not exist)")
+	require.Nil(err)
 }
 
 func TestReconcile_IgnorePodsWithoutInjectLabel(t *testing.T) {


### PR DESCRIPTION
The ordering for stopping pods is:
1. Kube invokes preStop hook
1. Kube sends SIGTERM's to all containers
1. Kube waits for gracePeriod, then sends SIGKILL to non-stopped containers
1. Kube sends event to reconciler where all containers have their state "terminated"

In step 4, previously we would then try and update the status of the health check to failing because the pod is no longer ready. This would result in an error because the service was deregistered in step 1.

How I've tested this PR:
* I investigated the state of the pods throughout the lifecycle and confirmed the state when the pod has been terminated. See JSON below.

How I expect reviewers to test this PR:
* You can use image `ghcr.io/lkysow/consul-k8s-dev:nov06-hc-term`
* Start and stop a connect pod
* Observe no errors in the logs

Checklist:
- [x] Tests added

<details><summary>Status after termination</summary>

```json
 "status": {
    "phase": "Running",
    "conditions": [
      {
        "type": "Initialized",
        "status": "True",
        "lastProbeTime": null,
        "lastTransitionTime": "2020-11-05T23:42:37Z"
      },
      {
        "type": "Ready",
        "status": "False",
        "lastProbeTime": null,
        "lastTransitionTime": "2020-11-05T23:43:32Z",
        "reason": "ContainersNotReady",
        "message": "containers with unready status: [static-client consul-connect-envoy-sidecar consul-connect-lifecycle-sidecar]"
      },
      {
        "type": "ContainersReady",
        "status": "False",
        "lastProbeTime": null,
        "lastTransitionTime": "2020-11-05T23:43:32Z",
        "reason": "ContainersNotReady",
        "message": "containers with unready status: [static-client consul-connect-envoy-sidecar consul-connect-lifecycle-sidecar]"
      },
      {
        "type": "PodScheduled",
        "status": "True",
        "lastProbeTime": null,
        "lastTransitionTime": "2020-11-05T23:42:25Z"
      }
    ],
    "hostIP": "172.18.0.2",
    "podIP": "10.244.0.19",
    "podIPs": [
      {
        "ip": "10.244.0.19"
      }
    ],
    "startTime": "2020-11-05T23:42:25Z",
    "initContainerStatuses": [
      {
        "name": "consul-connect-inject-init",
        "state": {
          "terminated": {
            "exitCode": 0,
            "reason": "Completed",
            "startedAt": "2020-11-05T23:42:26Z",
            "finishedAt": "2020-11-05T23:42:36Z",
            "containerID": "containerd://c27720e056a123f621b289ae3dd03b97223fc2bef9f9cd858140f6449f025d93"
          }
        },
        "lastState": {},
        "ready": true,
        "restartCount": 0,
        "image": "docker.io/library/consul:1.8.4",
        "imageID": "docker.io/library/consul@sha256:4cc02f91a918f08655b39c4369b65929013525cc020f01dadee6b0ec4cd972f5",
        "containerID": "containerd://c27720e056a123f621b289ae3dd03b97223fc2bef9f9cd858140f6449f025d93"
      }
    ],
    "containerStatuses": [
      {
        "name": "consul-connect-envoy-sidecar",
        "state": {
          "terminated": {
            "exitCode": 0,
            "reason": "Completed",
            "startedAt": "2020-11-05T23:42:40Z",
            "finishedAt": "2020-11-05T23:43:01Z",
            "containerID": "containerd://8c549db9a180a73b117db0b16bdc4bcc100b58f443af0be36708c48a7d4b4bf7"
          }
        },
        "lastState": {},
        "ready": false,
        "restartCount": 0,
        "image": "docker.io/envoyproxy/envoy-alpine:v1.14.4",
        "imageID": "docker.io/envoyproxy/envoy-alpine@sha256:9442ccf7b335045ab5ef596e26bec978b8ef46f8bce1dfeb19382c3f40208eb5",
        "containerID": "containerd://8c549db9a180a73b117db0b16bdc4bcc100b58f443af0be36708c48a7d4b4bf7",
        "started": false
      },
      {
        "name": "consul-connect-lifecycle-sidecar",
        "state": {
          "terminated": {
            "exitCode": 2,
            "reason": "Error",
            "startedAt": "2020-11-05T23:42:40Z",
            "finishedAt": "2020-11-05T23:43:01Z",
            "containerID": "containerd://6250bcc99ef9949e673900ad4ea542e4c86f45f897d9d644fcd4e4c769a088d2"
          }
        },
        "lastState": {},
        "ready": false,
        "restartCount": 0,
        "image": "ghcr.io/lkysow/consul-k8s-dev:nov04-early-reg3",
        "imageID": "sha256:228a53bab5c281bf1fd964a0dbed124be88b8f03340eae6b55a67838ab55464a",
        "containerID": "containerd://6250bcc99ef9949e673900ad4ea542e4c86f45f897d9d644fcd4e4c769a088d2",
        "started": false
      },
      {
        "name": "static-client",
        "state": {
          "terminated": {
            "exitCode": 137,
            "reason": "Error",
            "startedAt": "2020-11-05T23:42:40Z",
            "finishedAt": "2020-11-05T23:43:31Z",
            "containerID": "containerd://2efa28c88c73db86a3876a6804fe37bed2131b1a115840d9b23ea9fee268bdce"
          }
        },
        "lastState": {},
        "ready": false,
        "restartCount": 0,
        "image": "docker.io/tutum/curl:latest",
        "imageID": "sha256:1d133bc81b5f22bfcec1409c3154a53b8b15c89f78221117ca5422c77e080cf8",
        "containerID": "containerd://2efa28c88c73db86a3876a6804fe37bed2131b1a115840d9b23ea9fee268bdce",
        "started": false
      }
    ],
    "qosClass": "Burstable"
  }
```

</details>