### PR TITLE
Fix make dev-tree to pass in the correct directory for git functions

### DIFF
--- a/control-plane/build-support/scripts/dev.sh
+++ b/control-plane/build-support/scripts/dev.sh
@@ -86,21 +86,20 @@ function main {
 
    set_dev_mode "${sdir}" || return 1
 
-   # Currently we're in control-plane, but for git functions we should be in top-level.
-   cd ".."
 
    if is_set "${do_git}"
    then
       status_stage "==> Commiting Dev Mode Changes"
-      commit_dev_mode "${sdir}" || return 1
+      # Currently ${sdir} is consul-k8s/control-plane, but for git functions we should be in top-level, so we pass in "${sdir}/..".
+      commit_dev_mode "${sdir}/.." || return 1
 
       if is_set "${do_push}"
       then
          status_stage "==> Confirming Git Changes"
-         confirm_git_push_changes "${sdir}" || return 1
+         confirm_git_push_changes "${sdir}/.." || return 1
 
          status_stage "==> Pushing to Git"
-         git_push_ref "${sdir}" || return 1
+         git_push_ref "${sdir}/.." || return 1
       fi
    fi
 


### PR DESCRIPTION
Changes proposed in this PR:
- The previous fix did not work because the git functions were still being called with the control-plane directory, and we need those to be called from the top level repo.

How I've tested this PR:
We actually tested locally except for pushing to git, 🤞 



