### PR TITLE
Include object with delete events

### DIFF
--- a/catalog/to-consul/resource.go
+++ b/catalog/to-consul/resource.go
@@ -213,7 +213,7 @@ func (t *ServiceResource) Upsert(key string, raw interface{}) error {
 }
 
 // Delete implements the controller.Resource interface.
-func (t *ServiceResource) Delete(key string) error {
+func (t *ServiceResource) Delete(key string, _ interface{}) error {
 	t.serviceLock.Lock()
 	defer t.serviceLock.Unlock()
 	t.doDelete(key)
@@ -727,7 +727,7 @@ func (t *serviceEndpointsResource) Upsert(key string, raw interface{}) error {
 	return nil
 }
 
-func (t *serviceEndpointsResource) Delete(key string) error {
+func (t *serviceEndpointsResource) Delete(key string, _ interface{}) error {
 	t.Service.serviceLock.Lock()
 	defer t.Service.serviceLock.Unlock()
 

--- a/catalog/to-k8s/sink.go
+++ b/catalog/to-k8s/sink.go
@@ -159,7 +159,7 @@ func (s *K8SSink) Upsert(key string, raw interface{}) error {
 }
 
 // Delete implements the controller.Resource interface.
-func (s *K8SSink) Delete(key string) error {
+func (s *K8SSink) Delete(key string, _ interface{}) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 

--- a/connect-inject/health_check_resource.go
+++ b/connect-inject/health_check_resource.go
@@ -76,7 +76,7 @@ func (h *HealthCheckResource) Run(stopCh <-chan struct{}) {
 
 // Delete is not implemented because it is handled by the preStop phase whereby all services
 // related to the pod are deregistered which also deregisters health checks.
-func (h *HealthCheckResource) Delete(string) error {
+func (h *HealthCheckResource) Delete(string, interface{}) error {
 	return nil
 }
 

--- a/helper/controller/resource.go
+++ b/helper/controller/resource.go
@@ -7,7 +7,7 @@ import (
 // ResourceUpsertFunc and ResourceDeleteFunc are the callback types for
 // when a resource is inserted, updated, or deleted.
 type ResourceUpsertFunc func(string, interface{}) error
-type ResourceDeleteFunc func(string) error
+type ResourceDeleteFunc func(string, interface{}) error
 
 // Resource should be implemented by anything that should be watchable
 // by Controller. The Resource needs to be aware of how to create the Informer
@@ -23,7 +23,7 @@ type Resource interface {
 	// of changes from the Informer. If an error is returned, the given item
 	// will be retried.
 	Upsert(string, interface{}) error
-	Delete(string) error
+	Delete(string, interface{}) error
 }
 
 // Backgrounder should be implemented by a Resource that requires additional
@@ -60,4 +60,4 @@ type basicResource struct {
 
 func (r *basicResource) Informer() cache.SharedIndexInformer  { return r.informer }
 func (r *basicResource) Upsert(k string, v interface{}) error { return r.upsert(k, v) }
-func (r *basicResource) Delete(k string) error                { return r.delete(k) }
+func (r *basicResource) Delete(k string, v interface{}) error { return r.delete(k, v) }

--- a/helper/controller/resource.go
+++ b/helper/controller/resource.go
@@ -19,11 +19,15 @@ type Resource interface {
 	// holds blocking queries to K8S and stores data in a local store.
 	Informer() cache.SharedIndexInformer
 
-	// Upsert and Delete are the callbacks called when processing the queue
+	// Upsert is the callback called when processing the queue
 	// of changes from the Informer. If an error is returned, the given item
 	// will be retried.
-	Upsert(string, interface{}) error
-	Delete(string, interface{}) error
+	Upsert(key string, obj interface{}) error
+	// Delete is called on object deletion.
+	// obj is the last known state of the object before deletion. In some
+	// cases, it may not be up to date with the latest state of the object.
+	// If an error is returned, the given item will be retried.
+	Delete(key string, obj interface{}) error
 }
 
 // Backgrounder should be implemented by a Resource that requires additional


### PR DESCRIPTION
Refactor our controller implementation to include the resource as part
of the deletion event. During a delete event, we get the full object
however previously we would discard this object and record only the key
of the object that was deleted. Then later when we would dequeue this
event, the object could not be retrieved from our cache because it was
deleted from Kubernetes and our cache is usually up to date with the
state of Kubernetes.

This will be useful for cleaning up force deleted pods because we can
use the pod object from the event to determine which Consul service
instance that pod got registered as (and potentially delete it if it's
still registered).

Checklist:
- [x] Tests added