### PR TITLE
wait for serf check before starting the test

### DIFF
--- a/connect-inject/cleanup_resource_ent_test.go
+++ b/connect-inject/cleanup_resource_ent_test.go
@@ -89,6 +89,7 @@ func TestReconcile_ConsulNamespaces(t *testing.T) {
 			server.WaitForLeader(t)
 			consulClient, err := capi.NewClient(&capi.Config{Address: server.HTTPAddr})
 			require.NoError(err)
+			server.WaitForSerfCheck(t)
 
 			// Register Consul services.
 			for _, svc := range c.ConsulServices {
@@ -202,6 +203,7 @@ func TestDelete_ConsulNamespaces(t *testing.T) {
 			server.WaitForLeader(t)
 			consulClient, err := capi.NewClient(&capi.Config{Address: server.HTTPAddr})
 			require.NoError(err)
+			server.WaitForSerfCheck(t)
 
 			// Register Consul services.
 			for _, svc := range c.ConsulServices {

--- a/connect-inject/cleanup_resource_ent_test.go
+++ b/connect-inject/cleanup_resource_ent_test.go
@@ -86,10 +86,9 @@ func TestReconcile_ConsulNamespaces(t *testing.T) {
 			server, err := testutil.NewTestServerConfigT(t, nil)
 			defer server.Stop()
 			require.NoError(err)
-			server.WaitForLeader(t)
+			server.WaitForSerfCheck(t)
 			consulClient, err := capi.NewClient(&capi.Config{Address: server.HTTPAddr})
 			require.NoError(err)
-			server.WaitForSerfCheck(t)
 
 			// Register Consul services.
 			for _, svc := range c.ConsulServices {
@@ -200,10 +199,9 @@ func TestDelete_ConsulNamespaces(t *testing.T) {
 			server, err := testutil.NewTestServerConfigT(t, nil)
 			defer server.Stop()
 			require.NoError(err)
-			server.WaitForLeader(t)
+			server.WaitForSerfCheck(t)
 			consulClient, err := capi.NewClient(&capi.Config{Address: server.HTTPAddr})
 			require.NoError(err)
-			server.WaitForSerfCheck(t)
 
 			// Register Consul services.
 			for _, svc := range c.ConsulServices {


### PR DESCRIPTION
Changes proposed in this PR:
- wait for serf checks to pass before proceeding with the testing because the creation of the `consul` service is driven by completion of the serf check. Without this wait or a manual validation of the consul service existing *in the catalog* the test will run reconcile and pass before the consul service exists in the catalog resulting in the ENT tests failing because they use `Catalog()` API calls to validate final states.

How I've tested this PR:
Unit test fix with ent consul binary

How I expect reviewers to test this PR:
pass CI

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
