### PR TITLE
Re-enable psps in accceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,7 +611,6 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          failfast: true
           additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-pod-security-policies -enable-transparent-proxy
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,6 +611,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
+          failfast: true
           additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-pod-security-policies -enable-transparent-proxy
 
       - store_test_results:
@@ -880,6 +881,7 @@ workflows:
             - dev-upload-docker
             - unit-test-helm-templates
             - unit-acceptance-framework
+      - acceptance-gke-1-17
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -880,7 +880,6 @@ workflows:
             - dev-upload-docker
             - unit-test-helm-templates
             - unit-acceptance-framework
-      - acceptance-gke-1-17
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/charts/consul/test/acceptance/framework/consul/consul_cluster.go
+++ b/charts/consul/test/acceptance/framework/consul/consul_cluster.go
@@ -356,7 +356,7 @@ func configurePodSecurityPolicies(t *testing.T, client kubernetes.Interface, cfg
 					Name: "test-psp",
 				},
 				Spec: policyv1beta.PodSecurityPolicySpec{
-					Privileged:          false,
+					Privileged:          true,
 					AllowedCapabilities: []corev1.Capability{"NET_ADMIN"},
 					SELinux: policyv1beta.SELinuxStrategyOptions{
 						Rule: policyv1beta.SELinuxStrategyRunAsAny,

--- a/charts/consul/test/acceptance/framework/helpers/helpers.go
+++ b/charts/consul/test/acceptance/framework/helpers/helpers.go
@@ -37,7 +37,7 @@ func WaitForAllPodsToBeReady(t *testing.T, client kubernetes.Interface, namespac
 	// Wait up to 15m.
 	// On Azure, volume provisioning can sometimes take close to 5 min,
 	// so we need to give a bit more time for pods to become healthy.
-	counter := &retry.Counter{Count: 180, Wait: 5 * time.Second}
+	counter := &retry.Counter{Count: 180, Wait: 1 * time.Second}
 	retry.RunWith(counter, t, func(r *retry.R) {
 		pods, err := client.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: podLabelSelector})
 		require.NoError(r, err)

--- a/charts/consul/test/terraform/gke/main.tf
+++ b/charts/consul/test/terraform/gke/main.tf
@@ -26,7 +26,7 @@ resource "google_container_cluster" "cluster" {
   node_version       = data.google_container_engine_versions.main.latest_master_version
 
   pod_security_policy_config {
-    enabled = true # Helm does not currently work with pod security policies enabled, the acceptance tests fail with this enabled. Re-enable after fixing.
+    enabled = true
   }
 
   resource_labels = var.labels

--- a/charts/consul/test/terraform/gke/main.tf
+++ b/charts/consul/test/terraform/gke/main.tf
@@ -26,7 +26,7 @@ resource "google_container_cluster" "cluster" {
   node_version       = data.google_container_engine_versions.main.latest_master_version
 
   pod_security_policy_config {
-    enabled = false # Helm does not currently work with pod security policies enabled, the acceptance tests fail with this enabled. Re-enable after fixing.
+    enabled = true # Helm does not currently work with pod security policies enabled, the acceptance tests fail with this enabled. Re-enable after fixing.
   }
 
   resource_labels = var.labels


### PR DESCRIPTION
Changes proposed in this PR:
- Allow privileged containers in the test PSP used by services deployed in tests

How I've tested this PR:
Ran GKE tests [here](https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/2435/workflows/5cbda3ca-0ab4-40e0-96b0-0e725cfc76bb/jobs/14252)

How I expect reviewers to test this PR:
code review


