### PR TITLE
Bump Consul version to 1.10.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ executors:
       - image: docker.mirror.hashicorp.services/circleci/golang:1.16
     environment:
       TEST_RESULTS: /tmp/test-results # path to where test results are saved
-      CONSUL_VERSION: 1.10.0 # Consul's OSS version to use in tests
-      CONSUL_ENT_VERSION: 1.10.0+ent # Consul's enterprise version to use in tests
+      CONSUL_VERSION: 1.10.2 # Consul's OSS version to use in tests
+      CONSUL_ENT_VERSION: 1.10.2+ent # Consul's enterprise version to use in tests
 
 control-plane-path : &control-plane-path control-plane
 acceptance-test-path: &acceptance-test-path charts/consul/test/acceptance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,23 @@ IMPROVEMENTS:
   * Add support for setting container security contexts on client and server Pods. [[GH-620](https://github.com/hashicorp/consul-k8s/pull/620)]
   * Update Envoy image to 1.18.4 [[GH-699](https://github.com/hashicorp/consul-k8s/pull/699)]
   * Add configuration for webhook-cert-manager tolerations [[GH-712](https://github.com/hashicorp/consul-k8s/pull/712)]
+  * Update default Consul version to 1.10.2 [[GH-718](https://github.com/hashicorp/consul-k8s/pull/718)]
 * Control Plane
   * Add health endpoint to the connect inject webhook that will be healthy when webhook certs are present and not empty. [[GH-626](https://github.com/hashicorp/consul-k8s/pull/626)]
   * Catalog Sync: Fix issue registering NodePort services with wrong IPs when a node has multiple IP addresses. [[GH-619](https://github.com/hashicorp/consul-k8s/pull/619)]
   * Allow registering the same service in multiple namespaces. [[GH-697](https://github.com/hashicorp/consul-k8s/pull/697)]
+
+BUG FIXES:
+* Helm Chart
+  * Disable [streaming](https://www.consul.io/docs/agent/options#use_streaming_backend) on Consul clients because it is currently not supported when
+    doing mesh gateway federation. If you wish to enable it, override the setting using `client.extraConfig`:
+
+    ```yaml
+    client:
+      extraConfig: |
+        {"use_streaming_backend": true}
+    ```
+    [[GH-718](https://github.com/hashicorp/consul-k8s/pull/718)]
 
 ## 0.33.0 (August 12, 2021)
 

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: consul
 version: 0.33.0
-appVersion: 1.10.0
+appVersion: 1.10.2
 kubeVersion: ">=1.17.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
@@ -13,7 +13,7 @@ annotations:
   artifacthub.io/prerelease: false
   artifacthub.io/images: |
     - name: consul
-      image: hashicorp/consul:1.10.0
+      image: hashicorp/consul:1.10.2
     - name: consul-k8s-control-plane
       image: hashicorp/consul-k8s-control-plane:0.33.0
     - name: envoy

--- a/charts/consul/README.md
+++ b/charts/consul/README.md
@@ -44,7 +44,7 @@ Detailed installation instructions for Consul on Kubernetes are found [here](htt
 
         $ helm search repo hashicorp/consul
         NAME                CHART VERSION   APP VERSION DESCRIPTION
-        hashicorp/consul    0.33.0          1.10.0      Official HashiCorp Consul Chart
+        hashicorp/consul    x.xx.x          x.xx.x      Official HashiCorp Consul Chart
 
 3. Now you're ready to install Consul! To install Consul with the default configuration using Helm 3 run:
 

--- a/charts/consul/templates/client-config-configmap.yaml
+++ b/charts/consul/templates/client-config-configmap.yaml
@@ -24,7 +24,8 @@ data:
        in the UI. */}}
   config.json: |-
     {
-      "check_update_interval": "0s"
+      "check_update_interval": "0s",
+      "use_streaming_backend": false
     }
   {{- end }}
 {{- end }}

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -543,7 +543,7 @@ load _helpers
 #--------------------------------------------------------------------
 # config-configmap
 
-@test "client/DaemonSet: adds config-checksum annotation when extraConfig is blank" {
+@test "client/DaemonSet: config-checksum annotation when extraConfig is blank" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/client-daemonset.yaml  \
@@ -552,7 +552,7 @@ load _helpers
   [ "${actual}" = 779a0e24c2ed561c727730698a75b1c552f562c100f0c3315ff2cb925f5e296b ]
 }
 
-@test "client/DaemonSet: adds config-checksum annotation when extraConfig is provided" {
+@test "client/DaemonSet: config-checksum annotation changes when extraConfig is provided" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/client-daemonset.yaml  \
@@ -562,14 +562,14 @@ load _helpers
   [ "${actual}" = ba1ceb79d2d18e136d3cc40a9dfddcf2a252aa19ca1703bee3219ca28f1ee187 ]
 }
 
-@test "client/DaemonSet: adds config-checksum annotation when client config is updated" {
+@test "client/DaemonSet: config-checksum annotation changes when connectInject.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/client-daemonset.yaml  \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 8496f6bcdec460eac8a5c890e7899f5757111e13e54808af533aaf205ef18bd0 ]
+  [ "${actual}" = b45de202f61d7d3b6118c1f47c351d357c2a83af09675f269d3617ae4a65a01c ]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -42,7 +42,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.10.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: "hashicorp/consul:1.10.0"
+  image: "hashicorp/consul:1.10.2"
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.


### PR DESCRIPTION
-  Bump default Consul version to 1.10.2
- fix tests that were failing due to a change in how the
    DestinationUpstream field is set in Consul OSS vs Enterprise.
- set use_streaming_backend to false for Consul clients because
    streaming is not currently supported with mesh gateway federation

How I've tested this PR:
- acceptance tests

How I expect reviewers to test this PR:
- code

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

