### PR TITLE
Fix incorrect validation for ServiceResolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,20 @@
 FEATURES:
 * Metrics: add metrics configuration to inject-connect and metrics-merging capability to consul-sidecar. When metrics and metrics merging are enabled, the consul-sidecar will expose an endpoint that merges the app and proxy metrics.
 
-The flags `-merged-metrics-port`, `-service-metrics-port` and `-service-metrics-path` can be used to configure the merged metrics server, and the application service metrics endpoint on the consul sidecar.
+  The flags `-merged-metrics-port`, `-service-metrics-port` and `-service-metrics-path` can be used to configure the merged metrics server, and the application service metrics endpoint on the consul sidecar.
 
-The flags `-default-enable-metrics`, `-default-enable-metrics-merging`, `-default-merged-metrics-port`, `-default-prometheus-scrape-port` and `-default-prometheus-scrape-path` configure the inject-connect command.
+  The flags `-default-enable-metrics`, `-default-enable-metrics-merging`, `-default-merged-metrics-port`, `-default-prometheus-scrape-port` and `-default-prometheus-scrape-path` configure the inject-connect command.
 
-IMPROVEMENTS
+IMPROVEMENTS:
 * CRDs: add field Last Synced Time to CRD status and add printer column on CRD to display time since when the
   resource was last successfully synced with Consul. [[GH-448](https://github.com/hashicorp/consul-k8s/pull/448)]
+  
+BUG FIXES:
+* CRDs: fix incorrect validation for `ServiceResolver`. [[GH-456](https://github.com/hashicorp/consul-k8s/pull/456)]
 
 ## 0.24.0 (February 16, 2021)
 
-BREAKING CHANGES
+BREAKING CHANGES:
 * Connect: the `lifecycle-sidecar` command has been renamed to `consul-sidecar`. [[GH-428](https://github.com/hashicorp/consul-k8s/pull/428)]
 * Connect: the `consul-connect-lifecycle-sidecar` container name has been changed to `consul-sidecar` and the `consul-connect-envoy-sidecar` container name has been changed to `envoy-sidecar`. 
 [[GH-428](https://github.com/hashicorp/consul-k8s/pull/428)]

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -478,16 +478,21 @@ func (in *LoadBalancer) validate(path *field.Path) field.ErrorList {
 
 func (in HashPolicy) validate(path *field.Path) field.ErrorList {
 	var errs field.ErrorList
-	validFields := []string{"header", "cookie", "query_parameter"}
-	if !sliceContains(validFields, in.Field) {
-		errs = append(errs, field.Invalid(path.Child("field"), in.Field,
-			notInSliceMessage(validFields)))
+	if in.Field != "" {
+		validFields := []string{"header", "cookie", "query_parameter"}
+		if !sliceContains(validFields, in.Field) {
+			errs = append(errs, field.Invalid(path.Child("field"), in.Field,
+				notInSliceMessage(validFields)))
+		}
 	}
 
 	if in.Field != "" && in.SourceIP {
 		asJSON, _ := json.Marshal(in)
 		errs = append(errs, field.Invalid(path, string(asJSON),
 			"cannot set both field and sourceIP"))
+	} else if in.Field != "" && in.FieldValue == "" {
+		errs = append(errs, field.Invalid(path.Child("fieldValue"), in.FieldValue,
+			"fieldValue cannot be empty if field is set"))
 	}
 
 	if err := in.CookieConfig.validate(path.Child("cookieConfig")); err != nil {

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -484,15 +484,15 @@ func (in HashPolicy) validate(path *field.Path) field.ErrorList {
 			errs = append(errs, field.Invalid(path.Child("field"), in.Field,
 				notInSliceMessage(validFields)))
 		}
-	}
 
-	if in.Field != "" && in.SourceIP {
-		asJSON, _ := json.Marshal(in)
-		errs = append(errs, field.Invalid(path, string(asJSON),
-			"cannot set both field and sourceIP"))
-	} else if in.Field != "" && in.FieldValue == "" {
-		errs = append(errs, field.Invalid(path.Child("fieldValue"), in.FieldValue,
-			"fieldValue cannot be empty if field is set"))
+		if in.SourceIP {
+			asJSON, _ := json.Marshal(in)
+			errs = append(errs, field.Invalid(path, string(asJSON),
+				"cannot set both field and sourceIP"))
+		} else if in.FieldValue == "" {
+			errs = append(errs, field.Invalid(path.Child("fieldValue"), in.FieldValue,
+				"fieldValue cannot be empty if field is set"))
+		}
 	}
 
 	if err := in.CookieConfig.validate(path.Child("cookieConfig")); err != nil {


### PR DESCRIPTION
Changes proposed in this PR:
- `ServiceResolver` validation: if hashPolicy.field is set fieldValue must also be set 
- `ServiceResolver` validation: hashPolicy.field can be empty if hashPolicy.sourceIP is true

How I've tested this PR:
- unit tests

How I expect reviewers to test this PR:
- review tests & changes

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
