### PR TITLE
update tproxy logging messages to be a bit more informative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ IMPROVEMENTS:
 * Connect: support upgrades for services deployed before endpoints controller to
   upgrade to a version of consul-k8s with endpoints controller. [[GH-509](https://github.com/hashicorp/consul-k8s/pull/509)]
 
+* Connect: add additional logging to the endpoints controller and connect-init command to help
+  the user debug if pods arent starting right away. [[GH-514](https://github.com/hashicorp/consul-k8s/pull/514/)]
+
 BUG FIXES:
 * Connect: Use `runAsNonRoot: false` for connect-init's container when tproxy is enabled. [[GH-493](https://github.com/hashicorp/consul-k8s/pull/493)]
 * CRDs: Fix a bug where the `config` field in `ProxyDefaults` CR was not synced to Consul because

--- a/connect-inject/endpoints_controller.go
+++ b/connect-inject/endpoints_controller.go
@@ -161,7 +161,8 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 					// Note: the order of how we register services is important,
 					// and the connect-proxy service should come after the "main" service
 					// because its alias health check depends on the main service existing.
-					r.Log.Info("registering service with Consul", "name", serviceRegistration.Name)
+					r.Log.Info("registering service with Consul", "name", serviceRegistration.Name,
+						"serviceID", serviceRegistration.ID, "agentIP", pod.Status.HostIP)
 					err = client.Agent().ServiceRegister(serviceRegistration)
 					if err != nil {
 						r.Log.Error(err, "failed to register service", "name", serviceRegistration.Name)


### PR DESCRIPTION
Changes proposed in this PR:
- `connect-init` will now periodically log a message stating that the pod is waiting on a Kubernetes service to be registered against and direct the user to logs in the webhook.
- endpoints controller will now also log the serviceID and the remote agent's hostIP.

How I've tested this PR:
code review

How I expect reviewers to test this PR:
code review

Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
