### PR TITLE
Default namespaces for CRDs that support namespace when enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 BUG FIXES:
 * CRDs: Fix issue where a `ServiceIntentions` resource could be continually resynced with Consul
   because Consul's internal representation had a different order for an array than the Kubernetes resource. [[GH-416](https://github.com/hashicorp/consul-k8s/pull/416)] 
-* CRDs: default the `namespace` fields on resources where Consul performs namespace defaulting to prevent constant re-syncing.
+* CRDs: **(Consul Enterprise only)** default the `namespace` fields on resources where Consul performs namespace defaulting to prevent constant re-syncing.
   [[GH-413](https://github.com/hashicorp/consul-k8s/pull/413)]
+
 ## 0.22.0 (December 21, 2020)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 BUG FIXES:
 * CRDs: Fix issue where a `ServiceIntentions` resource could be continually resynced with Consul
   because Consul's internal representation had a different order for an array than the Kubernetes resource. [[GH-416](https://github.com/hashicorp/consul-k8s/pull/416)] 
-
+* CRDs: default the `namespace` fields on resources where Consul performs namespace defaulting to prevent constant re-syncing.
+  [[GH-413](https://github.com/hashicorp/consul-k8s/pull/413)]
 ## 0.22.0 (December 21, 2020)
 
 BUG FIXES:

--- a/api/common/configentry.go
+++ b/api/common/configentry.go
@@ -57,6 +57,7 @@ type ConfigEntryResource interface {
 	DeepCopyObject() runtime.Object
 	// Validate returns an error if the resource is invalid.
 	Validate(namespacesEnabled bool) error
-	// Default sets the namespace field on the config entry spec to their default values if namespaces are enabled.
+	// DefaultNamespaceFields sets Consul namespace fields on the config entry
+	// spec to their default values if namespaces are enabled.
 	DefaultNamespaceFields(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string)
 }

--- a/api/common/configentry.go
+++ b/api/common/configentry.go
@@ -58,5 +58,5 @@ type ConfigEntryResource interface {
 	// Validate returns an error if the resource is invalid.
 	Validate(namespacesEnabled bool) error
 	// Default sets the namespace field on the config entry spec to their default values if namespaces are enabled.
-	Default(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string)
+	DefaultNamespaceFields(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string)
 }

--- a/api/common/configentry.go
+++ b/api/common/configentry.go
@@ -57,4 +57,6 @@ type ConfigEntryResource interface {
 	DeepCopyObject() runtime.Object
 	// Validate returns an error if the resource is invalid.
 	Validate(namespacesEnabled bool) error
+	// Default sets the namespace field on the config entry spec to their default values if namespaces are enabled.
+	Default(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string)
 }

--- a/api/common/configentry_webhook.go
+++ b/api/common/configentry_webhook.go
@@ -34,7 +34,7 @@ func ValidateConfigEntry(
 	consulDestinationNamespace string,
 	nsMirroringPrefix string) admission.Response {
 
-	defaultingPatches, err := defaultingPatches(cfgEntry, enableConsulNamespaces, nsMirroring, consulDestinationNamespace, nsMirroringPrefix)
+	defaultingPatches, err := DefaultingPatches(cfgEntry, enableConsulNamespaces, nsMirroring, consulDestinationNamespace, nsMirroringPrefix)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
@@ -67,9 +67,9 @@ func ValidateConfigEntry(
 	return admission.Patched(fmt.Sprintf("valid %s request", cfgEntry.KubeKind()), defaultingPatches...)
 }
 
-// defaultingPatches returns the patches needed to set fields to their
+// DefaultingPatches returns the patches needed to set fields to their
 // defaults.
-func defaultingPatches(cfgEntry ConfigEntryResource, enableConsulNamespaces bool, nsMirroring bool, consulDestinationNamespace string, nsMirroringPrefix string) ([]jsonpatch.Operation, error) {
+func DefaultingPatches(cfgEntry ConfigEntryResource, enableConsulNamespaces bool, nsMirroring bool, consulDestinationNamespace string, nsMirroringPrefix string) ([]jsonpatch.Operation, error) {
 	beforeDefaulting, err := json.Marshal(cfgEntry)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling input: %s", err)

--- a/api/common/configentry_webhook.go
+++ b/api/common/configentry_webhook.go
@@ -69,13 +69,13 @@ func ValidateConfigEntry(
 
 // defaultingPatches returns the patches needed to set fields to their
 // defaults.
-func defaultingPatches(svcIntentions ConfigEntryResource, enableConsulNamespaces bool, nsMirroring bool, consulDestinationNamespace string, nsMirroringPrefix string) ([]jsonpatch.Operation, error) {
-	beforeDefaulting, err := json.Marshal(svcIntentions)
+func defaultingPatches(cfgEntry ConfigEntryResource, enableConsulNamespaces bool, nsMirroring bool, consulDestinationNamespace string, nsMirroringPrefix string) ([]jsonpatch.Operation, error) {
+	beforeDefaulting, err := json.Marshal(cfgEntry)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling input: %s", err)
 	}
-	svcIntentions.Default(enableConsulNamespaces, consulDestinationNamespace, nsMirroring, nsMirroringPrefix)
-	afterDefaulting, err := json.Marshal(svcIntentions)
+	cfgEntry.DefaultNamespaceFields(enableConsulNamespaces, consulDestinationNamespace, nsMirroring, nsMirroringPrefix)
+	afterDefaulting, err := json.Marshal(cfgEntry)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling after defaulting: %s", err)
 	}

--- a/api/common/configentry_webhook.go
+++ b/api/common/configentry_webhook.go
@@ -2,10 +2,12 @@ package common
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/go-logr/logr"
+	"gomodules.xyz/jsonpatch/v2"
 	"k8s.io/api/admission/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -28,8 +30,14 @@ func ValidateConfigEntry(
 	configEntryLister ConfigEntryLister,
 	cfgEntry ConfigEntryResource,
 	enableConsulNamespaces bool,
-	nsMirroring bool) admission.Response {
+	nsMirroring bool,
+	consulDestinationNamespace string,
+	nsMirroringPrefix string) admission.Response {
 
+	defaultingPatches, err := defaultingPatches(cfgEntry, enableConsulNamespaces, nsMirroring, consulDestinationNamespace, nsMirroringPrefix)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
 	// On create we need to validate that there isn't already a resource with
 	// the same name in a different namespace if we're need to mapping all Kube
 	// resources to a single Consul namespace. The only case where we're not
@@ -56,5 +64,25 @@ func ValidateConfigEntry(
 	if err := cfgEntry.Validate(enableConsulNamespaces); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	return admission.Allowed(fmt.Sprintf("valid %s request", cfgEntry.KubeKind()))
+	return admission.Patched(fmt.Sprintf("valid %s request", cfgEntry.KubeKind()), defaultingPatches...)
+}
+
+// defaultingPatches returns the patches needed to set fields to their
+// defaults.
+func defaultingPatches(svcIntentions ConfigEntryResource, enableConsulNamespaces bool, nsMirroring bool, consulDestinationNamespace string, nsMirroringPrefix string) ([]jsonpatch.Operation, error) {
+	beforeDefaulting, err := json.Marshal(svcIntentions)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling input: %s", err)
+	}
+	svcIntentions.Default(enableConsulNamespaces, consulDestinationNamespace, nsMirroring, nsMirroringPrefix)
+	afterDefaulting, err := json.Marshal(svcIntentions)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling after defaulting: %s", err)
+	}
+
+	defaultingPatches, err := jsonpatch.CreatePatch(beforeDefaulting, afterDefaulting)
+	if err != nil {
+		return nil, fmt.Errorf("creating patches: %s", err)
+	}
+	return defaultingPatches, nil
 }

--- a/api/common/configentry_webhook_test.go
+++ b/api/common/configentry_webhook_test.go
@@ -204,7 +204,7 @@ func (in *mockConfigEntry) Validate(bool) error {
 	return nil
 }
 
-func (in *mockConfigEntry) Default(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
+func (in *mockConfigEntry) DefaultNamespaceFields(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
 }
 
 func (in *mockConfigEntry) MatchesConsul(_ capi.ConfigEntry) bool {

--- a/api/common/configentry_webhook_test.go
+++ b/api/common/configentry_webhook_test.go
@@ -21,12 +21,14 @@ func TestValidateConfigEntry(t *testing.T) {
 	otherNS := "other"
 
 	cases := map[string]struct {
-		existingResources []ConfigEntryResource
-		newResource       ConfigEntryResource
-		enableNamespaces  bool
-		nsMirroring       bool
-		expAllow          bool
-		expErrMessage     string
+		existingResources   []ConfigEntryResource
+		newResource         ConfigEntryResource
+		enableNamespaces    bool
+		nsMirroring         bool
+		consulDestinationNS string
+		nsMirroringPrefix   string
+		expAllow            bool
+		expErrMessage       string
 	}{
 		"no duplicates, valid": {
 			existingResources: nil,
@@ -112,7 +114,9 @@ func TestValidateConfigEntry(t *testing.T) {
 				lister,
 				c.newResource,
 				c.enableNamespaces,
-				c.nsMirroring)
+				c.nsMirroring,
+				c.consulDestinationNS,
+				c.nsMirroringPrefix)
 			require.Equal(t, c.expAllow, response.Allowed)
 			if c.expErrMessage != "" {
 				require.Equal(t, c.expErrMessage, response.AdmissionResponse.Result.Message)
@@ -198,6 +202,9 @@ func (in *mockConfigEntry) Validate(bool) error {
 		return errors.New("invalid")
 	}
 	return nil
+}
+
+func (in *mockConfigEntry) Default(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
 }
 
 func (in *mockConfigEntry) MatchesConsul(_ capi.ConfigEntry) bool {

--- a/api/v1alpha1/ingressgateway_types.go
+++ b/api/v1alpha1/ingressgateway_types.go
@@ -233,6 +233,7 @@ func (in *IngressGateway) DefaultNamespaceFields(consulNamespacesEnabled bool, d
 	// namespace fields because this would cause errors
 	// making API calls (because namespace fields can't be set in OSS).
 	if consulNamespacesEnabled {
+		// Default to the current namespace (i.e. the namespace of the config entry).
 		namespace := namespaces.ConsulNamespace(in.Namespace, consulNamespacesEnabled, destinationNamespace, mirroring, prefix)
 		for i, listener := range in.Spec.Listeners {
 			for j, service := range listener.Services {

--- a/api/v1alpha1/ingressgateway_types.go
+++ b/api/v1alpha1/ingressgateway_types.go
@@ -226,7 +226,7 @@ func (in *IngressGateway) Validate(namespacesEnabled bool) error {
 	return nil
 }
 
-func (in *IngressGateway) Default(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
+func (in *IngressGateway) DefaultNamespaceFields(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
 	// If namespaces are enabled we want to set the namespace fields to it's
 	// default. If namespaces are not enabled (i.e. OSS) we don't set the
 	// namespace fields because this would cause errors

--- a/api/v1alpha1/ingressgateway_types.go
+++ b/api/v1alpha1/ingressgateway_types.go
@@ -226,9 +226,10 @@ func (in *IngressGateway) Validate(namespacesEnabled bool) error {
 	return nil
 }
 
+// DefaultNamespaceFields sets the namespace field on spec.listeners[].services to their default values if namespaces are enabled.
 func (in *IngressGateway) DefaultNamespaceFields(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
-	// If namespaces are enabled we want to set the namespace fields to it's
-	// default. If namespaces are not enabled (i.e. OSS) we don't set the
+	// If namespaces are enabled we want to set the namespace fields to their
+	// defaults. If namespaces are not enabled (i.e. OSS) we don't set the
 	// namespace fields because this would cause errors
 	// making API calls (because namespace fields can't be set in OSS).
 	if consulNamespacesEnabled {

--- a/api/v1alpha1/ingressgateway_types.go
+++ b/api/v1alpha1/ingressgateway_types.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/consul-k8s/namespaces"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -223,6 +224,23 @@ func (in *IngressGateway) Validate(namespacesEnabled bool) error {
 			in.KubernetesName(), errs)
 	}
 	return nil
+}
+
+func (in *IngressGateway) Default(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
+	// If namespaces are enabled we want to set the namespace fields to it's
+	// default. If namespaces are not enabled (i.e. OSS) we don't set the
+	// namespace fields because this would cause errors
+	// making API calls (because namespace fields can't be set in OSS).
+	if consulNamespacesEnabled {
+		namespace := namespaces.ConsulNamespace(in.Namespace, consulNamespacesEnabled, destinationNamespace, mirroring, prefix)
+		for i, listener := range in.Spec.Listeners {
+			for j, service := range listener.Services {
+				if service.Namespace == "" {
+					in.Spec.Listeners[i].Services[j].Namespace = namespace
+				}
+			}
+		}
+	}
 }
 
 func (in GatewayTLSConfig) toConsul() capi.GatewayTLSConfig {

--- a/api/v1alpha1/ingressgateway_types_test.go
+++ b/api/v1alpha1/ingressgateway_types_test.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/consul-k8s/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
@@ -455,6 +456,91 @@ func TestIngressGateway_Validate(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+// Test defaulting behavior when namespaces are enabled as well as disabled.
+func TestIngressGateway_Default(t *testing.T) {
+	namespaceConfig := map[string]struct {
+		enabled              bool
+		destinationNamespace string
+		mirroring            bool
+		prefix               string
+		expectedDestination  string
+	}{
+		"disabled": {
+			enabled:              false,
+			destinationNamespace: "",
+			mirroring:            false,
+			prefix:               "",
+			expectedDestination:  "",
+		},
+		"destinationNS": {
+			enabled:              true,
+			destinationNamespace: "foo",
+			mirroring:            false,
+			prefix:               "",
+			expectedDestination:  "foo",
+		},
+		"mirroringEnabledWithoutPrefix": {
+			enabled:              true,
+			destinationNamespace: "",
+			mirroring:            true,
+			prefix:               "",
+			expectedDestination:  "bar",
+		},
+		"mirroringWithPrefix": {
+			enabled:              true,
+			destinationNamespace: "",
+			mirroring:            true,
+			prefix:               "ns-",
+			expectedDestination:  "ns-bar",
+		},
+	}
+
+	for name, s := range namespaceConfig {
+		input := &IngressGateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: IngressGatewaySpec{
+				Listeners: []IngressListener{
+					{
+						Protocol: "tcp",
+						Services: []IngressService{
+							{
+								Name: "name",
+							},
+						},
+					},
+				},
+			},
+		}
+		output := &IngressGateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: IngressGatewaySpec{
+				Listeners: []IngressListener{
+					{
+						Protocol: "tcp",
+						Services: []IngressService{
+							{
+								Name:      "name",
+								Namespace: s.expectedDestination,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		t.Run(name, func(t *testing.T) {
+			input.Default(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
+			require.True(t, cmp.Equal(input, output))
 		})
 	}
 }

--- a/api/v1alpha1/ingressgateway_types_test.go
+++ b/api/v1alpha1/ingressgateway_types_test.go
@@ -514,6 +514,10 @@ func TestIngressGateway_DefaultNamespaceFields(t *testing.T) {
 								{
 									Name: "name",
 								},
+								{
+									Name:      "other-name",
+									Namespace: "other",
+								},
 							},
 						},
 					},
@@ -532,6 +536,10 @@ func TestIngressGateway_DefaultNamespaceFields(t *testing.T) {
 								{
 									Name:      "name",
 									Namespace: s.expectedDestination,
+								},
+								{
+									Name:      "other-name",
+									Namespace: "other",
 								},
 							},
 						},

--- a/api/v1alpha1/ingressgateway_types_test.go
+++ b/api/v1alpha1/ingressgateway_types_test.go
@@ -539,7 +539,7 @@ func TestIngressGateway_Default(t *testing.T) {
 		}
 
 		t.Run(name, func(t *testing.T) {
-			input.Default(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
+			input.DefaultNamespaceFields(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
 			require.True(t, cmp.Equal(input, output))
 		})
 	}

--- a/api/v1alpha1/ingressgateway_types_test.go
+++ b/api/v1alpha1/ingressgateway_types_test.go
@@ -461,7 +461,7 @@ func TestIngressGateway_Validate(t *testing.T) {
 }
 
 // Test defaulting behavior when namespaces are enabled as well as disabled.
-func TestIngressGateway_Default(t *testing.T) {
+func TestIngressGateway_DefaultNamespaceFields(t *testing.T) {
 	namespaceConfig := map[string]struct {
 		enabled              bool
 		destinationNamespace string
@@ -500,45 +500,44 @@ func TestIngressGateway_Default(t *testing.T) {
 	}
 
 	for name, s := range namespaceConfig {
-		input := &IngressGateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: IngressGatewaySpec{
-				Listeners: []IngressListener{
-					{
-						Protocol: "tcp",
-						Services: []IngressService{
-							{
-								Name: "name",
-							},
-						},
-					},
-				},
-			},
-		}
-		output := &IngressGateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: IngressGatewaySpec{
-				Listeners: []IngressListener{
-					{
-						Protocol: "tcp",
-						Services: []IngressService{
-							{
-								Name:      "name",
-								Namespace: s.expectedDestination,
-							},
-						},
-					},
-				},
-			},
-		}
-
 		t.Run(name, func(t *testing.T) {
+			input := &IngressGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: IngressGatewaySpec{
+					Listeners: []IngressListener{
+						{
+							Protocol: "tcp",
+							Services: []IngressService{
+								{
+									Name: "name",
+								},
+							},
+						},
+					},
+				},
+			}
+			output := &IngressGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: IngressGatewaySpec{
+					Listeners: []IngressListener{
+						{
+							Protocol: "tcp",
+							Services: []IngressService{
+								{
+									Name:      "name",
+									Namespace: s.expectedDestination,
+								},
+							},
+						},
+					},
+				},
+			}
 			input.DefaultNamespaceFields(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
 			require.True(t, cmp.Equal(input, output))
 		})

--- a/api/v1alpha1/ingressgateway_webhook.go
+++ b/api/v1alpha1/ingressgateway_webhook.go
@@ -26,8 +26,17 @@ type IngressGatewayWebhook struct {
 	// be created in the matching Consul namespace.
 	EnableNSMirroring bool
 
+	// ConsulDestinationNamespace is the namespace in Consul that the config entry created
+	// in k8s will get mapped into. If the Consul namespace does not already exist, it will
+	// be created.
 	ConsulDestinationNamespace string
-	NSMirroringPrefix          string
+
+	// NSMirroringPrefix works in conjunction with Namespace Mirroring.
+	// It is the prefix added to the Consul namespace to map to a specific.
+	// k8s namespace. For example, if `mirroringK8SPrefix` is set to "k8s-", a
+	// service in the k8s `staging` namespace will be registered into the
+	// `k8s-staging` Consul namespace.
+	NSMirroringPrefix string
 
 	decoder *admission.Decoder
 	client.Client

--- a/api/v1alpha1/ingressgateway_webhook.go
+++ b/api/v1alpha1/ingressgateway_webhook.go
@@ -26,6 +26,9 @@ type IngressGatewayWebhook struct {
 	// be created in the matching Consul namespace.
 	EnableNSMirroring bool
 
+	ConsulDestinationNamespace string
+	NSMirroringPrefix          string
+
 	decoder *admission.Decoder
 	client.Client
 }
@@ -51,7 +54,9 @@ func (v *IngressGatewayWebhook) Handle(ctx context.Context, req admission.Reques
 		v,
 		&resource,
 		v.EnableConsulNamespaces,
-		v.EnableNSMirroring)
+		v.EnableNSMirroring,
+		v.ConsulDestinationNamespace,
+		v.NSMirroringPrefix)
 }
 
 func (v *IngressGatewayWebhook) List(ctx context.Context) ([]common.ConfigEntryResource, error) {

--- a/api/v1alpha1/proxydefaults_types.go
+++ b/api/v1alpha1/proxydefaults_types.go
@@ -176,6 +176,11 @@ func (in *ProxyDefaults) Validate(namespacesEnabled bool) error {
 	return nil
 }
 
+// Default has no behaviour here as proxy-defaults have no namespace specific fields.
+func (in *ProxyDefaults) Default(_ bool, _ string, _ bool, _ string) {
+	return
+}
+
 // convertConfig converts the config of type json.RawMessage which is stored
 // by the resource into type map[string]interface{} which is saved by the
 // consul API.

--- a/api/v1alpha1/proxydefaults_types.go
+++ b/api/v1alpha1/proxydefaults_types.go
@@ -176,7 +176,7 @@ func (in *ProxyDefaults) Validate(namespacesEnabled bool) error {
 	return nil
 }
 
-// Default has no behaviour here as proxy-defaults have no namespace specific fields.
+// DefaultNamespaceFields has no behaviour here as proxy-defaults have no namespace specific fields.
 func (in *ProxyDefaults) DefaultNamespaceFields(_ bool, _ string, _ bool, _ string) {
 	return
 }

--- a/api/v1alpha1/proxydefaults_types.go
+++ b/api/v1alpha1/proxydefaults_types.go
@@ -177,7 +177,7 @@ func (in *ProxyDefaults) Validate(namespacesEnabled bool) error {
 }
 
 // Default has no behaviour here as proxy-defaults have no namespace specific fields.
-func (in *ProxyDefaults) Default(_ bool, _ string, _ bool, _ string) {
+func (in *ProxyDefaults) DefaultNamespaceFields(_ bool, _ string, _ bool, _ string) {
 	return
 }
 

--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -186,7 +186,7 @@ func (in *ServiceDefaults) Validate(namespacesEnabled bool) error {
 }
 
 // Default has no behaviour here as service-defaults have no namespace specific fields.
-func (in *ServiceDefaults) Default(_ bool, _ string, _ bool, _ string) {
+func (in *ServiceDefaults) DefaultNamespaceFields(_ bool, _ string, _ bool, _ string) {
 	return
 }
 

--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -185,6 +185,11 @@ func (in *ServiceDefaults) Validate(namespacesEnabled bool) error {
 	return nil
 }
 
+// Default has no behaviour here as service-defaults have no namespace specific fields.
+func (in *ServiceDefaults) Default(_ bool, _ string, _ bool, _ string) {
+	return
+}
+
 // MatchesConsul returns true if entry has the same config as this struct.
 func (in *ServiceDefaults) MatchesConsul(candidate capi.ConfigEntry) bool {
 	configEntry, ok := candidate.(*capi.ServiceConfigEntry)

--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -185,7 +185,7 @@ func (in *ServiceDefaults) Validate(namespacesEnabled bool) error {
 	return nil
 }
 
-// Default has no behaviour here as service-defaults have no namespace specific fields.
+// DefaultNamespaceFields has no behaviour here as service-defaults have no namespace specific fields.
 func (in *ServiceDefaults) DefaultNamespaceFields(_ bool, _ string, _ bool, _ string) {
 	return
 }

--- a/api/v1alpha1/servicedefaults_webhook.go
+++ b/api/v1alpha1/servicedefaults_webhook.go
@@ -26,6 +26,9 @@ type ServiceDefaultsWebhook struct {
 	// be created in the matching Consul namespace.
 	EnableNSMirroring bool
 
+	ConsulDestinationNamespace string
+	NSMirroringPrefix          string
+
 	decoder *admission.Decoder
 	client.Client
 }
@@ -51,7 +54,9 @@ func (v *ServiceDefaultsWebhook) Handle(ctx context.Context, req admission.Reque
 		v,
 		&svcDefaults,
 		v.EnableConsulNamespaces,
-		v.EnableNSMirroring)
+		v.EnableNSMirroring,
+		v.ConsulDestinationNamespace,
+		v.NSMirroringPrefix)
 }
 
 func (v *ServiceDefaultsWebhook) List(ctx context.Context) ([]common.ConfigEntryResource, error) {

--- a/api/v1alpha1/servicedefaults_webhook.go
+++ b/api/v1alpha1/servicedefaults_webhook.go
@@ -26,8 +26,17 @@ type ServiceDefaultsWebhook struct {
 	// be created in the matching Consul namespace.
 	EnableNSMirroring bool
 
+	// ConsulDestinationNamespace is the namespace in Consul that the config entry created
+	// in k8s will get mapped into. If the Consul namespace does not already exist, it will
+	// be created.
 	ConsulDestinationNamespace string
-	NSMirroringPrefix          string
+
+	// NSMirroringPrefix works in conjunction with Namespace Mirroring.
+	// It is the prefix added to the Consul namespace to map to a specific.
+	// k8s namespace. For example, if `mirroringK8SPrefix` is set to "k8s-", a
+	// service in the k8s `staging` namespace will be registered into the
+	// `k8s-staging` Consul namespace.
+	NSMirroringPrefix string
 
 	decoder *admission.Decoder
 	client.Client

--- a/api/v1alpha1/serviceintentions_types.go
+++ b/api/v1alpha1/serviceintentions_types.go
@@ -271,7 +271,7 @@ func (in *ServiceIntentions) Validate(namespacesEnabled bool) error {
 	return nil
 }
 
-// Default sets the namespace field on spec.destination to their default values if namespaces are enabled.
+// DefaultNamespaceFields sets the namespace field on spec.destination to their default values if namespaces are enabled.
 func (in *ServiceIntentions) DefaultNamespaceFields(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
 	// If namespaces are enabled we want to set the destination namespace field to it's
 	// default. If namespaces are not enabled (i.e. OSS) we don't set the

--- a/api/v1alpha1/serviceintentions_types.go
+++ b/api/v1alpha1/serviceintentions_types.go
@@ -278,6 +278,7 @@ func (in *ServiceIntentions) DefaultNamespaceFields(consulNamespacesEnabled bool
 	// namespace fields because this would cause errors
 	// making API calls (because namespace fields can't be set in OSS).
 	if consulNamespacesEnabled {
+		// Default to the current namespace (i.e. the namespace of the config entry).
 		namespace := namespaces.ConsulNamespace(in.Namespace, consulNamespacesEnabled, destinationNamespace, mirroring, prefix)
 		if in.Spec.Destination.Namespace == "" {
 			in.Spec.Destination.Namespace = namespace

--- a/api/v1alpha1/serviceintentions_types.go
+++ b/api/v1alpha1/serviceintentions_types.go
@@ -272,7 +272,7 @@ func (in *ServiceIntentions) Validate(namespacesEnabled bool) error {
 }
 
 // Default sets the namespace field on spec.destination to their default values if namespaces are enabled.
-func (in *ServiceIntentions) Default(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
+func (in *ServiceIntentions) DefaultNamespaceFields(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
 	// If namespaces are enabled we want to set the destination namespace field to it's
 	// default. If namespaces are not enabled (i.e. OSS) we don't set the
 	// namespace fields because this would cause errors

--- a/api/v1alpha1/serviceintentions_types_test.go
+++ b/api/v1alpha1/serviceintentions_types_test.go
@@ -503,7 +503,7 @@ func TestServiceIntentions_ObjectMeta(t *testing.T) {
 }
 
 // Test defaulting behavior when namespaces are enabled as well as disabled.
-func TestServiceIntentions_Default(t *testing.T) {
+func TestServiceIntentions_DefaultNamespaceFields(t *testing.T) {
 	namespaceConfig := map[string]struct {
 		enabled              bool
 		destinationNamespace string
@@ -542,31 +542,30 @@ func TestServiceIntentions_Default(t *testing.T) {
 	}
 
 	for name, s := range namespaceConfig {
-		input := &ServiceIntentions{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: ServiceIntentionsSpec{
-				Destination: Destination{
-					Name: "bar",
-				},
-			},
-		}
-		output := &ServiceIntentions{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: ServiceIntentionsSpec{
-				Destination: Destination{
-					Name:      "bar",
-					Namespace: s.expectedDestination,
-				},
-			},
-		}
-
 		t.Run(name, func(t *testing.T) {
+			input := &ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: Destination{
+						Name: "bar",
+					},
+				},
+			}
+			output := &ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: Destination{
+						Name:      "bar",
+						Namespace: s.expectedDestination,
+					},
+				},
+			}
 			input.DefaultNamespaceFields(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
 			require.True(t, cmp.Equal(input, output))
 		})

--- a/api/v1alpha1/serviceintentions_types_test.go
+++ b/api/v1alpha1/serviceintentions_types_test.go
@@ -567,7 +567,7 @@ func TestServiceIntentions_Default(t *testing.T) {
 		}
 
 		t.Run(name, func(t *testing.T) {
-			input.Default(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
+			input.DefaultNamespaceFields(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
 			require.True(t, cmp.Equal(input, output))
 		})
 	}

--- a/api/v1alpha1/serviceintentions_webhook.go
+++ b/api/v1alpha1/serviceintentions_webhook.go
@@ -112,7 +112,7 @@ func (v *ServiceIntentionsWebhook) defaultingPatches(err error, svcIntentions *S
 	if err != nil {
 		return nil, fmt.Errorf("marshalling input: %s", err)
 	}
-	svcIntentions.Default(v.EnableConsulNamespaces, v.ConsulDestinationNamespace, v.EnableNSMirroring, v.NSMirroringPrefix)
+	svcIntentions.DefaultNamespaceFields(v.EnableConsulNamespaces, v.ConsulDestinationNamespace, v.EnableNSMirroring, v.NSMirroringPrefix)
 	afterDefaulting, err := json.Marshal(svcIntentions)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling after defaulting: %s", err)

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -306,6 +306,8 @@ func (in *ServiceResolver) Validate(namespacesEnabled bool) error {
 	return nil
 }
 
+// DefaultNamespaceFields has no behaviour here as service-resolver have namespace fields
+// that do not default.
 func (in *ServiceResolver) DefaultNamespaceFields(_ bool, _ string, _ bool, _ string) {
 }
 

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/consul-k8s/namespaces"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -307,26 +306,7 @@ func (in *ServiceResolver) Validate(namespacesEnabled bool) error {
 	return nil
 }
 
-func (in *ServiceResolver) Default(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
-	// If namespaces are enabled we want to set the namespaces field to it's
-	// default. If namespaces are not enabled (i.e. OSS) we don't set the
-	// namespace fields because this would cause errors
-	// making API calls (because namespace fields can't be set in OSS).
-	if consulNamespacesEnabled {
-		namespace := namespaces.ConsulNamespace(in.Namespace, consulNamespacesEnabled, destinationNamespace, mirroring, prefix)
-		if in.Spec.Redirect != nil {
-			if in.Spec.Redirect.Namespace == "" {
-				in.Spec.Redirect.Namespace = namespace
-			}
-		}
-		for k, v := range in.Spec.Failover {
-			if v.Namespace == "" {
-				failover := in.Spec.Failover[k]
-				failover.Namespace = namespace
-				in.Spec.Failover[k] = failover
-			}
-		}
-	}
+func (in *ServiceResolver) DefaultNamespaceFields(_ bool, _ string, _ bool, _ string) {
 }
 
 func (in ServiceResolverSubsetMap) toConsul() map[string]capi.ServiceResolverSubset {

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -309,6 +309,7 @@ func (in *ServiceResolver) Validate(namespacesEnabled bool) error {
 // DefaultNamespaceFields has no behaviour here as service-resolver have namespace fields
 // that do not default.
 func (in *ServiceResolver) DefaultNamespaceFields(_ bool, _ string, _ bool, _ string) {
+	return
 }
 
 func (in ServiceResolverSubsetMap) toConsul() map[string]capi.ServiceResolverSubset {

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/consul-k8s/namespaces"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -304,6 +305,28 @@ func (in *ServiceResolver) Validate(namespacesEnabled bool) error {
 			in.KubernetesName(), errs)
 	}
 	return nil
+}
+
+func (in *ServiceResolver) Default(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
+	// If namespaces are enabled we want to set the namespaces field to it's
+	// default. If namespaces are not enabled (i.e. OSS) we don't set the
+	// namespace fields because this would cause errors
+	// making API calls (because namespace fields can't be set in OSS).
+	if consulNamespacesEnabled {
+		namespace := namespaces.ConsulNamespace(in.Namespace, consulNamespacesEnabled, destinationNamespace, mirroring, prefix)
+		if in.Spec.Redirect != nil {
+			if in.Spec.Redirect.Namespace == "" {
+				in.Spec.Redirect.Namespace = namespace
+			}
+		}
+		for k, v := range in.Spec.Failover {
+			if v.Namespace == "" {
+				failover := in.Spec.Failover[k]
+				failover.Namespace = namespace
+				in.Spec.Failover[k] = failover
+			}
+		}
+	}
 }
 
 func (in ServiceResolverSubsetMap) toConsul() map[string]capi.ServiceResolverSubset {

--- a/api/v1alpha1/serviceresolver_types_test.go
+++ b/api/v1alpha1/serviceresolver_types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/consul-k8s/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
@@ -650,6 +651,88 @@ func TestServiceResolver_Validate(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+// Test defaulting behavior when namespaces are enabled as well as disabled.
+func TestServiceResolver_Default(t *testing.T) {
+	namespaceConfig := map[string]struct {
+		enabled              bool
+		destinationNamespace string
+		mirroring            bool
+		prefix               string
+		expectedDestination  string
+	}{
+		"disabled": {
+			enabled:              false,
+			destinationNamespace: "",
+			mirroring:            false,
+			prefix:               "",
+			expectedDestination:  "",
+		},
+		"destinationNS": {
+			enabled:              true,
+			destinationNamespace: "foo",
+			mirroring:            false,
+			prefix:               "",
+			expectedDestination:  "foo",
+		},
+		"mirroringEnabledWithoutPrefix": {
+			enabled:              true,
+			destinationNamespace: "",
+			mirroring:            true,
+			prefix:               "",
+			expectedDestination:  "bar",
+		},
+		"mirroringWithPrefix": {
+			enabled:              true,
+			destinationNamespace: "",
+			mirroring:            true,
+			prefix:               "ns-",
+			expectedDestination:  "ns-bar",
+		},
+	}
+
+	for name, s := range namespaceConfig {
+		input := &ServiceResolver{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: ServiceResolverSpec{
+				Redirect: &ServiceResolverRedirect{
+					Service: "bar",
+				},
+				Failover: map[string]ServiceResolverFailover{
+					"failA": {
+						Service: "baz",
+					},
+				},
+			},
+		}
+		output := &ServiceResolver{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: ServiceResolverSpec{
+				Redirect: &ServiceResolverRedirect{
+					Service:   "bar",
+					Namespace: s.expectedDestination,
+				},
+				Failover: map[string]ServiceResolverFailover{
+					"failA": {
+						Service:   "baz",
+						Namespace: s.expectedDestination,
+					},
+				},
+			},
+		}
+
+		t.Run(name, func(t *testing.T) {
+			input.Default(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
+			require.True(t, cmp.Equal(input, output))
 		})
 	}
 }

--- a/api/v1alpha1/serviceresolver_types_test.go
+++ b/api/v1alpha1/serviceresolver_types_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/consul-k8s/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
@@ -651,88 +650,6 @@ func TestServiceResolver_Validate(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-		})
-	}
-}
-
-// Test defaulting behavior when namespaces are enabled as well as disabled.
-func TestServiceResolver_Default(t *testing.T) {
-	namespaceConfig := map[string]struct {
-		enabled              bool
-		destinationNamespace string
-		mirroring            bool
-		prefix               string
-		expectedDestination  string
-	}{
-		"disabled": {
-			enabled:              false,
-			destinationNamespace: "",
-			mirroring:            false,
-			prefix:               "",
-			expectedDestination:  "",
-		},
-		"destinationNS": {
-			enabled:              true,
-			destinationNamespace: "foo",
-			mirroring:            false,
-			prefix:               "",
-			expectedDestination:  "foo",
-		},
-		"mirroringEnabledWithoutPrefix": {
-			enabled:              true,
-			destinationNamespace: "",
-			mirroring:            true,
-			prefix:               "",
-			expectedDestination:  "bar",
-		},
-		"mirroringWithPrefix": {
-			enabled:              true,
-			destinationNamespace: "",
-			mirroring:            true,
-			prefix:               "ns-",
-			expectedDestination:  "ns-bar",
-		},
-	}
-
-	for name, s := range namespaceConfig {
-		input := &ServiceResolver{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: ServiceResolverSpec{
-				Redirect: &ServiceResolverRedirect{
-					Service: "bar",
-				},
-				Failover: map[string]ServiceResolverFailover{
-					"failA": {
-						Service: "baz",
-					},
-				},
-			},
-		}
-		output := &ServiceResolver{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: ServiceResolverSpec{
-				Redirect: &ServiceResolverRedirect{
-					Service:   "bar",
-					Namespace: s.expectedDestination,
-				},
-				Failover: map[string]ServiceResolverFailover{
-					"failA": {
-						Service:   "baz",
-						Namespace: s.expectedDestination,
-					},
-				},
-			},
-		}
-
-		t.Run(name, func(t *testing.T) {
-			input.Default(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
-			require.True(t, cmp.Equal(input, output))
 		})
 	}
 }

--- a/api/v1alpha1/serviceresolver_webhook.go
+++ b/api/v1alpha1/serviceresolver_webhook.go
@@ -26,6 +26,9 @@ type ServiceResolverWebhook struct {
 	// be created in the matching Consul namespace.
 	EnableNSMirroring bool
 
+	ConsulDestinationNamespace string
+	NSMirroringPrefix          string
+
 	decoder *admission.Decoder
 	client.Client
 }
@@ -51,7 +54,9 @@ func (v *ServiceResolverWebhook) Handle(ctx context.Context, req admission.Reque
 		v,
 		&svcResolver,
 		v.EnableConsulNamespaces,
-		v.EnableNSMirroring)
+		v.EnableNSMirroring,
+		v.ConsulDestinationNamespace,
+		v.NSMirroringPrefix)
 }
 
 func (v *ServiceResolverWebhook) List(ctx context.Context) ([]common.ConfigEntryResource, error) {

--- a/api/v1alpha1/serviceresolver_webhook.go
+++ b/api/v1alpha1/serviceresolver_webhook.go
@@ -26,8 +26,17 @@ type ServiceResolverWebhook struct {
 	// be created in the matching Consul namespace.
 	EnableNSMirroring bool
 
+	// ConsulDestinationNamespace is the namespace in Consul that the config entry created
+	// in k8s will get mapped into. If the Consul namespace does not already exist, it will
+	// be created.
 	ConsulDestinationNamespace string
-	NSMirroringPrefix          string
+
+	// NSMirroringPrefix works in conjunction with Namespace Mirroring.
+	// It is the prefix added to the Consul namespace to map to a specific.
+	// k8s namespace. For example, if `mirroringK8SPrefix` is set to "k8s-", a
+	// service in the k8s `staging` namespace will be registered into the
+	// `k8s-staging` Consul namespace.
+	NSMirroringPrefix string
 
 	decoder *admission.Decoder
 	client.Client

--- a/api/v1alpha1/servicerouter_types.go
+++ b/api/v1alpha1/servicerouter_types.go
@@ -256,9 +256,10 @@ func (in *ServiceRouter) Validate(namespacesEnabled bool) error {
 	return nil
 }
 
+// DefaultNamespaceFields sets the namespace field on spec.routes[].destination to their default values if namespaces are enabled.
 func (in *ServiceRouter) DefaultNamespaceFields(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
-	// If namespaces are enabled we want to set the namespace fields to it's
-	// default. If namespaces are not enabled (i.e. OSS) we don't set the
+	// If namespaces are enabled we want to set the namespace fields to their
+	// defaults. If namespaces are not enabled (i.e. OSS) we don't set the
 	// namespace fields because this would cause errors
 	// making API calls (because namespace fields can't be set in OSS).
 	if consulNamespacesEnabled {

--- a/api/v1alpha1/servicerouter_types.go
+++ b/api/v1alpha1/servicerouter_types.go
@@ -263,6 +263,7 @@ func (in *ServiceRouter) DefaultNamespaceFields(consulNamespacesEnabled bool, de
 	// namespace fields because this would cause errors
 	// making API calls (because namespace fields can't be set in OSS).
 	if consulNamespacesEnabled {
+		// Default to the current namespace (i.e. the namespace of the config entry).
 		namespace := namespaces.ConsulNamespace(in.Namespace, consulNamespacesEnabled, destinationNamespace, mirroring, prefix)
 		for i, r := range in.Spec.Routes {
 			if r.Destination != nil {

--- a/api/v1alpha1/servicerouter_types.go
+++ b/api/v1alpha1/servicerouter_types.go
@@ -256,7 +256,7 @@ func (in *ServiceRouter) Validate(namespacesEnabled bool) error {
 	return nil
 }
 
-func (in *ServiceRouter) Default(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
+func (in *ServiceRouter) DefaultNamespaceFields(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
 	// If namespaces are enabled we want to set the namespace fields to it's
 	// default. If namespaces are not enabled (i.e. OSS) we don't set the
 	// namespace fields because this would cause errors

--- a/api/v1alpha1/servicerouter_types_test.go
+++ b/api/v1alpha1/servicerouter_types_test.go
@@ -601,7 +601,7 @@ func TestServiceRouter_Validate(t *testing.T) {
 }
 
 // Test defaulting behavior when namespaces are enabled as well as disabled.
-func TestServiceRouter_Default(t *testing.T) {
+func TestServiceRouter_DefaultNamespaceFields(t *testing.T) {
 	namespaceConfig := map[string]struct {
 		enabled              bool
 		destinationNamespace string
@@ -640,49 +640,48 @@ func TestServiceRouter_Default(t *testing.T) {
 	}
 
 	for name, s := range namespaceConfig {
-		input := &ServiceRouter{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: ServiceRouterSpec{
-				Routes: []ServiceRoute{
-					{
-						Match: &ServiceRouteMatch{
-							HTTP: &ServiceRouteHTTPMatch{
-								PathPrefix: "/admin",
-							},
-						},
-						Destination: &ServiceRouteDestination{
-							Service: "destA",
-						},
-					},
-				},
-			},
-		}
-		output := &ServiceRouter{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: ServiceRouterSpec{
-				Routes: []ServiceRoute{
-					{
-						Match: &ServiceRouteMatch{
-							HTTP: &ServiceRouteHTTPMatch{
-								PathPrefix: "/admin",
-							},
-						},
-						Destination: &ServiceRouteDestination{
-							Service:   "destA",
-							Namespace: s.expectedDestination,
-						},
-					},
-				},
-			},
-		}
-
 		t.Run(name, func(t *testing.T) {
+			input := &ServiceRouter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: ServiceRouterSpec{
+					Routes: []ServiceRoute{
+						{
+							Match: &ServiceRouteMatch{
+								HTTP: &ServiceRouteHTTPMatch{
+									PathPrefix: "/admin",
+								},
+							},
+							Destination: &ServiceRouteDestination{
+								Service: "destA",
+							},
+						},
+					},
+				},
+			}
+			output := &ServiceRouter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: ServiceRouterSpec{
+					Routes: []ServiceRoute{
+						{
+							Match: &ServiceRouteMatch{
+								HTTP: &ServiceRouteHTTPMatch{
+									PathPrefix: "/admin",
+								},
+							},
+							Destination: &ServiceRouteDestination{
+								Service:   "destA",
+								Namespace: s.expectedDestination,
+							},
+						},
+					},
+				},
+			}
 			input.DefaultNamespaceFields(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
 			require.True(t, cmp.Equal(input, output))
 		})

--- a/api/v1alpha1/servicerouter_types_test.go
+++ b/api/v1alpha1/servicerouter_types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/consul-k8s/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
@@ -595,6 +596,95 @@ func TestServiceRouter_Validate(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+// Test defaulting behavior when namespaces are enabled as well as disabled.
+func TestServiceRouter_Default(t *testing.T) {
+	namespaceConfig := map[string]struct {
+		enabled              bool
+		destinationNamespace string
+		mirroring            bool
+		prefix               string
+		expectedDestination  string
+	}{
+		"disabled": {
+			enabled:              false,
+			destinationNamespace: "",
+			mirroring:            false,
+			prefix:               "",
+			expectedDestination:  "",
+		},
+		"destinationNS": {
+			enabled:              true,
+			destinationNamespace: "foo",
+			mirroring:            false,
+			prefix:               "",
+			expectedDestination:  "foo",
+		},
+		"mirroringEnabledWithoutPrefix": {
+			enabled:              true,
+			destinationNamespace: "",
+			mirroring:            true,
+			prefix:               "",
+			expectedDestination:  "bar",
+		},
+		"mirroringWithPrefix": {
+			enabled:              true,
+			destinationNamespace: "",
+			mirroring:            true,
+			prefix:               "ns-",
+			expectedDestination:  "ns-bar",
+		},
+	}
+
+	for name, s := range namespaceConfig {
+		input := &ServiceRouter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: ServiceRouterSpec{
+				Routes: []ServiceRoute{
+					{
+						Match: &ServiceRouteMatch{
+							HTTP: &ServiceRouteHTTPMatch{
+								PathPrefix: "/admin",
+							},
+						},
+						Destination: &ServiceRouteDestination{
+							Service: "destA",
+						},
+					},
+				},
+			},
+		}
+		output := &ServiceRouter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: ServiceRouterSpec{
+				Routes: []ServiceRoute{
+					{
+						Match: &ServiceRouteMatch{
+							HTTP: &ServiceRouteHTTPMatch{
+								PathPrefix: "/admin",
+							},
+						},
+						Destination: &ServiceRouteDestination{
+							Service:   "destA",
+							Namespace: s.expectedDestination,
+						},
+					},
+				},
+			},
+		}
+
+		t.Run(name, func(t *testing.T) {
+			input.Default(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
+			require.True(t, cmp.Equal(input, output))
 		})
 	}
 }

--- a/api/v1alpha1/servicerouter_types_test.go
+++ b/api/v1alpha1/servicerouter_types_test.go
@@ -658,6 +658,17 @@ func TestServiceRouter_DefaultNamespaceFields(t *testing.T) {
 								Service: "destA",
 							},
 						},
+						{
+							Match: &ServiceRouteMatch{
+								HTTP: &ServiceRouteHTTPMatch{
+									PathPrefix: "/other",
+								},
+							},
+							Destination: &ServiceRouteDestination{
+								Service:   "destB",
+								Namespace: "other",
+							},
+						},
 					},
 				},
 			}
@@ -677,6 +688,17 @@ func TestServiceRouter_DefaultNamespaceFields(t *testing.T) {
 							Destination: &ServiceRouteDestination{
 								Service:   "destA",
 								Namespace: s.expectedDestination,
+							},
+						},
+						{
+							Match: &ServiceRouteMatch{
+								HTTP: &ServiceRouteHTTPMatch{
+									PathPrefix: "/other",
+								},
+							},
+							Destination: &ServiceRouteDestination{
+								Service:   "destB",
+								Namespace: "other",
 							},
 						},
 					},

--- a/api/v1alpha1/servicerouter_types_test.go
+++ b/api/v1alpha1/servicerouter_types_test.go
@@ -683,7 +683,7 @@ func TestServiceRouter_Default(t *testing.T) {
 		}
 
 		t.Run(name, func(t *testing.T) {
-			input.Default(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
+			input.DefaultNamespaceFields(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
 			require.True(t, cmp.Equal(input, output))
 		})
 	}

--- a/api/v1alpha1/servicerouter_webhook.go
+++ b/api/v1alpha1/servicerouter_webhook.go
@@ -26,8 +26,17 @@ type ServiceRouterWebhook struct {
 	// be created in the matching Consul namespace.
 	EnableNSMirroring bool
 
+	// ConsulDestinationNamespace is the namespace in Consul that the config entry created
+	// in k8s will get mapped into. If the Consul namespace does not already exist, it will
+	// be created.
 	ConsulDestinationNamespace string
-	NSMirroringPrefix          string
+
+	// NSMirroringPrefix works in conjunction with Namespace Mirroring.
+	// It is the prefix added to the Consul namespace to map to a specific.
+	// k8s namespace. For example, if `mirroringK8SPrefix` is set to "k8s-", a
+	// service in the k8s `staging` namespace will be registered into the
+	// `k8s-staging` Consul namespace.
+	NSMirroringPrefix string
 
 	decoder *admission.Decoder
 	client.Client

--- a/api/v1alpha1/servicerouter_webhook.go
+++ b/api/v1alpha1/servicerouter_webhook.go
@@ -26,6 +26,9 @@ type ServiceRouterWebhook struct {
 	// be created in the matching Consul namespace.
 	EnableNSMirroring bool
 
+	ConsulDestinationNamespace string
+	NSMirroringPrefix          string
+
 	decoder *admission.Decoder
 	client.Client
 }
@@ -51,7 +54,9 @@ func (v *ServiceRouterWebhook) Handle(ctx context.Context, req admission.Request
 		v,
 		&svcRouter,
 		v.EnableConsulNamespaces,
-		v.EnableNSMirroring)
+		v.EnableNSMirroring,
+		v.ConsulDestinationNamespace,
+		v.NSMirroringPrefix)
 }
 
 func (v *ServiceRouterWebhook) List(ctx context.Context) ([]common.ConfigEntryResource, error) {

--- a/api/v1alpha1/servicesplitter_types.go
+++ b/api/v1alpha1/servicesplitter_types.go
@@ -170,6 +170,8 @@ func (in *ServiceSplitter) Validate(namespacesEnabled bool) error {
 	return nil
 }
 
+// DefaultNamespaceFields has no behaviour here as service-splitter have namespace fields
+// that do not default.
 func (in *ServiceSplitter) DefaultNamespaceFields(_ bool, _ string, _ bool, _ string) {
 }
 

--- a/api/v1alpha1/servicesplitter_types.go
+++ b/api/v1alpha1/servicesplitter_types.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/consul-k8s/api/common"
-	"github.com/hashicorp/consul-k8s/namespaces"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -171,19 +170,7 @@ func (in *ServiceSplitter) Validate(namespacesEnabled bool) error {
 	return nil
 }
 
-func (in *ServiceSplitter) Default(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
-	// If namespaces are enabled we want to set the namespace fields to it's
-	// default. If namespaces are not enabled (i.e. OSS) we don't set the
-	// namespace fields because this would cause errors
-	// making API calls (because namespace fields can't be set in OSS).
-	if consulNamespacesEnabled {
-		namespace := namespaces.ConsulNamespace(in.Namespace, consulNamespacesEnabled, destinationNamespace, mirroring, prefix)
-		for i, s := range in.Spec.Splits {
-			if s.Namespace == "" {
-				in.Spec.Splits[i].Namespace = namespace
-			}
-		}
-	}
+func (in *ServiceSplitter) DefaultNamespaceFields(_ bool, _ string, _ bool, _ string) {
 }
 
 func (in ServiceSplits) toConsul() []capi.ServiceSplit {

--- a/api/v1alpha1/servicesplitter_types.go
+++ b/api/v1alpha1/servicesplitter_types.go
@@ -173,6 +173,7 @@ func (in *ServiceSplitter) Validate(namespacesEnabled bool) error {
 // DefaultNamespaceFields has no behaviour here as service-splitter have namespace fields
 // that do not default.
 func (in *ServiceSplitter) DefaultNamespaceFields(_ bool, _ string, _ bool, _ string) {
+	return
 }
 
 func (in ServiceSplits) toConsul() []capi.ServiceSplit {

--- a/api/v1alpha1/servicesplitter_types_test.go
+++ b/api/v1alpha1/servicesplitter_types_test.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/consul-k8s/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
@@ -424,6 +425,88 @@ func TestServiceSplitter_Validate(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+// Test defaulting behavior when namespaces are enabled as well as disabled.
+func TestServiceSplitter_Default(t *testing.T) {
+	namespaceConfig := map[string]struct {
+		enabled              bool
+		destinationNamespace string
+		mirroring            bool
+		prefix               string
+		expectedDestination  string
+	}{
+		"disabled": {
+			enabled:              false,
+			destinationNamespace: "",
+			mirroring:            false,
+			prefix:               "",
+			expectedDestination:  "",
+		},
+		"destinationNS": {
+			enabled:              true,
+			destinationNamespace: "foo",
+			mirroring:            false,
+			prefix:               "",
+			expectedDestination:  "foo",
+		},
+		"mirroringEnabledWithoutPrefix": {
+			enabled:              true,
+			destinationNamespace: "",
+			mirroring:            true,
+			prefix:               "",
+			expectedDestination:  "bar",
+		},
+		"mirroringWithPrefix": {
+			enabled:              true,
+			destinationNamespace: "",
+			mirroring:            true,
+			prefix:               "ns-",
+			expectedDestination:  "ns-bar",
+		},
+	}
+
+	for name, s := range namespaceConfig {
+		input := &ServiceSplitter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: ServiceSplitterSpec{
+				Splits: []ServiceSplit{
+					{
+						Weight: 99.99,
+					},
+					{
+						Weight: 0.01,
+					},
+				},
+			},
+		}
+		output := &ServiceSplitter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: ServiceSplitterSpec{
+				Splits: []ServiceSplit{
+					{
+						Weight:    99.99,
+						Namespace: s.expectedDestination,
+					},
+					{
+						Weight:    0.01,
+						Namespace: s.expectedDestination,
+					},
+				},
+			},
+		}
+
+		t.Run(name, func(t *testing.T) {
+			input.Default(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
+			require.True(t, cmp.Equal(input, output))
 		})
 	}
 }

--- a/api/v1alpha1/servicesplitter_types_test.go
+++ b/api/v1alpha1/servicesplitter_types_test.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/consul-k8s/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
@@ -425,88 +424,6 @@ func TestServiceSplitter_Validate(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-		})
-	}
-}
-
-// Test defaulting behavior when namespaces are enabled as well as disabled.
-func TestServiceSplitter_Default(t *testing.T) {
-	namespaceConfig := map[string]struct {
-		enabled              bool
-		destinationNamespace string
-		mirroring            bool
-		prefix               string
-		expectedDestination  string
-	}{
-		"disabled": {
-			enabled:              false,
-			destinationNamespace: "",
-			mirroring:            false,
-			prefix:               "",
-			expectedDestination:  "",
-		},
-		"destinationNS": {
-			enabled:              true,
-			destinationNamespace: "foo",
-			mirroring:            false,
-			prefix:               "",
-			expectedDestination:  "foo",
-		},
-		"mirroringEnabledWithoutPrefix": {
-			enabled:              true,
-			destinationNamespace: "",
-			mirroring:            true,
-			prefix:               "",
-			expectedDestination:  "bar",
-		},
-		"mirroringWithPrefix": {
-			enabled:              true,
-			destinationNamespace: "",
-			mirroring:            true,
-			prefix:               "ns-",
-			expectedDestination:  "ns-bar",
-		},
-	}
-
-	for name, s := range namespaceConfig {
-		input := &ServiceSplitter{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: ServiceSplitterSpec{
-				Splits: []ServiceSplit{
-					{
-						Weight: 99.99,
-					},
-					{
-						Weight: 0.01,
-					},
-				},
-			},
-		}
-		output := &ServiceSplitter{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: ServiceSplitterSpec{
-				Splits: []ServiceSplit{
-					{
-						Weight:    99.99,
-						Namespace: s.expectedDestination,
-					},
-					{
-						Weight:    0.01,
-						Namespace: s.expectedDestination,
-					},
-				},
-			},
-		}
-
-		t.Run(name, func(t *testing.T) {
-			input.Default(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
-			require.True(t, cmp.Equal(input, output))
 		})
 	}
 }

--- a/api/v1alpha1/servicesplitter_webhook.go
+++ b/api/v1alpha1/servicesplitter_webhook.go
@@ -26,6 +26,9 @@ type ServiceSplitterWebhook struct {
 	// be created in the matching Consul namespace.
 	EnableNSMirroring bool
 
+	ConsulDestinationNamespace string
+	NSMirroringPrefix          string
+
 	decoder *admission.Decoder
 	client.Client
 }
@@ -52,7 +55,9 @@ func (v *ServiceSplitterWebhook) Handle(ctx context.Context, req admission.Reque
 		v,
 		&serviceSplitter,
 		v.EnableConsulNamespaces,
-		v.EnableNSMirroring)
+		v.EnableNSMirroring,
+		v.ConsulDestinationNamespace,
+		v.NSMirroringPrefix)
 }
 
 func (v *ServiceSplitterWebhook) List(ctx context.Context) ([]common.ConfigEntryResource, error) {

--- a/api/v1alpha1/servicesplitter_webhook.go
+++ b/api/v1alpha1/servicesplitter_webhook.go
@@ -26,8 +26,17 @@ type ServiceSplitterWebhook struct {
 	// be created in the matching Consul namespace.
 	EnableNSMirroring bool
 
+	// ConsulDestinationNamespace is the namespace in Consul that the config entry created
+	// in k8s will get mapped into. If the Consul namespace does not already exist, it will
+	// be created.
 	ConsulDestinationNamespace string
-	NSMirroringPrefix          string
+
+	// NSMirroringPrefix works in conjunction with Namespace Mirroring.
+	// It is the prefix added to the Consul namespace to map to a specific.
+	// k8s namespace. For example, if `mirroringK8SPrefix` is set to "k8s-", a
+	// service in the k8s `staging` namespace will be registered into the
+	// `k8s-staging` Consul namespace.
+	NSMirroringPrefix string
 
 	decoder *admission.Decoder
 	client.Client

--- a/api/v1alpha1/terminatinggateway_types.go
+++ b/api/v1alpha1/terminatinggateway_types.go
@@ -189,9 +189,10 @@ func (in *TerminatingGateway) Validate(namespacesEnabled bool) error {
 	return nil
 }
 
+// DefaultNamespaceFields sets the namespace field on spec.services to their default values if namespaces are enabled.
 func (in *TerminatingGateway) DefaultNamespaceFields(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
-	// If namespaces are enabled we want to set the namespace fields to it's
-	// default. If namespaces are not enabled (i.e. OSS) we don't set the
+	// If namespaces are enabled we want to set the namespace fields to their
+	// defaults. If namespaces are not enabled (i.e. OSS) we don't set the
 	// namespace fields because this would cause errors
 	// making API calls (because namespace fields can't be set in OSS).
 	if consulNamespacesEnabled {

--- a/api/v1alpha1/terminatinggateway_types.go
+++ b/api/v1alpha1/terminatinggateway_types.go
@@ -196,6 +196,7 @@ func (in *TerminatingGateway) DefaultNamespaceFields(consulNamespacesEnabled boo
 	// namespace fields because this would cause errors
 	// making API calls (because namespace fields can't be set in OSS).
 	if consulNamespacesEnabled {
+		// Default to the current namespace (i.e. the namespace of the config entry).
 		namespace := namespaces.ConsulNamespace(in.Namespace, consulNamespacesEnabled, destinationNamespace, mirroring, prefix)
 		for i, service := range in.Spec.Services {
 			if service.Namespace == "" {

--- a/api/v1alpha1/terminatinggateway_types.go
+++ b/api/v1alpha1/terminatinggateway_types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/consul-k8s/namespaces"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -186,6 +187,21 @@ func (in *TerminatingGateway) Validate(namespacesEnabled bool) error {
 			in.KubernetesName(), errs)
 	}
 	return nil
+}
+
+func (in *TerminatingGateway) Default(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
+	// If namespaces are enabled we want to set the namespace fields to it's
+	// default. If namespaces are not enabled (i.e. OSS) we don't set the
+	// namespace fields because this would cause errors
+	// making API calls (because namespace fields can't be set in OSS).
+	if consulNamespacesEnabled {
+		namespace := namespaces.ConsulNamespace(in.Namespace, consulNamespacesEnabled, destinationNamespace, mirroring, prefix)
+		for i, service := range in.Spec.Services {
+			if service.Namespace == "" {
+				in.Spec.Services[i].Namespace = namespace
+			}
+		}
+	}
 }
 
 func (in LinkedService) toConsul() capi.LinkedService {

--- a/api/v1alpha1/terminatinggateway_types.go
+++ b/api/v1alpha1/terminatinggateway_types.go
@@ -189,7 +189,7 @@ func (in *TerminatingGateway) Validate(namespacesEnabled bool) error {
 	return nil
 }
 
-func (in *TerminatingGateway) Default(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
+func (in *TerminatingGateway) DefaultNamespaceFields(consulNamespacesEnabled bool, destinationNamespace string, mirroring bool, prefix string) {
 	// If namespaces are enabled we want to set the namespace fields to it's
 	// default. If namespaces are not enabled (i.e. OSS) we don't set the
 	// namespace fields because this would cause errors

--- a/api/v1alpha1/terminatinggateway_types_test.go
+++ b/api/v1alpha1/terminatinggateway_types_test.go
@@ -331,6 +331,10 @@ func TestTerminatingGateway_DefaultNamespaceFields(t *testing.T) {
 						{
 							Name: "foo",
 						},
+						{
+							Name:      "bar",
+							Namespace: "other",
+						},
 					},
 				},
 			}
@@ -344,6 +348,10 @@ func TestTerminatingGateway_DefaultNamespaceFields(t *testing.T) {
 						{
 							Name:      "foo",
 							Namespace: s.expectedDestination,
+						},
+						{
+							Name:      "bar",
+							Namespace: "other",
 						},
 					},
 				},

--- a/api/v1alpha1/terminatinggateway_types_test.go
+++ b/api/v1alpha1/terminatinggateway_types_test.go
@@ -281,7 +281,7 @@ func TestTerminatingGateway_Validate(t *testing.T) {
 }
 
 // Test defaulting behavior when namespaces are enabled as well as disabled.
-func TestTerminatingGateway_Default(t *testing.T) {
+func TestTerminatingGateway_DefaultNamespaceFields(t *testing.T) {
 	namespaceConfig := map[string]struct {
 		enabled              bool
 		destinationNamespace string
@@ -320,35 +320,34 @@ func TestTerminatingGateway_Default(t *testing.T) {
 	}
 
 	for name, s := range namespaceConfig {
-		input := &TerminatingGateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: TerminatingGatewaySpec{
-				Services: []LinkedService{
-					{
-						Name: "foo",
-					},
-				},
-			},
-		}
-		output := &TerminatingGateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: TerminatingGatewaySpec{
-				Services: []LinkedService{
-					{
-						Name:      "foo",
-						Namespace: s.expectedDestination,
-					},
-				},
-			},
-		}
-
 		t.Run(name, func(t *testing.T) {
+			input := &TerminatingGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: TerminatingGatewaySpec{
+					Services: []LinkedService{
+						{
+							Name: "foo",
+						},
+					},
+				},
+			}
+			output := &TerminatingGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: TerminatingGatewaySpec{
+					Services: []LinkedService{
+						{
+							Name:      "foo",
+							Namespace: s.expectedDestination,
+						},
+					},
+				},
+			}
 			input.DefaultNamespaceFields(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
 			require.True(t, cmp.Equal(input, output))
 		})

--- a/api/v1alpha1/terminatinggateway_types_test.go
+++ b/api/v1alpha1/terminatinggateway_types_test.go
@@ -349,7 +349,7 @@ func TestTerminatingGateway_Default(t *testing.T) {
 		}
 
 		t.Run(name, func(t *testing.T) {
-			input.Default(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
+			input.DefaultNamespaceFields(s.enabled, s.destinationNamespace, s.mirroring, s.prefix)
 			require.True(t, cmp.Equal(input, output))
 		})
 	}

--- a/api/v1alpha1/terminatinggateway_webhook.go
+++ b/api/v1alpha1/terminatinggateway_webhook.go
@@ -26,8 +26,17 @@ type TerminatingGatewayWebhook struct {
 	// be created in the matching Consul namespace.
 	EnableNSMirroring bool
 
+	// ConsulDestinationNamespace is the namespace in Consul that the config entry created
+	// in k8s will get mapped into. If the Consul namespace does not already exist, it will
+	// be created.
 	ConsulDestinationNamespace string
-	NSMirroringPrefix          string
+
+	// NSMirroringPrefix works in conjunction with Namespace Mirroring.
+	// It is the prefix added to the Consul namespace to map to a specific.
+	// k8s namespace. For example, if `mirroringK8SPrefix` is set to "k8s-", a
+	// service in the k8s `staging` namespace will be registered into the
+	// `k8s-staging` Consul namespace.
+	NSMirroringPrefix string
 
 	decoder *admission.Decoder
 	client.Client

--- a/api/v1alpha1/terminatinggateway_webhook.go
+++ b/api/v1alpha1/terminatinggateway_webhook.go
@@ -26,6 +26,9 @@ type TerminatingGatewayWebhook struct {
 	// be created in the matching Consul namespace.
 	EnableNSMirroring bool
 
+	ConsulDestinationNamespace string
+	NSMirroringPrefix          string
+
 	decoder *admission.Decoder
 	client.Client
 }
@@ -51,7 +54,9 @@ func (v *TerminatingGatewayWebhook) Handle(ctx context.Context, req admission.Re
 		v,
 		&resource,
 		v.EnableConsulNamespaces,
-		v.EnableNSMirroring)
+		v.EnableNSMirroring,
+		v.ConsulDestinationNamespace,
+		v.NSMirroringPrefix)
 }
 
 func (v *TerminatingGatewayWebhook) List(ctx context.Context) ([]common.ConfigEntryResource, error) {

--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -226,19 +226,23 @@ func (c *Command) Run(args []string) int {
 		// annotation in each webhook file.
 		mgr.GetWebhookServer().Register("/mutate-v1alpha1-servicedefaults",
 			&webhook.Admission{Handler: &v1alpha1.ServiceDefaultsWebhook{
-				Client:                 mgr.GetClient(),
-				ConsulClient:           consulClient,
-				Logger:                 ctrl.Log.WithName("webhooks").WithName(common.ServiceDefaults),
-				EnableConsulNamespaces: c.flagEnableNamespaces,
-				EnableNSMirroring:      c.flagEnableNSMirroring,
+				Client:                     mgr.GetClient(),
+				ConsulClient:               consulClient,
+				Logger:                     ctrl.Log.WithName("webhooks").WithName(common.ServiceDefaults),
+				EnableConsulNamespaces:     c.flagEnableNamespaces,
+				EnableNSMirroring:          c.flagEnableNSMirroring,
+				ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
+				NSMirroringPrefix:          c.flagNSMirroringPrefix,
 			}})
 		mgr.GetWebhookServer().Register("/mutate-v1alpha1-serviceresolver",
 			&webhook.Admission{Handler: &v1alpha1.ServiceResolverWebhook{
-				Client:                 mgr.GetClient(),
-				ConsulClient:           consulClient,
-				Logger:                 ctrl.Log.WithName("webhooks").WithName(common.ServiceResolver),
-				EnableConsulNamespaces: c.flagEnableNamespaces,
-				EnableNSMirroring:      c.flagEnableNSMirroring,
+				Client:                     mgr.GetClient(),
+				ConsulClient:               consulClient,
+				Logger:                     ctrl.Log.WithName("webhooks").WithName(common.ServiceResolver),
+				EnableConsulNamespaces:     c.flagEnableNamespaces,
+				EnableNSMirroring:          c.flagEnableNSMirroring,
+				ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
+				NSMirroringPrefix:          c.flagNSMirroringPrefix,
 			}})
 		mgr.GetWebhookServer().Register("/mutate-v1alpha1-proxydefaults",
 			&webhook.Admission{Handler: &v1alpha1.ProxyDefaultsWebhook{
@@ -250,19 +254,23 @@ func (c *Command) Run(args []string) int {
 			}})
 		mgr.GetWebhookServer().Register("/mutate-v1alpha1-servicerouter",
 			&webhook.Admission{Handler: &v1alpha1.ServiceRouterWebhook{
-				Client:                 mgr.GetClient(),
-				ConsulClient:           consulClient,
-				Logger:                 ctrl.Log.WithName("webhooks").WithName(common.ServiceRouter),
-				EnableConsulNamespaces: c.flagEnableNamespaces,
-				EnableNSMirroring:      c.flagEnableNSMirroring,
+				Client:                     mgr.GetClient(),
+				ConsulClient:               consulClient,
+				Logger:                     ctrl.Log.WithName("webhooks").WithName(common.ServiceRouter),
+				EnableConsulNamespaces:     c.flagEnableNamespaces,
+				EnableNSMirroring:          c.flagEnableNSMirroring,
+				ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
+				NSMirroringPrefix:          c.flagNSMirroringPrefix,
 			}})
 		mgr.GetWebhookServer().Register("/mutate-v1alpha1-servicesplitter",
 			&webhook.Admission{Handler: &v1alpha1.ServiceSplitterWebhook{
-				Client:                 mgr.GetClient(),
-				ConsulClient:           consulClient,
-				Logger:                 ctrl.Log.WithName("webhooks").WithName(common.ServiceSplitter),
-				EnableConsulNamespaces: c.flagEnableNamespaces,
-				EnableNSMirroring:      c.flagEnableNSMirroring,
+				Client:                     mgr.GetClient(),
+				ConsulClient:               consulClient,
+				Logger:                     ctrl.Log.WithName("webhooks").WithName(common.ServiceSplitter),
+				EnableConsulNamespaces:     c.flagEnableNamespaces,
+				EnableNSMirroring:          c.flagEnableNSMirroring,
+				ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
+				NSMirroringPrefix:          c.flagNSMirroringPrefix,
 			}})
 		mgr.GetWebhookServer().Register("/mutate-v1alpha1-serviceintentions",
 			&webhook.Admission{Handler: &v1alpha1.ServiceIntentionsWebhook{
@@ -276,19 +284,23 @@ func (c *Command) Run(args []string) int {
 			}})
 		mgr.GetWebhookServer().Register("/mutate-v1alpha1-ingressgateway",
 			&webhook.Admission{Handler: &v1alpha1.IngressGatewayWebhook{
-				Client:                 mgr.GetClient(),
-				ConsulClient:           consulClient,
-				Logger:                 ctrl.Log.WithName("webhooks").WithName(common.IngressGateway),
-				EnableConsulNamespaces: c.flagEnableNamespaces,
-				EnableNSMirroring:      c.flagEnableNSMirroring,
+				Client:                     mgr.GetClient(),
+				ConsulClient:               consulClient,
+				Logger:                     ctrl.Log.WithName("webhooks").WithName(common.IngressGateway),
+				EnableConsulNamespaces:     c.flagEnableNamespaces,
+				EnableNSMirroring:          c.flagEnableNSMirroring,
+				ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
+				NSMirroringPrefix:          c.flagNSMirroringPrefix,
 			}})
 		mgr.GetWebhookServer().Register("/mutate-v1alpha1-terminatinggateway",
 			&webhook.Admission{Handler: &v1alpha1.TerminatingGatewayWebhook{
-				Client:                 mgr.GetClient(),
-				ConsulClient:           consulClient,
-				Logger:                 ctrl.Log.WithName("webhooks").WithName(common.TerminatingGateway),
-				EnableConsulNamespaces: c.flagEnableNamespaces,
-				EnableNSMirroring:      c.flagEnableNSMirroring,
+				Client:                     mgr.GetClient(),
+				ConsulClient:               consulClient,
+				Logger:                     ctrl.Log.WithName("webhooks").WithName(common.TerminatingGateway),
+				EnableConsulNamespaces:     c.flagEnableNamespaces,
+				EnableNSMirroring:          c.flagEnableNSMirroring,
+				ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
+				NSMirroringPrefix:          c.flagNSMirroringPrefix,
 			}})
 	}
 	// +kubebuilder:scaffold:builder


### PR DESCRIPTION
Changes proposed in this PR:
- Default the namespace fields of resources when namespaces are enabled so that the controller doesnt continuously attempt to reconcile them as the value presented by consul does not match the spec (because Consul defaults the namespace field where we don't).

How to test this PR:
- Code Review
- Deploy `consul-enterprise` with the consul-k8s image `ashwinvenkatesh/consul-k8s:default-ns`. Allow namespaces on the `consul` installation.

Verify that creating an `ingress-gateway`, `terminating-gateway` and `service-router` without namespace fields reconciles just once and does not lead to a reconcile loop.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
