### PR TITLE
Update Envoy image to 1.18.4

### DIFF
--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -17,7 +17,7 @@ annotations:
     - name: consul-k8s-control-plane
       image: hashicorp/consul-k8s-control-plane:0.33.0
     - name: envoy
-      image: envoyproxy/envoy-alpine:v1.18.3
+      image: envoyproxy/envoy-alpine:v1.18.4
   artifacthub.io/license: MPL-2.0
   artifacthub.io/links: |
     - name: Documentation

--- a/charts/consul/test/unit/ingress-gateways-deployment.bats
+++ b/charts/consul/test/unit/ingress-gateways-deployment.bats
@@ -83,7 +83,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "envoyproxy/envoy-alpine:v1.18.3" ]
+  [ "${actual}" = "envoyproxy/envoy-alpine:v1.18.4" ]
 }
 
 @test "ingressGateways/Deployment: envoy image can be set using the global value" {

--- a/charts/consul/test/unit/mesh-gateway-deployment.bats
+++ b/charts/consul/test/unit/mesh-gateway-deployment.bats
@@ -335,7 +335,7 @@ key2: value2' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "envoyproxy/envoy-alpine:v1.18.3" ]
+  [ "${actual}" = "envoyproxy/envoy-alpine:v1.18.4" ]
 }
 
 @test "meshGateway/Deployment: setting meshGateway.imageEnvoy fails" {

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -83,7 +83,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "envoyproxy/envoy-alpine:v1.18.3" ]
+  [ "${actual}" = "envoyproxy/envoy-alpine:v1.18.4" ]
 }
 
 @test "terminatingGateways/Deployment: envoy image can be set using the global value" {

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -285,7 +285,7 @@ global:
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
   # See https://www.consul.io/docs/connect/proxies/envoy for full compatibility matrix between Consul and Envoy.
   # @default: envoyproxy/envoy-alpine:<latest supported version>
-  imageEnvoy: "envoyproxy/envoy-alpine:v1.18.3"
+  imageEnvoy: "envoyproxy/envoy-alpine:v1.18.4"
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.


### PR DESCRIPTION
Envoy 1.18.3 has a security vulnerability outlined in this advisory:
https://github.com/envoyproxy/envoy/security/advisories/GHSA-6g4j-5vrw-2m8h

This PR updates the Envoy image version.

----

Depends on: https://github.com/hashicorp/consul/pull/10961
