### PR TITLE
Migrating config entries into custom resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ BREAKING CHANGES
     protocol: "http"
   ```
 
+FEATURES:
+* CRDs: support annotation `consul.hashicorp.com/migrate-entry` on custom resources
+  that will allow an existing config entry to be migrated onto a Kubernetes custom resource. [[GH-419](https://github.com/hashicorp/consul-k8s/pull/419)] 
+
 ## 0.23.0 (January 22, 2021)
 
 BUG FIXES:

--- a/api/common/common.go
+++ b/api/common/common.go
@@ -15,7 +15,9 @@ const (
 	DefaultConsulNamespace string = "default"
 	WildcardNamespace      string = "*"
 
-	SourceKey     string = "external-source"
-	DatacenterKey string = "consul.hashicorp.com/source-datacenter"
-	SourceValue   string = "kubernetes"
+	SourceKey        string = "external-source"
+	DatacenterKey    string = "consul.hashicorp.com/source-datacenter"
+	MigrateEntryKey  string = "consul.hashicorp.com/migrate-entry"
+	MigrateEntryTrue string = "true"
+	SourceValue      string = "kubernetes"
 )


### PR DESCRIPTION
Support annotation consul.hashicorp.com/migrate-entry on custom
resources that will allow an existing config entry to be migrated onto
Kubernetes. The config entry from then on will be managed by Kubernetes.

This will support existing users of the Helm chart that already have
config entries in Consul and allow them to migrate to CRDs.

How I've tested this PR:
* code
* manual testing

How I expect reviewers to test this PR:
1. spin up cluster with
    ```yaml
    global:
      name: consul
      imageK8S: ghcr.io/lkysow/consul-k8s-dev:jan12
    server:
      replicas: 1
    connectInject:
      enabled: true
    controller:
      enabled: true
    ```
1. create a service-defaults config:
    
    ```bash
    kubectl exec consul-server-0 -- echo '{"kind": "service-defaults", "name": "foo", "protocol": "http"}' | consul config write -
    ```
1. read it
    ```bash
    kubectl exec consul-server-0 -- consul config read -kind service-defaults -name foo
    {
        "Kind": "service-defaults",
        "Name": "foo",
        "Protocol": "http",
        "MeshGateway": {},
        "Expose": {},
        "CreateIndex": 973,
        "ModifyIndex": 973
    }
    ```
1. create a matching CR:
    ```bash
    cat <<EOF | kubectl apply -f -
    apiVersion: consul.hashicorp.com/v1alpha1
    kind: ServiceDefaults
    metadata:
      name: foo
    spec:
      protocol: "http"
    EOF
    ```
1. check that it's not syncing:
    ```bash
    kubectl describe servicedefaults foo
    ...
    Status:
      Conditions:
        Last Transition Time:  2021-01-12T21:03:29Z
        Message:               config entry managed in different datacenter: ""
        Reason:                ExternallyManagedConfigError
        Status:                False
        Type:                  Synced
    ```
1. add the annotation:
    ```bash
    cat <<EOF | kubectl apply -f -
    apiVersion: consul.hashicorp.com/v1alpha1
    kind: ServiceDefaults
    metadata:
      name: foo
      annotations:
        "consul.hashicorp.com/migrate-entry": "true"
    spec:
      protocol: "http"
    EOF
    ```
1. check that it's synced:
    ```bash
    kubectl describe servicedefaults foo
    ...
    Status:
      Conditions:
        Last Transition Time:  2021-01-12T21:04:37Z
        Status:                True
        Type:                  Synced
    ```
1. check it's got the expected metadata
    ```bash
    kubectl exec consul-server-0 -- consul config read -kind service-defaults -name foo
    {
        "Kind": "service-defaults",
        "Name": "foo",
        "Protocol": "http",
        "MeshGateway": {},
        "Expose": {},
        "Meta": {
            "consul.hashicorp.com/source-datacenter": "dc1",
            "external-source": "kubernetes"
        },
        "CreateIndex": 973,
        "ModifyIndex": 1065
    }
    ```

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
