### PR TITLE
Enable injecting sidecar container via helm configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ IMPROVEMENTS:
 * Control Plane
   * Upgrade Docker image Alpine version from 3.13 to 3.14. [[GH-737](https://github.com/hashicorp/consul-k8s/pull/737)]
 * Helm Chart
-  * Enable injecting sidecar container via helm configuration.  [[GH-749](https://github.com/hashicorp/consul-k8s/pull/749)]
+  * Enable adding extra containers to server and client Pods.  [[GH-749](https://github.com/hashicorp/consul-k8s/pull/749)]
+
 ## 0.34.1 (September 17, 2021)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 IMPROVEMENTS:
 * Control Plane
   * Upgrade Docker image Alpine version from 3.13 to 3.14. [[GH-737](https://github.com/hashicorp/consul-k8s/pull/737)]
-
+* Helm Chart
+  * Enable injecting sidecar container via helm configuration.  [[GH-749](https://github.com/hashicorp/consul-k8s/pull/749)]
 ## 0.34.1 (September 17, 2021)
 
 BUG FIXES:

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -362,8 +362,8 @@ spec:
           securityContext:
             {{- toYaml .Values.client.containerSecurityContext.client | nindent 12 }}
           {{- end }}
-        {{- if .Values.server.extraContainers }}
-        {{ toYaml .Values.server.extraContainers | nindent 8 }}
+        {{- if .Values.client.extraContainers }}
+        {{ toYaml .Values.client.extraContainers | nindent 8 }}
         {{- end }}
       {{- if (or .Values.global.acls.manageSystemACLs (and .Values.global.tls.enabled (not .Values.global.tls.enableAutoEncrypt))) }}
       initContainers:

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -362,6 +362,9 @@ spec:
           securityContext:
             {{- toYaml .Values.client.containerSecurityContext.client | nindent 12 }}
           {{- end }}
+        {{- if .Values.server.extraContainers }}
+        {{ toYaml .Values.server.extraContainers | nindent 8 }}
+        {{- end }}
       {{- if (or .Values.global.acls.manageSystemACLs (and .Values.global.tls.enabled (not .Values.global.tls.enableAutoEncrypt))) }}
       initContainers:
       {{- if .Values.global.acls.manageSystemACLs }}

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -351,6 +351,9 @@ spec:
           securityContext:
             {{- toYaml .Values.server.containerSecurityContext.server | nindent 12 }}
           {{- end }}
+          {{- if .Values.server.extraContainers }}
+          {{ toYaml .Values.server.extraContainers | nindent 8 }}
+          {{- end }}
       {{- if .Values.server.nodeSelector }}
       nodeSelector:
         {{ tpl .Values.server.nodeSelector . | indent 8 | trim }}

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -1429,13 +1429,13 @@ rollingUpdate:
   # Test that it defines the extra container
   local object=$(helm template \
       -s templates/client-daemonset.yaml  \
-      --set 'server.extraContainers[0].image=test-image' \
-      --set 'server.extraContainers[0].name=test-container' \
-      --set 'server.extraContainers[0].ports[0].name=test-port' \
-      --set 'server.extraContainers[0].ports[0].containerPort=9410' \
-      --set 'server.extraContainers[0].ports[0].protocol=TCP' \
-      --set 'server.extraContainers[0].env[0].name=TEST_ENV' \
-      --set 'server.extraContainers[0].env[0].value=test_env_value' \
+      --set 'client.extraContainers[0].image=test-image' \
+      --set 'client.extraContainers[0].name=test-container' \
+      --set 'client.extraContainers[0].ports[0].name=test-port' \
+      --set 'client.extraContainers[0].ports[0].containerPort=9410' \
+      --set 'client.extraContainers[0].ports[0].protocol=TCP' \
+      --set 'client.extraContainers[0].env[0].name=TEST_ENV' \
+      --set 'client.extraContainers[0].env[0].value=test_env_value' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[] | select(.name == "test-container")' | tee /dev/stderr)
 
@@ -1474,10 +1474,10 @@ rollingUpdate:
 
   local object=$(helm template \
       -s templates/client-daemonset.yaml  \
-      --set 'server.extraContainers[0].image=test-image' \
-      --set 'server.extraContainers[0].name=test-container' \
-      --set 'server.extraContainers[1].image=test-image' \
-      --set 'server.extraContainers[1].name=test-container-2' \
+      --set 'client.extraContainers[0].image=test-image' \
+      --set 'client.extraContainers[0].name=test-container' \
+      --set 'client.extraContainers[1].image=test-image' \
+      --set 'client.extraContainers[1].name=test-container-2' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers' | tee /dev/stderr)
 

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -1493,9 +1493,7 @@ rollingUpdate:
   local object=$(helm template \
       -s templates/client-daemonset.yaml  \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers' | tee /dev/stderr)
+      yq -r '.spec.template.spec.containers | length' | tee /dev/stderr)
 
-  local containers_count=$(echo $object |
-      yq -r 'length' | tee /dev/stderr)
-  [ "${containers_count}" = 1 ]
+  [ "${object}" = 1 ]
 }

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -1469,7 +1469,7 @@ rollingUpdate:
 
 }
 
-@test "client/DaemonSet: adds two extra client containers" {
+@test "client/DaemonSet: extraContainers supports adding two containers" {
   cd `chart_dir`
 
   local object=$(helm template \

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -1423,7 +1423,7 @@ rollingUpdate:
 #--------------------------------------------------------------------
 # extraContainers
 
-@test "client/DaemonSet: adds extra client container" {
+@test "client/DaemonSet: extraContainers adds extra container" {
   cd `chart_dir`
 
   # Test that it defines the extra container

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -1487,7 +1487,7 @@ rollingUpdate:
 
 }
 
-@test "client/DaemonSet: no extra client containers added" {
+@test "client/DaemonSet: no extra client containers added by default" {
   cd `chart_dir`
 
   local object=$(helm template \

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -1479,11 +1479,9 @@ rollingUpdate:
       --set 'client.extraContainers[1].image=test-image' \
       --set 'client.extraContainers[1].name=test-container-2' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers' | tee /dev/stderr)
+      yq -r '.spec.template.spec.containers | length' | tee /dev/stderr)
 
-  local containers_count=$(echo $object |
-      yq -r 'length' | tee /dev/stderr)
-  [ "${containers_count}" = 3 ]
+  [ "${object}" = 3 ]
 
 }
 

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1308,7 +1308,6 @@ load _helpers
       [ "${actual}" = '{"name":"CONSUL_LICENSE_PATH","value":"/consul/license/bar"}' ]
 }
 
-
 @test "server/StatefulSet: -recursor can be set by global.recursors" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -1317,4 +1316,84 @@ load _helpers
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].command | join(" ") | contains("-recursor=\"1.2.3.4\"")' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# extraContainers
+
+@test "server/StatefulSet: adds extra container" {
+  cd `chart_dir`
+
+  # Test that it defines the extra container
+  local object=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.extraContainers[0].image=test-image' \
+      --set 'server.extraContainers[0].name=test-container' \
+      --set 'server.extraContainers[0].ports[0].name=test-port' \
+      --set 'server.extraContainers[0].ports[0].containerPort=9410' \
+      --set 'server.extraContainers[0].ports[0].protocol=TCP' \
+      --set 'server.extraContainers[0].env[0].name=TEST_ENV' \
+      --set 'server.extraContainers[0].env[0].value=test_env_value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[] | select(.name == "test-container")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "test-container" ]
+
+  local actual=$(echo $object |
+      yq -r '.image' | tee /dev/stderr)
+  [ "${actual}" = "test-image" ]
+
+  local actual=$(echo $object |
+      yq -r '.ports[0].name' | tee /dev/stderr)
+  [ "${actual}" = "test-port" ]
+
+  local actual=$(echo $object |
+      yq -r '.ports[0].containerPort' | tee /dev/stderr)
+  [ "${actual}" = "9410" ]
+
+  local actual=$(echo $object |
+      yq -r '.ports[0].protocol' | tee /dev/stderr)
+  [ "${actual}" = "TCP" ]
+
+  local actual=$(echo $object |
+      yq -r '.env[0].name' | tee /dev/stderr)
+  [ "${actual}" = "TEST_ENV" ]
+
+  local actual=$(echo $object |
+      yq -r '.env[0].value' | tee /dev/stderr)
+  [ "${actual}" = "test_env_value" ]
+
+}
+
+@test "server/StatefulSet: adds two extra containers" {
+  cd `chart_dir`
+
+  local object=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.extraContainers[0].image=test-image' \
+      --set 'server.extraContainers[0].name=test-container' \
+      --set 'server.extraContainers[1].image=test-image' \
+      --set 'server.extraContainers[1].name=test-container-2' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers' | tee /dev/stderr)
+
+  local containers_count=$(echo $object |
+      yq -r 'length' | tee /dev/stderr)
+  [ "${containers_count}" = 3 ]
+
+}
+
+@test "server/StatefulSet: no extra containers added" {
+  cd `chart_dir`
+
+  local object=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers' | tee /dev/stderr)
+
+  local containers_count=$(echo $object |
+      yq -r 'length' | tee /dev/stderr)
+  [ "${containers_count}" = 1 ]
 }

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1385,7 +1385,7 @@ load _helpers
 
 }
 
-@test "server/StatefulSet: no extra containers added" {
+@test "server/StatefulSet: no extra containers added by default" {
   cd `chart_dir`
 
   local object=$(helm template \

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1377,11 +1377,9 @@ load _helpers
       --set 'server.extraContainers[1].image=test-image' \
       --set 'server.extraContainers[1].name=test-container-2' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers' | tee /dev/stderr)
+      yq -r '.spec.template.spec.containers | length' | tee /dev/stderr)
 
-  local containers_count=$(echo $object |
-      yq -r 'length' | tee /dev/stderr)
-  [ "${containers_count}" = 3 ]
+  [ "${object}" = 3 ]
 
 }
 
@@ -1391,9 +1389,7 @@ load _helpers
   local object=$(helm template \
       -s templates/server-statefulset.yaml  \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers' | tee /dev/stderr)
+      yq -r '.spec.template.spec.containers | length' | tee /dev/stderr)
 
-  local containers_count=$(echo $object |
-      yq -r 'length' | tee /dev/stderr)
-  [ "${containers_count}" = 1 ]
+  [ "${object}" = 1 ]
 }

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -151,10 +151,6 @@ global:
   # @type: array<string>
   recursors: []
 
-  # A list of sidecar containers. Specified as a raw YAML string.
-  # TODO- Add example
-  extraContainers: []
-
   # Enables TLS (https://learn.hashicorp.com/tutorials/consul/tls-encryption-secure)
   # across the cluster to verify authenticity of the Consul servers and clients.
   # Requires Consul v1.4.1+.
@@ -600,6 +596,19 @@ server:
   # @type: array<map>
   extraVolumes: []
 
+  # A list of sidecar containers.
+  # @type: array<string>
+  # Example:
+  #
+  # ```yaml
+  # extraContainers:
+  # - name: extra-container
+  #   image: example-image:latest
+  #   command:
+  #    - ...
+  # ```
+  extraContainers: []
+
   # This value defines the affinity (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
   # for server pods. It defaults to allowing only a single server pod on each node, which
   # minimizes risk of the cluster becoming unusable if a node is lost. If you need
@@ -928,6 +937,19 @@ client:
   #
   # @type: array<map>
   extraVolumes: []
+
+  # A list of sidecar containers.
+  # @type: array<string>
+  # Example:
+  #
+  # ```yaml
+  # extraContainers:
+  # - name: extra-container
+  #   image: example-image:latest
+  #   command:
+  #    - ...
+  # ```
+  extraContainers: []
 
   # Toleration Settings for Client pods
   # This should be a multi-line string matching the Toleration array

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -597,7 +597,6 @@ server:
   extraVolumes: []
 
   # A list of sidecar containers.
-  # @type: array<string>
   # Example:
   #
   # ```yaml
@@ -607,6 +606,7 @@ server:
   #   command:
   #    - ...
   # ```
+  # @type: array<map>
   extraContainers: []
 
   # This value defines the affinity (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
@@ -939,7 +939,6 @@ client:
   extraVolumes: []
 
   # A list of sidecar containers.
-  # @type: array<string>
   # Example:
   #
   # ```yaml
@@ -949,6 +948,7 @@ client:
   #   command:
   #    - ...
   # ```
+  # @type: array<map>
   extraContainers: []
 
   # Toleration Settings for Client pods

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -151,6 +151,10 @@ global:
   # @type: array<string>
   recursors: []
 
+  # A list of sidecar containers. Specified as a raw YAML string.
+  # TODO- Add example
+  extraContainers: []
+
   # Enables TLS (https://learn.hashicorp.com/tutorials/consul/tls-encryption-secure)
   # across the cluster to verify authenticity of the Consul servers and clients.
   # Requires Consul v1.4.1+.


### PR DESCRIPTION
Changes proposed in this PR:

[Enable injecting sidecar container via helm configuration.](https://app.asana.com/0/1159647457614001/1200520400490111/f)
Based off Vault implementation https://github.com/hashicorp/vault-helm/pull/87/files#
- Add `server.extraContainers` and `client.extraContainers` to `values.yaml`
- Change `client-daemonset.yaml` and `server-statefulset.yaml` to check for extraContainers
- Add bats tests 
 

How I've tested this PR:
- ran bats tests locally
- tested locally that the additional containers were created when extraContainers was specified
- ```helm install -f config.yaml nicoleta charts/consul```

Sample `config.yaml` file used:

```
server:
  replicas: 1
  extraContainers:
    - name: static-server
      image: docker.mirror.hashicorp.services/hashicorp/http-echo:latest
      args:
        - -text="hello world"
        - -listen=:8080
      ports:
        - containerPort: 8080
          name: http
client:
  extraContainers:
    - name: static-server
      image: docker.mirror.hashicorp.services/hashicorp/http-echo:latest
      args:
        - -text="hello world"
        - -listen=:8080
      ports:
        - containerPort: 8080
          name: http
```
How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

