### PR TITLE
Add metrics merging and Prometheus annotations to connect-injected Pods

### DIFF
--- a/subcommand/common/common.go
+++ b/subcommand/common/common.go
@@ -2,8 +2,10 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/hashicorp/go-hclog"
 )
@@ -29,4 +31,18 @@ func Logger(level string) (hclog.Logger, error) {
 		Level:  parsedLevel,
 		Output: os.Stderr,
 	}), nil
+}
+
+// ValidatePort converts flags representing ports into integer and validates
+// that it's in the port range.
+func ValidatePort(flagName, flagValue string) error {
+	port, err := strconv.Atoi(flagValue)
+	if err != nil {
+		return errors.New(fmt.Sprintf("%s value of %s is not a valid integer.", flagName, flagValue))
+	}
+	// This checks if the port is in the valid port range.
+	if port < 1024 || port > 65535 {
+		return errors.New(fmt.Sprintf("%s value of %d is not in the port range 1024-65535.", flagName, port))
+	}
+	return nil
 }

--- a/subcommand/common/common_test.go
+++ b/subcommand/common/common_test.go
@@ -17,3 +17,12 @@ func TestLogger(t *testing.T) {
 	require.NotNil(t, lgr)
 	require.True(t, lgr.IsDebug())
 }
+
+func TestValidatePort(t *testing.T) {
+	err := ValidatePort("-test-flag-name", "1234")
+	require.NoError(t, err)
+	err = ValidatePort("-test-flag-name", "invalid-port")
+	require.EqualError(t, err, "-test-flag-name value of invalid-port is not a valid integer.")
+	err = ValidatePort("-test-flag-name", "22")
+	require.EqualError(t, err, "-test-flag-name value of 22 is not in the port range 1024-65535.")
+}


### PR DESCRIPTION
Adds metrics merging feature to consul-k8s.

Changes proposed in this PR:
- inject-connect takes default metrics flags
- supports annotations for overriding the default flags
- inject-connect passes metrics flags to connect-inject handler
- handler now has functions to grab configuration from the default flags or the overridden values from the annotations
- from the handler:
  - init container adds envoy_prometheus_bind_addr and flags to consul connect envoy
  - consul-sidecar is given the appropriate flags to run the merged metrics server
  - added prometheus annotations to pod to scrape from

How I've tested this PR:
- consul-helm (`test-metrics` branch)
- consul-k8s (`merged-metrics` branch)
- consul (`metrics-merging` branch)
- Build the consul and consul-k8s images or use:
  - `gcr.io/nitya-293720/consul-k8s-dev:metrics28`
  - `gcr.io/nitya-293720/consul-dev:metrics10`
  - Set those in values.yaml, make sure connectInject is enabled
- Deploy prometheus: `helm install prom prometheus-community/prometheus`
- Helm install consul
- `k apply -f example-app.yaml`
example-app.yaml: 
```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/name: prometheus-example-app
  name: prometheus-example-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: prometheus-example-app
  template:
    metadata:
      annotations:
        'consul.hashicorp.com/connect-inject': 'true'
      labels:
        app.kubernetes.io/name: prometheus-example-app
    spec:
      containers:
      - name: prometheus-example-app
        image: quay.io/brancz/prometheus-example-app:v0.3.0
        ports:
        - name: web
          containerPort: 8080
```
- Port forward to prometheus
  - `export POD_NAME=$(kubectl get pods --namespace default -l "app=prometheus,component=server" -o jsonpath="{.items[0].metadata.name}")`
  - `kubectl --namespace default port-forward $POD_NAME 9090`
- go to localhost:9090 and look at targets, you should see prometheus-example-app under kubernetes pods
- try graphing the "version" metric (an app metric) and an envoy metric

How I expect reviewers to test this PR:
- Give the steps above a shot
- Code review


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
