### PR TITLE
Handle TransparentProxy field CRD syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ BUG FIXES:
 * Connect: Use `AdmissionregistrationV1` instead of `AdmissionregistrationV1beta1` API as it was deprecated in k8s 1.16. [[GH-558](https://github.com/hashicorp/consul-k8s/pull/558)]
 * Connect: Fix bug where environment variables `<NAME>_CONNECT_SERVICE_HOST` and
   `<NAME>_CONNECT_SERVICE_PORT` weren't being set when the upstream annotation was used. [[GH-549](https://github.com/hashicorp/consul-k8s/issues/549)]
+* CRDs: Fix ProxyDefaults and ServiceDefaults resources not syncing with Consul < 1.10.0 [[GH-1023](https://github.com/hashicorp/consul-helm/issues/1023)]
 
 ## 0.26.0 (June 22, 2021)
 

--- a/api/v1alpha1/proxydefaults_types.go
+++ b/api/v1alpha1/proxydefaults_types.go
@@ -174,7 +174,8 @@ func (in *ProxyDefaults) MatchesConsul(candidate api.ConfigEntry) bool {
 		return false
 	}
 	// No datacenter is passed to ToConsul as we ignore the Meta field when checking for equality.
-	return cmp.Equal(in.ToConsul(""), configEntry, cmpopts.IgnoreFields(capi.ProxyConfigEntry{}, "Namespace", "Meta", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
+	return cmp.Equal(in.ToConsul(""), configEntry, cmpopts.IgnoreFields(capi.ProxyConfigEntry{}, "Namespace", "Meta", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty(),
+		cmp.Comparer(transparentProxyConfigComparer))
 }
 
 func (in *ProxyDefaults) Validate(namespacesEnabled bool) error {

--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -365,7 +365,8 @@ func (in *ServiceDefaults) MatchesConsul(candidate capi.ConfigEntry) bool {
 		return false
 	}
 	// No datacenter is passed to ToConsul as we ignore the Meta field when checking for equality.
-	return cmp.Equal(in.ToConsul(""), configEntry, cmpopts.IgnoreFields(capi.ServiceConfigEntry{}, "Namespace", "Meta", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
+	return cmp.Equal(in.ToConsul(""), configEntry, cmpopts.IgnoreFields(capi.ServiceConfigEntry{}, "Namespace", "Meta", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty(),
+		cmp.Comparer(transparentProxyConfigComparer))
 }
 
 func (in *ServiceDefaults) ConsulGlobalResource() bool {

--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -181,15 +181,13 @@ func meta(datacenter string) map[string]string {
 // CRD as not synced and would continually try and write it to Consul.
 func transparentProxyConfigComparer(a, b *capi.TransparentProxyConfig) bool {
 	empty := capi.TransparentProxyConfig{}
-	if a == nil && b == nil {
-		return true
-	}
+
 	// If one is a nil pointer and the other is the empty struct
 	// then treat them as equal.
-	if a == nil && *b == empty {
+	if a == nil && b != nil && *b == empty {
 		return true
 	}
-	if b == nil && *a == empty {
+	if b == nil && a != nil && *a == empty {
 		return true
 	}
 


### PR DESCRIPTION
There is a bug (https://github.com/hashicorp/consul-helm/issues/1023) where if you're on Consul <1.10.0 then proxy-defaults no longer works. This is because we were always setting the `transparentProxy` key, even when it was `nil` on the source CRD.

Fixing this bug then caused another issue where Consul always returns the `transparentProxy` key as an empty struct, even when it was written as a nil pointer (https://github.com/hashicorp/consul/issues/10595). To fix this for now, when we do our equals comparison we need to treat the empty struct and nil pointer as equal.

* This fix applies for `ServiceDefaults` and `ProxyDefaults` CRDs that
both allow setting the `transparentProxy` key.
* First, if `transparentProxy` is not set on the CRD, don't write the
empty struct into Consul, instead set the key to `nil`. This fixes a bug
where the CRDs don't work with Consul <1.10 since earlier versions of
Consul don't support that key.
* Second, there is a bug in Consul
(hashicorp/consul#10595) where even if you
pass `transparentProxy` as `nil`, it is returned as the empty struct. To
handle that, write a custom comparator that treats the empty struct for
that field as equal to a nil pointer. This ensures we don't continually
re-sync the CRD.

Fixes https://github.com/hashicorp/consul-helm/issues/1023

How I've tested this PR:
- unit tests

How I expect reviewers to test this PR:
- code

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
