### PR TITLE
consul-server: allow users to mount their own volumes

### DIFF
--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -107,21 +107,8 @@ spec:
           secret:
             secretName: {{ .Values.server.enterpriseLicense.secretName }}
         {{- end }}
-        {{- range .Values.server.extraVolumes }}
-        - name: userconfig-{{ .name }}
-          {{ .type }}:
-            {{- if (eq .type "configMap") }}
-            name: {{ .name }}
-            {{- else if (eq .type "secret") }}
-            secretName: {{ .name }}
-            {{- end }}
-            {{- with .items }}
-            items:
-            {{- range . }}
-            - key: {{.key}}
-              path: {{.path}}
-            {{- end }}
-            {{- end }}
+        {{- with .Values.server.extraVolumes }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
       {{- if .Values.server.priorityClassName }}
       priorityClassName: {{ .Values.server.priorityClassName | quote }}
@@ -215,9 +202,8 @@ spec:
                 {{- /* Always include the extraVolumes at the end so that users can
                     override other Consul settings. The last -config-dir takes
                     precedence. */}}
-                {{- range .Values.server.extraVolumes }}
-                {{- if .load }}
-                -config-dir=/consul/userconfig/{{ .name }} \
+                {{- if .Values.server.configDir }}
+                -config-dir={{ .Values.server.configDir }} \
                 {{- end }}
                 {{- end }}
                 -datacenter={{ .Values.global.datacenter }} \
@@ -355,6 +341,7 @@ spec:
       nodeSelector:
         {{ tpl .Values.server.nodeSelector . | indent 8 | trim }}
       {{- end }}
+  {{- if .Values.server.storage.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: data-{{ .Release.Namespace }}
@@ -363,8 +350,8 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: {{ .Values.server.storage }}
-        {{- if .Values.server.storageClass }}
-        storageClassName: {{ .Values.server.storageClass }}
+            storage: {{ .Values.server.storage.size }}
+        {{- if .Values.server.storage.storageClass }}
+        storageClassName: {{ .Values.server.storage.storageClass }}
         {{- end }}
 {{- end }}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -369,6 +369,10 @@ server:
   # @type: int
   bootstrapExpect: null
 
+  # The user-defined config directory
+  # Defaults to: /consul/config
+  configDir: null
+
   # [Enterprise Only] This value refers to a Kubernetes secret that you have created
   # that contains your enterprise license. It is required if you are using an
   # enterprise binary. Defining it here applies it to your cluster once a leader
@@ -434,21 +438,24 @@ server:
     serflan:
       port: 8301
 
-  # This defines the disk size for configuring the
-  # servers' StatefulSet storage. For dynamically provisioned storage classes, this is the
-  # desired size. For manually defined persistent volumes, this should be set to
-  # the disk size of the attached volume.
-  storage: 10Gi
+  storage:
+    enabled: true
 
-  # The StorageClass to use for the servers' StatefulSet storage. It must be
-  # able to be dynamically provisioned if you want the storage
-  # to be automatically created. For example, to use local
-  # (https://kubernetes.io/docs/concepts/storage/storage-classes/#local)
-  # storage classes, the PersistentVolumeClaims would need to be manually created.
-  # A `null` value will use the Kubernetes cluster's default StorageClass. If a default
-  # StorageClass does not exist, you will need to create one.
-  # @type: string
-  storageClass: null
+    # This defines the disk size for configuring the
+    # servers' StatefulSet storage. For dynamically provisioned storage classes, this is the
+    # desired size. For manually defined persistent volumes, this should be set to
+    # the disk size of the attached volume.
+    size: 10Gi
+
+    # The StorageClass to use for the servers' StatefulSet storage. It must be
+    # able to be dynamically provisioned if you want the storage
+    # to be automatically created. For example, to use local
+    # (https://kubernetes.io/docs/concepts/storage/storage-classes/#local)
+    # storage classes, the PersistentVolumeClaims would need to be manually created.
+    # A `null` value will use the Kubernetes cluster's default StorageClass. If a default
+    # StorageClass does not exist, you will need to create one.
+    # @type: string
+    storageClass: null
 
   # This will enable/disable Connect (https://consul.io/docs/connect). Setting this to true
   # _will not_ automatically secure pod communication, this
@@ -570,28 +577,33 @@ server:
 
   # A list of extra volumes to mount for server agents. This
   # is useful for bringing in extra data that can be referenced by other configurations
-  # at a well known path, such as TLS certificates or Gossip encryption keys. The
-  # value of this should be a list of objects.
+  # at a well known path, such as TLS certificates or Gossip encryption keys.
+  # The value of this should be a list of objects.
   #
   # Example:
   #
   # ```yaml
   # extraVolumes:
-  #   - type: secret
-  #     name: consul-certs
-  #     load: false
+  # - name: config-vol
+  #   configMap:
+  #     name: log-config
+  #     items:
+  #       - key: log_level
+  #         path: log_level
   # ```
   #
-  # Each object supports the following keys:
+  # Example: emptyDir
   #
-  # - `type` - Type of the volume, must be one of "configMap" or "secret". Case sensitive.
+  # ```yaml
+  # extraVolumes:
+  # - name: data-consul
+  #   emptyDir:
+  #     medium: Memory
+  # ```
   #
-  # - `name` - Name of the configMap or secret to be mounted. This also controls
-  #   the path that it is mounted to. The volume will be mounted to `/consul/userconfig/<name>`.
+  # Each object supports the kubernetes volumes spec: https://kubernetes.io/docs/concepts/storage/volumes
   #
-  # - `load` - If true, then the agent will be
-  #   configured to automatically load HCL/JSON configuration files from this volume
-  #   with `-config-dir`. This defaults to false.
+  # - If using a custom volume to mount a consul config, `configDir` must be set to match the mountPath
   #
   # @type: array<map>
   extraVolumes: []
@@ -1599,7 +1611,7 @@ connectInject:
   # This setting can be safely disabled by setting to "Ignore".
   failurePolicy: "Fail"
 
-  # Selector for restricting the webhook to only specific namespaces. 
+  # Selector for restricting the webhook to only specific namespaces.
   # Use with `connectInject.default: true` to automatically inject all pods in namespaces that match the selector. This should be set to a multiline string.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
   # for more details.


### PR DESCRIPTION
Changes proposed in this PR:
- Allow users to mount their own volumes

How I've tested this PR: `helm template`

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

