### PR TITLE
Tproxy writefile changes

### DIFF
--- a/subcommand/common/common.go
+++ b/subcommand/common/common.go
@@ -86,8 +86,7 @@ func WriteFileWithPerms(outputFile, payload string, mode os.FileMode) error {
 	// os.WriteFile truncates existing files and overwrites them, but only if they are writable.
 	// If the file exists it will already likely be read-only. Remove it first.
 	if _, err := os.Stat(outputFile); err == nil {
-		err = os.Remove(outputFile)
-		if err != nil {
+		if err = os.Remove(outputFile); err != nil {
 			return fmt.Errorf("unable to delete existing file: %s", err)
 		}
 	}

--- a/subcommand/common/common.go
+++ b/subcommand/common/common.go
@@ -83,16 +83,15 @@ func ConsulLogin(client *api.Client, bearerTokenFile, authMethodName, tokenSinkF
 
 // WriteFileWithPerms will write payload as the contents of the outputFile and set permissions.
 func WriteFileWithPerms(outputFile, payload string, mode os.FileMode) error {
-	// ioutil.WriteFile truncates existing files or if they do not exist writes them as FileMode(0666), but only if
-	// the file is currently writable. If the file exists it will already likely be read-only. Remove it.
+	// os.WriteFile truncates existing files and overwrites them, but only if they are writable.
+	// If the file exists it will already likely be read-only. Remove it first.
 	if _, err := os.Stat(outputFile); err == nil {
 		err = os.Remove(outputFile)
 		if err != nil {
-			return fmt.Errorf("unable to delete existing token file: %s", err)
+			return fmt.Errorf("unable to delete existing file: %s", err)
 		}
 	}
-	err := ioutil.WriteFile(outputFile, []byte(payload), os.FileMode(0666))
-	if err != nil {
+	if err := ioutil.WriteFile(outputFile, []byte(payload), os.ModePerm); err != nil {
 		return fmt.Errorf("unable to write file: %s", err)
 	}
 	return os.Chmod(outputFile, mode)

--- a/subcommand/common/common.go
+++ b/subcommand/common/common.go
@@ -81,7 +81,7 @@ func ConsulLogin(client *api.Client, bearerTokenFile, authMethodName, tokenSinkF
 	return nil
 }
 
-// WriteFileWithPerms will write payload as the contents of the outputFile and set permissions.
+// WriteFileWithPerms will write payload as the contents of the outputFile and set permissions after writing the contents. This function is necessary since using ioutil.WriteFile() alone will create the new file with the requested permissions prior to actually writing the file, so you can't set read-only permissions.
 func WriteFileWithPerms(outputFile, payload string, mode os.FileMode) error {
 	// os.WriteFile truncates existing files and overwrites them, but only if they are writable.
 	// If the file exists it will already likely be read-only. Remove it first.

--- a/subcommand/common/common_test.go
+++ b/subcommand/common/common_test.go
@@ -134,7 +134,7 @@ func TestWriteFileWithPerms_OutputFileExists(t *testing.T) {
 	require.NoError(t, err)
 	data, err := ioutil.ReadFile(randFileName)
 	require.NoError(t, err)
-	require.Contains(t, string(data), payload)
+	require.Equal(t, payload, string(data))
 }
 
 func TestWriteFileWithPerms(t *testing.T) {
@@ -157,7 +157,7 @@ func TestWriteFileWithPerms(t *testing.T) {
 	// Validate the data was written correctly.
 	data, err := ioutil.ReadFile(randFileName)
 	require.NoError(t, err)
-	require.Contains(t, string(data), payload)
+	require.Equal(t, payload, string(data))
 }
 
 // startMockServer starts an httptest server used to mock a Consul server's

--- a/subcommand/common/common_test.go
+++ b/subcommand/common/common_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
@@ -105,6 +107,57 @@ func TestConsulLogin_TokenFileUnwritable(t *testing.T) {
 	)
 	require.Error(err)
 	require.Contains(err.Error(), "error writing token to file sink")
+}
+
+func TestWriteFileWithPerms_InvalidOutputFile(t *testing.T) {
+	t.Parallel()
+	rand.Seed(time.Now().UnixNano())
+	randFileName := fmt.Sprintf("/tmp/tmp/tmp/%d", rand.Int())
+	t.Cleanup(func() {
+		os.Remove(randFileName)
+	})
+	err := WriteFileWithPerms(randFileName, "", os.FileMode(0444))
+	require.Errorf(t, err, "unable to create file: %s", randFileName)
+}
+
+func TestWriteFileWithPerms_OutputFileExists(t *testing.T) {
+	t.Parallel()
+	rand.Seed(time.Now().UnixNano())
+	randFileName := fmt.Sprintf("/tmp/%d", rand.Int())
+	err := ioutil.WriteFile(randFileName, []byte("foo"), os.FileMode(0444))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.Remove(randFileName)
+	})
+	payload := "abcd"
+	err = WriteFileWithPerms(randFileName, payload, os.FileMode(0444))
+	require.NoError(t, err)
+	data, err := ioutil.ReadFile(randFileName)
+	require.NoError(t, err)
+	require.Contains(t, string(data), payload)
+}
+
+func TestWriteFileWithPerms(t *testing.T) {
+	t.Parallel()
+	payload := "foo-foo-foo-foo"
+	rand.Seed(time.Now().UnixNano())
+	randFileName := fmt.Sprintf("/tmp/%d", rand.Int())
+	t.Cleanup(func() {
+		os.Remove(randFileName)
+	})
+	// Issue the write.
+	mode := os.FileMode(0444)
+	err := WriteFileWithPerms(randFileName, payload, mode)
+	require.NoError(t, err)
+	file, err := os.Stat(randFileName)
+	require.NoError(t, err)
+	// Validate the size and mode are correct.
+	require.Equal(t, file.Mode(), mode)
+	require.Equal(t, file.Size(), int64(len(payload)))
+	// Validate the data was written correctly.
+	data, err := ioutil.ReadFile(randFileName)
+	require.NoError(t, err)
+	require.Contains(t, string(data), payload)
 }
 
 // startMockServer starts an httptest server used to mock a Consul server's

--- a/subcommand/connect-init/command.go
+++ b/subcommand/connect-init/command.go
@@ -3,7 +3,6 @@ package connectinit
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"sync"
 	"time"
 
@@ -158,7 +157,7 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 	// Write the proxy ID to the shared volume so `consul connect envoy` can use it for bootstrapping.
-	err = ioutil.WriteFile(c.proxyIDFile, []byte(proxyID), 0444)
+	err = common.WriteFileWithPerms(c.proxyIDFile, proxyID, 0444)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Unable to write proxy ID to file: %s", err))
 		return 1

--- a/subcommand/connect-init/command.go
+++ b/subcommand/connect-init/command.go
@@ -3,6 +3,7 @@ package connectinit
 import (
 	"flag"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -157,7 +158,7 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 	// Write the proxy ID to the shared volume so `consul connect envoy` can use it for bootstrapping.
-	err = common.WriteFileWithPerms(c.proxyIDFile, proxyID, 0444)
+	err = common.WriteFileWithPerms(c.proxyIDFile, proxyID, os.FileMode(0444))
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Unable to write proxy ID to file: %s", err))
 		return 1

--- a/subcommand/connect-init/command_test.go
+++ b/subcommand/connect-init/command_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 	"time"
 
@@ -66,8 +67,12 @@ func TestRun_ServicePollingWithACLsAndTLS(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			bearerFile := common.WriteTempFile(t, serviceAccountJWTToken)
-			proxyFile := common.WriteTempFile(t, "")
-			tokenFile := common.WriteTempFile(t, "")
+			tokenFile := fmt.Sprintf("/tmp/%d1", rand.Int())
+			proxyFile := fmt.Sprintf("/tmp/%d2", rand.Int())
+			t.Cleanup(func() {
+				os.Remove(proxyFile)
+				os.Remove(tokenFile)
+			})
 
 			var caFile, certFile, keyFile string
 			// Start Consul server with ACLs enabled and default deny policy.
@@ -205,7 +210,10 @@ func TestRun_ServicePollingOnly(t *testing.T) {
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			proxyFile := common.WriteTempFile(t, "")
+			proxyFile := fmt.Sprintf("/tmp/%d", rand.Int())
+			t.Cleanup(func() {
+				os.Remove(proxyFile)
+			})
 
 			var caFile, certFile, keyFile string
 			// Start Consul server with TLS enabled if required.
@@ -422,7 +430,10 @@ func TestRun_ServicePollingErrors(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			proxyFile := common.WriteTempFile(t, "")
+			proxyFile := fmt.Sprintf("/tmp/%d", rand.Int())
+			t.Cleanup(func() {
+				os.Remove(proxyFile)
+			})
 
 			// Start Consul server.
 			server, err := testutil.NewTestServerConfigT(t, nil)
@@ -528,7 +539,7 @@ func TestRun_InvalidProxyFile(t *testing.T) {
 		proxyIDFile:                        randFileName,
 		serviceRegistrationPollingAttempts: 3,
 	}
-	expErr := fmt.Sprintf("Unable to write proxy ID to file: open %s: no such file or directory\n", randFileName)
+	expErr := fmt.Sprintf("Unable to write proxy ID to file: unable to write file: open %s: no such file or directory\n", randFileName)
 	flags := []string{"-http-addr", server.HTTPAddr}
 	flags = append(flags, defaultTestFlags...)
 	code := cmd.Run(flags)
@@ -773,7 +784,7 @@ xtr5PSwH1DusYfVaGH2O
     "Tags": [],
     "Meta": {
       "k8s-namespace": "default",
-      "pod-name": "counting"
+      "pod-name": "counting-pod"
     },
     "Port": 9001,
     "Address": "10.32.3.26",
@@ -801,7 +812,7 @@ xtr5PSwH1DusYfVaGH2O
     "Tags": [],
     "Meta": {
       "k8s-namespace": "default",
-      "pod-name": "counting"
+      "pod-name": "counting-pod"
     },
     "Port": 20000,
     "Address": "10.32.3.26",


### PR DESCRIPTION
Changes proposed in this PR:
- `ioutil.WriteFile()` will create the new file with the requested permissions prior to actually writing the file. This causes us to accidentally create it with "0444" which will not allow us to complete the write.
- Use `ioutil.WriteFile(.., .., 0666)` in combination with  `os.Chmod(0444)`  to create the file with the correct privs, and remove it first if it already exists in the event that we failed the command and the container is restarted.
- We missed this in the previous tests because we were using `WriteTempFile()` to create the files prior to passing them into the functions to be tested so that we could have easy cleanup, and that had default 0666 privs on it. In end to end testing this produced permission denied errors.

How I've tested this PR:
unit tests
run this on live system with ACL Login.

How I expect reviewers to test this PR:
unit tests passes and live test with ACLs enabled.

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
