### PR TITLE
Add thumbs up template and revamp issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,6 +15,8 @@ labels: bug
 
 <!--- Thank you for keeping this note for the community --->
 
+---
+
 <!--- When filing a bug, please include the following headings if possible. Any example text in this template can be deleted. --->
 
 ### Overview of the Issue

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ labels: bug
 
 <!--- Thank you for keeping this note for the community --->
 
-When filing a bug, please include the following headings if possible. Any example text in this template can be deleted.
+<!--- When filing a bug, please include the following headings if possible. Any example text in this template can be deleted. --->
 
 ### Overview of the Issue
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,8 +10,8 @@ labels: bug
 ### Community Note
 
 * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request. Searching for pre-existing feature requests helps us consolidate datapoints for identical requirements into a single place, thank you!
-* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
-* If you are interested in working on this issue or have submitted a pull request, please leave a comment
+* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
+* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
 
 <!--- Thank you for keeping this note for the community --->
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,20 +5,31 @@ labels: bug
 
 ---
 
+<!--- Please keep this note for the community --->
+
+### Community Note
+
+* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request. Searching for pre-existing feature requests helps us consolidate datapoints for identical requirements into a single place, thank you!
+* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+* If you are interested in working on this issue or have submitted a pull request, please leave a comment
+
+<!--- Thank you for keeping this note for the community --->
+
 When filing a bug, please include the following headings if possible. Any example text in this template can be deleted.
 
 ### Overview of the Issue
 
-A paragraph or two about the issue you're experiencing.
+<!--- Please describe the issue you are having and how you encountered the problem. --->
 
 ### Reproduction Steps
 
-Steps to reproduce this issue.
-
+<!--- In order to effectively and quickly resolve the issue, please provide exact steps that allow us the reproduce the problem. If no steps are provided, then it will likely take longer to get the issue resolved.  --->
 
 ### Logs
 
-Include any relevant logs.
+<!---
+
+Provide log files from consul-k8s or other components. 
 
 <details>
   <summary>consul-k8s logs</summary>
@@ -28,12 +39,15 @@ output from 'kubectl logs' in consul-k8s and/or other relevant components
 ```
 
 </details>
+--->
 
 ### Expected behavior
 
-What was the expected result?
+<!--- What was the expected result after following the reproduction steps? --->
 
 ### Environment details
+
+<!---
 
 If not already included, please provide the following:
 - `consul-k8s` version:
@@ -42,6 +56,10 @@ If not already included, please provide the following:
 
 Any other information you can provide about the environment/deployment.
 
+--->
+
 ### Additional Context
 
-Additional context on the problem.
+<!---
+Additional context on the problem. Docs, links to blogs, or other material that lead you to discover this issue or were helpful in troubleshooting the issue. 
+--->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,6 +15,8 @@ labels: enhancement
 
 <!--- Thank you for keeping this note for the community --->
 
+---
+
 #### Is your feature request related to a problem? Please describe.
 
 <!--- A clear and concise description of the problem you are facing. Describe what workarounds, if any, that you have tried prior to creating this feature request. --->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,7 +17,7 @@ labels: enhancement
 
 #### Is your feature request related to a problem? Please describe.
 
-<!--- A clear and concise description of the problem you are facing. Describe what workarounds if any you have tried prior to creating this feature request. --->
+<!--- A clear and concise description of the problem you are facing. Describe what workarounds, if any, that you have tried prior to creating this feature request. --->
 
 #### Feature Description
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,21 +5,28 @@ labels: enhancement
 
 ---
 
-Please search the existing issues for relevant feature requests, and use the reaction feature (https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to add upvotes to pre-existing requests.
+<!--- Please keep this note for the community --->
+
+### Community Note
+
+* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request. Searching for pre-existing feature requests helps us consolidate datapoints for identical requirements into a single place, thank you!
+* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+* If you are interested in working on this issue or have submitted a pull request, please leave a comment
+
+<!--- Thank you for keeping this note for the community --->
 
 #### Is your feature request related to a problem? Please describe.
 
-A clear and concise description of what the problem is.
+<!--- A clear and concise description of the problem you are facing. Describe what workarounds if any you have tried prior to creating this feature request. --->
 
 #### Feature Description
 
-A written overview of the feature.
+<!--- A description what this feature is and how it addresses the problem you are having. Describe potential UX for the feature if possible. --->
 
 #### Use Case(s)
 
-Any relevant use-cases that you see.
+<!--- Use cases where this feature is applicable for Consul on Kubernetes (i.e. type of application, type of Consul Use case i.e. Service Mesh, Service Disovery) --->
 
 #### Contributions
 
-Are you able to contribute the changes to make this feature work?
-
+<!--- Are you able to contribute the changes to make this feature work? --->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,8 +10,8 @@ labels: enhancement
 ### Community Note
 
 * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request. Searching for pre-existing feature requests helps us consolidate datapoints for identical requirements into a single place, thank you!
-* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
-* If you are interested in working on this issue or have submitted a pull request, please leave a comment
+* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
+* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
 
 <!--- Thank you for keeping this note for the community --->
 
@@ -27,7 +27,7 @@ labels: enhancement
 
 #### Use Case(s)
 
-<!--- Use cases where this feature is applicable for Consul on Kubernetes (i.e. type of application, type of Consul Use case i.e. Service Mesh, Service Disovery) --->
+<!--- Use cases where this feature is applicable for Consul on Kubernetes (i.e. type of application, type of Consul use case i.e. Service Mesh, Service Disovery) --->
 
 #### Contributions
 


### PR DESCRIPTION
Changes proposed in this PR:
- Added thumbs up verbiage to the feature and bug report issue templates. Best viewed in RAW file format due to instructions that are embedded as comments, which will not be displayed when filing. 

How I've tested this PR:

How I expect reviewers to test this PR:

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
