### PR TITLE
Update v1beta1 to v1 for webhook cert manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ IMPROVEMENTS:
 * Add flags `-log-level`, `-log-json` to all subcommands to control log level and json formatting. [[GH-523](https://github.com/hashicorp/consul-k8s/pull/523)]
 
 BUG FIXES:
+* Connect: Use `AdmissionregistrationV1` instead of `AdmissionregistrationV1beta1` API as it was deprecated in k8s 1.16. [[GH-558](https://github.com/hashicorp/consul-k8s/pull/558)]
 * Connect: Fix bug where environment variables `<NAME>_CONNECT_SERVICE_HOST` and
   `<NAME>_CONNECT_SERVICE_PORT` weren't being set when the upstream annotation was used. [[GH-549](https://github.com/hashicorp/consul-k8s/issues/549)]
 

--- a/subcommand/webhook-cert-manager/command.go
+++ b/subcommand/webhook-cert-manager/command.go
@@ -318,7 +318,7 @@ func (c *Command) updateWebhookConfig(ctx context.Context, metaBundle cert.MetaB
 	}
 	value := base64.StdEncoding.EncodeToString(metaBundle.CACert)
 
-	webhookCfg, err := clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, metaBundle.WebhookConfigName, metav1.GetOptions{})
+	webhookCfg, err := clientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, metaBundle.WebhookConfigName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -335,7 +335,7 @@ func (c *Command) updateWebhookConfig(ctx context.Context, metaBundle cert.MetaB
 		return err
 	}
 
-	if _, err = clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Patch(ctx, metaBundle.WebhookConfigName, types.JSONPatchType, patchesJson, metav1.PatchOptions{}); err != nil {
+	if _, err = clientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Patch(ctx, metaBundle.WebhookConfigName, types.JSONPatchType, patchesJson, metav1.PatchOptions{}); err != nil {
 		return err
 	}
 	return nil
@@ -344,7 +344,7 @@ func (c *Command) updateWebhookConfig(ctx context.Context, metaBundle cert.MetaB
 // webhookUpdated verifies if every caBundle on the specified webhook configuration matches the desired CA certificate.
 // It returns true if the CA is up-to date and false if it needs to be updated.
 func (c *Command) webhookUpdated(ctx context.Context, bundle cert.MetaBundle, clientset kubernetes.Interface) bool {
-	webhookCfg, err := clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, bundle.WebhookConfigName, metav1.GetOptions{})
+	webhookCfg, err := clientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, bundle.WebhookConfigName, metav1.GetOptions{})
 	if err != nil {
 		return false
 	}
@@ -368,7 +368,7 @@ func (c webhookConfig) validate(ctx context.Context, client kubernetes.Interface
 	if c.Name == "" {
 		err = multierror.Append(err, errors.New(`config.Name cannot be ""`))
 	} else {
-		if _, err2 := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, c.Name, metav1.GetOptions{}); err2 != nil && k8serrors.IsNotFound(err2) {
+		if _, err2 := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, c.Name, metav1.GetOptions{}); err2 != nil && k8serrors.IsNotFound(err2) {
 			err = multierror.Append(err, errors.New(fmt.Sprintf("MutatingWebhookConfiguration with name \"%s\" must exist in cluster", c.Name)))
 		}
 	}

--- a/subcommand/webhook-cert-manager/command_test.go
+++ b/subcommand/webhook-cert-manager/command_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,33 +46,33 @@ func testSignalHandling(sig os.Signal) func(*testing.T) {
 			},
 		}
 
-		webhookOne := &admissionv1beta1.MutatingWebhookConfiguration{
+		webhookOne := &admissionv1.MutatingWebhookConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: webhookConfigOneName,
 			},
-			Webhooks: []admissionv1beta1.MutatingWebhook{
+			Webhooks: []admissionv1.MutatingWebhook{
 				{
 					Name: "webhook-under-test",
-					ClientConfig: admissionv1beta1.WebhookClientConfig{
+					ClientConfig: admissionv1.WebhookClientConfig{
 						CABundle: caBundleOne,
 					},
 				},
 			},
 		}
-		webhookTwo := &admissionv1beta1.MutatingWebhookConfiguration{
+		webhookTwo := &admissionv1.MutatingWebhookConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: webhookConfigTwoName,
 			},
-			Webhooks: []admissionv1beta1.MutatingWebhook{
+			Webhooks: []admissionv1.MutatingWebhook{
 				{
 					Name: "webhookOne-under-test",
-					ClientConfig: admissionv1beta1.WebhookClientConfig{
+					ClientConfig: admissionv1.WebhookClientConfig{
 						CABundle: caBundleTwo,
 					},
 				},
 				{
 					Name: "webhookTwo-under-test",
-					ClientConfig: admissionv1beta1.WebhookClientConfig{
+					ClientConfig: admissionv1.WebhookClientConfig{
 						CABundle: caBundleTwo,
 					},
 				},
@@ -169,33 +169,33 @@ func TestRun_SecretDoesNotExist(t *testing.T) {
 		},
 	}
 
-	webhookOne := &admissionv1beta1.MutatingWebhookConfiguration{
+	webhookOne := &admissionv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookConfigOneName,
 		},
-		Webhooks: []admissionv1beta1.MutatingWebhook{
+		Webhooks: []admissionv1.MutatingWebhook{
 			{
 				Name: "webhook-under-test",
-				ClientConfig: admissionv1beta1.WebhookClientConfig{
+				ClientConfig: admissionv1.WebhookClientConfig{
 					CABundle: caBundleOne,
 				},
 			},
 		},
 	}
-	webhookTwo := &admissionv1beta1.MutatingWebhookConfiguration{
+	webhookTwo := &admissionv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookConfigTwoName,
 		},
-		Webhooks: []admissionv1beta1.MutatingWebhook{
+		Webhooks: []admissionv1.MutatingWebhook{
 			{
 				Name: "webhookOne-under-test",
-				ClientConfig: admissionv1beta1.WebhookClientConfig{
+				ClientConfig: admissionv1.WebhookClientConfig{
 					CABundle: caBundleTwo,
 				},
 			},
 			{
 				Name: "webhookTwo-under-test",
-				ClientConfig: admissionv1beta1.WebhookClientConfig{
+				ClientConfig: admissionv1.WebhookClientConfig{
 					CABundle: caBundleTwo,
 				},
 			},
@@ -239,11 +239,11 @@ func TestRun_SecretDoesNotExist(t *testing.T) {
 		require.Equal(r, deploymentName, secretTwo.OwnerReferences[0].Name)
 		require.Equal(r, uid, secretTwo.OwnerReferences[0].UID)
 
-		webhookConfigOne, err := k8s.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, webhookConfigOneName, metav1.GetOptions{})
+		webhookConfigOne, err := k8s.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, webhookConfigOneName, metav1.GetOptions{})
 		require.NoError(r, err)
 		require.NotEqual(r, webhookConfigOne.Webhooks[0].ClientConfig.CABundle, caBundleOne)
 
-		webhookConfigTwo, err := k8s.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, webhookConfigTwoName, metav1.GetOptions{})
+		webhookConfigTwo, err := k8s.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, webhookConfigTwoName, metav1.GetOptions{})
 		require.NoError(r, err)
 		require.NotEqual(r, webhookConfigTwo.Webhooks[0].ClientConfig.CABundle, caBundleTwo)
 		require.NotEqual(r, webhookConfigTwo.Webhooks[1].ClientConfig.CABundle, caBundleTwo)
@@ -295,33 +295,33 @@ func TestRun_SecretExists(t *testing.T) {
 		Type: v1.SecretTypeTLS,
 	}
 
-	webhookOne := &admissionv1beta1.MutatingWebhookConfiguration{
+	webhookOne := &admissionv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookConfigOneName,
 		},
-		Webhooks: []admissionv1beta1.MutatingWebhook{
+		Webhooks: []admissionv1.MutatingWebhook{
 			{
 				Name: "webhook-under-test",
-				ClientConfig: admissionv1beta1.WebhookClientConfig{
+				ClientConfig: admissionv1.WebhookClientConfig{
 					CABundle: caBundleOne,
 				},
 			},
 		},
 	}
-	webhookTwo := &admissionv1beta1.MutatingWebhookConfiguration{
+	webhookTwo := &admissionv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookConfigTwoName,
 		},
-		Webhooks: []admissionv1beta1.MutatingWebhook{
+		Webhooks: []admissionv1.MutatingWebhook{
 			{
 				Name: "webhookOne-under-test",
-				ClientConfig: admissionv1beta1.WebhookClientConfig{
+				ClientConfig: admissionv1.WebhookClientConfig{
 					CABundle: caBundleTwo,
 				},
 			},
 			{
 				Name: "webhookTwo-under-test",
-				ClientConfig: admissionv1beta1.WebhookClientConfig{
+				ClientConfig: admissionv1.WebhookClientConfig{
 					CABundle: caBundleTwo,
 				},
 			},
@@ -367,11 +367,11 @@ func TestRun_SecretExists(t *testing.T) {
 		require.Equal(r, deploymentName, secretTwo.OwnerReferences[0].Name)
 		require.Equal(r, uid, secretTwo.OwnerReferences[0].UID)
 
-		webhookConfigOne, err := k8s.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, webhookConfigOneName, metav1.GetOptions{})
+		webhookConfigOne, err := k8s.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, webhookConfigOneName, metav1.GetOptions{})
 		require.NoError(r, err)
 		require.NotEqual(r, webhookConfigOne.Webhooks[0].ClientConfig.CABundle, caBundleOne)
 
-		webhookConfigTwo, err := k8s.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, webhookConfigTwoName, metav1.GetOptions{})
+		webhookConfigTwo, err := k8s.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, webhookConfigTwoName, metav1.GetOptions{})
 		require.NoError(r, err)
 		require.NotEqual(r, webhookConfigTwo.Webhooks[0].ClientConfig.CABundle, caBundleTwo)
 		require.NotEqual(r, webhookConfigTwo.Webhooks[1].ClientConfig.CABundle, caBundleTwo)
@@ -410,14 +410,14 @@ func TestRun_SecretUpdates(t *testing.T) {
 		Type: v1.SecretTypeTLS,
 	}
 
-	webhookOne := &admissionv1beta1.MutatingWebhookConfiguration{
+	webhookOne := &admissionv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookConfigOne,
 		},
-		Webhooks: []admissionv1beta1.MutatingWebhook{
+		Webhooks: []admissionv1.MutatingWebhook{
 			{
 				Name: "webhook-under-test",
-				ClientConfig: admissionv1beta1.WebhookClientConfig{
+				ClientConfig: admissionv1.WebhookClientConfig{
 					CABundle: caBundleOne,
 				},
 			},
@@ -465,7 +465,7 @@ func TestRun_SecretUpdates(t *testing.T) {
 		certificate = secret1.Data[v1.TLSCertKey]
 		key = secret1.Data[v1.TLSPrivateKeyKey]
 
-		webhookConfig1, err := k8s.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, webhookConfigOne, metav1.GetOptions{})
+		webhookConfig1, err := k8s.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, webhookConfigOne, metav1.GetOptions{})
 		require.NoError(r, err)
 		require.NotEqual(r, webhookConfig1.Webhooks[0].ClientConfig.CABundle, caBundleOne)
 	})
@@ -492,14 +492,14 @@ func TestCertWatcher(t *testing.T) {
 	t.Parallel()
 
 	webhookName := "webhookOne"
-	webhook := &admissionv1beta1.MutatingWebhookConfiguration{
+	webhook := &admissionv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookName,
 		},
-		Webhooks: []admissionv1beta1.MutatingWebhook{
+		Webhooks: []admissionv1.MutatingWebhook{
 			{
 				Name:         "webhook-under-test",
-				ClientConfig: admissionv1beta1.WebhookClientConfig{},
+				ClientConfig: admissionv1.WebhookClientConfig{},
 			},
 		},
 	}
@@ -543,21 +543,21 @@ func TestCertWatcher(t *testing.T) {
 	ctx := context.Background()
 	timer := &retry.Timer{Timeout: 5 * time.Second, Wait: 500 * time.Millisecond}
 	retry.RunWith(timer, t, func(r *retry.R) {
-		webhookConfig, err := k8s.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, webhookName, metav1.GetOptions{})
+		webhookConfig, err := k8s.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, webhookName, metav1.GetOptions{})
 		require.NoError(r, err)
 		// Verify that the CA cert has been initally set on the MWC.
 		require.Contains(r, string(webhookConfig.Webhooks[0].ClientConfig.CABundle), "ca-certificate-string")
 	})
 	// Update the CA bundle on the MWC to `""` to replicate a helm upgrade
 	webhook.Webhooks[0].ClientConfig.CABundle = []byte("")
-	_, err = k8s.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Update(ctx, webhook, metav1.UpdateOptions{})
+	_, err = k8s.AdmissionregistrationV1().MutatingWebhookConfigurations().Update(ctx, webhook, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// If this test passes, it implies that the system has recovered from the MWC
 	// getting updated to have the correct CA within a reasonable time window
 	timer = &retry.Timer{Timeout: 5 * time.Second, Wait: 500 * time.Millisecond}
 	retry.RunWith(timer, t, func(r *retry.R) {
-		webhookConfig, err := k8s.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, webhookName, metav1.GetOptions{})
+		webhookConfig, err := k8s.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, webhookName, metav1.GetOptions{})
 		require.NoError(r, err)
 		// Verify that the CA cert has been updated with the correct CA.
 		require.Contains(r, string(webhookConfig.Webhooks[0].ClientConfig.CABundle), "ca-certificate-string")
@@ -566,7 +566,7 @@ func TestCertWatcher(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	t.Parallel()
-	webhook := &admissionv1beta1.MutatingWebhookConfiguration{
+	webhook := &admissionv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "webhook-config-name",
 		},


### PR DESCRIPTION
Currently if you are running Kubernetes 1.19+ you will have the following logs flooding the the cert manager webhook:

```
W0709 18:25:22.612753       7 warnings.go:70] admissionregistration.k8s.io/v1beta1 MutatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration
```

Changes proposed in this PR:
- Use `clientset.AdmissionregistrationV1` instead of `clientset.AdmissionregistrationV1beta1` API as it was deprecated in k8s 1.16.
- Update tests accordingly.

How I've tested this PR:
manually deployed to k8s 1.20 and confirmed the warnings are gone
Unit tests updated and still pass.

How I expect reviewers to test this PR:
code review

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
