### PR TITLE
connect: don't get pods from the API to determine if ACL should be deleted

### DIFF
--- a/connect-inject/endpoints_controller.go
+++ b/connect-inject/endpoints_controller.go
@@ -746,7 +746,8 @@ func (r *EndpointsController) deregisterServiceOnAllAgents(ctx context.Context, 
 
 // reconcileACLTokensForService finds the ACL tokens that belongs to the service and deletes it from Consul.
 // It will only check for ACL tokens that have been created with the auth method this controller
-// has been configured with.
+// has been configured with and will only delete tokens for pods that aren't in endpointPods
+// (endpointPods is a set of pods that the endpoints object is pointing to).
 func (r *EndpointsController) reconcileACLTokensForService(client *api.Client, serviceName, k8sNS string, endpointPods mapset.Set) error {
 	tokens, _, err := client.ACL().TokenList(nil)
 	if err != nil {

--- a/connect-inject/endpoints_controller_ent_test.go
+++ b/connect-inject/endpoints_controller_ent_test.go
@@ -304,10 +304,6 @@ func TestReconcileCreateEndpointWithNamespaces(t *testing.T) {
 			if setup.expectedAgentHealthChecks != nil {
 				for i := range setup.expectedConsulSvcInstances {
 					filter := fmt.Sprintf("CheckID == `%s`", setup.expectedAgentHealthChecks[i].CheckID)
-					newChecks, _ := consulClient.Agent().Checks()
-					for key, value := range newChecks {
-						fmt.Printf("%s:%v\n", key, value)
-					}
 					check, err := consulClient.Agent().ChecksWithFilter(filter)
 					require.NoError(t, err)
 					require.EqualValues(t, 1, len(check))
@@ -1306,10 +1302,6 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 				if tt.expectedAgentHealthChecks != nil {
 					for i := range tt.expectedConsulSvcInstances {
 						filter := fmt.Sprintf("CheckID == `%s`", tt.expectedAgentHealthChecks[i].CheckID)
-						newChecks, _ := consulClient.Agent().Checks()
-						for key, value := range newChecks {
-							fmt.Printf("%s:%v\n", key, value)
-						}
 						check, err := consulClient.Agent().ChecksWithFilter(filter)
 						require.NoError(t, err)
 						require.EqualValues(t, 1, len(check))

--- a/connect-inject/endpoints_controller_test.go
+++ b/connect-inject/endpoints_controller_test.go
@@ -2,7 +2,6 @@ package connectinject
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -4591,10 +4590,6 @@ func TestCreateServiceRegistrations_withTransparentProxy(t *testing.T) {
 			if c.podContainers != nil {
 				pod.Spec.Containers = c.podContainers
 			}
-
-			marshalledPod, err := json.Marshal(pod)
-			fmt.Println(string(marshalledPod))
-			require.NoError(t, err)
 
 			// We set these annotations explicitly as these are set by the handler and we
 			// need these values to determine which port to use for the service registration.

--- a/subcommand/connect-init/command.go
+++ b/subcommand/connect-init/command.go
@@ -104,7 +104,6 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 	if c.flagACLAuthMethod != "" && c.flagServiceAccountName == "" {
-		fmt.Println(c.flagServiceAccountName)
 		c.UI.Error("-service-account-name must be set when ACLs are enabled")
 		return 1
 	}


### PR DESCRIPTION
This is a follow-up to #571 

Endpoints controller may have stale cache for pod objects since it's only
watching the endpoints objects. As a result when we try to get a pod
from cache, it may be stale. For the case of deleting ACL tokens,
we can't tolerate stale cache reads since we need to know for sure
if the pod exists to determine if an ACL token for that pod should be deleted.
This commit changes it to instead use the pod info stored in the endpoints addresses
as TargetRef.

This can be seen in the failed acceptance tests build [here](https://app.circleci.com/pipelines/github/hashicorp/consul-helm/3477/workflows/85035325-7c4d-48ef-9ea2-fdbb3a9a83f3/jobs/15657).

Also, remove `fmt.Printf` and `fmt.Println` statements in tests and code as I think they were left accidentally.

How I've tested this PR:
[acceptance tests](https://app.circleci.com/pipelines/github/hashicorp/consul-helm/3490/workflows/7ec1fc0b-0f7c-4c05-af84-2b71780fd03a)

How I expect reviewers to test this PR:
- code review

Checklist:
- [x] Tests added
- N/A CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
