### PR TITLE
Ensure ServiceIntentions aren't resynced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+BUG FIXES:
+* CRDs: Fix issue where a `ServiceIntentions` resource could be continually resynced with Consul
+  because Consul's internal representation had a different order for an array than the Kubernetes resource. [[GH-416](https://github.com/hashicorp/consul-k8s/pull/416)] 
+
 ## 0.22.0 (December 21, 2020)
 
 BUG FIXES:

--- a/api/v1alpha1/serviceintentions_types_test.go
+++ b/api/v1alpha1/serviceintentions_types_test.go
@@ -162,6 +162,49 @@ func TestServiceIntentions_MatchesConsul(t *testing.T) {
 			},
 			Matches: false,
 		},
+		"different order of sources matches": {
+			Ours: ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: Destination{
+						Name: "bar",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:   "*",
+							Action: "allow",
+						},
+						{
+							Name:   "foo",
+							Action: "allow",
+						},
+					},
+				},
+			},
+			Theirs: &capi.ServiceIntentionsConfigEntry{
+				Name:        "bar",
+				Kind:        capi.ServiceIntentions,
+				CreateIndex: 1,
+				ModifyIndex: 2,
+				Meta: map[string]string{
+					common.SourceKey:     common.SourceValue,
+					common.DatacenterKey: "datacenter",
+				},
+				Sources: []*capi.SourceIntention{
+					{
+						Name:   "foo",
+						Action: "allow",
+					},
+					{
+						Name:   "*",
+						Action: "allow",
+					},
+				},
+			},
+			Matches: true,
+		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Consul will internally sort the array of ServiceIntention sources by
precedence. For example, if it receives:

```
sources:
  - name: "*"
    action: allow
  - name: bar
    action: allow
```

It will return it in precedence sorted order:

```
sources:
  - name: bar
    action: allow
  - name: "*"
    action: allow
```

This sorting breaks our MatchesConsul function because we think the
resource has changed and so we will update it continually since it will
never match.

This change uses gocmp's SortSlices to re-sort the sources array so that
both the Kube resource and the Consul resource can be compared despite
Consul's sorting. We use a JSON encoded representation of the source
element with the fields that Consul set automatically zero'd out.

How I've tested this PR:
- unit tests
- tested with resource:
    ```yaml
    apiVersion: consul.hashicorp.com/v1alpha1
    kind: ServiceIntentions
    metadata:
      name: foo
    spec:
      destination:
        name: foo
      sources:
        - name: "*"
          action: allow
        - name: bar
          action: allow
    ```

  Before:
   ```
    2021-01-06T22:04:06.335Z  INFO  webhooks.serviceintentions  validate create {"name": "foo"}
    2021-01-06T22:04:06.347Z  INFO  webhooks.serviceintentions  validate update {"name": "foo"}
    2021-01-06T22:04:06.365Z  INFO  controller.serviceintentions  config entry not found in consul  {"request": "default/foo"}
    2021-01-06T22:04:06.377Z  INFO  controller.serviceintentions  config entry created  {"request": "default/foo", "request-time": "11.594086ms"}
    2021-01-06T22:04:06.390Z  INFO  controller.serviceintentions  config entry does not match consul  {"request": "default/foo", "modify-index": 511}
    2021-01-06T22:04:06.394Z  INFO  controller.serviceintentions  config entry updated  {"request": "default/foo", "request-time": "3.454279ms"}
   ```

   After:
    ```
    2021-01-06T22:07:19.745Z  INFO  webhooks.serviceintentions  validate create {"name": "foo"}
    2021-01-06T22:07:19.751Z  INFO  webhooks.serviceintentions  validate update {"name": "foo"}
    2021-01-06T22:07:19.759Z  INFO  controller.serviceintentions  config entry not found in consul  {"request": "default/foo"}
    2021-01-06T22:07:19.762Z  INFO  controller.serviceintentions  config entry created  {"request": "default/foo", "request-time": "3.048659ms"}
    ```

How I expect reviewers to test this PR: Code

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
