### PR TITLE
add some additional log msgs for connect-init

### DIFF
--- a/subcommand/connect-init/command.go
+++ b/subcommand/connect-init/command.go
@@ -172,7 +172,7 @@ func (c *Command) Run(args []string) int {
 			// it is not "lost" to the user at the end of the retries when the pod enters a CrashLoop.
 			if registrationRetryCount%10 == 0 {
 				c.logger.Info("Check to ensure a Kubernetes service has been created for this application." +
-					" Check the connect-inject deployment logs if your Pod is not starting.")
+					" If your pod is not starting also check the connect-inject deployment logs.")
 			}
 			return fmt.Errorf("did not find correct number of services: %d", len(serviceList))
 		}

--- a/subcommand/connect-init/command.go
+++ b/subcommand/connect-init/command.go
@@ -171,7 +171,8 @@ func (c *Command) Run(args []string) int {
 			// Once every 10 times we're going to print this informational message to the pod logs so that
 			// it is not "lost" to the user at the end of the retries when the pod enters a CrashLoop.
 			if registrationRetryCount%10 == 0 {
-				c.logger.Info("Check to ensure a Kubernetes service has been created for this application.")
+				c.logger.Info("Check to ensure a Kubernetes service has been created for this application." +
+					" Check the connect-inject deployment logs if your Pod is not starting.")
 			}
 			return fmt.Errorf("did not find correct number of services: %d", len(serviceList))
 		}


### PR DESCRIPTION
Changes proposed in this PR:
- After some feedback it seemed helpful to point users at the controller logs if connect-init is stuck in a wait loop, add this.

How I've tested this PR:
code review

How I expect reviewers to test this PR:
code review

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
