### PR TITLE
Add descriptions and missing validation for service-intentions

### DIFF
--- a/api/v1alpha1/serviceintentions_types.go
+++ b/api/v1alpha1/serviceintentions_types.go
@@ -388,7 +388,7 @@ func (in IntentionHTTPHeaderPermissions) validate(path *field.Path) field.ErrorL
 			hdrParts++
 		}
 		hdrParts += numNotEmpty(permission.Exact, permission.Regex, permission.Prefix, permission.Suffix)
-		if hdrParts != 1 {
+		if hdrParts > 1 {
 			asJson, _ := json.Marshal(in[i])
 			errs = append(errs, field.Invalid(path.Index(i), string(asJson), `at most only one of exact, prefix, suffix, regex, or present may be configured.`))
 		}

--- a/api/v1alpha1/serviceintentions_types_test.go
+++ b/api/v1alpha1/serviceintentions_types_test.go
@@ -736,7 +736,7 @@ func TestServiceIntentions_Validate(t *testing.T) {
 			},
 			namespacesEnabled: true,
 			expectedErrMsgs: []string{
-				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0]: Invalid value: v1alpha1.IntentionHTTPPermission{PathExact:"/foo", PathPrefix:"/bar", PathRegex:"", Header:v1alpha1.IntentionHTTPHeaderPermissions(nil), Methods:[]string(nil)}: At most only one of pathExact, pathPrefix, or pathRegex may be configured.`,
+				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0]: Invalid value: "{\"pathExact\":\"/foo\",\"pathPrefix\":\"/bar\"}": At most only one of pathExact, pathPrefix, or pathRegex may be configured.`,
 			},
 		},
 		"invalid permissions.http pathPrefix,pathRegex specified": {
@@ -768,7 +768,7 @@ func TestServiceIntentions_Validate(t *testing.T) {
 			},
 			namespacesEnabled: true,
 			expectedErrMsgs: []string{
-				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0]: Invalid value: v1alpha1.IntentionHTTPPermission{PathExact:"", PathPrefix:"/bar", PathRegex:"foo", Header:v1alpha1.IntentionHTTPHeaderPermissions(nil), Methods:[]string(nil)}: At most only one of pathExact, pathPrefix, or pathRegex may be configured.`,
+				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0]: Invalid value: "{\"pathPrefix\":\"/bar\",\"pathRegex\":\"foo\"}": At most only one of pathExact, pathPrefix, or pathRegex may be configured.`,
 			},
 		},
 		"invalid permissions.http pathRegex,pathExact specified": {
@@ -800,7 +800,7 @@ func TestServiceIntentions_Validate(t *testing.T) {
 			},
 			namespacesEnabled: true,
 			expectedErrMsgs: []string{
-				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0]: Invalid value: v1alpha1.IntentionHTTPPermission{PathExact:"/foo", PathPrefix:"", PathRegex:"bar", Header:v1alpha1.IntentionHTTPHeaderPermissions(nil), Methods:[]string(nil)}: At most only one of pathExact, pathPrefix, or pathRegex may be configured.`,
+				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0]: Invalid value: "{\"pathExact\":\"/foo\",\"pathRegex\":\"bar\"}": At most only one of pathExact, pathPrefix, or pathRegex may be configured.`,
 			},
 		},
 		"invalid permissions.http.pathExact": {
@@ -856,6 +856,8 @@ func TestServiceIntentions_Validate(t *testing.T) {
 											"FOO",
 											"GET",
 											"BAR",
+											"GET",
+											"POST",
 										},
 									},
 								},
@@ -866,7 +868,7 @@ func TestServiceIntentions_Validate(t *testing.T) {
 			},
 			namespacesEnabled: true,
 			expectedErrMsgs: []string{
-				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: [spec.sources[0].permissions[0].methods[0]: Invalid value: "FOO": must be one of "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", spec.sources[0].permissions[0].methods[2]: Invalid value: "BAR": must be one of "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"]`,
+				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: [spec.sources[0].permissions[0].methods[0]: Invalid value: "FOO": must be one of "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "CONNECT", "OPTIONS", "TRACE", spec.sources[0].permissions[0].methods[2]: Invalid value: "BAR": must be one of "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "CONNECT", "OPTIONS", "TRACE", spec.sources[0].permissions[0].methods[3]: Invalid value: "GET": Method contained more than once.`,
 			},
 		},
 		"invalid permissions.http.header": {

--- a/api/v1alpha1/serviceintentions_types_test.go
+++ b/api/v1alpha1/serviceintentions_types_test.go
@@ -736,7 +736,7 @@ func TestServiceIntentions_Validate(t *testing.T) {
 			},
 			namespacesEnabled: true,
 			expectedErrMsgs: []string{
-				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0]: Invalid value: "{\"pathExact\":\"/foo\",\"pathPrefix\":\"/bar\"}": At most only one of pathExact, pathPrefix, or pathRegex may be configured.`,
+				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0]: Invalid value: "{\"pathExact\":\"/foo\",\"pathPrefix\":\"/bar\"}": at most only one of pathExact, pathPrefix, or pathRegex may be configured.`,
 			},
 		},
 		"invalid permissions.http pathPrefix,pathRegex specified": {
@@ -768,7 +768,7 @@ func TestServiceIntentions_Validate(t *testing.T) {
 			},
 			namespacesEnabled: true,
 			expectedErrMsgs: []string{
-				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0]: Invalid value: "{\"pathPrefix\":\"/bar\",\"pathRegex\":\"foo\"}": At most only one of pathExact, pathPrefix, or pathRegex may be configured.`,
+				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0]: Invalid value: "{\"pathPrefix\":\"/bar\",\"pathRegex\":\"foo\"}": at most only one of pathExact, pathPrefix, or pathRegex may be configured.`,
 			},
 		},
 		"invalid permissions.http pathRegex,pathExact specified": {
@@ -800,7 +800,7 @@ func TestServiceIntentions_Validate(t *testing.T) {
 			},
 			namespacesEnabled: true,
 			expectedErrMsgs: []string{
-				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0]: Invalid value: "{\"pathExact\":\"/foo\",\"pathRegex\":\"bar\"}": At most only one of pathExact, pathPrefix, or pathRegex may be configured.`,
+				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0]: Invalid value: "{\"pathExact\":\"/foo\",\"pathRegex\":\"bar\"}": at most only one of pathExact, pathPrefix, or pathRegex may be configured.`,
 			},
 		},
 		"invalid permissions.http.pathExact": {
@@ -868,7 +868,7 @@ func TestServiceIntentions_Validate(t *testing.T) {
 			},
 			namespacesEnabled: true,
 			expectedErrMsgs: []string{
-				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: [spec.sources[0].permissions[0].methods[0]: Invalid value: "FOO": must be one of "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "CONNECT", "OPTIONS", "TRACE", spec.sources[0].permissions[0].methods[2]: Invalid value: "BAR": must be one of "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "CONNECT", "OPTIONS", "TRACE", spec.sources[0].permissions[0].methods[3]: Invalid value: "GET": Method contained more than once.`,
+				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: [spec.sources[0].permissions[0].methods[0]: Invalid value: "FOO": must be one of "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "CONNECT", "OPTIONS", "TRACE", spec.sources[0].permissions[0].methods[2]: Invalid value: "BAR": must be one of "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "CONNECT", "OPTIONS", "TRACE", spec.sources[0].permissions[0].methods[3]: Invalid value: "GET": method listed more than once.`,
 			},
 		},
 		"invalid permissions.http.header": {
@@ -925,11 +925,11 @@ func TestServiceIntentions_Validate(t *testing.T) {
 			},
 			namespacesEnabled: true,
 			expectedErrMsgs: []string{
-				`spec.sources[0].permissions[0].header[0]: Invalid value: v1alpha1.IntentionHTTPHeaderPermission{Name:"exact-present", Present:true, Exact:"foobar", Prefix:"", Suffix:"", Regex:"", Invert:false}: At most only one of exact, prefix, suffix, regex, or present may be configured.`,
-				`spec.sources[0].permissions[0].header[1]: Invalid value: v1alpha1.IntentionHTTPHeaderPermission{Name:"prefix-exact", Present:false, Exact:"foobar", Prefix:"barfood", Suffix:"", Regex:"", Invert:false}: At most only one of exact, prefix, suffix, regex, or present may be configured.`,
-				`spec.sources[0].permissions[0].header[2]: Invalid value: v1alpha1.IntentionHTTPHeaderPermission{Name:"suffix-prefix", Present:false, Exact:"", Prefix:"foo", Suffix:"bar", Regex:"", Invert:false}: At most only one of exact, prefix, suffix, regex, or present may be configured.`,
-				`spec.sources[0].permissions[0].header[3]: Invalid value: v1alpha1.IntentionHTTPHeaderPermission{Name:"suffix-regex", Present:false, Exact:"", Prefix:"", Suffix:"bar", Regex:"foo", Invert:false}: At most only one of exact, prefix, suffix, regex, or present may be configured.`,
-				`spec.sources[0].permissions[0].header[4]: Invalid value: v1alpha1.IntentionHTTPHeaderPermission{Name:"regex-present", Present:true, Exact:"", Prefix:"", Suffix:"", Regex:"foobar", Invert:false}: At most only one of exact, prefix, suffix, regex, or present may be configured.`,
+				`spec.sources[0].permissions[0].header[0]: Invalid value: "{\"name\":\"exact-present\",\"present\":true,\"exact\":\"foobar\"}": at most only one of exact, prefix, suffix, regex, or present may be configured.`,
+				`spec.sources[0].permissions[0].header[1]: Invalid value: "{\"name\":\"prefix-exact\",\"exact\":\"foobar\",\"prefix\":\"barfood\"}": at most only one of exact, prefix, suffix, regex, or present may be configured.`,
+				`spec.sources[0].permissions[0].header[2]: Invalid value: "{\"name\":\"suffix-prefix\",\"prefix\":\"foo\",\"suffix\":\"bar\"}": at most only one of exact, prefix, suffix, regex, or present may be configured.`,
+				`spec.sources[0].permissions[0].header[3]: Invalid value: "{\"name\":\"suffix-regex\",\"suffix\":\"bar\",\"regex\":\"foo\"}": at most only one of exact, prefix, suffix, regex, or present may be configured.`,
+				`spec.sources[0].permissions[0].header[4]: Invalid value: "{\"name\":\"regex-present\",\"present\":true,\"regex\":\"foobar\"}": at most only one of exact, prefix, suffix, regex, or present may be configured.`,
 			},
 		},
 		"invalid permissions.action": {

--- a/api/v1alpha1/serviceintentions_types_test.go
+++ b/api/v1alpha1/serviceintentions_types_test.go
@@ -564,17 +564,11 @@ func TestServiceIntentions_Validate(t *testing.T) {
 								{
 									Action: "allow",
 									HTTP: &IntentionHTTPPermission{
-										PathExact:  "/foo",
-										PathPrefix: "/bar",
-										PathRegex:  "/baz",
+										PathExact: "/foo",
 										Header: IntentionHTTPHeaderPermissions{
 											{
 												Name:    "header",
 												Present: true,
-												Exact:   "exact",
-												Prefix:  "prefix",
-												Suffix:  "suffix",
-												Regex:   "regex",
 												Invert:  true,
 											},
 										},
@@ -617,18 +611,12 @@ func TestServiceIntentions_Validate(t *testing.T) {
 								{
 									Action: "allow",
 									HTTP: &IntentionHTTPPermission{
-										PathExact:  "/foo",
-										PathPrefix: "/bar",
-										PathRegex:  "/baz",
+										PathRegex: "/baz",
 										Header: IntentionHTTPHeaderPermissions{
 											{
-												Name:    "header",
-												Present: true,
-												Exact:   "exact",
-												Prefix:  "prefix",
-												Suffix:  "suffix",
-												Regex:   "regex",
-												Invert:  true,
+												Name:   "header",
+												Regex:  "regex",
+												Invert: true,
 											},
 										},
 										Methods: []string{
@@ -719,6 +707,102 @@ func TestServiceIntentions_Validate(t *testing.T) {
 				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0].pathPrefix: Invalid value: "bar": must begin with a '/'`,
 			},
 		},
+		"invalid permissions.http pathPrefix,pathExact specified": {
+			input: &ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: Destination{
+						Name:      "dest-service",
+						Namespace: "namespace",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:      "svc-2",
+							Namespace: "bar",
+							Permissions: IntentionPermissions{
+								{
+									Action: "allow",
+									HTTP: &IntentionHTTPPermission{
+										PathPrefix: "/bar",
+										PathExact:  "/foo",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			namespacesEnabled: true,
+			expectedErrMsgs: []string{
+				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0]: Invalid value: v1alpha1.IntentionHTTPPermission{PathExact:"/foo", PathPrefix:"/bar", PathRegex:"", Header:v1alpha1.IntentionHTTPHeaderPermissions(nil), Methods:[]string(nil)}: At most only one of pathExact, pathPrefix, or pathRegex may be configured.`,
+			},
+		},
+		"invalid permissions.http pathPrefix,pathRegex specified": {
+			input: &ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: Destination{
+						Name:      "dest-service",
+						Namespace: "namespace",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:      "svc-2",
+							Namespace: "bar",
+							Permissions: IntentionPermissions{
+								{
+									Action: "allow",
+									HTTP: &IntentionHTTPPermission{
+										PathPrefix: "/bar",
+										PathRegex:  "foo",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			namespacesEnabled: true,
+			expectedErrMsgs: []string{
+				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0]: Invalid value: v1alpha1.IntentionHTTPPermission{PathExact:"", PathPrefix:"/bar", PathRegex:"foo", Header:v1alpha1.IntentionHTTPHeaderPermissions(nil), Methods:[]string(nil)}: At most only one of pathExact, pathPrefix, or pathRegex may be configured.`,
+			},
+		},
+		"invalid permissions.http pathRegex,pathExact specified": {
+			input: &ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: Destination{
+						Name:      "dest-service",
+						Namespace: "namespace",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:      "svc-2",
+							Namespace: "bar",
+							Permissions: IntentionPermissions{
+								{
+									Action: "allow",
+									HTTP: &IntentionHTTPPermission{
+										PathRegex: "bar",
+										PathExact: "/foo",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			namespacesEnabled: true,
+			expectedErrMsgs: []string{
+				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0]: Invalid value: v1alpha1.IntentionHTTPPermission{PathExact:"/foo", PathPrefix:"", PathRegex:"bar", Header:v1alpha1.IntentionHTTPHeaderPermissions(nil), Methods:[]string(nil)}: At most only one of pathExact, pathPrefix, or pathRegex may be configured.`,
+			},
+		},
 		"invalid permissions.http.pathExact": {
 			input: &ServiceIntentions{
 				ObjectMeta: metav1.ObjectMeta{
@@ -748,6 +832,102 @@ func TestServiceIntentions_Validate(t *testing.T) {
 			namespacesEnabled: true,
 			expectedErrMsgs: []string{
 				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].permissions[0].pathExact: Invalid value: "bar": must begin with a '/'`,
+			},
+		},
+		"invalid permissions.http.methods": {
+			input: &ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: Destination{
+						Name:      "dest-service",
+						Namespace: "namespace",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:      "svc-2",
+							Namespace: "bar",
+							Permissions: IntentionPermissions{
+								{
+									Action: "allow",
+									HTTP: &IntentionHTTPPermission{
+										Methods: []string{
+											"FOO",
+											"GET",
+											"BAR",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			namespacesEnabled: true,
+			expectedErrMsgs: []string{
+				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: [spec.sources[0].permissions[0].methods[0]: Invalid value: "FOO": must be one of "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", spec.sources[0].permissions[0].methods[2]: Invalid value: "BAR": must be one of "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"]`,
+			},
+		},
+		"invalid permissions.http.header": {
+			input: &ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: Destination{
+						Name:      "dest-service",
+						Namespace: "namespace",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:      "svc-2",
+							Namespace: "bar",
+							Permissions: IntentionPermissions{
+								{
+									Action: "allow",
+									HTTP: &IntentionHTTPPermission{
+										Header: IntentionHTTPHeaderPermissions{
+											{
+												Name:    "exact-present",
+												Present: true,
+												Exact:   "foobar",
+											},
+											{
+												Name:   "prefix-exact",
+												Exact:  "foobar",
+												Prefix: "barfood",
+											},
+											{
+												Name:   "suffix-prefix",
+												Prefix: "foo",
+												Suffix: "bar",
+											},
+											{
+												Name:   "suffix-regex",
+												Suffix: "bar",
+												Regex:  "foo",
+											},
+											{
+												Name:    "regex-present",
+												Present: true,
+												Regex:   "foobar",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			namespacesEnabled: true,
+			expectedErrMsgs: []string{
+				`spec.sources[0].permissions[0].header[0]: Invalid value: v1alpha1.IntentionHTTPHeaderPermission{Name:"exact-present", Present:true, Exact:"foobar", Prefix:"", Suffix:"", Regex:"", Invert:false}: At most only one of exact, prefix, suffix, regex, or present may be configured.`,
+				`spec.sources[0].permissions[0].header[1]: Invalid value: v1alpha1.IntentionHTTPHeaderPermission{Name:"prefix-exact", Present:false, Exact:"foobar", Prefix:"barfood", Suffix:"", Regex:"", Invert:false}: At most only one of exact, prefix, suffix, regex, or present may be configured.`,
+				`spec.sources[0].permissions[0].header[2]: Invalid value: v1alpha1.IntentionHTTPHeaderPermission{Name:"suffix-prefix", Present:false, Exact:"", Prefix:"foo", Suffix:"bar", Regex:"", Invert:false}: At most only one of exact, prefix, suffix, regex, or present may be configured.`,
+				`spec.sources[0].permissions[0].header[3]: Invalid value: v1alpha1.IntentionHTTPHeaderPermission{Name:"suffix-regex", Present:false, Exact:"", Prefix:"", Suffix:"bar", Regex:"foo", Invert:false}: At most only one of exact, prefix, suffix, regex, or present may be configured.`,
+				`spec.sources[0].permissions[0].header[4]: Invalid value: v1alpha1.IntentionHTTPHeaderPermission{Name:"regex-present", Present:true, Exact:"", Prefix:"", Suffix:"", Regex:"foobar", Invert:false}: At most only one of exact, prefix, suffix, regex, or present may be configured.`,
 			},
 		},
 		"invalid permissions.action": {

--- a/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
+++ b/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
@@ -42,6 +42,7 @@ spec:
           description: ServiceIntentionsSpec defines the desired state of ServiceIntentions
           properties:
             destination:
+              description: Destination is the intention destination that will have the authorization granted to.
               properties:
                 name:
                   description: Name is the destination of all intentions defined in this config entry. This may be set to the wildcard character (*) to match all services that don't otherwise have intentions defined.

--- a/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
+++ b/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
@@ -44,58 +44,78 @@ spec:
             destination:
               properties:
                 name:
+                  description: Name is the destination of all intentions defined in this config entry. This may be set to the wildcard character (*) to match all services that don't otherwise have intentions defined.
                   type: string
                 namespace:
+                  description: Namespace specifies the namespace the config entry will apply to. This may be set to the wildcard character (*) to match all services in all namespaces that don't otherwise have intentions defined.
                   type: string
               type: object
             sources:
+              description: Sources is the list of all intention sources and the authorization granted to those sources. The order of this list does not matter, but out of convenience Consul will always store this reverse sorted by intention precedence, as that is the order that they will be evaluated at enforcement time.
               items:
                 properties:
                   action:
-                    description: IntentionAction is the action that the intention represents. This can be "allow" or "deny" to allowlist or denylist intentions.
+                    description: Action is required for an L4 intention, and should be set to one of "allow" or "deny" for the action that should be taken if this intention matches a request.
                     type: string
                   description:
+                    description: Description for the intention. This is not used by Consul, but is presented in API responses to assist tooling.
                     type: string
                   name:
+                    description: Name is the source of the intention. This is the name of a Consul service. The service doesn't need to be registered.
                     type: string
                   namespace:
+                    description: Namespace is the namespace for the Name parameter.
                     type: string
                   permissions:
+                    description: Permissions is the list of all additional L7 attributes that extend the intention match criteria. Permission precedence is applied top to bottom. For any given request the first permission to match in the list is terminal and stops further evaluation. As with L4 intentions, traffic that fails to match any of the provided permissions in this intention will be subject to the default intention behavior is defined by the default ACL policy. This should be omitted for an L4 intention as it is mutually exclusive with the Action field.
                     items:
                       properties:
                         action:
-                          description: IntentionAction is the action that the intention represents. This can be "allow" or "deny" to allowlist or denylist intentions.
+                          description: Action is one of "allow" or "deny" for the action that should be taken if this permission matches a request.
                           type: string
                         http:
+                          description: HTTP is a set of HTTP-specific authorization criteria.
                           properties:
                             header:
+                              description: Header is a set of criteria that can match on HTTP request headers. If more than one is configured all must match for the overall match to apply.
                               items:
                                 properties:
                                   exact:
+                                    description: Exact matches if the header with the given name is this value.
                                     type: string
                                   invert:
+                                    description: Invert inverts the logic of the match.
                                     type: boolean
                                   name:
+                                    description: Name is the name of the header to match.
                                     type: string
                                   prefix:
+                                    description: Prefix matches if the header with the given name has this prefix.
                                     type: string
                                   present:
+                                    description: Present matches if the header with the given name is present with any value.
                                     type: boolean
                                   regex:
+                                    description: Regex matches if the header with the given name matches this pattern.
                                     type: string
                                   suffix:
+                                    description: Suffix matches if the header with the given name has this suffix.
                                     type: string
                                 type: object
                               type: array
                             methods:
+                              description: Methods is a list of HTTP methods for which this match applies. If unspecified all HTTP methods are matched. If provided the names must be a valid method.
                               items:
                                 type: string
                               type: array
                             pathExact:
+                              description: PathExact is the exact path to match on the HTTP request path.
                               type: string
                             pathPrefix:
+                              description: PathPrefix is the path prefix to match on the HTTP request path.
                               type: string
                             pathRegex:
+                              description: PathRegex is the regular expression to match on the HTTP request path.
                               type: string
                           type: object
                       type: object


### PR DESCRIPTION
Changes proposed in this PR:
- Add inline descriptions for the various fields of service-intentions
- Add missing validations for service intentions

How I've tested this PR:
- Unit tests

This was work that was previously skipped as we did not have enough documentation regarding service-intentions.

How I expect reviewers to test this PR:
- Code Review

Checklist:
- [x] Tests added
