### PR TITLE
Add namespace to all templates

### DIFF
--- a/charts/consul/templates/client-podsecuritypolicy.yaml
+++ b/charts/consul/templates/client-podsecuritypolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-client
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/client-securitycontextconstraints.yaml
+++ b/charts/consul/templates/client-securitycontextconstraints.yaml
@@ -3,6 +3,7 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   name: {{ template "consul.fullname" . }}-client
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/client-snapshot-agent-podsecuritypolicy.yaml
+++ b/charts/consul/templates/client-snapshot-agent-podsecuritypolicy.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-snapshot-agent
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/connect-inject-leader-election-role.yaml
+++ b/charts/consul/templates/connect-inject-leader-election-role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-connect-inject-leader-election
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/connect-inject-leader-election-rolebinding.yaml
+++ b/charts/consul/templates/connect-inject-leader-election-rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-connect-inject-leader-election
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/connect-inject-podsecuritypolicy.yaml
+++ b/charts/consul/templates/connect-inject-podsecuritypolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector-webhook
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/controller-deployment.yaml
+++ b/charts/consul/templates/controller-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "consul.fullname" . }}-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/controller-leader-election-role.yaml
+++ b/charts/consul/templates/controller-leader-election-role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-controller-leader-election
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/controller-leader-election-rolebinding.yaml
+++ b/charts/consul/templates/controller-leader-election-rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-controller-leader-election
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/controller-mutatingwebhookconfiguration.yaml
+++ b/charts/consul/templates/controller-mutatingwebhookconfiguration.yaml
@@ -3,6 +3,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "consul.fullname" . }}-controller-mutating-webhook-configuration
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/controller-podsecuritypolicy.yaml
+++ b/charts/consul/templates/controller-podsecuritypolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/create-federation-secret-job.yaml
+++ b/charts/consul/templates/create-federation-secret-job.yaml
@@ -5,6 +5,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "consul.fullname" . }}-create-federation-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/create-federation-secret-podsecuritypolicy.yaml
+++ b/charts/consul/templates/create-federation-secret-podsecuritypolicy.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-create-federation-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/enterprise-license-job.yaml
+++ b/charts/consul/templates/enterprise-license-job.yaml
@@ -4,6 +4,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "consul.fullname" . }}-license
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{.Release.Service | quote }}
     app.kubernetes.io/instance: {{.Release.Name | quote }}

--- a/charts/consul/templates/enterprise-license-podsecuritypolicy.yaml
+++ b/charts/consul/templates/enterprise-license-podsecuritypolicy.yaml
@@ -5,6 +5,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-enterprise-license
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/ingress-gateways-podsecuritypolicy.yaml
+++ b/charts/consul/templates/ingress-gateways-podsecuritypolicy.yaml
@@ -5,6 +5,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" $root }}-{{ .name }}
+  namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
     chart: {{ template "consul.chart" $root }}

--- a/charts/consul/templates/mesh-gateway-podsecuritypolicy.yaml
+++ b/charts/consul/templates/mesh-gateway-podsecuritypolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-mesh-gateway
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-acl-init-cleanup-podsecuritypolicy.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-podsecuritypolicy.yaml
@@ -6,6 +6,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-acl-init-podsecuritypolicy.yaml
+++ b/charts/consul/templates/server-acl-init-podsecuritypolicy.yaml
@@ -6,6 +6,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-podsecuritypolicy.yaml
+++ b/charts/consul/templates/server-podsecuritypolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-server
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-securitycontextconstraints.yaml
+++ b/charts/consul/templates/server-securitycontextconstraints.yaml
@@ -3,6 +3,7 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   name: {{ template "consul.fullname" . }}-server
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/sync-catalog-podsecuritypolicy.yaml
+++ b/charts/consul/templates/sync-catalog-podsecuritypolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-sync-catalog
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/terminating-gateways-podsecuritypolicy.yaml
+++ b/charts/consul/templates/terminating-gateways-podsecuritypolicy.yaml
@@ -5,6 +5,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name:  {{ template "consul.fullname" $root }}-{{ .name }}
+  namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
     chart: {{ template "consul.chart" $root }}

--- a/charts/consul/templates/tls-init-cleanup-job.yaml
+++ b/charts/consul/templates/tls-init-cleanup-job.yaml
@@ -5,6 +5,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init-cleanup
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/tls-init-cleanup-podsecuritypolicy.yaml
+++ b/charts/consul/templates/tls-init-cleanup-podsecuritypolicy.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init-cleanup
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/tls-init-job.yaml
+++ b/charts/consul/templates/tls-init-job.yaml
@@ -6,6 +6,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/tls-init-podsecuritypolicy.yaml
+++ b/charts/consul/templates/tls-init-podsecuritypolicy.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/webhook-cert-manager-podsecuritypolicy.yaml
+++ b/charts/consul/templates/webhook-cert-manager-podsecuritypolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-webhook-cert-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/test/unit/helpers.bats
+++ b/charts/consul/test/unit/helpers.bats
@@ -105,6 +105,21 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# template namespace
+#
+# This test ensures that we set "namespace: " in every file. The exceptions are files with CRDs and clusterroles and
+# clusterrolebindings.
+#
+# If this test fails, you're likely missing setting the namespace.
+
+@test "helper/namespace: used everywhere" {
+  cd `chart_dir`
+  # Grep for files that don't have 'namespace: ' in them
+  local actual=$(grep -L 'namespace: ' templates/*.yaml | grep -v 'crd' | grep -v 'clusterrole' | tee /dev/stderr )
+  [ "${actual}" = '' ]
+}
+
+#--------------------------------------------------------------------
 # consul.getAutoEncryptClientCA
 # Similarly to consul.fullname tests, these tests use test-runner.yaml to test the
 # consul.getAutoEncryptClientCA helper since we need an existing template that calls


### PR DESCRIPTION
Changes proposed in this PR:
- Add namespace to all templates. We saw this error when deploying with the CLI to the `consul` namespace, and a few resources were getting created in `default`. This only occurs using the Helm Go SDK, not the Helm CLI.
- NOTE: The test is not a catch all. It only greps for "namespace: " in every file. This means, if that string exists anywhere in the file, it won't error out. We couldn't use `yq` because this is still templated yaml. It would catch a majority of cases. If you have suggestions for making this better please let me know!

How I've tested this PR:
acceptance and unit tests.

How I expect reviewers to test this PR:
review, make any suggestions to testing

Checklist:
- [x] Bats tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

