### PR TITLE
Error when mesh gateway mode not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ BREAKING CHANGES
   spec:
     protocol: "http"
   ```
+* Connect: pods using an upstream that references a datacenter, e.g.
+  `consul.hashicorp.com/connect-service-upstreams: service:8080:dc2` will
+  error during injection if Consul does not have a `proxy-defaults` config entry
+  with a [mesh gateway mode](https://www.consul.io/docs/connect/config-entries/proxy-defaults#mode)
+  set to `local` or `remote`. [[GH-421](https://github.com/hashicorp/consul-k8s/pull/421)]
+
+  In practice, this would have already been causing issues since without that
+  config setting, traffic wouldn't have been routed through mesh gateways and
+  so would not be actually making it to the other service.
 
 FEATURES:
 * CRDs: support annotation `consul.hashicorp.com/migrate-entry` on custom resources

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	capi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1198,4 +1200,136 @@ func TestHandlerContainerInit_MismatchedServiceNameServiceAccountNameWithACLsDis
 
 	_, err := h.containerInit(pod, k8sNamespace)
 	require.NoError(err)
+}
+
+// Test errors for when the mesh gateway mode isn't local or remote and an
+// upstream is using a datacenter.
+func TestHandlerContainerInit_MeshGatewayModeErrors(t *testing.T) {
+	cases := map[string]struct {
+		ConsulDown         bool
+		UpstreamAnnotation string
+		ProxyDefaults      *capi.ProxyConfigEntry
+		ExpError           string
+	}{
+		"no upstreams": {
+			UpstreamAnnotation: "",
+			ProxyDefaults:      nil,
+			ExpError:           "",
+		},
+		"upstreams without datacenter": {
+			UpstreamAnnotation: "foo:1234,bar:4567",
+			ProxyDefaults:      nil,
+			ExpError:           "",
+		},
+		"no proxy defaults": {
+			UpstreamAnnotation: "foo:1234:dc2",
+			ProxyDefaults:      nil,
+			ExpError:           "upstream \"foo:1234:dc2\" is invalid: there is no ProxyDefaults config to set mesh gateway mode",
+		},
+		"consul is down but upstream does not have datacenter": {
+			ConsulDown:         true,
+			UpstreamAnnotation: "foo:1234",
+			ExpError:           "",
+		},
+		"consul is down": {
+			ConsulDown:         true,
+			UpstreamAnnotation: "foo:1234:dc2",
+			ExpError:           "",
+		},
+		"mesh gateway mode is empty": {
+			UpstreamAnnotation: "foo:1234:dc2",
+			ProxyDefaults: &capi.ProxyConfigEntry{
+				Kind: capi.ProxyDefaults,
+				Name: capi.ProxyConfigGlobal,
+				MeshGateway: capi.MeshGatewayConfig{
+					Mode: "",
+				},
+			},
+			ExpError: "upstream \"foo:1234:dc2\" is invalid: ProxyDefaults mesh gateway mode is neither \"local\" nor \"remote\"",
+		},
+		"mesh gateway mode is none": {
+			UpstreamAnnotation: "foo:1234:dc2",
+			ProxyDefaults: &capi.ProxyConfigEntry{
+				Kind: capi.ProxyDefaults,
+				Name: capi.ProxyConfigGlobal,
+				MeshGateway: capi.MeshGatewayConfig{
+					Mode: capi.MeshGatewayModeNone,
+				},
+			},
+			ExpError: "upstream \"foo:1234:dc2\" is invalid: ProxyDefaults mesh gateway mode is neither \"local\" nor \"remote\"",
+		},
+		"mesh gateway mode is local": {
+			UpstreamAnnotation: "foo:1234:dc2",
+			ProxyDefaults: &capi.ProxyConfigEntry{
+				Kind: capi.ProxyDefaults,
+				Name: capi.ProxyConfigGlobal,
+				MeshGateway: capi.MeshGatewayConfig{
+					Mode: capi.MeshGatewayModeLocal,
+				},
+			},
+			ExpError: "",
+		},
+		"mesh gateway mode is remote": {
+			UpstreamAnnotation: "foo:1234:dc2",
+			ProxyDefaults: &capi.ProxyConfigEntry{
+				Kind: capi.ProxyDefaults,
+				Name: capi.ProxyConfigGlobal,
+				MeshGateway: capi.MeshGatewayConfig{
+					Mode: capi.MeshGatewayModeRemote,
+				},
+			},
+			ExpError: "",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			consul, err := testutil.NewTestServerConfigT(t, nil)
+			require.NoError(err)
+			defer consul.Stop()
+			consul.WaitForLeader(t)
+
+			httpAddr := consul.HTTPAddr
+			if c.ConsulDown {
+				httpAddr = "hostname.does.not.exist"
+			}
+			consulClient, err := capi.NewClient(&capi.Config{
+				Address: httpAddr,
+			})
+			require.NoError(err)
+
+			if c.ProxyDefaults != nil {
+				written, _, err := consulClient.ConfigEntries().Set(c.ProxyDefaults, nil)
+				require.NoError(err)
+				require.True(written)
+			}
+
+			h := Handler{
+				ConsulClient: consulClient,
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotationService:   "foo",
+						annotationUpstreams: c.UpstreamAnnotation,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "foo",
+						},
+					},
+				},
+			}
+			_, err = h.containerInit(pod, k8sNamespace)
+			if c.ExpError == "" {
+				require.NoError(err)
+			} else {
+				require.EqualError(err, c.ExpError)
+			}
+		})
+	}
+
 }

--- a/subcommand/server-acl-init/command_test.go
+++ b/subcommand/server-acl-init/command_test.go
@@ -1906,6 +1906,7 @@ func completeBootstrappedSetup(t *testing.T, masterToken string) (*fake.Clientse
 		c.ACL.Tokens.Master = masterToken
 	})
 	require.NoError(t, err)
+	svr.WaitForActiveCARoot(t)
 
 	return k8s, svr
 }


### PR DESCRIPTION
To prevent users from being confused as to why their traffic isn't being
routed, give an error on connect injection if they've configured an
upstream to use a datacenter but they don't have a proxy-defaults config
with mesh gateway mode set to local or remote.

NOTE: No ACL changes need to be made because `proxy-defaults` does not require an ACL for reads (https://www.consul.io/api-docs/config#get-configuration)

How I tested:
* Install with:
  ```yaml
  global:
    name: consul
    imageK8S: ghcr.io/lkysow/consul-k8s-dev:jan20
    acls:
      manageSystemACLs: true
  connectInject:
    enabled: true
  controller:
    enabled: true
  server:
    replicas: 1
  ```
* Apply
  ```yaml
  apiVersion: v1
  kind: ServiceAccount
  metadata:
    name: static-client
  ---
  apiVersion: v1
  kind: Pod
  metadata:
    name: luke
    annotations:
      "consul.hashicorp.com/connect-inject": "true"
      "consul.hashicorp.com/connect-service-upstreams": "static-server:1234:dc2"
  spec:
    containers:
      - name: static-client
        image: tutum/curl:latest
        command: [ "/bin/sh", "-c", "--" ]
        args: [ "while true; do sleep 30; done;" ]
        ports:
          - containerPort: 8080
            name: http
    serviceAccountName: static-client
  ```

* Errors with
  ```
  Error from server: error when creating "scratch/static-client.yaml": admission webhook "consul-connect-injector.consul.hashicorp.com" denied the request: Error configuring injection init container: upstream "static-server:1234:dc2" is invalid: there is no ProxyDefaults config to set mesh gateway mode
  ```
* Apply
  ```yaml
  apiVersion: consul.hashicorp.com/v1alpha1
  kind: ProxyDefaults
  metadata:
    name: global
  spec:
    meshGateway:
      mode: local
  ```
* Re-apply static-client, it will schedule

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
