### PR TITLE
Refactor inject-connect command

### DIFF
--- a/subcommand/inject-connect/command_test.go
+++ b/subcommand/inject-connect/command_test.go
@@ -153,11 +153,6 @@ func TestRun_FlagValidation(t *testing.T) {
 			},
 			expErr: "request must be <= limit: -consul-sidecar-cpu-request value of \"50m\" is greater than the -consul-sidecar-cpu-limit value of \"25m\"",
 		},
-		{
-			flags: []string{"-consul-k8s-image", "hashicorpdev/consul-k8s:latest", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
-				"-enable-health-checks-controller=true"},
-			expErr: "CONSUL_HTTP_ADDR is not specified",
-		},
 	}
 
 	for _, c := range cases {
@@ -192,7 +187,7 @@ func TestRun_ResourceLimitDefaults(t *testing.T) {
 	require.Equal(t, cmd.flagConsulSidecarMemoryLimit, "50Mi")
 }
 
-func TestRun_ValidationHealthCheckEnv(t *testing.T) {
+func TestRun_ValidationConsulHTTPAddr(t *testing.T) {
 	cases := []struct {
 		name    string
 		envVars []string
@@ -200,10 +195,10 @@ func TestRun_ValidationHealthCheckEnv(t *testing.T) {
 		expErr  string
 	}{
 		{
-			envVars: []string{api.HTTPAddrEnvName, "0.0.0.0:999999"},
+			envVars: []string{api.HTTPAddrEnvName, "%"},
 			flags: []string{"-consul-k8s-image", "hashicorp/consul-k8s", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
 				"-enable-health-checks-controller=true"},
-			expErr: "Error parsing CONSUL_HTTP_ADDR: parse \"0.0.0.0:999999\": first path segment in URL cannot contain colon",
+			expErr: "Error parsing consul address \"http://%\": parse \"http://%\": invalid URL escape \"%",
 		},
 	}
 	for _, c := range cases {
@@ -246,7 +241,6 @@ func TestRun_CommandFailsWithInvalidListener(t *testing.T) {
 // Test that when healthchecks are enabled that SIGINT/SIGTERM exits the
 // command cleanly.
 func TestRun_CommandExitsCleanlyAfterSignal(t *testing.T) {
-
 	t.Run("SIGINT", testSignalHandling(syscall.SIGINT))
 	t.Run("SIGTERM", testSignalHandling(syscall.SIGTERM))
 }


### PR DESCRIPTION
This refactor paves the way for adding the cleanup controller. It
removes the if/else statement around starting the mutating webhook
server when health checks are enabled vs when they're not and instead
starts it the same way in both cases.

Previously the code looked like:

```
if healthChecks {
  // start goroutine for health checks
  // start goroutine for webhook server
  // use select{} to wait
} else {
  // start webhook server
}
```

Now it looks like:

```
// start goroutine for webhook server
if healthChecks {
  // start goroutine for health checks
}
// use select{} to wait
```

This makes it easier to later do the below because we're already starting everything in goroutines and using select to wait:

```
// start goroutine for webhook server
if cleanup {
  // start goroutine for cleanup controller
}
if healthChecks {
  // start goroutine for health checks
}
// use select{} to wait
```

Otherwise we'd need to do:
```
if healthChecks || cleanup {
  if healthChecks {
    // start goroutine for health checks
  }
  if cleanup {
    // start goroutine for webhook server
  }
  // use select{} to wait
} else {
  // start webhook server
}
```

Somewhat related, it also removes special validation around the CONSUL_HTTP_ADDR. This is because I discovered that earlier in the file we were already doing:
```go
	// create Consul API config object
	cfg := api.DefaultConfig()
	c.http.MergeOntoConfig(cfg)
```

This code already picks up `CONSUL_HTTP_ADDR` and so I don't think it needs to be done separately. This also matches the pattern in two other locations where we don't explicitly validate for that env var (https://github.com/hashicorp/consul-k8s/blob/master/subcommand/create-federation-secret/command.go#L191-L209, https://github.com/hashicorp/consul-k8s/blob/master/subcommand/get-consul-client-ca/command.go#L127-L154).

How I've tested this PR:
* I ran the connect inject acceptance tests locally

How I expect reviewers to test this PR:
* You can run the acceptance tests with `go test ./... -v -p 1 -run TestConnectInject -failfast -no-cleanup-on-failure -consul-k8s-image=ghcr.io/lkysow/consul-k8s-dev:feb03-inject-refactor3`


Checklist:
- [x] Tests added


Fixes https://github.com/hashicorp/consul-k8s/issues/436