### PR TITLE
fix make dev-tree to use module directory in set_dev_mode

### DIFF
--- a/control-plane/build-support/functions/10-util.sh
+++ b/control-plane/build-support/functions/10-util.sh
@@ -796,7 +796,7 @@ function set_dev_mode {
    local vers="$(parse_version "${sdir}" false false)"
 
    status_stage "==> Setting VersionPreRelease back to 'dev'"
-   update_version "${sdir}/version/version.go" "${vers}" dev || return 1
+   update_version "${sdir}/control-plane/version/version.go" "${vers}" dev || return 1
 
    status_stage "==> Adding new UNRELEASED label in CHANGELOG.md"
    add_unreleased_to_changelog "${sdir}" || return 1


### PR DESCRIPTION
Changes proposed in this PR:
- This script is being called from prod-upload-and-publish and is failing because changelog is top level but version/version.go is inside control-plane




