### PR TITLE
Set -envoy-version for Consul connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 IMPROVEMENTS:
 * Connect: Add `-log-level` flag to `inject-connect` command. [[GH-400](https://github.com/hashicorp/consul-k8s/pull/400)]
 
+BREAKING CHANGES:
+* Connect: the flags `-envoy-image` and `-consul-image` for command `inject-connect` are now required. [[GH-403](https://github.com/hashicorp/consul-k8s/pull/403)]
+* Connect: the Docker image passed to `-envoy-image` must contain a tag that can be parsed to determine
+  the Envoy image, e.g. `envoy:1.16.0`. The new flag `-envoy-version` can be used to set the Envoy version
+  if the image tag is not parseable. [[GH-403](https://github.com/hashicorp/consul-k8s/pull/403)]
+* Connect: the flag `-envoy-version` is passed to all Envoy sidecars now. This requires Consul >= 1.7.0. [[GH-403](https://github.com/hashicorp/consul-k8s/pull/403)]
+
 ## 0.20.0 (November 12, 2020)
 
 FEATURES:

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -35,6 +35,7 @@ type initContainerCommandData struct {
 	// The PEM-encoded CA certificate to use when
 	// communicating with Consul clients
 	ConsulCACert string
+	EnvoyVersion string
 }
 
 type initContainerCommandUpstreamData struct {
@@ -68,6 +69,7 @@ func (h *Handler) containerInit(pod *corev1.Pod, k8sNamespace string) (corev1.Co
 		ConsulNamespace:           h.consulNamespace(k8sNamespace),
 		NamespaceMirroringEnabled: h.EnableK8SNSMirroring,
 		ConsulCACert:              h.ConsulCACert,
+		EnvoyVersion:              h.EnvoyVersion.String(),
 	}
 	if data.ServiceName == "" {
 		// Assertion, since we call defaultAnnotations above and do
@@ -398,6 +400,7 @@ chmod 444 /consul/connect-inject/acl-token
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
   -proxy-id="${PROXY_SERVICE_ID}" \
+  -envoy-version="{{ .EnvoyVersion }}" \
   {{- if .AuthMethod }}
   -token-file="/consul/connect-inject/acl-token" \
   {{- end }}

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -101,6 +102,7 @@ EOF
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
   -proxy-id="${PROXY_SERVICE_ID}" \
+  -envoy-version="1.16.0" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
 
 # Copy the Consul binary
@@ -589,7 +591,9 @@ services {
 		t.Run(tt.Name, func(t *testing.T) {
 			require := require.New(t)
 
-			var h Handler
+			h := Handler{
+				EnvoyVersion: version.Must(version.NewVersion("1.16.0")),
+			}
 			container, err := h.containerInit(tt.Pod(minimal()), k8sNamespace)
 			require.NoError(err)
 			actual := strings.Join(container.Command, " ")
@@ -650,6 +654,7 @@ func TestHandlerContainerInit_namespacesEnabled(t *testing.T) {
 			Handler{
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "default",
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 			},
 			k8sNamespace,
 			`/bin/sh -ec 
@@ -707,6 +712,7 @@ EOF
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
   -proxy-id="${PROXY_SERVICE_ID}" \
+  -envoy-version="1.16.0" \
   -namespace="default" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
 
@@ -724,6 +730,7 @@ cp /bin/consul /consul/connect-inject/consul`,
 			Handler{
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "non-default",
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 			},
 			k8sNamespace,
 			`/bin/sh -ec 
@@ -781,6 +788,7 @@ EOF
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
   -proxy-id="${PROXY_SERVICE_ID}" \
+  -envoy-version="1.16.0" \
   -namespace="non-default" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
 
@@ -799,6 +807,7 @@ cp /bin/consul /consul/connect-inject/consul`,
 				AuthMethod:                 "auth-method",
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "non-default",
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 			},
 			k8sNamespace,
 			`/bin/sh -ec 
@@ -863,6 +872,7 @@ chmod 444 /consul/connect-inject/acl-token
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
   -proxy-id="${PROXY_SERVICE_ID}" \
+  -envoy-version="1.16.0" \
   -token-file="/consul/connect-inject/acl-token" \
   -namespace="non-default" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
@@ -883,6 +893,7 @@ cp /bin/consul /consul/connect-inject/consul`,
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "non-default", // Overridden by mirroring
 				EnableK8SNSMirroring:       true,
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 			},
 			k8sNamespace,
 			`/bin/sh -ec 
@@ -947,6 +958,7 @@ chmod 444 /consul/connect-inject/acl-token
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
   -proxy-id="${PROXY_SERVICE_ID}" \
+  -envoy-version="1.16.0" \
   -token-file="/consul/connect-inject/acl-token" \
   -namespace="k8snamespace" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
@@ -967,6 +979,7 @@ cp /bin/consul /consul/connect-inject/consul`,
 				DefaultProtocol:            "http",
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "non-default",
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 			},
 			k8sNamespace,
 			`/bin/sh -ec 
@@ -1034,6 +1047,7 @@ EOF
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
   -proxy-id="${PROXY_SERVICE_ID}" \
+  -envoy-version="1.16.0" \
   -namespace="non-default" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
 
@@ -1055,6 +1069,7 @@ cp /bin/consul /consul/connect-inject/consul`,
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "non-default", // Overridden by mirroring
 				EnableK8SNSMirroring:       true,
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 			},
 			k8sNamespace,
 			`/bin/sh -ec 
@@ -1130,6 +1145,7 @@ chmod 444 /consul/connect-inject/acl-token
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
   -proxy-id="${PROXY_SERVICE_ID}" \
+  -envoy-version="1.16.0" \
   -token-file="/consul/connect-inject/acl-token" \
   -namespace="k8snamespace" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
@@ -1149,6 +1165,7 @@ cp /bin/consul /consul/connect-inject/consul`,
 			Handler{
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "default",
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 			},
 			k8sNamespace,
 			`proxy {
@@ -1174,6 +1191,7 @@ cp /bin/consul /consul/connect-inject/consul`,
 			Handler{
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "default",
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 			},
 			k8sNamespace,
 			`proxy {
@@ -1211,6 +1229,7 @@ func TestHandlerContainerInit_writeServiceDefaultsDefaultProtocol(t *testing.T) 
 	h := Handler{
 		WriteServiceDefaults: true,
 		DefaultProtocol:      "grpc",
+		EnvoyVersion:         version.Must(version.NewVersion("1.16.0")),
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1246,6 +1265,7 @@ EOF
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
   -proxy-id="${PROXY_SERVICE_ID}" \
+  -envoy-version="1.16.0" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
 
 # Copy the Consul binary
@@ -1258,6 +1278,7 @@ func TestHandlerContainerInit_writeServiceDefaultsPodProtocol(t *testing.T) {
 	h := Handler{
 		WriteServiceDefaults: true,
 		DefaultProtocol:      "http",
+		EnvoyVersion:         version.Must(version.NewVersion("1.16.0")),
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1294,6 +1315,7 @@ EOF
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
   -proxy-id="${PROXY_SERVICE_ID}" \
+  -envoy-version="1.16.0" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
 
 # Copy the Consul binary
@@ -1303,7 +1325,8 @@ cp /bin/consul /consul/connect-inject/consul`)
 func TestHandlerContainerInit_authMethod(t *testing.T) {
 	require := require.New(t)
 	h := Handler{
-		AuthMethod: "release-name-consul-k8s-auth-method",
+		AuthMethod:   "release-name-consul-k8s-auth-method",
+		EnvoyVersion: version.Must(version.NewVersion("1.16.0")),
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1345,6 +1368,7 @@ chmod 444 /consul/connect-inject/acl-token
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
   -proxy-id="${PROXY_SERVICE_ID}" \
+  -envoy-version="1.16.0" \
   -token-file="/consul/connect-inject/acl-token" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`)
 }
@@ -1355,6 +1379,7 @@ func TestHandlerContainerInit_authMethodAndCentralConfig(t *testing.T) {
 		AuthMethod:           "release-name-consul-k8s-auth-method",
 		WriteServiceDefaults: true,
 		DefaultProtocol:      "grpc",
+		EnvoyVersion:         version.Must(version.NewVersion("1.16.0")),
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1405,6 +1430,7 @@ chmod 444 /consul/connect-inject/acl-token
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
   -proxy-id="${PROXY_SERVICE_ID}" \
+  -envoy-version="1.16.0" \
   -token-file="/consul/connect-inject/acl-token" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
 `)
@@ -1417,6 +1443,7 @@ func TestHandlerContainerInit_noDefaultProtocol(t *testing.T) {
 	h := Handler{
 		WriteServiceDefaults: true,
 		DefaultProtocol:      "",
+		EnvoyVersion:         version.Must(version.NewVersion("1.16.0")),
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1456,6 +1483,7 @@ func TestHandlerContainerInit_WithTLS(t *testing.T) {
 	require := require.New(t)
 	h := Handler{
 		ConsulCACert: "consul-ca-cert",
+		EnvoyVersion: version.Must(version.NewVersion("1.16.0")),
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1500,6 +1528,7 @@ func TestHandlerContainerInit_Resources(t *testing.T) {
 				corev1.ResourceMemory: resource.MustParse("25Mi"),
 			},
 		},
+		EnvoyVersion: version.Must(version.NewVersion("1.16.0")),
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1533,7 +1562,8 @@ func TestHandlerContainerInit_Resources(t *testing.T) {
 func TestHandlerContainerInit_MismatchedServiceNameServiceAccountNameWithACLsEnabled(t *testing.T) {
 	require := require.New(t)
 	h := Handler{
-		AuthMethod: "auth-method",
+		AuthMethod:   "auth-method",
+		EnvoyVersion: version.Must(version.NewVersion("1.16.0")),
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1557,7 +1587,9 @@ func TestHandlerContainerInit_MismatchedServiceNameServiceAccountNameWithACLsEna
 
 func TestHandlerContainerInit_MismatchedServiceNameServiceAccountNameWithACLsDisabled(t *testing.T) {
 	require := require.New(t)
-	h := Handler{}
+	h := Handler{
+		EnvoyVersion: version.Must(version.NewVersion("1.16.0")),
+	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/consul-k8s/namespaces"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-version"
 	"github.com/mattbaird/jsonpatch"
 	"k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -19,11 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-)
-
-const (
-	DefaultConsulImage = "consul:1.7.1"
-	DefaultEnvoyImage  = "envoyproxy/envoy-alpine:v1.13.0"
 )
 
 const (
@@ -118,6 +114,9 @@ type Handler struct {
 	// Both of these MUST be set.
 	ImageConsul string
 	ImageEnvoy  string
+
+	// EnvoyVersion is the version of Envoy contained in ImageEnvoy.
+	EnvoyVersion *version.Version
 
 	// ImageConsulK8S is the container image for consul-k8s to use.
 	// This image is used for the lifecycle-sidecar container.

--- a/connect-inject/handler_ent_test.go
+++ b/connect-inject/handler_ent_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-version"
 	"github.com/mattbaird/jsonpatch"
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/admission/v1beta1"
@@ -43,6 +44,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 			"single destination namespace 'default' from k8s 'default'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -61,6 +63,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 			"single destination namespace 'default' from k8s 'non-default'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -79,6 +82,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 			"single destination namespace 'dest' from k8s 'default'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -97,6 +101,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 			"single destination namespace 'dest' from k8s 'non-default'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -115,6 +120,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 			"mirroring from k8s 'default'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -134,6 +140,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 			"mirroring from k8s 'dest'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -153,6 +160,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 			"mirroring with prefix from k8s 'default'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -173,6 +181,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 			"mirroring with prefix from k8s 'dest'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -261,6 +270,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 			"acls + single destination namespace 'default' from k8s 'default'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -280,6 +290,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 			"acls + single destination namespace 'default' from k8s 'non-default'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -299,6 +310,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 			"acls + single destination namespace 'dest' from k8s 'default'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -318,6 +330,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 			"acls + single destination namespace 'dest' from k8s 'non-default'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -337,6 +350,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 			"acls + mirroring from k8s 'default'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -357,6 +371,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 			"acls + mirroring from k8s 'dest'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -377,6 +392,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 			"acls + mirroring with prefix from k8s 'default'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -398,6 +414,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 			"acls + mirroring with prefix from k8s 'dest'",
 			Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -558,6 +575,7 @@ func TestHandler_MutateWithNamespaces_Annotation(t *testing.T) {
 
 			handler := Handler{
 				Log:                        hclog.Default().Named("handler"),
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/deckarep/golang-set"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-version"
 	"github.com/mattbaird/jsonpatch"
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/admission/v1beta1"
@@ -38,6 +39,7 @@ func TestHandlerHandle(t *testing.T) {
 				Log:                   hclog.Default().Named("handler"),
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
+				EnvoyVersion:          version.Must(version.NewVersion("1.16.0")),
 			},
 			v1beta1.AdmissionRequest{
 				Namespace: metav1.NamespaceSystem,
@@ -55,6 +57,7 @@ func TestHandlerHandle(t *testing.T) {
 				Log:                   hclog.Default().Named("handler"),
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
+				EnvoyVersion:          version.Must(version.NewVersion("1.16.0")),
 			},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
@@ -77,6 +80,7 @@ func TestHandlerHandle(t *testing.T) {
 				Log:                   hclog.Default().Named("handler"),
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
+				EnvoyVersion:          version.Must(version.NewVersion("1.16.0")),
 			},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
@@ -122,6 +126,7 @@ func TestHandlerHandle(t *testing.T) {
 				Log:                   hclog.Default().Named("handler"),
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
+				EnvoyVersion:          version.Must(version.NewVersion("1.16.0")),
 			},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
@@ -189,6 +194,7 @@ func TestHandlerHandle(t *testing.T) {
 				Log:                   hclog.Default().Named("handler"),
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
+				EnvoyVersion:          version.Must(version.NewVersion("1.16.0")),
 			},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
@@ -211,6 +217,7 @@ func TestHandlerHandle(t *testing.T) {
 				Log:                   hclog.Default().Named("handler"),
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
+				EnvoyVersion:          version.Must(version.NewVersion("1.16.0")),
 			},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
@@ -264,6 +271,7 @@ func TestHandlerHandle(t *testing.T) {
 				Log:                   hclog.Default().Named("handler"),
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
+				EnvoyVersion:          version.Must(version.NewVersion("1.16.0")),
 			},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
@@ -311,6 +319,7 @@ func TestHandlerHandle(t *testing.T) {
 				Log:                   hclog.Default().Named("handler"),
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
+				EnvoyVersion:          version.Must(version.NewVersion("1.16.0")),
 			},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
@@ -360,6 +369,7 @@ func TestHandlerHandle(t *testing.T) {
 				Log:                   hclog.Default().Named("handler"),
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
+				EnvoyVersion:          version.Must(version.NewVersion("1.16.0")),
 			},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
@@ -409,6 +419,7 @@ func TestHandlerHandle(t *testing.T) {
 				Log:                   hclog.Default().Named("handler"),
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
+				EnvoyVersion:          version.Must(version.NewVersion("1.16.0")),
 			},
 			v1beta1.AdmissionRequest{
 				Object: encodeRaw(t, &corev1.Pod{
@@ -489,6 +500,7 @@ func TestHandlerHandle_badContentType(t *testing.T) {
 		Log:                   hclog.Default().Named("handler"),
 		AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 		DenyK8sNamespacesSet:  mapset.NewSet(),
+		EnvoyVersion:          version.Must(version.NewVersion("1.16.0")),
 	}
 	rec := httptest.NewRecorder()
 	h.Handle(rec, req)
@@ -506,6 +518,7 @@ func TestHandlerHandle_noBody(t *testing.T) {
 		Log:                   hclog.Default().Named("handler"),
 		AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 		DenyK8sNamespacesSet:  mapset.NewSet(),
+		EnvoyVersion:          version.Must(version.NewVersion("1.16.0")),
 	}
 	rec := httptest.NewRecorder()
 	h.Handle(rec, req)
@@ -663,7 +676,10 @@ func TestHandlerDefaultAnnotations(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			require := require.New(t)
 
-			var h Handler
+			h := Handler{
+				EnvoyVersion: version.Must(version.NewVersion("1.16.0")),
+			}
+
 			var patches []jsonpatch.JsonPatchOperation
 			err := h.defaultAnnotations(tt.Pod, &patches)
 			if (tt.Err != "") != (err != nil) {
@@ -861,6 +877,7 @@ func TestConsulNamespace(t *testing.T) {
 				ConsulDestinationNamespace: tt.ConsulDestinationNamespace,
 				EnableK8SNSMirroring:       tt.EnableK8SNSMirroring,
 				K8SNSMirroringPrefix:       tt.K8SNSMirroringPrefix,
+				EnvoyVersion:               version.Must(version.NewVersion("1.16.0")),
 			}
 
 			ns := h.consulNamespace(tt.K8sNamespace)
@@ -1163,6 +1180,7 @@ func TestShouldInject(t *testing.T) {
 				EnableNamespaces:      tt.EnableNamespaces,
 				AllowK8sNamespacesSet: tt.AllowK8sNamespacesSet,
 				DenyK8sNamespacesSet:  tt.DenyK8sNamespacesSet,
+				EnvoyVersion:          version.Must(version.NewVersion("1.16.0")),
 			}
 
 			injected, err := h.shouldInject(tt.Pod, tt.K8sNamespace)

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
+	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/serf v0.9.3
 	github.com/joyent/triton-go v1.7.1-0.20200416154420-6801d15b779f // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -285,6 +285,8 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
+github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=

--- a/subcommand/inject-connect/command_test.go
+++ b/subcommand/inject-connect/command_test.go
@@ -24,105 +24,139 @@ func TestRun_FlagValidation(t *testing.T) {
 			expErr: "-consul-k8s-image must be set",
 		},
 		{
-			flags:  []string{"-consul-k8s-image", "foo", "-log-level", "invalid"},
+			flags:  []string{"-consul-k8s-image", "foo"},
+			expErr: "-consul-image must be set",
+		},
+		{
+			flags:  []string{"-consul-k8s-image", "foo", "-consul-image", "foo"},
+			expErr: "-envoy-image must be set",
+		},
+		{
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-log-level", "invalid"},
 			expErr: "unknown log level: invalid",
 		},
 		{
-			flags:  []string{"-consul-k8s-image", "foo", "-ca-file", "bar"},
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-ca-file", "bar"},
 			expErr: "Error reading Consul's CA cert file \"bar\"",
 		},
 		{
-			flags:  []string{"-consul-k8s-image", "foo", "-default-sidecar-proxy-cpu-limit=unparseable"},
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-default-sidecar-proxy-cpu-limit=unparseable"},
 			expErr: "-default-sidecar-proxy-cpu-limit is invalid",
 		},
 		{
-			flags:  []string{"-consul-k8s-image", "foo", "-default-sidecar-proxy-cpu-request=unparseable"},
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-default-sidecar-proxy-cpu-request=unparseable"},
 			expErr: "-default-sidecar-proxy-cpu-request is invalid",
 		},
 		{
-			flags:  []string{"-consul-k8s-image", "foo", "-default-sidecar-proxy-memory-limit=unparseable"},
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-default-sidecar-proxy-memory-limit=unparseable"},
 			expErr: "-default-sidecar-proxy-memory-limit is invalid",
 		},
 		{
-			flags:  []string{"-consul-k8s-image", "foo", "-default-sidecar-proxy-memory-request=unparseable"},
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-default-sidecar-proxy-memory-request=unparseable"},
 			expErr: "-default-sidecar-proxy-memory-request is invalid",
 		},
 		{
-			flags: []string{"-consul-k8s-image", "foo",
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
 				"-default-sidecar-proxy-memory-request=50Mi",
 				"-default-sidecar-proxy-memory-limit=25Mi",
 			},
 			expErr: "request must be <= limit: -default-sidecar-proxy-memory-request value of \"50Mi\" is greater than the -default-sidecar-proxy-memory-limit value of \"25Mi\"",
 		},
 		{
-			flags: []string{"-consul-k8s-image", "foo",
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
 				"-default-sidecar-proxy-cpu-request=50m",
 				"-default-sidecar-proxy-cpu-limit=25m",
 			},
 			expErr: "request must be <= limit: -default-sidecar-proxy-cpu-request value of \"50m\" is greater than the -default-sidecar-proxy-cpu-limit value of \"25m\"",
 		},
 		{
-			flags:  []string{"-consul-k8s-image", "foo", "-init-container-cpu-limit=unparseable"},
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-init-container-cpu-limit=unparseable"},
 			expErr: "-init-container-cpu-limit 'unparseable' is invalid",
 		},
 		{
-			flags:  []string{"-consul-k8s-image", "foo", "-init-container-cpu-request=unparseable"},
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-init-container-cpu-request=unparseable"},
 			expErr: "-init-container-cpu-request 'unparseable' is invalid",
 		},
 		{
-			flags:  []string{"-consul-k8s-image", "foo", "-init-container-memory-limit=unparseable"},
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-init-container-memory-limit=unparseable"},
 			expErr: "-init-container-memory-limit 'unparseable' is invalid",
 		},
 		{
-			flags:  []string{"-consul-k8s-image", "foo", "-init-container-memory-request=unparseable"},
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-init-container-memory-request=unparseable"},
 			expErr: "-init-container-memory-request 'unparseable' is invalid",
 		},
 		{
-			flags: []string{"-consul-k8s-image", "foo",
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
 				"-init-container-memory-request=50Mi",
 				"-init-container-memory-limit=25Mi",
 			},
 			expErr: "request must be <= limit: -init-container-memory-request value of \"50Mi\" is greater than the -init-container-memory-limit value of \"25Mi\"",
 		},
 		{
-			flags: []string{"-consul-k8s-image", "foo",
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
 				"-init-container-cpu-request=50m",
 				"-init-container-cpu-limit=25m",
 			},
 			expErr: "request must be <= limit: -init-container-cpu-request value of \"50m\" is greater than the -init-container-cpu-limit value of \"25m\"",
 		},
 		{
-			flags:  []string{"-consul-k8s-image", "foo", "-lifecycle-sidecar-cpu-limit=unparseable"},
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-lifecycle-sidecar-cpu-limit=unparseable"},
 			expErr: "-lifecycle-sidecar-cpu-limit 'unparseable' is invalid",
 		},
 		{
-			flags:  []string{"-consul-k8s-image", "foo", "-lifecycle-sidecar-cpu-request=unparseable"},
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-lifecycle-sidecar-cpu-request=unparseable"},
 			expErr: "-lifecycle-sidecar-cpu-request 'unparseable' is invalid",
 		},
 		{
-			flags:  []string{"-consul-k8s-image", "foo", "-lifecycle-sidecar-memory-limit=unparseable"},
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-lifecycle-sidecar-memory-limit=unparseable"},
 			expErr: "-lifecycle-sidecar-memory-limit 'unparseable' is invalid",
 		},
 		{
-			flags:  []string{"-consul-k8s-image", "foo", "-lifecycle-sidecar-memory-request=unparseable"},
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-lifecycle-sidecar-memory-request=unparseable"},
 			expErr: "-lifecycle-sidecar-memory-request 'unparseable' is invalid",
 		},
 		{
-			flags: []string{"-consul-k8s-image", "foo",
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
 				"-lifecycle-sidecar-memory-request=50Mi",
 				"-lifecycle-sidecar-memory-limit=25Mi",
 			},
 			expErr: "request must be <= limit: -lifecycle-sidecar-memory-request value of \"50Mi\" is greater than the -lifecycle-sidecar-memory-limit value of \"25Mi\"",
 		},
 		{
-			flags: []string{"-consul-k8s-image", "foo",
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
 				"-lifecycle-sidecar-cpu-request=50m",
 				"-lifecycle-sidecar-cpu-limit=25m",
 			},
 			expErr: "request must be <= limit: -lifecycle-sidecar-cpu-request value of \"50m\" is greater than the -lifecycle-sidecar-cpu-limit value of \"25m\"",
 		},
 		{
-			flags: []string{"-consul-k8s-image", "hashicorpdev/consul-k8s:latest",
+			flags:  []string{"-consul-k8s-image", "hashicorpdev/consul-k8s:latest", "-consul-image", "foo", "-envoy-image", "no-tag"},
+			expErr: "envoy image \"no-tag\" has no tag and -envoy-version is not set so unable to determine Envoy version",
+		},
+		{
+			flags:  []string{"-consul-k8s-image", "hashicorpdev/consul-k8s:latest", "-consul-image", "foo", "-envoy-image", "envoy:unparseable"},
+			expErr: "error parsing Envoy version from -envoy-image \"envoy:unparseable\": Malformed version: unparseable; -envoy-version can be set to specify the version",
+		},
+		{
+			flags:  []string{"-consul-k8s-image", "hashicorpdev/consul-k8s:latest", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0", "-envoy-version", "unparseable"},
+			expErr: "error parsing -envoy-version \"unparseable\": Malformed version: unparseable",
+		},
+		{
+			flags: []string{"-consul-k8s-image", "hashicorpdev/consul-k8s:latest", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
 				"-enable-health-checks-controller=true"},
 			expErr: "CONSUL_HTTP_ADDR is not specified",
 		},
@@ -169,7 +203,7 @@ func TestRun_ValidationHealthCheckEnv(t *testing.T) {
 	}{
 		{
 			envVars: []string{api.HTTPAddrEnvName, "0.0.0.0:999999"},
-			flags: []string{"-consul-k8s-image", "hashicorp/consul-k8s",
+			flags: []string{"-consul-k8s-image", "hashicorp/consul-k8s", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
 				"-enable-health-checks-controller=true"},
 			expErr: "Error parsing CONSUL_HTTP_ADDR: parse \"0.0.0.0:999999\": first path segment in URL cannot contain colon",
 		},
@@ -202,7 +236,7 @@ func TestRun_CommandFailsWithInvalidListener(t *testing.T) {
 	}
 	os.Setenv(api.HTTPAddrEnvName, "http://0.0.0.0:9999")
 	code := cmd.Run([]string{
-		"-consul-k8s-image", "hashicorp/consul-k8s",
+		"-consul-k8s-image", "hashicorp/consul-k8s", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
 		"-enable-health-checks-controller=true",
 		"-listen", "999999",
 	})
@@ -235,7 +269,7 @@ func testSignalHandling(sig os.Signal) func(*testing.T) {
 
 		// Start the command asynchronously and then we'll send an interrupt.
 		exitChan := runCommandAsynchronously(&cmd, []string{
-			"-consul-k8s-image", "hashicorp/consul-k8s",
+			"-consul-k8s-image", "hashicorp/consul-k8s", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
 			"-enable-health-checks-controller=true",
 			"-listen", fmt.Sprintf(":%d", ports[0]),
 		})


### PR DESCRIPTION
- Make flags -envoy-image and -consul-image required because the Helm
chart has set them for a number of releases now (-consul-image since 2 years ago and -envoy-image since 9 months ago) and because their
defaults if not set were out of date.
- Try and parse Envoy version from -envoy-image tag, e.g.
  `envoy:1.16.0` will result in `1.16.0`.
- Add new flag -envoy-version that can be used to set the Envoy version
  if it can't be parsed from -envoy-image tag.

How I've tested this PR:
Ran with
```yaml
global:
  imageK8S: "ghcr.io/lkysow/consul-k8s-dev:nov24"
  name: consul
server:
  replicas: 1
  bootstrapExpect: 1
connectInject:
  enabled: true
```
and acceptance tests: https://github.com/hashicorp/consul-helm/pull/706

How I expect reviewers to test this PR:
In addition to the integration tests passing, if you run with this image you'll see the envoy version set in the `bootstrap.yaml` envoy file:
```
k exec static-client -c consul-connect-envoy-sidecar -- cat /consul/connect-inject/envoy-bootstrap.yaml | jq .node.metadata
{
  "namespace": "default",
  "envoy_version": "1.16.0"
}
```


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
