### PR TITLE
Tweak check id and output

### DIFF
--- a/connect-inject/health_check_resource.go
+++ b/connect-inject/health_check_resource.go
@@ -23,7 +23,7 @@ const (
 	labelInject = "consul.hashicorp.com/connect-inject-status"
 
 	// kubernetesSuccessReasonMsg will be passed for passing health check's Reason to Consul.
-	kubernetesSuccessReasonMsg = "Kubernetes Health Checks Passing"
+	kubernetesSuccessReasonMsg = "Kubernetes health checks passing"
 
 	podPendingReasonMsg = "Pod is pending"
 )
@@ -294,7 +294,7 @@ func (h *HealthCheckResource) shouldProcess(pod *corev1.Pod) bool {
 // getConsulHealthCheckID deterministically generates a health check ID that will be unique to the Agent
 // where the health check is registered and deregistered.
 func (h *HealthCheckResource) getConsulHealthCheckID(pod *corev1.Pod) string {
-	return fmt.Sprintf("%s_%s_kubernetes-health-check-ttl", pod.Namespace, h.getConsulServiceID(pod))
+	return fmt.Sprintf("%s/%s/kubernetes-health-check", pod.Namespace, h.getConsulServiceID(pod))
 }
 
 // getConsulServiceID returns the serviceID of the connect service.

--- a/connect-inject/health_check_resource_ent_test.go
+++ b/connect-inject/health_check_resource_ent_test.go
@@ -15,10 +15,10 @@ import (
 
 const (
 	testNamespace               = "testnamespace"
-	testNamespacedHealthCheckID = "testnamespace_test-pod-test-service_kubernetes-health-check-ttl"
+	testNamespacedHealthCheckID = "testnamespace/test-pod-test-service/kubernetes-health-check"
 
 	testAlternateNamespace               = "testalternatenamespace"
-	testAlternateNamespacedHealthCheckID = "testalternatenamespace_test-pod-test-service_kubernetes-health-check-ttl"
+	testAlternateNamespacedHealthCheckID = "testalternatenamespace/test-pod-test-service/kubernetes-health-check"
 )
 
 var ignoredFieldsEnterprise = []string{"Node", "Definition", "ServiceID", "ServiceName"}

--- a/connect-inject/health_check_resource_test.go
+++ b/connect-inject/health_check_resource_test.go
@@ -24,9 +24,9 @@ const (
 	testPodName               = "test-pod"
 	testServiceNameAnnotation = "test-service"
 	testServiceNameReg        = "test-pod-test-service"
-	testHealthCheckID         = "default_test-pod-test-service_kubernetes-health-check-ttl"
+	testHealthCheckID         = "default/test-pod-test-service/kubernetes-health-check"
 	testFailureMessage        = "Kubernetes pod readiness probe failed"
-	testCheckNotesPassing     = "Kubernetes Health Checks Passing"
+	testCheckNotesPassing     = "Kubernetes health checks passing"
 	ttl                       = "ttl"
 	name                      = "Kubernetes Health Check"
 )


### PR DESCRIPTION
Purely aesthetic changes. None of these are required, more of just a conversation starter based on some discrepancies I've noticed with other built-in checks.

* Changed success output from title case `Kubernetes Health Checks
Passing` to sentence case `Kubernetes health checks passing` to match
other built-in check outputs.
* Removed `-ttl` from end of check id because the type of check doesn't
matter for users and is listed as a separate field in the API responses.
* Changed check id to use `namespace/service-id` instead of
`namespace_service-id` to match Consul and Kube's regular formats
* Changed `service-id_kubernetes-health-check` to
`service_id/kubernetes-health-check` for purely asthetic reasons: clashing
`_` and `-`'s looks jarring.

What it would look like (with `/` now instead of `:`):
![image](https://user-images.githubusercontent.com/1034429/98616069-de0e4e00-22b0-11eb-941f-ce77850956bd.png)

How some of the other built-in checks look:
![image](https://user-images.githubusercontent.com/1034429/98616101-ee262d80-22b0-11eb-8825-20e6864467a3.png)
