### PR TITLE
Fix bug where upstream env vars not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+BUG FIXES:
+* Connect: Fix bug where environment variables `<NAME>_CONNECT_SERVICE_HOST` and
+  `<NAME>_CONNECT_SERVICE_PORT` weren't being set when the upstream annotation was used. [[GH-549](https://github.com/hashicorp/consul-k8s/issues/549)]
+
 ## 0.26.0 (June 22, 2021)
 
 FEATURES:

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -198,12 +198,12 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 	// Add the upstream services as environment variables for easy
 	// service discovery.
 	containerEnvVars := h.containerEnvVars(pod)
-	for _, container := range pod.Spec.InitContainers {
-		container.Env = append(container.Env, containerEnvVars...)
+	for i := range pod.Spec.InitContainers {
+		pod.Spec.InitContainers[i].Env = append(pod.Spec.InitContainers[i].Env, containerEnvVars...)
 	}
 
-	for _, container := range pod.Spec.Containers {
-		container.Env = append(container.Env, containerEnvVars...)
+	for i := range pod.Spec.Containers {
+		pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, containerEnvVars...)
 	}
 
 	// Add the init container which copies the Consul binary to /consul/connect-inject/.

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -180,6 +180,10 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/spec/containers/1",
 				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/env",
+				},
 			},
 		},
 


### PR DESCRIPTION
Fixes issue where we weren't setting the upstream environment variables
when the upstream annotation was set:
* `<NAME>_CONNECT_SERVICE_HOST`
* `<NAME>_CONNECT_SERVICE_PORT`

Since we're modifying a slice's values during iteration we must access
the element via reference using the index.

Fixes https://github.com/hashicorp/consul-k8s/issues/549

How I've tested this PR:
* unit tests

How I expect reviewers to test this PR:
* code

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
