### PR TITLE
Give better error if config entry already created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ FEATURES:
 * CRDs: support annotation `consul.hashicorp.com/migrate-entry` on custom resources
   that will allow an existing config entry to be migrated onto a Kubernetes custom resource. [[GH-419](https://github.com/hashicorp/consul-k8s/pull/419)] 
 
+IMPROVEMENTS:
+* CRDs: give a more descriptive error when a config entry already exists in Consul. [[GH-420](https://github.com/hashicorp/consul-k8s/pull/420)]
+
 ## 0.23.0 (January 22, 2021)
 
 BUG FIXES:


### PR DESCRIPTION
Previously if the config entry already existed in Consul we'd give an
error like:

    config entry managed in different datacenter: "other-dc"

This worked well if the config entry had been created by a controller
running in another Kube cluster, but if the user had created the config
entry directly in Consul then it wouldn't have the datacenter annotation
and so the error would actually read:

    config entry managed in different datacenter: ""

Which was confusing.

This change changes the error in that case to read:

    config entry already exists in Consul

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
