### PR TITLE
Fix logging

### DIFF
--- a/connect-inject/endpoints_controller.go
+++ b/connect-inject/endpoints_controller.go
@@ -120,8 +120,6 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		for _, address := range allAddresses {
 			if address.TargetRef != nil && address.TargetRef.Kind == "Pod" {
-				// Build the endpointAddressMap up for deregistering service instances later.
-				endpointAddressMap[address.IP] = true
 				// Get pod associated with this address.
 				var pod corev1.Pod
 				objectKey := types.NamespacedName{Name: address.TargetRef.Name, Namespace: address.TargetRef.Namespace}
@@ -131,6 +129,8 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 				}
 
 				if hasBeenInjected(pod) {
+					// Build the endpointAddressMap up for deregistering service instances later.
+					endpointAddressMap[pod.Status.PodIP] = true
 					// Create client for Consul agent local to the pod.
 					client, err := r.remoteConsulClient(pod.Status.HostIP, r.consulNamespace(pod.Namespace))
 					if err != nil {

--- a/connect-inject/endpoints_controller.go
+++ b/connect-inject/endpoints_controller.go
@@ -595,7 +595,7 @@ func shouldIgnore(namespace string, denySet, allowSet mapset.Set) bool {
 // which in this case are Pods. It only returns true if the Pod is a Consul Client Agent Pod. It reads the labels
 // from the meta of the resource and uses the values of the "app" and "component" label to validate that
 // the Pod is a Consul Client Agent.
-func (r EndpointsController) filterAgentPods(object client.Object) bool {
+func (r *EndpointsController) filterAgentPods(object client.Object) bool {
 	podLabels := object.GetLabels()
 	app, ok := podLabels["app"]
 	if !ok {
@@ -623,7 +623,7 @@ func (r EndpointsController) filterAgentPods(object client.Object) bool {
 // are on the same node as the new Consul Agent pod. It receives a Pod Object which is a
 // Consul Agent that has been filtered by filterAgentPods and only enqueues endpoints
 // for client agent pods where the Ready condition is true.
-func (r EndpointsController) requestsForRunningAgentPods(object client.Object) []ctrl.Request {
+func (r *EndpointsController) requestsForRunningAgentPods(object client.Object) []ctrl.Request {
 	var consulClientPod corev1.Pod
 	r.Log.Info("received update for Consul client pod", "name", object.GetName())
 	err := r.Client.Get(r.Context, types.NamespacedName{Name: object.GetName(), Namespace: object.GetNamespace()}, &consulClientPod)


### PR DESCRIPTION
Changes proposed in this PR:
- Add info logs to capture svcs getting deregistered and an error log when we fail to get the health of a pod.
- Ensure we populate the address map in the endpoints controller using the pod IP from the pod object and not from the endpoint to ensure consistency.
- Add pointers to the struct receivers to ensure we use them consistently as required by the Hashicorp style guide.
cc @lkysow 

How I've tested this PR: This is a refactor.

How I expect reviewers to test this PR: Code review


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
