### PR TITLE
Add consul login api

### DIFF
--- a/subcommand/common/common_test.go
+++ b/subcommand/common/common_test.go
@@ -1,8 +1,13 @@
 package common
 
 import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,4 +30,56 @@ func TestValidatePort(t *testing.T) {
 	require.EqualError(t, err, "-test-flag-name value of invalid-port is not a valid integer.")
 	err = ValidatePort("-test-flag-name", "22")
 	require.EqualError(t, err, "-test-flag-name value of 22 is not in the port range 1024-65535.")
+}
+
+// TestConsulAclLogin ensures that our implementation of consul login hits `/v1/acl/login`.
+func TestConsulAclLogin(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	type APICall struct {
+		Method string
+		Path   string
+	}
+	var consulAPICalls []APICall
+
+	// Stub the read of the bearerTokenFile inside the login function.
+	bearerTokenFile, err := ioutil.TempFile("", "bearerTokenFile")
+	require.NoError(err)
+	_, err = bearerTokenFile.WriteString("foo")
+	require.NoError(err)
+
+	// Start the Consul server.
+	consulServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Record all the API calls made.
+		consulAPICalls = append(consulAPICalls, APICall{
+			Method: r.Method,
+			Path:   r.URL.Path,
+		})
+	}))
+	defer consulServer.Close()
+	serverURL, err := url.Parse(consulServer.URL)
+	require.NoError(err)
+	clientConfig := &api.Config{Address: serverURL.String()}
+	client, err := api.NewClient(clientConfig)
+	require.NoError(err)
+
+	// We expect this to fail in the internal client.ACL().Login() path because we've not
+	// bootstrapped any auth methods.
+	err = ConsulAclLogin(
+		client,
+		bearerTokenFile.Name(),
+		"foo",
+		"/foo",
+		"/foo",
+		nil,
+	)
+	require.Error(err, "error logging in: EOF")
+	// Ensure that the /v1/acl/login url was correctly hit.
+	require.Equal([]APICall{
+		{
+			"POST",
+			"/v1/acl/login",
+		},
+	}, consulAPICalls)
 }


### PR DESCRIPTION
Changes proposed in this PR:
- Create a new API for the `consul login` command which uses only Consul APIs and removes a dependency on the Consul binary.
- Currently just putting this out there to see how people feel about the testing, its a bit complicated because we would need to bootstrap auth methods to fully duplicate the tests that `hashicorp/consul` already does on the same code.
- I've made one tweak to the code that the consul command runs which is to use ioutil to write the file instead of their own Sink library which seems to only additionaly do a fsync() on the file after writing. In our case this is not necessary as fsync is for disk persistence in the event of a crash and we're writing to an emptyDir volume which is destroyed on pod restart.

How I've tested this PR:
Unit tests so far.
Further integration is a little bit blocked on an incoming PR which adds the `consul-k8s consul-init` command.

How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
