### PR TITLE
Refactor merged metrics tests to use fewer ports and use freeport package

### DIFF
--- a/subcommand/consul-sidecar/command_ent_test.go
+++ b/subcommand/consul-sidecar/command_ent_test.go
@@ -1,6 +1,6 @@
 // +build enterprise
 
-package subcommand
+package consulsidecar
 
 import (
 	"os"


### PR DESCRIPTION
Refactor merged metrics tests to use fewer ports and use freeport package.

- This will help the tests run in parallel and not conflict with other
tests using freeport.

Co-authored-by: Kyle Schochenmaier <kschoche@users.noreply.github.com>


How I've tested this PR:
- Run through steps in https://github.com/hashicorp/consul-k8s/pull/438

How I expect reviewers to test this PR:
- Code review

Checklist:
- [x] Tests added

