### PR TITLE
update consul-k8s ci config to use consul 1.10.0-beta3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ executors:
       - image: docker.mirror.hashicorp.services/circleci/golang:1.14
     environment:
       TEST_RESULTS: /tmp/test-results # path to where test results are saved
-      CONSUL_VERSION: 1.10.0-beta2 # Consul's OSS version to use in tests
-      CONSUL_ENT_VERSION: 1.10.0+ent-beta2 # Consul's enterprise version to use in tests
+      CONSUL_VERSION: 1.10.0-beta3 # Consul's OSS version to use in tests
+      CONSUL_ENT_VERSION: 1.10.0+ent-beta3 # Consul's enterprise version to use in tests
 
 jobs:
   go-fmt-and-vet:


### PR DESCRIPTION
Changes proposed in this PR:
- update consul-k8s ci config to use consul 1.10.0-beta3

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
