### PR TITLE
add namespace toggle to tproxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ IMPROVEMENTS:
   * `consul.hashicorp.com/transparent-proxy-exclude-outbound-cidrs` - Comma-separated list of IPs or CIDRs to exclude.
   * `consul.hashicorp.com/transparent-proxy-exclude-uids` - Comma-separated list of Linux user IDs to exclude.
 
+* Connect: Add the ability to set default tproxy mode at namespace level via label. [[GH-501](https://github.com/hashicorp/consul-k8s/pull/510)]
+
+  Setting `consul.hashicorp.com/transparent-proxy` to `true/false` will have the following behaviour:
+  * If set as a `pod annotation` - This will define whether tproxy is enabled/disabled for the pod.
+  * If set as a `namespace label` - This will define the default behaviour for pods in this namespace which do not have their respective annotation set.
+  * If not set on either pod or namespace - The default behaviour will be defined by the `connectInject.transparentProxy.defaultEnabled` helm value.
+
 BUG FIXES:
 * Connect: Use `runAsNonRoot: false` for connect-init's container when tproxy is enabled. [[GH-493](https://github.com/hashicorp/consul-k8s/pull/493)]
 * CRDs: Fix a bug where the `config` field in `ProxyDefaults` CR was not synced to Consul because

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,9 @@ IMPROVEMENTS:
 
 * Connect: Add the ability to set default tproxy mode at namespace level via label. [[GH-501](https://github.com/hashicorp/consul-k8s/pull/510)]
 
-  Setting `consul.hashicorp.com/transparent-proxy` to `true/false` will have the following behaviour:
-  * If set as a `pod annotation` - This will define whether tproxy is enabled/disabled for the pod.
-  * If set as a `namespace label` - This will define the default behaviour for pods in this namespace which do not have their respective annotation set.
-  * If not set on either pod or namespace - The default behaviour will be defined by the `connectInject.transparentProxy.defaultEnabled` helm value.
+  Setting the annotation `consul.hashicorp.com/transparent-proxy` to `true/false` will define whether tproxy is enabled/disabled for the pod.
+  * If a `namespace` has the label `consul.hashicorp.com/transparent-proxy` set to `true/false` - this will define the default behaviour for pods in this namespace which do not also have the respective annotation set.
+  * If not set on both pod and namespace - The default tproxy behaviour will be defined by the value of `-enable-transparent-proxy` to the `consul-k8s inject-connect` command.
 
 BUG FIXES:
 * Connect: Use `runAsNonRoot: false` for connect-init's container when tproxy is enabled. [[GH-493](https://github.com/hashicorp/consul-k8s/pull/493)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ IMPROVEMENTS:
 
 * Connect: Add the ability to set default tproxy mode at namespace level via label. [[GH-501](https://github.com/hashicorp/consul-k8s/pull/510)]
 
-  Setting the annotation `consul.hashicorp.com/transparent-proxy` to `true/false` will define whether tproxy is enabled/disabled for the pod.
-  * If a `namespace` has the label `consul.hashicorp.com/transparent-proxy` set to `true/false` - this will define the default behaviour for pods in this namespace which do not also have the respective annotation set.
-  * If not set on both pod and namespace - The default tproxy behaviour will be defined by the value of `-enable-transparent-proxy` to the `consul-k8s inject-connect` command.
+  * Setting the annotation `consul.hashicorp.com/transparent-proxy` to `true/false` will define whether tproxy is enabled/disabled for the pod.
+  * Setting the label `consul.hashicorp.com/transparent-proxy` to `true/false` on a namespace will define the default behavior for pods in that namespace, which do not also have the annotation set.
+  * The default tproxy behavior will be defined by the value of `-enable-transparent-proxy` flag to the `consul-k8s inject-connect` command. It can be overridden in a namespace by the the label on the namespace or for a pod using the annotation on the pod.
 
 BUG FIXES:
 * Connect: Use `runAsNonRoot: false` for connect-init's container when tproxy is enabled. [[GH-493](https://github.com/hashicorp/consul-k8s/pull/493)]

--- a/connect-inject/annotations.go
+++ b/connect-inject/annotations.go
@@ -84,9 +84,9 @@ const (
 	// annotationConsulNamespace is the Consul namespace the service is registered into.
 	annotationConsulNamespace = "consul.hashicorp.com/consul-namespace"
 
-	// annotationTransparentProxy enables or disables transparent proxy mode for a given pod.
+	// annotationTransparentProxy enables or disables default transparent proxy behaviour for a given pod or namespace.
 	// This annotation takes a boolean value (true/false).
-	annotationTransparentProxy = "consul.hashicorp.com/transparent-proxy"
+	annotationTransparentProxy = "consul.hashicorp.com/transparent-proxy-default"
 
 	// annotationTProxyExcludeInboundPorts is a comma-separated list of inbound ports to exclude from traffic redirection.
 	annotationTProxyExcludeInboundPorts = "consul.hashicorp.com/transparent-proxy-exclude-inbound-ports"

--- a/connect-inject/annotations.go
+++ b/connect-inject/annotations.go
@@ -84,7 +84,7 @@ const (
 	// annotationConsulNamespace is the Consul namespace the service is registered into.
 	annotationConsulNamespace = "consul.hashicorp.com/consul-namespace"
 
-	// annotationTransparentProxy enables or disables transparent proxy for a given pod. It can also bet set as a label
+	// annotationTransparentProxy enables or disables transparent proxy for a given pod. It can also be set as a label
 	// on a namespace to define the default behaviour for connect-injected pods which do not otherwise override this setting
 	// with their own annotation.
 	// This annotation takes a boolean value (true/false).

--- a/connect-inject/annotations.go
+++ b/connect-inject/annotations.go
@@ -84,11 +84,11 @@ const (
 	// annotationConsulNamespace is the Consul namespace the service is registered into.
 	annotationConsulNamespace = "consul.hashicorp.com/consul-namespace"
 
-	// annotationTransparentProxy enables or disables transparent proxy for a given pod. It can also be set as a label
+	// keyTransparentProxy enables or disables transparent proxy for a given pod. It can also be set as a label
 	// on a namespace to define the default behaviour for connect-injected pods which do not otherwise override this setting
 	// with their own annotation.
 	// This annotation takes a boolean value (true/false).
-	annotationTransparentProxy = "consul.hashicorp.com/transparent-proxy"
+	keyTransparentProxy = "consul.hashicorp.com/transparent-proxy"
 
 	// annotationTProxyExcludeInboundPorts is a comma-separated list of inbound ports to exclude from traffic redirection.
 	annotationTProxyExcludeInboundPorts = "consul.hashicorp.com/transparent-proxy-exclude-inbound-ports"

--- a/connect-inject/annotations.go
+++ b/connect-inject/annotations.go
@@ -84,9 +84,11 @@ const (
 	// annotationConsulNamespace is the Consul namespace the service is registered into.
 	annotationConsulNamespace = "consul.hashicorp.com/consul-namespace"
 
-	// annotationTransparentProxy enables or disables default transparent proxy behaviour for a given pod or namespace.
+	// annotationTransparentProxy enables or disables transparent proxy for a given pod. It can also bet set as a label
+	// on a namespace to define the default behaviour for connect-injected pods which do not otherwise override this setting
+	// with their own annotation.
 	// This annotation takes a boolean value (true/false).
-	annotationTransparentProxy = "consul.hashicorp.com/transparent-proxy-default"
+	annotationTransparentProxy = "consul.hashicorp.com/transparent-proxy"
 
 	// annotationTProxyExcludeInboundPorts is a comma-separated list of inbound ports to exclude from traffic redirection.
 	annotationTProxyExcludeInboundPorts = "consul.hashicorp.com/transparent-proxy-exclude-inbound-ports"

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -92,16 +92,16 @@ func (h *Handler) containerInitCopyContainer() corev1.Container {
 
 // containerInit returns the init container spec for registering the Consul
 // service, setting up the Envoy bootstrap, etc.
-func (h *Handler) containerInit(pod corev1.Pod, k8sNamespace string) (corev1.Container, error) {
+func (h *Handler) containerInit(namespace *corev1.Namespace, pod corev1.Pod) (corev1.Container, error) {
 	// Check if tproxy is enabled on this pod.
-	tproxyEnabled, err := transparentProxyEnabled(pod, h.EnableTransparentProxy)
+	tproxyEnabled, err := transparentProxyEnabled(namespace, pod, h.EnableTransparentProxy)
 	if err != nil {
 		return corev1.Container{}, err
 	}
 
 	data := initContainerCommandData{
 		AuthMethod:                 h.AuthMethod,
-		ConsulNamespace:            h.consulNamespace(k8sNamespace),
+		ConsulNamespace:            h.consulNamespace(namespace.Name),
 		NamespaceMirroringEnabled:  h.EnableK8SNSMirroring,
 		ConsulCACert:               h.ConsulCACert,
 		EnableTransparentProxy:     tproxyEnabled,
@@ -214,12 +214,18 @@ func (h *Handler) containerInit(pod corev1.Pod, k8sNamespace string) (corev1.Con
 }
 
 // transparentProxyEnabled returns true if transparent proxy should be enabled for this pod.
-// It returns an error when the annotation value cannot be parsed by strconv.ParseBool.
-func transparentProxyEnabled(pod corev1.Pod, globalEnabled bool) (bool, error) {
+// It returns an error when the annotation value cannot be parsed by strconv.ParseBool or if we are unable
+// to read the pod's namespace label when it exists.
+func transparentProxyEnabled(namespace *corev1.Namespace, pod corev1.Pod, globalEnabled bool) (bool, error) {
+	// First check to see if the pod annotation exists to override the namespace or global settings.
 	if raw, ok := pod.Annotations[annotationTransparentProxy]; ok {
 		return strconv.ParseBool(raw)
 	}
-
+	// Next see if the namespace has been defaulted.
+	if raw, ok := namespace.Labels[annotationTransparentProxy]; ok {
+		return strconv.ParseBool(raw)
+	}
+	// Else fall back to the global default.
 	return globalEnabled, nil
 }
 

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -92,7 +92,7 @@ func (h *Handler) containerInitCopyContainer() corev1.Container {
 
 // containerInit returns the init container spec for registering the Consul
 // service, setting up the Envoy bootstrap, etc.
-func (h *Handler) containerInit(namespace *corev1.Namespace, pod corev1.Pod) (corev1.Container, error) {
+func (h *Handler) containerInit(namespace corev1.Namespace, pod corev1.Pod) (corev1.Container, error) {
 	// Check if tproxy is enabled on this pod.
 	tproxyEnabled, err := transparentProxyEnabled(namespace, pod, h.EnableTransparentProxy)
 	if err != nil {
@@ -216,13 +216,13 @@ func (h *Handler) containerInit(namespace *corev1.Namespace, pod corev1.Pod) (co
 // transparentProxyEnabled returns true if transparent proxy should be enabled for this pod.
 // It returns an error when the annotation value cannot be parsed by strconv.ParseBool or if we are unable
 // to read the pod's namespace label when it exists.
-func transparentProxyEnabled(namespace *corev1.Namespace, pod corev1.Pod, globalEnabled bool) (bool, error) {
+func transparentProxyEnabled(namespace corev1.Namespace, pod corev1.Pod, globalEnabled bool) (bool, error) {
 	// First check to see if the pod annotation exists to override the namespace or global settings.
-	if raw, ok := pod.Annotations[annotationTransparentProxy]; ok {
+	if raw, ok := pod.Annotations[keyTransparentProxy]; ok {
 		return strconv.ParseBool(raw)
 	}
 	// Next see if the namespace has been defaulted.
-	if raw, ok := namespace.Labels[annotationTransparentProxy]; ok {
+	if raw, ok := namespace.Labels[keyTransparentProxy]; ok {
 		return strconv.ParseBool(raw)
 	}
 	// Else fall back to the global default.

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -129,7 +129,7 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 
 			h := tt.Handler
 			pod := *tt.Pod(minimal())
-			container, err := h.containerInit(pod, k8sNamespace)
+			container, err := h.containerInit(&testNS, pod)
 			require.NoError(err)
 			actual := strings.Join(container.Command, " ")
 			require.Contains(actual, tt.Cmd)
@@ -146,64 +146,63 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 		annotations            map[string]string
 		expectedContainsCmd    string
 		expectedNotContainsCmd string
+		namespaceLabel         map[string]string
 	}{
-		"enabled globally, annotation not provided": {
+		"enabled globally, ns not set, annotation not provided": {
 			true,
 			nil,
 			`/consul/connect-inject/consul connect redirect-traffic \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
 			"",
+			nil,
 		},
-		"enabled globally, annotation is false": {
+		"enabled globally, ns not set, annotation is false": {
 			true,
-			map[string]string{
-				annotationTransparentProxy: "false",
-			},
+			map[string]string{annotationTransparentProxy: "false"},
 			"",
 			`/consul/connect-inject/consul connect redirect-traffic \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
+			nil,
 		},
-		"enabled globally, annotation is true": {
+		"enabled globally, ns not set, annotation is true": {
 			true,
-			map[string]string{
-				annotationTransparentProxy: "true",
-			},
+			map[string]string{annotationTransparentProxy: "true"},
 			`/consul/connect-inject/consul connect redirect-traffic \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
 			"",
+			nil,
 		},
-		"disabled globally, annotation not provided": {
+		"disabled globally, ns not set, annotation not provided": {
 			false,
 			nil,
 			"",
 			`/consul/connect-inject/consul connect redirect-traffic \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
+			nil,
 		},
-		"disabled globally, annotation is false": {
+		"disabled globally, ns not set, annotation is false": {
 			false,
-			map[string]string{
-				annotationTransparentProxy: "false",
-			},
+			map[string]string{annotationTransparentProxy: "false"},
 			"",
 			`/consul/connect-inject/consul connect redirect-traffic \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
+			nil,
 		},
-		"disabled globally, annotation is true": {
+		"disabled globally, ns not set, annotation is true": {
 			false,
-			map[string]string{
-				annotationTransparentProxy: "true",
-			},
+			map[string]string{annotationTransparentProxy: "true"},
 			`/consul/connect-inject/consul connect redirect-traffic \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
 			"",
+			nil,
 		},
-		"exclude-inbound-ports annotation is provided": {
+		"exclude-inbound-ports, ns is not set, annotation is provided": {
 			true,
 			map[string]string{
 				annotationTransparentProxy:          "true",
@@ -215,8 +214,9 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
 			"",
+			nil,
 		},
-		"exclude-outbound-ports annotation is provided": {
+		"exclude-outbound-ports, ns is not set, annotation is provided": {
 			true,
 			map[string]string{
 				annotationTransparentProxy:           "true",
@@ -228,6 +228,7 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
 			"",
+			nil,
 		},
 		"exclude-outbound-cidrs annotation is provided": {
 			true,
@@ -241,8 +242,9 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
 			"",
+			nil,
 		},
-		"exclude-uids annotation is provided": {
+		"exclude-uids annotation is provided, ns is not set": {
 			true,
 			map[string]string{
 				annotationTransparentProxy:  "true",
@@ -254,6 +256,25 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
 			"",
+			nil,
+		},
+		"disabled globally, ns enabled, annotation not set": {
+			false,
+			nil,
+			`/consul/connect-inject/consul connect redirect-traffic \
+  -proxy-id="$(cat /consul/connect-inject/proxyid)" \
+  -proxy-uid=5995`,
+			"",
+			map[string]string{annotationTransparentProxy: "true"},
+		},
+		"enabled globally, ns disabled, annotation not set": {
+			true,
+			nil,
+			"",
+			`/consul/connect-inject/consul connect redirect-traffic \
+  -proxy-id="$(cat /consul/connect-inject/proxyid)" \
+  -proxy-uid=5995`,
+			map[string]string{annotationTransparentProxy: "false"},
 		},
 	}
 	for name, c := range cases {
@@ -270,7 +291,9 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 				},
 				RunAsNonRoot: pointerToBool(false),
 			}
-			container, err := h.containerInit(*pod, k8sNamespace)
+			ns := testNS
+			ns.Labels = c.namespaceLabel
+			container, err := h.containerInit(&ns, *pod)
 			require.NoError(t, err)
 			actualCmd := strings.Join(container.Command, " ")
 
@@ -529,7 +552,7 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 			require := require.New(t)
 
 			h := tt.Handler
-			container, err := h.containerInit(*tt.Pod(minimal()), k8sNamespace)
+			container, err := h.containerInit(&testNS, *tt.Pod(minimal()))
 			require.NoError(err)
 			actual := strings.Join(container.Command, " ")
 			require.Equal(tt.Cmd, actual)
@@ -565,7 +588,7 @@ func TestHandlerContainerInit_authMethod(t *testing.T) {
 			ServiceAccountName: "foo",
 		},
 	}
-	container, err := h.containerInit(*pod, k8sNamespace)
+	container, err := h.containerInit(&testNS, *pod)
 	require.NoError(err)
 	actual := strings.Join(container.Command, " ")
 	require.Contains(actual, `
@@ -602,7 +625,7 @@ func TestHandlerContainerInit_WithTLS(t *testing.T) {
 			},
 		},
 	}
-	container, err := h.containerInit(*pod, k8sNamespace)
+	container, err := h.containerInit(&testNS, *pod)
 	require.NoError(err)
 	actual := strings.Join(container.Command, " ")
 	require.Contains(actual, `
@@ -646,7 +669,7 @@ func TestHandlerContainerInit_Resources(t *testing.T) {
 			},
 		},
 	}
-	container, err := h.containerInit(*pod, k8sNamespace)
+	container, err := h.containerInit(&testNS, *pod)
 	require.NoError(err)
 	require.Equal(corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
@@ -674,4 +697,10 @@ func TestHandlerContainerInitCopyContainer(t *testing.T) {
 	require.Equal(container.SecurityContext, expectedSecurityContext)
 	actual := strings.Join(container.Command, " ")
 	require.Contains(actual, `cp /bin/consul /consul/connect-inject/consul`)
+}
+
+var testNS = corev1.Namespace{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: k8sNamespace,
+	},
 }

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -129,7 +129,7 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 
 			h := tt.Handler
 			pod := *tt.Pod(minimal())
-			container, err := h.containerInit(&testNS, pod)
+			container, err := h.containerInit(testNS, pod)
 			require.NoError(err)
 			actual := strings.Join(container.Command, " ")
 			require.Contains(actual, tt.Cmd)
@@ -159,7 +159,7 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 		},
 		"enabled globally, ns not set, annotation is false": {
 			true,
-			map[string]string{annotationTransparentProxy: "false"},
+			map[string]string{keyTransparentProxy: "false"},
 			"",
 			`/consul/connect-inject/consul connect redirect-traffic \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
@@ -168,7 +168,7 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 		},
 		"enabled globally, ns not set, annotation is true": {
 			true,
-			map[string]string{annotationTransparentProxy: "true"},
+			map[string]string{keyTransparentProxy: "true"},
 			`/consul/connect-inject/consul connect redirect-traffic \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
@@ -186,7 +186,7 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 		},
 		"disabled globally, ns not set, annotation is false": {
 			false,
-			map[string]string{annotationTransparentProxy: "false"},
+			map[string]string{keyTransparentProxy: "false"},
 			"",
 			`/consul/connect-inject/consul connect redirect-traffic \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
@@ -195,7 +195,7 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 		},
 		"disabled globally, ns not set, annotation is true": {
 			false,
-			map[string]string{annotationTransparentProxy: "true"},
+			map[string]string{keyTransparentProxy: "true"},
 			`/consul/connect-inject/consul connect redirect-traffic \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
@@ -205,7 +205,7 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 		"exclude-inbound-ports, ns is not set, annotation is provided": {
 			true,
 			map[string]string{
-				annotationTransparentProxy:          "true",
+				keyTransparentProxy:                 "true",
 				annotationTProxyExcludeInboundPorts: "9090,9091",
 			},
 			`/consul/connect-inject/consul connect redirect-traffic \
@@ -219,7 +219,7 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 		"exclude-outbound-ports, ns is not set, annotation is provided": {
 			true,
 			map[string]string{
-				annotationTransparentProxy:           "true",
+				keyTransparentProxy:                  "true",
 				annotationTProxyExcludeOutboundPorts: "9090,9091",
 			},
 			`/consul/connect-inject/consul connect redirect-traffic \
@@ -233,7 +233,7 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 		"exclude-outbound-cidrs annotation is provided": {
 			true,
 			map[string]string{
-				annotationTransparentProxy:           "true",
+				keyTransparentProxy:                  "true",
 				annotationTProxyExcludeOutboundCIDRs: "1.1.1.1,2.2.2.2/24",
 			},
 			`/consul/connect-inject/consul connect redirect-traffic \
@@ -247,7 +247,7 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 		"exclude-uids annotation is provided, ns is not set": {
 			true,
 			map[string]string{
-				annotationTransparentProxy:  "true",
+				keyTransparentProxy:         "true",
 				annotationTProxyExcludeUIDs: "6000,7000",
 			},
 			`/consul/connect-inject/consul connect redirect-traffic \
@@ -265,7 +265,7 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
 			"",
-			map[string]string{annotationTransparentProxy: "true"},
+			map[string]string{keyTransparentProxy: "true"},
 		},
 		"enabled globally, ns disabled, annotation not set": {
 			true,
@@ -274,7 +274,7 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 			`/consul/connect-inject/consul connect redirect-traffic \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,
-			map[string]string{annotationTransparentProxy: "false"},
+			map[string]string{keyTransparentProxy: "false"},
 		},
 	}
 	for name, c := range cases {
@@ -293,7 +293,7 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 			}
 			ns := testNS
 			ns.Labels = c.namespaceLabel
-			container, err := h.containerInit(&ns, *pod)
+			container, err := h.containerInit(ns, *pod)
 			require.NoError(t, err)
 			actualCmd := strings.Join(container.Command, " ")
 
@@ -552,7 +552,7 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 			require := require.New(t)
 
 			h := tt.Handler
-			container, err := h.containerInit(&testNS, *tt.Pod(minimal()))
+			container, err := h.containerInit(testNS, *tt.Pod(minimal()))
 			require.NoError(err)
 			actual := strings.Join(container.Command, " ")
 			require.Equal(tt.Cmd, actual)
@@ -588,7 +588,7 @@ func TestHandlerContainerInit_authMethod(t *testing.T) {
 			ServiceAccountName: "foo",
 		},
 	}
-	container, err := h.containerInit(&testNS, *pod)
+	container, err := h.containerInit(testNS, *pod)
 	require.NoError(err)
 	actual := strings.Join(container.Command, " ")
 	require.Contains(actual, `
@@ -625,7 +625,7 @@ func TestHandlerContainerInit_WithTLS(t *testing.T) {
 			},
 		},
 	}
-	container, err := h.containerInit(&testNS, *pod)
+	container, err := h.containerInit(testNS, *pod)
 	require.NoError(err)
 	actual := strings.Join(container.Command, " ")
 	require.Contains(actual, `
@@ -669,7 +669,7 @@ func TestHandlerContainerInit_Resources(t *testing.T) {
 			},
 		},
 	}
-	container, err := h.containerInit(&testNS, *pod)
+	container, err := h.containerInit(testNS, *pod)
 	require.NoError(err)
 	require.Equal(corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{

--- a/connect-inject/endpoints_controller.go
+++ b/connect-inject/endpoints_controller.go
@@ -339,7 +339,14 @@ func (r *EndpointsController) createServiceRegistrations(pod corev1.Pod, service
 		proxyService.Tags = tags
 	}
 
-	tproxyEnabled, err := transparentProxyEnabled(pod, r.EnableTransparentProxy)
+	// A user can enable/disable tproxy for an entire namespace.
+	var ns corev1.Namespace
+	err = r.Client.Get(r.Context, types.NamespacedName{Name: pod.Namespace, Namespace: ""}, &ns)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tproxyEnabled, err := transparentProxyEnabled(&ns, pod, r.EnableTransparentProxy)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/connect-inject/endpoints_controller.go
+++ b/connect-inject/endpoints_controller.go
@@ -352,7 +352,7 @@ func (r *EndpointsController) createServiceRegistrations(pod corev1.Pod, service
 		return nil, nil, err
 	}
 
-	tproxyEnabled, err := transparentProxyEnabled(&ns, pod, r.EnableTransparentProxy)
+	tproxyEnabled, err := transparentProxyEnabled(ns, pod, r.EnableTransparentProxy)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/connect-inject/endpoints_controller_ent_test.go
+++ b/connect-inject/endpoints_controller_ent_test.go
@@ -203,8 +203,10 @@ func TestReconcileCreateEndpointWithNamespaces(t *testing.T) {
 			fakeClientPod := createPod("fake-consul-client", "127.0.0.1", false)
 			fakeClientPod.Labels = map[string]string{"component": "client", "app": "consul", "release": "consul"}
 
+			// Add the pods namespace.
+			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: test.SourceKubeNS}}
 			// Create fake k8s client.
-			k8sObjects := append(setup.k8sObjects(), fakeClientPod)
+			k8sObjects := append(setup.k8sObjects(), fakeClientPod, &ns)
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
 
 			// Create test Consul server.
@@ -926,8 +928,10 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					fakeClientPod := createPod("fake-consul-client", "127.0.0.1", false)
 					fakeClientPod.Labels = map[string]string{"component": "client", "app": "consul", "release": "consul"}
 
+					// Add the pods namespace.
+					ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ts.SourceKubeNS}}
 					// Create fake k8s client.
-					k8sObjects := append(tt.k8sObjects(), fakeClientPod)
+					k8sObjects := append(tt.k8sObjects(), fakeClientPod, &ns)
 					fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
 
 					masterToken := "b78d37c7-0ca7-5f4d-99ee-6d9975ce4586"

--- a/connect-inject/endpoints_controller_test.go
+++ b/connect-inject/endpoints_controller_test.go
@@ -1618,9 +1618,9 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				fakeClientPod.Labels = map[string]string{"component": "client", "app": "consul", "release": "consul"}
 
 				// Add the default namespace.
-				ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+				ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 				// Create fake k8s client
-				k8sObjects := append(tt.k8sObjects(), fakeClientPod, ns)
+				k8sObjects := append(tt.k8sObjects(), fakeClientPod, &ns)
 				fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
 
 				masterToken := "b78d37c7-0ca7-5f4d-99ee-6d9975ce4586"
@@ -1794,9 +1794,9 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 			fakeClientPod.Labels = map[string]string{"component": "client", "app": "consul", "release": "consul"}
 
 			// Add the default namespace.
-			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 			// Create fake k8s client
-			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(fakeClientPod, ns).Build()
+			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(fakeClientPod, &ns).Build()
 
 			// Create test consul server
 			consul, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
@@ -3058,9 +3058,9 @@ func TestEndpointsController_createServiceRegistrations_withTransparentProxy(t *
 			}
 			var fakeClient client.Client
 			if c.service != nil {
-				fakeClient = fake.NewClientBuilder().WithRuntimeObjects(&ns, pod, endpoints, c.service).Build()
+				fakeClient = fake.NewClientBuilder().WithRuntimeObjects(pod, endpoints, c.service, &ns).Build()
 			} else {
-				fakeClient = fake.NewClientBuilder().WithRuntimeObjects(&ns, pod, endpoints).Build()
+				fakeClient = fake.NewClientBuilder().WithRuntimeObjects(pod, endpoints, &ns).Build()
 			}
 
 			epCtrl := EndpointsController{

--- a/connect-inject/endpoints_controller_test.go
+++ b/connect-inject/endpoints_controller_test.go
@@ -2739,7 +2739,7 @@ func TestEndpointsController_createServiceRegistrations_withTransparentProxy(t *
 					ClusterIP: "10.0.0.1",
 					Ports: []corev1.ServicePort{
 						{
-							Port: 80,
+							Port: 8081,
 						},
 					},
 				},
@@ -2748,7 +2748,7 @@ func TestEndpointsController_createServiceRegistrations_withTransparentProxy(t *
 			expTaggedAddresses: map[string]api.ServiceAddress{
 				"virtual": {
 					Address: "10.0.0.1",
-					Port:    80,
+					Port:    8081,
 				},
 			},
 			namespaceLabels: map[string]string{annotationTransparentProxy: "true"},

--- a/connect-inject/endpoints_controller_test.go
+++ b/connect-inject/endpoints_controller_test.go
@@ -798,8 +798,11 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 			fakeClientPod := createPod("fake-consul-client", "127.0.0.1", false)
 			fakeClientPod.Labels = map[string]string{"component": "client", "app": "consul", "release": "consul"}
 
+			// Add the default namespace.
+			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 			// Create fake k8s client
-			k8sObjects := append(tt.k8sObjects(), fakeClientPod)
+			k8sObjects := append(tt.k8sObjects(), fakeClientPod, &ns)
+
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
 
 			// Create test consul server
@@ -1613,8 +1616,10 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				fakeClientPod := createPod("fake-consul-client", "127.0.0.1", false)
 				fakeClientPod.Labels = map[string]string{"component": "client", "app": "consul", "release": "consul"}
 
+				// Add the default namespace.
+				ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 				// Create fake k8s client
-				k8sObjects := append(tt.k8sObjects(), fakeClientPod)
+				k8sObjects := append(tt.k8sObjects(), fakeClientPod, ns)
 				fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
 
 				masterToken := "b78d37c7-0ca7-5f4d-99ee-6d9975ce4586"
@@ -1787,8 +1792,10 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 			fakeClientPod := createPod("fake-consul-client", "127.0.0.1", false)
 			fakeClientPod.Labels = map[string]string{"component": "client", "app": "consul", "release": "consul"}
 
+			// Add the default namespace.
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 			// Create fake k8s client
-			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(fakeClientPod).Build()
+			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(fakeClientPod, ns).Build()
 
 			// Create test consul server
 			consul, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
@@ -2576,6 +2583,7 @@ func TestEndpointsController_createServiceRegistrations_withTransparentProxy(t *
 		service            *corev1.Service
 		expTaggedAddresses map[string]api.ServiceAddress
 		proxyMode          api.ProxyMode
+		namespaceLabels    map[string]string
 		expErr             string
 	}{
 		"enabled globally, annotation not provided": {
@@ -2718,6 +2726,53 @@ func TestEndpointsController_createServiceRegistrations_withTransparentProxy(t *
 				},
 			},
 			expErr: "",
+		},
+		"disabled globally, namespace enabled, no annotation": {
+			globalEnabled: false,
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName,
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Ports: []corev1.ServicePort{
+						{
+							Port: 80,
+						},
+					},
+				},
+			},
+			proxyMode: api.ProxyModeTransparent,
+			expTaggedAddresses: map[string]api.ServiceAddress{
+				"virtual": {
+					Address: "10.0.0.1",
+					Port:    80,
+				},
+			},
+			namespaceLabels: map[string]string{annotationTransparentProxy: "true"},
+			expErr:          "",
+		},
+		"enabled globally, namespace disabled, no annotation": {
+			globalEnabled: true,
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName,
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Ports: []corev1.ServicePort{
+						{
+							Port: 80,
+						},
+					},
+				},
+			},
+			proxyMode:          api.ProxyModeDefault,
+			expTaggedAddresses: nil,
+			namespaceLabels:    map[string]string{annotationTransparentProxy: "false"},
+			expErr:             "",
 		},
 		// This case is impossible since we're always passing an endpoints object to this function,
 		// and Kubernetes will ensure that there is only an endpoints object if there is a service object.
@@ -2927,11 +2982,15 @@ func TestEndpointsController_createServiceRegistrations_withTransparentProxy(t *
 					},
 				},
 			}
+			// Add the pods namespace.
+			ns := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: pod.Namespace, Labels: c.namespaceLabels},
+			}
 			var fakeClient client.Client
 			if c.service != nil {
-				fakeClient = fake.NewClientBuilder().WithRuntimeObjects(pod, endpoints, c.service).Build()
+				fakeClient = fake.NewClientBuilder().WithRuntimeObjects(&ns, pod, endpoints, c.service).Build()
 			} else {
-				fakeClient = fake.NewClientBuilder().WithRuntimeObjects(pod, endpoints).Build()
+				fakeClient = fake.NewClientBuilder().WithRuntimeObjects(&ns, pod, endpoints).Build()
 			}
 
 			epCtrl := EndpointsController{

--- a/connect-inject/endpoints_controller_test.go
+++ b/connect-inject/endpoints_controller_test.go
@@ -2751,7 +2751,7 @@ func TestEndpointsController_createServiceRegistrations_withTransparentProxy(t *
 					Port:    8081,
 				},
 			},
-			namespaceLabels: map[string]string{annotationTransparentProxy: "true"},
+			namespaceLabels: map[string]string{keyTransparentProxy: "true"},
 			expErr:          "",
 		},
 		"enabled globally, namespace disabled, no annotation": {
@@ -2772,7 +2772,7 @@ func TestEndpointsController_createServiceRegistrations_withTransparentProxy(t *
 			},
 			proxyMode:          api.ProxyModeDefault,
 			expTaggedAddresses: nil,
-			namespaceLabels:    map[string]string{annotationTransparentProxy: "false"},
+			namespaceLabels:    map[string]string{keyTransparentProxy: "false"},
 			expErr:             "",
 		},
 		// This case is impossible since we're always passing an endpoints object to this function,
@@ -3014,7 +3014,7 @@ func TestEndpointsController_createServiceRegistrations_withTransparentProxy(t *
 		t.Run(name, func(t *testing.T) {
 			pod := createPod("test-pod-1", "1.2.3.4", true)
 			if c.annotationEnabled != nil {
-				pod.Annotations[annotationTransparentProxy] = strconv.FormatBool(*c.annotationEnabled)
+				pod.Annotations[keyTransparentProxy] = strconv.FormatBool(*c.annotationEnabled)
 			}
 			pod.Spec.Containers = []corev1.Container{
 				{

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -205,7 +205,7 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 	}
 
 	// Add the init container that registers the service and sets up the Envoy configuration.
-	initContainer, err := h.containerInit(ns, pod)
+	initContainer, err := h.containerInit(*ns, pod)
 	if err != nil {
 		h.Log.Error(err, "error configuring injection init container", "request name", req.Name)
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error configuring injection init container: %s", err))

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -197,11 +197,11 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 	initCopyContainer := h.containerInitCopyContainer()
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, initCopyContainer)
 
-	// A user can enable/disable tproxy for an entire namespace.
+	// A user can enable/disable tproxy for an entire namespace via a label.
 	ns, err := h.Clientset.CoreV1().Namespaces().Get(ctx, req.Namespace, metav1.GetOptions{})
 	if err != nil {
-		h.Log.Error(err, "error fetching namespace metadata for init container", "request name", req.Name)
-		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error getting namespace metadata for init container: %s", err))
+		h.Log.Error(err, "error fetching namespace metadata for container", "request name", req.Name)
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error getting namespace metadata for container: %s", err))
 	}
 
 	// Add the init container that registers the service and sets up the Envoy configuration.

--- a/connect-inject/handler_ent_test.go
+++ b/connect-inject/handler_ent_test.go
@@ -55,6 +55,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "default",
 				decoder:                    decoder,
+				Clientset:                  defaultTestClientWithNamespace(),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -76,6 +77,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "default",
 				decoder:                    decoder,
+				Clientset:                  clientWithNamespace("non-default"),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -97,6 +99,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "dest",
 				decoder:                    decoder,
+				Clientset:                  defaultTestClientWithNamespace(),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -118,6 +121,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "dest",
 				decoder:                    decoder,
+				Clientset:                  clientWithNamespace("non-default"),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -140,6 +144,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 				ConsulDestinationNamespace: "default", // will be overridden
 				EnableK8SNSMirroring:       true,
 				decoder:                    decoder,
+				Clientset:                  defaultTestClientWithNamespace(),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -162,6 +167,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 				ConsulDestinationNamespace: "default", // will be overridden
 				EnableK8SNSMirroring:       true,
 				decoder:                    decoder,
+				Clientset:                  clientWithNamespace("dest"),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -185,6 +191,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 				EnableK8SNSMirroring:       true,
 				K8SNSMirroringPrefix:       "k8s-",
 				decoder:                    decoder,
+				Clientset:                  defaultTestClientWithNamespace(),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -208,6 +215,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 				EnableK8SNSMirroring:       true,
 				K8SNSMirroringPrefix:       "k8s-",
 				decoder:                    decoder,
+				Clientset:                  clientWithNamespace("dest"),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -304,6 +312,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 				ConsulDestinationNamespace: "default",
 				CrossNamespaceACLPolicy:    "cross-namespace-policy",
 				decoder:                    decoder,
+				Clientset:                  defaultTestClientWithNamespace(),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -326,6 +335,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 				ConsulDestinationNamespace: "default",
 				CrossNamespaceACLPolicy:    "cross-namespace-policy",
 				decoder:                    decoder,
+				Clientset:                  clientWithNamespace("non-default"),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -348,6 +358,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 				ConsulDestinationNamespace: "dest",
 				CrossNamespaceACLPolicy:    "cross-namespace-policy",
 				decoder:                    decoder,
+				Clientset:                  defaultTestClientWithNamespace(),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -370,6 +381,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 				ConsulDestinationNamespace: "dest",
 				CrossNamespaceACLPolicy:    "cross-namespace-policy",
 				decoder:                    decoder,
+				Clientset:                  clientWithNamespace("non-default"),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -393,6 +405,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 				EnableK8SNSMirroring:       true,
 				CrossNamespaceACLPolicy:    "cross-namespace-policy",
 				decoder:                    decoder,
+				Clientset:                  defaultTestClientWithNamespace(),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -416,6 +429,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 				EnableK8SNSMirroring:       true,
 				CrossNamespaceACLPolicy:    "cross-namespace-policy",
 				decoder:                    decoder,
+				Clientset:                  clientWithNamespace("dest"),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -440,6 +454,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 				K8SNSMirroringPrefix:       "k8s-",
 				CrossNamespaceACLPolicy:    "cross-namespace-policy",
 				decoder:                    decoder,
+				Clientset:                  defaultTestClientWithNamespace(),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -464,6 +479,7 @@ func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 				K8SNSMirroringPrefix:       "k8s-",
 				CrossNamespaceACLPolicy:    "cross-namespace-policy",
 				decoder:                    decoder,
+				Clientset:                  clientWithNamespace("dest"),
 			},
 			Req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -634,6 +650,7 @@ func TestHandler_MutateWithNamespaces_Annotation(t *testing.T) {
 				K8SNSMirroringPrefix:       c.MirroringPrefix,
 				ConsulClient:               client,
 				decoder:                    decoder,
+				Clientset:                  clientWithNamespace(sourceKubeNS),
 			}
 
 			pod := corev1.Pod{

--- a/connect-inject/metrics_configuration_test.go
+++ b/connect-inject/metrics_configuration_test.go
@@ -3,6 +3,7 @@ package connectinject
 import (
 	"testing"
 
+	"github.com/hashicorp/consul-k8s/namespaces"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -507,7 +508,8 @@ func TestMetricsConfigMergedMetricsServerConfiguration(t *testing.T) {
 func minimal() *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "minimal",
+			Namespace: namespaces.DefaultNamespace,
+			Name:      "minimal",
 			Annotations: map[string]string{
 				annotationService: "foo",
 			},

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -418,6 +418,7 @@ func (c *Command) Run(args []string) int {
 
 	mgr.GetWebhookServer().Register("/mutate",
 		&webhook.Admission{Handler: &connectinject.Handler{
+			Clientset:                  c.clientset,
 			ConsulClient:               c.consulClient,
 			ImageConsul:                c.flagConsulImage,
 			ImageEnvoy:                 c.flagEnvoyImage,


### PR DESCRIPTION
Changes proposed in this PR:
- Adds ability to define default tproxy mode settings at the k8s namespace level.
- ~~renames tproxy annotation to "consul.hashicorp.com/transparent-proxy-default"~~

How I've tested this PR:
Unit tests, manual testing via deploying a simple counting service with no tproxy annotations set, then toggling the namespace label true/false and redeploying:
```
% kubectl describe pod counting | grep redirect
      # Apply traffic redirection rules.
      /consul/connect-inject/consul connect redirect-traffic \
% kubectl get namespaces --show-labels| grep transparent
default           Active   261d   consul.hashicorp.com/transparent-proxy=true
% kubectl delete -f svc.yaml
service "counting" deleted
serviceaccount "counting" deleted
pod "counting" deleted
% kubectl label namespace default consul.hashicorp.com/transparent-proxy=false --overwrite
namespace/default labeled
% kubectl apply -f svc.yaml
service/counting created
serviceaccount/counting created
pod/counting created
% kubectl describe pod counting | grep redirect
%
```

NOTE: https://github.com/hashicorp/consul-helm/pull/942 must be merged in order to support this.

How I expect reviewers to test this PR:
Unit tests, manual test

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
