### PR TITLE
Update dev dockerfile to use latest image

### DIFF
--- a/control-plane/build-support/docker/Dev.dockerfile
+++ b/control-plane/build-support/docker/Dev.dockerfile
@@ -1,11 +1,2 @@
-FROM hashicorp/consul-k8s:latest
-
-# change the user to root so we can install stuff
-USER root
-RUN rm /bin/consul-k8s
-RUN apk update && apk add iptables
-
+FROM hashicorp/consul-k8s-control-plane:latest
 COPY pkg/bin/linux_amd64/consul-k8s-control-plane /bin
-RUN ln -s /bin/consul-k8s-control-plane /bin/consul-k8s
-
-USER consul-k8s

--- a/control-plane/build-support/functions/20-build.sh
+++ b/control-plane/build-support/functions/20-build.sh
@@ -245,7 +245,7 @@ function build_consul_local {
          -osarch="!darwin/arm !darwin/arm64" \
          -ldflags="${GOLDFLAGS}" \
          -parallel="${GOXPARALLEL:-"-1"}" \
-         -output "pkg.bin.new/${extra_dir}{{.OS}}_{{.Arch}}/control-plane" \
+         -output "pkg.bin.new/${extra_dir}{{.OS}}_{{.Arch}}/${bin_name}" \
          -tags="${GOTAGS}" \
          .
 


### PR DESCRIPTION
How I've tested this PR:
```
make dev-docker
==> Building Consul - OSes: linux, Architectures: amd64
Using gox for concurrent compilation
Number of parallel builds: 11

-->     linux/amd64: github.com/hashicorp/consul-k8s/control-plane
[+] Building 8.1s (8/8) FINISHED
 => [internal] load build definition from Dev.dockerfile                                                         0.0s
 => => transferring dockerfile: 180B                                                                             0.0s
 => [internal] load .dockerignore                                                                                0.0s
 => => transferring context: 2B                                                                                  0.0s
 => [internal] load metadata for docker.io/hashicorp/consul-k8s-control-plane:latest                             1.3s
Update dev dockerfile to build off of new image
 => [auth] hashicorp/consul-k8s-control-plane:pull token for registry-1.docker.io                                0.0s
 => [internal] load build context                                                                                1.3s
 => => transferring context: 77.47MB                                                                             1.3s
 => [1/2] FROM docker.io/hashicorp/consul-k8s-control-plane:latest@sha256:0922baee29751d366c3a311d0a9c73a97c91d  5.6s
 => => resolve docker.io/hashicorp/consul-k8s-control-plane:latest@sha256:0922baee29751d366c3a311d0a9c73a97c91d  0.0s
 => => sha256:81c72c0d554dff58eb334ebd2d450763018bd524e89ff7a6bb78cd0255ab4697 4.42kB / 4.42kB                   0.0s
 => => sha256:1bca9bb64b49fa0bac054982f5ba3efc31e3c012bb7b563b6debc9caf7902471 1.26kB / 1.26kB                   0.3s
 => => sha256:2ff270639d40700019fc550c2a53ae88bc955041ba10ee0eee09c60be85e5d12 30.93MB / 30.93MB                 4.6s
 => => sha256:0922baee29751d366c3a311d0a9c73a97c91dcfa78111abbce32908422d30ae3 1.38kB / 1.38kB                   0.0s
 => => sha256:26d37fc8b00305a0dcf8463fd3ab5c1df71c0a29c79194177acf3002eb38ce6b 948B / 948B                       0.0s
 => => extracting sha256:1bca9bb64b49fa0bac054982f5ba3efc31e3c012bb7b563b6debc9caf7902471                        0.0s
 => => extracting sha256:2ff270639d40700019fc550c2a53ae88bc955041ba10ee0eee09c60be85e5d12                        0.9s
 => [2/2] COPY pkg/bin/linux_amd64/consul-k8s-control-plane /bin                                                 0.6s
 => exporting to image                                                                                           0.3s
 => => exporting layers                                                                                          0.3s
 => => writing image sha256:d2fda9474ecc15a2c35a778ae4b441e318d94ad1bd11b86bdc1729f53f98d3b4                     0.0s
 => => naming to docker.io/library/consul-k8s-control-plane-dev                                                  0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
```