### PR TITLE
Add golangci-lint to consul-k8s repo as github action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.41.1
+          version: v1.23.6
 
           # Optional: working directory, useful for monorepos
           # TODO: we may need to modify this when monorepo comes, it could be helpful for when we test

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,12 +1,10 @@
 name: golangci-lint
-on:
-  push:
-    tags:
-      - v*
-    branches:
-      - master
-      - main
-  pull_request:
+on: [push, pull_request]
+  tags:
+    - v*
+  branches:
+    - master
+    - main
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,19 +16,9 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.41.1
-
           # Optional: working directory, useful for monorepos
           # TODO: we may need to modify this when monorepo comes, it could be helpful for when we test
           # only control-plane components in a PR, or some other scenario.
           # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
-          # args: --config .golangci.yml
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # TODO: if we fix all the issues.. remove
-          # only-new-issues: true
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,34 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.29
+
+          # Optional: working directory, useful for monorepos
+          # TODO: we may need to modify this when monorepo comes, it could be helpful for when we test
+          # only control-plane components in a PR, or some other scenario.
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+          args: --config .golangci.yml
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # TODO: if we fix all the issues.. remove
+          only-new-issues: true
+

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,10 +1,12 @@
 name: golangci-lint
-on: [push, pull_request]
-  tags:
-    - v*
-  branches:
-    - master
-    - main
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,9 +26,9 @@ jobs:
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0
-          args: --config .golangci.yml
+          # args: --config .golangci.yml
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # TODO: if we fix all the issues.. remove
-          only-new-issues: true
+          # only-new-issues: true
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          version: v1.41.1
 
           # Optional: working directory, useful for monorepos
           # TODO: we may need to modify this when monorepo comes, it could be helpful for when we test

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.23.6
+          version: v1.41.1
 
           # Optional: working directory, useful for monorepos
           # TODO: we may need to modify this when monorepo comes, it could be helpful for when we test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,27 @@
+linters:
+  # enables all defaults + the below, `golangci-lint linters` to see the list of active linters.
+  enable:
+    - gofmt
+    # TODO: re-enable things as we have master cleaned up vs the defaults
+    #- stylecheck
+    #- goconst
+    #- prealloc
+    #- unparam
+
+issues:
+  # Disable the default exclude list so that all excludes are explicitly
+  # defined in this file.
+  exclude-use-default: false
+
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - errcheck
+
+linters-settings:
+  gofmt:
+    simplify: true
+
+run:
+  timeout: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,9 @@ issues:
     - path: _test\.go
       linters:
         - errcheck
+    - path: test_util\.go
+      linters:
+        - errcheck
 
 linters-settings:
   gofmt:

--- a/api/v1alpha1/mesh_types.go
+++ b/api/v1alpha1/mesh_types.go
@@ -159,5 +159,4 @@ func (in *Mesh) Validate(_ bool) error {
 
 // DefaultNamespaceFields has no behaviour here as meshes have no namespace specific fields.
 func (in *Mesh) DefaultNamespaceFields(_ bool, _ string, _ bool, _ string) {
-	return
 }

--- a/api/v1alpha1/proxydefaults_types.go
+++ b/api/v1alpha1/proxydefaults_types.go
@@ -206,7 +206,6 @@ func (in *ProxyDefaults) Validate(namespacesEnabled bool) error {
 
 // DefaultNamespaceFields has no behaviour here as proxy-defaults have no namespace specific fields.
 func (in *ProxyDefaults) DefaultNamespaceFields(_ bool, _ string, _ bool, _ string) {
-	return
 }
 
 // convertConfig converts the config of type json.RawMessage which is stored
@@ -220,7 +219,7 @@ func (in *ProxyDefaults) convertConfig() map[string]interface{} {
 	// We explicitly ignore the error returned by Unmarshall
 	// because validate() ensures that if we get to here that it
 	// won't return an error.
-	json.Unmarshal(in.Spec.Config, &outConfig)
+	_ = json.Unmarshal(in.Spec.Config, &outConfig)
 	return outConfig
 }
 

--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	ServiceDefaultsKubeKind string = "servicedefaults"
-	defaultUpstream                = "default"
-	overrideUpstream               = "override"
+	ServiceDefaultsKubeKind = "servicedefaults"
+	defaultUpstream         = "default"
+	overrideUpstream        = "override"
 )
 
 func init() {

--- a/api/v1alpha1/servicedefaults_types.go
+++ b/api/v1alpha1/servicedefaults_types.go
@@ -355,7 +355,6 @@ func (in *PassiveHealthCheck) toConsul() *capi.PassiveHealthCheck {
 
 // DefaultNamespaceFields has no behaviour here as service-defaults have no namespace specific fields.
 func (in *ServiceDefaults) DefaultNamespaceFields(_ bool, _ string, _ bool, _ string) {
-	return
 }
 
 // MatchesConsul returns true if entry has the same config as this struct.

--- a/api/v1alpha1/serviceintentions_webhook_test.go
+++ b/api/v1alpha1/serviceintentions_webhook_test.go
@@ -426,6 +426,7 @@ func TestHandle_ServiceIntentions_Update(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 			marshalledRequestObject, err := json.Marshal(c.newResource)
+			require.NoError(t, err)
 			marshalledOldRequestObject, err := json.Marshal(c.existingResources[0])
 			require.NoError(t, err)
 			s := runtime.NewScheme()

--- a/api/v1alpha1/serviceresolver_types.go
+++ b/api/v1alpha1/serviceresolver_types.go
@@ -313,7 +313,6 @@ func (in *ServiceResolver) Validate(namespacesEnabled bool) error {
 // DefaultNamespaceFields has no behaviour here as service-resolver have namespace fields
 // that do not default.
 func (in *ServiceResolver) DefaultNamespaceFields(_ bool, _ string, _ bool, _ string) {
-	return
 }
 
 func (in ServiceResolverSubsetMap) toConsul() map[string]capi.ServiceResolverSubset {

--- a/api/v1alpha1/servicesplitter_types.go
+++ b/api/v1alpha1/servicesplitter_types.go
@@ -178,7 +178,6 @@ func (in *ServiceSplitter) Validate(namespacesEnabled bool) error {
 // DefaultNamespaceFields has no behaviour here as service-splitter have namespace fields
 // that do not default.
 func (in *ServiceSplitter) DefaultNamespaceFields(_ bool, _ string, _ bool, _ string) {
-	return
 }
 
 func (in ServiceSplits) toConsul() []capi.ServiceSplit {

--- a/catalog/to-consul/syncer.go
+++ b/catalog/to-consul/syncer.go
@@ -166,9 +166,7 @@ func (s *ConsulSyncer) watchReapableServices(ctx context.Context) {
 	// We must wait for the initial sync to be complete and our maps to be
 	// populated. If we don't wait, we will reap all services tagged with k8s
 	// because we have no tracked services in our maps yet.
-	select {
-	case <-s.initialSync:
-	}
+	<-s.initialSync
 
 	opts := &api.QueryOptions{
 		AllowStale: true,

--- a/catalog/to-k8s/sink.go
+++ b/catalog/to-k8s/sink.go
@@ -77,7 +77,6 @@ type K8SSink struct {
 	// It's populated from Kubernetes data.
 	serviceMapConsul map[string]*apiv1.Service
 	triggerCh        chan struct{}
-	readyCh          chan struct{}
 }
 
 // SetServices implements Sink

--- a/commands.go
+++ b/commands.go
@@ -92,7 +92,7 @@ func helpFunc() cli.HelpFunc {
 	// aren't shown in any help output. We use this for prerelease functionality
 	// or advanced features.
 	hidden := map[string]struct{}{
-		"inject-connect": struct{}{},
+		"inject-connect": {},
 	}
 
 	var include []string

--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -249,9 +249,7 @@ func pointerToBool(b bool) *bool {
 func splitCommaSeparatedItemsFromAnnotation(annotation string, pod corev1.Pod) []string {
 	var items []string
 	if raw, ok := pod.Annotations[annotation]; ok {
-		for _, item := range strings.Split(raw, ",") {
-			items = append(items, item)
-		}
+		items = append(items, strings.Split(raw, ",")...)
 	}
 
 	return items

--- a/connect-inject/endpoints_controller_test.go
+++ b/connect-inject/endpoints_controller_test.go
@@ -1016,7 +1016,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 
 			// Check that the Consul health check was created for the k8s pod.
 			if tt.expectedAgentHealthChecks != nil {
-				for i, _ := range tt.expectedConsulSvcInstances {
+				for i := range tt.expectedConsulSvcInstances {
 					filter := fmt.Sprintf("CheckID == `%s`", tt.expectedAgentHealthChecks[i].CheckID)
 					check, err := consulClient.Agent().ChecksWithFilter(filter)
 					require.NoError(t, err)
@@ -2134,7 +2134,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				}
 				// Check that the Consul health check was created for the k8s pod.
 				if tt.expectedAgentHealthChecks != nil {
-					for i, _ := range tt.expectedConsulSvcInstances {
+					for i := range tt.expectedConsulSvcInstances {
 						filter := fmt.Sprintf("CheckID == `%s`", tt.expectedAgentHealthChecks[i].CheckID)
 						check, err := consulClient.Agent().ChecksWithFilter(filter)
 						require.NoError(t, err)
@@ -3010,6 +3010,7 @@ func TestServiceInstancesForK8SServiceNameAndNamespace(t *testing.T) {
 			consulClient, err := api.NewClient(&api.Config{
 				Address: consul.HTTPAddr,
 			})
+			require.NoError(t, err)
 
 			for _, svc := range servicesInConsul {
 				err := consulClient.Agent().ServiceRegister(svc)
@@ -4417,6 +4418,7 @@ func TestRegisterServicesAndHealthCheck_skipsWhenDuplicateServiceFound(t *testin
 			}
 
 			err = ep.registerServicesAndHealthCheck(context.Background(), *endpoints, endpointsAddress, api.HealthPassing, make(map[string]bool))
+			require.NoError(t, err)
 
 			// Check that the service is not registered with Consul.
 			_, _, err = consulClient.Agent().Service("test-pod-test-service", nil)

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
-	mapset "github.com/deckarep/golang-set"
+	"github.com/deckarep/golang-set"
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/consul-k8s/namespaces"
 	"github.com/hashicorp/consul/api"

--- a/connect-inject/handler.go
+++ b/connect-inject/handler.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set"
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/consul-k8s/namespaces"
 	"github.com/hashicorp/consul/api"
@@ -16,8 +16,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -25,9 +23,6 @@ import (
 )
 
 var (
-	codecs       = serializer.NewCodecFactory(runtime.NewScheme())
-	deserializer = codecs.UniversalDeserializer()
-
 	// kubeSystemNamespaces is a set of namespaces that are considered
 	// "system" level namespaces and are always skipped (never injected).
 	kubeSystemNamespaces = mapset.NewSetWith(metav1.NamespaceSystem, metav1.NamespacePublic)

--- a/connect-inject/handler_test.go
+++ b/connect-inject/handler_test.go
@@ -542,7 +542,7 @@ func TestHandlerHandle(t *testing.T) {
 
 			actual := resp.Patches
 			if len(actual) > 0 {
-				for i, _ := range actual {
+				for i := range actual {
 					actual[i].Value = nil
 				}
 			}

--- a/hack/crds-to-consul-helm/main.go
+++ b/hack/crds-to-consul-helm/main.go
@@ -55,9 +55,7 @@ func realMain(helmPathAbs string) error {
 		contents := string(contentBytes)
 
 		// Strip leading newline.
-		if strings.HasPrefix(contents, "\n") {
-			contents = strings.TrimPrefix(contents, "\n")
-		}
+		contents = strings.TrimPrefix(contents, "\n")
 
 		// Add {{- if .Values.controller.enabled }} {{- end }} wrapper.
 		contents = fmt.Sprintf("{{- if .Values.controller.enabled }}\n%s{{- end }}\n", contents)

--- a/hack/lint-api-new-client/main.go
+++ b/hack/lint-api-new-client/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	broken           = make(map[string]bool, 0) // Stored in a map for deduplication
+	broken           = make(map[string]bool) // Stored in a map for deduplication
 	exitCode         = 0
 	fset             = token.NewFileSet()
 	consulApiPackage = "github.com/hashicorp/consul/api"
@@ -25,19 +25,19 @@ var (
 func main() {
 	dir, err := os.Getwd()
 	if err != nil {
-		os.Stderr.WriteString(fmt.Sprintf("failed to get cwd: %v", err))
+		_, _ = os.Stderr.WriteString(fmt.Sprintf("failed to get cwd: %v", err))
 		os.Exit(1)
 	}
 	err = walkDir(dir)
 	if err != nil {
-		os.Stderr.WriteString(err.Error())
+		_, _ = os.Stderr.WriteString(err.Error())
 		os.Exit(1)
 	}
 	if len(broken) > 0 {
 		exitCode = 1
-		os.Stderr.WriteString("Found code using github.com/hashicorp/consul/api.NewClient()\ninstead of github.com/hashicorp/consul-k8s/consul.NewClient()\nin the following files:\n")
+		_, _ = os.Stderr.WriteString("Found code using github.com/hashicorp/consul/api.NewClient()\ninstead of github.com/hashicorp/consul-k8s/consul.NewClient()\nin the following files:\n")
 		for filePath := range broken {
-			os.Stderr.WriteString(fmt.Sprintf("-  %s\n", filePath))
+			_, _ = os.Stderr.WriteString(fmt.Sprintf("-  %s\n", filePath))
 		}
 	}
 	os.Exit(exitCode)

--- a/helper/cert/source_gen.go
+++ b/helper/cert/source_gen.go
@@ -93,15 +93,6 @@ func (s *GenSource) expiry() time.Duration {
 	return 24 * time.Hour
 }
 
-func (s *GenSource) expiryWithin() time.Duration {
-	if s.ExpiryWithin > 0 {
-		return s.ExpiryWithin
-	}
-
-	// Roughly 10% accounting for float errors
-	return time.Duration(float64(s.expiry()) * 0.10)
-}
-
 func (s *GenSource) generateCA() error {
 	// generate the CA
 	signer, _, caCertPem, caCertTemplate, err := GenerateCA(s.Name + " CA")

--- a/helper/cert/source_gen.go
+++ b/helper/cert/source_gen.go
@@ -58,7 +58,7 @@ func (s *GenSource) Certificate(ctx context.Context, last *Bundle) (Bundle, erro
 			return result, err
 		}
 
-		waitTime := cert.NotAfter.Sub(time.Now()) - s.expiryWithin()
+		waitTime := time.Until(cert.NotAfter)
 		if waitTime < 0 {
 			waitTime = 1 * time.Millisecond
 		}

--- a/helper/cert/source_gen.go
+++ b/helper/cert/source_gen.go
@@ -58,7 +58,7 @@ func (s *GenSource) Certificate(ctx context.Context, last *Bundle) (Bundle, erro
 			return result, err
 		}
 
-		waitTime := time.Until(cert.NotAfter)
+		waitTime := time.Until(cert.NotAfter) - s.expiryWithin()
 		if waitTime < 0 {
 			waitTime = 1 * time.Millisecond
 		}
@@ -91,6 +91,15 @@ func (s *GenSource) expiry() time.Duration {
 	}
 
 	return 24 * time.Hour
+}
+
+func (s *GenSource) expiryWithin() time.Duration {
+	if s.ExpiryWithin > 0 {
+		return s.ExpiryWithin
+	}
+
+	// Roughly 10% accounting for float errors
+	return time.Duration(float64(s.expiry()) * 0.10)
 }
 
 func (s *GenSource) generateCA() error {

--- a/helper/cert/source_gen_test.go
+++ b/helper/cert/source_gen_test.go
@@ -58,7 +58,7 @@ func TestGenSource_expiry(t *testing.T) {
 	// Generate again
 	start := time.Now()
 	next, err := source.Certificate(context.Background(), &bundle)
-	dur := time.Now().Sub(start)
+	dur := time.Since(start)
 	require.NoError(t, err)
 	require.False(t, bundle.Equal(&next))
 	require.True(t, dur > time.Second)
@@ -70,14 +70,6 @@ func testGenSource() *GenSource {
 		Name:  "Test",
 		Hosts: []string{"127.0.0.1", "localhost"},
 	}
-}
-
-// testBundle returns a valid bundle.
-func testBundle(t *testing.T) *Bundle {
-	source := testGenSource()
-	bundle, err := source.Certificate(context.Background(), nil)
-	require.NoError(t, err)
-	return &bundle
 }
 
 // testBundleDir writes the bundle contents to a directory and returns the

--- a/helper/coalesce/coalesce_test.go
+++ b/helper/coalesce/coalesce_test.go
@@ -18,7 +18,7 @@ func TestCoalesce_quiet(t *testing.T) {
 		100*time.Millisecond,
 		500*time.Millisecond,
 		testSummer(&total, deltaCh))
-	duration := time.Now().Sub(start)
+	duration := time.Since(start)
 	if total != 42 {
 		t.Fatalf("total != 42: %d", total)
 	}
@@ -44,7 +44,7 @@ func TestCoalesce_max(t *testing.T) {
 		200*time.Millisecond,
 		500*time.Millisecond,
 		testSummer(&total, deltaCh))
-	duration := time.Now().Sub(start)
+	duration := time.Since(start)
 	if total < 4 || total > 6 {
 		// 4 to 6 to account for CI weirdness
 		t.Fatalf("total should be 4 to 6: %d", total)
@@ -78,7 +78,7 @@ func TestCoalesce_cancel(t *testing.T) {
 		500*time.Millisecond,
 		1000*time.Millisecond,
 		testSummer(&total, deltaCh))
-	duration := time.Now().Sub(start)
+	duration := time.Since(start)
 	// The check on total here isn't super important since it should
 	// never fail but I kept it in to match the rest of the tests.
 	if total != 1 {

--- a/subcommand/acl-init/command.go
+++ b/subcommand/acl-init/command.go
@@ -60,7 +60,7 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 	if len(c.flags.Args()) > 0 {
-		c.UI.Error(fmt.Sprintf("Should have no non-flag arguments."))
+		c.UI.Error("Should have no non-flag arguments.")
 		return 1
 	}
 

--- a/subcommand/common/common.go
+++ b/subcommand/common/common.go
@@ -2,7 +2,6 @@
 package common
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -62,11 +61,11 @@ func ZapLogger(level string, jsonLogging bool) (logr.Logger, error) {
 func ValidateUnprivilegedPort(flagName, flagValue string) error {
 	port, err := strconv.Atoi(flagValue)
 	if err != nil {
-		return errors.New(fmt.Sprintf("%s value of %s is not a valid integer", flagName, flagValue))
+		return fmt.Errorf("%s value of %s is not a valid integer", flagName, flagValue)
 	}
 	// This checks if the port is in the unprivileged port range.
 	if port < 1024 || port > 65535 {
-		return errors.New(fmt.Sprintf("%s value of %d is not in the unprivileged port range 1024-65535", flagName, port))
+		return fmt.Errorf("%s value of %d is not in the unprivileged port range 1024-65535", flagName, port)
 	}
 	return nil
 }

--- a/subcommand/connect-init/command_test.go
+++ b/subcommand/connect-init/command_test.go
@@ -588,6 +588,7 @@ func TestRun_InvalidProxyFile(t *testing.T) {
 	code := cmd.Run(flags)
 	require.Equal(t, 1, code)
 	proxyFile, err := os.Stat(randFileName)
+	require.NoError(t, err)
 	// If the file has not been written it wont exist and proxyFile will be nil.
 	require.Nil(t, proxyFile)
 }

--- a/subcommand/connect-init/command_test.go
+++ b/subcommand/connect-init/command_test.go
@@ -587,10 +587,8 @@ func TestRun_InvalidProxyFile(t *testing.T) {
 	}
 	code := cmd.Run(flags)
 	require.Equal(t, 1, code)
-	proxyFile, err := os.Stat(randFileName)
-	require.NoError(t, err)
-	// If the file has not been written it wont exist and proxyFile will be nil.
-	require.Nil(t, proxyFile)
+	_, err = os.Stat(randFileName)
+	require.Error(t, err)
 }
 
 // TestRun_FailsWithBadServerResponses tests error handling with invalid server responses.

--- a/subcommand/consul-sidecar/command.go
+++ b/subcommand/consul-sidecar/command.go
@@ -268,7 +268,7 @@ func (c *Command) mergedMetricsHandler(rw http.ResponseWriter, _ *http.Request) 
 	defer func() {
 		err = envoyMetrics.Body.Close()
 		if err != nil {
-			c.logger.Info(fmt.Sprintf("Error closing envoy metrics body: %s", err.Error()))
+			c.logger.Error(fmt.Sprintf("Error closing envoy metrics body: %s", err.Error()))
 		}
 	}()
 	envoyMetricsBody, err := ioutil.ReadAll(envoyMetrics.Body)
@@ -278,7 +278,7 @@ func (c *Command) mergedMetricsHandler(rw http.ResponseWriter, _ *http.Request) 
 	}
 	_, err = rw.Write(envoyMetricsBody)
 	if err != nil {
-		c.logger.Info(fmt.Sprintf("Error writing envoy metrics body: %s", err.Error()))
+		c.logger.Error(fmt.Sprintf("Error writing envoy metrics body: %s", err.Error()))
 	}
 
 	serviceMetricsAddr := fmt.Sprintf("http://127.0.0.1:%s%s", c.flagServiceMetricsPort, c.flagServiceMetricsPath)
@@ -295,7 +295,7 @@ func (c *Command) mergedMetricsHandler(rw http.ResponseWriter, _ *http.Request) 
 	defer func() {
 		err = serviceMetrics.Body.Close()
 		if err != nil {
-			c.logger.Info(fmt.Sprintf("Error closing service metrics body: %s", err.Error()))
+			c.logger.Error(fmt.Sprintf("Error closing service metrics body: %s", err.Error()))
 		}
 	}()
 	serviceMetricsBody, err := ioutil.ReadAll(serviceMetrics.Body)
@@ -305,7 +305,7 @@ func (c *Command) mergedMetricsHandler(rw http.ResponseWriter, _ *http.Request) 
 	}
 	_, err = rw.Write(serviceMetricsBody)
 	if err != nil {
-		c.logger.Info(fmt.Sprintf("Error writing service metrics body: %s", err.Error()))
+		c.logger.Error(fmt.Sprintf("Error writing service metrics body: %s", err.Error()))
 	}
 }
 

--- a/subcommand/consul-sidecar/command.go
+++ b/subcommand/consul-sidecar/command.go
@@ -136,12 +136,9 @@ func (c *Command) Run(args []string) int {
 	// on shutdown. Also passing a context in so that it can interrupt the cmd and exit cleanly.
 	signalCtx, cancelFunc := context.WithCancel(context.Background())
 	go func() {
-		select {
-		case sig := <-c.sigCh:
-			c.logger.Info(fmt.Sprintf("%s received, shutting down", sig))
-			cancelFunc()
-			return
-		}
+		sig := <-c.sigCh
+		c.logger.Info(fmt.Sprintf("%s received, shutting down", sig))
+		cancelFunc()
 	}()
 
 	// If metrics merging is enabled, run a merged metrics server in a goroutine
@@ -268,13 +265,21 @@ func (c *Command) mergedMetricsHandler(rw http.ResponseWriter, _ *http.Request) 
 	}
 
 	// Write Envoy metrics to the response.
-	defer envoyMetrics.Body.Close()
+	defer func() {
+		err = envoyMetrics.Body.Close()
+		if err != nil {
+			c.logger.Info(fmt.Sprintf("Error closing envoy metrics body: %s", err.Error()))
+		}
+	}()
 	envoyMetricsBody, err := ioutil.ReadAll(envoyMetrics.Body)
 	if err != nil {
 		c.logger.Error(fmt.Sprintf("Couldn't read Envoy proxy metrics: %s", err.Error()))
 		return
 	}
-	rw.Write(envoyMetricsBody)
+	_, err = rw.Write(envoyMetricsBody)
+	if err != nil {
+		c.logger.Info(fmt.Sprintf("Error writing envoy metrics body: %s", err.Error()))
+	}
 
 	serviceMetricsAddr := fmt.Sprintf("http://127.0.0.1:%s%s", c.flagServiceMetricsPort, c.flagServiceMetricsPath)
 	serviceMetrics, err := c.serviceMetricsGetter.Get(serviceMetricsAddr)
@@ -287,13 +292,21 @@ func (c *Command) mergedMetricsHandler(rw http.ResponseWriter, _ *http.Request) 
 
 	// Since serviceMetrics will be non-nil if there are no errors, write the
 	// service metrics to the response as well.
-	defer serviceMetrics.Body.Close()
+	defer func() {
+		err = serviceMetrics.Body.Close()
+		if err != nil {
+			c.logger.Info(fmt.Sprintf("Error closing service metrics body: %s", err.Error()))
+		}
+	}()
 	serviceMetricsBody, err := ioutil.ReadAll(serviceMetrics.Body)
 	if err != nil {
 		c.logger.Error(fmt.Sprintf("Couldn't read service metrics: %s", err.Error()))
 		return
 	}
-	rw.Write(serviceMetricsBody)
+	_, err = rw.Write(serviceMetricsBody)
+	if err != nil {
+		c.logger.Info(fmt.Sprintf("Error writing service metrics body: %s", err.Error()))
+	}
 }
 
 // validateFlags validates the flags.

--- a/subcommand/consul-sidecar/command_test.go
+++ b/subcommand/consul-sidecar/command_test.go
@@ -563,10 +563,8 @@ func stopCommand(t *testing.T, cmd *Command, exitChan chan int) {
 	if len(exitChan) == 0 {
 		cmd.interrupt()
 	}
-	select {
-	case c := <-exitChan:
-		require.Equal(t, 0, c, string(cmd.UI.(*cli.MockUi).ErrorWriter.Bytes()))
-	}
+	c := <-exitChan
+	require.Equal(t, 0, c, string(cmd.UI.(*cli.MockUi).ErrorWriter.Bytes()))
 }
 
 // createServicesTmpFile creates a temp directory

--- a/subcommand/controller/command.go
+++ b/subcommand/controller/command.go
@@ -24,7 +24,6 @@ type Command struct {
 	UI cli.Ui
 
 	flagSet   *flag.FlagSet
-	k8s       *flags.K8SFlags
 	httpFlags *flags.HTTPFlags
 
 	flagWebhookTLSCertDir    string

--- a/subcommand/create-federation-secret/command.go
+++ b/subcommand/create-federation-secret/command.go
@@ -295,7 +295,7 @@ func (c *Command) replicationToken(logger hclog.Logger) ([]byte, error) {
 	// requires all servers to be running and a leader elected.
 	// This will run forever but it's running as a Helm hook so Helm will timeout
 	// after a configurable time period.
-	backoff.Retry(func() error {
+	_ = backoff.Retry(func() error {
 		secret, err := c.k8sClient.CoreV1().Secrets(c.flagK8sNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 		if k8serrors.IsNotFound(err) {
 			logger.Warn("secret not yet created, retrying", "secret", secretName, "ns", c.flagK8sNamespace)
@@ -329,7 +329,7 @@ func (c *Command) meshGatewayAddrs(logger hclog.Logger) ([]string, error) {
 	var meshGWSvcs []*api.CatalogService
 
 	// Run in a retry in case the mesh gateways haven't yet been registered.
-	backoff.Retry(func() error {
+	_ = backoff.Retry(func() error {
 		var err error
 		meshGWSvcs, _, err = c.consulClient.Catalog().Service(c.flagMeshGatewayServiceName, "", nil)
 		if err != nil {
@@ -387,7 +387,7 @@ func (c *Command) consulDatacenter(logger hclog.Logger) string {
 
 	// Run in a retry because the Consul clients may not be running yet.
 	var dc string
-	backoff.Retry(withLog(func() error {
+	_ = backoff.Retry(withLog(func() error {
 		agentCfg, err := c.consulClient.Agent().Self()
 		if err != nil {
 			return err

--- a/subcommand/create-federation-secret/command_test.go
+++ b/subcommand/create-federation-secret/command_test.go
@@ -650,6 +650,7 @@ func TestRun_MeshGatewayUniqueAddrs(tt *testing.T) {
 						},
 					},
 				})
+				require.NoError(t, err)
 			}
 			require.NoError(t, err)
 

--- a/subcommand/flags/flag_slice_value_test.go
+++ b/subcommand/flags/flag_slice_value_test.go
@@ -11,8 +11,7 @@ import (
 
 func TestAppendSliceValue_implements(t *testing.T) {
 	t.Parallel()
-	var raw interface{}
-	raw = new(AppendSliceValue)
+	var raw interface{} = new(AppendSliceValue)
 	if _, ok := raw.(flag.Value); !ok {
 		t.Fatalf("AppendSliceValue should be a Value")
 	}

--- a/subcommand/get-consul-client-ca/command.go
+++ b/subcommand/get-consul-client-ca/command.go
@@ -70,17 +70,17 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 	if len(c.flags.Args()) > 0 {
-		c.UI.Error(fmt.Sprintf("Should have no non-flag arguments."))
+		c.UI.Error("Should have no non-flag arguments.")
 		return 1
 	}
 
 	if c.flagOutputFile == "" {
-		c.UI.Error(fmt.Sprintf("-output-file must be set"))
+		c.UI.Error("-output-file must be set")
 		return 1
 	}
 
 	if c.flagServerAddr == "" {
-		c.UI.Error(fmt.Sprintf("-server-addr must be set"))
+		c.UI.Error("-server-addr must be set")
 		return 1
 	}
 

--- a/subcommand/get-consul-client-ca/command.go
+++ b/subcommand/get-consul-client-ca/command.go
@@ -27,14 +27,13 @@ type Command struct {
 
 	flags *flag.FlagSet
 
-	flagOutputFile      string
-	flagServerAddr      string
-	flagServerPort      string
-	flagCAFile          string
-	flagTLSServerName   string
-	flagPollingInterval time.Duration
-	flagLogLevel        string
-	flagLogJSON         bool
+	flagOutputFile    string
+	flagServerAddr    string
+	flagServerPort    string
+	flagCAFile        string
+	flagTLSServerName string
+	flagLogLevel      string
+	flagLogJSON       bool
 
 	once sync.Once
 	help string
@@ -101,7 +100,7 @@ func (c *Command) Run(args []string) int {
 	// Get the active CA root from Consul
 	// Wait until it gets a successful response
 	var activeRoot string
-	backoff.Retry(func() error {
+	_ = backoff.Retry(func() error {
 		caRoots, _, err := consulClient.Agent().ConnectCARoots(nil)
 		if err != nil {
 			logger.Error("Error retrieving CA roots from Consul", "err", err)

--- a/subcommand/inject-connect/command.go
+++ b/subcommand/inject-connect/command.go
@@ -5,12 +5,10 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 
 	connectinject "github.com/hashicorp/consul-k8s/connect-inject"
 	"github.com/hashicorp/consul-k8s/consul"
@@ -102,7 +100,6 @@ type Command struct {
 
 	once sync.Once
 	help string
-	cert atomic.Value
 }
 
 var (
@@ -463,13 +460,6 @@ func (c *Command) Run(args []string) int {
 	}
 	c.UI.Info("shutting down")
 	return 0
-}
-
-func (c *Command) handleReady(rw http.ResponseWriter, req *http.Request) {
-	// Always ready at this point. The main readiness check is whether
-	// there is a TLS certificate. If we reached this point it means we
-	// served a TLS certificate.
-	rw.WriteHeader(204)
 }
 
 func (c *Command) parseAndValidateResourceFlags() (corev1.ResourceRequirements, corev1.ResourceRequirements, error) {

--- a/subcommand/server-acl-init/command.go
+++ b/subcommand/server-acl-init/command.go
@@ -43,10 +43,9 @@ type Command struct {
 	flagCreateSyncToken    bool
 	flagSyncConsulNodeName string
 
-	flagCreateInjectToken      bool
-	flagCreateInjectAuthMethod bool
-	flagInjectAuthMethodHost   string
-	flagBindingRuleSelector    string
+	flagCreateInjectToken    bool
+	flagInjectAuthMethodHost string
+	flagBindingRuleSelector  string
 
 	flagCreateControllerToken bool
 

--- a/subcommand/server-acl-init/servers.go
+++ b/subcommand/server-acl-init/servers.go
@@ -125,6 +125,9 @@ func (c *Command) setServerTokens(consulClient *api.Client, serverAddresses []st
 				CAFile:  c.flagConsulCACert,
 			},
 		})
+		if err != nil {
+			return err
+		}
 
 		// Create token for the server
 		err = c.untilSucceeds(fmt.Sprintf("creating server token for %s - PUT /v1/acl/token", host),

--- a/subcommand/service-address/command.go
+++ b/subcommand/service-address/command.go
@@ -95,7 +95,7 @@ func (c *Command) Run(args []string) int {
 	// Run until we get an address from the service.
 	var address string
 	var unretryableErr error
-	backoff.Retry(withErrLogger(logger, func() error {
+	err = backoff.Retry(withErrLogger(logger, func() error {
 		svc, err := c.k8sClient.CoreV1().Services(c.flagNamespace).Get(context.TODO(), c.flagServiceName, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("getting service %s: %s", c.flagServiceName, err)
@@ -131,8 +131,8 @@ func (c *Command) Run(args []string) int {
 		}
 	}), backoff.NewConstantBackOff(c.retryDuration))
 
-	if unretryableErr != nil {
-		c.UI.Error(fmt.Sprintf("Unable to get service address: %s", unretryableErr.Error()))
+	if err != nil || unretryableErr != nil {
+		c.UI.Error(fmt.Sprintf("Unable to get service address: %s, err: %s", unretryableErr.Error(), err))
 		return 1
 	}
 

--- a/subcommand/sync-catalog/command.go
+++ b/subcommand/sync-catalog/command.go
@@ -165,7 +165,7 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 	if len(c.flags.Args()) > 0 {
-		c.UI.Error(fmt.Sprintf("Should have no non-flag arguments."))
+		c.UI.Error("Should have no non-flag arguments.")
 		return 1
 	}
 

--- a/subcommand/sync-catalog/command_test.go
+++ b/subcommand/sync-catalog/command_test.go
@@ -607,10 +607,8 @@ func stopCommand(t *testing.T, cmd *Command, exitChan chan int) {
 	if len(exitChan) == 0 {
 		cmd.interrupt()
 	}
-	select {
-	case c := <-exitChan:
-		require.Equal(t, 0, c, string(cmd.UI.(*cli.MockUi).ErrorWriter.Bytes()))
-	}
+	c := <-exitChan
+	require.Equal(t, 0, c, string(cmd.UI.(*cli.MockUi).ErrorWriter.Bytes()))
 }
 
 // lbService returns a Kubernetes service of type LoadBalancer.

--- a/subcommand/webhook-cert-manager/command.go
+++ b/subcommand/webhook-cert-manager/command.go
@@ -98,17 +98,17 @@ func (c *Command) Run(args []string) int {
 	}
 
 	if c.flagConfigFile == "" {
-		c.UI.Error(fmt.Sprintf("-config-file must be set"))
+		c.UI.Error("-config-file must be set")
 		return 1
 	}
 
 	if c.flagDeploymentName == "" {
-		c.UI.Error(fmt.Sprintf("-deployment-name must be set"))
+		c.UI.Error("-deployment-name must be set")
 		return 1
 	}
 
 	if c.flagDeploymentNamespace == "" {
-		c.UI.Error(fmt.Sprintf("-deployment-namespace must be set"))
+		c.UI.Error("-deployment-namespace must be set")
 		return 1
 	}
 

--- a/subcommand/webhook-cert-manager/command.go
+++ b/subcommand/webhook-cert-manager/command.go
@@ -189,15 +189,13 @@ func (c *Command) Run(args []string) int {
 	// We define a signal handler for OS interrupts, and when an SIGINT or SIGTERM is received,
 	// we gracefully shut down, by first stopping our cert notifiers and then cancelling
 	// all the contexts that have been created by the process.
-	select {
-	case sig := <-c.sigCh:
-		c.logger.Info(fmt.Sprintf("%s received, shutting down", sig))
-		cancelFunc()
-		for _, notifier := range notifiers {
-			notifier.Stop()
-		}
-		return 0
+	sig := <-c.sigCh
+	c.logger.Info(fmt.Sprintf("%s received, shutting down", sig))
+	cancelFunc()
+	for _, notifier := range notifiers {
+		notifier.Stop()
 	}
+	return 0
 }
 
 // certWatcher listens for a new MetaBundle on the ch channel for all webhooks and updates
@@ -369,7 +367,7 @@ func (c webhookConfig) validate(ctx context.Context, client kubernetes.Interface
 		err = multierror.Append(err, errors.New(`config.Name cannot be ""`))
 	} else {
 		if _, err2 := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, c.Name, metav1.GetOptions{}); err2 != nil && k8serrors.IsNotFound(err2) {
-			err = multierror.Append(err, errors.New(fmt.Sprintf("MutatingWebhookConfiguration with name \"%s\" must exist in cluster", c.Name)))
+			err = multierror.Append(err, fmt.Errorf("MutatingWebhookConfiguration with name \"%s\" must exist in cluster", c.Name))
 		}
 	}
 	if c.SecretName == "" {

--- a/subcommand/webhook-cert-manager/command_test.go
+++ b/subcommand/webhook-cert-manager/command_test.go
@@ -660,10 +660,8 @@ func stopCommand(t *testing.T, cmd *Command, exitChan chan int) {
 	if len(exitChan) == 0 {
 		cmd.interrupt()
 	}
-	select {
-	case c := <-exitChan:
-		require.Equal(t, 0, c, string(cmd.UI.(*cli.MockUi).ErrorWriter.Bytes()))
-	}
+	c := <-exitChan
+	require.Equal(t, 0, c, string(cmd.UI.(*cli.MockUi).ErrorWriter.Bytes()))
 }
 
 const configFile = `[


### PR DESCRIPTION
Changes proposed in this PR:
- Add golangci-lint to the pipeline as a github action
- Add .golangci.yaml file to top level dir in repo so that users can run it locally via `golangci-lint run`.
- Update all of consul-k8s (minus the tests files) to be in-line with code standards.

Users should install golangci-lint locally via `brew install golangci-lint` and target version `1.41.1`

How I've tested this PR:
Run it locally + in CI in this branch.

How I expect reviewers to test this PR:
Pull the branch and run it locally with various changes to your code.

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
