### PR TITLE
Remove default service name annotation

### DIFF
--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -298,13 +298,6 @@ func (h *Handler) shouldInject(pod corev1.Pod, namespace string) (bool, error) {
 		return false, nil
 	}
 
-	// A service name is required. Whether a proxy accepting connections
-	// or just establishing outbound, a service name is required to acquire
-	// the correct certificate.
-	if pod.Annotations[annotationService] == "" {
-		return false, nil
-	}
-
 	// If the explicit true/false is on, then take that value. Note that
 	// this has to be the last check since it sets a default value after
 	// all other checks.
@@ -318,14 +311,6 @@ func (h *Handler) shouldInject(pod corev1.Pod, namespace string) (bool, error) {
 func (h *Handler) defaultAnnotations(pod *corev1.Pod) error {
 	if pod.Annotations == nil {
 		pod.Annotations = make(map[string]string)
-	}
-
-	// Default service name is the name of the first container.
-	if _, ok := pod.ObjectMeta.Annotations[annotationService]; !ok {
-		if cs := pod.Spec.Containers; len(cs) > 0 {
-			// Set the annotation for checking in shouldInject
-			pod.Annotations[annotationService] = cs[0].Name
-		}
 	}
 
 	// Default service port is the first port exported in the container

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 	"gomodules.xyz/jsonpatch/v2"
@@ -159,10 +159,6 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
-					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationService),
-				},
-				{
-					Operation: "add",
 					Path:      "/spec/volumes",
 				},
 				{
@@ -222,10 +218,6 @@ func TestHandlerHandle(t *testing.T) {
 			},
 			"",
 			[]jsonpatch.Operation{
-				{
-					Operation: "add",
-					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationService),
-				},
 				{
 					Operation: "add",
 					Path:      "/spec/volumes",
@@ -390,10 +382,6 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
-					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationService),
-				},
-				{
-					Operation: "add",
 					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationPrometheusScrape),
 				},
 				{
@@ -531,9 +519,7 @@ func TestHandlerDefaultAnnotations(t *testing.T) {
 					},
 				},
 			},
-			map[string]string{
-				annotationService: "web",
-			},
+			nil,
 			"",
 		},
 
@@ -586,8 +572,7 @@ func TestHandlerDefaultAnnotations(t *testing.T) {
 				},
 			},
 			map[string]string{
-				annotationService: "web",
-				annotationPort:    "http",
+				annotationPort: "http",
 			},
 			"",
 		},
@@ -613,8 +598,7 @@ func TestHandlerDefaultAnnotations(t *testing.T) {
 				},
 			},
 			map[string]string{
-				annotationService: "web",
-				annotationPort:    "8080",
+				annotationPort: "8080",
 			},
 			"",
 		},

--- a/subcommand/connect-init/command_ent_test.go
+++ b/subcommand/connect-init/command_ent_test.go
@@ -223,6 +223,7 @@ func TestRun_ServicePollingWithACLsAndTLSWithNamespaces(t *testing.T) {
 			flags := []string{"-pod-name", testPodName,
 				"-pod-namespace", testPodNamespace,
 				"-acl-auth-method", test.authMethod,
+				"-service-account-name", testServiceAccountName,
 				"-http-addr", fmt.Sprintf("%s://%s", cfg.Scheme, cfg.Address),
 				"-consul-service-namespace", test.consulServiceNamespace,
 				"-auth-method-namespace", test.authMethodNamespace,


### PR DESCRIPTION
Changes proposed in this PR:
- Remove the default service name annotation
- ~There's a check in container_init.go to make sure the annotation and the service account name match. That check has been modified so it only compares the annotation and the service account name if the annotation is set.~
- ~If the annotation is *not* set, then the error handling moves to the connect-init command in the init container. When it polls for the matching service, if the k8s-service-name metadata does not match the service account name, it will fail to set up the init container so the user will continue to see the error before the pod comes up, rather than a mismatched token being created.~
- The connect-init command uses the values of the new `service-name` and `service-account-name` flags, and if `service-name` is set (via the annotation) compares `service-account-name` to that. If `service-name` is not set, it compares `service-account-name` to the kubernetes service name.

How I've tested this PR:
- Acceptance tests, unit tests. (Will wait till [this](https://github.com/hashicorp/consul-helm/pull/897) goes green to merge)

How I expect reviewers to test this PR:
- Code review

Checklist:
- [x] Tests added

