### PR TITLE
Update health check status based on the endpoints object instead of pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 BUG FIXES:
 * Connect: Use `runAsNonRoot: false` for connect-init's container when tproxy is enabled. [[GH-493](https://github.com/hashicorp/consul-k8s/pull/493)]
+* CRDs: Fix a bug where the `config` field in `ProxyDefaults` CR was not synced to Consul because
+  `apiextensions.k8s.io/v1` requires CRD spec to have structured schema. [[GH-495](https://github.com/hashicorp/consul-k8s/pull/495)]
+* Connect: Fix a bug where health status in Consul is updated incorrectly due to stale pod information in cache.
+  [[GH-503](https://github.com/hashicorp/consul-k8s/pull/503)]
 
 BREAKING CHANGES:
 * Connect: Add a security context to the init copy container and the envoy sidecar and ensure they
   do not run as root. If a pod container shares the same `runAsUser` (5995) as Envoy an error is returned
   on scheduling. [[GH-493](https://github.com/hashicorp/consul-k8s/pull/493)]
-* CRDs: Fix a bug where the `config` field in `ProxyDefaults` CR was not synced to Consul because
-  `apiextensions.k8s.io/v1` requires CRD spec to have structured schema. [[GH-495](https://github.com/hashicorp/consul-k8s/pull/495)]
 
 ## 0.26.0-beta1 (April 16, 2021)
 

--- a/connect-inject/endpoints_controller.go
+++ b/connect-inject/endpoints_controller.go
@@ -115,10 +115,17 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Register all addresses of this Endpoints object as service instances in Consul.
 	for _, subset := range serviceEndpoints.Subsets {
-		// Do the same thing for all addresses, regardless of whether they're ready.
-		allAddresses := append(subset.Addresses, subset.NotReadyAddresses...)
+		// Combine all addresses to a map, with a value indicating whether an address is ready or not.
+		allAddresses := make(map[corev1.EndpointAddress]string)
+		for _, readyAddress := range subset.Addresses {
+			allAddresses[readyAddress] = api.HealthPassing
+		}
 
-		for _, address := range allAddresses {
+		for _, notReadyAddress := range subset.NotReadyAddresses {
+			allAddresses[notReadyAddress] = api.HealthCritical
+		}
+
+		for address, healthStatus := range allAddresses {
 			if address.TargetRef != nil && address.TargetRef.Kind == "Pod" {
 				// Get pod associated with this address.
 				var pod corev1.Pod
@@ -139,7 +146,7 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 					}
 
 					// Get information from the pod to create service instance registrations.
-					serviceRegistration, proxyServiceRegistration, err := r.createServiceRegistrations(pod, serviceEndpoints)
+					serviceRegistration, proxyServiceRegistration, err := r.createServiceRegistrations(pod, serviceEndpoints, healthStatus)
 					if err != nil {
 						r.Log.Error(err, "failed to create service registrations for endpoints", "name", serviceEndpoints.Name, "ns", serviceEndpoints.Namespace)
 						return ctrl.Result{}, err
@@ -166,15 +173,11 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 
 					// Update the TTL health check for the service.
 					// This is required because ServiceRegister() does not update the TTL if the service already exists.
-					status, reason, err := getReadyStatusAndReason(pod)
+					reason := getHealthCheckStatusReason(address, healthStatus)
+					r.Log.Info("updating health check status for service", "name", serviceRegistration.Name, "reason", reason, "status", healthStatus)
+					err = client.Agent().UpdateTTL(getConsulHealthCheckID(pod, serviceRegistration.ID), reason, healthStatus)
 					if err != nil {
-						r.Log.Error(err, "failed to get status and reason from pod", "name", serviceRegistration.Name)
-						return ctrl.Result{}, err
-					}
-					r.Log.Info("updating TTL health check for service", "name", serviceRegistration.Name, "reason", reason, "status", status)
-					err = client.Agent().UpdateTTL(getConsulHealthCheckID(pod, serviceRegistration.ID), reason, status)
-					if err != nil {
-						r.Log.Error(err, "failed to update TTL health check", "name", serviceRegistration.Name)
+						r.Log.Error(err, "failed to update health check status for service", "name", serviceRegistration.Name)
 						return ctrl.Result{}, err
 					}
 				}
@@ -209,7 +212,7 @@ func (r *EndpointsController) SetupWithManager(mgr ctrl.Manager) error {
 
 // createServiceRegistrations creates the service and proxy service instance registrations with the information from the
 // Pod.
-func (r *EndpointsController) createServiceRegistrations(pod corev1.Pod, serviceEndpoints corev1.Endpoints) (*api.AgentServiceRegistration, *api.AgentServiceRegistration, error) {
+func (r *EndpointsController) createServiceRegistrations(pod corev1.Pod, serviceEndpoints corev1.Endpoints, healthStatus string) (*api.AgentServiceRegistration, *api.AgentServiceRegistration, error) {
 	// If a port is specified, then we determine the value of that port
 	// and register that port for the host service.
 	var servicePort int
@@ -222,7 +225,6 @@ func (r *EndpointsController) createServiceRegistrations(pod corev1.Pod, service
 		}
 	}
 
-	// TODO: remove logic in handler to always set the service name annotation
 	// We only want that annotation to be present when explicitly overriding the consul svc name
 	// Otherwise, the Consul service name should equal the Kubernetes Service name.
 	// The service name in Consul defaults to the Endpoints object name, and is overridden by the pod
@@ -254,14 +256,6 @@ func (r *EndpointsController) createServiceRegistrations(pod corev1.Pod, service
 		tags = append(tags, strings.Split(raw, ",")...)
 	}
 
-	// We do not set the Notes field with the 'reason' on creation because it does not set the Output field which
-	// gets read by Consul and you'll end up with both Notes and Output set.
-	// Notes (reason) will updated by UpdateTTL() as soon as this function returns.
-	status, _, err := getReadyStatusAndReason(pod)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	service := &api.AgentServiceRegistration{
 		ID:        serviceID,
 		Name:      serviceName,
@@ -273,7 +267,7 @@ func (r *EndpointsController) createServiceRegistrations(pod corev1.Pod, service
 			CheckID:                getConsulHealthCheckID(pod, serviceID),
 			Name:                   "Kubernetes Health Check",
 			TTL:                    "100000h",
-			Status:                 status,
+			Status:                 healthStatus,
 			SuccessBeforePassing:   1,
 			FailuresBeforeCritical: 1,
 		},
@@ -392,24 +386,23 @@ func getConsulHealthCheckID(pod corev1.Pod, serviceID string) string {
 	return fmt.Sprintf("%s/%s/kubernetes-health-check", pod.Namespace, serviceID)
 }
 
-// getReadyStatusAndReason returns the formatted status string to pass to Consul based on the
-// ready state of the pod along with the reason message which will be passed into the Notes
-// field of the Consul health check.
-func getReadyStatusAndReason(pod corev1.Pod) (string, string, error) {
-	for _, cond := range pod.Status.Conditions {
-		var consulStatus, reason string
-		if cond.Type == corev1.PodReady {
-			if cond.Status != corev1.ConditionTrue {
-				consulStatus = api.HealthCritical
-				reason = cond.Message
-			} else {
-				consulStatus = api.HealthPassing
-				reason = kubernetesSuccessReasonMsg
-			}
-			return consulStatus, reason, nil
-		}
+// getHealthCheckStatusReason takes an endpoint address and Consul's health check status (either passing or critical)
+// and returns the reason message. It assumes that the address has a TargetRef pointing to a pod,
+// otherwise it returns an empty string.
+func getHealthCheckStatusReason(address corev1.EndpointAddress, healthCheckStatus string) string {
+	if healthCheckStatus == api.HealthPassing {
+		return kubernetesSuccessReasonMsg
 	}
-	return "", "", fmt.Errorf("no ready status for pod: %s", pod.Name)
+
+	// Get the pod name from the address if it points to a pod,
+	// otherwise use the IP of the endpoint address in the reason message.
+	if address.TargetRef != nil && address.TargetRef.Kind == "Pod" {
+		return fmt.Sprintf("Pod \"%s/%s\" is not ready", address.TargetRef.Namespace, address.TargetRef.Name)
+	} else {
+		// If TargetRef is not a pod, the endpoints controller will ignore it and not call this function,
+		// and so we don't need to worry about the reason message in that case.
+		return ""
+	}
 }
 
 // deregisterServiceOnAllAgents queries all agents for service instances that have the metadata


### PR DESCRIPTION
Previously, we were updating health check status based on the pod status
of the pod that the endpoints address is pointing to. However, since the
endpoints controller is not watching pod objects, it will not always have
the most updated pod information in the cache. This results in incorrect behavior
where sometimes the pod we get will have stale information and we update the
health check status in Consul incorrectly.

This PR changes this behavior to instead get the health check status from
the endpoints object. The endpoints object already has information about ready
and not ready addresses, and it will always have updated cache since we receive
events based on updates from the Kubernetes API server to the cached Informer.

How I've tested this PR:
Acceptance test [here](https://app.circleci.com/pipelines/github/hashicorp/consul-helm/2887/workflows/a020c8e2-16e3-40bc-bd85-dfd31bb699f4)

How I expect reviewers to test this PR:
code review


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
