### PR TITLE
cli: uninstall command

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -109,12 +109,10 @@ Command Options:
       Namespace for the Consul installation.
 
   -wipe-data
-      This behaviour of this flag depends on the value of -auto-approve.
-      When -wipe-data=true, the CLI will delete PVCs and Secrets if
-      -auto-approve=true. When -wipe-data=false, the CLI will prompt to
-      wipe PVCs and Secrets if -auto-approve=false, and skip wiping them
-      if -auto-approve=true. Only set this to true when persisted data from
-      previous installations is no longer necessary. The default is false.
+      When used in combination with -auto-approve, all persisted data (PVCs
+      and Secrets) from previous installations will be deleted. Only set this
+      to true when data from previous installations is no longer necessary.
+      The default is false.
 
 Global Options:
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -4,7 +4,7 @@ This repository contains a CLI tool for installing and operating [Consul](https:
 
 ## Installation & Setup
 Currently the tool is not available on any releases page. Instead clone the repository and run `go build -o bin/consul-k8s`
-and proceed to run the binary.
+from this directory and proceed to run the binary.
 
 ## Commands
 * [consul-k8s install](#consul-k8s-install)
@@ -94,17 +94,16 @@ consul-k8s uninstall
 
 ```
 Usage: kubectl consul uninstall [options]
+Uninstall Consul with options to delete data and resources associated with Consul installation.
 
-Uninstall Consul and clean up all data.
-Any data store in Consul will not be recoverable.
 Command Options:
 
   -auto-approve
       Skip approval prompt for uninstalling Consul. The default is false.
 
   -name=<string>
-      Name of the installation. This will be prefixed to resources installed
-      on the cluster.
+      Name of the installation. This can be used to uninstall and/or delete
+      the resources of a specific Helm release.
 
   -namespace=<string>
       Namespace for the Consul installation.
@@ -127,6 +126,4 @@ Global Options:
 
   -kubeconfig=<string>
       Path to kubeconfig file. This is aliased as "-c".
-
-
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -8,6 +8,7 @@ and proceed to run the binary.
 
 ## Commands
 * [consul-k8s install](#consul-k8s-install)
+* [consul-k8s uninstall](#consul-k8s-uninstall)
 
 ### consul-k8s install
 This command installs Consul on a Kubernetes cluster. It allows `demo` and `secure` installations via preset configurations
@@ -79,5 +80,53 @@ Global Options:
 
   -kubeconfig=<string>
       Path to kubeconfig file. This is aliased as "-c".
+
+```
+
+### consul-k8s uninstall
+This command uninstalls Consul on Kubernetes, while prompting whether to uninstall the release and whether to delete all
+related resources such as PVCs, Secrets, and ServiceAccounts.
+
+Get started with:
+```bash
+consul-k8s uninstall
+```
+
+```
+Usage: kubectl consul uninstall [options]
+
+Uninstall Consul and clean up all data.
+Any data store in Consul will not be recoverable.
+Command Options:
+
+  -auto-approve
+      Skip approval prompt for uninstalling Consul. The default is false.
+
+  -name=<string>
+      Name of the installation. This will be prefixed to resources installed
+      on the cluster.
+
+  -namespace=<string>
+      Namespace for the Consul installation.
+
+  -skip-wipe-data
+      Skip deleting all PVCs, Secrets, and Service Accounts associated with
+      Consul Helm installation without prompting for approval to delete. The
+      default is false.
+
+  -wipe-data
+      Delete all PVCs, Secrets, and Service Accounts associated with Consul
+      Helm installation without prompting for approval to delete. Only use
+      this when persisted data from previous installations is no longer
+      necessary. The default is false.
+
+Global Options:
+
+  -context=<string>
+      Kubernetes context to use.
+
+  -kubeconfig=<string>
+      Path to kubeconfig file. This is aliased as "-c".
+
 
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -108,16 +108,13 @@ Command Options:
   -namespace=<string>
       Namespace for the Consul installation.
 
-  -skip-wipe-data
-      Skip deleting all PVCs, Secrets, and Service Accounts associated with
-      Consul Helm installation without prompting for approval to delete. The
-      default is false.
-
   -wipe-data
-      Delete all PVCs, Secrets, and Service Accounts associated with Consul
-      Helm installation without prompting for approval to delete. Only use
-      this when persisted data from previous installations is no longer
-      necessary. The default is false.
+      This behaviour of this flag depends on the value of -auto-approve.
+      When -wipe-data=true, the CLI will delete PVCs and Secrets if
+      -auto-approve=true. When -wipe-data=false, the CLI will prompt to
+      wipe PVCs and Secrets if -auto-approve=false, and skip wiping them
+      if -auto-approve=true. Only set this to true when persisted data from
+      previous installations is no longer necessary. The default is false.
 
 Global Options:
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -93,7 +93,7 @@ consul-k8s uninstall
 ```
 
 ```
-Usage: kubectl consul uninstall [options]
+Usage: consul-k8s uninstall [flags]
 Uninstall Consul with options to delete data and resources associated with Consul installation.
 
 Command Options:
@@ -107,6 +107,9 @@ Command Options:
 
   -namespace=<string>
       Namespace for the Consul installation.
+
+  -timeout=<string>
+      Timeout to wait for uninstall. The default is 10m.
 
   -wipe-data
       When used in combination with -auto-approve, all persisted data (PVCs

--- a/cli/cmd/common/utils.go
+++ b/cli/cmd/common/utils.go
@@ -1,0 +1,11 @@
+package common
+
+import "strings"
+
+func PrefixLines(prefix, lines string) string {
+	var prefixedLines string
+	for _, l := range strings.Split(lines, "\n") {
+		prefixedLines += prefix + l + "\n"
+	}
+	return strings.TrimSuffix(prefixedLines, "\n")
+}

--- a/cli/cmd/common/utils.go
+++ b/cli/cmd/common/utils.go
@@ -2,10 +2,11 @@ package common
 
 import "strings"
 
-func PrefixLines(prefix, lines string) string {
-	var prefixedLines string
-	for _, l := range strings.Split(lines, "\n") {
-		prefixedLines += prefix + l + "\n"
+// Abort returns true if the raw input string is not equal to "y" or "yes".
+func Abort(raw string) bool {
+	confirmation := strings.TrimSuffix(raw, "\n")
+	if !(strings.ToLower(confirmation) == "y" || strings.ToLower(confirmation) == "yes") {
+		return true
 	}
-	return strings.TrimSuffix(prefixedLines, "\n")
+	return false
 }

--- a/cli/cmd/common/utils.go
+++ b/cli/cmd/common/utils.go
@@ -10,6 +10,11 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
+const (
+	DefaultReleaseName      = "consul"
+	DefaultReleaseNamespace = "consul"
+)
+
 // Abort returns true if the raw input string is not equal to "y" or "yes".
 func Abort(raw string) bool {
 	confirmation := strings.TrimSuffix(raw, "\n")

--- a/cli/cmd/common/utils.go
+++ b/cli/cmd/common/utils.go
@@ -1,6 +1,14 @@
 package common
 
-import "strings"
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"helm.sh/helm/v3/pkg/action"
+	helmCLI "helm.sh/helm/v3/pkg/cli"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
 
 // Abort returns true if the raw input string is not equal to "y" or "yes".
 func Abort(raw string) bool {
@@ -9,4 +17,18 @@ func Abort(raw string) bool {
 		return true
 	}
 	return false
+}
+
+// InitActionConfig initializes a Helm Go SDK action configuration. This function currently uses a hack to override the
+// namespace field that gets set in the K8s client set up by the SDK.
+func InitActionConfig(actionConfig *action.Configuration, namespace string, settings *helmCLI.EnvSettings, logger action.DebugLog) (*action.Configuration, error) {
+	getter := settings.RESTClientGetter()
+	configFlags := getter.(*genericclioptions.ConfigFlags)
+	configFlags.Namespace = &namespace
+	err := actionConfig.Init(settings.RESTClientGetter(), namespace,
+		os.Getenv("HELM_DRIVER"), logger)
+	if err != nil {
+		return nil, fmt.Errorf("error setting up helm action configuration to find existing installations: %s", err)
+	}
+	return actionConfig, nil
 }

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -86,82 +86,80 @@ func (c *Command) init() {
 	}
 
 	c.set = flag.NewSets()
-	{
-		f := c.set.NewSet("Command Options")
-		f.BoolVar(&flag.BoolVar{
-			Name:    flagNameAutoApprove,
-			Target:  &c.flagAutoApprove,
-			Default: defaultAutoApprove,
-			Usage:   "Skip confirmation prompt.",
-		})
-		f.BoolVar(&flag.BoolVar{
-			Name:    flagNameDryRun,
-			Target:  &c.flagDryRun,
-			Default: defaultDryRun,
-			Usage:   "Run pre-install checks and display summary of installation.",
-		})
-		f.StringSliceVar(&flag.StringSliceVar{
-			Name:    flagNameConfigFile,
-			Aliases: []string{"f"},
-			Target:  &c.flagValueFiles,
-			Usage:   "Path to a file to customize the installation, such as Consul Helm chart values file. Can be specified multiple times.",
-		})
-		f.StringVar(&flag.StringVar{
-			Name:    flagNameNamespace,
-			Target:  &c.flagNamespace,
-			Default: defaultNamespace,
-			Usage:   "Namespace for the Consul installation.",
-		})
-		f.StringVar(&flag.StringVar{
-			Name:    flagNamePreset,
-			Target:  &c.flagPreset,
-			Default: defaultPreset,
-			Usage:   fmt.Sprintf("Use an installation preset, one of %s. Defaults to none", strings.Join(presetList, ", ")),
-		})
-		f.StringSliceVar(&flag.StringSliceVar{
-			Name:   flagNameSetValues,
-			Target: &c.flagSetValues,
-			Usage:  "Set a value to customize. Can be specified multiple times. Supports Consul Helm chart values.",
-		})
-		f.StringSliceVar(&flag.StringSliceVar{
-			Name:   flagNameFileValues,
-			Target: &c.flagFileValues,
-			Usage: "Set a value to customize via a file. The contents of the file will be set as the value. Can be " +
-				"specified multiple times. Supports Consul Helm chart values.",
-		})
-		f.StringSliceVar(&flag.StringSliceVar{
-			Name:   flagNameSetStringValues,
-			Target: &c.flagSetStringValues,
-			Usage:  "Set a string value to customize. Can be specified multiple times. Supports Consul Helm chart values.",
-		})
-		f.StringVar(&flag.StringVar{
-			Name:    flagNameTimeout,
-			Target:  &c.flagTimeout,
-			Default: defaultTimeout,
-			Usage:   "Timeout to wait for installation to be ready.",
-		})
-		f.BoolVar(&flag.BoolVar{
-			Name:    flagNameWait,
-			Target:  &c.flagWait,
-			Default: defaultWait,
-			Usage:   "Determines whether to wait for resources in installation to be ready before exiting command.",
-		})
+	f := c.set.NewSet("Command Options")
+	f.BoolVar(&flag.BoolVar{
+		Name:    flagNameAutoApprove,
+		Target:  &c.flagAutoApprove,
+		Default: defaultAutoApprove,
+		Usage:   "Skip confirmation prompt.",
+	})
+	f.BoolVar(&flag.BoolVar{
+		Name:    flagNameDryRun,
+		Target:  &c.flagDryRun,
+		Default: defaultDryRun,
+		Usage:   "Run pre-install checks and display summary of installation.",
+	})
+	f.StringSliceVar(&flag.StringSliceVar{
+		Name:    flagNameConfigFile,
+		Aliases: []string{"f"},
+		Target:  &c.flagValueFiles,
+		Usage:   "Path to a file to customize the installation, such as Consul Helm chart values file. Can be specified multiple times.",
+	})
+	f.StringVar(&flag.StringVar{
+		Name:    flagNameNamespace,
+		Target:  &c.flagNamespace,
+		Default: defaultNamespace,
+		Usage:   "Namespace for the Consul installation.",
+	})
+	f.StringVar(&flag.StringVar{
+		Name:    flagNamePreset,
+		Target:  &c.flagPreset,
+		Default: defaultPreset,
+		Usage:   fmt.Sprintf("Use an installation preset, one of %s. Defaults to none", strings.Join(presetList, ", ")),
+	})
+	f.StringSliceVar(&flag.StringSliceVar{
+		Name:   flagNameSetValues,
+		Target: &c.flagSetValues,
+		Usage:  "Set a value to customize. Can be specified multiple times. Supports Consul Helm chart values.",
+	})
+	f.StringSliceVar(&flag.StringSliceVar{
+		Name:   flagNameFileValues,
+		Target: &c.flagFileValues,
+		Usage: "Set a value to customize via a file. The contents of the file will be set as the value. Can be " +
+			"specified multiple times. Supports Consul Helm chart values.",
+	})
+	f.StringSliceVar(&flag.StringSliceVar{
+		Name:   flagNameSetStringValues,
+		Target: &c.flagSetStringValues,
+		Usage:  "Set a string value to customize. Can be specified multiple times. Supports Consul Helm chart values.",
+	})
+	f.StringVar(&flag.StringVar{
+		Name:    flagNameTimeout,
+		Target:  &c.flagTimeout,
+		Default: defaultTimeout,
+		Usage:   "Timeout to wait for installation to be ready.",
+	})
+	f.BoolVar(&flag.BoolVar{
+		Name:    flagNameWait,
+		Target:  &c.flagWait,
+		Default: defaultWait,
+		Usage:   "Determines whether to wait for resources in installation to be ready before exiting command.",
+	})
 
-		f = c.set.NewSet("Global Options")
-		f.StringVar(&flag.StringVar{
-			Name:    "kubeconfig",
-			Aliases: []string{"c"},
-			Target:  &c.flagKubeConfig,
-			Default: "",
-			Usage:   "Path to kubeconfig file.",
-		})
-		f.StringVar(&flag.StringVar{
-			Name:    "context",
-			Target:  &c.flagKubeContext,
-			Default: "",
-			Usage:   "Kubernetes context to use.",
-		})
-	}
+	f = c.set.NewSet("Global Options")
+	f.StringVar(&flag.StringVar{
+		Name:    "kubeconfig",
+		Aliases: []string{"c"},
+		Target:  &c.flagKubeConfig,
+		Default: "",
+		Usage:   "Path to kubeconfig file.",
+	})
+	f.StringVar(&flag.StringVar{
+		Name:    "context",
+		Target:  &c.flagKubeContext,
+		Default: "",
+		Usage:   "Kubernetes context to use.",
+	})
 
 	c.help = c.set.Help()
 

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -301,9 +301,9 @@ func (c *Command) Run(args []string) int {
 
 	// Setup action configuration for Helm Go SDK function calls.
 	actionConfig := new(action.Configuration)
-	if err := actionConfig.Init(settings.RESTClientGetter(), c.flagNamespace,
-		os.Getenv("HELM_DRIVER"), uiLogger); err != nil {
-		c.UI.Output(err.Error())
+	actionConfig, err = common.InitActionConfig(actionConfig, c.flagNamespace, settings, uiLogger)
+	if err != nil {
+		c.UI.Output(err.Error(), terminal.WithErrorStyle())
 		return 1
 	}
 

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -182,17 +182,12 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	// A hack to set namespace via the HELM_NAMESPACE env var until we merge a PR that will allow us to use the latest
-	// Helm templates.
-	prevHelmNSEnv := os.Getenv("HELM_NAMESPACE")
-	os.Setenv("HELM_NAMESPACE", c.flagNamespace)
 	// helmCLI.New() will create a settings object which is used by the Helm Go SDK calls.
+	settings := helmCLI.New()
+
 	// Any overrides by our kubeconfig and kubecontext flags is done here. The Kube client that
 	// is created will use this command's flags first, then the HELM_KUBECONTEXT environment variable,
 	// then call out to genericclioptions.ConfigFlag
-	settings := helmCLI.New()
-	os.Setenv("HELM_NAMESPACE", prevHelmNSEnv)
-
 	if c.flagKubeConfig != "" {
 		settings.KubeConfig = c.flagKubeConfig
 	}

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -27,8 +27,6 @@ const (
 	flagNamePreset = "preset"
 	defaultPreset  = ""
 
-	defaultReleaseName = "consul"
-
 	flagNameConfigFile      = "config-file"
 	flagNameSetStringValues = "set-string"
 	flagNameSetValues       = "set"
@@ -41,7 +39,6 @@ const (
 	defaultAutoApprove  = false
 
 	flagNameNamespace = "namespace"
-	defaultNamespace  = "consul"
 
 	flagNameTimeout = "timeout"
 	defaultTimeout  = "10m"
@@ -108,7 +105,7 @@ func (c *Command) init() {
 	f.StringVar(&flag.StringVar{
 		Name:    flagNameNamespace,
 		Target:  &c.flagNamespace,
-		Default: defaultNamespace,
+		Default: common.DefaultReleaseNamespace,
 		Usage:   "Namespace for the Consul installation.",
 	})
 	f.StringVar(&flag.StringVar{
@@ -259,7 +256,7 @@ func (c *Command) Run(args []string) int {
 	// Print out the installation summary.
 	if !c.flagAutoApprove {
 		c.UI.Output("Consul Installation Summary", terminal.WithHeaderStyle())
-		c.UI.Output("Installation name: %s", defaultReleaseName, terminal.WithInfoStyle())
+		c.UI.Output("Installation name: %s", common.DefaultReleaseName, terminal.WithInfoStyle())
 		c.UI.Output("Namespace: %s", c.flagNamespace, terminal.WithInfoStyle())
 
 		if len(vals) == 0 {
@@ -309,7 +306,7 @@ func (c *Command) Run(args []string) int {
 
 	// Setup the installation action.
 	install := action.NewInstall(actionConfig)
-	install.ReleaseName = defaultReleaseName
+	install.ReleaseName = common.DefaultReleaseName
 	install.Namespace = c.flagNamespace
 	install.CreateNamespace = true
 	install.ChartPathOptions.RepoURL = helmRepository

--- a/cli/cmd/install/install_test.go
+++ b/cli/cmd/install/install_test.go
@@ -26,8 +26,8 @@ func TestCheckForPreviousPVCs(t *testing.T) {
 			Name: "consul-server-test2",
 		},
 	}
-	c.kubernetes.CoreV1().PersistentVolumeClaims("default").Create(context.TODO(), pvc, metav1.CreateOptions{})
-	c.kubernetes.CoreV1().PersistentVolumeClaims("default").Create(context.TODO(), pvc2, metav1.CreateOptions{})
+	c.kubernetes.CoreV1().PersistentVolumeClaims("default").Create(context.Background(), pvc, metav1.CreateOptions{})
+	c.kubernetes.CoreV1().PersistentVolumeClaims("default").Create(context.Background(), pvc2, metav1.CreateOptions{})
 	err := c.checkForPreviousPVCs()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "found PVCs from previous installations (default/consul-server-test1,default/consul-server-test2), delete before re-installing")
@@ -43,7 +43,7 @@ func TestCheckForPreviousPVCs(t *testing.T) {
 			Name: "irrelevant-pvc",
 		},
 	}
-	c.kubernetes.CoreV1().PersistentVolumeClaims("default").Create(context.TODO(), pvc, metav1.CreateOptions{})
+	c.kubernetes.CoreV1().PersistentVolumeClaims("default").Create(context.Background(), pvc, metav1.CreateOptions{})
 	err = c.checkForPreviousPVCs()
 	require.NoError(t, err)
 }
@@ -56,7 +56,7 @@ func TestCheckForPreviousSecrets(t *testing.T) {
 			Name: "test-consul-bootstrap-acl-token",
 		},
 	}
-	c.kubernetes.CoreV1().Secrets("default").Create(context.TODO(), secret, metav1.CreateOptions{})
+	c.kubernetes.CoreV1().Secrets("default").Create(context.Background(), secret, metav1.CreateOptions{})
 	err := c.checkForPreviousSecrets()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "found consul-acl-bootstrap-token secret from previous installations: \"test-consul-bootstrap-acl-token\" in namespace \"default\". To delete, run kubectl delete secret test-consul-bootstrap-acl-token --namespace default")
@@ -72,7 +72,7 @@ func TestCheckForPreviousSecrets(t *testing.T) {
 			Name: "irrelevant-secret",
 		},
 	}
-	c.kubernetes.CoreV1().Secrets("default").Create(context.TODO(), secret, metav1.CreateOptions{})
+	c.kubernetes.CoreV1().Secrets("default").Create(context.Background(), secret, metav1.CreateOptions{})
 	err = c.checkForPreviousSecrets()
 	require.NoError(t, err)
 }

--- a/cli/cmd/uninstall/uninstall.go
+++ b/cli/cmd/uninstall/uninstall.go
@@ -18,20 +18,20 @@ import (
 )
 
 const (
-	FlagAutoApprove    = "auto-approve"
-	DefaultAutoApprove = false
+	flagAutoApprove    = "auto-approve"
+	defaultAutoApprove = false
 
-	FlagNamespace        = "namespace"
-	DefaultAllNamespaces = ""
+	flagNamespace        = "namespace"
+	defaultAllNamespaces = ""
 
-	FlagReleaseName       = "name"
-	DefaultAnyReleaseName = ""
+	flagReleaseName       = "name"
+	defaultAnyReleaseName = ""
 
-	FlagWipeData    = "wipe-data"
-	DefaultWipeData = false
+	flagWipeData    = "wipe-data"
+	defaultWipeData = false
 
-	FlagSkipWipeData    = "skip-wipe-data"
-	DefaultSkipWipeData = false
+	flagSkipWipeData    = "skip-wipe-data"
+	defaultSkipWipeData = false
 )
 
 type Command struct {
@@ -56,58 +56,56 @@ type Command struct {
 
 func (c *Command) init() {
 	c.set = flag.NewSets()
-	{
-		f := c.set.NewSet("Command Options")
-		f.BoolVar(&flag.BoolVar{
-			Name:    FlagAutoApprove,
-			Target:  &c.flagAutoApprove,
-			Default: DefaultAutoApprove,
-			Usage:   "Skip approval prompt for uninstalling Consul.",
-		})
-		// This is like the auto-approve to wipe all data without prompting for non-interactive environments that want
-		// to remove everything.
-		f.BoolVar(&flag.BoolVar{
-			Name:    FlagWipeData,
-			Target:  &c.flagWipeData,
-			Default: DefaultWipeData,
-			Usage:   "Delete all PVCs, Secrets, and Service Accounts associated with Consul Helm installation without prompting for approval to delete. Only use this when persisted data from previous installations is no longer necessary.",
-		})
-		// This is like the auto-approve to NOT wipe all data without prompting for non-interactive environments that
-		// only want to remove the Consul Helm installation but keep the data.
-		f.BoolVar(&flag.BoolVar{
-			Name:    FlagSkipWipeData,
-			Target:  &c.flagSkipWipeData,
-			Default: DefaultSkipWipeData,
-			Usage:   "Skip deleting all PVCs, Secrets, and Service Accounts associated with Consul Helm installation without prompting for approval to delete.",
-		})
-		f.StringVar(&flag.StringVar{
-			Name:    FlagNamespace,
-			Target:  &c.flagNamespace,
-			Default: DefaultAllNamespaces,
-			Usage:   "Namespace for the Consul installation.",
-		})
-		f.StringVar(&flag.StringVar{
-			Name:    FlagReleaseName,
-			Target:  &c.flagReleaseName,
-			Default: DefaultAnyReleaseName,
-			Usage:   "Name of the installation. This will be prefixed to resources installed on the cluster.",
-		})
+	f := c.set.NewSet("Command Options")
+	f.BoolVar(&flag.BoolVar{
+		Name:    flagAutoApprove,
+		Target:  &c.flagAutoApprove,
+		Default: defaultAutoApprove,
+		Usage:   "Skip approval prompt for uninstalling Consul.",
+	})
+	// This is like the auto-approve to wipe all data without prompting for non-interactive environments that want
+	// to remove everything.
+	f.BoolVar(&flag.BoolVar{
+		Name:    flagWipeData,
+		Target:  &c.flagWipeData,
+		Default: defaultWipeData,
+		Usage:   "Delete all PVCs, Secrets, and Service Accounts associated with Consul Helm installation without prompting for approval to delete. Only use this when persisted data from previous installations is no longer necessary.",
+	})
+	// This is like the auto-approve to NOT wipe all data without prompting for non-interactive environments that
+	// only want to remove the Consul Helm installation but keep the data.
+	f.BoolVar(&flag.BoolVar{
+		Name:    flagSkipWipeData,
+		Target:  &c.flagSkipWipeData,
+		Default: defaultSkipWipeData,
+		Usage:   "Skip deleting all PVCs, Secrets, and Service Accounts associated with Consul Helm installation without prompting for approval to delete.",
+	})
+	f.StringVar(&flag.StringVar{
+		Name:    flagNamespace,
+		Target:  &c.flagNamespace,
+		Default: defaultAllNamespaces,
+		Usage:   "Namespace for the Consul installation.",
+	})
+	f.StringVar(&flag.StringVar{
+		Name:    flagReleaseName,
+		Target:  &c.flagReleaseName,
+		Default: defaultAnyReleaseName,
+		Usage:   "Name of the installation. This can be used to uninstall and/or delete the resources of a specific Helm release.",
+	})
 
-		f = c.set.NewSet("Global Options")
-		f.StringVar(&flag.StringVar{
-			Name:    "kubeconfig",
-			Aliases: []string{"c"},
-			Target:  &c.flagKubeConfig,
-			Default: "",
-			Usage:   "Path to kubeconfig file.",
-		})
-		f.StringVar(&flag.StringVar{
-			Name:    "context",
-			Target:  &c.flagKubeContext,
-			Default: "",
-			Usage:   "Kubernetes context to use.",
-		})
-	}
+	f = c.set.NewSet("Global Options")
+	f.StringVar(&flag.StringVar{
+		Name:    "kubeconfig",
+		Aliases: []string{"c"},
+		Target:  &c.flagKubeConfig,
+		Default: "",
+		Usage:   "Path to kubeconfig file.",
+	})
+	f.StringVar(&flag.StringVar{
+		Name:    "context",
+		Target:  &c.flagKubeContext,
+		Default: "",
+		Usage:   "Kubernetes context to use.",
+	})
 
 	c.help = c.set.Help()
 
@@ -165,7 +163,7 @@ func (c *Command) Run(args []string) int {
 	// Setup logger to stream Helm library logs
 	var uiLogger = func(s string, args ...interface{}) {
 		logMsg := fmt.Sprintf(s, args...)
-		c.UI.Output(logMsg, terminal.WithInfoStyle())
+		c.UI.Output(logMsg, terminal.WithLibraryStyle())
 	}
 
 	c.UI.Output("Existing Installation", terminal.WithHeaderStyle())
@@ -194,7 +192,7 @@ func (c *Command) Run(args []string) int {
 		// Prompt for approval to uninstall Helm release.
 		if !c.flagAutoApprove {
 			confirmation, err := c.UI.Input(&terminal.Input{
-				Prompt: "Proceed with uninstall? (y/n)",
+				Prompt: "Proceed with uninstall? (y/N)",
 				Style:  terminal.InfoStyle,
 				Secret: false,
 			})
@@ -250,7 +248,7 @@ func (c *Command) Run(args []string) int {
 	// then it will proceed to delete those without a prompt.
 	if !c.flagWipeData {
 		confirmation, err := c.UI.Input(&terminal.Input{
-			Prompt: "WARNING: Proceed with deleting PVCs, Secrets, and ServiceAccounts? \n Only approve if all data from previous installation can be deleted (y/n)",
+			Prompt: "WARNING: Proceed with deleting PVCs, Secrets, and ServiceAccounts? \n Only approve if all data from previous installation can be deleted (y/N)",
 			Style:  terminal.WarningStyle,
 			Secret: false,
 		})
@@ -288,8 +286,7 @@ func (c *Command) Run(args []string) int {
 
 func (c *Command) Help() string {
 	c.once.Do(c.init)
-	s := "Usage: kubectl consul uninstall [options]" + "\n\n" + "Uninstall Consul and clean up all data." + "\n" +
-		"Any data store in Consul will not be recoverable." + "\n" + c.help
+	s := "Usage: kubectl consul uninstall [options]" + "\n" + "Uninstall Consul with options to delete data and resources associated with Consul installation." + "\n\n" + c.help
 	return s
 }
 
@@ -297,17 +294,9 @@ func (c *Command) Synopsis() string {
 	return "Uninstall Consul deployment."
 }
 
-const help = `
-Usage: kubectl consul uninstall [options]
-
-  Uninstall Consul and clean up all data.
-  This is a destructive action. Any data store in Consul will
-  not be recoverable.
-`
-
 func (c *Command) initActionConfig(actionConfig *action.Configuration, namespace string, settings *helmCLI.EnvSettings, logger action.DebugLog) (*action.Configuration, error) {
 	var err error
-	if namespace == DefaultAllNamespaces {
+	if namespace == defaultAllNamespaces {
 		err = actionConfig.Init(settings.RESTClientGetter(), "",
 			os.Getenv("HELM_DRIVER"), logger)
 	} else {
@@ -322,7 +311,7 @@ func (c *Command) initActionConfig(actionConfig *action.Configuration, namespace
 
 func (c *Command) findExistingInstallation(actionConfig *action.Configuration) (bool, string, string, error) {
 	lister := action.NewList(actionConfig)
-	if c.flagNamespace == DefaultAllNamespaces {
+	if c.flagNamespace == defaultAllNamespaces {
 		lister.AllNamespaces = true
 	}
 	res, err := lister.Run()
@@ -335,7 +324,7 @@ func (c *Command) findExistingInstallation(actionConfig *action.Configuration) (
 	foundReleaseNamespace := ""
 	for _, rel := range res {
 		if rel.Chart.Metadata.Name == "consul" {
-			if c.flagNamespace != DefaultAllNamespaces {
+			if c.flagNamespace != defaultAllNamespaces {
 				if c.flagNamespace == rel.Name {
 					found = true
 					foundReleaseName = rel.Name

--- a/cli/cmd/uninstall/uninstall.go
+++ b/cli/cmd/uninstall/uninstall.go
@@ -1,0 +1,363 @@
+package uninstall
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/consul-k8s/cli/cmd/common"
+	"github.com/hashicorp/consul-k8s/cli/cmd/common/flag"
+	"github.com/hashicorp/consul-k8s/cli/cmd/common/terminal"
+	"helm.sh/helm/v3/pkg/action"
+	helmCLI "helm.sh/helm/v3/pkg/cli"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	FlagSkipConfirm    = "skip-confirm"
+	DefaultSkipConfirm = false
+
+	FlagNamespace = "namespace"
+	AllNamespaces = ""
+
+	FlagReleaseName    = "name"
+	DefaultReleaseName = ""
+)
+
+type Command struct {
+	*common.BaseCommand
+
+	kubernetes kubernetes.Interface
+
+	set *flag.Sets
+
+	flagNamespace   string
+	flagReleaseName string
+	flagSkipConfirm bool
+
+	flagKubeConfig  string
+	flagKubeContext string
+
+	once sync.Once
+	help string
+}
+
+func (c *Command) init() {
+	c.set = flag.NewSets()
+	{
+		f := c.set.NewSet("Command Options")
+		f.BoolVar(&flag.BoolVar{
+			Name:    FlagSkipConfirm,
+			Target:  &c.flagSkipConfirm,
+			Default: DefaultSkipConfirm,
+			Usage:   "Skip confirmation prompt.",
+		})
+		f.StringVar(&flag.StringVar{
+			Name:    FlagNamespace,
+			Target:  &c.flagNamespace,
+			Default: AllNamespaces,
+			Usage:   fmt.Sprintf("Namespace for the Consul installation. Defaults to \"%q\".", AllNamespaces),
+		})
+		f.StringVar(&flag.StringVar{
+			Name:    FlagReleaseName,
+			Target:  &c.flagReleaseName,
+			Default: DefaultReleaseName,
+			Usage:   "Name of the installation. This will be prefixed to resources installed on the cluster.",
+		})
+
+		f = c.set.NewSet("Global Options")
+		f.StringVar(&flag.StringVar{
+			Name:    "kubeconfig",
+			Aliases: []string{"c"},
+			Target:  &c.flagKubeConfig,
+			Default: "",
+			Usage:   "Path to kubeconfig file.",
+		})
+		f.StringVar(&flag.StringVar{
+			Name:    "context",
+			Target:  &c.flagKubeContext,
+			Default: "",
+			Usage:   "Kubernetes context to use.",
+		})
+	}
+
+	c.help = c.set.Help()
+}
+
+func (c *Command) Run(args []string) int {
+	c.once.Do(c.init)
+	// Note that `c.init` and `c.Init` are NOT the same thing. One initializes the command struct,
+	// the other the UI. It looks similar because BaseCommand is embedded in Command.
+	c.Init()
+	defer func() {
+		if err := c.Close(); err != nil {
+			c.UI.Output(err.Error())
+			os.Exit(1)
+		}
+	}()
+
+	// The logger is initialized in main with the name cli. Here, we reset the name to uninstall so log lines would be prefixed with uninstall.
+	c.Log.ResetNamed("uninstall")
+
+	if err := c.set.Parse(args); err != nil {
+		c.UI.Output(err.Error())
+		os.Exit(1)
+	} else if len(c.set.Args()) > 0 {
+		c.UI.Output("Should have no non-flag arguments.")
+		os.Exit(1)
+	}
+
+	// helmCLI.New() will create a settings object which is used by the Helm Go SDK calls.
+	settings := helmCLI.New()
+
+	if c.flagKubeConfig != "" {
+		settings.KubeConfig = c.flagKubeConfig
+	}
+	if c.flagKubeContext != "" {
+		settings.KubeContext = c.flagKubeContext
+	}
+
+	// Set up the kubernetes client to use for non Helm SDK calls to the Kubernetes API
+	// The Helm SDK will use settings.RESTClientGetter for its calls as well, so this will
+	// use a consistent method to target the right cluster for both Helm SDK and non Helm SDK calls.
+	if c.kubernetes == nil {
+		restConfig, err := settings.RESTClientGetter().ToRESTConfig()
+		if err != nil {
+			c.UI.Output("retrieving Kubernetes auth: %v", err, terminal.WithErrorStyle())
+			os.Exit(1)
+		}
+		c.kubernetes, err = kubernetes.NewForConfig(restConfig)
+		if err != nil {
+			c.UI.Output("initializing Kubernetes client: %v", err, terminal.WithErrorStyle())
+			return 1
+		}
+	}
+
+	// Library functions should not log.
+	var nopLogger = func(_ string, _ ...interface{}) {}
+	// Setup logger to stream Helm library logs
+	//var uiLogger = func(s string, args ...interface{}) {
+	//	logMsg := fmt.Sprintf(s, args...)
+	//	c.UI.Output(logMsg, terminal.WithInfoStyle())
+	//}
+
+	c.UI.Output("Verification Checks", terminal.WithHeaderStyle())
+	// Search for Consul installation by calling `helm list`. Depends on what's already specified.
+
+	//var actionConfig *action.Configuration
+	actionConfig, err := c.createActionConfig(settings, nopLogger)
+	if err != nil {
+		c.UI.Output(err.Error(), terminal.WithErrorStyle())
+		return 1
+	}
+
+	found, foundReleaseName, foundReleaseNamespace, err := c.findExistingInstallation(actionConfig)
+	if err != nil {
+		c.UI.Output(err.Error(), terminal.WithErrorStyle())
+		return 1
+	}
+	if !found {
+		c.UI.Output("No existing Consul installations.", terminal.WithSuccessStyle())
+		return 0
+		// TODO should we exit here? how do we continue allowing deleting pvc and secrets?
+	}
+
+	c.UI.Output("Existing Consul installation found.", terminal.WithSuccessStyle())
+
+	c.UI.Output("Consul Un-Install Summary", terminal.WithHeaderStyle())
+	c.UI.Output("Installation name: %s", foundReleaseName, terminal.WithInfoStyle())
+	c.UI.Output("Namespace: %s", foundReleaseNamespace, terminal.WithInfoStyle())
+
+	if !c.flagSkipConfirm {
+		confirmation, err := c.UI.Input(&terminal.Input{
+			Prompt: "Proceed with uninstall? (y/n)",
+			Style:  terminal.InfoStyle,
+			Secret: false,
+		})
+		if err != nil {
+			c.UI.Output(err.Error(), terminal.WithErrorStyle())
+			return 1
+		}
+		confirmation = strings.TrimSuffix(confirmation, "\n")
+		if !(strings.ToLower(confirmation) == "y" || strings.ToLower(confirmation) == "yes") {
+			c.UI.Output("Un-install aborted. To learn how to customize the uninstall, run:\nconsul-k8s install --help", terminal.WithInfoStyle())
+			return 1
+		}
+	}
+
+	c.UI.Output("Running Un-Install Steps", terminal.WithHeaderStyle())
+	// Actually call out to `helm delete`
+	// TODO: Commenting these out fixes it. But why?
+	//actionConfig = new(action.Configuration)
+	actionConfig.Init(settings.RESTClientGetter(), c.flagNamespace,
+		os.Getenv("HELM_DRIVER"), nopLogger)
+	uninstaller := action.NewUninstall(actionConfig)
+	res, err := uninstaller.Run(c.flagReleaseName)
+	if err != nil {
+		c.UI.Output("unable to uninstall: %s", err, terminal.WithErrorStyle())
+		return 1
+	} else if res != nil && res.Info != "" {
+		c.UI.Output("uninstall result: %s", res.Info, terminal.WithErrorStyle())
+		return 1
+	} else {
+		c.UI.Output("Helm uninstall successful", terminal.WithSuccessStyle())
+	}
+
+	// Delete PVCs
+	var pvcNames []string
+	pvcSelector := metav1.ListOptions{LabelSelector: "release=" + c.flagReleaseName}
+	pvcs, err := c.kubernetes.CoreV1().PersistentVolumeClaims(c.flagNamespace).List(c.Ctx, pvcSelector)
+	if err != nil {
+		c.UI.Output("error listing PVCs: %s", err, terminal.WithErrorStyle())
+		return 1
+	}
+	for _, pvc := range pvcs.Items {
+		err := c.kubernetes.CoreV1().PersistentVolumeClaims(c.flagNamespace).Delete(c.Ctx, pvc.Name, metav1.DeleteOptions{})
+		if err != nil {
+			c.UI.Output("error deleting PVC %s: %s", pvc.Name, err, terminal.WithErrorStyle())
+			return 1
+		}
+		pvcNames = append(pvcNames, pvc.Name)
+	}
+	maxWait := 1800
+	var i int
+	for i = 0; i < maxWait; i++ {
+		pvcs, err := c.kubernetes.CoreV1().PersistentVolumeClaims(c.flagNamespace).List(c.Ctx, pvcSelector)
+		if err != nil {
+			c.UI.Output("error listing PVCs: %s", err, terminal.WithErrorStyle())
+			return 1
+		}
+		if len(pvcs.Items) == 0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if i == maxWait {
+		c.UI.Output("timed out waiting for PVCs to be deleted", terminal.WithErrorStyle())
+		return 1
+	}
+	if len(pvcNames) > 0 {
+		c.UI.Output(common.PrefixLines(" Deleted PVC => ", strings.Join(pvcNames, "\n")), terminal.WithSuccessStyle())
+	}
+	c.UI.Output("Persistent volume claims deleted.", terminal.WithSuccessStyle())
+
+	// Delete any secrets that have releaseName in their name.
+	var secretNames []string
+	secrets, err := c.kubernetes.CoreV1().Secrets(c.flagNamespace).List(c.Ctx, metav1.ListOptions{})
+	if err != nil {
+		c.UI.Output("error listing Secrets: %s", err, terminal.WithErrorStyle())
+		return 1
+	}
+	for _, secret := range secrets.Items {
+		if strings.HasPrefix(secret.Name, c.flagReleaseName) {
+			err := c.kubernetes.CoreV1().Secrets(c.flagNamespace).Delete(c.Ctx, secret.Name, metav1.DeleteOptions{})
+			if err != nil {
+				c.UI.Output("error deleting Secret %s: %s", secret.Name, err, terminal.WithErrorStyle())
+				return 1
+			}
+			secretNames = append(secretNames, secret.Name)
+		}
+	}
+	if len(secretNames) > 0 {
+		c.UI.Output("Consul secrets deleted.", terminal.WithSuccessStyle())
+	} else {
+		c.UI.Output("No Consul secrets found.", terminal.WithSuccessStyle())
+	}
+
+	// Delete service accounts that have releaseName in their name.
+	var serviceAccountNames []string
+	sas, err := c.kubernetes.CoreV1().ServiceAccounts(c.flagNamespace).List(c.Ctx, metav1.ListOptions{})
+	if err != nil {
+		c.UI.Output("error listing ServiceAccounts: %s", err, terminal.WithErrorStyle())
+		return 1
+	}
+	for _, sa := range sas.Items {
+		if strings.HasPrefix(sa.Name, c.flagReleaseName) {
+			err := c.kubernetes.CoreV1().ServiceAccounts(c.flagNamespace).Delete(c.Ctx, sa.Name, metav1.DeleteOptions{})
+			if err != nil {
+				c.UI.Output("error deleting Service Account %s: %s", sa.Name, err, terminal.WithErrorStyle())
+				return 1
+			}
+			serviceAccountNames = append(serviceAccountNames, sa.Name)
+		}
+	}
+	if len(serviceAccountNames) > 0 {
+		c.UI.Output("Consul service accounts deleted.", terminal.WithSuccessStyle())
+	} else {
+		c.UI.Output("No Consul service accounts found.", terminal.WithSuccessStyle())
+	}
+
+	return 0
+}
+
+func (c *Command) Help() string {
+	c.once.Do(c.init)
+	s := "Usage: kubectl consul uninstall [options]" + "\n\n" + "Uninstall Consul and clean up all data." + "\n" +
+		"Any data store in Consul will not be recoverable." + "\n" + c.help
+	return s
+}
+
+func (c *Command) Synopsis() string {
+	return "Uninstall Consul deployment."
+}
+
+const help = `
+Usage: kubectl consul uninstall [options]
+
+  Uninstall Consul and clean up all data.
+  This is a destructive action. Any data store in Consul will
+  not be recoverable.
+`
+
+func (c *Command) createActionConfig(settings *helmCLI.EnvSettings, logger action.DebugLog) (*action.Configuration, error) {
+	actionConfig := new(action.Configuration)
+	var err error
+	if c.flagNamespace == AllNamespaces {
+		err = actionConfig.Init(settings.RESTClientGetter(), "",
+			os.Getenv("HELM_DRIVER"), logger)
+	} else {
+		err = actionConfig.Init(settings.RESTClientGetter(), c.flagNamespace,
+			os.Getenv("HELM_DRIVER"), logger)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error setting up helm action configuration to find existing installations: %s", err)
+	}
+	return actionConfig, nil
+}
+
+func (c *Command) findExistingInstallation(actionConfig *action.Configuration) (bool, string, string, error) {
+	lister := action.NewList(actionConfig)
+	if c.flagNamespace == AllNamespaces {
+		lister.AllNamespaces = true
+	}
+	res, err := lister.Run()
+	if err != nil {
+		return false, "", "", fmt.Errorf("error finding existing installations: %s", err)
+	}
+
+	found := false
+	foundReleaseName := ""
+	foundReleaseNamespace := ""
+	for _, rel := range res {
+		if rel.Chart.Metadata.Name == "consul" {
+			if c.flagNamespace != AllNamespaces {
+				if c.flagNamespace == rel.Name {
+					found = true
+					foundReleaseName = rel.Name
+					foundReleaseNamespace = rel.Namespace
+					break
+				}
+			}
+			found = true
+			foundReleaseName = rel.Name
+			foundReleaseNamespace = rel.Namespace
+			break
+		}
+	}
+
+	return found, foundReleaseName, foundReleaseNamespace, nil
+
+}

--- a/cli/cmd/uninstall/uninstall.go
+++ b/cli/cmd/uninstall/uninstall.go
@@ -110,13 +110,14 @@ func (c *Command) init() {
 	}
 
 	c.help = c.set.Help()
+
+	// c.Init() calls the embedded BaseCommand's initialization function.
+	c.Init()
 }
 
 func (c *Command) Run(args []string) int {
 	c.once.Do(c.init)
-	// Note that `c.init` and `c.Init` are NOT the same thing. One initializes the command struct,
-	// the other the UI. It looks similar because BaseCommand is embedded in Command.
-	c.Init()
+
 	defer func() {
 		if err := c.Close(); err != nil {
 			c.UI.Output(err.Error())

--- a/cli/cmd/uninstall/uninstall.go
+++ b/cli/cmd/uninstall/uninstall.go
@@ -307,7 +307,7 @@ func (c *Command) Run(args []string) int {
 
 func (c *Command) Help() string {
 	c.once.Do(c.init)
-	s := "Usage: consul-k8s uninstall [options]" + "\n" + "Uninstall Consul with options to delete data and resources associated with Consul installation." + "\n\n" + c.help
+	s := "Usage: consul-k8s uninstall [flags]" + "\n" + "Uninstall Consul with options to delete data and resources associated with Consul installation." + "\n\n" + c.help
 	return s
 }
 

--- a/cli/cmd/uninstall/uninstall.go
+++ b/cli/cmd/uninstall/uninstall.go
@@ -339,14 +339,13 @@ func (c *Command) findExistingInstallation(actionConfig *action.Configuration) (
 				foundReleaseName = rel.Name
 				foundReleaseNamespace = rel.Namespace
 				break
-			} else {
-				continue
 			}
-
-			found = true
-			foundReleaseName = rel.Name
-			foundReleaseNamespace = rel.Namespace
-			break
+			if c.flagNamespace == defaultAllNamespaces {
+				found = true
+				foundReleaseName = rel.Name
+				foundReleaseNamespace = rel.Namespace
+				break
+			}
 		}
 	}
 

--- a/cli/cmd/uninstall/uninstall.go
+++ b/cli/cmd/uninstall/uninstall.go
@@ -246,8 +246,8 @@ func (c *Command) Run(args []string) int {
 	// installation name and "consul" for the namespace.
 	if !found {
 		if c.flagReleaseName == "" || c.flagNamespace == "" {
-			foundReleaseName = "consul"
-			foundReleaseNamespace = "consul"
+			foundReleaseName = common.DefaultReleaseName
+			foundReleaseNamespace = common.DefaultReleaseNamespace
 		} else {
 			foundReleaseName = c.flagReleaseName
 			foundReleaseNamespace = c.flagNamespace
@@ -332,18 +332,17 @@ func (c *Command) findExistingInstallation(actionConfig *action.Configuration) (
 	foundReleaseNamespace := ""
 	for _, rel := range res {
 		if rel.Chart.Metadata.Name == "consul" {
-			if c.flagNamespace != defaultAllNamespaces {
+			if c.flagNamespace != defaultAllNamespaces && c.flagNamespace == rel.Namespace {
 				// If we found a chart named "consul" and -namespace was specified, we only found the release if the
 				// release namespace matches the -namespace flag.
-				if c.flagNamespace == rel.Namespace {
-					found = true
-					foundReleaseName = rel.Name
-					foundReleaseNamespace = rel.Namespace
-					break
-				} else {
-					continue
-				}
+				found = true
+				foundReleaseName = rel.Name
+				foundReleaseNamespace = rel.Namespace
+				break
+			} else {
+				continue
 			}
+
 			found = true
 			foundReleaseName = rel.Name
 			foundReleaseNamespace = rel.Namespace

--- a/cli/cmd/uninstall/uninstall.go
+++ b/cli/cmd/uninstall/uninstall.go
@@ -14,7 +14,6 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	helmCLI "helm.sh/helm/v3/pkg/cli"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -178,7 +177,7 @@ func (c *Command) Run(args []string) int {
 
 	// Search for Consul installation by calling `helm list`. Depends on what's already specified.
 	actionConfig := new(action.Configuration)
-	actionConfig, err = c.initActionConfig(actionConfig, c.flagNamespace, settings, uiLogger)
+	actionConfig, err = common.InitActionConfig(actionConfig, c.flagNamespace, settings, uiLogger)
 	if err != nil {
 		c.UI.Output(err.Error(), terminal.WithErrorStyle())
 		return 1
@@ -215,7 +214,7 @@ func (c *Command) Run(args []string) int {
 		}
 
 		// Actually call out to `helm delete`.
-		actionConfig, err = c.initActionConfig(actionConfig, foundReleaseNamespace, settings, uiLogger)
+		actionConfig, err = common.InitActionConfig(actionConfig, foundReleaseNamespace, settings, uiLogger)
 		if err != nil {
 			c.UI.Output(err.Error(), terminal.WithErrorStyle())
 			return 1
@@ -314,18 +313,6 @@ func (c *Command) Help() string {
 
 func (c *Command) Synopsis() string {
 	return "Uninstall Consul deployment."
-}
-
-func (c *Command) initActionConfig(actionConfig *action.Configuration, namespace string, settings *helmCLI.EnvSettings, logger action.DebugLog) (*action.Configuration, error) {
-	getter := settings.RESTClientGetter()
-	configFlags := getter.(*genericclioptions.ConfigFlags)
-	configFlags.Namespace = &namespace
-	err := actionConfig.Init(settings.RESTClientGetter(), namespace,
-		os.Getenv("HELM_DRIVER"), logger)
-	if err != nil {
-		return nil, fmt.Errorf("error setting up helm action configuration to find existing installations: %s", err)
-	}
-	return actionConfig, nil
 }
 
 func (c *Command) findExistingInstallation(actionConfig *action.Configuration) (bool, string, string, error) {

--- a/cli/cmd/uninstall/uninstall.go
+++ b/cli/cmd/uninstall/uninstall.go
@@ -213,11 +213,6 @@ func (c *Command) Run(args []string) int {
 				return 1
 			}
 		}
-		// Recreating settings with the found namespace so that the kube client in Helm is re-initialized with the right namespace facepalm
-		//prevHelmNSEnv := os.Getenv("HELM_NAMESPACE")
-		//os.Setenv("HELM_NAMESPACE", foundReleaseNamespace)
-		//settings = helmCLI.New()
-		//os.Setenv("HELM_NAMESPACE", prevHelmNSEnv)
 
 		// Actually call out to `helm delete`.
 		actionConfig, err = c.initActionConfig(actionConfig, foundReleaseNamespace, settings, uiLogger)

--- a/cli/cmd/uninstall/uninstall_test.go
+++ b/cli/cmd/uninstall/uninstall_test.go
@@ -1,0 +1,115 @@
+package uninstall
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/consul-k8s/cli/cmd/common"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// Helper function which sets up a Command struct for you.
+func getInitializedCommand(t *testing.T) *Command {
+	t.Helper()
+	log := hclog.New(&hclog.LoggerOptions{
+		Name:   "cli",
+		Level:  hclog.Info,
+		Output: os.Stdout,
+	})
+	ctx, _ := context.WithCancel(context.Background())
+
+	baseCommand := &common.BaseCommand{
+		Ctx: ctx,
+		Log: log,
+	}
+
+	c := &Command{
+		BaseCommand: baseCommand,
+	}
+	c.init()
+	c.Init()
+	return c
+}
+
+// TestDebugger is used to play with install.go for ad-hoc testing.
+//func TestDebugger(t *testing.T) {
+//	c := getInitializedCommand(t)
+//	c.Run([]string{"-auto-approve", "-f=../../config.yaml"})
+//}
+
+func TestDeletePVCs(t *testing.T) {
+	c := getInitializedCommand(t)
+	c.kubernetes = fake.NewSimpleClientset()
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "consul-server-test1",
+			Labels: map[string]string{
+				"release": "consul",
+			},
+		},
+	}
+	pvc2 := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "consul-server-test2",
+			Labels: map[string]string{
+				"release": "consul",
+			},
+		},
+	}
+	c.kubernetes.CoreV1().PersistentVolumeClaims("default").Create(context.TODO(), pvc, metav1.CreateOptions{})
+	c.kubernetes.CoreV1().PersistentVolumeClaims("default").Create(context.TODO(), pvc2, metav1.CreateOptions{})
+	err := c.deletePVCs("consul", "default")
+	require.NoError(t, err)
+	pvcs, err := c.kubernetes.CoreV1().PersistentVolumeClaims("default").List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, pvcs.Items, 0)
+
+	// Clear out the client and make sure the check now passes.
+	//c.kubernetes = fake.NewSimpleClientset()
+	//err = c.checkForPreviousPVCs()
+	//require.NoError(t, err)
+
+	// Add a new irrelevant PVC and make sure the check continues to pass.
+	//pvc = &v1.PersistentVolumeClaim{
+	//	ObjectMeta: metav1.ObjectMeta{
+	//		Name: "irrelevant-pvc",
+	//	},
+	//}
+	//c.kubernetes.CoreV1().PersistentVolumeClaims("default").Create(context.TODO(), pvc, metav1.CreateOptions{})
+	//err = c.checkForPreviousPVCs()
+	//require.NoError(t, err)
+}
+
+//func TestCheckForPreviousSecrets(t *testing.T) {
+//	c := getInitializedCommand(t)
+//	c.kubernetes = fake.NewSimpleClientset()
+//	secret := &v1.Secret{
+//		ObjectMeta: metav1.ObjectMeta{
+//			Name: "test-consul-bootstrap-acl-token",
+//		},
+//	}
+//	c.kubernetes.CoreV1().Secrets("default").Create(context.TODO(), secret, metav1.CreateOptions{})
+//	err := c.checkForPreviousSecrets()
+//	require.Error(t, err)
+//	require.Contains(t, err.Error(), "found consul-acl-bootstrap-token secret from previous installations: \"test-consul-bootstrap-acl-token\" in namespace \"default\". To delete, run kubectl delete secret test-consul-bootstrap-acl-token --namespace default")
+//
+//	// Clear out the client and make sure the check now passes.
+//	c.kubernetes = fake.NewSimpleClientset()
+//	err = c.checkForPreviousSecrets()
+//	require.NoError(t, err)
+//
+//	// Add a new irrelevant secret and make sure the check continues to pass.
+//	secret = &v1.Secret{
+//		ObjectMeta: metav1.ObjectMeta{
+//			Name: "irrelevant-secret",
+//		},
+//	}
+//	c.kubernetes.CoreV1().Secrets("default").Create(context.TODO(), secret, metav1.CreateOptions{})
+//	err = c.checkForPreviousSecrets()
+//	require.NoError(t, err)
+//}

--- a/cli/cmd/uninstall/uninstall_test.go
+++ b/cli/cmd/uninstall/uninstall_test.go
@@ -13,29 +13,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-// Helper function which sets up a Command struct for you.
-func getInitializedCommand(t *testing.T) *Command {
-	t.Helper()
-	log := hclog.New(&hclog.LoggerOptions{
-		Name:   "cli",
-		Level:  hclog.Info,
-		Output: os.Stdout,
-	})
-	ctx, _ := context.WithCancel(context.Background())
-
-	baseCommand := &common.BaseCommand{
-		Ctx: ctx,
-		Log: log,
-	}
-
-	c := &Command{
-		BaseCommand: baseCommand,
-	}
-	c.init()
-	c.Init()
-	return c
-}
-
 func TestDeletePVCs(t *testing.T) {
 	c := getInitializedCommand(t)
 	c.kubernetes = fake.NewSimpleClientset()
@@ -77,7 +54,7 @@ func TestDeleteSecrets(t *testing.T) {
 			},
 		},
 	}
-	secret2 := &v1.PersistentVolumeClaim{
+	secret2 := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "consul-test-secret2",
 			Labels: map[string]string{
@@ -124,4 +101,26 @@ func TestDeleteServiceAccounts(t *testing.T) {
 	sas, err := c.kubernetes.CoreV1().ServiceAccounts("default").List(context.TODO(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, sas.Items, 0)
+}
+
+// getInitializedCommand sets up a command struct for tests.
+func getInitializedCommand(t *testing.T) *Command {
+	t.Helper()
+	log := hclog.New(&hclog.LoggerOptions{
+		Name:   "cli",
+		Level:  hclog.Info,
+		Output: os.Stdout,
+	})
+	ctx, _ := context.WithCancel(context.Background())
+
+	baseCommand := &common.BaseCommand{
+		Ctx: ctx,
+		Log: log,
+	}
+
+	c := &Command{
+		BaseCommand: baseCommand,
+	}
+	c.init()
+	return c
 }

--- a/cli/cmd/uninstall/uninstall_test.go
+++ b/cli/cmd/uninstall/uninstall_test.go
@@ -33,15 +33,25 @@ func TestDeletePVCs(t *testing.T) {
 			},
 		},
 	}
-	_, err := c.kubernetes.CoreV1().PersistentVolumeClaims("default").Create(context.TODO(), pvc, metav1.CreateOptions{})
+	pvc3 := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "unrelated-pvc",
+			Labels: map[string]string{
+				"release": "unrelated",
+			},
+		},
+	}
+	_, err := c.kubernetes.CoreV1().PersistentVolumeClaims("default").Create(context.Background(), pvc, metav1.CreateOptions{})
 	require.NoError(t, err)
-	_, err = c.kubernetes.CoreV1().PersistentVolumeClaims("default").Create(context.TODO(), pvc2, metav1.CreateOptions{})
+	_, err = c.kubernetes.CoreV1().PersistentVolumeClaims("default").Create(context.Background(), pvc2, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = c.kubernetes.CoreV1().PersistentVolumeClaims("default").Create(context.Background(), pvc3, metav1.CreateOptions{})
 	require.NoError(t, err)
 	err = c.deletePVCs("consul", "default")
 	require.NoError(t, err)
-	pvcs, err := c.kubernetes.CoreV1().PersistentVolumeClaims("default").List(context.TODO(), metav1.ListOptions{})
+	pvcs, err := c.kubernetes.CoreV1().PersistentVolumeClaims("default").List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
-	require.Len(t, pvcs.Items, 0)
+	require.Len(t, pvcs.Items, 1)
 }
 
 func TestDeleteSecrets(t *testing.T) {
@@ -63,13 +73,13 @@ func TestDeleteSecrets(t *testing.T) {
 			},
 		},
 	}
-	_, err := c.kubernetes.CoreV1().Secrets("default").Create(context.TODO(), secret, metav1.CreateOptions{})
+	_, err := c.kubernetes.CoreV1().Secrets("default").Create(context.Background(), secret, metav1.CreateOptions{})
 	require.NoError(t, err)
-	_, err = c.kubernetes.CoreV1().Secrets("default").Create(context.TODO(), secret2, metav1.CreateOptions{})
+	_, err = c.kubernetes.CoreV1().Secrets("default").Create(context.Background(), secret2, metav1.CreateOptions{})
 	require.NoError(t, err)
 	err = c.deleteSecrets("consul", "default")
 	require.NoError(t, err)
-	secrets, err := c.kubernetes.CoreV1().Secrets("default").List(context.TODO(), metav1.ListOptions{})
+	secrets, err := c.kubernetes.CoreV1().Secrets("default").List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, secrets.Items, 0)
 }
@@ -93,13 +103,13 @@ func TestDeleteServiceAccounts(t *testing.T) {
 			},
 		},
 	}
-	_, err := c.kubernetes.CoreV1().ServiceAccounts("default").Create(context.TODO(), sa, metav1.CreateOptions{})
+	_, err := c.kubernetes.CoreV1().ServiceAccounts("default").Create(context.Background(), sa, metav1.CreateOptions{})
 	require.NoError(t, err)
-	_, err = c.kubernetes.CoreV1().ServiceAccounts("default").Create(context.TODO(), sa2, metav1.CreateOptions{})
+	_, err = c.kubernetes.CoreV1().ServiceAccounts("default").Create(context.Background(), sa2, metav1.CreateOptions{})
 	require.NoError(t, err)
 	err = c.deleteServiceAccounts("consul", "default")
 	require.NoError(t, err)
-	sas, err := c.kubernetes.CoreV1().ServiceAccounts("default").List(context.TODO(), metav1.ListOptions{})
+	sas, err := c.kubernetes.CoreV1().ServiceAccounts("default").List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, sas.Items, 0)
 }
@@ -123,13 +133,13 @@ func TestDeleteRoles(t *testing.T) {
 			},
 		},
 	}
-	_, err := c.kubernetes.RbacV1().Roles("default").Create(context.TODO(), role, metav1.CreateOptions{})
+	_, err := c.kubernetes.RbacV1().Roles("default").Create(context.Background(), role, metav1.CreateOptions{})
 	require.NoError(t, err)
-	_, err = c.kubernetes.RbacV1().Roles("default").Create(context.TODO(), role2, metav1.CreateOptions{})
+	_, err = c.kubernetes.RbacV1().Roles("default").Create(context.Background(), role2, metav1.CreateOptions{})
 	require.NoError(t, err)
 	err = c.deleteRoles("consul", "default")
 	require.NoError(t, err)
-	roles, err := c.kubernetes.RbacV1().Roles("default").List(context.TODO(), metav1.ListOptions{})
+	roles, err := c.kubernetes.RbacV1().Roles("default").List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, roles.Items, 0)
 }
@@ -153,13 +163,13 @@ func TestDeleteRoleBindings(t *testing.T) {
 			},
 		},
 	}
-	_, err := c.kubernetes.RbacV1().RoleBindings("default").Create(context.TODO(), rolebinding, metav1.CreateOptions{})
+	_, err := c.kubernetes.RbacV1().RoleBindings("default").Create(context.Background(), rolebinding, metav1.CreateOptions{})
 	require.NoError(t, err)
-	_, err = c.kubernetes.RbacV1().RoleBindings("default").Create(context.TODO(), rolebinding2, metav1.CreateOptions{})
+	_, err = c.kubernetes.RbacV1().RoleBindings("default").Create(context.Background(), rolebinding2, metav1.CreateOptions{})
 	require.NoError(t, err)
 	err = c.deleteRoleBindings("consul", "default")
 	require.NoError(t, err)
-	rolebindings, err := c.kubernetes.RbacV1().RoleBindings("default").List(context.TODO(), metav1.ListOptions{})
+	rolebindings, err := c.kubernetes.RbacV1().RoleBindings("default").List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, rolebindings.Items, 0)
 }

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/consul-k8s/cli/cmd/common"
 	"github.com/hashicorp/consul-k8s/cli/cmd/install"
+	"github.com/hashicorp/consul-k8s/cli/cmd/uninstall"
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
 )
@@ -19,6 +20,11 @@ func initializeCommands(ctx context.Context, log hclog.Logger) (*common.BaseComm
 	commands := map[string]cli.CommandFactory{
 		"install": func() (cli.Command, error) {
 			return &install.Command{
+				BaseCommand: baseCommand,
+			}, nil
+		},
+		"uninstall": func() (cli.Command, error) {
+			return &uninstall.Command{
 				BaseCommand: baseCommand,
 			}, nil
 		},

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/bgentry/speakeasy v0.1.0
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/go-hclog v0.16.2

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -22,6 +22,7 @@ require (
 	helm.sh/helm/v3 v3.6.1
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2
+	k8s.io/cli-runtime v0.21.0
 	k8s.io/client-go v0.21.2
 	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/yaml v1.2.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -125,6 +125,7 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=


### PR DESCRIPTION
Based off of a demo branch @sadjamz worked on here: https://github.com/hashicorp/consul-k8s-cli/tree/uninstall

**Changes proposed in this PR:**
- `consul-k8s uninstall` uninstalls the Consul Helm installation with options to wipe all data
- If you don't provide the release name/namespace, it will find the release whose metadata.name matches "consul", and then prompt to uninstall that release and any pvcs/secrets based on that.
- You can provide the release name/namespace in a case where you have already `helm uninstall`'ed the consul helm installation, but still have PVCs, Secrets, etc to clean up.
- Note that this PR is difficult to unit test-- acceptance tests are coming as the next task after install/uninstall are complete. The Helm steps are difficult to mock out for reasons mentioned in the install PR:

  - https://github.com/hashicorp/consul-k8s/pull/713#discussion_r705794524

  - https://github.com/hashicorp/consul-k8s/blob/e77da79f99bbd1038f7b3dc203c6492127341e6b/cli/cmd/install/install.go#L338



How I've tested this PR:
Manual testing of the cases mentioned below, a few unit tests.

**How I expect reviewers to test this PR:**
1) Code review

2) Test it out:
`cd cli`
`go build -o ./bin/consul-k8s`
`./bin/consul-k8s uninstall`
If you can test out the command with the following flags and let me know if you have behaviour suggestions. 
  a) no flags
  b) -name and -namespace set
  c) -auto-approve
  d) -wipe-all-data

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

