### PR TITLE
Add config for `webhook-cert-manager` tolerations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ IMPROVEMENTS:
   * Add readiness, liveness and startup probes to the connect inject deployment. [[GH-626](https://github.com/hashicorp/consul-k8s/pull/626)][[GH-701](https://github.com/hashicorp/consul-k8s/pull/701)]
   * Add support for setting container security contexts on client and server Pods. [[GH-620](https://github.com/hashicorp/consul-k8s/pull/620)]
   * Update Envoy image to 1.18.4 [[GH-699](https://github.com/hashicorp/consul-k8s/pull/699)]
+  * Add configuration for webhook-cert-manager tolerations [[GH-XXX]]()
 * Control Plane
   * Add health endpoint to the connect inject webhook that will be healthy when webhook certs are present and not empty. [[GH-626](https://github.com/hashicorp/consul-k8s/pull/626)]
   * Catalog Sync: Fix issue registering NodePort services with wrong IPs when a node has multiple IP addresses. [[GH-619](https://github.com/hashicorp/consul-k8s/pull/619)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ IMPROVEMENTS:
   * Add readiness, liveness and startup probes to the connect inject deployment. [[GH-626](https://github.com/hashicorp/consul-k8s/pull/626)][[GH-701](https://github.com/hashicorp/consul-k8s/pull/701)]
   * Add support for setting container security contexts on client and server Pods. [[GH-620](https://github.com/hashicorp/consul-k8s/pull/620)]
   * Update Envoy image to 1.18.4 [[GH-699](https://github.com/hashicorp/consul-k8s/pull/699)]
-  * Add configuration for webhook-cert-manager tolerations [[GH-XXX]]()
+  * Add configuration for webhook-cert-manager tolerations [[GH-712](https://github.com/hashicorp/consul-k8s/pull/712)]
 * Control Plane
   * Add health endpoint to the connect inject webhook that will be healthy when webhook certs are present and not empty. [[GH-626](https://github.com/hashicorp/consul-k8s/pull/626)]
   * Catalog Sync: Fix issue registering NodePort services with wrong IPs when a node has multiple IP addresses. [[GH-619](https://github.com/hashicorp/consul-k8s/pull/619)]

--- a/charts/consul/templates/webhook-cert-manager-deployment.yaml
+++ b/charts/consul/templates/webhook-cert-manager-deployment.yaml
@@ -60,4 +60,9 @@ spec:
       - name: config
         configMap:
           name: {{ template "consul.fullname" . }}-webhook-cert-manager-config
+      {{- if .Values.webhookCertManager.tolerations }}
+      tolerations:
+        {{ tpl .Values.webhookCertManager.tolerations . | indent 8 | trim }}
+      {{- end}}
+
 {{- end }}

--- a/charts/consul/test/unit/webhook-cert-manager-deployment.bats
+++ b/charts/consul/test/unit/webhook-cert-manager-deployment.bats
@@ -39,3 +39,26 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "webhookCertManager/Deployment: no tolerations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-deployment.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.tolerations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "webhookCertManager/Deployment: tolerations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-deployment.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'webhookCertManager.tolerations=- key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.tolerations[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2246,7 +2246,7 @@ terminatingGateways:
     - name: terminating-gateway
 
 # Configuration settings for the webhook-cert-manager
-# webhook-cert-manager ensures that cert bundles are up to date for mutating webhooks
+# `webhook-cert-manager` ensures that cert bundles are up to date for the mutating webhook.
 webhookCertManager:
 
   # Toleration Settings

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2246,6 +2246,7 @@ terminatingGateways:
     - name: terminating-gateway
 
 # Configuration settings for the webhook-cert-manager
+# webhook-cert-manager ensures that cert bundles are up to date for mutating webhooks
 webhookCertManager:
 
   # Toleration Settings

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2245,6 +2245,15 @@ terminatingGateways:
   gateways:
     - name: terminating-gateway
 
+# Configuration settings for the webhook-cert-manager
+webhookCertManager:
+
+  # Toleration Settings
+  # This should be a multi-line string matching the Toleration array
+  # in a PodSpec.
+  # @type: string
+  tolerations: null
+
 # Configures a demo Prometheus installation.
 prometheus:
   # When true, the Helm chart will install a demo Prometheus server instance


### PR DESCRIPTION
Changes proposed in this PR:
- Add configuration for the webhook-cert-manager deployment tolerations

This work closes issue #655 where the user was running Consul on a private cluster in GKE.

How I've tested this PR:
Added bats and manually produced the deployment YAML using helm.

How I expect reviewers to test this PR:
Run bats

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

