### PR TITLE
Add present tense note to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,5 +9,7 @@ How I expect reviewers to test this PR:
 
 Checklist:
 - [ ] Tests added
-- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)
+- [ ] CHANGELOG entry added 
+  > HashiCorp engineers only, community PRs should not add a changelog entry.
+  > Entries should use present tense (e.g. Adds support for...)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,5 +11,5 @@ Checklist:
 - [ ] Tests added
 - [ ] CHANGELOG entry added 
   > HashiCorp engineers only, community PRs should not add a changelog entry.
-  > Entries should use present tense (e.g. Adds support for...)
+  > Entries should use present tense (e.g. Add support for...)
 


### PR DESCRIPTION
Changes proposed in this PR:
- Add note to use present tense in the changelog entries

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Adds support for...)

