### PR TITLE
Enable custom consul-client ports (HTTP, HTTPS & GRPC) for connect-inject

### DIFF
--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -73,6 +73,28 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 		},
 
 		{
+			"Whole template, custom ports",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				return pod
+			},
+			Handler{
+				ConsulClientPortHTTP: "9500",
+				ConsulClientPortGRPC: "9502",
+			},
+			`/bin/sh -ec 
+export CONSUL_HTTP_ADDR="${HOST_IP}:9500"
+export CONSUL_GRPC_ADDR="${HOST_IP}:9502"
+consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
+
+# Generate the envoy bootstrap code
+/consul/connect-inject/consul connect envoy \
+  -proxy-id="$(cat /consul/connect-inject/proxyid)" \
+  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`,
+			"",
+		},
+
+		{
 			"When auth method is set -service-account-name and -service-name are passed in",
 			func(pod *corev1.Pod) *corev1.Pod {
 				pod.Annotations[annotationService] = "web"

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -56,7 +56,10 @@ func TestHandlerContainerInit(t *testing.T) {
 				pod.Annotations[annotationService] = "web"
 				return pod
 			},
-			Handler{},
+			Handler{
+				ConsulClientPortHTTP: "8500",
+				ConsulClientPortGRPC: "8502",
+			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
 export CONSUL_GRPC_ADDR="${HOST_IP}:8502"
@@ -83,7 +86,9 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 				return pod
 			},
 			Handler{
-				AuthMethod: "an-auth-method",
+				AuthMethod:           "an-auth-method",
+				ConsulClientPortHTTP: "8500",
+				ConsulClientPortGRPC: "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
@@ -113,7 +118,10 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 				pod.Annotations[annotationPrometheusScrapePath] = "/scrape-path"
 				return pod
 			},
-			Handler{},
+			Handler{
+				ConsulClientPortHTTP: "8500",
+				ConsulClientPortGRPC: "8502",
+			},
 			`# Generate the envoy bootstrap code
 /consul/connect-inject/consul connect envoy \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
@@ -357,6 +365,8 @@ func TestHandlerContainerInit_namespacesEnabled(t *testing.T) {
 			Handler{
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "default",
+				ConsulClientPortHTTP:       "8500",
+				ConsulClientPortGRPC:       "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
@@ -380,6 +390,8 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 			Handler{
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "non-default",
+				ConsulClientPortHTTP:       "8500",
+				ConsulClientPortGRPC:       "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
@@ -404,6 +416,8 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 				AuthMethod:                 "auth-method",
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "non-default",
+				ConsulClientPortHTTP:       "8500",
+				ConsulClientPortGRPC:       "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
@@ -433,6 +447,8 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "non-default", // Overridden by mirroring
 				EnableK8SNSMirroring:       true,
+				ConsulClientPortHTTP:       "8500",
+				ConsulClientPortGRPC:       "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
@@ -461,6 +477,8 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "default",
 				EnableTransparentProxy:     true,
+				ConsulClientPortHTTP:       "8500",
+				ConsulClientPortGRPC:       "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
@@ -491,6 +509,8 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "non-default",
 				EnableTransparentProxy:     true,
+				ConsulClientPortHTTP:       "8500",
+				ConsulClientPortGRPC:       "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
@@ -523,6 +543,8 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 				ConsulDestinationNamespace: "non-default", // Overridden by mirroring
 				EnableK8SNSMirroring:       true,
 				EnableTransparentProxy:     true,
+				ConsulClientPortHTTP:       "8500",
+				ConsulClientPortGRPC:       "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="${HOST_IP}:8500"
@@ -610,7 +632,9 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 func TestHandlerContainerInit_WithTLS(t *testing.T) {
 	require := require.New(t)
 	h := Handler{
-		ConsulCACert: "consul-ca-cert",
+		ConsulCACert:          "consul-ca-cert",
+		ConsulClientPortHTTPS: "8501",
+		ConsulClientPortGRPC:  "8502",
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -139,6 +139,11 @@ type Handler struct {
 	// those containers to be created otherwise.
 	EnableOpenShift bool
 
+	// ConsulClientPort needs to be set to the ports the Consul client is using.
+	ConsulClientPortHTTP  string
+	ConsulClientPortHTTPS string
+	ConsulClientPortGRPC  string
+
 	// Log
 	Log logr.Logger
 	// Log settings for consul-sidecar


### PR DESCRIPTION
Changes proposed in this PR:
- This PR makes it possible to customize the hardcoded Consul client ports for the connect-inject init container by providing optional parameters. If the parameters are not specified the default Consul client ports are used.
- As the parameters are optional, backwards compatibility should be guaranteed, i.e. we'll open another PR for consul-helm to allow configuring these new port parameters.
- See https://github.com/hashicorp/consul-helm/pull/1004 for the consul-helm counterpart
- Fixes #544 

How I've tested this PR:
- Built a consul-k8s container image based on this PR and uploaded it to Dockerhub. Then adjusted the image flag in consul-helm to deploy it accordingly. Finally tested the inject workflow by deploying a simple NGINX hello world app and scaling the replicas to a higher number. All Pods were correctly registered.
- Do the same as above but this time adjust the parameters and check in the connect-inject deployment if the parameters are there. When deploying an example NGINX app check the logs if they now try to connect to the Consul client with the specified ports (this will of course fail unless the client ports were adjusted as well).

How I expect reviewers to test this PR:
- Deploy connect-inject based on this PR, check if everything is still working
- Deploy connect-inject based on this PR, then configure the new parameters but with default ports and check if everything is still working
 - Deploy connect-inject based on this PR, then configure the new parameters but with custom ports and check if everything is still working

Checklist:
- [ ] Tests added
- [n/a] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
