### PR TITLE
Give better error if namespaces not enabled

### DIFF
--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -423,7 +423,13 @@ func (c *Command) Run(args []string) int {
 		}
 		_, _, err = consulClient.Namespaces().Update(&consulNamespace, &api.WriteOptions{})
 		if err != nil {
-			c.log.Error("Error updating the default namespace to include the cross namespace policy", "err", err)
+			if strings.Contains(strings.ToLower(err.Error()), "unexpected response code: 404") {
+				// If this returns a 404 it's most likely because they're not running
+				// Consul Enterprise.
+				c.log.Error("Error updating the default namespace to include the cross namespace policy - ensure you're running Consul Enterprise with namespaces enabled", "err", err)
+			} else {
+				c.log.Error("Error updating the default namespace to include the cross namespace policy", "err", err)
+			}
 			return 1
 		}
 	}


### PR DESCRIPTION
If the user is running Consul OSS by accident it would be nice to give them a better error message than:
```
2020-11-19T16:12:17.514Z [INFO]  Bootstrap token is provided so skipping Consul server ACL bootstrapping
2020-11-19T16:12:18.416Z [INFO]  Success: calling /agent/self to get datacenter
2020-11-19T16:12:18.416Z [INFO]  Current datacenter: datacenter=gcp-us-central-1
2020-11-19T16:12:18.610Z [INFO]  Policy "cross-namespace-policy" already exists, updating
2020-11-19T16:12:18.710Z [INFO]  Success: creating cross-namespace-policy policy
2020-11-19T16:12:18.711Z [ERROR] Error updating the default namespace to include the cross namespace policy: err="Unexpected response code: 404 ()"
```

How I've tested this PR: I didn't test it, I looked at the logs from an internal issue.

How I expect reviewers to test this PR: Code only. But possible to try and stand up a cluster with ACLs enabled, consul namespaces enabled and OSS binary.

Checklist:
No tests or changelog added because we don't test log messages and this isn't big enough for a changelog entry I don't think?
