### PR TITLE
Add acls and tls to endpoints controller

### DIFF
--- a/connect-inject/endpoints_controller.go
+++ b/connect-inject/endpoints_controller.go
@@ -102,7 +102,7 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 
 				if hasBeenInjected(pod) {
 					// Create client for Consul agent local to the pod.
-					client, err := r.getConsulClient(r.ConsulScheme, r.ConsulPort, pod.Status.HostIP)
+					client, err := r.getConsulClient(pod.Status.HostIP)
 					if err != nil {
 						r.Log.Error(err, "failed to create a new Consul client", "address", pod.Status.HostIP)
 						return ctrl.Result{}, err
@@ -302,7 +302,7 @@ func (r *EndpointsController) deregisterServiceOnAllAgents(ctx context.Context, 
 	// On each agent, we need to get services matching "k8s-service-name" and "k8s-namespace" metadata.
 	for _, pod := range list.Items {
 		// Create client for this agent.
-		client, err := r.getConsulClient(r.ConsulScheme, r.ConsulPort, pod.Status.PodIP)
+		client, err := r.getConsulClient(pod.Status.PodIP)
 		if err != nil {
 			r.Log.Error(err, "failed to create a new Consul client", "address", pod.Status.PodIP)
 			return err
@@ -413,8 +413,8 @@ func (r *EndpointsController) processUpstreams(pod corev1.Pod) ([]api.Upstream, 
 }
 
 // getConsulClient returns an *api.Client that points at the consul agent local to the pod.
-func (r *EndpointsController) getConsulClient(scheme, port, ip string) (*api.Client, error) {
-	newAddr := fmt.Sprintf("%s://%s:%s", scheme, ip, port)
+func (r *EndpointsController) getConsulClient(ip string) (*api.Client, error) {
+	newAddr := fmt.Sprintf("%s://%s:%s", r.ConsulScheme, ip, r.ConsulPort)
 	localConfig := r.ConsulClientCfg
 	localConfig.Address = newAddr
 

--- a/connect-inject/endpoints_controller.go
+++ b/connect-inject/endpoints_controller.go
@@ -102,7 +102,7 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 
 				if hasBeenInjected(pod) {
 					// Create client for Consul agent local to the pod.
-					client, err := r.getConsulClient(pod.Status.HostIP)
+					client, err := r.remoteConsulClient(pod.Status.HostIP)
 					if err != nil {
 						r.Log.Error(err, "failed to create a new Consul client", "address", pod.Status.HostIP)
 						return ctrl.Result{}, err
@@ -302,7 +302,7 @@ func (r *EndpointsController) deregisterServiceOnAllAgents(ctx context.Context, 
 	// On each agent, we need to get services matching "k8s-service-name" and "k8s-namespace" metadata.
 	for _, pod := range list.Items {
 		// Create client for this agent.
-		client, err := r.getConsulClient(pod.Status.PodIP)
+		client, err := r.remoteConsulClient(pod.Status.PodIP)
 		if err != nil {
 			r.Log.Error(err, "failed to create a new Consul client", "address", pod.Status.PodIP)
 			return err
@@ -412,8 +412,8 @@ func (r *EndpointsController) processUpstreams(pod corev1.Pod) ([]api.Upstream, 
 	return upstreams, nil
 }
 
-// getConsulClient returns an *api.Client that points at the consul agent local to the pod.
-func (r *EndpointsController) getConsulClient(ip string) (*api.Client, error) {
+// remoteConsulClient returns an *api.Client that points at the consul agent local to the pod.
+func (r *EndpointsController) remoteConsulClient(ip string) (*api.Client, error) {
 	newAddr := fmt.Sprintf("%s://%s:%s", r.ConsulScheme, ip, r.ConsulPort)
 	localConfig := r.ConsulClientCfg
 	localConfig.Address = newAddr

--- a/connect-inject/endpoints_controller.go
+++ b/connect-inject/endpoints_controller.go
@@ -54,7 +54,7 @@ type EndpointsController struct {
 	// GetClientFunc allows us to specify how to get a consul client handle.
 	// This is used so that we can provide our own function for testing that is
 	// not dependent on having then ENV set up to pick up tokens and ca certs.
-	GetClientFunc func(string, string, string) (*api.Client, error)
+	GetClient func(string, string, string) (*api.Client, error)
 }
 
 func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/connect-inject/endpoints_controller.go
+++ b/connect-inject/endpoints_controller.go
@@ -105,7 +105,7 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 
 				if hasBeenInjected(pod) {
 					// Create client for Consul agent local to the pod.
-					client, err := r.GetClientFunc(r.ConsulScheme, r.ConsulPort, pod.Status.HostIP)
+					client, err := r.GetClient(r.ConsulScheme, r.ConsulPort, pod.Status.HostIP)
 					if err != nil {
 						r.Log.Error(err, "failed to create a new Consul client", "address", pod.Status.HostIP)
 						return ctrl.Result{}, err
@@ -305,7 +305,7 @@ func (r *EndpointsController) deregisterServiceOnAllAgents(ctx context.Context, 
 	// On each agent, we need to get services matching "k8s-service-name" and "k8s-namespace" metadata.
 	for _, pod := range list.Items {
 		// Create client for this agent.
-		client, err := r.GetClientFunc(r.ConsulScheme, r.ConsulPort, pod.Status.PodIP)
+		client, err := r.GetClient(r.ConsulScheme, r.ConsulPort, pod.Status.PodIP)
 		if err != nil {
 			r.Log.Error(err, "failed to create a new Consul client", "address", pod.Status.PodIP)
 			return err

--- a/connect-inject/endpoints_controller_test.go
+++ b/connect-inject/endpoints_controller_test.go
@@ -701,6 +701,10 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			getclientfunction := func(string, string, string) (*api.Client, error) {
+				return consulClient, nil
+			}
+
 			// Create the endpoints controller
 			ep := &EndpointsController{
 				Client:                fakeClient,
@@ -712,6 +716,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 				DenyK8sNamespacesSet:  mapset.NewSetWith(),
 				ReleaseName:           "consul",
 				ReleaseNamespace:      "default",
+				GetClientFunc:         getclientfunction,
 			}
 			namespacedName := types.NamespacedName{
 				Namespace: "default",
@@ -1474,6 +1479,10 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			getclientfunction := func(string, string, string) (*api.Client, error) {
+				return consulClient, nil
+			}
+
 			// Create the endpoints controller
 			ep := &EndpointsController{
 				Client:                fakeClient,
@@ -1485,6 +1494,7 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 				DenyK8sNamespacesSet:  mapset.NewSetWith(),
 				ReleaseName:           "consul",
 				ReleaseNamespace:      "default",
+				GetClientFunc:         getclientfunction,
 			}
 
 			// Set up the Endpoint that will be reconciled, and reconcile

--- a/connect-inject/endpoints_controller_test.go
+++ b/connect-inject/endpoints_controller_test.go
@@ -716,7 +716,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 				DenyK8sNamespacesSet:  mapset.NewSetWith(),
 				ReleaseName:           "consul",
 				ReleaseNamespace:      "default",
-				GetClient:         getTestClient,
+				GetClient:             getTestClient,
 			}
 			namespacedName := types.NamespacedName{
 				Namespace: "default",
@@ -1352,7 +1352,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					DenyK8sNamespacesSet:  mapset.NewSetWith(),
 					ReleaseName:           "consul",
 					ReleaseNamespace:      "default",
-					GetClientFunc:         getclientfunction,
+					GetClient:             getTestClient,
 				}
 				namespacedName := types.NamespacedName{
 					Namespace: "default",
@@ -1494,7 +1494,7 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 				DenyK8sNamespacesSet:  mapset.NewSetWith(),
 				ReleaseName:           "consul",
 				ReleaseNamespace:      "default",
-				GetClientFunc:         getclientfunction,
+				GetClient:             getTestClient,
 			}
 
 			// Set up the Endpoint that will be reconciled, and reconcile

--- a/connect-inject/endpoints_controller_test.go
+++ b/connect-inject/endpoints_controller_test.go
@@ -701,7 +701,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			getclientfunction := func(string, string, string) (*api.Client, error) {
+			getTestClient := func(string, string, string) (*api.Client, error) {
 				return consulClient, nil
 			}
 
@@ -716,7 +716,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 				DenyK8sNamespacesSet:  mapset.NewSetWith(),
 				ReleaseName:           "consul",
 				ReleaseNamespace:      "default",
-				GetClientFunc:         getclientfunction,
+				GetClient:         getTestClient,
 			}
 			namespacedName := types.NamespacedName{
 				Namespace: "default",
@@ -778,7 +778,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 // For the register and deregister codepath, this also tests that they work when the Consul service name is different
 // from the K8s service name.
 // This test covers EndpointsController.deregisterServiceOnAllAgents when services should be selectively deregistered
-// since the map will not be nil. This test also runs each test with ACLs+TLS enabled and disabled.
+// since the map will not be nil. This test also runs each test with ACLs+TLS enabled and disabled, since it covers all the cases where a Consul client is created.
 func TestReconcileUpdateEndpoint(t *testing.T) {
 	t.Parallel()
 	nodeName := "test-node"
@@ -1336,8 +1336,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				// Normally this is provided through the Command via `-ca-file`, etc, httpFlags
 				// which are later re-read for each new consul client in api.DefaultConfig(), but this test does
 				// not run as part of a Command and so api.DefaultConfig() would set our TLS and ACL config to empty.
-				// We can re-use this client as the test defines the fakeClientPod to be 127.0.0.1.
-				getclientfunction := func(string, string, string) (*api.Client, error) {
+				// We can re-use consulClient as the local agent client since the test defines the fakeClientPod to be 127.0.0.1.
+				getTestClient := func(string, string, string) (*api.Client, error) {
 					return consulClient, nil
 				}
 
@@ -1479,7 +1479,7 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			getclientfunction := func(string, string, string) (*api.Client, error) {
+			getTestClient := func(string, string, string) (*api.Client, error) {
 				return consulClient, nil
 			}
 

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -418,7 +418,7 @@ func (c *Command) Run(args []string) int {
 			ReleaseName:           c.flagReleaseName,
 			ReleaseNamespace:      c.flagReleaseNamespace,
 			Context:               ctx,
-			GetClientFunc:         connectinject.GetConsulClient,
+			GetClient:             connectinject.GetConsulClient,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", connectinject.EndpointsController{})
 			return 1

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -418,7 +418,7 @@ func (c *Command) Run(args []string) int {
 			ReleaseName:           c.flagReleaseName,
 			ReleaseNamespace:      c.flagReleaseNamespace,
 			Context:               ctx,
-			ConsulClientCfg:       api.DefaultConfig(),
+			ConsulClientCfg:       cfg,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", connectinject.EndpointsController{})
 			return 1

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -418,6 +418,7 @@ func (c *Command) Run(args []string) int {
 			ReleaseName:           c.flagReleaseName,
 			ReleaseNamespace:      c.flagReleaseNamespace,
 			Context:               ctx,
+			GetClientFunc:         connectinject.GetConsulClient,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", connectinject.EndpointsController{})
 			return 1

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -418,7 +418,7 @@ func (c *Command) Run(args []string) int {
 			ReleaseName:           c.flagReleaseName,
 			ReleaseNamespace:      c.flagReleaseNamespace,
 			Context:               ctx,
-			GetClient:             connectinject.GetConsulClient,
+			ConsulClientCfg:       api.DefaultConfig(),
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", connectinject.EndpointsController{})
 			return 1


### PR DESCRIPTION
Changes proposed in this PR:
- Adds support for ACLs and TLS to endpoints controller
- Minor change to how we deal with consul clients in the endpoints controller+tests.

How I've tested this PR:
Unit tests for ACLS+TLS have been added which cover normal paths as well as the three places that where we request a new consulClient:
1. processUpstreams()
2. 2x in Reconcile()  (deregisterServiceOnAllAgents() and regular Reconcile)

Manually run the connect-inject acceptance tests using https://github.com/hashicorp/consul-helm/pull/886/, with `imageK8S: "kschoche/consul-k8s-dev"` and uncommenting the TLS table tests.

How I expect reviewers to test this PR:
Run unit tests / manually deploy and run acceptance tests.

Note: I'm willing to table-fy and add ACL/TLS support to all of the endpoints-controller tests if we think this is really necessary.
I think the tests which use the consul client (`TestReconcileDeleteEndpoint()`, `TestReconcileUpdateEndpoint()`) where I have NOT added ACL/TLS tests are already covered by the the tests I added. I'm willing to make changes but for the sake of readability I didn't want to unnecessarily add complexity to the already long+awesome tests. Thoughts?

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
