### PR TITLE
Don't set security context when on OpenShift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 IMPROVEMENTS:
 * Connect: Overwrite Kubernetes HTTP readiness and/or liveness probes to point to Envoy proxy when
   transparent proxy is enabled. [[GH-517](https://github.com/hashicorp/consul-k8s/pull/517)]
+* Connect: Don't set security context for the Envoy proxy when on OpenShift and transparent proxy is disabled.
+  [[GH-521](https://github.com/hashicorp/consul-k8s/pull/521)]
 
 BUG FIXES:
 * Connect: Process every Address in an Endpoints object before returning an error. This ensures an address that isn't reconciled successfully doesn't prevent the remaining addresses from getting reconciled. [[GH-519](https://github.com/hashicorp/consul-k8s/pull/519)]

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -690,10 +690,7 @@ func TestHandlerInitCopyContainer(t *testing.T) {
 
 	for _, openShiftEnabled := range openShiftEnabledCases {
 		t.Run(fmt.Sprintf("openshift enabled: %t", openShiftEnabled), func(t *testing.T) {
-			h := Handler{}
-			if openShiftEnabled {
-				h.EnableOpenShift = true
-			}
+			h := Handler{EnableOpenShift: openShiftEnabled}
 
 			container := h.initCopyContainer()
 

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -1,6 +1,7 @@
 package connectinject
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -684,19 +685,34 @@ func TestHandlerContainerInit_Resources(t *testing.T) {
 }
 
 // Test that the init copy container has the correct command and SecurityContext.
-func TestHandlerContainerInitCopyContainer(t *testing.T) {
-	require := require.New(t)
-	h := Handler{}
-	container := h.containerInitCopyContainer()
-	expectedSecurityContext := &corev1.SecurityContext{
-		RunAsUser:              pointerToInt64(copyContainerUserAndGroupID),
-		RunAsGroup:             pointerToInt64(copyContainerUserAndGroupID),
-		RunAsNonRoot:           pointerToBool(true),
-		ReadOnlyRootFilesystem: pointerToBool(true),
+func TestHandlerInitCopyContainer(t *testing.T) {
+	openShiftEnabledCases := []bool{false, true}
+
+	for _, openShiftEnabled := range openShiftEnabledCases {
+		t.Run(fmt.Sprintf("openshift enabled: %t", openShiftEnabled), func(t *testing.T) {
+			h := Handler{}
+			if openShiftEnabled {
+				h.EnableOpenShift = true
+			}
+
+			container := h.initCopyContainer()
+
+			if openShiftEnabled {
+				require.Nil(t, container.SecurityContext)
+			} else {
+				expectedSecurityContext := &corev1.SecurityContext{
+					RunAsUser:              pointerToInt64(copyContainerUserAndGroupID),
+					RunAsGroup:             pointerToInt64(copyContainerUserAndGroupID),
+					RunAsNonRoot:           pointerToBool(true),
+					ReadOnlyRootFilesystem: pointerToBool(true),
+				}
+				require.Equal(t, expectedSecurityContext, container.SecurityContext)
+			}
+
+			actual := strings.Join(container.Command, " ")
+			require.Contains(t, actual, `cp /bin/consul /consul/connect-inject/consul`)
+		})
 	}
-	require.Equal(container.SecurityContext, expectedSecurityContext)
-	actual := strings.Join(container.Command, " ")
-	require.Contains(actual, `cp /bin/consul /consul/connect-inject/consul`)
 }
 
 var testNS = corev1.Namespace{

--- a/connect-inject/envoy_sidecar.go
+++ b/connect-inject/envoy_sidecar.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func (h *Handler) envoySidecar(pod corev1.Pod) (corev1.Container, error) {
+func (h *Handler) envoySidecar(namespace corev1.Namespace, pod corev1.Pod) (corev1.Container, error) {
 	resources, err := h.envoySidecarResources(pod)
 	if err != nil {
 		return corev1.Container{}, err
@@ -19,21 +19,6 @@ func (h *Handler) envoySidecar(pod corev1.Pod) (corev1.Container, error) {
 	cmd, err := h.getContainerSidecarCommand(pod)
 	if err != nil {
 		return corev1.Container{}, err
-	}
-
-	if pod.Spec.SecurityContext != nil {
-		// User container and Envoy container cannot have the same UID.
-		if pod.Spec.SecurityContext.RunAsUser != nil && *pod.Spec.SecurityContext.RunAsUser == envoyUserAndGroupID {
-			return corev1.Container{}, fmt.Errorf("pod security context cannot have the same uid as envoy: %v", envoyUserAndGroupID)
-		}
-	}
-	// Ensure that none of the user's containers have the same UID as Envoy. At this point in injection the handler
-	// has only injected init containers so all containers defined in pod.Spec.Containers are from the user.
-	for _, c := range pod.Spec.Containers {
-		// User container and Envoy container cannot have the same UID.
-		if c.SecurityContext != nil && c.SecurityContext.RunAsUser != nil && *c.SecurityContext.RunAsUser == envoyUserAndGroupID {
-			return corev1.Container{}, fmt.Errorf("container %q has runAsUser set to the same uid %q as envoy which is not allowed", c.Name, envoyUserAndGroupID)
-		}
 	}
 
 	container := corev1.Container{
@@ -55,13 +40,40 @@ func (h *Handler) envoySidecar(pod corev1.Pod) (corev1.Container, error) {
 			},
 		},
 		Command: cmd,
-		SecurityContext: &corev1.SecurityContext{
+	}
+
+	// If not running in transparent proxy mode and in an OpenShift environment,
+	// skip setting the security context and let OpenShift set it for us.
+	// When transparent proxy is enabled, then Envoy needs to run as our specific user
+	// so that traffic redirection will work.
+	tproxyEnabled, err := transparentProxyEnabled(namespace, pod, h.EnableTransparentProxy)
+	if err != nil {
+		return corev1.Container{}, err
+	}
+
+	if tproxyEnabled || !h.EnableOpenShift {
+		if pod.Spec.SecurityContext != nil {
+			// User container and Envoy container cannot have the same UID.
+			if pod.Spec.SecurityContext.RunAsUser != nil && *pod.Spec.SecurityContext.RunAsUser == envoyUserAndGroupID {
+				return corev1.Container{}, fmt.Errorf("pod security context cannot have the same uid as envoy: %v", envoyUserAndGroupID)
+			}
+		}
+		// Ensure that none of the user's containers have the same UID as Envoy. At this point in injection the handler
+		// has only injected init containers so all containers defined in pod.Spec.Containers are from the user.
+		for _, c := range pod.Spec.Containers {
+			// User container and Envoy container cannot have the same UID.
+			if c.SecurityContext != nil && c.SecurityContext.RunAsUser != nil && *c.SecurityContext.RunAsUser == envoyUserAndGroupID {
+				return corev1.Container{}, fmt.Errorf("container %q has runAsUser set to the same uid %q as envoy which is not allowed", c.Name, envoyUserAndGroupID)
+			}
+		}
+		container.SecurityContext = &corev1.SecurityContext{
 			RunAsUser:              pointerToInt64(envoyUserAndGroupID),
 			RunAsGroup:             pointerToInt64(envoyUserAndGroupID),
 			RunAsNonRoot:           pointerToBool(true),
 			ReadOnlyRootFilesystem: pointerToBool(true),
-		},
+		}
 	}
+
 	return container, nil
 }
 func (h *Handler) getContainerSidecarCommand(pod corev1.Pod) ([]string, error) {

--- a/connect-inject/envoy_sidecar.go
+++ b/connect-inject/envoy_sidecar.go
@@ -42,15 +42,15 @@ func (h *Handler) envoySidecar(namespace corev1.Namespace, pod corev1.Pod) (core
 		Command: cmd,
 	}
 
-	// If not running in transparent proxy mode and in an OpenShift environment,
-	// skip setting the security context and let OpenShift set it for us.
-	// When transparent proxy is enabled, then Envoy needs to run as our specific user
-	// so that traffic redirection will work.
 	tproxyEnabled, err := transparentProxyEnabled(namespace, pod, h.EnableTransparentProxy)
 	if err != nil {
 		return corev1.Container{}, err
 	}
 
+	// If not running in transparent proxy mode and in an OpenShift environment,
+	// skip setting the security context and let OpenShift set it for us.
+	// When transparent proxy is enabled, then Envoy needs to run as our specific user
+	// so that traffic redirection will work.
 	if tproxyEnabled || !h.EnableOpenShift {
 		if pod.Spec.SecurityContext != nil {
 			// User container and Envoy container cannot have the same UID.

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -92,6 +92,8 @@ type Command struct {
 	flagDefaultEnableTransparentProxy          bool
 	flagTransparentProxyDefaultOverwriteProbes bool
 
+	flagEnableOpenShift bool
+
 	flagSet *flag.FlagSet
 	http    *flags.HTTPFlags
 
@@ -158,6 +160,8 @@ func (c *Command) init() {
 		"Enable transparent proxy mode for all Consul service mesh applications by default.")
 	c.flagSet.BoolVar(&c.flagTransparentProxyDefaultOverwriteProbes, "transparent-proxy-default-overwrite-probes", true,
 		"Overwrite Kubernetes probes to point to Envoy by default when in Transparent Proxy mode.")
+	c.flagSet.BoolVar(&c.flagEnableOpenShift, "enable-openshift", false,
+		"Indicates that the command runs in an OpenShift cluster.")
 	c.flagSet.StringVar(&c.flagLogLevel, "log-level", zapcore.InfoLevel.String(),
 		fmt.Sprintf("Log verbosity level. Supported values (in order of detail) are "+
 			"%q, %q, %q, and %q.", zapcore.DebugLevel.String(), zapcore.InfoLevel.String(), zapcore.WarnLevel.String(), zapcore.ErrorLevel.String()))
@@ -447,6 +451,7 @@ func (c *Command) Run(args []string) int {
 			CrossNamespaceACLPolicy:    c.flagCrossNamespaceACLPolicy,
 			EnableTransparentProxy:     c.flagDefaultEnableTransparentProxy,
 			TProxyOverwriteProbes:      c.flagTransparentProxyDefaultOverwriteProbes,
+			EnableOpenShift:            c.flagEnableOpenShift,
 			Log:                        ctrl.Log.WithName("handler").WithName("connect"),
 		}})
 


### PR DESCRIPTION
* Envoy container should not have security context set when on OpenShift
  and when tproxy is disabled because we want to let OpenShift set a random
  user/group. When tproxy is enabled though, we need to still set it on OpenShift
  because we require Envoy to have a specific user for the traffic redirection to work.
* init-copy-container doesn't need to have security context set whenever running on OpenShift
  (regardless of whether tproxy is enabled or not) so that OpenShift can set its own random user/group.

How I've tested this PR:
[acceptance tests on openshift](https://app.circleci.com/pipelines/github/hashicorp/consul-helm/3020/workflows/7784b7b3-dfea-4980-b52b-263a57f49ea8/jobs/12238)

How I expect reviewers to test this PR:
code review


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
