### PR TITLE
Refactor health resource to match cleanup resource

### DIFF
--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -391,7 +391,8 @@ func (c *Command) Run(args []string) int {
 		healthResource := connectinject.HealthCheckResource{
 			Log:                 logger.Named("healthCheckResource"),
 			KubernetesClientset: c.clientset,
-			ConsulUrl:           consulURL,
+			ConsulScheme:        consulURL.Scheme,
+			ConsulPort:          consulURL.Port(),
 			Ctx:                 ctx,
 			ReconcilePeriod:     c.flagHealthChecksReconcilePeriod,
 		}


### PR DESCRIPTION
- refactor Run loop
- use ConsulPort and ConsulScheme instead of ConsulURL
- reconcile() does not return an error since it is logged during that
function

Matches https://github.com/hashicorp/consul-k8s/pull/433#discussion_r573365394
