### PR TITLE
connect: redirect-traffic command should pass ACL token when ACL are enabled

### DIFF
--- a/connect-inject/container_init.go
+++ b/connect-inject/container_init.go
@@ -313,6 +313,9 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 
 # Apply traffic redirection rules.
 /consul/connect-inject/consul connect redirect-traffic \
+  {{- if .AuthMethod }}
+  -token-file="/consul/connect-inject/acl-token" \
+  {{- end }}
   {{- if .ConsulNamespace }}
   -namespace="{{ .ConsulNamespace }}" \
   {{- end }}

--- a/connect-inject/container_init_test.go
+++ b/connect-inject/container_init_test.go
@@ -543,6 +543,7 @@ consul-k8s connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
 
 # Apply traffic redirection rules.
 /consul/connect-inject/consul connect redirect-traffic \
+  -token-file="/consul/connect-inject/acl-token" \
   -namespace="k8snamespace" \
   -proxy-id="$(cat /consul/connect-inject/proxyid)" \
   -proxy-uid=5995`,


### PR DESCRIPTION
Fixes #570,#568

Changes proposed in this PR:
- `redirect-traffic` command should use an ACL token that we get from running `consul login`

How I've tested this PR:
* unit tests
* acceptance tests in hashicorp/consul-helm#1058

How I expect reviewers to test this PR:
- code review 👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
