### PR TITLE
Add startup probe to connect inject deployment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ IMPROVEMENTS:
 * Helm Chart
   * Add ability to specify port for ui service. [[GH-604](https://github.com/hashicorp/consul-k8s/pull/604)]
   * Use `policy/v1` for Consul server `PodDisruptionBudget` if supported. [[GH-606](https://github.com/hashicorp/consul-k8s/pull/606)]
-  * Added readiness and liveness checks to the connect inject deployment. [[GH-626](https://github.com/hashicorp/consul-k8s/pull/626)]
+  * Added readiness, liveness and startup probes to the connect inject deployment. [[GH-626](https://github.com/hashicorp/consul-k8s/pull/626)][[GH-701](https://github.com/hashicorp/consul-k8s/pull/701)]
   * Add support for setting container security contexts on client and server Pods. [[GH-620](https://github.com/hashicorp/consul-k8s/pull/620)]
 * Control Plane
   * Added health endpoint to the connect inject webhook that will be healthy when webhook certs are present and not empty. [[GH-626](https://github.com/hashicorp/consul-k8s/pull/626)]

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -193,6 +193,14 @@ spec:
                 -consul-sidecar-cpu-request={{ $consulSidecarResources.requests.cpu }} \
                 {{- end }}
                 {{- end }}
+          startupProbe:
+            httpGet:
+              path: /readyz/ready
+              port: 9445
+              scheme: HTTP
+            failureThreshold: 15
+            periodSeconds: 2
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /readyz/ready
@@ -200,7 +208,6 @@ spec:
               scheme: HTTP
             failureThreshold: 2
             initialDelaySeconds: 1
-            periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5
           readinessProbe:
@@ -210,7 +217,6 @@ spec:
               scheme: HTTP
             failureThreshold: 2
             initialDelaySeconds: 2
-            periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5
           volumeMounts:


### PR DESCRIPTION
We did so in https://github.com/hashicorp/consul-helm/pull/885, but it never got released.
This adds the same probe now that we have a health endpoint in the webhook.

This also changes the periodSeconds for the liveness and readiness probes
to use the default of 10s instead of 2s we used previously.
That is because now with the startup probe in place,
we don't need to check for certs being present that frequently.

How I've tested this PR:
- acceptance tests

How I expect reviewers to test this PR:
- code review

Checklist:
- [n/a] Tests added
- [x] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

