### PR TITLE
Use command struct ctx in server-acl-init

### DIFF
--- a/control-plane/subcommand/server-acl-init/command_test.go
+++ b/control-plane/subcommand/server-acl-init/command_test.go
@@ -1448,8 +1448,8 @@ func TestConsulDatacenterList(t *testing.T) {
 			require.NoError(t, err)
 
 			command := Command{
-				log:        hclog.New(hclog.DefaultOptions),
-				cmdTimeout: context.Background(),
+				log: hclog.New(hclog.DefaultOptions),
+				ctx: context.Background(),
 			}
 			actDC, actPrimaryDC, err := command.consulDatacenterList(consulClient)
 			if c.expErr != "" {

--- a/control-plane/subcommand/server-acl-init/connect_inject.go
+++ b/control-plane/subcommand/server-acl-init/connect_inject.go
@@ -1,7 +1,6 @@
 package serveraclinit
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -144,7 +143,7 @@ func (c *Command) createAuthMethodTmpl(authMethodName string) (api.ACLAuthMethod
 	err := c.untilSucceeds(fmt.Sprintf("getting %s ServiceAccount", saName),
 		func() error {
 			var err error
-			authMethodServiceAccount, err = c.clientset.CoreV1().ServiceAccounts(c.flagK8sNamespace).Get(context.TODO(), saName, metav1.GetOptions{})
+			authMethodServiceAccount, err = c.clientset.CoreV1().ServiceAccounts(c.flagK8sNamespace).Get(c.ctx, saName, metav1.GetOptions{})
 			return err
 		})
 	if err != nil {
@@ -161,7 +160,7 @@ func (c *Command) createAuthMethodTmpl(authMethodName string) (api.ACLAuthMethod
 		err = c.untilSucceeds(fmt.Sprintf("getting %s Secret", secretRef.Name),
 			func() error {
 				var err error
-				secret, err = c.clientset.CoreV1().Secrets(c.flagK8sNamespace).Get(context.TODO(), secretRef.Name, metav1.GetOptions{})
+				secret, err = c.clientset.CoreV1().Secrets(c.flagK8sNamespace).Get(c.ctx, secretRef.Name, metav1.GetOptions{})
 				return err
 			})
 		if secret != nil && secret.Type == apiv1.SecretTypeServiceAccountToken {

--- a/control-plane/subcommand/server-acl-init/connect_inject_test.go
+++ b/control-plane/subcommand/server-acl-init/connect_inject_test.go
@@ -19,23 +19,24 @@ import (
 // Also note that the remainder of this function is tested in the command_test.go.
 func TestCommand_createAuthMethodTmpl_SecretNotFound(t *testing.T) {
 	k8s := fake.NewSimpleClientset()
+	ctx := context.Background()
 
 	cmd := &Command{
 		flagK8sNamespace:   ns,
 		flagResourcePrefix: resourcePrefix,
 		clientset:          k8s,
 		log:                hclog.New(nil),
-		cmdTimeout:         context.TODO(),
+		cmdTimeout:         ctx,
 	}
 
 	serviceAccountName := resourcePrefix + "-connect-injector-authmethod-svc-account"
 	secretName := resourcePrefix + "-connect-injector-authmethod-svc-account"
 
 	// Create a service account referencing secretName
-	sa, _ := k8s.CoreV1().ServiceAccounts(ns).Get(context.Background(), serviceAccountName, metav1.GetOptions{})
+	sa, _ := k8s.CoreV1().ServiceAccounts(ns).Get(ctx, serviceAccountName, metav1.GetOptions{})
 	if sa == nil {
 		_, err := k8s.CoreV1().ServiceAccounts(ns).Create(
-			context.Background(),
+			ctx,
 			&v1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: serviceAccountName,
@@ -58,7 +59,7 @@ func TestCommand_createAuthMethodTmpl_SecretNotFound(t *testing.T) {
 		Data: map[string][]byte{},
 		Type: v1.SecretTypeOpaque,
 	}
-	_, err := k8s.CoreV1().Secrets(ns).Create(context.TODO(), secret, metav1.CreateOptions{})
+	_, err := k8s.CoreV1().Secrets(ns).Create(ctx, secret, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	_, err = cmd.createAuthMethodTmpl("test")

--- a/control-plane/subcommand/server-acl-init/connect_inject_test.go
+++ b/control-plane/subcommand/server-acl-init/connect_inject_test.go
@@ -26,7 +26,7 @@ func TestCommand_createAuthMethodTmpl_SecretNotFound(t *testing.T) {
 		flagResourcePrefix: resourcePrefix,
 		clientset:          k8s,
 		log:                hclog.New(nil),
-		cmdTimeout:         ctx,
+		ctx:                ctx,
 	}
 
 	serviceAccountName := resourcePrefix + "-connect-injector-authmethod-svc-account"

--- a/control-plane/subcommand/server-acl-init/create_or_update.go
+++ b/control-plane/subcommand/server-acl-init/create_or_update.go
@@ -1,7 +1,6 @@
 package serveraclinit
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -57,7 +56,7 @@ func (c *Command) createACL(name, rules string, localToken bool, dc string, isPr
 	// Check if the secret already exists, if so, we assume the ACL has already been
 	// created and return.
 	secretName := c.withPrefix(name + "-acl-token")
-	_, err = c.clientset.CoreV1().Secrets(c.flagK8sNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	_, err = c.clientset.CoreV1().Secrets(c.flagK8sNamespace).Get(c.ctx, secretName, metav1.GetOptions{})
 	if err == nil {
 		c.log.Info(fmt.Sprintf("Secret %q already exists", secretName))
 		return nil
@@ -93,7 +92,7 @@ func (c *Command) createACL(name, rules string, localToken bool, dc string, isPr
 					common.ACLTokenSecretKey: []byte(token),
 				},
 			}
-			_, err := c.clientset.CoreV1().Secrets(c.flagK8sNamespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+			_, err := c.clientset.CoreV1().Secrets(c.flagK8sNamespace).Create(c.ctx, secret, metav1.CreateOptions{})
 			return err
 		})
 }

--- a/control-plane/subcommand/server-acl-init/servers.go
+++ b/control-plane/subcommand/server-acl-init/servers.go
@@ -1,7 +1,6 @@
 package serveraclinit
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -73,7 +72,7 @@ func (c *Command) bootstrapServers(serverAddresses []string, bootTokenSecretName
 					common.ACLTokenSecretKey: bootstrapToken,
 				},
 			}
-			_, err := c.clientset.CoreV1().Secrets(c.flagK8sNamespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+			_, err := c.clientset.CoreV1().Secrets(c.flagK8sNamespace).Create(c.ctx, secret, metav1.CreateOptions{})
 			return err
 		})
 	if err != nil {


### PR DESCRIPTION
## Commits

- Change to single `ctx` in `connect_inject_test`
- Use `ctx` from command struct

## Changes proposed in this PR:

- Instead of using `context.TODO()` throughout the `server-acl-init` package, use the `ctx` (previously called `cmdTimeout`) which is created within the `Run` function.

## How I've tested this PR:

I still see test failures when I run this locally. I think I have something configured improperly or am missing a dependency. I'll sync up with @lkysow tomorrow and figure it out.

## How I expect reviewers to test this PR:

Check that the rename of `cmdTimeout` to `ctx` doesn't break anything. I think it should be ok. Also just run the tests for `control-plane` 🤷 .