### PR TITLE
Feature/cleanup controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,11 @@ BREAKING CHANGES
 
 FEATURES:
 * CRDs: support annotation `consul.hashicorp.com/migrate-entry` on custom resources
-  that will allow an existing config entry to be migrated onto a Kubernetes custom resource. [[GH-419](https://github.com/hashicorp/consul-k8s/pull/419)] 
+  that will allow an existing config entry to be migrated onto a Kubernetes custom resource. [[GH-419](https://github.com/hashicorp/consul-k8s/pull/419)]
+* Connect: add new cleanup controller that runs in the connect-inject deployment. This
+  controller cleans up Consul service instances that remain registered despite their
+  pods being deleted. This could happen if the pod's `preStop` hook failed to execute
+  for some reason. [[GH-433](https://github.com/hashicorp/consul-k8s/pull/433)]
 
 IMPROVEMENTS:
 * CRDs: give a more descriptive error when a config entry already exists in Consul. [[GH-420](https://github.com/hashicorp/consul-k8s/pull/420)]

--- a/connect-inject/cleanup_resource.go
+++ b/connect-inject/cleanup_resource.go
@@ -1,0 +1,238 @@
+package connectinject
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/consul-k8s/consul"
+	capi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-hclog"
+	"golang.org/x/net/context"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// CleanupResource implements Resource and is used to clean up Consul service
+// instances that weren't deregistered when their pods were deleted.
+// Usually the preStop hook in the pods handles this but during a force delete
+// or OOM the preStop hook doesn't run.
+type CleanupResource struct {
+	Log              hclog.Logger
+	KubernetesClient kubernetes.Interface
+	// ConsulClient points at the agent on the same node as this pod.
+	ConsulClient    *capi.Client
+	ReconcilePeriod time.Duration
+	Ctx             context.Context
+	// ConsulScheme is the scheme to use when making API calls to Consul,
+	// i.e. "http" or "https".
+	ConsulScheme string
+	// ConsulPort is the port to make HTTP API calls to Consul agents on.
+	ConsulPort string
+
+	lock sync.Mutex
+}
+
+// Run starts the long-running Reconcile loop that runs on a timer.
+func (c *CleanupResource) Run(stopCh <-chan struct{}) {
+	reconcileTimer := time.NewTimer(c.ReconcilePeriod)
+	defer reconcileTimer.Stop()
+
+	for {
+		c.reconcile()
+		reconcileTimer.Reset(c.ReconcilePeriod)
+
+		select {
+		case <-stopCh:
+			c.Log.Info("received stop signal, shutting down")
+			return
+
+		case <-reconcileTimer.C:
+			// Fall through and continue the loop.
+		}
+	}
+}
+
+// reconcile checks all registered Consul connect service instances and ensures
+// the pod they represent is still running. If the pod is no longer running,
+// it deregisters the service instance from its agent.
+func (c *CleanupResource) reconcile() {
+	c.Log.Debug("starting reconcile")
+
+	// currentPods is a map of currently existing pods. Keys are in the form
+	// "namespace/pod-name". Value doesn't matter since we're using this
+	// solely for quick "exists" checks.
+	// Use currentPodsKey() to construct the key when accessing this map.
+	currentPods := make(map[string]bool)
+
+	// Gather needed data on nodes, services and pods.
+	kubeNodes, err := c.KubernetesClient.CoreV1().Nodes().List(c.Ctx, metav1.ListOptions{})
+	if err != nil {
+		c.Log.Error("unable to get nodes", "error", err)
+		return
+	}
+	serviceNames, _, err := c.ConsulClient.Catalog().Services(nil)
+	if err != nil {
+		c.Log.Error("unable to get Consul services", "error", err)
+		return
+	}
+	podList, err := c.KubernetesClient.CoreV1().Pods(corev1.NamespaceAll).List(c.Ctx,
+		metav1.ListOptions{LabelSelector: labelInject})
+	if err != nil {
+		c.Log.Error("unable to get pods", "error", err)
+		return
+	}
+
+	// Build up our map of currently running pods.
+	for _, pod := range podList.Items {
+		currentPods[currentPodsKey(pod.Name, pod.Namespace)] = true
+	}
+
+	// For each registered service, find the associated pod.
+	for serviceName := range serviceNames {
+		serviceInstances, _, err := c.ConsulClient.Catalog().Service(serviceName, "", nil)
+		if err != nil {
+			c.Log.Error("unable to get Consul service", "name", serviceName, "error", err)
+			return
+		}
+		for _, instance := range serviceInstances {
+			podName, hasPodMeta := instance.ServiceMeta[MetaKeyPodName]
+			k8sNamespace, hasNSMeta := instance.ServiceMeta[MetaKeyKubeNS]
+			if hasPodMeta && hasNSMeta {
+
+				// Check if the instance matches a running pod. If not, deregister it.
+				if _, podExists := currentPods[currentPodsKey(podName, k8sNamespace)]; !podExists {
+					if !nodeInCluster(kubeNodes, instance.Node) {
+						c.Log.Debug("skipping deregistration because instance is from node not in this cluster",
+							"pod", podName, "id", instance.ServiceID, "node", instance.Node)
+						continue
+					}
+
+					c.Log.Info("found service instance from terminated pod still registered", "pod", podName, "id", instance.ServiceID)
+					err := c.deregisterInstance(instance, instance.Address)
+					if err != nil {
+						c.Log.Error("unable to deregister service instance", "id", instance.ServiceID, "error", err)
+						continue
+					}
+					c.Log.Info("service instance deregistered", "id", instance.ServiceID)
+				}
+			}
+		}
+	}
+
+	c.Log.Debug("finished reconcile")
+	return
+}
+
+// Delete is called when a pod is deleted. It checks that the Consul service
+// instance for that pod is no longer registered with Consul.
+// If the instance is still registered, it deregisters it.
+func (c *CleanupResource) Delete(key string, obj interface{}) error {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return fmt.Errorf("expected pod, got: %#v", obj)
+	}
+	if pod == nil {
+		return fmt.Errorf("object for key %s was nil", key)
+	}
+	serviceName, ok := pod.ObjectMeta.Annotations[annotationService]
+	if !ok {
+		return fmt.Errorf("pod did not have %s annotation", annotationService)
+	}
+	kubeNS := pod.Namespace
+	podName := pod.Name
+
+	// Look for both the service and its sidecar proxy.
+	consulServiceNames := []string{serviceName, fmt.Sprintf("%s-sidecar-proxy", serviceName)}
+
+	for _, consulServiceName := range consulServiceNames {
+		instances, _, err := c.ConsulClient.Catalog().Service(consulServiceName, "", &capi.QueryOptions{
+			Filter: fmt.Sprintf(`ServiceMeta[%q] == %q and ServiceMeta[%q] == %q`, MetaKeyPodName, podName, MetaKeyKubeNS, kubeNS),
+		})
+		if err != nil {
+			c.Log.Error("unable to get Consul Services", "error", err)
+			return err
+		}
+		if len(instances) == 0 {
+			c.Log.Debug("terminated pod had no still-registered instances", "service", consulServiceName, "pod", podName)
+			continue
+		}
+
+		// NOTE: We only expect a single instance because there's only one
+		// per pod but we may as well range over all of them just to be safe.
+		for _, instance := range instances {
+			// NOTE: We don't need to check if this instance belongs to a kube
+			// node in this cluster (like we do in Reconcile) because we only
+			// get the delete event if a pod in this cluster is deleted so
+			// we know this is one of our instances.
+
+			c.Log.Info("found service instance from terminated pod still registered", "pod", podName, "id", instance.ServiceID)
+			err := c.deregisterInstance(instance, pod.Status.HostIP)
+			if err != nil {
+				c.Log.Error("unable to deregister service instance", "id", instance.ServiceID, "error", err)
+				return err
+			}
+			c.Log.Info("service instance deregistered", "id", instance.ServiceID)
+		}
+	}
+	return nil
+}
+
+// Upsert is a no-op because we're only interested in pods that are deleted.
+func (c *CleanupResource) Upsert(_ string, _ interface{}) error {
+	return nil
+}
+
+func (c *CleanupResource) Informer() cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return c.KubernetesClient.CoreV1().Pods(metav1.NamespaceAll).List(c.Ctx,
+					metav1.ListOptions{LabelSelector: labelInject})
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return c.KubernetesClient.CoreV1().Pods(metav1.NamespaceAll).Watch(c.Ctx,
+					metav1.ListOptions{LabelSelector: labelInject})
+			},
+		},
+		&corev1.Pod{},
+		// Resync is 0 because we perform our own reconcile loop on our own timer.
+		0,
+		cache.Indexers{},
+	)
+}
+
+// deregisterInstance deregisters instance from Consul by calling the agent at
+// hostIP's deregister service API.
+func (c *CleanupResource) deregisterInstance(instance *capi.CatalogService, hostIP string) error {
+	fullAddr := fmt.Sprintf("%s://%s:%s", c.ConsulScheme, hostIP, c.ConsulPort)
+	localConfig := capi.DefaultConfig()
+	localConfig.Address = fullAddr
+	client, err := consul.NewClient(localConfig)
+	if err != nil {
+		return fmt.Errorf("constructing client for address %q: %s", hostIP, err)
+	}
+
+	return client.Agent().ServiceDeregister(instance.ServiceID)
+}
+
+// currentPodsKey should be used to construct the key to access the
+// currentPods map.
+func currentPodsKey(podName, k8sNamespace string) string {
+	return fmt.Sprintf("%s/%s", k8sNamespace, podName)
+}
+
+// nodeInCluster returns whether nodeName is the name of a node in nodes, i.e.
+// it's the name of a node in this cluster.
+func nodeInCluster(nodes *corev1.NodeList, nodeName string) bool {
+	for _, n := range nodes.Items {
+		if n.Name == nodeName {
+			return true
+		}
+	}
+	return false
+}

--- a/connect-inject/cleanup_resource_ent_test.go
+++ b/connect-inject/cleanup_resource_ent_test.go
@@ -1,0 +1,324 @@
+// +build enterprise
+
+package connectinject
+
+import (
+	"net/url"
+	"testing"
+
+	capi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestReconcile_ConsulNamespaces(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		ConsulServices []capi.AgentServiceRegistration
+		KubePods       []runtime.Object
+		// ExpConsulServiceIDs maps from Consul namespace to
+		// list of expected service ids in that namespace.
+		ExpConsulServiceIDs map[string][]string
+	}{
+		"default namespace, pod deleted": {
+			ConsulServices: []capi.AgentServiceRegistration{
+				consulFooSvcDefaultNS,
+			},
+			KubePods: nil,
+			ExpConsulServiceIDs: map[string][]string{
+				"default": {"consul"},
+			},
+		},
+		"default namespace, pod not deleted": {
+			ConsulServices: []capi.AgentServiceRegistration{
+				consulFooSvcDefaultNS,
+			},
+			KubePods: []runtime.Object{consulFooPodDefaultNS},
+			ExpConsulServiceIDs: map[string][]string{
+				"default": {"consul", "foo-abc123-foo"},
+			},
+		},
+		"foo namespace, pod deleted": {
+			ConsulServices: []capi.AgentServiceRegistration{
+				consulFooSvcFooNS,
+			},
+			KubePods: nil,
+			ExpConsulServiceIDs: map[string][]string{
+				"default": {"consul"},
+				"foo":     nil,
+			},
+		},
+		"foo namespace, pod not deleted": {
+			ConsulServices: []capi.AgentServiceRegistration{
+				consulFooSvcFooNS,
+			},
+			KubePods: []runtime.Object{consulFooPodFooNS},
+			ExpConsulServiceIDs: map[string][]string{
+				"default": {"consul"},
+				"foo":     {"foo-abc123-foo"},
+			},
+		},
+		"does not delete instances with same id in different namespaces": {
+			ConsulServices: []capi.AgentServiceRegistration{
+				consulFooSvcFooNS,
+				consulFooSvcBarNS,
+			},
+			KubePods: []runtime.Object{consulFooPodFooNS},
+			ExpConsulServiceIDs: map[string][]string{
+				"default": {"consul"},
+				"foo":     {"foo-abc123-foo"},
+				"bar":     nil,
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			// Start Consul server.
+			server, err := testutil.NewTestServerConfigT(t, nil)
+			defer server.Stop()
+			require.NoError(err)
+			server.WaitForLeader(t)
+			consulClient, err := capi.NewClient(&capi.Config{Address: server.HTTPAddr})
+			require.NoError(err)
+
+			// Register Consul services.
+			for _, svc := range c.ConsulServices {
+				_, _, err := consulClient.Namespaces().Create(&capi.Namespace{
+					Name: svc.Namespace,
+				}, nil)
+				require.NoError(err)
+				require.NoError(consulClient.Agent().ServiceRegister(&svc))
+			}
+
+			// Create the cleanup resource.
+			log := hclog.Default().Named("cleanupResource")
+			log.SetLevel(hclog.Debug)
+			consulURL, err := url.Parse("http://" + server.HTTPAddr)
+			require.NoError(err)
+			node := nodeName(t, consulClient)
+			// NOTE: we need to add the node because the reconciler checks if
+			// the node the service is registered with actually exists in this
+			// cluster.
+			kubeResources := append(c.KubePods, &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: node,
+				},
+			})
+			cleanupResource := CleanupResource{
+				Log:                    log,
+				KubernetesClient:       fake.NewSimpleClientset(kubeResources...),
+				ConsulClient:           consulClient,
+				ConsulScheme:           consulURL.Scheme,
+				ConsulPort:             consulURL.Port(),
+				EnableConsulNamespaces: true,
+			}
+
+			// Run Reconcile.
+			cleanupResource.reconcile()
+
+			// Test that the remaining services are what we expect.
+			for ns, expSvcs := range c.ExpConsulServiceIDs {
+				// Note: we need to use the catalog endpoints because
+				// Agent().Services() does not currently support namespaces
+				// (https://github.com/hashicorp/consul/issues/9710).
+				services, _, err := consulClient.Catalog().Services(&capi.QueryOptions{Namespace: ns})
+				require.NoError(err)
+
+				var actualServiceIDs []string
+				for actSvcName := range services {
+					services, _, err := consulClient.Catalog().Service(actSvcName, "", &capi.QueryOptions{Namespace: ns})
+					require.NoError(err)
+					for _, actSvc := range services {
+						actualServiceIDs = append(actualServiceIDs, actSvc.ServiceID)
+					}
+				}
+				require.ElementsMatch(actualServiceIDs, expSvcs, "ns=%s act=%v", ns, actualServiceIDs)
+			}
+		})
+	}
+}
+
+func TestDelete_ConsulNamespaces(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		Pod            *corev1.Pod
+		ConsulServices []capi.AgentServiceRegistration
+		// ExpConsulServiceIDs maps from Consul namespace to
+		// list of expected service ids in that namespace.
+		ExpConsulServiceIDs map[string][]string
+		ExpErr              string
+	}{
+		"default namespace": {
+			ConsulServices: []capi.AgentServiceRegistration{
+				consulFooSvcDefaultNS,
+			},
+			Pod: consulFooPodDefaultNS,
+			ExpConsulServiceIDs: map[string][]string{
+				"default": {"consul"},
+			},
+		},
+		"foo namespace": {
+			ConsulServices: []capi.AgentServiceRegistration{
+				consulFooSvcFooNS,
+			},
+			Pod: consulFooPodFooNS,
+			ExpConsulServiceIDs: map[string][]string{
+				"default": {"consul"},
+				"foo":     nil,
+			},
+		},
+		"does not delete instances with same id in different namespaces": {
+			ConsulServices: []capi.AgentServiceRegistration{
+				consulFooSvcFooNS,
+				consulFooSvcBarNS,
+			},
+			Pod: consulFooPodFooNS,
+			ExpConsulServiceIDs: map[string][]string{
+				"default": {"consul"},
+				"foo":     nil,
+				"bar":     {"foo-abc123-foo"},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			// Start Consul server.
+			server, err := testutil.NewTestServerConfigT(t, nil)
+			defer server.Stop()
+			require.NoError(err)
+			server.WaitForLeader(t)
+			consulClient, err := capi.NewClient(&capi.Config{Address: server.HTTPAddr})
+			require.NoError(err)
+
+			// Register Consul services.
+			for _, svc := range c.ConsulServices {
+				_, _, err := consulClient.Namespaces().Create(&capi.Namespace{
+					Name: svc.Namespace,
+				}, nil)
+				require.NoError(err)
+				require.NoError(consulClient.Agent().ServiceRegister(&svc))
+			}
+
+			// Create the cleanup resource.
+			log := hclog.Default().Named("cleanupResource")
+			log.SetLevel(hclog.Debug)
+			consulURL, err := url.Parse("http://" + server.HTTPAddr)
+			require.NoError(err)
+			cleanupResource := CleanupResource{
+				Log:                    log,
+				KubernetesClient:       fake.NewSimpleClientset(),
+				ConsulClient:           consulClient,
+				ConsulScheme:           consulURL.Scheme,
+				ConsulPort:             consulURL.Port(),
+				EnableConsulNamespaces: true,
+			}
+
+			// Run Delete.
+			err = cleanupResource.Delete("default/foo", c.Pod)
+			if c.ExpErr != "" {
+				require.EqualError(err, c.ExpErr)
+			} else {
+				require.NoError(err)
+
+				// Test that the remaining services are what we expect.
+				for ns, expSvcs := range c.ExpConsulServiceIDs {
+					// Note: we need to use the catalog endpoints because
+					// Agent().Services() does not currently support namespaces
+					// (https://github.com/hashicorp/consul/issues/9710).
+					services, _, err := consulClient.Catalog().Services(&capi.QueryOptions{Namespace: ns})
+					require.NoError(err)
+
+					var actualServiceIDs []string
+					for actSvcName := range services {
+						services, _, err := consulClient.Catalog().Service(actSvcName, "", &capi.QueryOptions{Namespace: ns})
+						require.NoError(err)
+						for _, actSvc := range services {
+							actualServiceIDs = append(actualServiceIDs, actSvc.ServiceID)
+						}
+					}
+					require.ElementsMatch(actualServiceIDs, expSvcs, "ns=%s act=%v", ns, actualServiceIDs)
+				}
+			}
+		})
+	}
+}
+
+var (
+	consulFooSvcDefaultNS = capi.AgentServiceRegistration{
+		ID:        "foo-abc123-foo",
+		Name:      "foo",
+		Namespace: "default",
+		Address:   "127.0.0.1",
+		Meta: map[string]string{
+			MetaKeyPodName: "foo-abc123",
+			MetaKeyKubeNS:  "default",
+		},
+	}
+	consulFooSvcFooNS = capi.AgentServiceRegistration{
+		ID:        "foo-abc123-foo",
+		Name:      "foo",
+		Namespace: "foo",
+		Address:   "127.0.0.1",
+		Meta: map[string]string{
+			MetaKeyPodName: "foo-abc123",
+			MetaKeyKubeNS:  "default",
+		},
+	}
+	consulFooSvcBarNS = capi.AgentServiceRegistration{
+		ID:        "foo-abc123-foo",
+		Name:      "foo",
+		Namespace: "bar",
+		Address:   "127.0.0.1",
+		Meta: map[string]string{
+			MetaKeyPodName: "foo-abc123",
+			MetaKeyKubeNS:  "bar",
+		},
+	}
+	consulFooPodDefaultNS = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-abc123",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelInject: injected,
+			},
+			Annotations: map[string]string{
+				annotationStatus:          injected,
+				annotationService:         "foo",
+				annotationConsulNamespace: "default",
+			},
+		},
+		Status: corev1.PodStatus{
+			HostIP: "127.0.0.1",
+		},
+	}
+	consulFooPodFooNS = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-abc123",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelInject: injected,
+			},
+			Annotations: map[string]string{
+				annotationStatus:          injected,
+				annotationService:         "foo",
+				annotationConsulNamespace: "foo",
+			},
+		},
+		Status: corev1.PodStatus{
+			HostIP: "127.0.0.1",
+		},
+	}
+)

--- a/connect-inject/cleanup_resource_test.go
+++ b/connect-inject/cleanup_resource_test.go
@@ -1,0 +1,338 @@
+package connectinject
+
+import (
+	"net/url"
+	"testing"
+
+	capi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestReconcile(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		ConsulServices      []capi.AgentServiceRegistration
+		KubePods            []runtime.Object
+		ExpConsulServiceIDs []string
+		// OutOfClusterNode controls whether the services are registered on a
+		// node that does not exist in this Kube cluster.
+		OutOfClusterNode bool
+	}{
+		"no instances running": {
+			ConsulServices:      nil,
+			KubePods:            nil,
+			ExpConsulServiceIDs: nil,
+		},
+		"instance does not have pod-name meta key": {
+			ConsulServices:      []capi.AgentServiceRegistration{consulNoPodNameMetaSvc},
+			ExpConsulServiceIDs: []string{"foo-abc123-foo"},
+		},
+		"instance does not have k8s-namespace meta key": {
+			ConsulServices:      []capi.AgentServiceRegistration{consulNoK8sNSMetaSvc},
+			ExpConsulServiceIDs: []string{"foo-abc123-foo"},
+		},
+		"out of cluster node": {
+			ConsulServices:      []capi.AgentServiceRegistration{consulFooSvc, consulFooSvcSidecar},
+			ExpConsulServiceIDs: []string{"foo-abc123-foo", "foo-abc123-foo-sidecar-proxy"},
+			OutOfClusterNode:    true,
+		},
+		"app and sidecar still running": {
+			ConsulServices:      []capi.AgentServiceRegistration{consulFooSvc, consulFooSvcSidecar},
+			KubePods:            []runtime.Object{fooPod},
+			ExpConsulServiceIDs: []string{"foo-abc123-foo", "foo-abc123-foo-sidecar-proxy"},
+		},
+		"app and sidecar terminated": {
+			ConsulServices:      []capi.AgentServiceRegistration{consulFooSvc, consulFooSvcSidecar},
+			KubePods:            nil,
+			ExpConsulServiceIDs: nil,
+		},
+		"only app is registered, no sidecar": {
+			ConsulServices:      []capi.AgentServiceRegistration{consulFooSvc},
+			KubePods:            nil,
+			ExpConsulServiceIDs: nil,
+		},
+		"only sidecar is registered, no app": {
+			ConsulServices:      []capi.AgentServiceRegistration{consulFooSvcSidecar},
+			KubePods:            nil,
+			ExpConsulServiceIDs: nil,
+		},
+		"multiple instances of the same service": {
+			ConsulServices: []capi.AgentServiceRegistration{
+				consulFooSvc,
+				consulFooSvcSidecar,
+				consulFooSvcPod2,
+				consulFooSvcSidecarPod2,
+			},
+			KubePods:            []runtime.Object{fooPod},
+			ExpConsulServiceIDs: []string{"foo-abc123-foo", "foo-abc123-foo-sidecar-proxy"},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			// Start Consul server.
+			server, err := testutil.NewTestServerConfigT(t, nil)
+			defer server.Stop()
+			require.NoError(err)
+			server.WaitForLeader(t)
+			consulClient, err := capi.NewClient(&capi.Config{Address: server.HTTPAddr})
+			require.NoError(err)
+
+			// Register Consul services.
+			for _, svc := range c.ConsulServices {
+				require.NoError(consulClient.Agent().ServiceRegister(&svc))
+			}
+
+			// Create the cleanup resource.
+			log := hclog.Default().Named("cleanupResource")
+			log.SetLevel(hclog.Debug)
+			consulURL, err := url.Parse("http://" + server.HTTPAddr)
+			require.NoError(err)
+			kubeResources := c.KubePods
+			if !c.OutOfClusterNode {
+				node := nodeName(t, consulClient)
+				// NOTE: we need to add the node because the reconciler checks if
+				// the node the service is registered with actually exists in this
+				// cluster.
+				kubeResources = append(kubeResources, &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node,
+					},
+				})
+
+			}
+			cleanupResource := CleanupResource{
+				Log:              log,
+				KubernetesClient: fake.NewSimpleClientset(kubeResources...),
+				ConsulClient:     consulClient,
+				ConsulScheme:     consulURL.Scheme,
+				ConsulPort:       consulURL.Port(),
+			}
+
+			// Run Reconcile.
+			cleanupResource.reconcile()
+
+			// Test that the remaining services are what we expect.
+			services, err := consulClient.Agent().Services()
+			require.NoError(err)
+			var actualServiceIDs []string
+			for id := range services {
+				actualServiceIDs = append(actualServiceIDs, id)
+			}
+			require.ElementsMatch(actualServiceIDs, c.ExpConsulServiceIDs)
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+
+	var nilPod *corev1.Pod
+	cases := map[string]struct {
+		Pod                 interface{}
+		ConsulServices      []capi.AgentServiceRegistration
+		ExpConsulServiceIDs []string
+		ExpErr              string
+	}{
+		"pod is nil": {
+			Pod:    nilPod,
+			ExpErr: "object for key default/foo was nil",
+		},
+		"not expected type": {
+			Pod:    &corev1.Service{},
+			ExpErr: "expected pod, got: &v1.Service",
+		},
+		"pod does not have service-name annotation": {
+			Pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo-abc123",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					HostIP: "127.0.0.1",
+				},
+			},
+			ExpErr: "pod did not have consul.hashicorp.com/connect-service annotation",
+		},
+		"instance does not have pod-name meta": {
+			Pod:                 fooPod,
+			ConsulServices:      []capi.AgentServiceRegistration{consulNoPodNameMetaSvc},
+			ExpConsulServiceIDs: []string{"foo-abc123-foo"},
+		},
+		"instance does not have k8s-namespace meta": {
+			Pod:                 fooPod,
+			ConsulServices:      []capi.AgentServiceRegistration{consulNoK8sNSMetaSvc},
+			ExpConsulServiceIDs: []string{"foo-abc123-foo"},
+		},
+		"no instances still registered": {
+			Pod:                 fooPod,
+			ConsulServices:      nil,
+			ExpConsulServiceIDs: nil,
+		},
+		"app and sidecar terminated": {
+			Pod:                 fooPod,
+			ConsulServices:      []capi.AgentServiceRegistration{consulFooSvc, consulFooSvcSidecar},
+			ExpConsulServiceIDs: nil,
+		},
+		"only app is registered, no sidecar": {
+			Pod:                 fooPod,
+			ConsulServices:      []capi.AgentServiceRegistration{consulFooSvc},
+			ExpConsulServiceIDs: nil,
+		},
+		"only sidecar is registered, no app": {
+			Pod:                 fooPod,
+			ConsulServices:      []capi.AgentServiceRegistration{consulFooSvcSidecar},
+			ExpConsulServiceIDs: nil,
+		},
+		"multiple instances of the same service": {
+			Pod: fooPod,
+			ConsulServices: []capi.AgentServiceRegistration{
+				consulFooSvc,
+				consulFooSvcSidecar,
+				consulFooSvcPod2,
+				consulFooSvcSidecarPod2,
+			},
+			ExpConsulServiceIDs: []string{"foo-def456-foo", "foo-def456-foo-sidecar-proxy"},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			// Start Consul server.
+			server, err := testutil.NewTestServerConfigT(t, nil)
+			defer server.Stop()
+			require.NoError(err)
+			server.WaitForLeader(t)
+			consulClient, err := capi.NewClient(&capi.Config{Address: server.HTTPAddr})
+			require.NoError(err)
+
+			// Register Consul services.
+			for _, svc := range c.ConsulServices {
+				require.NoError(consulClient.Agent().ServiceRegister(&svc))
+			}
+
+			// Create the cleanup resource.
+			log := hclog.Default().Named("cleanupResource")
+			log.SetLevel(hclog.Debug)
+			consulURL, err := url.Parse("http://" + server.HTTPAddr)
+			require.NoError(err)
+			cleanupResource := CleanupResource{
+				Log:              log,
+				KubernetesClient: fake.NewSimpleClientset(),
+				ConsulClient:     consulClient,
+				ConsulScheme:     consulURL.Scheme,
+				ConsulPort:       consulURL.Port(),
+			}
+
+			// Run Delete.
+			err = cleanupResource.Delete("default/foo", c.Pod)
+			if c.ExpErr != "" {
+				require.Error(err)
+				require.Contains(err.Error(), c.ExpErr)
+			} else {
+				require.NoError(err)
+
+				// Test that the remaining services are what we expect.
+				services, err := consulClient.Agent().Services()
+				require.NoError(err)
+				var actualServiceIDs []string
+				for id := range services {
+					actualServiceIDs = append(actualServiceIDs, id)
+				}
+				require.ElementsMatch(actualServiceIDs, c.ExpConsulServiceIDs)
+			}
+		})
+	}
+}
+
+// nodeName returns the Consul node name for the agent that client
+// points at.
+func nodeName(t *testing.T, client *capi.Client) string {
+	self, err := client.Agent().Self()
+	require.NoError(t, err)
+	require.Contains(t, self, "Config")
+	require.Contains(t, self["Config"], "NodeName")
+	return self["Config"]["NodeName"].(string)
+}
+
+var (
+	consulFooSvc = capi.AgentServiceRegistration{
+		ID:      "foo-abc123-foo",
+		Name:    "foo",
+		Address: "127.0.0.1",
+		Meta: map[string]string{
+			MetaKeyPodName: "foo-abc123",
+			MetaKeyKubeNS:  "default",
+		},
+	}
+	consulFooSvcSidecar = capi.AgentServiceRegistration{
+		ID:      "foo-abc123-foo-sidecar-proxy",
+		Name:    "foo-sidecar-proxy",
+		Address: "127.0.0.1",
+		Meta: map[string]string{
+			MetaKeyPodName: "foo-abc123",
+			MetaKeyKubeNS:  "default",
+		},
+	}
+	consulFooSvcPod2 = capi.AgentServiceRegistration{
+		ID:      "foo-def456-foo",
+		Name:    "foo",
+		Address: "127.0.0.1",
+		Meta: map[string]string{
+			MetaKeyPodName: "foo-def456",
+			MetaKeyKubeNS:  "default",
+		},
+	}
+	consulFooSvcSidecarPod2 = capi.AgentServiceRegistration{
+		ID:      "foo-def456-foo-sidecar-proxy",
+		Name:    "foo-sidecar-proxy",
+		Address: "127.0.0.1",
+		Meta: map[string]string{
+			MetaKeyPodName: "foo-def456",
+			MetaKeyKubeNS:  "default",
+		},
+	}
+	consulNoPodNameMetaSvc = capi.AgentServiceRegistration{
+		ID:      "foo-abc123-foo",
+		Name:    "foo",
+		Address: "127.0.0.1",
+		Meta: map[string]string{
+			MetaKeyKubeNS: "default",
+		},
+	}
+	consulNoK8sNSMetaSvc = capi.AgentServiceRegistration{
+		ID:      "foo-abc123-foo",
+		Name:    "foo",
+		Address: "127.0.0.1",
+		Meta: map[string]string{
+			MetaKeyPodName: "foo-abc123",
+		},
+	}
+	fooPod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-abc123",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelInject: injected,
+			},
+			Annotations: map[string]string{
+				annotationStatus:  injected,
+				annotationService: "foo",
+			},
+		},
+		Status: corev1.PodStatus{
+			HostIP: "127.0.0.1",
+		},
+	}
+)

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -65,6 +65,7 @@ services {
   port = 0
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 }
 
@@ -76,6 +77,7 @@ services {
   port = 20000
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 
   proxy {
@@ -124,6 +126,7 @@ cp /bin/consul /consul/connect-inject/consul`,
   port = 1234
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 }
 
@@ -135,6 +138,7 @@ services {
   port = 20000
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 
   proxy {
@@ -303,6 +307,7 @@ services {
   tags = ["abc"]
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 }
 
@@ -315,6 +320,7 @@ services {
   tags = ["abc"]
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 
   proxy {
@@ -355,6 +361,7 @@ services {
   tags = ["abc","123"]
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 }
 
@@ -367,6 +374,7 @@ services {
   tags = ["abc","123"]
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 
   proxy {
@@ -407,6 +415,7 @@ services {
   tags = ["abc","123"]
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 }
 
@@ -419,6 +428,7 @@ services {
   tags = ["abc","123"]
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 
   proxy {
@@ -460,6 +470,7 @@ services {
   tags = ["abc","123","abc","123","def","456"]
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 }
 
@@ -472,6 +483,7 @@ services {
   tags = ["abc","123","abc","123","def","456"]
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 
   proxy {
@@ -523,6 +535,7 @@ services {
     name = "abc"
     version = "2"
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 }
 
@@ -536,6 +549,7 @@ services {
     name = "abc"
     version = "2"
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 
   proxy {
@@ -568,6 +582,7 @@ services {
 			},
 			`  meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 `,
 			"",
@@ -581,6 +596,7 @@ services {
 			},
 			`  meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 `,
 			"",
@@ -691,6 +707,7 @@ services {
   namespace = "default"
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 }
 
@@ -703,6 +720,7 @@ services {
   namespace = "default"
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 
   proxy {
@@ -765,6 +783,7 @@ services {
   namespace = "non-default"
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 }
 
@@ -777,6 +796,7 @@ services {
   namespace = "non-default"
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 
   proxy {
@@ -840,6 +860,7 @@ services {
   namespace = "non-default"
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 }
 
@@ -852,6 +873,7 @@ services {
   namespace = "non-default"
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 
   proxy {
@@ -924,6 +946,7 @@ services {
   namespace = "k8snamespace"
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 }
 
@@ -936,6 +959,7 @@ services {
   namespace = "k8snamespace"
   meta = {
     pod-name = "${POD_NAME}"
+    k8s-namespace = "${POD_NAMESPACE}"
   }
 
   proxy {

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -398,13 +398,14 @@ func (c *Command) Run(args []string) int {
 
 	if c.flagEnableCleanupController {
 		cleanupResource := connectinject.CleanupResource{
-			Log:              logger.Named("cleanupResource"),
-			KubernetesClient: c.clientset,
-			Ctx:              ctx,
-			ReconcilePeriod:  c.flagCleanupControllerReconcilePeriod,
-			ConsulClient:     c.consulClient,
-			ConsulScheme:     consulURL.Scheme,
-			ConsulPort:       consulURL.Port(),
+			Log:                    logger.Named("cleanupResource"),
+			KubernetesClient:       c.clientset,
+			Ctx:                    ctx,
+			ReconcilePeriod:        c.flagCleanupControllerReconcilePeriod,
+			ConsulClient:           c.consulClient,
+			ConsulScheme:           consulURL.Scheme,
+			ConsulPort:             consulURL.Port(),
+			EnableConsulNamespaces: c.flagEnableNamespaces,
 		}
 		cleanupCtrl := &controller.Controller{
 			Log:      logger.Named("cleanupController"),

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -65,6 +65,10 @@ type Command struct {
 	flagEnableHealthChecks          bool          // Start the health check controller.
 	flagHealthChecksReconcilePeriod time.Duration // Period for health check reconcile.
 
+	// Flags for cleanup controller.
+	flagEnableCleanupController          bool          // Start the cleanup controller.
+	flagCleanupControllerReconcilePeriod time.Duration // Period for cleanup controller reconcile.
+
 	// Proxy resource settings.
 	flagDefaultSidecarProxyCPULimit      string
 	flagDefaultSidecarProxyCPURequest    string
@@ -130,6 +134,9 @@ func (c *Command) init() {
 	c.flagSet.BoolVar(&c.flagEnableHealthChecks, "enable-health-checks-controller", false,
 		"Enables health checks controller.")
 	c.flagSet.DurationVar(&c.flagHealthChecksReconcilePeriod, "health-checks-reconcile-period", 1*time.Minute, "Reconcile period for health checks controller.")
+	c.flagSet.BoolVar(&c.flagEnableCleanupController, "enable-cleanup-controller", true,
+		"Enables cleanup controller that cleans up stale Consul service instances.")
+	c.flagSet.DurationVar(&c.flagCleanupControllerReconcilePeriod, "cleanup-controller-reconcile-period", 5*time.Minute, "Reconcile period for cleanup controller.")
 	c.flagSet.BoolVar(&c.flagEnableNamespaces, "enable-namespaces", false,
 		"[Enterprise Only] Enables namespaces, in either a single Consul namespace or mirrored.")
 	c.flagSet.StringVar(&c.flagConsulDestinationNamespace, "consul-destination-namespace", "default",
@@ -385,8 +392,32 @@ func (c *Command) Run(args []string) int {
 		}
 	}()
 
-	// Start the health checks controller.
+	// Start the cleanup controller that cleans up Consul service instances
+	// still registered after the pod has been deleted (usually due to a force delete).
 	ctrlExitCh := make(chan error)
+
+	if c.flagEnableCleanupController {
+		cleanupResource := connectinject.CleanupResource{
+			Log:              logger.Named("cleanupResource"),
+			KubernetesClient: c.clientset,
+			Ctx:              ctx,
+			ReconcilePeriod:  c.flagCleanupControllerReconcilePeriod,
+			ConsulClient:     c.consulClient,
+			ConsulScheme:     consulURL.Scheme,
+			ConsulPort:       consulURL.Port(),
+		}
+		cleanupCtrl := &controller.Controller{
+			Log:      logger.Named("cleanupController"),
+			Resource: &cleanupResource,
+		}
+		go func() {
+			cleanupCtrl.Run(ctx.Done())
+			if ctx.Err() == nil {
+				ctrlExitCh <- fmt.Errorf("cleanup controller exited unexpectedly")
+			}
+		}()
+	}
+
 	if c.flagEnableHealthChecks {
 		healthResource := connectinject.HealthCheckResource{
 			Log:                 logger.Named("healthCheckResource"),

--- a/subcommand/inject-connect/command_test.go
+++ b/subcommand/inject-connect/command_test.go
@@ -227,13 +227,12 @@ func TestRun_CommandFailsWithInvalidListener(t *testing.T) {
 		UI:        ui,
 		clientset: k8sClient,
 	}
-	os.Setenv(api.HTTPAddrEnvName, "http://0.0.0.0:9999")
 	code := cmd.Run([]string{
 		"-consul-k8s-image", "hashicorp/consul-k8s", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
 		"-enable-health-checks-controller=true",
+		"-http-addr=http://0.0.0.0:9999",
 		"-listen", "999999",
 	})
-	os.Unsetenv(api.HTTPAddrEnvName)
 	require.Equal(t, 1, code)
 	require.Contains(t, ui.ErrorWriter.String(), "Error listening: listen tcp: address 999999: missing port in address")
 }

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -83,6 +83,8 @@ type Command struct {
 	// Flag to indicate that the health checks controller is enabled.
 	flagEnableHealthChecks bool
 
+	flagEnableCleanupController bool
+
 	flagLogLevel string
 	flagTimeout  time.Duration
 
@@ -197,6 +199,9 @@ func (c *Command) init() {
 
 	c.flags.BoolVar(&c.flagEnableHealthChecks, "enable-health-checks", false,
 		"Toggle for adding ACL rules for the health check controller to the connect ACL token. Requires -create-inject-token to be also be set.")
+
+	c.flags.BoolVar(&c.flagEnableCleanupController, "enable-cleanup-controller", true,
+		"Toggle for adding ACL rules for the cleanup controller to the connect ACL token. Requires -create-inject-token to be also be set.")
 
 	c.flags.DurationVar(&c.flagTimeout, "timeout", 10*time.Minute,
 		"How long we'll try to bootstrap ACLs for before timing out, e.g. 1ms, 2s, 3m")
@@ -481,7 +486,7 @@ func (c *Command) Run(args []string) int {
 
 		// If health checks or namespaces are enabled,
 		// then the connect injector needs an ACL token.
-		if c.flagEnableNamespaces || c.flagEnableHealthChecks {
+		if c.flagEnableNamespaces || c.flagEnableHealthChecks || c.flagEnableCleanupController {
 			injectRules, err := c.injectRules()
 			if err != nil {
 				c.log.Error("Error templating inject rules", "err", err)

--- a/subcommand/server-acl-init/command_ent_test.go
+++ b/subcommand/server-acl-init/command_ent_test.go
@@ -268,6 +268,7 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 				"anothergw-ingress-gateway-token",
 				"gw-terminating-gateway-token",
 				"anothergw-terminating-gateway-token",
+				"connect-inject-token",
 				"controller-token",
 			}
 			policies, _, err := consul.ACL().PolicyList(nil)


### PR DESCRIPTION
Add new cleanup controller that runs in the connect-inject deployment. This
controller cleans up Consul service instances that remain registered despite their
pods being deleted. This could happen if the pod's `preStop` hook failed to execute
for some reason.