### PR TITLE
add wait to test to prevent race on ACL read

### DIFF
--- a/namespaces/namespaces_test.go
+++ b/namespaces/namespaces_test.go
@@ -37,6 +37,7 @@ func TestEnsureExists_AlreadyExists(tt *testing.T) {
 			})
 			req.NoError(err)
 			defer consul.Stop()
+			consul.WaitForSerfCheck(t)
 			consulClient, err := capi.NewClient(&capi.Config{
 				Address: consul.HTTPAddr,
 				Token:   masterToken,


### PR DESCRIPTION
Changes proposed in this PR:
- Add a wait on the consul server so that we do not race on the bootstrap ACL existing.
This test previously failed in CI and locally but only about 1/10 times:
```    
namespaces_test.go:50: 
        	Error Trace:	namespaces_test.go:50
        	Error:      	Received unexpected error:
        	            	Unexpected response code: 403 (ACL not found)
        	Test:       	TestEnsureExists_AlreadyExists/acls:_true
```

How I've tested this PR:
unit tests pass

How I expect reviewers to test this PR:
code review

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
