### PR TITLE
consul-connect-inject-init needs to run privileged: true when tproxy is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ IMPROVEMENTS:
   transparent proxy is enabled. [[GH-517](https://github.com/hashicorp/consul-k8s/pull/517)]
 * Connect: Don't set security context for the Envoy proxy when on OpenShift and transparent proxy is disabled.
   [[GH-521](https://github.com/hashicorp/consul-k8s/pull/521)]
+* Connect: `consul-connect-inject-init` run with `privileged: true` when transparent proxy is enabled.
+  [[GH-524](https://github.com/hashicorp/consul-k8s/pull/524)]
 
 BUG FIXES:
 * Connect: Process every Address in an Endpoints object before returning an error. This ensures an address that isn't reconciled successfully doesn't prevent the remaining addresses from getting reconciled. [[GH-519](https://github.com/hashicorp/consul-k8s/pull/519)]

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -208,6 +208,7 @@ func (h *Handler) containerInit(namespace corev1.Namespace, pod corev1.Pod) (cor
 			RunAsGroup: pointerToInt64(rootUserAndGroupID),
 			// RunAsNonRoot overrides any setting in the Pod so that we can still run as root here as required.
 			RunAsNonRoot: pointerToBool(false),
+			Privileged:   pointerToBool(true),
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{netAdminCapability},
 			},

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -287,6 +287,7 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 			expectedSecurityContext := &corev1.SecurityContext{
 				RunAsUser:  pointerToInt64(0),
 				RunAsGroup: pointerToInt64(0),
+				Privileged: pointerToBool(true),
 				Capabilities: &corev1.Capabilities{
 					Add: []corev1.Capability{netAdminCapability},
 				},


### PR DESCRIPTION
On OpenShift, if we don't set this value, the container will not provisioned with proper
privileges to run iptabels commands

How I've tested this PR:
manually, on openshift

How I expect reviewers to test this PR:
code review

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
