### PR TITLE
acceptance-tests-framework: create ent image from values.yaml isntead of Chart.yaml

### DIFF
--- a/charts/consul/test/acceptance/framework/config/config.go
+++ b/charts/consul/test/acceptance/framework/config/config.go
@@ -117,6 +117,14 @@ func (t *TestConfig) entImage() (string, error) {
 		return "", err
 	}
 
+	// Check if the image contains digest instead of a tag.
+	// If it does, we want to use that image instead rather than
+	// trying to change the tag to an enterprise tag.
+	if strings.Contains(v.Global.Image, "@sha256") {
+		return v.Global.Image, nil
+	}
+
+	// Otherwise, assume that we have an image tag with a version in it.
 	consulImageSplits := strings.Split(v.Global.Image, ":")
 	if len(consulImageSplits) != 2 {
 		return "", fmt.Errorf("could not determine consul version from global.image: %s", v.Global.Image)

--- a/charts/consul/test/acceptance/framework/config/config_test.go
+++ b/charts/consul/test/acceptance/framework/config/config_test.go
@@ -136,6 +136,10 @@ func TestConfig_HelmValuesFromConfig_EntImage(t *testing.T) {
 			consulImage: "invalid",
 			expErr:      "could not determine consul version from global.image: invalid",
 		},
+		{
+			consulImage: "hashicorp/consul@sha256:oioi2452345kjhlkh",
+			expImage:    "hashicorp/consul@sha256:oioi2452345kjhlkh",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.consulImage, func(t *testing.T) {

--- a/charts/consul/test/acceptance/framework/config/config_test.go
+++ b/charts/consul/test/acceptance/framework/config/config_test.go
@@ -116,39 +116,38 @@ func TestConfig_HelmValuesFromConfig(t *testing.T) {
 
 func TestConfig_HelmValuesFromConfig_EntImage(t *testing.T) {
 	tests := []struct {
-		appVersion string
-		expImage   string
-		expErr     string
+		consulImage string
+		expImage    string
+		expErr      string
 	}{
 		{
-			appVersion: "1.9.0",
-			expImage:   "hashicorp/consul-enterprise:1.9.0-ent",
+			consulImage: "hashicorp/consul:1.9.0",
+			expImage:    "hashicorp/consul-enterprise:1.9.0-ent",
 		},
 		{
-			appVersion: "1.8.5-rc1",
-			expImage:   "hashicorp/consul-enterprise:1.8.5-ent-rc1",
+			consulImage: "hashicorp/consul:1.8.5-rc1",
+			expImage:    "hashicorp/consul-enterprise:1.8.5-ent-rc1",
 		},
 		{
-			appVersion: "1.7.0-beta3",
-			expImage:   "hashicorp/consul-enterprise:1.7.0-ent-beta3",
+			consulImage: "hashicorp/consul:1.7.0-beta3",
+			expImage:    "hashicorp/consul-enterprise:1.7.0-ent-beta3",
 		},
 		{
-			appVersion: "1",
-			expErr:     "unable to cast chartMap.appVersion to string",
+			consulImage: "invalid",
+			expErr:      "could not determine consul version from global.image: invalid",
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.appVersion, func(t *testing.T) {
+		t.Run(tt.consulImage, func(t *testing.T) {
 
-			// Write Chart.yaml to a temp dir which will then get parsed.
-			chartYAML := fmt.Sprintf(`apiVersion: v1
-name: consul
-appVersion: %s
-`, tt.appVersion)
+			// Write values.yaml to a temp dir which will then get parsed.
+			valuesYAML := fmt.Sprintf(`global:
+  image: %s
+`, tt.consulImage)
 			tmp, err := ioutil.TempDir("", "")
 			require.NoError(t, err)
 			defer os.RemoveAll(tmp)
-			require.NoError(t, ioutil.WriteFile(filepath.Join(tmp, "Chart.yaml"), []byte(chartYAML), 0644))
+			require.NoError(t, ioutil.WriteFile(filepath.Join(tmp, "values.yaml"), []byte(valuesYAML), 0644))
 
 			cfg := TestConfig{
 				EnableEnterprise: true,


### PR DESCRIPTION
Changes proposed in this PR:
- ☝️ Previously we'd parse the consul version from Chart.yaml, but this is confusing if we're trying to test a consul version that hasn't been released yet when it wouldn't make sense to update chart.yaml with it. This could result in false positives if we run tests by setting `global.image` and pass `-enable-enterprise` flag, since that will overwrite `global.image` to the ent version of the Consul image from Chart.yaml.

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

