### PR TITLE
Allow unstructured schema for the ProxyDefaults CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+BUG FIXES:
+* CRDs: Fix a bug where the `config` field in `ProxyDefaults` CR was not synced to Consul because
+  `apiextensions.k8s.io/v1` requires CRD spec to have structured schema. [[GH-495](https://github.com/hashicorp/consul-k8s/pull/495)]
+
 ## 0.26.0-beta1 (April 16, 2021)
 
 BREAKING CHANGES:

--- a/api/v1alpha1/proxydefaults_types.go
+++ b/api/v1alpha1/proxydefaults_types.go
@@ -56,6 +56,7 @@ type ProxyDefaultsSpec struct {
 	// Supports JSON config values. See https://www.consul.io/docs/connect/proxies/envoy#configuration-formatting
 	// +kubebuilder:validation:Type=object
 	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Config json.RawMessage `json:"config,omitempty"`
 	// MeshGateway controls the default mesh gateway configuration for this service.
 	MeshGateway MeshGatewayConfig `json:"meshGateway,omitempty"`

--- a/config/crd/bases/consul.hashicorp.com_proxydefaults.yaml
+++ b/config/crd/bases/consul.hashicorp.com_proxydefaults.yaml
@@ -48,6 +48,7 @@ spec:
               config:
                 description: Config is an arbitrary map of configuration values used by Connect proxies. Any values that your proxy allows can be configured globally here. Supports JSON config values. See https://www.consul.io/docs/connect/proxies/envoy#configuration-formatting
                 type: object
+                x-kubernetes-preserve-unknown-fields: true
               expose:
                 description: Expose controls the default expose path configuration for Envoy.
                 properties:


### PR DESCRIPTION
Prior to `apiextensions.k8s.io/v1`, structured schema was [optional](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema) for CRD spec, but now it is required. Since `config` field can have arbitrary keys, we need to tell Kubernetes to allow that explicitly now that we've upgraded from `v1beta1` to `v1`.

Changes proposed in this PR:
- Set `x-kubernetes-preserve-unknown-fields` to `true` for the `config` field in `ProxyDefaults`

How I've tested this PR:
by running acceptance tests

How I expect reviewers to test this PR:
code review (acceptance tests in hashicorp/consul-helm#921)

Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
