### PR TITLE
ci: fix installing helm prerequisite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,13 +47,8 @@ commands:
 
             wget https://get.helm.sh/helm-v3.7.0-linux-amd64.tar.gz
             tar -zxvf helm-v3.7.0-linux-amd64.tar.gz
-            mv linux-amd64/helm /usr/local/bin/helm
+            sudo mv linux-amd64/helm /usr/local/bin/helm
 
-#            curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
-#            sudo apt-get install apt-transport-https --yes
-#            echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-#            sudo apt-get update
-#            sudo apt-get install helm
   create-kind-clusters:
     parameters:
       version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,11 +45,15 @@ commands:
             chmod +x ./kubectl
             sudo mv ./kubectl /usr/local/bin/kubectl
 
-            curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
-            sudo apt-get install apt-transport-https --yes
-            echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-            sudo apt-get update
-            sudo apt-get install helm
+            wget https://get.helm.sh/helm-v3.7.0-linux-amd64.tar.gz
+            tar -zxvf helm-v3.7.0-linux-amd64.tar.gz
+            mv linux-amd64/helm /usr/local/bin/helm
+
+#            curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+#            sudo apt-get install apt-transport-https --yes
+#            echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+#            sudo apt-get update
+#            sudo apt-get install helm
   create-kind-clusters:
     parameters:
       version:


### PR DESCRIPTION
Changes proposed in this PR:
- Grab helm binary from releases page rather than apt installing it. 
- The apt install stopped working because of an expired certificate on baltocdn: https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/2798/workflows/54156ea4-54c6-4622-a4ec-4a623a266cb5/jobs/18933 

How I've tested this PR:
acceptance tests should go green

How I expect reviewers to test this PR:
acceptance tests should go green


