### PR TITLE
Add script to comment on all open PRs

### DIFF
--- a/charts/consul/hack/mass-pr-commenter/README.md
+++ b/charts/consul/hack/mass-pr-commenter/README.md
@@ -1,0 +1,25 @@
+# Mass PR Commenter Script
+
+This script allows the user to comment on every open pull request in a given repository.
+
+## Prerequisites
+
+- [Python](https://www.python.org/)
+  ```bash
+  brew install python
+  ```
+
+## Usage
+
+```bash
+python3 comment.py OWNER/REPO ./comment.md
+```
+
+The first argument is the repository whose open pull requests will be commented on. The second argument is the path to a markdown file whose contents will be posted as the comment on each pull request.
+
+The script will collect the number ids of each open pull request and prompt you for confirmation before creating the comments.
+
+```bash
+Comment on 19 pull requests to the hashicorp/consul-helm repository with the contents of ./comment.md? [y/N]
+```
+

--- a/charts/consul/hack/mass-pr-commenter/README.md
+++ b/charts/consul/hack/mass-pr-commenter/README.md
@@ -8,6 +8,10 @@ This script allows the user to comment on every open pull request in a given rep
   ```bash
   brew install python
   ```
+- [GitHub CLI](https://cli.github.com/)
+  ```bash
+  brew install gh
+  ```
 
 ## Usage
 

--- a/charts/consul/hack/mass-pr-commenter/comment.py
+++ b/charts/consul/hack/mass-pr-commenter/comment.py
@@ -1,0 +1,44 @@
+"""Comment Script
+
+This script fetches all PRs on a given GitHub repository and adds a comment
+using the text in ./comment.md
+"""
+
+from json import loads
+from subprocess import PIPE, run
+from sys import argv
+
+
+def fetch(repo: str) -> bytes:
+    # returns a byte array of JSON with the number ids of each PR on the given repo
+    return run(
+        ["gh", "pr", "list", "--json", '"number"', "-R", repo], stdout=PIPE
+    ).stdout
+
+
+def format(prs: bytes) -> list[int]:
+    # returns the number ids of the PRs for the given bytes array of JSON
+    return [pr["number"] for pr in loads(prs.decode("utf-8"))]
+
+
+def comment(prs: list[int], repo: str, comment_file: str) -> str:
+    # comments on each PR in the given list of ids on the given repo with the
+    # contents of comment_file
+    return "".join(
+        run(
+            ["gh", "pr", "comment", str(pr), "-F", comment_file, "-R", repo],
+            stdout=PIPE,
+        ).stdout.decode("utf-8")
+        for pr in prs
+    )
+
+
+if __name__ == "__main__":
+    repo = argv[1]
+    comment_file = argv[2]
+    prs = format(fetch(repo))
+    response = input(
+        f"Comment on {len(prs)} pull requests to the {repo} repository with the contents of {comment_file}? [y/N] "
+    )
+    if response in ("y", "Y"):
+        comment(prs, repo, comment_file)

--- a/charts/consul/hack/mass-pr-commenter/comment.py
+++ b/charts/consul/hack/mass-pr-commenter/comment.py
@@ -1,7 +1,13 @@
 """Comment Script
 
 This script fetches all PRs on a given GitHub repository and adds a comment
-using the text in ./comment.md
+
+Expects 2 arguments, a repository as OWNER/REPOSITORY and the path to a text
+file which will be the content of the comments.
+
+```python
+python3 comment.py OWNER/REPOSITORY ./comment.md
+```
 """
 
 from json import loads
@@ -42,3 +48,4 @@ if __name__ == "__main__":
     )
     if response in ("y", "Y"):
         comment(prs, repo, comment_file)
+        print("Done")


### PR DESCRIPTION
Changes proposed in this PR:
- Adds a script for commenting on all open PRs to a repository

How I've tested this PR:

I ran the script against my own repository and it commented on all the open pull requests successfully. You can see the results here: https://github.com/hashicorp/issue-shepherd/pull/1

How I expect reviewers to test this PR:

You can also run the script against a sample repository.

