### PR TITLE
Add support for Admin Partitions to endpoints controller

### DIFF
--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -131,6 +131,9 @@ spec:
                 {{- range $value := .Values.connectInject.k8sDenyNamespaces }}
                 -deny-k8s-namespace="{{ $value }}" \
                 {{- end }}
+                {{- if .Values.global.adminPartitions.enabled }}
+                -enable-partitions=true \
+                {{- end }}
                 {{- if .Values.global.enableConsulNamespaces }}
                 -enable-namespaces=true \
                 {{- if .Values.connectInject.consulNamespaces.consulDestinationNamespace }}

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -687,6 +687,32 @@ EOF
 }
 
 #--------------------------------------------------------------------
+# partitions
+
+@test "connectInject/Deployment: partitions options disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("enable-partitions"))' | tee /dev/stderr)
+
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: partitions set with .global.adminPartitions.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("enable-partitions"))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # namespaces
 
 @test "connectInject/Deployment: fails if namespaces are disabled and mirroringK8S is true" {

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -72,6 +72,9 @@ type EndpointsController struct {
 	AllowK8sNamespacesSet mapset.Set
 	// Endpoints in the DenyK8sNamespacesSet are ignored.
 	DenyK8sNamespacesSet mapset.Set
+	// EnableConsulPartitions indicates that a user is running Consul Enterprise
+	// with version 1.11+ which supports Admin Partitions.
+	EnableConsulPartitions bool
 	// EnableConsulNamespaces indicates that a user is running Consul Enterprise
 	// with version 1.7+ which supports namespaces.
 	EnableConsulNamespaces bool
@@ -826,7 +829,7 @@ func (r *EndpointsController) processUpstreams(pod corev1.Pod) ([]api.Upstream, 
 		for _, raw := range strings.Split(raw, ",") {
 			parts := strings.SplitN(raw, ":", 3)
 
-			var datacenter, serviceName, preparedQuery, namespace string
+			var datacenter, serviceName, preparedQuery, namespace, partition string
 			var port int32
 			if strings.TrimSpace(parts[0]) == "prepared_query" {
 				port, _ = portValue(pod, strings.TrimSpace(parts[2]))
@@ -834,13 +837,19 @@ func (r *EndpointsController) processUpstreams(pod corev1.Pod) ([]api.Upstream, 
 			} else {
 				port, _ = portValue(pod, strings.TrimSpace(parts[1]))
 
-				// If Consul Namespaces are enabled, attempt to parse the
+				// If Consul Namespaces or Admin Partitions are enabled, attempt to parse the
 				// upstream for a namespace.
-				if r.EnableConsulNamespaces {
-					pieces := strings.SplitN(parts[0], ".", 2)
-					serviceName = strings.TrimSpace(pieces[0])
-					if len(pieces) > 1 {
+				if r.EnableConsulNamespaces || r.EnableConsulPartitions {
+					pieces := strings.SplitN(parts[0], ".", 3)
+					switch len(pieces) {
+					case 3:
+						partition = strings.TrimSpace(pieces[2])
+						fallthrough
+					case 2:
 						namespace = strings.TrimSpace(pieces[1])
+						fallthrough
+					default:
+						serviceName = strings.TrimSpace(pieces[0])
 					}
 				} else {
 					serviceName = strings.TrimSpace(parts[0])
@@ -873,6 +882,7 @@ func (r *EndpointsController) processUpstreams(pod corev1.Pod) ([]api.Upstream, 
 			if port > 0 {
 				upstream := api.Upstream{
 					DestinationType:      api.UpstreamDestTypeService,
+					DestinationPartition: partition,
 					DestinationNamespace: namespace,
 					DestinationName:      serviceName,
 					Datacenter:           datacenter,

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -50,6 +50,8 @@ type Command struct {
 	flagAllowK8sNamespacesList []string // K8s namespaces to explicitly inject
 	flagDenyK8sNamespacesList  []string // K8s namespaces to deny injection (has precedence)
 
+	flagEnablePartitions bool // Use Admin Partitions on all components
+
 	// Flags to support Consul namespaces
 	flagEnableNamespaces           bool   // Use namespacing on all components
 	flagConsulDestinationNamespace string // Consul namespace to register everything if not mirroring
@@ -141,6 +143,8 @@ func (c *Command) init() {
 		"K8s namespaces to explicitly deny. Takes precedence over allow. May be specified multiple times.")
 	c.flagSet.StringVar(&c.flagReleaseName, "release-name", "consul", "The Consul Helm installation release name, e.g 'helm install <RELEASE-NAME>'")
 	c.flagSet.StringVar(&c.flagReleaseNamespace, "release-namespace", "default", "The Consul Helm installation namespace, e.g 'helm install <RELEASE-NAME> --namespace <RELEASE-NAMESPACE>'")
+	c.flagSet.BoolVar(&c.flagEnablePartitions, "enable-partitions", false,
+		"[Enterprise Only] Enables Admin Partitions.")
 	c.flagSet.BoolVar(&c.flagEnableNamespaces, "enable-namespaces", false,
 		"[Enterprise Only] Enables namespaces, in either a single Consul namespace or mirrored.")
 	c.flagSet.StringVar(&c.flagConsulDestinationNamespace, "consul-destination-namespace", "default",
@@ -402,6 +406,7 @@ func (c *Command) Run(args []string) int {
 		DenyK8sNamespacesSet:       denyK8sNamespaces,
 		MetricsConfig:              metricsConfig,
 		ConsulClientCfg:            cfg,
+		EnableConsulPartitions:     c.flagEnablePartitions,
 		EnableConsulNamespaces:     c.flagEnableNamespaces,
 		ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
 		EnableNSMirroring:          c.flagEnableK8SNSMirroring,


### PR DESCRIPTION
Changes proposed in this PR:
- set a flag on endpoints controller with the status of Admin Partitions being enabled.
- when Admin Partitions are enabled, that first part of the upstream will be attempted to be broken into 3 pieces, named `x.y.z` where x is the service name, y is the namespace and z is the admin partition. if there are only 2 pieces, service name and namespace are assumed. if there is only 1 piece, service name is assumed.

How I've tested this PR:
- unit tests.

How I expect reviewers to test this PR:
- code review

Checklist:
- [x] Tests added

