### PR TITLE
Disable openshift tests until we can use UBI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -946,9 +946,10 @@ workflows:
       - cleanup-gcp-resources
       - cleanup-azure-resources
       - cleanup-eks-resources
-      - acceptance-openshift:
-          requires:
-          - cleanup-azure-resources
+# Disable until we can use UBI images.
+#      - acceptance-openshift:
+#          requires:
+#          - cleanup-azure-resources
       - acceptance-gke-1-17:
           requires:
             - cleanup-gcp-resources


### PR DESCRIPTION
Changes proposed in this PR:
Currently, all tests fail because the user is not allowed to `mkdir /consul/extra-config` ([link](https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/2503/workflows/2bf83d1d-baf1-4024-907a-7d2385dd08bc/jobs/15161)) in the consul server and client pods. We need to wait for UBI images as that problem is fixed in that docker image.


How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

