### PR TITLE
Update connect-inject with partition name

### DIFF
--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -133,6 +133,7 @@ spec:
                 {{- end }}
                 {{- if .Values.global.adminPartitions.enabled }}
                 -enable-partitions=true \
+                -partition-name={{ .Values.global.adminPartitions.name }} \
                 {{- end }}
                 {{- if .Values.global.enableConsulNamespaces }}
                 -enable-namespaces=true \

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -712,6 +712,18 @@ EOF
   [ "${actual}" = "true" ]
 }
 
+@test "connectInject/Deployment: partition name set with .global.adminPartitions.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("partition-name=default"))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
 #--------------------------------------------------------------------
 # namespaces
 

--- a/control-plane/connect-inject/container_init.go
+++ b/control-plane/connect-inject/container_init.go
@@ -22,6 +22,10 @@ type initContainerCommandData struct {
 	ServiceName        string
 	ServiceAccountName string
 	AuthMethod         string
+	// ConsulPartition is the Consul admin partition to register the service
+	// and proxy in. An empty string indicates partitions are not
+	// enabled in Consul (necessary for OSS).
+	ConsulPartition string
 	// ConsulNamespace is the Consul namespace to register the service
 	// and proxy in. An empty string indicates namespaces are not
 	// enabled in Consul (necessary for OSS).
@@ -105,6 +109,7 @@ func (h *Handler) containerInit(namespace corev1.Namespace, pod corev1.Pod) (cor
 
 	data := initContainerCommandData{
 		AuthMethod:                 h.AuthMethod,
+		ConsulPartition:            h.ConsulPartition,
 		ConsulNamespace:            h.consulNamespace(namespace.Name),
 		NamespaceMirroringEnabled:  h.EnableK8SNSMirroring,
 		ConsulCACert:               h.ConsulCACert,
@@ -284,6 +289,9 @@ consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD
   {{- end }}
   {{- end }}
   {{- end }}
+  {{- if .ConsulPartition }}
+  -partition="{{ .ConsulPartition }}" \
+  {{- end }}
   {{- if .ConsulNamespace }}
   -consul-service-namespace="{{ .ConsulNamespace }}" \
   {{- end }}
@@ -300,6 +308,9 @@ consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD
   {{- if .AuthMethod }}
   -token-file="/consul/connect-inject/acl-token" \
   {{- end }}
+  {{- if .ConsulPartition }}
+  -partition="{{ .ConsulPartition }}" \
+  {{- end }}
   {{- if .ConsulNamespace }}
   -namespace="{{ .ConsulNamespace }}" \
   {{- end }}
@@ -313,6 +324,9 @@ consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD
 /consul/connect-inject/consul connect redirect-traffic \
   {{- if .AuthMethod }}
   -token-file="/consul/connect-inject/acl-token" \
+  {{- end }}
+  {{- if .ConsulPartition }}
+  -partition="{{ .ConsulPartition }}" \
   {{- end }}
   {{- if .ConsulNamespace }}
   -namespace="{{ .ConsulNamespace }}" \

--- a/control-plane/connect-inject/handler.go
+++ b/control-plane/connect-inject/handler.go
@@ -61,6 +61,11 @@ type Handler struct {
 	// If not set, will use HTTP.
 	ConsulCACert string
 
+	// ConsulPartition is the name of the Admin Partition that the controller
+	// is deployed in. It is an enterprise feature requiring Consul Enterprise 1.11+.
+	// Its value is an empty string if partitions aren't enabled.
+	ConsulPartition string
+
 	// EnableNamespaces indicates that a user is running Consul Enterprise
 	// with version 1.7+ which is namespace aware. It enables Consul namespaces,
 	// with injection into either a single Consul namespace or mirrored from

--- a/control-plane/subcommand/connect-init/command.go
+++ b/control-plane/subcommand/connect-init/command.go
@@ -32,6 +32,7 @@ type Command struct {
 	UI cli.Ui
 
 	flagACLAuthMethod          string // Auth Method to use for ACLs, if enabled.
+	flagPartition              string // Admin Partition name. Consul Enterprise 1.11+ feature.
 	flagPodName                string // Pod name.
 	flagPodNamespace           string // Pod namespace.
 	flagAuthMethodNamespace    string // Consul namespace the auth-method is defined in.
@@ -57,6 +58,7 @@ type Command struct {
 func (c *Command) init() {
 	c.flagSet = flag.NewFlagSet("", flag.ContinueOnError)
 	c.flagSet.StringVar(&c.flagACLAuthMethod, "acl-auth-method", "", "Name of the auth method to login to.")
+	c.flagSet.StringVar(&c.flagPartition, "partition", "", "Name of the Admin Partition of deployment.")
 	c.flagSet.StringVar(&c.flagPodName, "pod-name", "", "Name of the pod.")
 	c.flagSet.StringVar(&c.flagPodNamespace, "pod-namespace", "", "Name of the pod namespace.")
 	c.flagSet.StringVar(&c.flagAuthMethodNamespace, "auth-method-namespace", "", "Consul namespace the auth-method is defined in")
@@ -118,6 +120,7 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 	cfg := api.DefaultConfig()
+	cfg.Partition = c.flagPartition
 	cfg.Namespace = c.flagConsulServiceNamespace
 	c.http.MergeOntoConfig(cfg)
 	consulClient, err := consul.NewClient(cfg)

--- a/control-plane/subcommand/connect-init/command_ent_test.go
+++ b/control-plane/subcommand/connect-init/command_ent_test.go
@@ -26,84 +26,97 @@ func TestRun_ServicePollingWithACLsAndTLSWithNamespaces(t *testing.T) {
 		consulServiceNamespace string
 		acls                   bool
 		authMethodNamespace    string
+		adminPartition         string
 	}{
 		{
-			name:                   "ACLs enabled, no tls, serviceNS=default, authMethodNS=default",
+			name:                   "ACLs enabled, no tls, serviceNS=default, authMethodNS=default, partition=default",
 			tls:                    false,
 			consulServiceNamespace: "default",
 			authMethodNamespace:    "default",
 			acls:                   true,
+			adminPartition:         "default",
 		},
 		{
-			name:                   "ACLs enabled, tls, serviceNS=default, authMethodNS=default",
+			name:                   "ACLs enabled, tls, serviceNS=default, authMethodNS=default, partition=default",
 			tls:                    true,
 			consulServiceNamespace: "default",
 			authMethodNamespace:    "default",
 			acls:                   true,
+			adminPartition:         "default",
 		},
 		{
-			name:                   "ACLs enabled, no tls, serviceNS=default-ns, authMethodNS=default",
+			name:                   "ACLs enabled, no tls, serviceNS=default-ns, authMethodNS=default, partition=default",
 			tls:                    false,
 			consulServiceNamespace: "default-ns",
 			authMethodNamespace:    "default",
 			acls:                   true,
+			adminPartition:         "default",
 		},
 		{
-			name:                   "ACLs enabled, tls, serviceNS=default-ns, authMethodNS=default",
+			name:                   "ACLs enabled, tls, serviceNS=default-ns, authMethodNS=default, partition=default",
 			tls:                    true,
 			consulServiceNamespace: "default-ns",
 			authMethodNamespace:    "default",
 			acls:                   true,
+			adminPartition:         "default",
 		},
 		{
-			name:                   "ACLs enabled, no tls, serviceNS=other, authMethodNS=other",
+			name:                   "ACLs enabled, no tls, serviceNS=other, authMethodNS=other, partition=default",
 			tls:                    false,
 			consulServiceNamespace: "other",
 			authMethodNamespace:    "other",
 			acls:                   true,
+			adminPartition:         "default",
 		},
 		{
-			name:                   "ACLs enabled, tls, serviceNS=other, authMethodNS=other",
+			name:                   "ACLs enabled, tls, serviceNS=other, authMethodNS=other, partition=default",
 			tls:                    true,
 			consulServiceNamespace: "other",
 			authMethodNamespace:    "other",
 			acls:                   true,
+			adminPartition:         "default",
 		},
 		{
-			name:                   "ACLs disabled, no tls, serviceNS=default, authMethodNS=default",
+			name:                   "ACLs disabled, no tls, serviceNS=default, authMethodNS=default, partition=default",
 			tls:                    false,
 			consulServiceNamespace: "default",
 			authMethodNamespace:    "default",
+			adminPartition:         "default",
 		},
 		{
-			name:                   "ACLs disabled, tls, serviceNS=default, authMethodNS=default",
+			name:                   "ACLs disabled, tls, serviceNS=default, authMethodNS=default, partition=default",
 			tls:                    true,
 			consulServiceNamespace: "default",
 			authMethodNamespace:    "default",
+			adminPartition:         "default",
 		},
 		{
-			name:                   "ACLs disabled, no tls, serviceNS=default-ns, authMethodNS=default",
+			name:                   "ACLs disabled, no tls, serviceNS=default-ns, authMethodNS=default, partition=default",
 			tls:                    false,
 			consulServiceNamespace: "default-ns",
 			authMethodNamespace:    "default",
+			adminPartition:         "default",
 		},
 		{
-			name:                   "ACLs disabled, tls, serviceNS=default-ns, authMethodNS=default",
+			name:                   "ACLs disabled, tls, serviceNS=default-ns, authMethodNS=default, partition=default",
 			tls:                    true,
 			consulServiceNamespace: "default-ns",
 			authMethodNamespace:    "default",
+			adminPartition:         "default",
 		},
 		{
-			name:                   "ACLs disabled, no tls, serviceNS=other, authMethodNS=other",
+			name:                   "ACLs disabled, no tls, serviceNS=other, authMethodNS=other, partition=default",
 			tls:                    false,
 			consulServiceNamespace: "other",
 			authMethodNamespace:    "other",
+			adminPartition:         "default",
 		},
 		{
-			name:                   "ACLs disabled, tls, serviceNS=other, authMethodNS=other",
+			name:                   "ACLs disabled, tls, serviceNS=other, authMethodNS=other, partition=default",
 			tls:                    true,
 			consulServiceNamespace: "other",
 			authMethodNamespace:    "other",
+			adminPartition:         "default",
 		},
 	}
 	for _, c := range cases {
@@ -139,6 +152,7 @@ func TestRun_ServicePollingWithACLsAndTLSWithNamespaces(t *testing.T) {
 				Scheme:    "http",
 				Address:   server.HTTPAddr,
 				Namespace: c.consulServiceNamespace,
+				Partition: c.adminPartition,
 			}
 			if c.acls {
 				cfg.Token = masterToken
@@ -174,6 +188,7 @@ func TestRun_ServicePollingWithACLsAndTLSWithNamespaces(t *testing.T) {
 				tokenSinkFile:                      tokenFile,
 				proxyIDFile:                        proxyFile,
 				serviceRegistrationPollingAttempts: 5,
+				flagPartition:                      c.adminPartition,
 			}
 			// We build the http-addr because normally it's defined by the init container setting
 			// CONSUL_HTTP_ADDR when it processes the command template.

--- a/control-plane/subcommand/inject-connect/command_test.go
+++ b/control-plane/subcommand/inject-connect/command_test.go
@@ -49,6 +49,16 @@ func TestRun_FlagValidation(t *testing.T) {
 		},
 		{
 			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-enable-partitions", "true"},
+			expErr: "-partition-name must set if -enable-partitions is set to 'true'",
+		},
+		{
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
+				"-partition-name", "default"},
+			expErr: "-enable-partitions must be set to 'true' if -partition-name is set",
+		},
+		{
+			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
 				"-default-sidecar-proxy-cpu-limit=unparseable"},
 			expErr: "-default-sidecar-proxy-cpu-limit is invalid",
 		},


### PR DESCRIPTION
Changes proposed in this PR:
- Update the envoy bootstrap config with the partition name so that it can correctly generate the envoy config. This was causing an error for Consul Connect 
`Unexpected response code: 400 (request targets partition \"default\" which does not match agent partition \"alpha\"\n)`

How I've tested this PR:
- Unit tests
– Deploying it to k8s and testing connect

How I expect reviewers to test this PR:
- Code review

Checklist:
- [x] Tests added


