### PR TITLE
add service registration polling to connect-init

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -19,10 +19,9 @@ const (
 )
 
 type initContainerCommandData struct {
-	ServiceName        string
-	ServiceAccountName string
-	ProxyServiceName   string
-	ServicePort        int32
+	ServiceName      string
+	ProxyServiceName string
+	ServicePort      int32
 	// ServiceProtocol is the protocol for the service-defaults config
 	// that will be written if WriteServiceDefaults is true.
 	ServiceProtocol string
@@ -96,7 +95,6 @@ func (h *Handler) containerInit(pod *corev1.Pod, k8sNamespace string) (corev1.Co
 		ConsulCACert:              h.ConsulCACert,
 		MetaKeyPodName:            MetaKeyPodName,
 		MetaKeyKubeNS:             MetaKeyKubeNS,
-		ServiceAccountName:        pod.Spec.ServiceAccountName,
 	}
 	if data.ServiceName == "" {
 		// Assertion, since we call defaultAnnotations above and do

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -325,23 +325,6 @@ func (h *Handler) containerInit(pod *corev1.Pod, k8sNamespace string) (corev1.Co
 // and the connect-proxy service should come after the "main" service
 // because its alias health check depends on the main service to exist.
 const initContainerCommandTpl = `
-<<<<<<< Updated upstream
-=======
-{{- if .AuthMethod }}
-consul-k8s connect-init -method="{{ .AuthMethod }}" \
-  -service-account-name="{{ .ServiceAccountName }}" \
-  {{- if.ConsulNamespace }}
-  {{- if .NamespaceMirroringEnabled }}
-  {{- /* If namespace mirroring is enabled, the auth method is
-         defined in the default namespace */}}
-  -namespace="default" \
-  {{- else }}
-  -namespace="{{ .ConsulNamespace }}" \
-  {{- end }}
-  {{- end }}
-  -meta="pod=${POD_NAMESPACE}/${POD_NAME}"
-{{- end }}
->>>>>>> Stashed changes
 {{- if .ConsulCACert}}
 export CONSUL_HTTP_ADDR="https://${HOST_IP}:8501"
 export CONSUL_GRPC_ADDR="https://${HOST_IP}:8502"

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -19,9 +19,10 @@ const (
 )
 
 type initContainerCommandData struct {
-	ServiceName      string
-	ProxyServiceName string
-	ServicePort      int32
+	ServiceName        string
+	ServiceAccountName string
+	ProxyServiceName   string
+	ServicePort        int32
 	// ServiceProtocol is the protocol for the service-defaults config
 	// that will be written if WriteServiceDefaults is true.
 	ServiceProtocol string
@@ -95,6 +96,7 @@ func (h *Handler) containerInit(pod *corev1.Pod, k8sNamespace string) (corev1.Co
 		ConsulCACert:              h.ConsulCACert,
 		MetaKeyPodName:            MetaKeyPodName,
 		MetaKeyKubeNS:             MetaKeyKubeNS,
+		ServiceAccountName:        pod.Spec.ServiceAccountName,
 	}
 	if data.ServiceName == "" {
 		// Assertion, since we call defaultAnnotations above and do
@@ -323,6 +325,23 @@ func (h *Handler) containerInit(pod *corev1.Pod, k8sNamespace string) (corev1.Co
 // and the connect-proxy service should come after the "main" service
 // because its alias health check depends on the main service to exist.
 const initContainerCommandTpl = `
+<<<<<<< Updated upstream
+=======
+{{- if .AuthMethod }}
+consul-k8s connect-init -method="{{ .AuthMethod }}" \
+  -service-account-name="{{ .ServiceAccountName }}" \
+  {{- if.ConsulNamespace }}
+  {{- if .NamespaceMirroringEnabled }}
+  {{- /* If namespace mirroring is enabled, the auth method is
+         defined in the default namespace */}}
+  -namespace="default" \
+  {{- else }}
+  -namespace="{{ .ConsulNamespace }}" \
+  {{- end }}
+  {{- end }}
+  -meta="pod=${POD_NAMESPACE}/${POD_NAME}"
+{{- end }}
+>>>>>>> Stashed changes
 {{- if .ConsulCACert}}
 export CONSUL_HTTP_ADDR="https://${HOST_IP}:8501"
 export CONSUL_GRPC_ADDR="https://${HOST_IP}:8502"

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -334,19 +334,19 @@ EOF
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 {{- end}}
-consul-k8s connect-init -acl-auth-method="{{ .AuthMethod }}" \
-  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   {{- if .AuthMethod }}
+  -acl-auth-method="{{ .AuthMethod }}" \
+  -meta="pod=${POD_NAMESPACE}/${POD_NAME}" \
   {{- if .ConsulNamespace }}
   {{- if .NamespaceMirroringEnabled }}
   {{- /* If namespace mirroring is enabled, the auth method is
          defined in the default namespace */}}
-  -namespace="default" \
+  -namespace="default"
   {{- else }}
-  -namespace="{{ .ConsulNamespace }}" \
+  -namespace="{{ .ConsulNamespace }}"
   {{- end }}
   {{- end }}
-  -meta="pod=${POD_NAMESPACE}/${POD_NAME}"
   {{- end }}
 
 # Register the service. The HCL is stored in the volume so that

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -338,6 +338,8 @@ export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 {{- end}}
 {{- if .AuthMethod }}
 consul-k8s connect-init -acl-auth-method="{{ .AuthMethod }}" \
+  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+  -service-account-name={{ .ServiceAccountName }} \
   {{- if .ConsulNamespace }}
   {{- if .NamespaceMirroringEnabled }}
   {{- /* If namespace mirroring is enabled, the auth method is
@@ -348,6 +350,9 @@ consul-k8s connect-init -acl-auth-method="{{ .AuthMethod }}" \
   {{- end }}
   {{- end }}
   -meta="pod=${POD_NAMESPACE}/${POD_NAME}"
+{{- else }}
+consul-k8s connect-init \
+  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE}
 {{- end }}
 
 # Register the service. The HCL is stored in the volume so that

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -337,7 +337,6 @@ export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   {{- if .AuthMethod }}
   -acl-auth-method="{{ .AuthMethod }}" \
-  -meta="pod=${POD_NAMESPACE}/${POD_NAME}" \
   {{- if .ConsulNamespace }}
   {{- if .NamespaceMirroringEnabled }}
   {{- /* If namespace mirroring is enabled, the auth method is

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -336,10 +336,9 @@ EOF
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 {{- end}}
-{{- if .AuthMethod }}
 consul-k8s connect-init -acl-auth-method="{{ .AuthMethod }}" \
   -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -service-account-name={{ .ServiceAccountName }} \
+  {{- if .AuthMethod }}
   {{- if .ConsulNamespace }}
   {{- if .NamespaceMirroringEnabled }}
   {{- /* If namespace mirroring is enabled, the auth method is
@@ -350,10 +349,7 @@ consul-k8s connect-init -acl-auth-method="{{ .AuthMethod }}" \
   {{- end }}
   {{- end }}
   -meta="pod=${POD_NAMESPACE}/${POD_NAME}"
-{{- else }}
-consul-k8s connect-init \
-  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE}
-{{- end }}
+  {{- end }}
 
 # Register the service. The HCL is stored in the volume so that
 # the preStop hook can access it to deregister the service.

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -54,8 +54,7 @@ func TestHandlerContainerInit(t *testing.T) {
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
-consul-k8s connect-init -acl-auth-method="" \
-  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 
 # Register the service. The HCL is stored in the volume so that
 # the preStop hook can access it to deregister the service.
@@ -738,8 +737,7 @@ func TestHandlerContainerInit_namespacesEnabled(t *testing.T) {
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
-consul-k8s connect-init -acl-auth-method="" \
-  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 
 # Register the service. The HCL is stored in the volume so that
 # the preStop hook can access it to deregister the service.
@@ -812,8 +810,7 @@ EOF
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
-consul-k8s connect-init -acl-auth-method="" \
-  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 
 # Register the service. The HCL is stored in the volume so that
 # the preStop hook can access it to deregister the service.
@@ -887,10 +884,10 @@ EOF
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
-consul-k8s connect-init -acl-auth-method="auth-method" \
-  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -namespace="non-default" \
-  -meta="pod=${POD_NAMESPACE}/${POD_NAME}"
+consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+  -acl-auth-method="auth-method" \
+  -meta="pod=${POD_NAMESPACE}/${POD_NAME}" \
+  -namespace="non-default"
 
 # Register the service. The HCL is stored in the volume so that
 # the preStop hook can access it to deregister the service.
@@ -967,10 +964,10 @@ EOF
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
-consul-k8s connect-init -acl-auth-method="auth-method" \
-  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -namespace="default" \
-  -meta="pod=${POD_NAMESPACE}/${POD_NAME}"
+consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+  -acl-auth-method="auth-method" \
+  -meta="pod=${POD_NAMESPACE}/${POD_NAME}" \
+  -namespace="default"
 
 # Register the service. The HCL is stored in the volume so that
 # the preStop hook can access it to deregister the service.
@@ -1151,8 +1148,8 @@ func TestHandlerContainerInit_authMethod(t *testing.T) {
 	require.NoError(err)
 	actual := strings.Join(container.Command, " ")
 	require.Contains(actual, `
-consul-k8s connect-init -acl-auth-method="release-name-consul-k8s-auth-method" \
-  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+  -acl-auth-method="release-name-consul-k8s-auth-method" \
   -meta="pod=${POD_NAMESPACE}/${POD_NAME}"`)
 	require.Contains(actual, `
 /consul/connect-inject/consul services register \

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -54,6 +54,8 @@ func TestHandlerContainerInit(t *testing.T) {
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
+consul-k8s connect-init \
+  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE}
 
 # Register the service. The HCL is stored in the volume so that
 # the preStop hook can access it to deregister the service.
@@ -736,6 +738,8 @@ func TestHandlerContainerInit_namespacesEnabled(t *testing.T) {
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
+consul-k8s connect-init \
+  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE}
 
 # Register the service. The HCL is stored in the volume so that
 # the preStop hook can access it to deregister the service.
@@ -808,6 +812,8 @@ EOF
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
+consul-k8s connect-init \
+  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE}
 
 # Register the service. The HCL is stored in the volume so that
 # the preStop hook can access it to deregister the service.
@@ -882,6 +888,8 @@ EOF
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 consul-k8s connect-init -acl-auth-method="auth-method" \
+  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+  -service-account-name=web \
   -namespace="non-default" \
   -meta="pod=${POD_NAMESPACE}/${POD_NAME}"
 
@@ -961,6 +969,8 @@ EOF
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 consul-k8s connect-init -acl-auth-method="auth-method" \
+  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+  -service-account-name=web \
   -namespace="default" \
   -meta="pod=${POD_NAMESPACE}/${POD_NAME}"
 
@@ -1144,6 +1154,8 @@ func TestHandlerContainerInit_authMethod(t *testing.T) {
 	actual := strings.Join(container.Command, " ")
 	require.Contains(actual, `
 consul-k8s connect-init -acl-auth-method="release-name-consul-k8s-auth-method" \
+  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+  -service-account-name=foo \
   -meta="pod=${POD_NAMESPACE}/${POD_NAME}"`)
 	require.Contains(actual, `
 /consul/connect-inject/consul services register \

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -54,8 +54,8 @@ func TestHandlerContainerInit(t *testing.T) {
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
-consul-k8s connect-init \
-  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE}
+consul-k8s connect-init -acl-auth-method="" \
+  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 
 # Register the service. The HCL is stored in the volume so that
 # the preStop hook can access it to deregister the service.
@@ -738,8 +738,8 @@ func TestHandlerContainerInit_namespacesEnabled(t *testing.T) {
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
-consul-k8s connect-init \
-  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE}
+consul-k8s connect-init -acl-auth-method="" \
+  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 
 # Register the service. The HCL is stored in the volume so that
 # the preStop hook can access it to deregister the service.
@@ -812,8 +812,8 @@ EOF
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
-consul-k8s connect-init \
-  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE}
+consul-k8s connect-init -acl-auth-method="" \
+  -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 
 # Register the service. The HCL is stored in the volume so that
 # the preStop hook can access it to deregister the service.
@@ -889,7 +889,6 @@ export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 consul-k8s connect-init -acl-auth-method="auth-method" \
   -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -service-account-name=web \
   -namespace="non-default" \
   -meta="pod=${POD_NAMESPACE}/${POD_NAME}"
 
@@ -970,7 +969,6 @@ export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 consul-k8s connect-init -acl-auth-method="auth-method" \
   -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -service-account-name=web \
   -namespace="default" \
   -meta="pod=${POD_NAMESPACE}/${POD_NAME}"
 
@@ -1155,7 +1153,6 @@ func TestHandlerContainerInit_authMethod(t *testing.T) {
 	require.Contains(actual, `
 consul-k8s connect-init -acl-auth-method="release-name-consul-k8s-auth-method" \
   -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -service-account-name=foo \
   -meta="pod=${POD_NAMESPACE}/${POD_NAME}"`)
 	require.Contains(actual, `
 /consul/connect-inject/consul services register \

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -886,7 +886,6 @@ export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   -acl-auth-method="auth-method" \
-  -meta="pod=${POD_NAMESPACE}/${POD_NAME}" \
   -namespace="non-default"
 
 # Register the service. The HCL is stored in the volume so that
@@ -966,7 +965,6 @@ export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
 consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   -acl-auth-method="auth-method" \
-  -meta="pod=${POD_NAMESPACE}/${POD_NAME}" \
   -namespace="default"
 
 # Register the service. The HCL is stored in the volume so that
@@ -1149,8 +1147,7 @@ func TestHandlerContainerInit_authMethod(t *testing.T) {
 	actual := strings.Join(container.Command, " ")
 	require.Contains(actual, `
 consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -acl-auth-method="release-name-consul-k8s-auth-method" \
-  -meta="pod=${POD_NAMESPACE}/${POD_NAME}"`)
+  -acl-auth-method="release-name-consul-k8s-auth-method"`)
 	require.Contains(actual, `
 /consul/connect-inject/consul services register \
   -token-file="/consul/connect-inject/acl-token" \

--- a/subcommand/common/test_util.go
+++ b/subcommand/common/test_util.go
@@ -58,7 +58,7 @@ func GenerateServerCerts(t *testing.T) (string, string, string, func()) {
 // name. It will remove the file once the test completes.
 func WriteTempFile(t *testing.T, contents string) string {
 	t.Helper()
-	file, err := ioutil.TempFile("", contents)
+	file, err := ioutil.TempFile("", "testName")
 	require.NoError(t, err)
 	_, err = file.WriteString(contents)
 	require.NoError(t, err)

--- a/subcommand/connect-init/command.go
+++ b/subcommand/connect-init/command.go
@@ -59,7 +59,7 @@ func (c *Command) init() {
 	c.flagSet.StringVar(&c.flagPodNamespace, "pod-namespace", "", "Name of the pod namespace.")
 	c.flagSet.StringVar(&c.flagServiceAccountName, "service-account-name", "", "The service account name for this service.")
 
-	// TODO: we dont need this if we can mock the login bits
+	// TODO: when the endpoints controller manages service registration this can be removed. For now it preserves back compatibility.
 	c.flagSet.BoolVar(&c.flagSkipServiceRegistrationPolling, "skip-service-registration-polling", true,
 		"The service account name for this service.")
 

--- a/subcommand/connect-init/command.go
+++ b/subcommand/connect-init/command.go
@@ -137,7 +137,7 @@ func (c *Command) Run(args []string) int {
 		}
 		// Wait for the service and the connect-proxy service to be registered.
 		if len(serviceList) != 2 {
-			c.UI.Info(fmt.Sprintf("Unable to find registered services; retrying, %d", len(serviceList)))
+			c.UI.Info("Unable to find registered services; retrying")
 			return fmt.Errorf("did not find correct number of services: %d", len(serviceList))
 		}
 		for _, svc := range serviceList {

--- a/subcommand/connect-init/command.go
+++ b/subcommand/connect-init/command.go
@@ -61,7 +61,7 @@ func (c *Command) init() {
 
 	// TODO: when the endpoints controller manages service registration this can be removed. For now it preserves back compatibility.
 	c.flagSet.BoolVar(&c.flagSkipServiceRegistrationPolling, "skip-service-registration-polling", true,
-		"The service account name for this service.")
+		"Flag to preserve backward compatibility with service registration.")
 
 	c.http = &flags.HTTPFlags{}
 	flags.Merge(c.flagSet, c.http.Flags())

--- a/subcommand/connect-init/command.go
+++ b/subcommand/connect-init/command.go
@@ -128,11 +128,10 @@ func (c *Command) Run(args []string) int {
 	data := ""
 	err = backoff.Retry(func() error {
 		if c.flagACLAuthMethod == "" {
-			// TODO: can we filter this request somehow?
 			filter := fmt.Sprintf("Kind != `%s` and Meta.pod-name == %s and Meta.k8s-namespace == %s", "connect-proxy", c.flagPodName, c.flagPodNamespace)
 			serviceList, err := c.consulClient.Agent().ServicesWithFilter(filter)
 			if err != nil {
-				c.UI.Error(fmt.Sprintf("Unable to get agent services: %s", err))
+				c.UI.Error(fmt.Sprintf("Unable to get agent service: %s", err))
 				return err
 			}
 			for _, y := range serviceList {

--- a/subcommand/connect-init/command.go
+++ b/subcommand/connect-init/command.go
@@ -155,7 +155,7 @@ func (c *Command) Run(args []string) int {
 		c.UI.Error("Timed out waiting for service registration")
 		return 1
 	}
-	// Write the proxyid to the shared volume.
+	// Write the proxyid to the shared volume so `consul connect envoy` can use it for bootstrapping.
 	err = ioutil.WriteFile(c.proxyIDFile, []byte(proxyID), 0444)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("unable to write proxy ID to file: %s", err))

--- a/subcommand/connect-init/command.go
+++ b/subcommand/connect-init/command.go
@@ -3,6 +3,7 @@ package connectinit
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"sync"
 	"time"
 
@@ -16,15 +17,22 @@ import (
 
 const bearerTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 const tokenSinkFile = "/consul/connect-inject/acl-token"
+const proxyIDFile = "/consul/connect-inject/proxyid"
 const numLoginRetries = 3
+const serviceRegistrationPollingRetries = 6 // This maps to 60 seconds
 
 type Command struct {
 	UI cli.Ui
 
-	flagACLAuthMethod   string            // Auth Method to use for ACLs, if enabled
-	flagMeta            map[string]string // Flag for metadata to consul login.
-	flagBearerTokenFile string            // Location of the bearer token.
-	flagTokenSinkFile   string            // Location to write the output token.
+	flagACLAuthMethod                  string            // Auth Method to use for ACLs, if enabled.
+	flagMeta                           map[string]string // Flag for metadata to consul login.
+	flagBearerTokenFile                string            // Location of the bearer token.
+	flagTokenSinkFile                  string            // Location to write the output token.
+	flagProxyIDFile                    string            // Location to write the output proxyID.
+	flagPodName                        string            // Pod name.
+	flagPodNamespace                   string            // Pod namespace.
+	flagServiceAccountName             string            // ServiceAccountName for this service.
+	flagSkipServiceRegistrationPolling bool              // Whether or not to skip service registration.
 
 	flagSet *flag.FlagSet
 	http    *flags.HTTPFlags
@@ -37,8 +45,7 @@ type Command struct {
 
 func (c *Command) init() {
 	c.flagSet = flag.NewFlagSet("", flag.ContinueOnError)
-	c.flagSet.StringVar(&c.flagACLAuthMethod, "acl-auth-method", "",
-		"Name of the auth method to login to.")
+	c.flagSet.StringVar(&c.flagACLAuthMethod, "acl-auth-method", "", "Name of the auth method to login to.")
 	c.flagSet.Var((*flags.FlagMapValue)(&c.flagMeta), "meta",
 		"Metadata to set on the token, formatted as key=value. This flag may be specified multiple "+
 			"times to set multiple meta fields.")
@@ -47,9 +54,16 @@ func (c *Command) init() {
 			"Default is /var/run/secrets/kubernetes.io/serviceaccount/token.")
 	c.flagSet.StringVar(&c.flagTokenSinkFile, "token-sink-file", tokenSinkFile,
 		"The most recent token's SecretID is kept up to date in this file. Default is /consul/connect-inject/acl-token.")
+	c.flagSet.StringVar(&c.flagProxyIDFile, "proxyid-file", proxyIDFile, "Location to write the output proxyid file.")
+	c.flagSet.StringVar(&c.flagPodName, "pod-name", "", "Name of the pod.")
+	c.flagSet.StringVar(&c.flagPodNamespace, "pod-namespace", "", "Name of the pod namespace.")
+	c.flagSet.StringVar(&c.flagServiceAccountName, "service-account-name", "", "The service account name for this service.")
+
+	// TODO: we dont need this if we can mock the login bits
+	c.flagSet.BoolVar(&c.flagSkipServiceRegistrationPolling, "skip-service-registration-polling", true,
+		"The service account name for this service.")
 
 	c.http = &flags.HTTPFlags{}
-
 	flags.Merge(c.flagSet, c.http.Flags())
 	c.help = flags.Usage(help, c.flagSet)
 }
@@ -60,17 +74,14 @@ func (c *Command) Run(args []string) int {
 	if err := c.flagSet.Parse(args); err != nil {
 		return 1
 	}
-
-	// Validate flags.
-	if c.flagACLAuthMethod == "" {
-		c.UI.Error("-acl-auth-method must be set")
+	if c.flagPodName == "" {
+		c.UI.Error("-pod-name must be set")
 		return 1
 	}
-	if c.flagMeta == nil {
-		c.UI.Error("-meta must be set")
+	if c.flagPodNamespace == "" {
+		c.UI.Error("-pod-namespace must be set")
 		return 1
 	}
-
 	// TODO: Add namespace support
 	if c.consulClient == nil {
 		cfg := api.DefaultConfig()
@@ -81,19 +92,85 @@ func (c *Command) Run(args []string) int {
 			return 1
 		}
 	}
-
-	err = backoff.Retry(func() error {
-		err := common.ConsulLogin(c.consulClient, c.flagBearerTokenFile, c.flagACLAuthMethod, c.flagTokenSinkFile, c.flagMeta)
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("Consul login failed; retrying: %s", err))
+	// First do the ACL Login, if necessary.
+	if c.flagACLAuthMethod != "" {
+		// Validate flags related to ACL login.
+		if c.flagMeta == nil {
+			c.UI.Error("-meta must be set")
+			return 1
 		}
-		return err
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), numLoginRetries))
+		if c.flagServiceAccountName == "" {
+			c.UI.Error("-service-account-name must be set")
+			return 1
+		}
+		err = backoff.Retry(func() error {
+			err := common.ConsulLogin(c.consulClient, c.flagBearerTokenFile, c.flagACLAuthMethod, c.flagTokenSinkFile, c.flagMeta)
+			if err != nil {
+				c.UI.Error(fmt.Sprintf("Consul login failed; retrying: %s", err))
+			}
+			return err
+		}, backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), uint64(numLoginRetries)))
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Hit maximum retries for consul login: %s", err))
+			return 1
+		}
+		c.UI.Info("Consul login complete")
+	}
+	if c.flagSkipServiceRegistrationPolling {
+		return 0
+	}
+
+	// Now wait for the service to be registered. Do this by querying the Agent for a service
+	// which maps to this one.
+	// In the case of ACLs this will match the serviceAccountName, we query on this.
+	// If ACLs are disabled we query all services and search through
+	// the list for a service with `meta["pod-name"]` that matches this pod.
+	data := ""
+	err = backoff.Retry(func() error {
+		if c.flagACLAuthMethod == "" {
+			// TODO: can we filter this request somehow?
+			filter := fmt.Sprintf("Kind != `%s` and Meta.pod-name == %s and Meta.k8s-namespace == %s", "connect-proxy", c.flagPodName, c.flagPodNamespace)
+			serviceList, err := c.consulClient.Agent().ServicesWithFilter(filter)
+			if err != nil {
+				c.UI.Error(fmt.Sprintf("Unable to get agent services: %s", err))
+				return err
+			}
+			for _, y := range serviceList {
+				// TODO: in theory we've already filtered enough.. can we just return?
+				if y.Kind != "connect-proxy" && y.Meta["pod-name"] == c.flagPodName && y.Meta["k8s-namespace"] == c.flagPodNamespace {
+					c.UI.Info(fmt.Sprintf("Registered pod has been detected: %s", y.Meta["pod-name"]))
+					data = fmt.Sprintf("%s-%s-%s", c.flagPodName, y.ID, "sidecar-proxy")
+					return nil
+				}
+			}
+			return fmt.Errorf("Unable to find registered service")
+		} else {
+			// If ACLs are enabled we don't have permission to go through the list of all services
+			svc, _, err := c.consulClient.Agent().Service(c.flagServiceAccountName, &api.QueryOptions{})
+			if err != nil {
+				c.UI.Error(fmt.Sprintf("Unable to write proxyid out: %s", err))
+				return err
+			} else {
+				if svc == nil {
+					c.UI.Info(fmt.Sprintf("unable to fetch registered service for %v", c.flagServiceAccountName))
+					return fmt.Errorf("Unable to find registered service")
+				}
+				data = fmt.Sprintf("%s-%s-%s", c.flagPodName, svc.ID, "sidecar-proxy")
+			}
+			return nil
+		}
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), serviceRegistrationPollingRetries))
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Hit maximum retries for consul login: %s", err))
+		c.UI.Error("Timed out waiting for service registration")
 		return 1
 	}
-	c.UI.Info("Consul login complete")
+	// Write the proxyid to the shared volume.
+	err = ioutil.WriteFile(c.flagProxyIDFile, []byte(data), 0444)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Unable to write proxyid out: %s", err))
+		return 1
+	}
+	c.UI.Info("Bootstrapping completed")
 	return 0
 }
 

--- a/subcommand/connect-init/command.go
+++ b/subcommand/connect-init/command.go
@@ -50,7 +50,7 @@ func (c *Command) init() {
 	c.flagSet.StringVar(&c.flagPodNamespace, "pod-namespace", "", "Name of the pod namespace.")
 
 	// TODO: when the endpoints controller manages service registration this can be removed. For now it preserves back compatibility.
-	c.flagSet.BoolVar(&c.flagSkipServiceRegistrationPolling, "skip-service-registration-polling", false,
+	c.flagSet.BoolVar(&c.flagSkipServiceRegistrationPolling, "skip-service-registration-polling", true,
 		"Flag to preserve backward compatibility with service registration.")
 
 	if c.bearerTokenFile == "" {

--- a/subcommand/connect-init/command_test.go
+++ b/subcommand/connect-init/command_test.go
@@ -1,6 +1,7 @@
 package connectinit
 
 import (
+	"fmt"
 	"github.com/hashicorp/consul-k8s/consul"
 	"github.com/hashicorp/consul-k8s/subcommand/common"
 	"github.com/hashicorp/consul/api"
@@ -13,18 +14,117 @@ import (
 	"testing"
 )
 
+// Tests:
+//  ACLS disabled (polling on/off)
+//  ACLS enabled (polling on/off)
+// TODO: when endpoints controller is ready "polling" as a flag will be removed and this will just be a test of the command
+// passing with ACLs enabled or disabled.
+// TestRun_LoginAndPolling tests basic happy path of combinations of ACL/Polling
+func TestRun_LoginAndPolling(t *testing.T) {
+	cases := []struct {
+		name    string
+		flags   []string
+		secure  bool
+		polling bool
+	}{
+		{
+			name: "acls enabled, registration polling enabled",
+			flags: []string{
+				"-pod-name", testPodName,
+				"-pod-namespace", testPodNamespace,
+				"-acl-auth-method", testAuthMethod, "-meta", testPodMeta,
+				"-service-account-name", testServiceAccountName},
+			secure:  true,
+			polling: true,
+		},
+		{
+			name: "acls enabled, registration polling disabled",
+			flags: []string{
+				"-pod-name", testPodName,
+				"-pod-namespace", testPodNamespace,
+				"-acl-auth-method", testAuthMethod, "-meta", testPodMeta,
+				"-service-account-name", testServiceAccountName},
+			secure:  true,
+			polling: false,
+		},
+		{
+			name:    "acls disabled, registration polling enabled",
+			flags:   []string{"-pod-name", testPodName, "-pod-namespace", testPodNamespace},
+			secure:  false,
+			polling: true,
+		},
+		{
+			name:    "acls disabled, registration polling disabled",
+			flags:   []string{"-pod-name", testPodName, "-pod-namespace", testPodNamespace},
+			secure:  false,
+			polling: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			extraFlags := []string{}
+			bearerTokenFile := common.WriteTempFile(t, "bearerTokenFile")
+			proxyFile := common.WriteTempFile(t, "")
+			tokenFile := common.WriteTempFile(t, "")
+			extraFlags = append(extraFlags, "-bearer-token-file", bearerTokenFile, "-token-sink-file", tokenFile, "-proxyid-file", proxyFile)
+
+			// Start the mock Consul server.
+			consulServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if c.secure {
+					// ACL login request
+					if r != nil && r.URL.Path == "/v1/acl/login" && r.Method == "POST" {
+						w.Write([]byte(testLoginResponse))
+					}
+					// Agent service get, this is used when ACLs are enabled
+					if r != nil && r.URL.Path == fmt.Sprintf("/v1/agent/service/%s", testServiceAccountName) && r.Method == "GET" {
+						w.Write([]byte(testServiceGetResponse))
+					}
+				} else {
+					// Agent services list request, used when ACLs are disabled
+					if r != nil && r.URL.Path == "/v1/agent/services" && r.Method == "GET" {
+						w.Write([]byte(testServiceListResponse))
+					}
+				}
+			}))
+			defer consulServer.Close()
+			serverURL, err := url.Parse(consulServer.URL)
+			require.NoError(t, err)
+			clientConfig := &api.Config{Address: serverURL.String()}
+			client, err := consul.NewClient(clientConfig)
+			require.NoError(t, err)
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI:           ui,
+				consulClient: client,
+			}
+			c.flags = append(c.flags, extraFlags...)
+			c.flags = append(c.flags, fmt.Sprintf("-skip-service-registration-polling=%t", !c.polling))
+			code := cmd.Run(c.flags)
+			require.Equal(t, 0, code)
+		})
+	}
+}
+
 func TestRun_FlagValidation(t *testing.T) {
 	cases := []struct {
 		flags  []string
 		expErr string
 	}{
 		{
-			flags:  []string{"-acl-auth-method", testAuthMethod},
+			flags:  []string{},
+			expErr: "-pod-name must be set",
+		},
+		{
+			flags:  []string{"-pod-name", testPodName},
+			expErr: "-pod-namespace must be set",
+		},
+		{
+			flags:  []string{"-pod-name", testPodName, "-pod-namespace", testPodNamespace, "-acl-auth-method", testAuthMethod},
 			expErr: "-meta must be set",
 		},
 		{
-			flags:  []string{"-meta", "pod=default/foo"},
-			expErr: "-acl-auth-method must be set",
+			flags:  []string{"-pod-name", testPodName, "-pod-namespace", testPodNamespace, "-acl-auth-method", testAuthMethod, "-meta", "pod=default/foo"},
+			expErr: "-service-account-name must be set",
 		},
 	}
 	for _, c := range cases {
@@ -46,12 +146,14 @@ func TestRun_RetryACLLoginFails(t *testing.T) {
 	cmd := Command{
 		UI: ui,
 	}
-	code := cmd.Run([]string{"-acl-auth-method", testAuthMethod, "-meta", testPodMeta})
+	code := cmd.Run([]string{"-pod-name", testPodName, "-pod-namespace", testPodNamespace,
+		"-acl-auth-method", testAuthMethod, "-meta", testPodMeta,
+		"-skip-service-registration-polling", "-service-account-name", testServiceAccountName})
 	require.Equal(t, 1, code)
 	require.Contains(t, ui.ErrorWriter.String(), "Hit maximum retries for consul login")
 }
 
-func TestRun_withRetries(t *testing.T) {
+func TestRun_LoginwithRetries(t *testing.T) {
 	cases := []struct {
 		Description        string
 		TestRetry          bool
@@ -83,7 +185,7 @@ func TestRun_withRetries(t *testing.T) {
 				if r != nil && r.URL.Path == "/v1/acl/login" && r.Method == "POST" {
 					counter++
 					if !c.TestRetry || (c.TestRetry && c.LoginAttemptsCount == counter) {
-						w.Write([]byte(loginResponse))
+						w.Write([]byte(testLoginResponse))
 					}
 				}
 			}))
@@ -100,10 +202,13 @@ func TestRun_withRetries(t *testing.T) {
 				UI:           ui,
 				consulClient: client,
 			}
-			code := cmd.Run([]string{"-bearer-token-file", bearerTokenFile,
-				"-token-sink-file", tokenFile,
-				"-meta", "host=foo",
-				"-acl-auth-method", testAuthMethod, "-meta", testPodMeta})
+			code := cmd.Run([]string{
+				"-pod-name", testPodName,
+				"-pod-namespace", testPodNamespace,
+				"-token-sink-file", tokenFile, "-bearer-token-file", bearerTokenFile,
+				"-acl-auth-method", testAuthMethod, "-meta", testPodMeta,
+				"-service-account-name", testServiceAccountName,
+				"-skip-service-registration-polling"})
 			require.Equal(t, c.ExpCode, code)
 			// Cmd will return 1 after numACLLoginRetries, so bound LoginAttemptsCount if we exceeded it.
 			require.Equal(t, c.LoginAttemptsCount, counter)
@@ -115,10 +220,44 @@ func TestRun_withRetries(t *testing.T) {
 	}
 }
 
+const testPodNamespace = "default"
+const testPodName = "counting"
+const testServiceAccountName = "counting"
+const testPodMeta = "pod=default/counting"
 const testAuthMethod = "consul-k8s-auth-method"
 
+const testServiceGetResponse = `{
+  "ID": "counting-counting",
+  "Service": "counting",
+  "Tags": [],
+  "Meta": {
+    "k8s-namespace": "default",
+    "pod-name": "counting"
+  },
+  "Port": 9001,
+  "Address": "10.32.3.22",
+  "TaggedAddresses": {
+    "lan_ipv4": {
+      "Address": "10.32.3.22",
+      "Port": 9001
+    },
+    "wan_ipv4": {
+      "Address": "10.32.3.22",
+      "Port": 9001
+    }
+  },
+  "Weights": {
+    "Passing": 1,
+    "Warning": 1
+  },
+  "EnableTagOverride": false,
+  "ContentHash": "43efce0313d03c9",
+  "Datacenter": "dc1"
+}
+`
+
 // sample response from https://consul.io/api-docs/acl#sample-response
-const loginResponse = `{
+const testLoginResponse = `{
   "AccessorID": "926e2bd2-b344-d91b-0c83-ae89f372cd9b",
   "SecretID": "b78d37c7-0ca7-5f4d-99ee-6d9975ce4586",
   "Description": "token created via login",
@@ -141,4 +280,68 @@ const loginResponse = `{
   "ModifyIndex": 36
 }`
 
-const testPodMeta = "pod=default/podName"
+const testServiceListResponse = `{
+  "counting-counting": {
+    "ID": "counting-counting",
+    "Service": "counting",
+    "Tags": [],
+    "Meta": {
+      "k8s-namespace": "default",
+      "pod-name": "counting"
+    },
+    "Port": 9001,
+    "Address": "10.32.3.26",
+    "TaggedAddresses": {
+      "lan_ipv4": {
+        "Address": "10.32.3.26",
+        "Port": 9001
+      },
+      "wan_ipv4": {
+        "Address": "10.32.3.26",
+        "Port": 9001
+      }
+    },
+    "Weights": {
+      "Passing": 1,
+      "Warning": 1
+    },
+    "EnableTagOverride": false,
+    "Datacenter": "dc1"
+  },
+  "counting-counting-sidecar-proxy": {
+    "Kind": "connect-proxy",
+    "ID": "counting-counting-sidecar-proxy",
+    "Service": "counting-sidecar-proxy",
+    "Tags": [],
+    "Meta": {
+      "k8s-namespace": "default",
+      "pod-name": "counting"
+    },
+    "Port": 20000,
+    "Address": "10.32.3.26",
+    "TaggedAddresses": {
+      "lan_ipv4": {
+        "Address": "10.32.3.26",
+        "Port": 20000
+      },
+      "wan_ipv4": {
+        "Address": "10.32.3.26",
+        "Port": 20000
+      }
+    },
+    "Weights": {
+      "Passing": 1,
+      "Warning": 1
+    },
+    "EnableTagOverride": false,
+    "Proxy": {
+      "DestinationServiceName": "counting",
+      "DestinationServiceID": "counting-counting",
+      "LocalServiceAddress": "127.0.0.1",
+      "LocalServicePort": 9001,
+      "MeshGateway": {},
+      "Expose": {}
+    },
+    "Datacenter": "dc1"
+  }
+}`

--- a/subcommand/connect-init/command_test.go
+++ b/subcommand/connect-init/command_test.go
@@ -32,10 +32,6 @@ func TestRun_FlagValidation(t *testing.T) {
 			flags:  []string{"-pod-name", testPodName},
 			expErr: "-pod-namespace must be set",
 		},
-		{
-			flags:  []string{"-pod-name", testPodName, "-pod-namespace", testPodNamespace, "-acl-auth-method", testAuthMethod},
-			expErr: "-meta must be set",
-		},
 	}
 	for _, c := range cases {
 		t.Run(c.expErr, func(t *testing.T) {
@@ -85,7 +81,7 @@ func TestRun_happyPathACLs(t *testing.T) {
 	}
 	flags := []string{"-pod-name", testPodName,
 		"-pod-namespace", testPodNamespace,
-		"-acl-auth-method", testAuthMethod, "-meta", testPodMeta,
+		"-acl-auth-method", testAuthMethod,
 		"-skip-service-registration-polling=false"}
 	// Run the command.
 	code := cmd.Run(flags)
@@ -271,7 +267,7 @@ func TestRun_FailsWithBadServerResponses(t *testing.T) {
 
 			flags := []string{
 				"-pod-name", testPodName, "-pod-namespace", testPodNamespace,
-				"-meta", testPodMeta, "-acl-auth-method", testAuthMethod,
+				"-acl-auth-method", testAuthMethod,
 				"-skip-service-registration-polling=false"}
 			code := cmd.Run(flags)
 			require.Equal(t, 1, code)
@@ -343,7 +339,7 @@ func TestRun_LoginwithRetries(t *testing.T) {
 			code := cmd.Run([]string{
 				"-pod-name", testPodName,
 				"-pod-namespace", testPodNamespace,
-				"-acl-auth-method", testAuthMethod, "-meta", testPodMeta,
+				"-acl-auth-method", testAuthMethod,
 				"-skip-service-registration-polling=false"})
 			require.Equal(t, c.ExpCode, code)
 			// Cmd will return 1 after numACLLoginRetries, so bound LoginAttemptsCount if we exceeded it.

--- a/subcommand/connect-init/command_test.go
+++ b/subcommand/connect-init/command_test.go
@@ -133,8 +133,7 @@ func TestRun_ServicePollingWithACLs(t *testing.T) {
 	require.NotEmpty(t, tokenData)
 
 	// Check that the token has the metadata with pod name and pod namespace.
-	consulClient,
-		err = api.NewClient(&api.Config{Address: server.HTTPAddr, Token: string(tokenData)})
+	consulClient, err = api.NewClient(&api.Config{Address: server.HTTPAddr, Token: string(tokenData)})
 	require.NoError(t, err)
 	token, _, err := consulClient.ACL().TokenReadSelf(nil)
 	require.NoError(t, err)

--- a/subcommand/connect-init/command_test.go
+++ b/subcommand/connect-init/command_test.go
@@ -112,7 +112,6 @@ func TestRun_happyPathACLs(t *testing.T) {
 
 // This test validates happy path without ACLs : wait on proxy+service to be registered and write out proxyid file
 func TestRun_happyPathNoACLs(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 	// This is the output file for the proxyid.
 	proxyFile := common.WriteTempFile(t, "")
@@ -149,7 +148,6 @@ func TestRun_happyPathNoACLs(t *testing.T) {
 // TestRun_RetryServicePolling starts the command and does not register the consul service
 // for 2 seconds and then asserts that the proxyid file gets written correctly.
 func TestRun_RetryServicePolling(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 	proxyFile := common.WriteTempFile(t, "")
 
@@ -199,7 +197,6 @@ func TestRun_RetryServicePolling(t *testing.T) {
 // TestRun_invalidProxyFile validates that we correctly fail in case the proxyid file
 // is not writable. This functions as coverage for both ACL and non-ACL codepaths.
 func TestRun_invalidProxyFile(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 	// This is the output file for the proxyid.
 	randFileName := fmt.Sprintf("/foo/%d/%d", rand.Int(), rand.Int())


### PR DESCRIPTION
Changes proposed in this PR:
- Extends `connect-init` command to wait for the service to be registered. When the endpoints controller is added this will be allow the init container to wait for the service to be registered prior to bootstrapping envoy.
- Adds  `pod-name` , `pod-namespace` flags to `connect-init` as well as a flag to disable the new service registration polling feature to preserve backwards compatibility until the endpoints controller is merged.

How I've tested this PR:
Unit tests added and old ones passing.
Manually build consul-k8s dev image and deploy with ACLs enabled and connect inject an application.

How I expect reviewers to test this PR:
code review and manually test by deploying consul and an injected app and seeing that it gets injected and started.

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
