### PR TITLE
Add ability to specify port for ui service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+IMPROVEMENTS:
+* Helm Chart
+  * Add ability to specify port for ui service. [[GH-604](https://github.com/hashicorp/consul-k8s/pull/604)]
+
 ## 0.33.0 (August 12, 2021)
 
 BREAKING CHANGES:

--- a/charts/consul/templates/ui-service.yaml
+++ b/charts/consul/templates/ui-service.yaml
@@ -23,7 +23,7 @@ spec:
   ports:
     {{- if (or (not .Values.global.tls.enabled) (not .Values.global.tls.httpsOnly)) }}
     - name: http
-      port: 80
+      port: {{ .Values.ui.service.port.http }}
       targetPort: 8500
       {{- if .Values.ui.service.type }}{{ if (and (eq .Values.ui.service.type "NodePort") .Values.ui.service.nodePort.http) }}
       nodePort: {{ .Values.ui.service.nodePort.http }}
@@ -31,7 +31,7 @@ spec:
     {{- end }}
     {{- if .Values.global.tls.enabled }}
     - name: https
-      port: 443
+      port: {{ .Values.ui.service.port.https }}
       targetPort: 8501
       {{- if .Values.ui.service.type }}{{ if (and (eq .Values.ui.service.type "NodePort") .Values.ui.service.nodePort.https) }}
       nodePort: {{ .Values.ui.service.nodePort.https }}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1075,6 +1075,15 @@ ui:
     # @type: string
     type: null
 
+    # Set the port value of the UI service.
+    port:
+
+      # HTTP port.
+      http: 80
+
+      # HTTPS port.
+      https: 443
+
     # Optionally set the nodePort value of the ui service if using a NodePort service.
     # If not set and using a NodePort service, Kubernetes will automatically assign
     # a port.


### PR DESCRIPTION
I followed the same pattern as for `nodePort`. This is generally useful for specifying load balancer ports and we have this option already for mesh gateways. This is also useful for running in Minikube because `minikube tunnel` will open up `localhost:<port>` and so you can have the Consul UI on `localhost:8500` rather than `localhost:80`.

Taken from https://github.com/hashicorp/consul-helm/pull/1062

How I've tested this PR:
* helm tests

How I expect reviewers to test this PR: code

Checklist:
- [x] Bats tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)