### PR TITLE
Proof of Concept: Autogeneration of Gossip Encryption Key

### DIFF
--- a/charts/consul/templates/autogen-encryption-job.yaml
+++ b/charts/consul/templates/autogen-encryption-job.yaml
@@ -1,0 +1,65 @@
+{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if (and .Values.global.tls.enabled (not .Values.server.serverCert.secretName)) }}
+# autogenerate encryption key for gossip protocol and save in Kubernetes secrets
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "consul.fullname" . }}-autogen-encryption
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy":  hook-succeeded,before-hook-creation
+spec:
+  template:
+    metadata:
+      name: {{ template "consul.fullname" . }}-autogen-encryption
+      labels:
+        app: {{ template "consul.name" . }}
+        chart: {{ template "consul.chart" . }}
+        release: {{ .Release.Name }}
+        component: autogen-encryption
+# NOTE: unsure if I should delete this annotation
+      annotations:
+        "consul.hashicorp.com/connect-inject": "false"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ template "consul.fullname" . }}-autogen-encryption
+      {{- if (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey) }}
+# NOTE: are there any volumes I will need? 
+      {{- end }}
+      containers:
+        - name: autogen-encryption
+          image: "{{ .Values.global.imageK8S }}"
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          workingDir: /tmp
+          command:
+            - "/bin/sh"
+            - "-ec"
+# NOTE: this should generate the key using Consul and then use curl to add it to K8s
+            - |
+              key=$(consul keygen) # TODO: get consul into this container
+              echo $key > key.txt
+# TODO: yeet this into k8s with curl
+          {{- if (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey) }}
+# NOTE: are there any volumeMounts I will need? 
+          {{- end }}
+# NOTE: no idea what resources I will need from the node. This is just copied from ./tls-init-job.yaml
+          resources:
+            requests:
+              memory: "50Mi"
+              cpu: "50m"
+            limits:
+              memory: "50Mi"
+              cpu: "50m"
+{{- end }}
+{{- end }}

--- a/charts/consul/templates/autogen-encryption-job.yaml
+++ b/charts/consul/templates/autogen-encryption-job.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.global.gossipEncryption.autogenerate }}
-# autogenerate encryption key for gossip protocol and save in Kubernetes secrets
+{{- if .Values.global.gossipEncryption.autoGenerate }}
+# automatically generate encryption key for gossip protocol and save in Kubernetes secrets
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/consul/templates/autogen-encryption-job.yaml
+++ b/charts/consul/templates/autogen-encryption-job.yaml
@@ -1,5 +1,4 @@
-{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and .Values.global.tls.enabled (not .Values.server.serverCert.secretName)) }}
+{{- if (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey .Values.global.gossipEncryption.autogenerate) }}
 # autogenerate encryption key for gossip protocol and save in Kubernetes secrets
 apiVersion: batch/v1
 kind: Job
@@ -61,5 +60,4 @@ spec:
             limits:
               memory: "50Mi"
               cpu: "50m"
-{{- end }}
 {{- end }}

--- a/charts/consul/templates/autogen-encryption-job.yaml
+++ b/charts/consul/templates/autogen-encryption-job.yaml
@@ -1,4 +1,4 @@
-{{- if (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey .Values.global.gossipEncryption.autogenerate) }}
+{{- if .Values.global.gossipEncryption.autogenerate }}
 # autogenerate encryption key for gossip protocol and save in Kubernetes secrets
 apiVersion: batch/v1
 kind: Job
@@ -23,18 +23,14 @@ spec:
         chart: {{ template "consul.chart" . }}
         release: {{ .Release.Name }}
         component: autogen-encryption
-# NOTE: unsure if I should delete this annotation
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-autogen-encryption
-      {{- if (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey) }}
-# NOTE: are there any volumes I will need? 
-      {{- end }}
       containers:
         - name: autogen-encryption
-          image: "{{ .Values.global.imageK8S }}"
+          image: "{{ .Values.global.image }}"
           env:
             - name: NAMESPACE
               valueFrom:
@@ -44,15 +40,29 @@ spec:
           command:
             - "/bin/sh"
             - "-ec"
-# NOTE: this should generate the key using Consul and then use curl to add it to K8s
             - |
-              key=$(consul keygen) # TODO: get consul into this container
-              echo $key > key.txt
-# TODO: yeet this into k8s with curl
-          {{- if (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey) }}
-# NOTE: are there any volumeMounts I will need? 
-          {{- end }}
-# NOTE: no idea what resources I will need from the node. This is just copied from ./tls-init-job.yaml
+              $(consul keygen) > key.txt
+              {{- if .Values.global.gossipEncryption.secretName }}
+              secretName={{ .Values.global.gossipEncryption.secretName }}
+              {{- else }}
+              secretName={{ template "consul.fullname" . }}-gossip-encryption-key
+              {{- end }}
+              {{- if .Values.global.gossipEncryption.secretKey }}
+              secretKey={{ .Values.global.gossipEncryption.secretKey }}
+              {{- else }}
+              secretKey=key
+              {{- end }}
+              # Check if secret already exists
+              curl -s -X GET --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+                https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets/${secretName}/data/${secretKey}
+              # If secret does not exist, create it
+              curl -s -X POST --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+                https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${NAMESPACE}/secrets \
+                -H "Authorization: Bearer $( cat /var/run/secrets/kubernetes.io/serviceaccount/token )" \
+                -H "Content-Type: application/json" \
+                -H "Accept: application/json" \
+                # TODO put the key in a secret
+                -d "{ \"kind\": \"Secret\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"${secretName}\", \"namespace\": \"${NAMESPACE}\" }, \"type\": \"Opaque\", \"data\": {  }}" > /dev/null
           resources:
             requests:
               memory: "50Mi"

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -156,6 +156,9 @@ spec:
                   fieldPath: metadata.namespace
             - name: CONSUL_DISABLE_PERM_MGMT
               value: "true"
+# TODO: properly reference the gossip encryption key here
+# if autoencrypt is true OR secretName and secretKey are non null, load the gossip key
+            {{- if .Values.global.gossipEncryption.autoGenerate }}
             {{- if (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey) }}
             - name: GOSSIP_KEY
               valueFrom:

--- a/charts/consul/test/unit/autogen-encryption-job.bats
+++ b/charts/consul/test/unit/autogen-encryption-job.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "autogenEncryption/Job: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/autogen-encryption-job.yaml  \
+      .
+}
+
+@test "autogenEncryption/Job: enabled with global.gossipEncryption.autogenerate=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/autogen-encryption-job.yaml  \
+      --set 'global.gossipEncryption.autogenerate=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "autogenEncryption/Job: disabled when global.gossipEncryption.autogenerate=false" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/autogen-encryption-job.yaml  \
+      --set 'global.gossipEncryption.autogenerate=false' \
+      .
+}
+
+# TODO test when user sets secretKey
+# TODO test when user sets secretName
+# TODO test when user sets secretKey and secretName
+# TODO test when user does not set either

--- a/charts/consul/test/unit/autogen-encryption-job.bats
+++ b/charts/consul/test/unit/autogen-encryption-job.bats
@@ -27,7 +27,47 @@ load _helpers
       .
 }
 
-# TODO test when user sets secretKey
-# TODO test when user sets secretName
-# TODO test when user sets secretKey and secretName
-# TODO test when user does not set either
+@test "autogenEncryption/Job: secretName and secretKey set by user are respected" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/autogen-encryption-job.yaml \
+      --set 'global.gossipEncryption.autogenerate=true' \
+      --set 'global.gossipEncryption.secretName=userName' \
+      --set 'global.gossipEncryption.secretKey=userKey' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("secretName=userName\nsecretKey=userKey"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "autogenEncryption/Job: secretKey set by user is respected while secretName is generated" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/autogen-encryption-job.yaml \
+      --set 'global.gossipEncryption.autogenerate=true' \
+      --set 'global.gossipEncryption.secretKey=userKey' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("secretName=RELEASE-NAME-consul-gossip-encryption-key\nsecretKey=userKey"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "autogenEncryption/Job: secretName set by user is respected while secretKey is generated" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/autogen-encryption-job.yaml \
+      --set 'global.gossipEncryption.autogenerate=true' \
+      --set 'global.gossipEncryption.secretName=userName' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("secretName=userName\nsecretKey=key"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "autogenEncryption/Job: secretName and secretKey are generated if not provided" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/autogen-encryption-job.yaml \
+      --set 'global.gossipEncryption.autogenerate=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("secretName=RELEASE-NAME-consul-gossip-encryption-key\nsecretKey=key"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -79,7 +79,10 @@ global:
   # secretKey are not set, gossip encryption will not be enabled. The secret must
   # be in the same namespace that Consul is installed into.
   #
-  # The secret can be created by running:
+  # The secret can be generated automatically by setting autogenerate to true. This will create an encryption key
+  # for you at the given secretName and secretKey.
+  #
+  # If you prefer to create your own key, you may do so by running with autogenerate set to false:
   #
   # ```shell
   # $ kubectl create secret generic consul-gossip-encryption-key --from-literal=key=$(consul keygen)
@@ -92,6 +95,7 @@ global:
   #   gossipEncryption:
   #     secretName: consul-gossip-encryption-key
   #     secretKey: key
+  #     autogenerate: true
   # ```
   gossipEncryption:
     # secretName is the name of the Kubernetes secret that holds the gossip
@@ -101,7 +105,7 @@ global:
     # encryption key.
     secretKey: ""
     # autogenerate a gossip encryption key at the given secretName and secretKey.
-    autogenerate: false
+    autogenerate: true
 
   # A list of addresses of upstream DNS servers that are used to recursively resolve DNS queries.
   # These values are given as `-recursor` flags to Consul servers and clients.

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -105,7 +105,8 @@ global:
     # encryption key.
     secretKey: ""
     # autogenerate a gossip encryption key at the given secretName and secretKey.
-    autogenerate: true
+    autogenerate: false
+    # If user supplies autogen true and name or key are empty make our own names
 
   # A list of addresses of upstream DNS servers that are used to recursively resolve DNS queries.
   # These values are given as `-recursor` flags to Consul servers and clients.

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -100,6 +100,8 @@ global:
     # secretKey is the key within the Kubernetes secret that holds the gossip
     # encryption key.
     secretKey: ""
+    # autogenerate a gossip encryption key at the given secretName and secretKey.
+    autogenerate: false
 
   # A list of addresses of upstream DNS servers that are used to recursively resolve DNS queries.
   # These values are given as `-recursor` flags to Consul servers and clients.

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -74,39 +74,27 @@ global:
   # created by this chart. See https://kubernetes.io/docs/concepts/policy/pod-security-policy/.
   enablePodSecurityPolicies: false
 
-  # Configures which Kubernetes secret to retrieve Consul's
-  # gossip encryption key from (see `-encrypt` (https://consul.io/docs/agent/options#_encrypt)). If secretName or
-  # secretKey are not set, gossip encryption will not be enabled. The secret must
-  # be in the same namespace that Consul is installed into.
-  #
-  # The secret can be generated automatically by setting autogenerate to true. This will create an encryption key
-  # for you at the given secretName and secretKey.
-  #
-  # If you prefer to create your own key, you may do so by running with autogenerate set to false:
+  # Configures Consul's gossip encryption key, set as a Kubernetes secret
+  # (see `-encrypt` (https://consul.io/docs/agent/options#_encrypt)).
+  # By default, gossip encryption is not enabled. The gossip encryption key may be set automatically or manually.
+  # To automatically generate and set a gossip encryption key, set autoGenerate to true. The values for secretName
+  # and secretKey may be left empty. If values are supplied for these keys, they will be respected.
+  # To manually generate a gossip encryption key, set secretName and secretKey and use Consul to generate
+  # the gossip key referencing these values.
   #
   # ```shell
-  # $ kubectl create secret generic consul-gossip-encryption-key --from-literal=key=$(consul keygen)
+  # $ kubectl create secret generic <secretName> --from-literal=<key>=$(consul keygen)
   # ```
   #
-  # To reference, use:
-  #
-  # ```yaml
-  # global:
-  #   gossipEncryption:
-  #     secretName: consul-gossip-encryption-key
-  #     secretKey: key
-  #     autogenerate: true
-  # ```
   gossipEncryption:
+    # automatically generate a gossip encryption key and load it as a Kubernetes secret
+    autoGenerate: false
     # secretName is the name of the Kubernetes secret that holds the gossip
     # encryption key. The secret must be in the same namespace that Consul is installed into.
     secretName: ""
     # secretKey is the key within the Kubernetes secret that holds the gossip
     # encryption key.
     secretKey: ""
-    # autogenerate a gossip encryption key at the given secretName and secretKey.
-    autogenerate: false
-    # If user supplies autogen true and name or key are empty make our own names
 
   # A list of addresses of upstream DNS servers that are used to recursively resolve DNS queries.
   # These values are given as `-recursor` flags to Consul servers and clients.


### PR DESCRIPTION
**DRAFT**

Changes proposed in this PR:

- Add global.gossipEncryption.autogenerate to values.yaml
- Add description of key autogen
- Add autogen-encryption-job to create and set the encryption key for gossip

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

