### PR TITLE
Use root context in sync-catalog to-k8s

### DIFF
--- a/control-plane/catalog/to-k8s/sink.go
+++ b/control-plane/catalog/to-k8s/sink.go
@@ -38,7 +38,7 @@ type Sink interface {
 
 // K8SSink is a Sink implementation that registers services with Kubernetes.
 //
-// K8SSink also implements controller.Resource and is meant to run as a K8S
+// K8SSink also implements controller. Resource and is meant to run as a K8S
 // controller that watches services. This is the primary way that the
 // sink should be run.
 type K8SSink struct {
@@ -50,6 +50,9 @@ type K8SSink struct {
 	// services in Kubernetes. This can be fairly short since no work will be
 	// done if there are no changes.
 	SyncPeriod time.Duration
+
+	// Ctx is used to cancel the Sink
+	Ctx context.Context
 
 	// lock gates concurrent access to all the maps.
 	lock sync.Mutex
@@ -105,11 +108,11 @@ func (s *K8SSink) Informer() cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return s.Client.CoreV1().Services(s.namespace()).List(context.TODO(), options)
+				return s.Client.CoreV1().Services(s.namespace()).List(s.Ctx, options)
 			},
 
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return s.Client.CoreV1().Services(s.namespace()).Watch(context.TODO(), options)
+				return s.Client.CoreV1().Services(s.namespace()).Watch(s.Ctx, options)
 			},
 		},
 		&apiv1.Service{},
@@ -207,7 +210,7 @@ func (s *K8SSink) Run(ch <-chan struct{}) {
 			return
 		case <-triggerCh:
 			// Coalesce to prevent lots of API calls during churn periods.
-			coalesce.Coalesce(context.TODO(),
+			coalesce.Coalesce(s.Ctx,
 				K8SQuietPeriod, K8SMaxPeriod,
 				func(ctx context.Context) {
 					select {
@@ -224,20 +227,20 @@ func (s *K8SSink) Run(ch <-chan struct{}) {
 
 		svcClient := s.Client.CoreV1().Services(s.namespace())
 		for _, name := range delete {
-			if err := svcClient.Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
+			if err := svcClient.Delete(s.Ctx, name, metav1.DeleteOptions{}); err != nil {
 				s.Log.Warn("error deleting service", "name", name, "error", err)
 			}
 		}
 
 		for _, svc := range update {
-			_, err := svcClient.Update(context.TODO(), svc, metav1.UpdateOptions{})
+			_, err := svcClient.Update(s.Ctx, svc, metav1.UpdateOptions{})
 			if err != nil {
 				s.Log.Warn("error updating service", "name", svc.Name, "error", err)
 			}
 		}
 
 		for _, svc := range create {
-			_, err := svcClient.Create(context.TODO(), svc, metav1.CreateOptions{})
+			_, err := svcClient.Create(s.Ctx, svc, metav1.CreateOptions{})
 			if err != nil {
 				s.Log.Warn("error creating service", "name", svc.Name, "error", err)
 			}

--- a/control-plane/catalog/to-k8s/sink.go
+++ b/control-plane/catalog/to-k8s/sink.go
@@ -38,7 +38,7 @@ type Sink interface {
 
 // K8SSink is a Sink implementation that registers services with Kubernetes.
 //
-// K8SSink also implements controller. Resource and is meant to run as a K8S
+// K8SSink also implements controller.Resource and is meant to run as a K8S
 // controller that watches services. This is the primary way that the
 // sink should be run.
 type K8SSink struct {
@@ -51,7 +51,7 @@ type K8SSink struct {
 	// done if there are no changes.
 	SyncPeriod time.Duration
 
-	// Ctx is used to cancel the Sink
+	// Ctx is used to cancel the Sink.
 	Ctx context.Context
 
 	// lock gates concurrent access to all the maps.

--- a/control-plane/catalog/to-k8s/sink_test.go
+++ b/control-plane/catalog/to-k8s/sink_test.go
@@ -398,6 +398,7 @@ func testSink(t *testing.T, client kubernetes.Interface) (*K8SSink, func()) {
 	sink := &K8SSink{
 		Client: client,
 		Log:    hclog.Default(),
+		Ctx:    context.Background(),
 	}
 
 	closer := controller.TestControllerRun(sink)

--- a/control-plane/subcommand/sync-catalog/command.go
+++ b/control-plane/subcommand/sync-catalog/command.go
@@ -293,6 +293,7 @@ func (c *Command) Run(args []string) int {
 			Client:    c.clientset,
 			Namespace: c.flagK8SWriteNamespace,
 			Log:       c.logger.Named("to-k8s/sink"),
+			Ctx:       ctx,
 		}
 
 		source := &catalogtok8s.Source{


### PR DESCRIPTION
Changes proposed in this PR:
- Add a context to the `K8SSink` struct
- Use the context in the struct for processes spawned by `K8SSink`
- Update tests on `K8SSink` to pass in a `context.Background()`
- Update the `sync-catalog` command which instantiates and uses `K8SSink` to pass in the `ctx` created when in its `Run` function

How I've tested this PR:

I ran the unit tests for the `catalog` and `sync-catalog` packages. They passed :).

How I expect reviewers to test this PR:

Unit tests

Checklist:
- [x] Tests added (modified)
- [-] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

