### PR TITLE
Give better error when policy was created manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ BUG FIXES:
 * CRDs: Fix issue where a `ServiceIntentions` resource could be continually resynced with Consul
   because Consul's internal representation had a different order for an array than the Kubernetes resource. [[GH-416](https://github.com/hashicorp/consul-k8s/pull/416)] 
 
+IMPROVEMENTS:
+* ACLs: give better error if policy that consul-k8s tries to update was created manually by user. [[GH-412](https://github.com/hashicorp/consul-k8s/pull/412)]
+
 ## 0.22.0 (December 21, 2020)
 
 BUG FIXES:

--- a/subcommand/server-acl-init/create_or_update.go
+++ b/subcommand/server-acl-init/create_or_update.go
@@ -2,7 +2,6 @@ package serveraclinit
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -130,8 +129,13 @@ func (c *Command) createOrUpdateACLPolicy(policy api.ACLPolicy, consulClient *ap
 
 			// This shouldn't happen, because we're looking for a policy
 			// only after we've hit a `Policy already exists` error.
+			// The only time it might happen is if a user has manually created a policy
+			// with this name but used a different description. In this case,
+			// we don't want to overwrite the policy so we just error.
 			if policy.ID == "" {
-				return errors.New("Unable to find existing ACL policy")
+				return fmt.Errorf("policy found with name %q but not with expected description %q; "+
+					"if this policy was created manually it must be renamed to something else because this name is reserved by consul-k8s",
+					policy.Name, policy.Description)
 			}
 
 			// Update the policy now that we've found its ID

--- a/subcommand/server-acl-init/create_or_update_test.go
+++ b/subcommand/server-acl-init/create_or_update_test.go
@@ -33,7 +33,7 @@ func TestCreateOrUpdateACLPolicy_ErrorsIfDescriptionDoesNotMatch(t *testing.T) {
 		c.ACL.Tokens.Master = bootToken
 	})
 	require.NoError(err)
-	svr.WaitForServiceIntentions(t)
+	svr.WaitForLeader(t)
 
 	// Get a Consul client.
 	consul, err := api.NewClient(&api.Config{

--- a/subcommand/server-acl-init/create_or_update_test.go
+++ b/subcommand/server-acl-init/create_or_update_test.go
@@ -1,0 +1,68 @@
+package serveraclinit
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/go-hclog"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// Test that we give an error if an ACL policy we were going to create
+// already exists but it has a different description than what consul-k8s
+// expected. In this case, it's likely that a user manually created an ACL
+// policy with the same name and so we want to error.
+func TestCreateOrUpdateACLPolicy_ErrorsIfDescriptionDoesNotMatch(t *testing.T) {
+	require := require.New(t)
+	ui := cli.NewMockUi()
+	k8s := fake.NewSimpleClientset()
+	cmd := Command{
+		UI:                  ui,
+		clientset:           k8s,
+		log:                 hclog.NewNullLogger(),
+		flagCreateSyncToken: true,
+	}
+
+	// Start Consul.
+	bootToken := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	svr, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
+		c.ACL.Enabled = true
+		c.ACL.Tokens.Master = bootToken
+	})
+	require.NoError(err)
+	svr.WaitForServiceIntentions(t)
+
+	// Get a Consul client.
+	consul, err := api.NewClient(&api.Config{
+		Address: svr.HTTPAddr,
+		Token:   bootToken,
+	})
+	require.NoError(err)
+
+	// Create the policy manually.
+	policyDescription := "not the expected description"
+	policyName := "policy-name"
+	policy, _, err := consul.ACL().PolicyCreate(&api.ACLPolicy{
+		Name:        policyName,
+		Description: policyDescription,
+	}, nil)
+	require.NoError(err)
+
+	// Now run the function.
+	err = cmd.createOrUpdateACLPolicy(api.ACLPolicy{
+		Name:        policyName,
+		Description: "expected description",
+	}, consul)
+	require.EqualError(err,
+		"policy found with name \"policy-name\" but not with expected description \"expected description\";"+
+			" if this policy was created manually it must be renamed to something else because this name is reserved by consul-k8s",
+	)
+
+	// Check that the policy wasn't modified.
+	rereadPolicy, _, err := consul.ACL().PolicyRead(policy.ID, nil)
+	require.NoError(err)
+	require.Equal(policyDescription, rereadPolicy.Description)
+}


### PR DESCRIPTION
In cases where a user creates a policy out-of-band with the same name as
one consul-k8s tries to update, give a better error.

This is definitely an edge case but has occurred when a user created the
cross-namespace-acl-policy manually when trying to work around another
issue. This will at least give a better error message in this case.

How I've tested this PR:
- unit tests

How I expect reviewers to test this PR:
- code

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
