### PR TITLE
Enable tproxy for the Consul service mesh

### DIFF
--- a/build-support/docker/Dev.dockerfile
+++ b/build-support/docker/Dev.dockerfile
@@ -1,2 +1,8 @@
 FROM hashicorp/consul-k8s:latest
+
+# change the user to root so we can install stuff
+USER root
+RUN apk update && apk add iptables
+USER consul-k8s
+
 COPY pkg/bin/linux_amd64/consul-k8s /bin

--- a/build-support/docker/Release.dockerfile
+++ b/build-support/docker/Release.dockerfile
@@ -25,7 +25,7 @@ RUN addgroup ${NAME} && \
 
 # Set up certificates, base tools, and software.
 RUN set -eux && \
-    apk add --no-cache ca-certificates curl gnupg libcap openssl su-exec iputils && \
+    apk add --no-cache ca-certificates curl gnupg libcap openssl su-exec iputils iptables && \
     BUILD_GPGKEY=91A6E7F85D05C65630BEF18951852D87348FFC4C; \
     found=''; \
     for server in \

--- a/connect-inject/annotations.go
+++ b/connect-inject/annotations.go
@@ -84,6 +84,10 @@ const (
 	// annotationConsulNamespace is the Consul namespace the service is registered into.
 	annotationConsulNamespace = "consul.hashicorp.com/consul-namespace"
 
+	// annotationTransparentProxy enables or disables transparent proxy mode for a given pod.
+	// This annotation takes a boolean value (true/false).
+	annotationTransparentProxy = "consul.hashicorp.com/transparent-proxy"
+
 	// injected is used as the annotation value for annotationInjected.
 	injected = "injected"
 )

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -2,6 +2,7 @@ package connectinject
 
 import (
 	"bytes"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -11,6 +12,8 @@ import (
 const (
 	InjectInitCopyContainerName = "copy-consul-bin"
 	InjectInitContainerName     = "consul-connect-inject-init"
+	rootUserAndGroupID          = 0
+	netAdminCapability          = "NET_ADMIN"
 )
 
 type initContainerCommandData struct {
@@ -29,15 +32,16 @@ type initContainerCommandData struct {
 	// EnableMetrics adds a listener to Envoy where Prometheus will scrape
 	// metrics from.
 	EnableMetrics bool
-	// todo: remove once endpoints controller supports metrics
-	// PrometheusScrapeListener configures the listener on Envoy where
-	// Prometheus will scrape metrics from.
-	PrometheusScrapeListener string
 	// PrometheusScrapePath configures the path on the listener on Envoy where
 	// Prometheus will scrape metrics from.
 	PrometheusScrapePath string
 	// PrometheusBackendPort configures where the listener on Envoy will point to.
 	PrometheusBackendPort string
+
+	// EnableTransparentProxy configures this init container to run in transparent proxy mode,
+	// i.e. run consul connect redirect-traffic command and add the required privileges to the
+	// container to do that.
+	EnableTransparentProxy bool
 }
 
 // containerInitCopyContainer returns the init container spec for the copy container which places
@@ -62,11 +66,18 @@ func (h *Handler) containerInitCopyContainer() corev1.Container {
 // containerInit returns the init container spec for registering the Consul
 // service, setting up the Envoy bootstrap, etc.
 func (h *Handler) containerInit(pod corev1.Pod, k8sNamespace string) (corev1.Container, error) {
+	// Check if tproxy is enabled on this pod.
+	tproxyEnabled, err := transparentProxyEnabled(pod, h.EnableTransparentProxy)
+	if err != nil {
+		return corev1.Container{}, err
+	}
+
 	data := initContainerCommandData{
 		AuthMethod:                h.AuthMethod,
 		ConsulNamespace:           h.consulNamespace(k8sNamespace),
 		NamespaceMirroringEnabled: h.EnableK8SNSMirroring,
 		ConsulCACert:              h.ConsulCACert,
+		EnableTransparentProxy:    tproxyEnabled,
 	}
 
 	if data.AuthMethod != "" {
@@ -119,7 +130,7 @@ func (h *Handler) containerInit(pod corev1.Pod, k8sNamespace string) (corev1.Con
 		return corev1.Container{}, err
 	}
 
-	return corev1.Container{
+	container := corev1.Container{
 		Name:  InjectInitContainerName,
 		Image: h.ImageConsulK8S,
 		Env: []corev1.EnvVar{
@@ -151,7 +162,36 @@ func (h *Handler) containerInit(pod corev1.Pod, k8sNamespace string) (corev1.Con
 		Resources:    h.InitContainerResources,
 		VolumeMounts: volMounts,
 		Command:      []string{"/bin/sh", "-ec", buf.String()},
-	}, nil
+	}
+
+	if tproxyEnabled {
+		// Running consul connect redirect-traffic with iptables
+		// requires both being a root user and having NET_ADMIN capability.
+		container.SecurityContext = &corev1.SecurityContext{
+			RunAsUser:  pointerToInt64(rootUserAndGroupID),
+			RunAsGroup: pointerToInt64(rootUserAndGroupID),
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{netAdminCapability},
+			},
+		}
+	}
+
+	return container, nil
+}
+
+// transparentProxyEnabled returns true if transparent proxy should is enabled for this pod.
+// It returns an error when the annotation value cannot be parsed by strconv.ParseBool.
+func transparentProxyEnabled(pod corev1.Pod, globalEnabled bool) (bool, error) {
+	if raw, ok := pod.Annotations[annotationTransparentProxy]; ok {
+		return strconv.ParseBool(raw)
+	}
+
+	return globalEnabled, nil
+}
+
+// pointerToInt64 takes an int64 and returns a pointer to it.
+func pointerToInt64(i int64) *int64 {
+	return &i
 }
 
 // initContainerCommandTpl is the template for the command executed by
@@ -202,4 +242,16 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   {{- if .ConsulNamespace }}
   -namespace="{{ .ConsulNamespace }}" \
   {{- end }}
-  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`
+  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
+
+{{- if .EnableTransparentProxy }}
+
+# Apply traffic redirection rules.
+/consul/connect-inject/consul connect redirect-traffic \
+  {{- if .ConsulNamespace }}
+  -namespace="{{ .ConsulNamespace }}" \
+  {{- end }}
+  -proxy-id="$(cat /consul/connect-inject/proxyid)" \
+  -proxy-uid=0
+{{- end }}
+`

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -245,6 +245,8 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
 
 {{- if .EnableTransparentProxy }}
+{{- /* The newline below is intentional to allow extra space
+       in the rendered template between this and the previous commands. */}}
 
 # Apply traffic redirection rules.
 /consul/connect-inject/consul connect redirect-traffic \

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -179,7 +179,7 @@ func (h *Handler) containerInit(pod corev1.Pod, k8sNamespace string) (corev1.Con
 	return container, nil
 }
 
-// transparentProxyEnabled returns true if transparent proxy should is enabled for this pod.
+// transparentProxyEnabled returns true if transparent proxy should be enabled for this pod.
 // It returns an error when the annotation value cannot be parsed by strconv.ParseBool.
 func transparentProxyEnabled(pod corev1.Pod, globalEnabled bool) (bool, error) {
 	if raw, ok := pod.Annotations[annotationTransparentProxy]; ok {

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -1,11 +1,10 @@
 package connectinject
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
-	capi "github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -142,6 +141,77 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 	}
 }
 
+func TestHandlerContainerInit_transparentProxy(t *testing.T) {
+	cases := map[string]struct {
+		globalEnabled     bool
+		annotationEnabled *bool
+		expectEnabled     bool
+	}{
+		"enabled globally, annotation not provided": {
+			true,
+			nil,
+			true,
+		},
+		"enabled globally, annotation is false": {
+			true,
+			pointerToBool(false),
+			false,
+		},
+		"enabled globally, annotation is true": {
+			true,
+			pointerToBool(true),
+			true,
+		},
+		"disabled globally, annotation not provided": {
+			false,
+			nil,
+			false,
+		},
+		"disabled globally, annotation is false": {
+			false,
+			pointerToBool(false),
+			false,
+		},
+		"disabled globally, annotation is true": {
+			false,
+			pointerToBool(true),
+			true,
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := Handler{EnableTransparentProxy: c.globalEnabled}
+			pod := minimal()
+			if c.annotationEnabled != nil {
+				pod.Annotations[annotationTransparentProxy] = strconv.FormatBool(*c.annotationEnabled)
+			}
+
+			expectedSecurityContext := &corev1.SecurityContext{
+				RunAsUser:  pointerToInt64(0),
+				RunAsGroup: pointerToInt64(0),
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{"NET_ADMIN"},
+				},
+			}
+			expectedCmd := `/consul/connect-inject/consul connect redirect-traffic \
+  -proxy-id="$(cat /consul/connect-inject/proxyid)" \
+  -proxy-uid=0`
+			container, err := h.containerInit(*pod, k8sNamespace)
+			require.NoError(t, err)
+
+			if c.expectEnabled {
+				require.Equal(t, expectedSecurityContext, container.SecurityContext)
+				cmd := strings.Join(container.Command, " ")
+				require.Contains(t, cmd, expectedCmd)
+			} else {
+				require.Nil(t, container.SecurityContext)
+				cmd := strings.Join(container.Command, " ")
+				require.NotContains(t, cmd, expectedCmd)
+			}
+		})
+	}
+}
+
 func TestHandlerContainerInit_namespacesEnabled(t *testing.T) {
 	minimal := func() *corev1.Pod {
 		return &corev1.Pod{
@@ -175,12 +245,11 @@ func TestHandlerContainerInit_namespacesEnabled(t *testing.T) {
 	}
 
 	cases := []struct {
-		Name         string
-		Pod          func(*corev1.Pod) *corev1.Pod
-		Handler      Handler
-		K8sNamespace string
-		Cmd          string // Strings.Contains test
-		CmdNot       string // Not contains
+		Name    string
+		Pod     func(*corev1.Pod) *corev1.Pod
+		Handler Handler
+		Cmd     string // Strings.Contains test
+		CmdNot  string // Not contains
 	}{
 		{
 			"whole template, default namespace",
@@ -192,7 +261,6 @@ func TestHandlerContainerInit_namespacesEnabled(t *testing.T) {
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "default",
 			},
-			k8sNamespace,
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
@@ -217,7 +285,6 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "non-default",
 			},
-			k8sNamespace,
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
@@ -243,7 +310,6 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "non-default",
 			},
-			k8sNamespace,
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
@@ -262,7 +328,6 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`,
 			"",
 		},
-
 		{
 			"Whole template, auth method, non-default namespace, mirroring enabled",
 			func(pod *corev1.Pod) *corev1.Pod {
@@ -275,7 +340,6 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 				ConsulDestinationNamespace: "non-default", // Overridden by mirroring
 				EnableK8SNSMirroring:       true,
 			},
-			k8sNamespace,
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
@@ -294,6 +358,105 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`,
 			"",
 		},
+		{
+			"whole template, default namespace, tproxy enabled",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				return pod
+			},
+			Handler{
+				EnableNamespaces:           true,
+				ConsulDestinationNamespace: "default",
+				EnableTransparentProxy:     true,
+			},
+			`/bin/sh -ec 
+export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
+export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
+consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+  -consul-service-namespace="default" \
+
+# Generate the envoy bootstrap code
+/consul/connect-inject/consul connect envoy \
+  -proxy-id="$(cat /consul/connect-inject/proxyid)" \
+  -namespace="default" \
+  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
+
+# Apply traffic redirection rules.
+/consul/connect-inject/consul connect redirect-traffic \
+  -namespace="default" \
+  -proxy-id="$(cat /consul/connect-inject/proxyid)" \
+  -proxy-uid=0`,
+			"",
+		},
+
+		{
+			"whole template, non-default namespace, tproxy enabled",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				return pod
+			},
+			Handler{
+				EnableNamespaces:           true,
+				ConsulDestinationNamespace: "non-default",
+				EnableTransparentProxy:     true,
+			},
+			`/bin/sh -ec 
+export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
+export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
+consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+  -consul-service-namespace="non-default" \
+
+# Generate the envoy bootstrap code
+/consul/connect-inject/consul connect envoy \
+  -proxy-id="$(cat /consul/connect-inject/proxyid)" \
+  -namespace="non-default" \
+  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
+
+# Apply traffic redirection rules.
+/consul/connect-inject/consul connect redirect-traffic \
+  -namespace="non-default" \
+  -proxy-id="$(cat /consul/connect-inject/proxyid)" \
+  -proxy-uid=0`,
+			"",
+		},
+
+		{
+			"Whole template, auth method, non-default namespace, mirroring enabled, tproxy enabled",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				return pod
+			},
+			Handler{
+				AuthMethod:                 "auth-method",
+				EnableNamespaces:           true,
+				ConsulDestinationNamespace: "non-default", // Overridden by mirroring
+				EnableK8SNSMirroring:       true,
+				EnableTransparentProxy:     true,
+			},
+			`/bin/sh -ec 
+export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
+export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
+consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+  -acl-auth-method="auth-method" \
+  -service-account-name="web" \
+  -service-name="web" \
+  -auth-method-namespace="default" \
+  -consul-service-namespace="k8snamespace" \
+
+# Generate the envoy bootstrap code
+/consul/connect-inject/consul connect envoy \
+  -proxy-id="$(cat /consul/connect-inject/proxyid)" \
+  -token-file="/consul/connect-inject/acl-token" \
+  -namespace="k8snamespace" \
+  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml
+
+# Apply traffic redirection rules.
+/consul/connect-inject/consul connect redirect-traffic \
+  -namespace="k8snamespace" \
+  -proxy-id="$(cat /consul/connect-inject/proxyid)" \
+  -proxy-uid=0`,
+			"",
+		},
 	}
 
 	for _, tt := range cases {
@@ -302,31 +465,10 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 
 			h := tt.Handler
 
-			// Create a Consul server/client and proxy-defaults config because
-			// the handler will call out to Consul if the upstream uses a datacenter.
-			consul, err := testutil.NewTestServerConfigT(t, nil)
-			require.NoError(err)
-			defer consul.Stop()
-			consul.WaitForLeader(t)
-			consulClient, err := capi.NewClient(&capi.Config{
-				Address: consul.HTTPAddr,
-			})
-			require.NoError(err)
-			written, _, err := consulClient.ConfigEntries().Set(&capi.ProxyConfigEntry{
-				Kind: capi.ProxyDefaults,
-				Name: capi.ProxyConfigGlobal,
-				MeshGateway: capi.MeshGatewayConfig{
-					Mode: capi.MeshGatewayModeLocal,
-				},
-			}, nil)
-			require.NoError(err)
-			require.True(written)
-			h.ConsulClient = consulClient
-
 			container, err := h.containerInit(*tt.Pod(minimal()), k8sNamespace)
 			require.NoError(err)
 			actual := strings.Join(container.Command, " ")
-			require.Contains(actual, tt.Cmd)
+			require.Equal(actual, tt.Cmd)
 			if tt.CmdNot != "" {
 				require.NotContains(actual, tt.CmdNot)
 			}
@@ -464,4 +606,9 @@ func TestHandlerContainerInitCopyContainer(t *testing.T) {
 	container := h.containerInitCopyContainer()
 	actual := strings.Join(container.Command, " ")
 	require.Contains(actual, `cp /bin/consul /consul/connect-inject/consul`)
+}
+
+// pointerToBool takes a boolean and returns a pointer to it.
+func pointerToBool(b bool) *bool {
+	return &b
 }

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -190,7 +190,7 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 				RunAsUser:  pointerToInt64(0),
 				RunAsGroup: pointerToInt64(0),
 				Capabilities: &corev1.Capabilities{
-					Add: []corev1.Capability{"NET_ADMIN"},
+					Add: []corev1.Capability{netAdminCapability},
 				},
 			}
 			expectedCmd := `/consul/connect-inject/consul connect redirect-traffic \
@@ -198,15 +198,14 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
   -proxy-uid=0`
 			container, err := h.containerInit(*pod, k8sNamespace)
 			require.NoError(t, err)
+			actualCmd := strings.Join(container.Command, " ")
 
 			if c.expectEnabled {
 				require.Equal(t, expectedSecurityContext, container.SecurityContext)
-				cmd := strings.Join(container.Command, " ")
-				require.Contains(t, cmd, expectedCmd)
+				require.Contains(t, actualCmd, expectedCmd)
 			} else {
 				require.Nil(t, container.SecurityContext)
-				cmd := strings.Join(container.Command, " ")
-				require.NotContains(t, cmd, expectedCmd)
+				require.NotContains(t, actualCmd, expectedCmd)
 			}
 		})
 	}

--- a/connect-inject/endpoints_controller.go
+++ b/connect-inject/endpoints_controller.go
@@ -31,7 +31,6 @@ const (
 	MetaKeyKubeServiceName     = "k8s-service-name"
 	MetaKeyKubeNS              = "k8s-namespace"
 	kubernetesSuccessReasonMsg = "Kubernetes health checks passing"
-	podPendingReasonMsg        = "Pod is pending"
 	envoyPrometheusBindAddr    = "envoy_prometheus_bind_addr"
 	clusterIPTaggedAddressName = "virtual"
 )

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -122,6 +122,11 @@ type Handler struct {
 	// will be populated by the defaults provided in the initial flags.
 	ConsulSidecarResources corev1.ResourceRequirements
 
+	// EnableTransparentProxy enables transparent proxy mode.
+	// This means that the injected init container will apply traffic redirection rules
+	// so that all traffic will go through the Envoy proxy.
+	EnableTransparentProxy bool
+
 	// Log
 	Log hclog.Logger
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/go-cmp v0.5.2
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
-	github.com/hashicorp/consul/api v1.4.1-0.20210203205937-0d1301c408a3
+	github.com/hashicorp/consul/api v1.4.1-0.20210413184425-7cb3f326720e
 	github.com/hashicorp/consul/sdk v0.7.0
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-discover v0.0.0-20200812215701-c4b85f6ed31f

--- a/go.sum
+++ b/go.sum
@@ -318,6 +318,12 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.4.1-0.20210203205937-0d1301c408a3 h1:tpdztuA6xykU8LH3SeAxefJ4nab0K4KbE8Fu/F9C/ZI=
 github.com/hashicorp/consul/api v1.4.1-0.20210203205937-0d1301c408a3/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+XbolEz1952UB+mk=
+github.com/hashicorp/consul/api v1.4.1-0.20210408182656-a02245b75af5 h1:HDhRkzUwg8jamBYilD08jFrKeha9ELx+NSahITYxl5U=
+github.com/hashicorp/consul/api v1.4.1-0.20210408182656-a02245b75af5/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+XbolEz1952UB+mk=
+github.com/hashicorp/consul/api v1.4.1-0.20210412223704-18decbba9d2e h1:Dwls4EgykZYn/GW/QCz76NDBiBV/xOZEu5mM3/mMBd4=
+github.com/hashicorp/consul/api v1.4.1-0.20210412223704-18decbba9d2e/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+XbolEz1952UB+mk=
+github.com/hashicorp/consul/api v1.4.1-0.20210413184425-7cb3f326720e h1:s8kw6kDUBF36BhNN4d1DcQZBQuE+deUqAh1SbyW56Cw=
+github.com/hashicorp/consul/api v1.4.1-0.20210413184425-7cb3f326720e/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+XbolEz1952UB+mk=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.7.0 h1:H6R9d008jDcHPQPAqPNuydAshJ4v5/8URdFnUvK/+sc=
 github.com/hashicorp/consul/sdk v0.7.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=

--- a/go.sum
+++ b/go.sum
@@ -316,12 +316,6 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
-github.com/hashicorp/consul/api v1.4.1-0.20210203205937-0d1301c408a3 h1:tpdztuA6xykU8LH3SeAxefJ4nab0K4KbE8Fu/F9C/ZI=
-github.com/hashicorp/consul/api v1.4.1-0.20210203205937-0d1301c408a3/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+XbolEz1952UB+mk=
-github.com/hashicorp/consul/api v1.4.1-0.20210408182656-a02245b75af5 h1:HDhRkzUwg8jamBYilD08jFrKeha9ELx+NSahITYxl5U=
-github.com/hashicorp/consul/api v1.4.1-0.20210408182656-a02245b75af5/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+XbolEz1952UB+mk=
-github.com/hashicorp/consul/api v1.4.1-0.20210412223704-18decbba9d2e h1:Dwls4EgykZYn/GW/QCz76NDBiBV/xOZEu5mM3/mMBd4=
-github.com/hashicorp/consul/api v1.4.1-0.20210412223704-18decbba9d2e/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+XbolEz1952UB+mk=
 github.com/hashicorp/consul/api v1.4.1-0.20210413184425-7cb3f326720e h1:s8kw6kDUBF36BhNN4d1DcQZBQuE+deUqAh1SbyW56Cw=
 github.com/hashicorp/consul/api v1.4.1-0.20210413184425-7cb3f326720e/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+XbolEz1952UB+mk=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -88,6 +88,9 @@ type Command struct {
 	flagInitContainerMemoryLimit   string
 	flagInitContainerMemoryRequest string
 
+	// Transparent proxy flag(s).
+	flagEnableTransparentProxy bool
+
 	flagSet *flag.FlagSet
 	http    *flags.HTTPFlags
 
@@ -150,6 +153,8 @@ func (c *Command) init() {
 	c.flagSet.StringVar(&c.flagCrossNamespaceACLPolicy, "consul-cross-namespace-acl-policy", "",
 		"[Enterprise Only] Name of the ACL policy to attach to all created Consul namespaces to allow service "+
 			"discovery across Consul namespaces. Only necessary if ACLs are enabled.")
+	c.flagSet.BoolVar(&c.flagEnableTransparentProxy, "enable-transparent-proxy", false,
+		"Enable transparent proxy mode for all Consul service mesh applications.")
 	c.flagSet.StringVar(&c.flagLogLevel, "log-level", "info",
 		"Log verbosity level. Supported values (in order of detail) are \"trace\", "+
 			"\"debug\", \"info\", \"warn\", and \"error\".")
@@ -397,6 +402,7 @@ func (c *Command) Run(args []string) int {
 		EnableNSMirroring:          c.flagEnableK8SNSMirroring,
 		NSMirroringPrefix:          c.flagK8SNSMirroringPrefix,
 		CrossNSACLPolicy:           c.flagCrossNamespaceACLPolicy,
+		EnableTransparentProxy:     c.flagEnableTransparentProxy,
 		Log:                        ctrl.Log.WithName("controller").WithName("endpoints"),
 		Scheme:                     mgr.GetScheme(),
 		ReleaseName:                c.flagReleaseName,
@@ -433,6 +439,7 @@ func (c *Command) Run(args []string) int {
 			EnableK8SNSMirroring:       c.flagEnableK8SNSMirroring,
 			K8SNSMirroringPrefix:       c.flagK8SNSMirroringPrefix,
 			CrossNamespaceACLPolicy:    c.flagCrossNamespaceACLPolicy,
+			EnableTransparentProxy:     c.flagEnableTransparentProxy,
 			Log:                        logger.Named("handler"),
 		}})
 

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -153,7 +153,7 @@ func (c *Command) init() {
 	c.flagSet.StringVar(&c.flagCrossNamespaceACLPolicy, "consul-cross-namespace-acl-policy", "",
 		"[Enterprise Only] Name of the ACL policy to attach to all created Consul namespaces to allow service "+
 			"discovery across Consul namespaces. Only necessary if ACLs are enabled.")
-	c.flagSet.BoolVar(&c.flagEnableTransparentProxy, "enable-transparent-proxy", false,
+	c.flagSet.BoolVar(&c.flagEnableTransparentProxy, "enable-transparent-proxy", true,
 		"Enable transparent proxy mode for all Consul service mesh applications.")
 	c.flagSet.StringVar(&c.flagLogLevel, "log-level", "info",
 		"Log verbosity level. Supported values (in order of detail) are \"trace\", "+


### PR DESCRIPTION
Changes proposed in this PR:
* add new -enable-transparent-proxy flag to inject-connect command,
  which will enable all transparent proxy mode for all applications running
  on the Consul service mesh.
* add a new pod annotation consul.hashicorp.com/transparent-proxy to allow
  enabling or disabling transparent proxy mode.
* endpoints-controller will configure proxy service registrations to enable
  transparent proxy when the above flag is passed or when tproxy annotation is set.
  It will also add service's cluster IP to both the service and proxy registrations
  as a tagged address so that Consul can configure Envoy filter traffic based on that IP.
* consul-connect-inject-init container will apply traffic redirection rules
  via consul connect redirect-traffic command which runs iptables under the hood.
  To run the command, the init container needs to both be a root user and have
  NET_ADMIN capability.

How I've tested this PR:
Ran acceptance tests in hashicorp/consul-helm#905. Note that we can't yet run enterprise acceptance tests as we're still waiting for some fixes to make it to the enterprise image

How I expect reviewers to test this PR:
- Code review
- If you'd like you can try it out with consul-k8s image `ishustava/consul-k8s-dev:04-13-2021-65883b7` and consul image: `ishustava/consul-dev:tproxy-test`

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
