### PR TITLE
Tproxy split init containers

### DIFF
--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -105,10 +105,7 @@ EOF
 # Generate the envoy bootstrap code
 /bin/consul connect envoy \
   -proxy-id="${PROXY_SERVICE_ID}" \
-  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
-
-# Copy the Consul binary
-cp /bin/consul /consul/connect-inject/consul`,
+  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`,
 			"",
 		},
 
@@ -795,10 +792,7 @@ EOF
 /bin/consul connect envoy \
   -proxy-id="${PROXY_SERVICE_ID}" \
   -namespace="default" \
-  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
-
-# Copy the Consul binary
-cp /bin/consul /consul/connect-inject/consul`,
+  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`,
 			"",
 		},
 
@@ -871,10 +865,7 @@ EOF
 /bin/consul connect envoy \
   -proxy-id="${PROXY_SERVICE_ID}" \
   -namespace="non-default" \
-  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
-
-# Copy the Consul binary
-cp /bin/consul /consul/connect-inject/consul`,
+  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`,
 			"",
 		},
 
@@ -956,10 +947,7 @@ chmod 444 /consul/connect-inject/acl-token
   -proxy-id="${PROXY_SERVICE_ID}" \
   -token-file="/consul/connect-inject/acl-token" \
   -namespace="non-default" \
-  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
-
-# Copy the Consul binary
-cp /bin/consul /consul/connect-inject/consul`,
+  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`,
 			"",
 		},
 
@@ -1042,10 +1030,7 @@ chmod 444 /consul/connect-inject/acl-token
   -proxy-id="${PROXY_SERVICE_ID}" \
   -token-file="/consul/connect-inject/acl-token" \
   -namespace="k8snamespace" \
-  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
-
-# Copy the Consul binary
-cp /bin/consul /consul/connect-inject/consul`,
+  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`,
 			"",
 		},
 
@@ -1445,4 +1430,13 @@ func TestHandlerContainerInit_MeshGatewayModeErrors(t *testing.T) {
 		})
 	}
 
+}
+
+// Test that the init copy container has the correct command.
+func TestHandlerContainerInitCopyContainer(t *testing.T) {
+	require := require.New(t)
+	h := Handler{}
+	container := h.containerInitCopyContainer()
+	actual := strings.Join(container.Command, " ")
+	require.Contains(actual, `cp /bin/consul /consul/connect-inject/consul`)
 }

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -99,6 +99,10 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
+					Path:      "/spec/initContainers/-",
+				},
+				{
+					Operation: "add",
 					Path:      "/spec/containers/-",
 				},
 				{
@@ -163,6 +167,10 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/spec/initContainers",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers/-",
 				},
 				{
 					Operation: "add",
@@ -239,6 +247,10 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
+					Path:      "/spec/initContainers/-",
+				},
+				{
+					Operation: "add",
 					Path:      "/spec/containers/-",
 				},
 				{
@@ -282,6 +294,10 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/spec/initContainers",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers/-",
 				},
 				{
 					Operation: "add",
@@ -333,6 +349,10 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/spec/initContainers",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers/-",
 				},
 				{
 					Operation: "add",


### PR DESCRIPTION
Changes proposed in this PR:
- split the existing connect init container into two init containers:  1 does the consul binary copy and the other does the existing leg-work for registration. This is part of the tproxy refactor which sees the existing init container functionality replaced by a new consul-k8s command (incoming PR).

How I've tested this PR:
manually deployed and confirmed connect inject still works with the correct init containers.
new and existing unit tests work.

How I expect reviewers to test this PR:
deploy kschoche/consul-k8s-dev and a sample connect injected app to confirm it still mutates and now has 2 containers instead of 1.

```
Events:
  Type     Reason     Age   From               Message
  ----     ------     ----  ----               -------
  Normal   Scheduled  22s   default-scheduler  Successfully assigned default/counting to [redacted]
  Normal   Pulled     21s   kubelet            Container image "hashicorp/consul:1.9.3" already present on machine
  Normal   Created    21s   kubelet            Created container consul-connect-inject-init-copy-container
  Normal   Started    21s   kubelet            Started container consul-connect-inject-init-copy-container
  Normal   Pulled     17s   kubelet            Container image "hashicorp/consul:1.9.3" already present on machine
  Normal   Created    17s   kubelet            Created container consul-connect-inject-init
  Normal   Started    16s   kubelet            Started container consul-connect-inject-init
  Normal   Pulled     12s   kubelet            Container image "hashicorp/counting-service:0.0.2" already present on machine
  Normal   Started    11s   kubelet            Started container counting
```

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
