### PR TITLE
Overwrite k8s HTTP probes when transparent proxy is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+IMPROVEMENTS:
+* Connect: Overwrite Kubernetes HTTP readiness and/or liveness probes to point to Envoy proxy when
+  transparent proxy is enabled. [[GH-517](https://github.com/hashicorp/consul-k8s/pull/517)]
+
 ## 0.26.0-beta2 (May 06, 2021)
 
 BREAKING CHANGES:

--- a/connect-inject/annotations.go
+++ b/connect-inject/annotations.go
@@ -93,7 +93,7 @@ const (
 	// keyTransparentProxy enables or disables transparent proxy for a given pod. It can also be set as a label
 	// on a namespace to define the default behaviour for connect-injected pods which do not otherwise override this setting
 	// with their own annotation.
-	// This annotation takes a boolean value (true/false).
+	// This annotation/label takes a boolean value (true/false).
 	keyTransparentProxy = "consul.hashicorp.com/transparent-proxy"
 
 	// annotationTProxyExcludeInboundPorts is a comma-separated list of inbound ports to exclude from traffic redirection.
@@ -107,6 +107,26 @@ const (
 
 	// annotationTProxyExcludeUIDs is a comma-separated list of additional user IDs to exclude from traffic redirection.
 	annotationTProxyExcludeUIDs = "consul.hashicorp.com/transparent-proxy-exclude-uids"
+
+	// annotationTransparentProxyOverwriteProbes controls whether the Kubernetes probes should be overwritten
+	// to point to the Envoy proxy when running in Transparent Proxy mode.
+	annotationTransparentProxyOverwriteProbes = "consul.hashicorp.com/transparent-proxy-overwrite-probes"
+
+	// annotationTransparentProxyReadinessListenerPort is the port for the readiness probe
+	// that we will expose through Envoy when overwrite probes is enabled.
+	annotationTransparentProxyReadinessListenerPort = "consul.hashicorp.com/transparent-proxy-readiness-listener-port"
+
+	// annotationTransparentProxyLivenessListenerPort is the port for the liveness probe
+	// that we will expose through Envoy when overwrite probes is enabled.
+	annotationTransparentProxyLivenessListenerPort = "consul.hashicorp.com/transparent-proxy-liveness-listener-port"
+
+	// annotationOriginalLivenessProbePort is the value of the port originally defined on the liveness probe
+	// of the pod before we overwrote it.
+	annotationOriginalLivenessProbePort = "consul.hashicorp.com/original-liveness-probe-port"
+
+	// annotationOriginalReadinessProbePort is the value of the port originally defined on the readiness probe
+	// of the pod before we overwrote it.
+	annotationOriginalReadinessProbePort = "consul.hashicorp.com/original-readiness-probe-port"
 
 	// injected is used as the annotation value for annotationInjected.
 	injected = "injected"

--- a/connect-inject/endpoints_controller.go
+++ b/connect-inject/endpoints_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 
 	"github.com/deckarep/golang-set"
@@ -39,6 +40,14 @@ const (
 	// in Consul. Note: This value should not be changed without a corresponding change in Consul.
 	// TODO: change this to a constant shared with Consul to avoid accidentally changing this.
 	clusterIPTaggedAddressName = "virtual"
+
+	// defaultExposedPathsListenerPortLiveness is the default port that we will use as the ListenerPort
+	// for the Expose configuration of the proxy registration for a liveness probe.
+	defaultExposedPathsListenerPortLiveness = 20300
+
+	// defaultExposedPathsListenerPortReadiness is the default port that we will use as the ListenerPort
+	// for the Expose configuration of the proxy registration for a readiness probe.
+	defaultExposedPathsListenerPortReadiness = 20301
 )
 
 type EndpointsController struct {
@@ -82,11 +91,14 @@ type EndpointsController struct {
 	// EnableTransparentProxy controls whether transparent proxy should be enabled
 	// for all proxy service registrations.
 	EnableTransparentProxy bool
+	// TProxyOverwriteProbes controls whether the endpoints controller should expose pod's HTTP probes
+	// via Envoy proxy.
+	TProxyOverwriteProbes bool
 
 	MetricsConfig MetricsConfig
 	Log           logr.Logger
-	Scheme        *runtime.Scheme
 
+	Scheme *runtime.Scheme
 	context.Context
 }
 
@@ -526,6 +538,59 @@ func (r *EndpointsController) createServiceRegistrations(pod corev1.Pod, service
 			proxyService.Proxy.Mode = api.ProxyModeTransparent
 		} else {
 			r.Log.Info("skipping syncing service cluster IP to Consul", "name", k8sService.Name, "ns", k8sService.Namespace, "ip", k8sService.Spec.ClusterIP)
+		}
+
+		// Expose k8s probes as Envoy listeners if needed.
+		overwriteProbes, err := shouldOverwriteProbes(pod, r.TProxyOverwriteProbes)
+		if err != nil {
+			return nil, nil, err
+		}
+		if overwriteProbes {
+			if cs := pod.Spec.Containers; len(cs) > 0 {
+				appContainer := cs[0]
+				if appContainer.LivenessProbe != nil && appContainer.LivenessProbe.HTTPGet != nil {
+					if raw, ok := pod.Annotations[annotationOriginalLivenessProbePort]; ok {
+						originalLivenessPort, err := strconv.Atoi(raw)
+						if err != nil {
+							return nil, nil, err
+						}
+
+						listenerPort := defaultExposedPathsListenerPortLiveness
+						if raw, ok := pod.Annotations[annotationTransparentProxyLivenessListenerPort]; ok {
+							listenerPort, err = strconv.Atoi(raw)
+							if err != nil {
+								return nil, nil, err
+							}
+						}
+						proxyConfig.Expose.Paths = append(proxyConfig.Expose.Paths, api.ExposePath{
+							ListenerPort:  listenerPort,
+							LocalPathPort: originalLivenessPort,
+							Path:          appContainer.LivenessProbe.HTTPGet.Path,
+						})
+					}
+
+				}
+				if appContainer.ReadinessProbe != nil && appContainer.ReadinessProbe.HTTPGet != nil {
+					if raw, ok := pod.Annotations[annotationOriginalReadinessProbePort]; ok {
+						originalReadinessPort, err := strconv.Atoi(raw)
+						if err != nil {
+							return nil, nil, err
+						}
+						listenerPort := defaultExposedPathsListenerPortReadiness
+						if raw, ok := pod.Annotations[annotationTransparentProxyReadinessListenerPort]; ok {
+							listenerPort, err = strconv.Atoi(raw)
+							if err != nil {
+								return nil, nil, err
+							}
+						}
+						proxyConfig.Expose.Paths = append(proxyConfig.Expose.Paths, api.ExposePath{
+							ListenerPort:  listenerPort,
+							LocalPathPort: originalReadinessPort,
+							Path:          appContainer.ReadinessProbe.HTTPGet.Path,
+						})
+					}
+				}
+			}
 		}
 	}
 

--- a/connect-inject/endpoints_controller.go
+++ b/connect-inject/endpoints_controller.go
@@ -555,20 +555,12 @@ func (r *EndpointsController) createServiceRegistrations(pod corev1.Pod, service
 							return nil, nil, err
 						}
 
-						listenerPort := defaultExposedPathsListenerPortLiveness
-						if raw, ok := pod.Annotations[annotationTransparentProxyLivenessListenerPort]; ok {
-							listenerPort, err = strconv.Atoi(raw)
-							if err != nil {
-								return nil, nil, err
-							}
-						}
 						proxyConfig.Expose.Paths = append(proxyConfig.Expose.Paths, api.ExposePath{
-							ListenerPort:  listenerPort,
+							ListenerPort:  appContainer.LivenessProbe.HTTPGet.Port.IntValue(),
 							LocalPathPort: originalLivenessPort,
 							Path:          appContainer.LivenessProbe.HTTPGet.Path,
 						})
 					}
-
 				}
 				if appContainer.ReadinessProbe != nil && appContainer.ReadinessProbe.HTTPGet != nil {
 					if raw, ok := pod.Annotations[annotationOriginalReadinessProbePort]; ok {
@@ -576,15 +568,9 @@ func (r *EndpointsController) createServiceRegistrations(pod corev1.Pod, service
 						if err != nil {
 							return nil, nil, err
 						}
-						listenerPort := defaultExposedPathsListenerPortReadiness
-						if raw, ok := pod.Annotations[annotationTransparentProxyReadinessListenerPort]; ok {
-							listenerPort, err = strconv.Atoi(raw)
-							if err != nil {
-								return nil, nil, err
-							}
-						}
+
 						proxyConfig.Expose.Paths = append(proxyConfig.Expose.Paths, api.ExposePath{
-							ListenerPort:  listenerPort,
+							ListenerPort:  appContainer.ReadinessProbe.HTTPGet.Port.IntValue(),
 							LocalPathPort: originalReadinessPort,
 							Path:          appContainer.ReadinessProbe.HTTPGet.Path,
 						})

--- a/connect-inject/endpoints_controller_test.go
+++ b/connect-inject/endpoints_controller_test.go
@@ -3645,14 +3645,16 @@ func TestEndpointsController_createServiceRegistrations_withTransparentProxy(t *
 			podLivenessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Port: intstr.FromInt(8080),
+						// We expect that the port of the liveness probe is overwritten by the webhook.
+						Port: intstr.FromInt(23000),
 					},
 				},
 			},
 			podReadinessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Port: intstr.FromInt(8081),
+						// We expect that the port of the readiness probe is overwritten by the webhook.
+						Port: intstr.FromInt(23001),
 					},
 				},
 			},

--- a/connect-inject/endpoints_controller_test.go
+++ b/connect-inject/endpoints_controller_test.go
@@ -3365,7 +3365,7 @@ func TestEndpointsController_createServiceRegistrations_withTransparentProxy(t *
 			podLivenessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Port: intstr.FromInt(8080),
+						Port: intstr.FromInt(defaultExposedPathsListenerPortLiveness),
 					},
 				},
 			},
@@ -3408,7 +3408,7 @@ func TestEndpointsController_createServiceRegistrations_withTransparentProxy(t *
 			podLivenessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Port: intstr.FromInt(8080),
+						Port: intstr.FromInt(defaultExposedPathsListenerPortLiveness),
 					},
 				},
 			},
@@ -3477,7 +3477,7 @@ func TestEndpointsController_createServiceRegistrations_withTransparentProxy(t *
 			podReadinessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Port: intstr.FromInt(8080),
+						Port: intstr.FromInt(defaultExposedPathsListenerPortReadiness),
 					},
 				},
 			},
@@ -3515,19 +3515,19 @@ func TestEndpointsController_createServiceRegistrations_withTransparentProxy(t *
 			overwriteProbes:     true,
 			podAnnotations: map[string]string{
 				annotationOriginalLivenessProbePort:  "8080",
-				annotationOriginalReadinessProbePort: "8080",
+				annotationOriginalReadinessProbePort: "8081",
 			},
 			podLivenessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Port: intstr.FromInt(8080),
+						Port: intstr.FromInt(defaultExposedPathsListenerPortLiveness),
 					},
 				},
 			},
 			podReadinessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Port: intstr.FromInt(8080),
+						Port: intstr.FromInt(defaultExposedPathsListenerPortReadiness),
 					},
 				},
 			},
@@ -3559,7 +3559,7 @@ func TestEndpointsController_createServiceRegistrations_withTransparentProxy(t *
 				},
 				{
 					ListenerPort:  defaultExposedPathsListenerPortReadiness,
-					LocalPathPort: 8080,
+					LocalPathPort: 8081,
 				},
 			},
 			expErr: "",

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -337,13 +337,27 @@ func (h *Handler) overwriteProbes(ns corev1.Namespace, pod *corev1.Pod) error {
 			if appContainer.LivenessProbe != nil && appContainer.LivenessProbe.HTTPGet != nil {
 				// We need to save original port first so that endpoints controller can use it for exposing paths.
 				pod.Annotations[annotationOriginalLivenessProbePort] = appContainer.LivenessProbe.HTTPGet.Port.String()
-				appContainer.LivenessProbe.HTTPGet.Port = intstr.FromInt(defaultExposedPathsListenerPortLiveness)
+				listenerPort := defaultExposedPathsListenerPortLiveness
+				if raw, ok := pod.Annotations[annotationTransparentProxyLivenessListenerPort]; ok {
+					listenerPort, err = strconv.Atoi(raw)
+					if err != nil {
+						return err
+					}
+				}
+				appContainer.LivenessProbe.HTTPGet.Port = intstr.FromInt(listenerPort)
 
 			}
 			if appContainer.ReadinessProbe != nil && appContainer.ReadinessProbe.HTTPGet != nil {
 				// We need to save original port first so that endpoints controller can use it for exposing paths.
 				pod.Annotations[annotationOriginalReadinessProbePort] = appContainer.ReadinessProbe.HTTPGet.Port.String()
-				appContainer.ReadinessProbe.HTTPGet.Port = intstr.FromInt(defaultExposedPathsListenerPortReadiness)
+				listenerPort := defaultExposedPathsListenerPortReadiness
+				if raw, ok := pod.Annotations[annotationTransparentProxyReadinessListenerPort]; ok {
+					listenerPort, err = strconv.Atoi(raw)
+					if err != nil {
+						return err
+					}
+				}
+				appContainer.ReadinessProbe.HTTPGet.Port = intstr.FromInt(listenerPort)
 			}
 		}
 	}

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -3,6 +3,7 @@ package connectinject
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -16,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -422,6 +424,92 @@ func TestHandlerHandle(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			"tproxy with overwriteProbes is enabled",
+			Handler{
+				Log:                    logrtest.TestLogger{T: t},
+				AllowK8sNamespacesSet:  mapset.NewSetWith("*"),
+				DenyK8sNamespacesSet:   mapset.NewSet(),
+				EnableTransparentProxy: true,
+				TProxyOverwriteProbes:  true,
+				decoder:                decoder,
+				Clientset:              defaultTestClientWithNamespace(),
+			},
+			admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Namespace: namespaces.DefaultNamespace,
+					Object: encodeRaw(t, &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{},
+							// We're setting an existing annotation so that we can assert on the
+							// specific annotations that are set as a result of probes being overwritten.
+							Annotations: map[string]string{"foo": "bar"},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "web",
+									LivenessProbe: &corev1.Probe{
+										Handler: corev1.Handler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Port: intstr.FromInt(8080),
+											},
+										},
+									},
+									ReadinessProbe: &corev1.Probe{
+										Handler: corev1.Handler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Port: intstr.FromInt(8081),
+											},
+										},
+									},
+								},
+							},
+						},
+					}),
+				},
+			},
+			"",
+			[]jsonpatch.Operation{
+				{
+					Operation: "add",
+					Path:      "/spec/volumes",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/1",
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/labels",
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/" + escapeJSONPointer(keyInjectStatus),
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationOriginalLivenessProbePort),
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/" + escapeJSONPointer(annotationOriginalReadinessProbePort),
+				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/0/livenessProbe/httpGet/port",
+				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/0/readinessProbe/httpGet/port",
+				},
+			},
+		},
 	}
 
 	for _, tt := range cases {
@@ -721,17 +809,17 @@ func TestHandlerPortValue(t *testing.T) {
 			&corev1.Pod{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
-						corev1.Container{
+						{
 							Name: "web",
 							Ports: []corev1.ContainerPort{
-								corev1.ContainerPort{
+								{
 									Name:          "http",
 									ContainerPort: 8080,
 								},
 							},
 						},
 
-						corev1.Container{
+						{
 							Name: "web-side",
 						},
 					},
@@ -747,16 +835,16 @@ func TestHandlerPortValue(t *testing.T) {
 			&corev1.Pod{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
-						corev1.Container{
+						{
 							Name: "web",
 							Ports: []corev1.ContainerPort{
-								corev1.ContainerPort{
+								{
 									ContainerPort: 8080,
 								},
 							},
 						},
 
-						corev1.Container{
+						{
 							Name: "web-side",
 						},
 					},
@@ -886,7 +974,7 @@ func TestConsulNamespace(t *testing.T) {
 	}
 }
 
-// Test shouldInject function
+// Test shouldInject function.
 func TestShouldInject(t *testing.T) {
 	cases := []struct {
 		Name                  string
@@ -1185,6 +1273,146 @@ func TestShouldInject(t *testing.T) {
 
 			require.Equal(nil, err)
 			require.Equal(tt.Expected, injected)
+		})
+	}
+}
+
+func TestOverwriteProbes(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		tproxyEnabled            bool
+		overwriteProbes          bool
+		livenessProbe            *corev1.Probe
+		readinessProbe           *corev1.Probe
+		expLivenessPort          int
+		expReadinessPort         int
+		expOriginalLivenessPort  int
+		expOriginalReadinessPort int
+	}{
+		"transparent proxy disabled; overwrites probes disabled": {
+			tproxyEnabled: false,
+			readinessProbe: &corev1.Probe{
+				Handler: corev1.Handler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Port: intstr.FromInt(8080),
+					},
+				},
+			},
+			expReadinessPort:         8080,
+			expOriginalReadinessPort: 0,
+		},
+		"transparent proxy enabled; overwrite probes disabled": {
+			tproxyEnabled: true,
+			readinessProbe: &corev1.Probe{
+				Handler: corev1.Handler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Port: intstr.FromInt(8080),
+					},
+				},
+			},
+			expReadinessPort:         8080,
+			expOriginalReadinessPort: 0,
+		},
+		"transparent proxy disabled; overwrite probes enabled": {
+			tproxyEnabled:   false,
+			overwriteProbes: true,
+			readinessProbe: &corev1.Probe{
+				Handler: corev1.Handler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Port: intstr.FromInt(8080),
+					},
+				},
+			},
+			expReadinessPort:         8080,
+			expOriginalReadinessPort: 0,
+		},
+		"just the readiness probe": {
+			tproxyEnabled:   true,
+			overwriteProbes: true,
+			readinessProbe: &corev1.Probe{
+				Handler: corev1.Handler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Port: intstr.FromInt(8080),
+					},
+				},
+			},
+			expReadinessPort:         defaultExposedPathsListenerPortReadiness,
+			expOriginalReadinessPort: 8080,
+		},
+		"just the liveness probe": {
+			tproxyEnabled:   true,
+			overwriteProbes: true,
+			livenessProbe: &corev1.Probe{
+				Handler: corev1.Handler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Port: intstr.FromInt(8081),
+					},
+				},
+			},
+			expLivenessPort:         defaultExposedPathsListenerPortLiveness,
+			expOriginalLivenessPort: 8081,
+		},
+		"both readiness and liveness probes": {
+			tproxyEnabled:   true,
+			overwriteProbes: true,
+			livenessProbe: &corev1.Probe{
+				Handler: corev1.Handler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Port: intstr.FromInt(8081),
+					},
+				},
+			},
+			readinessProbe: &corev1.Probe{
+				Handler: corev1.Handler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Port: intstr.FromInt(8080),
+					},
+				},
+			},
+			expLivenessPort:          defaultExposedPathsListenerPortLiveness,
+			expOriginalLivenessPort:  8081,
+			expReadinessPort:         defaultExposedPathsListenerPortReadiness,
+			expOriginalReadinessPort: 8080,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test"}},
+				},
+			}
+			if c.readinessProbe != nil {
+				pod.Spec.Containers[0].ReadinessProbe = c.readinessProbe
+			}
+			if c.livenessProbe != nil {
+				pod.Spec.Containers[0].LivenessProbe = c.livenessProbe
+			}
+
+			h := Handler{
+				EnableTransparentProxy: c.tproxyEnabled,
+				TProxyOverwriteProbes:  c.overwriteProbes,
+			}
+			err := h.overwriteProbes(corev1.Namespace{}, pod)
+			require.NoError(t, err)
+			if c.readinessProbe != nil {
+				require.Equal(t, c.expReadinessPort, pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Port.IntValue())
+				if c.expOriginalReadinessPort != 0 {
+					require.Equal(t, strconv.Itoa(c.expOriginalReadinessPort), pod.Annotations[annotationOriginalReadinessProbePort])
+				}
+			}
+			if c.livenessProbe != nil && c.expLivenessPort != 0 {
+				require.Equal(t, c.expLivenessPort, pod.Spec.Containers[0].LivenessProbe.HTTPGet.Port.IntValue())
+				if c.expOriginalLivenessPort != 0 {
+					require.Equal(t, strconv.Itoa(c.expOriginalLivenessPort), pod.Annotations[annotationOriginalLivenessProbePort])
+				}
+			}
 		})
 	}
 }

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -88,8 +88,9 @@ type Command struct {
 	flagInitContainerMemoryLimit   string
 	flagInitContainerMemoryRequest string
 
-	// Transparent proxy flag(s).
-	flagEnableTransparentProxy bool
+	// Transparent proxy flags.
+	flagDefaultEnableTransparentProxy          bool
+	flagTransparentProxyDefaultOverwriteProbes bool
 
 	flagSet *flag.FlagSet
 	http    *flags.HTTPFlags
@@ -153,8 +154,10 @@ func (c *Command) init() {
 	c.flagSet.StringVar(&c.flagCrossNamespaceACLPolicy, "consul-cross-namespace-acl-policy", "",
 		"[Enterprise Only] Name of the ACL policy to attach to all created Consul namespaces to allow service "+
 			"discovery across Consul namespaces. Only necessary if ACLs are enabled.")
-	c.flagSet.BoolVar(&c.flagEnableTransparentProxy, "enable-transparent-proxy", true,
-		"Enable transparent proxy mode for all Consul service mesh applications.")
+	c.flagSet.BoolVar(&c.flagDefaultEnableTransparentProxy, "default-enable-transparent-proxy", true,
+		"Enable transparent proxy mode for all Consul service mesh applications by default.")
+	c.flagSet.BoolVar(&c.flagTransparentProxyDefaultOverwriteProbes, "transparent-proxy-default-overwrite-probes", true,
+		"Overwrite Kubernetes probes to point to Envoy by default when in Transparent Proxy mode.")
 	c.flagSet.StringVar(&c.flagLogLevel, "log-level", zapcore.InfoLevel.String(),
 		fmt.Sprintf("Log verbosity level. Supported values (in order of detail) are "+
 			"%q, %q, %q, and %q.", zapcore.DebugLevel.String(), zapcore.InfoLevel.String(), zapcore.WarnLevel.String(), zapcore.ErrorLevel.String()))
@@ -403,7 +406,8 @@ func (c *Command) Run(args []string) int {
 		EnableNSMirroring:          c.flagEnableK8SNSMirroring,
 		NSMirroringPrefix:          c.flagK8SNSMirroringPrefix,
 		CrossNSACLPolicy:           c.flagCrossNamespaceACLPolicy,
-		EnableTransparentProxy:     c.flagEnableTransparentProxy,
+		EnableTransparentProxy:     c.flagDefaultEnableTransparentProxy,
+		TProxyOverwriteProbes:      c.flagTransparentProxyDefaultOverwriteProbes,
 		Log:                        ctrl.Log.WithName("controller").WithName("endpoints"),
 		Scheme:                     mgr.GetScheme(),
 		ReleaseName:                c.flagReleaseName,
@@ -441,7 +445,8 @@ func (c *Command) Run(args []string) int {
 			EnableK8SNSMirroring:       c.flagEnableK8SNSMirroring,
 			K8SNSMirroringPrefix:       c.flagK8SNSMirroringPrefix,
 			CrossNamespaceACLPolicy:    c.flagCrossNamespaceACLPolicy,
-			EnableTransparentProxy:     c.flagEnableTransparentProxy,
+			EnableTransparentProxy:     c.flagDefaultEnableTransparentProxy,
+			TProxyOverwriteProbes:      c.flagTransparentProxyDefaultOverwriteProbes,
 			Log:                        ctrl.Log.WithName("handler").WithName("connect"),
 		}})
 


### PR DESCRIPTION
When this is enabled, the mutating webhook will also overwrite the HTTP probes
of the application container to point them to Envoy, while saving the original
ports of the probes as annotations. The endpoints controller will set Expose
configuration for the proxy, setting the LocalPathPort to the port saved
in the annotation.

- Add a new flag -transparent-proxy-default-overwrite-probes (default to true)
  to allow overwriting k8s probes.
- Allow setting this on a per-pod basis via the "consul.hashicorp.com/transparent-proxy-overwrite-probes"
  annotation
- Add new annotations to allow for choosing custom ports for Envoy listeners to expose
  readiness and liveness probes
- Also, rename the `-enable-transparent-proxy` to `-default-enable-transparent-proxy`

How I've tested this PR:
Acceptance test and the helm PR here: hashicorp/consul-helm#953

How I expect reviewers to test this PR:
code review


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
