### PR TITLE
remove processing of pods in PodPending phase in endpoints controller

### DIFF
--- a/connect-inject/endpoints_controller.go
+++ b/connect-inject/endpoints_controller.go
@@ -332,13 +332,6 @@ func getConsulHealthCheckID(pod corev1.Pod, serviceID string) string {
 // ready state of the pod along with the reason message which will be passed into the Notes
 // field of the Consul health check.
 func getReadyStatusAndReason(pod corev1.Pod) (string, string, error) {
-	// A pod might be pending if the init containers have run but the non-init
-	// containers haven't reached running state. In this case we set a failing health
-	// check so the pod doesn't receive traffic before it's ready.
-	if pod.Status.Phase == corev1.PodPending {
-		return api.HealthCritical, podPendingReasonMsg, nil
-	}
-
 	for _, cond := range pod.Status.Conditions {
 		var consulStatus, reason string
 		if cond.Type == corev1.PodReady {


### PR DESCRIPTION
Changes proposed in this PR:
- remove check for PodPending in `getReadyStatusAndReason()` as pods which are in PodPending phase are not part of the endpoints object and as such we would never be reconciling a pod from an endpoint object that is in this state.

How I've tested this PR:
Per @ishustava 's excellent investigation pods which are in PodPending phase are not included in the endpoints object list so we would never need to have this check.
https://github.com/hashicorp/consul-k8s/pull/476#discussion_r610080955
Unit tests still pass

How I expect reviewers to test this PR:
Read background in link above, code review

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
