### PR TITLE
Use an underscore instead of a dash for the pod name meta key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ BREAKING CHANGES
   In practice, this would have already been causing issues since without that
   config setting, traffic wouldn't have been routed through mesh gateways and
   so would not be actually making it to the other service.
+* Connect: change meta key for the pod name in the service instance registered with Consul
+  from `pod-name` to `pod_name` so that it can be used with Consul's [filtering](https://www.consul.io/api/features/filtering) APIs.
+  [[GH-427](https://github.com/hashicorp/consul-k8s/pull/427)]
 
 FEATURES:
 * CRDs: support annotation `consul.hashicorp.com/migrate-entry` on custom resources

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -281,7 +281,7 @@ services {
     {{$key}} = "{{$value}}"
     {{- end }}
     {{- end }}
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 }
 
@@ -303,7 +303,7 @@ services {
     {{$key}} = "{{$value}}"
     {{- end }}
     {{- end }}
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 
   proxy {

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -64,7 +64,7 @@ services {
   address = "${POD_IP}"
   port = 0
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 }
 
@@ -75,7 +75,7 @@ services {
   address = "${POD_IP}"
   port = 20000
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 
   proxy {
@@ -123,7 +123,7 @@ cp /bin/consul /consul/connect-inject/consul`,
   address = "${POD_IP}"
   port = 1234
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 }
 
@@ -134,7 +134,7 @@ services {
   address = "${POD_IP}"
   port = 20000
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 
   proxy {
@@ -302,7 +302,7 @@ services {
   port = 1234
   tags = ["abc"]
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 }
 
@@ -314,7 +314,7 @@ services {
   port = 20000
   tags = ["abc"]
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 
   proxy {
@@ -354,7 +354,7 @@ services {
   port = 1234
   tags = ["abc","123"]
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 }
 
@@ -366,7 +366,7 @@ services {
   port = 20000
   tags = ["abc","123"]
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 
   proxy {
@@ -406,7 +406,7 @@ services {
   port = 1234
   tags = ["abc","123"]
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 }
 
@@ -418,7 +418,7 @@ services {
   port = 20000
   tags = ["abc","123"]
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 
   proxy {
@@ -459,7 +459,7 @@ services {
   port = 1234
   tags = ["abc","123","abc","123","def","456"]
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 }
 
@@ -471,7 +471,7 @@ services {
   port = 20000
   tags = ["abc","123","abc","123","def","456"]
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 
   proxy {
@@ -522,7 +522,7 @@ services {
   meta = {
     name = "abc"
     version = "2"
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 }
 
@@ -535,7 +535,7 @@ services {
   meta = {
     name = "abc"
     version = "2"
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 
   proxy {
@@ -567,7 +567,7 @@ services {
 				return pod
 			},
 			`  meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 `,
 			"",
@@ -580,7 +580,7 @@ services {
 				return pod
 			},
 			`  meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 `,
 			"",
@@ -690,7 +690,7 @@ services {
   port = 0
   namespace = "default"
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 }
 
@@ -702,7 +702,7 @@ services {
   port = 20000
   namespace = "default"
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 
   proxy {
@@ -764,7 +764,7 @@ services {
   port = 0
   namespace = "non-default"
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 }
 
@@ -776,7 +776,7 @@ services {
   port = 20000
   namespace = "non-default"
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 
   proxy {
@@ -839,7 +839,7 @@ services {
   port = 0
   namespace = "non-default"
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 }
 
@@ -851,7 +851,7 @@ services {
   port = 20000
   namespace = "non-default"
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 
   proxy {
@@ -923,7 +923,7 @@ services {
   port = 0
   namespace = "k8snamespace"
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 }
 
@@ -935,7 +935,7 @@ services {
   port = 20000
   namespace = "k8snamespace"
   meta = {
-    pod-name = "${POD_NAME}"
+    pod_name = "${POD_NAME}"
   }
 
   proxy {


### PR DESCRIPTION
Consul [filtering]((https://www.consul.io/api/features/filtering#selectors)) API only supports ASCII character, numbers, and underscores
as selectors.
So if someone tries to use that meta key for e.g. a service-resolver,
it won't work.

Changes proposed in this PR:
- Switch the meta key for the pod name from `pod-name` to `pod_name`

How I've tested this PR:
- Steps outlined [here](https://github.com/hashicorp/consul-k8s/issues/373#issuecomment-769351345).

How I expect reviewers to test this PR:
- code review

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
