### PR TITLE
values.yaml: Make it more clear how to utilize connectInject.namespaceSelector

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1556,8 +1556,8 @@ connectInject:
   # This setting can be safely disabled by setting to "Ignore".
   failurePolicy: "Fail"
 
-  # Selector for restricting the webhook to only
-  # specific namespaces. This should be set to a multiline string.
+  # Selector for restricting the webhook to only specific namespaces. 
+  # Use with `connectInject.default` to enable/disable connectInject by default via the selector. This should be set to a multiline string.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
   # for more details.
   #

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1557,7 +1557,7 @@ connectInject:
   failurePolicy: "Fail"
 
   # Selector for restricting the webhook to only specific namespaces. 
-  # Use with `connectInject.default` to enable/disable connectInject by default via the selector. This should be set to a multiline string.
+  # Use with `connectInject.default: true` to automatically inject all pods in namespaces that match the selector. This should be set to a multiline string.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
   # for more details.
   #


### PR DESCRIPTION
Describe that `connectInject.default` should be used if trying to enable/disable `connectInject` by default. Addresses: https://github.com/hashicorp/consul-k8s/issues/698

Changes proposed in this PR:
- Comment to describe you should use namespaceSelector with `connectInject.default

How I've tested this PR:

```
❯ cat config.yaml
global:
  name: consul
  datacenter: dc1
  tls:
    enabled: true
server:
  replicas: 1
ui:
  enabled: true
meshGateway:
  enabled: true
  replicas: 1
connectInject:
  enabled: true
  default: true
  namespaceSelector: |
    matchLabels:
      connect-inject : enabled
controller:
  enabled: true

❯ kubectl describe ns foo
Name:         foo
Labels:       connect-inject=enabled
Annotations:  <none>
Status:       Active

Resource Quotas
 Name:                              gke-resource-quotas
 Resource                           Used  Hard
 --------                           ---   ---
 count/ingresses.extensions         0     100
 count/ingresses.networking.k8s.io  0     100
 count/jobs.batch                   0     5k
 pods                               2     1500
 services                           2     500

No LimitRange resource.

❯ kubectl get pods -n foo
NAME                        READY   STATUS    RESTARTS   AG
tcp-echo-866d7f8dcb-wxqnt   2/2     Running   0          70s

❯ kubectl get pods -n bar
NAME                        READY   STATUS    RESTARTS   AGE
tcp-echo-866d7f8dcb-n7j8s   1/1     Running   0          59s

```

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

