### PR TITLE
chart: support setting ui.content_path

### DIFF
--- a/charts/consul/templates/server-config-configmap.yaml
+++ b/charts/consul/templates/server-config-configmap.yaml
@@ -32,6 +32,7 @@ data:
     {
       "ui_config": {
         "enabled": true,
+        "content_path": "{{ .Values.ui.contentPath }}",
         "metrics_provider": "{{ .Values.ui.metrics.provider }}",
         "metrics_proxy": {
           "base_url": "{{ .Values.ui.metrics.baseURL }}"

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1135,6 +1135,9 @@ ui:
   # @type: boolean
   enabled: "-"
 
+  # Specifies where the UI is served from
+  contentPath: "/ui/"
+
   # Configure the service for the Consul UI.
   service:
     # This will enable/disable registering a
@@ -1599,7 +1602,7 @@ connectInject:
   # This setting can be safely disabled by setting to "Ignore".
   failurePolicy: "Fail"
 
-  # Selector for restricting the webhook to only specific namespaces. 
+  # Selector for restricting the webhook to only specific namespaces.
   # Use with `connectInject.default: true` to automatically inject all pods in namespaces that match the selector. This should be set to a multiline string.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
   # for more details.


### PR DESCRIPTION
Source: https://www.consul.io/docs/agent/options#ui_config_content_path

Changes proposed in this PR:
- Support setting ui.content_path in the Helm chart

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

