### PR TITLE
[sync-catalog] Fix NodePort register service with wrong internal IP when multiple internal IPs are reported on the node

### DIFF
--- a/control-plane/catalog/to-consul/resource.go
+++ b/control-plane/catalog/to-consul/resource.go
@@ -553,6 +553,12 @@ func (t *ServiceResource) generateRegistrations(key string) {
 						r.Service.Address = address.Address
 
 						t.consulMap[key] = append(t.consulMap[key], &r)
+						// Only consider the first address that matches. In some cases
+						// there will be multiple addresses like when using AWS CNI.
+						// In those cases, Kubernetes will ensure eth0 is always the first
+						// address in the list.
+						// See https://github.com/kubernetes/kubernetes/blob/b559434c02f903dbcd46ee7d6c78b216d3f0aca0/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L1462-L1464
+						break
 					}
 				}
 
@@ -568,6 +574,12 @@ func (t *ServiceResource) generateRegistrations(key string) {
 							r.Service.Address = address.Address
 
 							t.consulMap[key] = append(t.consulMap[key], &r)
+							// Only consider the first address that matches. In some cases
+							// there will be multiple addresses like when using AWS CNI.
+							// In those cases, Kubernetes will ensure eth0 is always the first
+							// address in the list.
+							// See https://github.com/kubernetes/kubernetes/blob/b559434c02f903dbcd46ee7d6c78b216d3f0aca0/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L1462-L1464
+							break
 						}
 					}
 				}

--- a/control-plane/catalog/to-consul/resource_test.go
+++ b/control-plane/catalog/to-consul/resource_test.go
@@ -1527,6 +1527,7 @@ func createNodes(t *testing.T, client *fake.Clientset) (*apiv1.Node, *apiv1.Node
 			Addresses: []apiv1.NodeAddress{
 				{Type: apiv1.NodeExternalIP, Address: "1.2.3.4"},
 				{Type: apiv1.NodeInternalIP, Address: "4.5.6.7"},
+				{Type: apiv1.NodeInternalIP, Address: "7.8.9.10"},
 			},
 		},
 	}
@@ -1542,6 +1543,7 @@ func createNodes(t *testing.T, client *fake.Clientset) (*apiv1.Node, *apiv1.Node
 			Addresses: []apiv1.NodeAddress{
 				{Type: apiv1.NodeExternalIP, Address: "2.3.4.5"},
 				{Type: apiv1.NodeInternalIP, Address: "3.4.5.6"},
+				{Type: apiv1.NodeInternalIP, Address: "6.7.8.9"},
 			},
 		},
 	}


### PR DESCRIPTION
This PR fixed an issue where consul-sync will register NodePort services with wrong internal IPs when multiple internal IPs are reported on the node, and this is a common pattern when using the AWS CNI plugin.

When using the AWS CNI plugin, multiple ENIs could be used and the secondary ENI with multiple IPs are not used by the node itself, but assigned to individual pods. In this case kubelet will end up reporting all used IPs on all ENIs as internal IPs on the node. ([Detailed explanation](https://github.com/kubernetes/kubernetes/issues/61921#issuecomment-384089455))

Kubernetes has since [made sure the first IP would be equal to the IP on eth0](https://github.com/kubernetes/kubernetes/blob/fe099b2abdb023b21a17cd6a127e381b846c1a1f/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go) ([reference 2](https://github.com/kubernetes/kubernetes/issues/61921#issuecomment-586036594)) and it would be the actual IP of the Node.

Prior to my fix the consul-sync program always sync the last matching IP to consul and it ends up being a Pod IP on that node. This PR fixed it by always picking the first matching IP as how Kubernetes is implemented.

Changes proposed in this PR:
- Use the first found Node IP address when syncing NodePort service to consul

How I've tested this PR:

- make test
- Built a docker image with my change then tested in our AWS cluster that has multiple ENIs and verify it now syncs the correct Node IP address for NodePort service.

How I expect reviewers to test this PR:

- Run test suite should be good enough since I've already tested in a real cluster.

Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

