### PR TITLE
Change references of `master` to `main`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -887,7 +887,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - cleanup-gcp-resources
       - cleanup-azure-resources

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ To create a docker image with your local changes:
 $ make dev-docker
 ```
 
-### Rebasing contributions against master
+### Rebasing contributions against main
 
 PRs in this repo are merged using the [`rebase`](https://git-scm.com/docs/git-rebase) method. This keeps
 the git history clean by adding the PR commits to the most recent end of the commit history. It also has
@@ -62,7 +62,7 @@ git history based on when the commits were first created.
 If the changes in your PR do not conflict with any of the existing code in the project, then Github supports
 automatic rebasing when the PR is accepted into the code. However, if there are conflicts (there will be
 a warning on the PR that reads "This branch cannot be rebased due to conflicts"), you will need to manually
-rebase the branch on master, fixing any conflicts along the way before the code can be merged.
+rebase the branch on main, fixing any conflicts along the way before the code can be merged.
 
 ## Creating a new CRD
 

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -5,7 +5,7 @@ appVersion: 1.10.0
 kubeVersion: ">=1.17.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
-icon: https://raw.githubusercontent.com/hashicorp/consul-k8s/master/assets/icon.png
+icon: https://raw.githubusercontent.com/hashicorp/consul-k8s/main/assets/icon.png
 sources:
   - https://github.com/hashicorp/consul
   - https://github.com/hashicorp/consul-k8s

--- a/control-plane/Makefile
+++ b/control-plane/Makefile
@@ -115,7 +115,7 @@ ci.dev-docker:
 	@echo $(DOCKER_PASS) | docker login -u="$(DOCKER_USER)" --password-stdin
 	@echo "Pushing dev image to: https://cloud.docker.com/u/$(CI_DEV_DOCKER_NAMESPACE)/repository/docker/$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME)"
 	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT)
-ifeq ($(CIRCLE_BRANCH), master)
+ifeq ($(CIRCLE_BRANCH), main)
 	@docker tag $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT) $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
 	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
 endif

--- a/control-plane/build-support/functions/10-util.sh
+++ b/control-plane/build-support/functions/10-util.sh
@@ -558,7 +558,7 @@ function git_push_ref {
       local upstream=$(git_upstream "${sdir}") || return 1
 
       # upstream branch for this branch does not track the remote we need to push to
-      # basically this checks that the upstream (could be something like origin/master) references the correct remote
+      # basically this checks that the upstream (could be something like origin/main) references the correct remote
       # if it doesn't then the string modification wont apply and the var will reamin unchanged and equal to itself.
       if test "${upstream#${remote}/}" == "${upstream}"
       then


### PR DESCRIPTION
> 🚨 Do not merge until `master` is renamed to `main`

Changes proposed in this PR:
- All meaningful references to `master` have been changed to reference `main`
  I grepped for `master` in the repo and filtered out instances that did not refer to the repo itself (e.g. master token) or referred to other repositories. Then I replaced the remaining instances.

How I've tested this PR:  
This is a hard one to test. I'm very open to suggestions.


