### PR TITLE
Only support default partition in server cluster

### DIFF
--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -1,5 +1,7 @@
 {{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if (and (and .Values.global.tls.enabled .Values.global.tls.httpsOnly) (and .Values.global.metrics.enabled .Values.global.metrics.enableAgentMetrics))}}{{ fail "global.metrics.enableAgentMetrics cannot be enabled if TLS (HTTPS only) is enabled" }}{{ end -}}
+{{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (and .Values.global.adminPartitions.enabled $serverEnabled (ne (.Values.global.adminPartitions.name | toString) "default"))}}{{ fail "global.adminPartitions.name has to be \"default\" in the server cluster" }}{{ end -}}
 # DaemonSet to run the Consul clients on every node.
 apiVersion: apps/v1
 kind: DaemonSet

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -1,7 +1,7 @@
 {{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if (and (and .Values.global.tls.enabled .Values.global.tls.httpsOnly) (and .Values.global.metrics.enabled .Values.global.metrics.enableAgentMetrics))}}{{ fail "global.metrics.enableAgentMetrics cannot be enabled if TLS (HTTPS only) is enabled" }}{{ end -}}
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
-{{- if (and .Values.global.adminPartitions.enabled $serverEnabled (ne (.Values.global.adminPartitions.name | toString) "default"))}}{{ fail "global.adminPartitions.name has to be \"default\" in the server cluster" }}{{ end -}}
+{{- if (and .Values.global.adminPartitions.enabled $serverEnabled (ne .Values.global.adminPartitions.name "default"))}}{{ fail "global.adminPartitions.name has to be \"default\" in the server cluster" }}{{ end -}}
 # DaemonSet to run the Consul clients on every node.
 apiVersion: apps/v1
 kind: DaemonSet

--- a/charts/consul/templates/partition-init-job.yaml
+++ b/charts/consul/templates/partition-init-job.yaml
@@ -11,7 +11,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:

--- a/charts/consul/templates/partition-name-configmap.yaml
+++ b/charts/consul/templates/partition-name-configmap.yaml
@@ -1,0 +1,18 @@
+{{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
+{{- if (and .Values.global.adminPartitions.enabled (not $serverEnabled)) }}
+# Immutable ConfigMap which saves the partition name. Attempting to update this configmap
+# with a new Admin Partition name will cause the helm upgrade to fail
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "consul.fullname" . }}-partition
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+immutable: true
+data:
+  partitionName: {{ .Values.global.adminPartitions.name }}
+{{- end }}

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -1402,7 +1402,20 @@ rollingUpdate:
       -s templates/client-daemonset.yaml  \
       --set 'global.adminPartitions.enabled=true' \
       --set 'global.adminPartitions.name=test' \
+      --set 'server.enabled=false' \
       . | tee /dev/stderr |
       yq -c -r '.spec.template.spec.containers[0].command | join(" ") | contains("partition = \"test\"")' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: partition name has to be default in server cluster" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.adminPartitions.name=test' \
+      .
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "global.adminPartitions.name has to be \"default\" in the server cluster" ]]
 }

--- a/charts/consul/test/unit/partition-name-configmap.bats
+++ b/charts/consul/test/unit/partition-name-configmap.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "partitionName/ConfigMap: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/partition-init-role.yaml  \
+      .
+}
+
+@test "partitionName/ConfigMap: enabled with global.adminPartitions.enabled=true and servers = false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/partition-init-role.yaml  \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'server.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "partitionName/ConfigMap: disabled with global.adminPartitions.enabled=true and servers = true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/partition-init-role.yaml  \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'server.enabled=true' \
+      .
+}
+
+@test "partitionName/ConfigMap: disabled with global.adminPartitions.enabled=true and global.enabled = true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/partition-init-role.yaml  \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enabled=true' \
+      .
+}
+
+@test "partitionName/ConfigMap: disabled with global.adminPartitions.enabled=false" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/partition-init-role.yaml  \
+      --set 'global.adminPartitions.enabled=false' \
+      .
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -35,10 +35,12 @@ global:
   # a set of Consul servers.
   adminPartitions:
     # If true, the Helm chart will enable Admin Partitions for the cluster. The clients in the server cluster
-    # must be installed in the default partition.
+    # must be installed in the default partition. Creation of Admin Partitions is only supported during installation.
+    # Admin Partitions cannot be installed via a Helm upgrade operation. Only Helm installs are supported.
     enabled: false
-    # The name of the Admin Partition. Must be "default" in the server cluster ie the Kubernetes cluster that
-    # the Consul server pods are deployed onto.
+    # The name of the Admin Partition. The partition name cannot be modified once the partition has been installed.
+    # Changing the partition name would require an un-install and a re-install with the updated name.
+    # Must be "default" in the server cluster ie the Kubernetes cluster that the Consul server pods are deployed onto.
     name: "default"
     # Partition service properties.
     service:


### PR DESCRIPTION
Changes proposed in this PR:
- Fail if the user attempts to update the admin partition name on the server cluster to a value that isn't "default"
- Create an immutable configmap with the partition name which will cause `helm upgrade` to fail if the admin partition name is updated between the install and the upgrade.

Questions:
Even though the helm upgrade fails when the partition name is changed, the partition-init job runs and the agents get reassigned. I could make the partition-init job a `pre-install` job and not a `pre-upgrade` job, BUT the drawback of doing so would be anyone trying to upgrade an existing non-partition cluster to a partitioned cluster cannot. Should we ignore this use case? Ignore the upgrade use-case will ensure that the partition-init job will not run thereby not creating a new partition.

FOLLOW UP:
After conversations with the team, it was decided that in the near term, we will not support updating to a partition that is non-default. Removing the `pre-upgrade` hook from `partition-init` job. This will ensure we don't create a partition when a user errantly updates the partition-name and performs a helm upgrade.

How I've tested this PR:
Manual testing.
Bats tests

How I expect reviewers to test this PR:
Code review
Would love to hear thoughts on the above questions.

Checklist:
- [x] Tests added