### PR TITLE
use rootless containers where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## UNRELEASED
 
-FEATURES:
-* Connect: Add a security context to the init copy container and the envoy sidecar and ensure they do not run as root. [[GH-493](https://github.com/hashicorp/consul-k8s/pull/493)]
-
 BUG FIXES:
-* Connect: Use `RunAsNonRoot: false` for connect-init's container when tproxy is enabled. [[GH-493](https://github.com/hashicorp/consul-k8s/pull/493)]
+* Connect: Use `runAsNonRoot: false` for connect-init's container when tproxy is enabled. [[GH-493](https://github.com/hashicorp/consul-k8s/pull/493)]
+
+BREAKING CHANGES:
+* Connect: Add a security context to the init copy container and the envoy sidecar and ensure they do not run as root. If a pod container shares the same `runAsUser` (5995) as Envoy an error is returned on scheduling. [[GH-493](https://github.com/hashicorp/consul-k8s/pull/493)]
 
 ## 0.26.0-beta1 (April 16, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## UNRELEASED
 
 FEATURES:
-* Connect: Add a security context to the init copy container and the envoy sidecar and ensure they do not run as root. Also use `RunAsNonRoot: false` for connect-init's container when tproxy is enabled. [[GH-493](https://github.com/hashicorp/consul-k8s/pull/493)]
+* Connect: Add a security context to the init copy container and the envoy sidecar and ensure they do not run as root. [[GH-493](https://github.com/hashicorp/consul-k8s/pull/493)]
 
+BUG FIXES:
+* Connect: Use `RunAsNonRoot: false` for connect-init's container when tproxy is enabled. [[GH-493](https://github.com/hashicorp/consul-k8s/pull/493)]
 
 ## 0.26.0-beta1 (April 16, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+FEATURES:
+* Connect: Add a security context to the init copy container and the envoy sidecar and ensure they do not run as root. Also use `RunAsNonRoot: false` for connect-init's container when tproxy is enabled. [[GH-493](https://github.com/hashicorp/consul-k8s/pull/493)]
+
+
 ## 0.26.0-beta1 (April 16, 2021)
 
 BREAKING CHANGES:

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -2,6 +2,7 @@ package connectinject
 
 import (
 	"bytes"
+	"fmt"
 	"strconv"
 	"strings"
 	"text/template"
@@ -13,6 +14,7 @@ const (
 	InjectInitCopyContainerName = "copy-consul-bin"
 	InjectInitContainerName     = "consul-connect-inject-init"
 	rootUserAndGroupID          = 0
+	envoyUserAndGroupID         = 5995
 	netAdminCapability          = "NET_ADMIN"
 )
 
@@ -37,6 +39,8 @@ type initContainerCommandData struct {
 	PrometheusScrapePath string
 	// PrometheusBackendPort configures where the listener on Envoy will point to.
 	PrometheusBackendPort string
+	// EnvoyUID is the UID that `consul connect redirect-traffic` will use when tproxy is enabled.
+	EnvoyUID string
 
 	// EnableTransparentProxy configures this init container to run in transparent proxy mode,
 	// i.e. run consul connect redirect-traffic command and add the required privileges to the
@@ -60,6 +64,12 @@ func (h *Handler) containerInitCopyContainer() corev1.Container {
 			},
 		},
 		Command: []string{"/bin/sh", "-ec", cmd},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:              pointerToInt64(envoyUserAndGroupID),
+			RunAsGroup:             pointerToInt64(envoyUserAndGroupID),
+			RunAsNonRoot:           pointerToBool(true),
+			ReadOnlyRootFilesystem: pointerToBool(true),
+		},
 	}
 }
 
@@ -78,6 +88,7 @@ func (h *Handler) containerInit(pod corev1.Pod, k8sNamespace string) (corev1.Con
 		NamespaceMirroringEnabled: h.EnableK8SNSMirroring,
 		ConsulCACert:              h.ConsulCACert,
 		EnableTransparentProxy:    tproxyEnabled,
+		EnvoyUID:                  fmt.Sprintf("%d", envoyUserAndGroupID),
 	}
 
 	if data.AuthMethod != "" {
@@ -170,6 +181,8 @@ func (h *Handler) containerInit(pod corev1.Pod, k8sNamespace string) (corev1.Con
 		container.SecurityContext = &corev1.SecurityContext{
 			RunAsUser:  pointerToInt64(rootUserAndGroupID),
 			RunAsGroup: pointerToInt64(rootUserAndGroupID),
+			// RunAsNonRoot overrides any setting in the Pod so that we can still run as root here as required.
+			RunAsNonRoot: pointerToBool(false),
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{netAdminCapability},
 			},
@@ -191,6 +204,11 @@ func transparentProxyEnabled(pod corev1.Pod, globalEnabled bool) (bool, error) {
 
 // pointerToInt64 takes an int64 and returns a pointer to it.
 func pointerToInt64(i int64) *int64 {
+	return &i
+}
+
+// pointerToBool takes a bool and returns a pointer to it.
+func pointerToBool(i bool) *bool {
 	return &i
 }
 
@@ -254,6 +272,6 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   -namespace="{{ .ConsulNamespace }}" \
   {{- end }}
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
-  -proxy-uid=0
+  -proxy-uid={{ .EnvoyUID }}
 {{- end }}
 `

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -2,7 +2,6 @@ package connectinject
 
 import (
 	"bytes"
-	"fmt"
 	"strconv"
 	"strings"
 	"text/template"
@@ -88,7 +87,7 @@ func (h *Handler) containerInit(pod corev1.Pod, k8sNamespace string) (corev1.Con
 		NamespaceMirroringEnabled: h.EnableK8SNSMirroring,
 		ConsulCACert:              h.ConsulCACert,
 		EnableTransparentProxy:    tproxyEnabled,
-		EnvoyUID:                  fmt.Sprintf("%d", envoyUserAndGroupID),
+		EnvoyUID:                  strconv.Itoa(envoyUserAndGroupID),
 	}
 
 	if data.AuthMethod != "" {
@@ -208,8 +207,8 @@ func pointerToInt64(i int64) *int64 {
 }
 
 // pointerToBool takes a bool and returns a pointer to it.
-func pointerToBool(i bool) *bool {
-	return &i
+func pointerToBool(b bool) *bool {
+	return &b
 }
 
 // initContainerCommandTpl is the template for the command executed by

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -249,7 +249,6 @@ func TestHandlerContainerInit_namespacesEnabled(t *testing.T) {
 		Pod     func(*corev1.Pod) *corev1.Pod
 		Handler Handler
 		Cmd     string // Strings.Contains test
-		CmdNot  string // Not contains
 	}{
 		{
 			"whole template, default namespace",
@@ -272,7 +271,6 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -namespace="default" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`,
-			"",
 		},
 
 		{
@@ -296,7 +294,6 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -namespace="non-default" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`,
-			"",
 		},
 
 		{
@@ -326,7 +323,6 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   -token-file="/consul/connect-inject/acl-token" \
   -namespace="non-default" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`,
-			"",
 		},
 		{
 			"Whole template, auth method, non-default namespace, mirroring enabled",
@@ -356,7 +352,6 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   -token-file="/consul/connect-inject/acl-token" \
   -namespace="k8snamespace" \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`,
-			"",
 		},
 		{
 			"whole template, default namespace, tproxy enabled",
@@ -386,7 +381,6 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   -namespace="default" \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
-			"",
 		},
 
 		{
@@ -417,7 +411,6 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   -namespace="non-default" \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
-			"",
 		},
 
 		{
@@ -455,7 +448,6 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   -namespace="k8snamespace" \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
-			"",
 		},
 	}
 
@@ -464,14 +456,10 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 			require := require.New(t)
 
 			h := tt.Handler
-
 			container, err := h.containerInit(*tt.Pod(minimal()), k8sNamespace)
 			require.NoError(err)
 			actual := strings.Join(container.Command, " ")
 			require.Equal(tt.Cmd, actual)
-			if tt.CmdNot != "" {
-				require.NotContains(tt.CmdNot, actual)
-			}
 		})
 	}
 }
@@ -605,8 +593,8 @@ func TestHandlerContainerInitCopyContainer(t *testing.T) {
 	h := Handler{}
 	container := h.containerInitCopyContainer()
 	expectedSecurityContext := &corev1.SecurityContext{
-		RunAsUser:              pointerToInt64(envoyUserAndGroupID),
-		RunAsGroup:             pointerToInt64(envoyUserAndGroupID),
+		RunAsUser:              pointerToInt64(copyContainerUserAndGroupID),
+		RunAsGroup:             pointerToInt64(copyContainerUserAndGroupID),
 		RunAsNonRoot:           pointerToBool(true),
 		ReadOnlyRootFilesystem: pointerToBool(true),
 	}

--- a/connect-inject/envoy_sidecar.go
+++ b/connect-inject/envoy_sidecar.go
@@ -32,7 +32,7 @@ func (h *Handler) envoySidecar(pod corev1.Pod) (corev1.Container, error) {
 	for _, c := range pod.Spec.Containers {
 		// User container and Envoy container cannot have the same UID.
 		if c.SecurityContext != nil && c.SecurityContext.RunAsUser != nil && *c.SecurityContext.RunAsUser == envoyUserAndGroupID {
-			return corev1.Container{}, fmt.Errorf("user containers cannot have the same uid as envoy: %v", envoyUserAndGroupID)
+			return corev1.Container{}, fmt.Errorf("container %q has runAsUser set to the same uid %q as envoy which is not allowed", c.Name, envoyUserAndGroupID)
 		}
 	}
 

--- a/connect-inject/envoy_sidecar_test.go
+++ b/connect-inject/envoy_sidecar_test.go
@@ -74,9 +74,14 @@ func TestHandlerEnvoySidecar_FailsWithDuplicateContainerSecurityContextUID(t *te
 			Containers: []corev1.Container{
 				{
 					Name: "web",
+					// Setting RunAsUser: 1 should succeed.
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser: pointerToInt64(1),
+					},
 				},
 				{
 					Name: "app",
+					// Setting RunAsUser: 5995 should fail.
 					SecurityContext: &corev1.SecurityContext{
 						RunAsUser: pointerToInt64(envoyUserAndGroupID),
 					},
@@ -85,7 +90,7 @@ func TestHandlerEnvoySidecar_FailsWithDuplicateContainerSecurityContextUID(t *te
 		},
 	}
 	_, err := h.envoySidecar(pod)
-	require.Error(err, fmt.Sprintf("user containers cannot have the same uid as envoy: %v", envoyUserAndGroupID))
+	require.Error(err, fmt.Sprintf("container %q has runAsUser set to the same uid %q as envoy which is not allowed", pod.Spec.Containers[1].Name, envoyUserAndGroupID))
 }
 
 // Test that we can pass extra args to envoy via the extraEnvoyArgs flag

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -191,8 +191,7 @@ func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Res
 		container.Env = append(container.Env, containerEnvVars...)
 	}
 
-	// TODO: rename both of these initcontainers appropriately
-	// Add the consul-init container
+	// Add the init container which copies the Consul binary to /consul/connect-inject/.
 	initCopyContainer := h.containerInitCopyContainer()
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, initCopyContainer)
 
@@ -205,8 +204,8 @@ func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Res
 	}
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
 
-	// Add the Envoy and Consul sidecars.
-	envoySidecar, err := h.envoySidecar(pod, req.Namespace)
+	// Add the Envoy sidecar.
+	envoySidecar, err := h.envoySidecar(pod)
 	if err != nil {
 		h.Log.Error(err, "error configuring injection sidecar container", "request name", req.Name)
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error configuring injection sidecar container: %s", err))


### PR DESCRIPTION
Changes proposed in this PR:
- Add a security context to the init copy container and the envoy sidecar and ensure they run as non-root.
- Add `RunAsNonRoot: false` to the connt-init container so that it can run as root even if the Pod has this disabled. This should address https://github.com/hashicorp/consul-helm/issues/918. 
- Remove an unused param in the envoySidecar() function.

How I've tested this PR:
unit tests.
I've deployed this into a test cluster with a sample app that has:
  (1) no pod security contexts  
 and
 (2) pod security context : 
```
  securityContext:
    runAsUser: 1000
    runAsGroup: 3000
    fsGroup: 2000
    runAsNonRoot: true
``` 
and confirmed that the pod deploys succesfully with the changes to the init container and fails without them. 

How I expect reviewers to test this PR:
unit tests / run it.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
