### PR TITLE
connect-init: Allow setting -k8s-service-name flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 IMPROVEMENTS:
 * Add flags `-log-level`, `-log-json` to all subcommands to control log level and json formatting. [[GH-523](https://github.com/hashicorp/consul-k8s/pull/523)]
+* Connect: Add flag `-k8s-service-name` to `connect-init` command which will narrow the search in Consul to services
+  that have a meta key matching that K8s service name. [[GH-584](https://github.com/hashicorp/consul-k8s/pull/584)]
 
 BUG FIXES:
 * Connect: Use `AdmissionregistrationV1` instead of `AdmissionregistrationV1beta1` API as it was deprecated in k8s 1.16. [[GH-558](https://github.com/hashicorp/consul-k8s/pull/558)]


### PR DESCRIPTION
Changes proposed in this PR:
- connect-init: Setting `-k8s-service-name` will narrow search in Consul for service in init container to services with a meta key matching that K8s service name. The reason to use `-k8s-service-name` rather than `-service-name` as originally discussed, is because `-service-name` is an already existing flag which we expect to be the Consul service name from the pod annotation, which in many cases will NOT match the K8s service name.

How I've tested this PR:
- unit tests

How I expect reviewers to test this PR:
- code review

Fixes #578 

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
