### PR TITLE
Increase the wait time in connect-init

### DIFF
--- a/subcommand/connect-init/command.go
+++ b/subcommand/connect-init/command.go
@@ -23,8 +23,8 @@ const (
 
 	// The number of times to attempt ACL Login.
 	numLoginRetries = 3
-	// The number of times to attempt to read this service (60s).
-	defaultServicePollingRetries = 60
+	// The number of times to attempt to read this service (120s).
+	defaultServicePollingRetries = 120
 )
 
 type Command struct {


### PR DESCRIPTION
- While waiting for registered services to get listed in the connect init, it waits for 60 seconds before failing. Valid service
registrations could take longer than 60 seconds. Upping the wait time to 120 seconds to ensure we dont fail prematurely.

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
