### PR TITLE
Allow to exclude inbound and outbound traffic when using tproxy via annotations

### DIFF
--- a/connect-inject/annotations.go
+++ b/connect-inject/annotations.go
@@ -88,6 +88,18 @@ const (
 	// This annotation takes a boolean value (true/false).
 	annotationTransparentProxy = "consul.hashicorp.com/transparent-proxy"
 
+	// annotationTProxyExcludeInboundPorts is a comma-separated list of inbound ports to exclude from traffic redirection.
+	annotationTProxyExcludeInboundPorts = "consul.hashicorp.com/transparent-proxy-exclude-inbound-ports"
+
+	// annotationTProxyExcludeOutboundPorts is a comma-separated list of outbound ports to exclude from traffic redirection.
+	annotationTProxyExcludeOutboundPorts = "consul.hashicorp.com/transparent-proxy-exclude-outbound-ports"
+
+	// annotationTProxyExcludeOutboundCIDRs is a comma-separated list of outbound CIDRs to exclude from traffic redirection.
+	annotationTProxyExcludeOutboundCIDRs = "consul.hashicorp.com/transparent-proxy-exclude-outbound-cidrs"
+
+	// annotationTProxyExcludeUIDs is a comma-separated list of additional user IDs to exclude from traffic redirection.
+	annotationTProxyExcludeUIDs = "consul.hashicorp.com/transparent-proxy-exclude-uids"
+
 	// injected is used as the annotation value for annotationInjected.
 	injected = "injected"
 )

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -126,7 +126,6 @@ func TestHandlerHandle(t *testing.T) {
 			},
 		},
 
-		// todo: why is upstreams different then basic
 		{
 			"pod with upstreams specified",
 			Handler{


### PR DESCRIPTION
## Changes proposed in this PR:
This PR depends on hashicorp/consul#10134

We allow the exclusion of the following:
* Exclude inbound ports
* Exclude outbound ports
* Exclude outbound CIDRs
* Exclude UIDs

## How I've tested this PR:
I tested it manually. Here are the steps I followed

Install the helm chart on kind: 
```
helm install iryna --set connectInject.enabled=true  --set server.replicas=1 hashicorp/consul --set global.imageK8S=ishustava/consul-k8s-dev:04-27-2021-b4826d4 --set global.image=ishustava/consul-dev:iptables-exclude --version 0.32.0-beta1
```

I've used the following to test these annotations:
1. To test inbound port exclude static-server's inbound port `8080` on the static-server deployment
2. To test outbound port exclude port `80` so we can reach google.com from the static-client deployment
3. To test outbound IPs set consul client's host IP (172.18.0.2 on kind) on the static-client deployment.

First, I deployed without annotations to check that I can't reach any of the above.

`static-server.yaml`:
<details>

```yaml
apiVersion: v1
kind: Service
metadata:
  name: static-server
spec:
  selector:
    app: static-server
  ports:
    - protocol: TCP
      port: 80
      targetPort: 8080
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: static-server
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: static-server
spec:
  replicas: 1
  selector:
    matchLabels:
      app: static-server
  template:
    metadata:
      name: static-server
      labels:
        app: static-server
      annotations:
        "consul.hashicorp.com/connect-inject": "true"
    spec:
      containers:
        - name: static-server
          image: docker.mirror.hashicorp.services/hashicorp/http-echo:latest
          args:
            - -text="hello world"
            - -listen=:8080
          ports:
            - containerPort: 8080
              name: http
      serviceAccountName: static-server
      terminationGracePeriodSeconds: 0
```

</details>

`static-client.yaml`:
<details>

```yaml
apiVersion: v1
kind: Service
metadata:
  name: static-client
spec:
  selector:
    app: static-client
  ports:
    - port: 80
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: static-client
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: static-client
spec:
  replicas: 1
  selector:
    matchLabels:
      app: static-client
  template:
    metadata:
      name: static-client
      labels:
        app: static-client
      annotations:
        "consul.hashicorp.com/connect-inject": "true"
    spec:
      containers:
        - name: static-client
          image: tutum/curl:latest
          command: [ "/bin/sh", "-c", "--" ]
          args: [ "while true; do sleep 30; done;" ]
      serviceAccountName: static-client
```

</details>

Tried to reach the static server over pod IP and port 8080 from another pod:

```
$ kubectl exec ds/iryna-consul -- curl -s 10.244.0.14:8080
command terminated with exit code 56
```

Tried to reach google.com (on port 80) and consul API using the host IP from the static-client pod:
```
$ kubectl exec deploy/static-client -c static-client -- curl -s google.com
command terminated with exit code 56
$ kubectl exec deploy/static-client -c static-client -- curl -s 172.18.0.2:8500/v1/catalog/services
command terminated with exit code 56
```

Redeployed static-server and static-client with as follows:
```
kubectl patch deployment static-server -p '{"spec":{"template":{"metadata":{"annotations":{"consul.hashicorp.com/transparent-proxy-exclude-inbound-ports": "8080"}}}}}'
```
```
kubectl patch deployment static-client -p '{"spec":{"template":{"metadata":{"annotations":{"consul.hashicorp.com/transparent-proxy-exclude-outbound-ports": "80","consul.hashicorp.com/transparent-proxy-exclude-outbound-cidrs":"172.18.0.2"}}}}}'
```

Ran the commands again:

Note the new pod IP of the static-server.
```
$ kubectl exec ds/iryna-consul -- curl -s 10.244.0.18:8080
"hello world"
```
```
$ kubectl exec deploy/static-client -c static-client -- curl -s google.com
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.com/">here</A>.
</BODY></HTML>
```

```
$ kubectl exec deploy/static-client -c static-client -- curl -s 172.18.0.2:8500/v1/catalog/services
{"consul":[],"static-client":[],"static-client-sidecar-proxy":[],"static-server":[],"static-server-sidecar-proxy":[]}
```

## How I expect reviewers to test this PR:
- Code review
- If you can, you could run through the same steps as I've outlined above.

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
