### PR TITLE
Update AKS version in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -934,7 +934,6 @@ workflows:
             - dev-upload-docker
             - unit-test-helm-templates
             - unit-acceptance-framework
-      - acceptance-aks-1-19
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -934,6 +934,7 @@ workflows:
             - dev-upload-docker
             - unit-test-helm-templates
             - unit-acceptance-framework
+      - acceptance-aks-1-19
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/charts/consul/test/terraform/aks/main.tf
+++ b/charts/consul/test/terraform/aks/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   location            = azurerm_resource_group.default[count.index].location
   resource_group_name = azurerm_resource_group.default[count.index].name
   dns_prefix          = "consul-k8s-${random_id.suffix[count.index].dec}"
-  kubernetes_version  = "1.19.9"
+  kubernetes_version  = "1.19.13"
 
   default_node_pool {
     name            = "default"


### PR DESCRIPTION
Changes proposed in this PR:
- 1.19.9 is no longer supported; switch to the latest supported 1.19.x which is 1.19.13

How I've tested this PR:
[acceptance tests](https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/2507/workflows/fc68f21e-be84-4691-b56d-56743ec20416/jobs/15210)

How I expect reviewers to test this PR:
code review

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

