### PR TITLE
Add -log-level flag to inject-connect, healthchecks debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UNRELEASED
 
+IMPROVEMENTS:
+* Connect: Add `-log-level` flag to `inject-connect` command. [[GH-400](https://github.com/hashicorp/consul-k8s/pull/400)]
+
 ## 0.20.0 (November 12, 2020)
 
 FEATURES:

--- a/connect-inject/health_check_resource.go
+++ b/connect-inject/health_check_resource.go
@@ -177,6 +177,7 @@ func (h *HealthCheckResource) reconcilePod(pod *corev1.Pod) error {
 		} else if err != nil {
 			return fmt.Errorf("unable to register health check: %s", err)
 		}
+		h.Log.Debug("updating health check status", "name", pod.Name, "status", status, "reason", reason)
 		// Also update it, the reason this is separate is there is no way to set the Output field of the health check
 		// at creation time, and this is what is displayed on the UI as opposed to the Notes field.
 		err = h.updateConsulHealthCheckStatus(client, healthCheckID, status, reason)
@@ -185,6 +186,7 @@ func (h *HealthCheckResource) reconcilePod(pod *corev1.Pod) error {
 		}
 	} else if serviceCheck.Status != status {
 		// Update the healthCheck.
+		h.Log.Debug("updating health check status", "name", pod.Name, "status", status, "reason", reason)
 		err = h.updateConsulHealthCheckStatus(client, healthCheckID, status, reason)
 		if err != nil {
 			return fmt.Errorf("error updating health check: %s", err)

--- a/subcommand/common/common.go
+++ b/subcommand/common/common.go
@@ -1,6 +1,13 @@
 // Package common holds code needed by multiple commands.
 package common
 
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/go-hclog"
+)
+
 const (
 	// ACLReplicationTokenName is the name used for the ACL replication policy and
 	// Kubernetes secret. It is consumed in both the server-acl-init and
@@ -11,3 +18,15 @@ const (
 	// create Kubernetes secrets.
 	ACLTokenSecretKey = "token"
 )
+
+// Logger returns an hclog instance or an error if level is invalid.
+func Logger(level string) (hclog.Logger, error) {
+	parsedLevel := hclog.LevelFromString(level)
+	if parsedLevel == hclog.NoLevel {
+		return nil, fmt.Errorf("unknown log level: %s", level)
+	}
+	return hclog.New(&hclog.LoggerOptions{
+		Level:  parsedLevel,
+		Output: os.Stderr,
+	}), nil
+}

--- a/subcommand/common/common_test.go
+++ b/subcommand/common/common_test.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogger_InvalidLogLevel(t *testing.T) {
+	_, err := Logger("invalid")
+	require.EqualError(t, err, "unknown log level: invalid")
+}
+
+func TestLogger(t *testing.T) {
+	lgr, err := Logger("debug")
+	require.NoError(t, err)
+	require.NotNil(t, lgr)
+	require.True(t, lgr.IsDebug())
+}

--- a/subcommand/create-federation-secret/command.go
+++ b/subcommand/create-federation-secret/command.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -108,16 +107,11 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	// Create logger.
-	level := hclog.LevelFromString(c.flagLogLevel)
-	if level == hclog.NoLevel {
-		c.UI.Error(fmt.Sprintf("Unknown log level: %s", c.flagLogLevel))
+	logger, err := common.Logger(c.flagLogLevel)
+	if err != nil {
+		c.UI.Error(err.Error())
 		return 1
 	}
-	logger := hclog.New(&hclog.LoggerOptions{
-		Level:  level,
-		Output: os.Stderr,
-	})
 
 	// The initial secret struct. We will be filling in its data map
 	// as we continue.

--- a/subcommand/create-federation-secret/command_test.go
+++ b/subcommand/create-federation-secret/command_test.go
@@ -68,7 +68,7 @@ func TestRun_FlagValidation(t *testing.T) {
 				"-mesh-gateway-service-name=name",
 				"-log-level=invalid",
 			},
-			expErr: "Unknown log level: invalid",
+			expErr: "unknown log level: invalid",
 		},
 	}
 

--- a/subcommand/delete-completed-job/command.go
+++ b/subcommand/delete-completed-job/command.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
 	"github.com/hashicorp/consul-k8s/subcommand"
+	"github.com/hashicorp/consul-k8s/subcommand/common"
 	"github.com/hashicorp/consul-k8s/subcommand/flags"
-	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
 	v1 "k8s.io/api/batch/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -18,6 +17,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
+
+const logLevel = "info"
 
 // Command is the command for deleting completed jobs.
 type Command struct {
@@ -95,10 +96,11 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
-	logger := hclog.New(&hclog.LoggerOptions{
-		Level:  hclog.Info,
-		Output: os.Stderr,
-	})
+	logger, err := common.Logger(logLevel)
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
 
 	// Wait for job to complete.
 	logger.Info(fmt.Sprintf("waiting for job %q to complete successfully", jobName))

--- a/subcommand/get-consul-client-ca/command.go
+++ b/subcommand/get-consul-client-ca/command.go
@@ -4,13 +4,13 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff"
 	godiscover "github.com/hashicorp/consul-k8s/helper/go-discover"
+	"github.com/hashicorp/consul-k8s/subcommand/common"
 	"github.com/hashicorp/consul-k8s/subcommand/flags"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-discover"
@@ -81,16 +81,11 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	// create a logger
-	level := hclog.LevelFromString(c.flagLogLevel)
-	if level == hclog.NoLevel {
-		c.UI.Error(fmt.Sprintf("Unknown log level: %s", c.flagLogLevel))
+	logger, err := common.Logger(c.flagLogLevel)
+	if err != nil {
+		c.UI.Error(err.Error())
 		return 1
 	}
-	logger := hclog.New(&hclog.LoggerOptions{
-		Level:  level,
-		Output: os.Stderr,
-	})
 
 	// create Consul client
 	consulClient, err := c.consulClient(logger)

--- a/subcommand/get-consul-client-ca/command_test.go
+++ b/subcommand/get-consul-client-ca/command_test.go
@@ -44,7 +44,7 @@ func TestRun_FlagsValidation(t *testing.T) {
 				"-server-addr=foo.com",
 				"-log-level=invalid-log-level",
 			},
-			expErr: "Unknown log level: invalid-log-level",
+			expErr: "unknown log level: invalid-log-level",
 		},
 	}
 

--- a/subcommand/inject-connect/command_test.go
+++ b/subcommand/inject-connect/command_test.go
@@ -24,6 +24,10 @@ func TestRun_FlagValidation(t *testing.T) {
 			expErr: "-consul-k8s-image must be set",
 		},
 		{
+			flags:  []string{"-consul-k8s-image", "foo", "-log-level", "invalid"},
+			expErr: "unknown log level: invalid",
+		},
+		{
 			flags:  []string{"-consul-k8s-image", "foo", "-ca-file", "bar"},
 			expErr: "Error reading Consul's CA cert file \"bar\"",
 		},

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -276,16 +275,12 @@ func (c *Command) Run(args []string) int {
 	// The context will only ever be intentionally ended by the timeout.
 	defer cancel()
 
-	// Configure our logger
-	level := hclog.LevelFromString(c.flagLogLevel)
-	if level == hclog.NoLevel {
-		c.UI.Error(fmt.Sprintf("Unknown log level: %s", c.flagLogLevel))
+	var err error
+	c.log, err = common.Logger(c.flagLogLevel)
+	if err != nil {
+		c.UI.Error(err.Error())
 		return 1
 	}
-	c.log = hclog.New(&hclog.LoggerOptions{
-		Level:  level,
-		Output: os.Stderr,
-	})
 
 	serverAddresses := c.flagServerAddresses
 	// Check if the provided addresses contain a cloud-auto join string.

--- a/subcommand/service-address/command.go
+++ b/subcommand/service-address/command.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"os"
 	"sync"
 	"time"
 
@@ -79,15 +78,12 @@ func (c *Command) Run(args []string) int {
 	if c.retryDuration == 0 {
 		c.retryDuration = 1 * time.Second
 	}
-	log := hclog.New(&hclog.LoggerOptions{
-		Level:  hclog.Info,
-		Output: os.Stderr,
-	})
+	logger := hclog.Default()
 
 	// Run until we get an address from the service.
 	var address string
 	var unretryableErr error
-	backoff.Retry(withErrLogger(log, func() error {
+	backoff.Retry(withErrLogger(logger, func() error {
 		svc, err := c.k8sClient.CoreV1().Services(c.flagNamespace).Get(context.TODO(), c.flagServiceName, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("getting service %s: %s", c.flagServiceName, err)

--- a/subcommand/sync-catalog/command.go
+++ b/subcommand/sync-catalog/command.go
@@ -17,6 +17,7 @@ import (
 	catalogtok8s "github.com/hashicorp/consul-k8s/catalog/to-k8s"
 	"github.com/hashicorp/consul-k8s/helper/controller"
 	"github.com/hashicorp/consul-k8s/subcommand"
+	"github.com/hashicorp/consul-k8s/subcommand/common"
 	"github.com/hashicorp/consul-k8s/subcommand/flags"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
@@ -198,15 +199,12 @@ func (c *Command) Run(args []string) int {
 
 	// Set up logging
 	if c.logger == nil {
-		level := hclog.LevelFromString(c.flagLogLevel)
-		if level == hclog.NoLevel {
-			c.UI.Error(fmt.Sprintf("Unknown log level: %s", c.flagLogLevel))
+		var err error
+		c.logger, err = common.Logger(c.flagLogLevel)
+		if err != nil {
+			c.UI.Error(err.Error())
 			return 1
 		}
-		c.logger = hclog.New(&hclog.LoggerOptions{
-			Level:  level,
-			Output: os.Stderr,
-		})
 	}
 
 	// Convert allow/deny lists to sets

--- a/subcommand/webhook-cert-manager/command.go
+++ b/subcommand/webhook-cert-manager/command.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/hashicorp/consul-k8s/helper/cert"
 	"github.com/hashicorp/consul-k8s/subcommand"
+	"github.com/hashicorp/consul-k8s/subcommand/common"
 	"github.com/hashicorp/consul-k8s/subcommand/flags"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
@@ -106,15 +107,12 @@ func (c *Command) Run(args []string) int {
 	}
 
 	if c.logger == nil {
-		level := hclog.LevelFromString(c.flagLogLevel)
-		if level == hclog.NoLevel {
-			c.UI.Error(fmt.Sprintf("Unknown log level: %s", c.flagLogLevel))
+		var err error
+		c.logger, err = common.Logger(c.flagLogLevel)
+		if err != nil {
+			c.UI.Error(err.Error())
 			return 1
 		}
-		c.logger = hclog.New(&hclog.LoggerOptions{
-			Level:  level,
-			Output: os.Stderr,
-		})
 	}
 
 	configFile, err := ioutil.ReadFile(c.flagConfigFile)


### PR DESCRIPTION
Changes proposed in this PR:
- Add `-log-level` flag to `inject-connect` so we can configure the health check log level
- Add debug logs to health checks so we can see when it's setting a check status
- Move logger construction to `common` so it can be reused

How I've tested this PR:
- I haven't yet!

How I expect reviewers to test this PR:
- code

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
