### PR TITLE
Set owner reference to secrets created by webhook cert manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 * Connect: skip service registration when a service with the same name but in a different Kubernetes namespace is found
   and Consul namespaces are not enabled. [[GH-527](https://github.com/hashicorp/consul-k8s/pull/527)]
+* Delete secrets created by webhook-cert-manager when the deployment is deleted. [[GH-530](https://github.com/hashicorp/consul-k8s/pull/530)]
 
 BUG FIXES:
 * CRDs: Update the type of connectTimeout and TTL in ServiceResolver and ServiceRouter from time.Duration to metav1.Duration.

--- a/subcommand/webhook-cert-manager/command.go
+++ b/subcommand/webhook-cert-manager/command.go
@@ -44,6 +44,9 @@ type Command struct {
 	flagConfigFile string
 	flagLogLevel   string
 
+	flagDeploymentName      string
+	flagDeploymentNamespace string
+
 	clientset kubernetes.Interface
 
 	once   sync.Once
@@ -59,6 +62,10 @@ func (c *Command) init() {
 	c.flagSet = flag.NewFlagSet("", flag.ContinueOnError)
 	c.flagSet.StringVar(&c.flagConfigFile, "config-file", "",
 		"Path to a config file to read webhook configs from. This file must be in JSON format.")
+	c.flagSet.StringVar(&c.flagDeploymentName, "deployment-name", "",
+		"Name of deployment that the cert-manager pod is managed by.")
+	c.flagSet.StringVar(&c.flagDeploymentNamespace, "deployment-namespace", "",
+		"Namespace of deployment that the cert-manager pod is managed by.")
 	c.flagSet.StringVar(&c.flagLogLevel, "log-level", "info",
 		"Log verbosity level. Supported values (in order of detail) are \"trace\", "+
 			"\"debug\", \"info\", \"warn\", and \"error\".")
@@ -89,6 +96,16 @@ func (c *Command) Run(args []string) int {
 
 	if c.flagConfigFile == "" {
 		c.UI.Error(fmt.Sprintf("-config-file must be set"))
+		return 1
+	}
+
+	if c.flagDeploymentName == "" {
+		c.UI.Error(fmt.Sprintf("-deployment-name must be set"))
+		return 1
+	}
+
+	if c.flagDeploymentNamespace == "" {
+		c.UI.Error(fmt.Sprintf("-deployment-namespace must be set"))
 		return 1
 	}
 
@@ -214,11 +231,24 @@ func (c *Command) certWatcher(ctx context.Context, ch <-chan cert.MetaBundle, cl
 func (c *Command) reconcileCertificates(ctx context.Context, clientset kubernetes.Interface, bundle cert.MetaBundle, log hclog.Logger) error {
 	iterLog := log.With("mutatingwebhookconfig", bundle.WebhookConfigName, "secret", bundle.SecretName, "secretNS", bundle.SecretNamespace)
 
+	deployment, err := clientset.AppsV1().Deployments(c.flagDeploymentNamespace).Get(ctx, c.flagDeploymentName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
 	certSecret, err := clientset.CoreV1().Secrets(bundle.SecretNamespace).Get(ctx, bundle.SecretName, metav1.GetOptions{})
 	if err != nil && k8serrors.IsNotFound(err) {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: bundle.SecretName,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       deployment.Name,
+						UID:        deployment.UID,
+					},
+				},
 			},
 			Data: map[string][]byte{
 				corev1.TLSCertKey:       bundle.Cert,
@@ -251,6 +281,16 @@ func (c *Command) reconcileCertificates(ctx context.Context, clientset kubernete
 
 	certSecret.Data[corev1.TLSCertKey] = bundle.Cert
 	certSecret.Data[corev1.TLSPrivateKeyKey] = bundle.Key
+	// Update the Owner Reference on an existing secret in case the secret
+	// already existed in the cluster and was not created by this job.
+	certSecret.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       deployment.Name,
+			UID:        deployment.UID,
+		},
+	}
 
 	iterLog.Info("Updating secret with new certificate")
 	_, err = clientset.CoreV1().Secrets(bundle.SecretNamespace).Update(ctx, certSecret, metav1.UpdateOptions{})


### PR DESCRIPTION
Changes proposed in this PR:

When the certificate secret is created or updated, set an OwnerReference on the secret as the `webhook-cert-manager` deployment. This ensures that deletion of the deployment will also delete the secrets. This addresses the race condition bug that we sometimes see when re-installing consul on a cluster that had a consul deleted from it. This was because the helm delete would not delete the existing secrets with certificates. When the controller would get created with a new installation, it would mount the existing secret (which was stale) and the secret on disk would get rotated before the cert watcher started which would lead to the controller using certificates signed by a CA different from the CA bundle on the MWC which would lead to x509 errors.

This change would ensure the secrets get deleted every single time and hence, a new secret would always get created during a helm install. This also ensure an existing secret, when updated is updated with the owner ref ensuring helm upgrades or installs to a cluster with an existing secret give people the desired behavior as well.

How I've tested this PR: https://github.com/hashicorp/consul-helm/pull/987

How I expect reviewers to test this PR: Code review


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
