### PR TITLE
Update the handler to use zap logger

### DIFF
--- a/connect-inject/consul_sidecar_test.go
+++ b/connect-inject/consul_sidecar_test.go
@@ -3,7 +3,7 @@ package connectinject
 import (
 	"testing"
 
-	"github.com/hashicorp/go-hclog"
+	logrtest "github.com/go-logr/logr/testing"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +13,7 @@ import (
 // that we pass the metrics flags to consul sidecar.
 func TestConsulSidecar_MetricsFlags(t *testing.T) {
 	handler := Handler{
-		Log:            hclog.Default().Named("handler"),
+		Log:            logrtest.TestLogger{T: t},
 		ImageConsulK8S: "hashicorp/consul-k8s:9.9.9",
 		MetricsConfig: MetricsConfig{
 			DefaultEnableMetrics:        true,

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -174,6 +174,8 @@ func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Res
 		return admission.Allowed(fmt.Sprintf("%s %s does not require injection", pod.Kind, pod.Name))
 	}
 
+	h.Log.Info("received pod", "name", pod.Name, "ns", pod.Namespace)
+
 	// Add our volume that will be shared by the init container and
 	// the sidecar for passing data in the pod.
 	pod.Spec.Volumes = append(pod.Spec.Volumes, h.containerVolume())

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -9,9 +9,9 @@ import (
 	"strconv"
 
 	"github.com/deckarep/golang-set"
+	"github.com/go-logr/logr"
 	"github.com/hashicorp/consul-k8s/namespaces"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/go-hclog"
 	"gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -128,7 +128,7 @@ type Handler struct {
 	EnableTransparentProxy bool
 
 	// Log
-	Log hclog.Logger
+	Log logr.Logger
 
 	decoder *admission.Decoder
 }
@@ -141,7 +141,7 @@ func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Res
 
 	// Decode the pod from the request
 	if err := h.decoder.Decode(req, &pod); err != nil {
-		h.Log.Error("Could not unmarshal request to pod", "err", err)
+		h.Log.Error(err, "could not unmarshal request to pod")
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
@@ -153,7 +153,7 @@ func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Res
 	}
 
 	if err := h.validatePod(pod); err != nil {
-		h.Log.Error("Error validating pod", "err", err, "Request Name", req.Name)
+		h.Log.Error(err, "error validating pod", "request name", req.Name)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
@@ -161,14 +161,14 @@ func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Res
 	// This MUST be done before shouldInject is called since that function
 	// uses these annotations.
 	if err := h.defaultAnnotations(&pod); err != nil {
-		h.Log.Error("Error creating default annotations", "err", err, "Request Name", req.Name)
+		h.Log.Error(err, "error creating default annotations", "request name", req.Name)
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error creating default annotations: %s", err))
 	}
 
 	// Check if we should inject, for example we don't inject in the
 	// system namespaces.
 	if shouldInject, err := h.shouldInject(pod, req.Namespace); err != nil {
-		h.Log.Error("Error checking if should inject", "err", err, "Request Name", req.Name)
+		h.Log.Error(err, "error checking if should inject", "request name", req.Name)
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error checking if should inject: %s", err))
 	} else if !shouldInject {
 		return admission.Allowed(fmt.Sprintf("%s %s does not require injection", pod.Kind, pod.Name))
@@ -198,7 +198,7 @@ func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Res
 	// the Envoy configuration.
 	initContainer, err := h.containerInit(pod, req.Namespace)
 	if err != nil {
-		h.Log.Error("Error configuring injection init container", "err", err, "Request Name", req.Name)
+		h.Log.Error(err, "error configuring injection init container", "request name", req.Name)
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error configuring injection init container: %s", err))
 	}
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
@@ -206,7 +206,7 @@ func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Res
 	// Add the Envoy and Consul sidecars.
 	envoySidecar, err := h.envoySidecar(pod, req.Namespace)
 	if err != nil {
-		h.Log.Error("Error configuring injection sidecar container", "err", err, "Request Name", req.Name)
+		h.Log.Error(err, "error configuring injection sidecar container", "request name", req.Name)
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error configuring injection sidecar container: %s", err))
 	}
 	pod.Spec.Containers = append(pod.Spec.Containers, envoySidecar)
@@ -217,7 +217,7 @@ func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Res
 	// First, determine if we need to run the metrics merging server.
 	shouldRunMetricsMerging, err := h.MetricsConfig.shouldRunMergedMetricsServer(pod)
 	if err != nil {
-		h.Log.Error("Error determining if metrics merging server should be run", "err", err, "Request Name", req.Name)
+		h.Log.Error(err, "error determining if metrics merging server should be run", "request name", req.Name)
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error determining if metrics merging server should be run: %s", err))
 	}
 
@@ -225,7 +225,7 @@ func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Res
 	if shouldRunMetricsMerging {
 		consulSidecar, err := h.consulSidecar(pod)
 		if err != nil {
-			h.Log.Error("Error configuring consul sidecar container", "err", err, "Request Name", req.Name)
+			h.Log.Error(err, "error configuring consul sidecar container", "request name", req.Name)
 			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error configuring consul sidecar container: %s", err))
 		}
 		pod.Spec.Containers = append(pod.Spec.Containers, consulSidecar)
@@ -237,7 +237,7 @@ func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Res
 
 	// Add annotations for metrics.
 	if err = h.prometheusAnnotations(&pod); err != nil {
-		h.Log.Error("Error configuring prometheus annotations", "err", err, "Request Name", req.Name)
+		h.Log.Error(err, "error configuring prometheus annotations", "request name", req.Name)
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error configuring prometheus annotations: %s", err))
 	}
 
@@ -270,8 +270,8 @@ func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Res
 	// that process before modifying the Consul cluster.
 	if h.EnableNamespaces {
 		if _, err := namespaces.EnsureExists(h.ConsulClient, h.consulNamespace(req.Namespace), h.CrossNamespaceACLPolicy); err != nil {
-			h.Log.Error("Error checking or creating namespace", "err", err,
-				"Namespace", h.consulNamespace(req.Namespace), "Request Name", req.Name)
+			h.Log.Error(err, "error checking or creating namespace",
+				"ns", h.consulNamespace(req.Namespace), "request name", req.Name)
 			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error checking or creating namespace: %s", err))
 		}
 	}

--- a/connect-inject/handler_ent_test.go
+++ b/connect-inject/handler_ent_test.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	"github.com/deckarep/golang-set"
+	logrtest "github.com/go-logr/logr/testing"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -49,7 +49,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 		{
 			Name: "single destination namespace 'default' from k8s 'default'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -70,7 +70,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 		{
 			Name: "single destination namespace 'default' from k8s 'non-default'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -91,7 +91,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 		{
 			Name: "single destination namespace 'dest' from k8s 'default'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -112,7 +112,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 		{
 			Name: "single destination namespace 'dest' from k8s 'non-default'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -133,7 +133,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 		{
 			Name: "mirroring from k8s 'default'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -155,7 +155,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 		{
 			Name: "mirroring from k8s 'dest'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -177,7 +177,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 		{
 			Name: "mirroring with prefix from k8s 'default'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -200,7 +200,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 		{
 			Name: "mirroring with prefix from k8s 'dest'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -297,7 +297,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 		{
 			Name: "acls + single destination namespace 'default' from k8s 'default'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -319,7 +319,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 		{
 			Name: "acls + single destination namespace 'default' from k8s 'non-default'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -341,7 +341,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 		{
 			Name: "acls + single destination namespace 'dest' from k8s 'default'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -363,7 +363,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 		{
 			Name: "acls + single destination namespace 'dest' from k8s 'non-default'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -385,7 +385,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 		{
 			Name: "acls + mirroring from k8s 'default'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -408,7 +408,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 		{
 			Name: "acls + mirroring from k8s 'dest'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -431,7 +431,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 		{
 			Name: "acls + mirroring with prefix from k8s 'default'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -455,7 +455,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 		{
 			Name: "acls + mirroring with prefix from k8s 'dest'",
 			Handler: Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,
@@ -625,7 +625,7 @@ func TestHandler_MutateWithNamespaces_Annotation(t *testing.T) {
 			require.NoError(err)
 
 			handler := Handler{
-				Log:                        hclog.Default().Named("handler"),
+				Log:                        logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet:      mapset.NewSet("*"),
 				DenyK8sNamespacesSet:       mapset.NewSet(),
 				EnableNamespaces:           true,

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	mapset "github.com/deckarep/golang-set"
-	"github.com/hashicorp/go-hclog"
+	logrtest "github.com/go-logr/logr/testing"
 	"github.com/stretchr/testify/require"
 	"gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -45,7 +45,7 @@ func TestHandlerHandle(t *testing.T) {
 		{
 			"kube-system namespace",
 			Handler{
-				Log:                   hclog.Default().Named("handler"),
+				Log:                   logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
 				decoder:               decoder,
@@ -65,7 +65,7 @@ func TestHandlerHandle(t *testing.T) {
 		{
 			"already injected",
 			Handler{
-				Log:                   hclog.Default().Named("handler"),
+				Log:                   logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
 				decoder:               decoder,
@@ -89,7 +89,7 @@ func TestHandlerHandle(t *testing.T) {
 		{
 			"empty pod basic",
 			Handler{
-				Log:                   hclog.Default().Named("handler"),
+				Log:                   logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
 				decoder:               decoder,
@@ -130,7 +130,7 @@ func TestHandlerHandle(t *testing.T) {
 		{
 			"pod with upstreams specified",
 			Handler{
-				Log:                   hclog.Default().Named("handler"),
+				Log:                   logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
 				decoder:               decoder,
@@ -175,7 +175,7 @@ func TestHandlerHandle(t *testing.T) {
 		{
 			"empty pod with injection disabled",
 			Handler{
-				Log:                   hclog.Default().Named("handler"),
+				Log:                   logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
 				decoder:               decoder,
@@ -199,7 +199,7 @@ func TestHandlerHandle(t *testing.T) {
 		{
 			"empty pod with injection truthy",
 			Handler{
-				Log:                   hclog.Default().Named("handler"),
+				Log:                   logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
 				decoder:               decoder,
@@ -244,7 +244,7 @@ func TestHandlerHandle(t *testing.T) {
 		{
 			"pod with service annotation",
 			Handler{
-				Log:                   hclog.Default().Named("handler"),
+				Log:                   logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
 				decoder:               decoder,
@@ -289,7 +289,7 @@ func TestHandlerHandle(t *testing.T) {
 		{
 			"pod with existing label",
 			Handler{
-				Log:                   hclog.Default().Named("handler"),
+				Log:                   logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
 				decoder:               decoder,
@@ -334,7 +334,7 @@ func TestHandlerHandle(t *testing.T) {
 		{
 			"when metrics merging is enabled, we should inject the consul-sidecar and add prometheus annotations",
 			Handler{
-				Log:                   hclog.Default().Named("handler"),
+				Log:                   logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
 				MetricsConfig: MetricsConfig{
@@ -459,7 +459,7 @@ func TestHandler_ErrorsOnDeprecatedAnnotations(t *testing.T) {
 			require.NoError(err)
 
 			handler := Handler{
-				Log:                   hclog.Default().Named("handler"),
+				Log:                   logrtest.TestLogger{T: t},
 				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
 				DenyK8sNamespacesSet:  mapset.NewSet(),
 				decoder:               decoder,

--- a/subcommand/connect-init/command.go
+++ b/subcommand/connect-init/command.go
@@ -166,13 +166,16 @@ func (c *Command) Run(args []string) int {
 			if svc.Kind == api.ServiceKindConnectProxy {
 				// This is the proxy service ID.
 				proxyID = svc.ID
-				return nil
 			}
 		}
-		// In theory we can't reach this point unless we have 2 services registered against
-		// this pod and neither are the connect-proxy. We don't support this case anyway, but it
-		// is necessary to return from the function.
-		return fmt.Errorf("unable to find registered connect-proxy service")
+
+		if proxyID == "" {
+			// In theory we can't reach this point unless we have 2 services registered against
+			// this pod and neither are the connect-proxy. We don't support this case anyway, but it
+			// is necessary to return from the function.
+			return fmt.Errorf("unable to find registered connect-proxy service")
+		}
+		return nil
 	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), c.serviceRegistrationPollingAttempts))
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Timed out waiting for service registration: %v", err))

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -155,9 +155,9 @@ func (c *Command) init() {
 			"discovery across Consul namespaces. Only necessary if ACLs are enabled.")
 	c.flagSet.BoolVar(&c.flagEnableTransparentProxy, "enable-transparent-proxy", true,
 		"Enable transparent proxy mode for all Consul service mesh applications.")
-	c.flagSet.StringVar(&c.flagLogLevel, "log-level", "info",
-		"Log verbosity level. Supported values (in order of detail) are \"trace\", "+
-			"\"debug\", \"info\", \"warn\", and \"error\".")
+	c.flagSet.StringVar(&c.flagLogLevel, "log-level", zapcore.InfoLevel.String(),
+		fmt.Sprintf("Log verbosity level. Supported values (in order of detail) are "+
+			"%q, %q, %q, and %q.", zapcore.DebugLevel.String(), zapcore.InfoLevel.String(), zapcore.WarnLevel.String(), zapcore.ErrorLevel.String()))
 
 	// Proxy sidecar resource setting flags.
 	c.flagSet.StringVar(&c.flagDefaultSidecarProxyCPURequest, "default-sidecar-proxy-cpu-request", "", "Default sidecar proxy CPU request.")

--- a/subcommand/inject-connect/command_test.go
+++ b/subcommand/inject-connect/command_test.go
@@ -30,7 +30,7 @@ func TestRun_FlagValidation(t *testing.T) {
 		{
 			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
 				"-log-level", "invalid"},
-			expErr: "unknown log level: invalid",
+			expErr: "Error parsing -log-level \"invalid\": unrecognized level: \"invalid\"",
 		},
 		{
 			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",


### PR DESCRIPTION
Changes proposed in this PR:
- Previously the handler was using hclog, which logs the webhook logs to a different output from the controller logs. In order for them to be written to where the controller logs are, we update the handler to now use zaplogger over hclog.

How I've tested this PR: Run tests

How I expect reviewers to test this PR: Code review


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
