### PR TITLE
Add testutil for test server

### DIFF
--- a/catalog/to-consul/consul_node_services_client_ent_test.go
+++ b/catalog/to-consul/consul_node_services_client_ent_test.go
@@ -5,8 +5,8 @@ package catalog
 import (
 	"testing"
 
+	"github.com/hashicorp/consul-k8s/testutil"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -327,22 +327,15 @@ func TestNamespacesNodeServicesClient_NodeServices(t *testing.T) {
 		}
 		t.Run(name, func(tt *testing.T) {
 			require := require.New(tt)
-			svr, err := testutil.NewTestServerConfigT(tt, nil)
-			require.NoError(err)
-			defer svr.Stop()
-
-			consulClient, err := api.NewClient(&api.Config{
-				Address: svr.HTTPAddr,
-			})
-			require.NoError(err)
+			consulClient := testutil.NewConsulTestServer(tt, nil)
 			for _, registration := range c.ConsulServices {
 				if registration.Service.Namespace != "" && registration.Service.Namespace != "default" {
-					_, _, err = consulClient.Namespaces().Create(&api.Namespace{
+					_, _, err := consulClient.Namespaces().Create(&api.Namespace{
 						Name: registration.Service.Namespace,
 					}, nil)
 					require.NoError(err)
 				}
-				_, err = consulClient.Catalog().Register(&registration, nil)
+				_, err := consulClient.Catalog().Register(&registration, nil)
 				require.NoError(err)
 			}
 

--- a/connect-inject/handler_ent_test.go
+++ b/connect-inject/handler_ent_test.go
@@ -8,8 +8,9 @@ import (
 	"time"
 
 	"github.com/deckarep/golang-set"
+	"github.com/hashicorp/consul-k8s/testutil"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
+	ctestutil "github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/go-hclog"
 	"github.com/mattbaird/jsonpatch"
@@ -193,17 +194,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			require := require.New(t)
-
-			// Set up consul server
-			a, err := testutil.NewTestServerConfigT(t, nil)
-			require.NoError(err)
-			defer a.Stop()
-
-			// Set up consul client
-			client, err := api.NewClient(&api.Config{
-				Address: a.HTTPAddr,
-			})
-			require.NoError(err)
+			client := testutil.NewConsulTestServer(t, nil)
 
 			// Add the client to the test's handler
 			tt.Handler.ConsulClient = client
@@ -419,7 +410,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			// Set up consul server
-			a, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
+			a, err := ctestutil.NewTestServerConfigT(t, func(c *ctestutil.TestServerConfig) {
 				c.ACL.Enabled = true
 			})
 			defer a.Stop()
@@ -544,17 +535,7 @@ func TestHandler_MutateWithNamespaces_Annotation(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
-
-			// Set up consul server
-			a, err := testutil.NewTestServerConfigT(t, nil)
-			require.NoError(err)
-			defer a.Stop()
-
-			// Set up consul client
-			client, err := api.NewClient(&api.Config{
-				Address: a.HTTPAddr,
-			})
-			require.NoError(err)
+			client := testutil.NewConsulTestServer(t, nil)
 
 			handler := Handler{
 				Log:                        hclog.Default().Named("handler"),

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -1,0 +1,24 @@
+package testutil
+
+import (
+	"testing"
+
+	capi "github.com/hashicorp/consul/api"
+	ctestutil "github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func NewConsulTestServer(t *testing.T, cb ctestutil.ServerConfigCallback) *capi.Client {
+	server, err := ctestutil.NewTestServerConfigT(t, cb)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		server.Stop()
+	})
+	server.WaitForLeader(t)
+
+	client, err := capi.NewClient(&capi.Config{
+		Address: server.HTTPAddr,
+	})
+	require.NoError(t, err)
+	return client
+}


### PR DESCRIPTION
There are a lot of places (64) in our tests where we're doing:

```go
			// Set up consul server
			a, err := testutil.NewTestServerConfigT(t, nil)
			require.NoError(err)
			defer a.Stop()

			// Set up consul client
			client, err := api.NewClient(&api.Config{
				Address: a.HTTPAddr,
			})
			require.NoError(err)
```

This code can be dried up into our own util. In addition, sometimes we get flaky tests because we haven't waited for a leader to be elected (https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/1558/workflows/160a47ab-8cfd-46b5-a3c8-2c5649d4fae2/jobs/7669). To fix this we can add `server.WaitForLeader(t)` but then we'd have to do it in all 64 locations which prompted this change.