### PR TITLE
update circleci to use consul 1.9.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ executors:
       - image: docker.mirror.hashicorp.services/circleci/golang:1.14
     environment:
       TEST_RESULTS: /tmp/test-results # path to where test results are saved
-      CONSUL_VERSION: 1.9.0-rc1 # Consul's OSS version to use in tests
-      CONSUL_ENT_VERSION: 1.9.0+ent-rc1 # Consul's enterprise version to use in tests
+      CONSUL_VERSION: 1.9.4 # Consul's OSS version to use in tests
+      CONSUL_ENT_VERSION: 1.9.4+ent # Consul's enterprise version to use in tests
 
 jobs:
   go-fmt-and-vet:


### PR DESCRIPTION
Changes proposed in this PR:
- Update Consul version from 1.9.1-rc1 to 1.9.4 so that it matches consul-helm's default!

How I've tested this PR:
Ran it against a branch of mine and things looked good.

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
