### PR TITLE
Add flag for service registration in consul sidecar

### DIFF
--- a/subcommand/common/common.go
+++ b/subcommand/common/common.go
@@ -2,8 +2,10 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/hashicorp/go-hclog"
 )
@@ -29,4 +31,18 @@ func Logger(level string) (hclog.Logger, error) {
 		Level:  parsedLevel,
 		Output: os.Stderr,
 	}), nil
+}
+
+// ValidatePort converts flags representing ports into integer and validates
+// that it's in the port range.
+func ValidatePort(flagName, flagValue string) error {
+	port, err := strconv.Atoi(flagValue)
+	if err != nil {
+		return errors.New(fmt.Sprintf("%s value of %s is not a valid integer.", flagName, flagValue))
+	}
+	// This checks if the port is in the valid port range.
+	if port < 1024 || port > 65535 {
+		return errors.New(fmt.Sprintf("%s value of %d is not in the port range 1024-65535.", flagName, port))
+	}
+	return nil
 }

--- a/subcommand/common/common_test.go
+++ b/subcommand/common/common_test.go
@@ -17,3 +17,12 @@ func TestLogger(t *testing.T) {
 	require.NotNil(t, lgr)
 	require.True(t, lgr.IsDebug())
 }
+
+func TestValidatePort(t *testing.T) {
+	err := ValidatePort("-test-flag-name", "1234")
+	require.NoError(t, err)
+	err = ValidatePort("-test-flag-name", "invalid-port")
+	require.EqualError(t, err, "-test-flag-name value of invalid-port is not a valid integer.")
+	err = ValidatePort("-test-flag-name", "22")
+	require.EqualError(t, err, "-test-flag-name value of 22 is not in the port range 1024-65535.")
+}

--- a/subcommand/consul-sidecar/command_ent_test.go
+++ b/subcommand/consul-sidecar/command_ent_test.go
@@ -1,6 +1,6 @@
 // +build enterprise
 
-package subcommand
+package consulsidecar
 
 import (
 	"os"


### PR DESCRIPTION
EDIT: Redrafting in favor of moving some of this into feature-metrics for better exit handling both there and in here

Changes proposed in this PR:
- Add flag for service registration in consul sidecar.
- This flag allows configuring the consul sidecar to run service
    registration, or disable it in favor of a centralized service
    regitstration controller.

How I've tested this PR:
Unit tests

How I expect reviewers to test this PR:
Code review

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
