### PR TITLE
README: Fix broken link to helm chart and wrong binary name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-The `consul-k8s` binary includes first-class integrations between Consul and
+The `consul-k8s-control-plane` binary includes first-class integrations between Consul and
 Kubernetes. The project encapsulates multiple use cases such as syncing
 services, injecting Connect sidecars, and more.
 The Kubernetes integrations with Consul are
@@ -41,7 +41,7 @@ by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
 `consul-k8s` is distributed in multiple forms:
 
   * The recommended installation method is the official
-    [Consul Helm chart](https://github.com/hashicorp/consul-k8s/tree/merge-repos/charts/consul). This will
+    [Consul Helm chart](https://github.com/hashicorp/consul-k8s/tree/main/charts/consul). This will
     automatically configure the Consul and Kubernetes integration to run within
     an existing Kubernetes cluster.
 


### PR DESCRIPTION
Changes proposed in this PR:
* Fix broken link to helm chart
* Fix wrong binary name: replace `consul-k8s` by `consul-k8s-control-plane` (see https://github.com/hashicorp/consul-k8s/releases/tag/v0.33.0)

How I've tested this PR:
N/A

How I expect reviewers to test this PR:
N/A

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

