### PR TITLE
Change references of consul-k8s to control-plane

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -45,7 +45,7 @@ global:
   image: "hashicorp/consul:1.10.0"
 
   # Array of objects containing image pull secret names that will be applied to each service account.
-  # This can be used to reference image pull secrets if using a custom consul or consul-k8s Docker image.
+  # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.
   # See https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry for reference.
   #
   # Example:
@@ -110,16 +110,16 @@ global:
 
   # Enables TLS (https://learn.hashicorp.com/tutorials/consul/tls-encryption-secure)
   # across the cluster to verify authenticity of the Consul servers and clients.
-  # Requires Consul v1.4.1+ and consul-k8s v0.16.2+
+  # Requires Consul v1.4.1+.
   tls:
     # If true, the Helm chart will enable TLS for Consul
-    # servers and clients and all consul-k8s components, as well as generate certificate
+    # servers and clients and all consul-k8s-control-plane components, as well as generate certificate
     # authority (optional) and server and client certificates.
     enabled: false
 
     # If true, turns on the auto-encrypt feature on clients and servers.
-    # It also switches consul-k8s components to retrieve the CA from the servers
-    # via the API. Requires Consul 1.7.1+ and consul-k8s 0.13.0
+    # It also switches consul-k8s-control-plane components to retrieve the CA from the servers
+    # via the API. Requires Consul 1.7.1+.
     enableAutoEncrypt: false
 
     # A list of additional DNS names to set as Subject Alternative Names (SANs)
@@ -183,7 +183,7 @@ global:
   # [Enterprise Only] `enableConsulNamespaces` indicates that you are running
   # Consul Enterprise v1.7+ with a valid Consul Enterprise license and would
   # like to make use of configuration beyond registering everything into
-  # the `default` Consul namespace. Requires consul-k8s v0.12+. Additional configuration
+  # the `default` Consul namespace. Additional configuration
   # options are found in the `consulNamespaces` section of both the catalog sync
   # and connect injector.
   enableConsulNamespaces: false
@@ -192,15 +192,14 @@ global:
   acls:
 
     # If true, the Helm chart will automatically manage ACL tokens and policies
-    # for all Consul and consul-k8s components.
-    # This requires Consul >= 1.4 and consul-k8s >= 0.14.0.
+    # for all Consul and consul-k8s-control-plane components.
+    # This requires Consul >= 1.4.
     manageSystemACLs: false
 
     # A Kubernetes secret containing the bootstrap token to use for
-    # creating policies and tokens for all Consul and consul-k8s components.
+    # creating policies and tokens for all Consul and consul-k8s-control-plane components.
     # If set, we will skip ACL bootstrapping of the servers and will only
-    # initialize ACLs for the Consul clients and consul-k8s system components.
-    # Requires consul-k8s >= 0.14.0.
+    # initialize ACLs for the Consul clients and consul-k8s-control-plane system components.
     bootstrapToken:
       # The name of the Kubernetes secret.
       secretName: null
@@ -213,14 +212,12 @@ global:
     # datacenter.
     # In secondary datacenters, the secret needs to be imported from the primary
     # datacenter and referenced via `global.acls.replicationToken`.
-    # Requires consul-k8s >= 0.13.0.
     createReplicationToken: false
 
     # replicationToken references a secret containing the replication ACL token.
     # This token will be used by secondary datacenters to perform ACL replication
     # and create ACL tokens and policies.
     # This value is ignored if `bootstrapToken` is also set.
-    # Requires consul-k8s >= 0.13.0.
     replicationToken:
       # The name of the Kubernetes secret.
       secretName: null
@@ -242,7 +239,7 @@ global:
     # and authenticate with this datacenter. This should only be set to true
     # in your primary datacenter. The secret name is
     # `<global.name>-federation` (if setting `global.name`), otherwise
-    # `<helm-release-name>-consul-federation`. Requires consul-k8s 0.15.0+.
+    # `<helm-release-name>-consul-federation`.
     createFederationSecret: false
 
   # Configures metrics for Consul service mesh
@@ -675,8 +672,8 @@ server:
 
 # Configuration for Consul servers when the servers are running outside of Kubernetes.
 # When running external servers, configuring these values is recommended
-# if setting `global.tls.enableAutoEncrypt` to true (requires consul-k8s >= 0.13.0)
-# or `global.acls.manageSystemACLs` to true (requires consul-k8s >= 0.14.0).
+# if setting `global.tls.enableAutoEncrypt` to true
+# or `global.acls.manageSystemACLs` to true.
 externalServers:
   # If true, the Helm chart will be configured to talk to the external servers.
   # If setting this to true, you must also set `server.enabled` to false.
@@ -700,10 +697,10 @@ externalServers:
   # @type: string
   tlsServerName: null
 
-  # If true, consul-k8s components will ignore the CA set in
+  # If true, consul-k8s-control-plane components will ignore the CA set in
   # `global.tls.caCert` when making HTTPS calls to Consul servers and
-  # will instead use the consul-k8s image's system CAs for TLS verification.
-  # If false, consul-k8s components will use `global.tls.caCert` when
+  # will instead use the consul-k8s-control-plane image's system CAs for TLS verification.
+  # If false, consul-k8s-control-plane components will use `global.tls.caCert` when
   # making HTTPS calls to Consul servers.
   # **NOTE:** This does not affect Consul's internal RPC communication which will
   # always use `global.tls.caCert`.
@@ -713,7 +710,6 @@ externalServers:
   # `connectInject.enabled` to true, set `k8sAuthMethodHost` to the address of the Kubernetes API server.
   # This address must be reachable from the Consul servers.
   # Please see the Kubernetes Auth Method documentation (https://consul.io/docs/acl/auth-methods/kubernetes).
-  # Requires consul-k8s >= 0.14.0.
   #
   # You could retrieve this value from your `kubeconfig` by running:
   #
@@ -1226,7 +1222,7 @@ syncCatalog:
   # global.enabled.
   enabled: false
 
-  # The name of the Docker image (including any tag) for consul-k8s
+  # The name of the Docker image (including any tag) for consul-k8s-control-plane
   # to run the sync program.
   # @type: string
   image: null
@@ -1266,14 +1262,12 @@ syncCatalog:
   # To deny all namespaces, set this to `[]`.
   #
   # Note: `k8sDenyNamespaces` takes precedence over values defined here.
-  # Requires consul-k8s v0.12+
   # @type: array<string>
   k8sAllowNamespaces: ["*"]
 
   # List of k8s namespaces that should not have their
   # services synced. This list takes precedence over `k8sAllowNamespaces`.
   # `*` is not supported because then nothing would be allowed to sync.
-  # Requires consul-k8s v0.12+.
   #
   # For example, if `k8sAllowNamespaces` is `["*"]` and `k8sDenyNamespaces` is
   # `["namespace1", "namespace2"]`, then all k8s namespaces besides `namespace1`
@@ -1291,7 +1285,7 @@ syncCatalog:
   k8sSourceNamespace: null
 
   # [Enterprise Only] These settings manage the catalog sync's interaction with
-  # Consul namespaces (requires consul-ent v1.7+ and consul-k8s v0.12+).
+  # Consul namespaces (requires consul-ent v1.7+).
   # Also, `global.enableConsulNamespaces` must be true.
   consulNamespaces:
     # Name of the Consul namespace to register all
@@ -1447,7 +1441,7 @@ connectInject:
   # The number of deployment replicas.
   replicas: 2
 
-  # Image for consul-k8s that contains the injector
+  # Image for consul-k8s-control-plane that contains the injector.
   # @type: string
   image: null
 
@@ -1459,7 +1453,7 @@ connectInject:
   default: false
 
   # Configures Transparent Proxy for Consul Service mesh services.
-  # Using this feature requires Consul 1.10.0-beta1+ and consul-k8s 0.26.0-beta1+.
+  # Using this feature requires Consul 1.10.0-beta1+.
   transparentProxy:
     # If true, then all Consul Service mesh will run with transparent proxy enabled by default,
     # i.e. we enforce that all traffic within the pod will go through the proxy.
@@ -1591,7 +1585,6 @@ connectInject:
   # Note: `k8sDenyNamespaces` takes precedence over values defined here and
   # `namespaceSelector` takes precedence over both since it is applied first.
   # `kube-system` and `kube-public` are never injected, even if included here.
-  # Requires consul-k8s v0.12+
   # @type: array<string>
   k8sAllowNamespaces: ["*"]
 
@@ -1605,12 +1598,11 @@ connectInject:
   #
   # Note: `namespaceSelector` takes precedence over this since it is applied first.
   # `kube-system` and `kube-public` are never injected.
-  # Requires consul-k8s v0.12+.
   # @type: array<string>
   k8sDenyNamespaces: []
 
   # [Enterprise Only] These settings manage the connect injector's interaction with
-  # Consul namespaces (requires consul-ent v1.7+ and consul-k8s v0.12+).
+  # Consul namespaces (requires consul-ent v1.7+).
   # Also, `global.enableConsulNamespaces` must be true.
   consulNamespaces:
     # Name of the Consul namespace to register all
@@ -1664,7 +1656,7 @@ connectInject:
   # See https://www.consul.io/docs/acl/acl-auth-methods.html#binding-rules
   # and https://www.consul.io/docs/acl/auth-methods/kubernetes.html#trusted-identity-attributes
   # for more details.
-  # Requires Consul >= v1.5 and consul-k8s >= v0.8.0.
+  # Requires Consul >= v1.5.
   aclBindingRuleSelector: "serviceaccount.name!=default"
 
   # If you are not using global.acls.manageSystemACLs and instead manually setting up an
@@ -1805,7 +1797,7 @@ meshGateway:
   # If mesh gateways are enabled, a Deployment will be created that runs
   # gateways and Consul Connect will be configured to use gateways.
   # See https://www.consul.io/docs/connect/mesh_gateway.html
-  # Requirements: consul 1.6.0+ and consul-k8s 0.15.0+ if using
+  # Requirements: consul 1.6.0+ if using
   # global.acls.manageSystemACLs.
   enabled: false
 
@@ -1989,8 +1981,7 @@ meshGateway:
 # specific gateway with the exception of annotations. Annotations will
 # include both the default annotations and any additional ones defined
 # for a specific gateway.
-# Requirements: consul >= 1.8.0 and consul-k8s >= 0.16.0 if using
-# global.acls.manageSystemACLs and consul-k8s >= 0.10.0 if not.
+# Requirements: consul >= 1.8.0
 ingressGateways:
   # Enable ingress gateway deployment. Requires `connectInject.enabled=true`
   # and `client.enabled=true`.
@@ -2136,8 +2127,7 @@ ingressGateways:
 # specific gateway with the exception of annotations. Annotations will
 # include both the default annotations and any additional ones defined
 # for a specific gateway.
-# Requirements: consul >= 1.8.0 and consul-k8s >= 0.16.0 if using
-# global.acls.manageSystemACLs and consul-k8s >= 0.10.0 if not.
+# Requirements: consul >= 1.8.0
 terminatingGateways:
   # Enable terminating gateway deployment. Requires `connectInject.enabled=true`
   # and `client.enabled=true`.


### PR DESCRIPTION
Removed references to versions of consul-k8s since new expectation is that if you're reading the values docs then your'e on the latest version.