### PR TITLE
fix signal handling for lifecycle sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+BUG FIXES:
+* Connect: on termination of a connect injected pod the lifecycle-sidecar sometimes re-registered the application resulting in
+  stale service entries for applications which no longer existed. [[GH-409](https://github.com/hashicorp/consul-k8s/pull/409/)]
+
 BREAKING CHANGES:
 * Connect: the flags `-envoy-image` and `-consul-image` for command `inject-connect` are now required. [[GH-405](https://github.com/hashicorp/consul-k8s/pull/405)]
 

--- a/subcommand/lifecycle-sidecar/command.go
+++ b/subcommand/lifecycle-sidecar/command.go
@@ -116,13 +116,10 @@ func (c *Command) Run(args []string) int {
 
 		// Run the command and record the stdout and stderr output
 		output, err := cmd.CombinedOutput()
-		// Currently this command is taking >7s, need to investigate
-		logger.Debug("time to run resync:", "time", time.Since(start))
-
 		if err != nil {
-			logger.Error("failed to sync service", "output", strings.TrimSpace(string(output)), "err", err)
+			logger.Error("failed to sync service", "output", strings.TrimSpace(string(output)), "err", err, "duration", time.Since(start))
 		} else {
-			logger.Info("successfully synced service", "output", strings.TrimSpace(string(output)))
+			logger.Info("successfully synced service", "output", strings.TrimSpace(string(output)), "duration", time.Since(start))
 		}
 		select {
 		// Re-loop after syncPeriod or exit if we receive interrupt or terminate signals.

--- a/subcommand/lifecycle-sidecar/command_test.go
+++ b/subcommand/lifecycle-sidecar/command_test.go
@@ -52,6 +52,8 @@ func testRunSignalHandling(sig os.Signal) func(*testing.T) {
 		// Run async because we need to kill it when the test is over.
 		exitChan := runCommandAsynchronously(&cmd, []string{
 			"-service-config", configFile,
+			"-http-addr", a.HTTPAddr,
+			"-sync-period", "1s",
 		})
 		cmd.sendSignal(sig)
 


### PR DESCRIPTION
This fixes issues related to stale service registrations created when pods are terminated, causing services to be registered with no pods backing them. This was caused by a race condition in shutdown logic of the lifecycle-sidecar, so the fix address shutdown path for it.

Changes proposed in this PR:
- move signal handling to a go func in lifecycle sidecar so that it can exit cleanly and avoid race conditions if resync were to take a long time.

How I've tested this PR:
existing unit tests + manual tests

How I expect reviewers to test this PR:
Spin up latest release of consul-k8s and deploy a sample app that is connect injected, it is helpful to see the issue in the UI so enable that as well. Once the app is online delete the application, you can watch the logs of the lifecycle-sidecar for the pod side by side with the agent logs and see that lifecycle sidecar runs a register after the pod de-registers its service, or see that in the UI the service never goes away.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
