### PR TITLE
add resource config for ServiceInit

### DIFF
--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -225,13 +225,14 @@ spec:
               mountPath: /consul/tls/ca
               readOnly: true
             {{- end }}
+          {{- if .Values.meshGateway.initServiceInitContainer.resources }}
           resources:
-            requests:
-              memory: "50Mi"
-              cpu: "50m"
-            limits:
-              memory: "50Mi"
-              cpu: "50m"
+            {{- if eq (typeOf .Values.meshGateway.initServiceInitContainer.resources) "string" }}
+            {{ tpl .Values.meshGateway.initServiceInitContainer.resources . | nindent 12 | trim }}
+            {{- else }}
+            {{- toYaml .Values.meshGateway.initServiceInitContainer.resources | nindent 12 }}
+            {{- end }}
+          {{- end }}
       containers:
         - name: mesh-gateway
           image: {{ .Values.global.imageEnvoy | quote }}

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -226,12 +226,7 @@ spec:
               readOnly: true
             {{- end }}
           {{- if .Values.meshGateway.initServiceInitContainer.resources }}
-          resources:
-            {{- if eq (typeOf .Values.meshGateway.initServiceInitContainer.resources) "string" }}
-            {{ tpl .Values.meshGateway.initServiceInitContainer.resources . | nindent 12 | trim }}
-            {{- else }}
-            {{- toYaml .Values.meshGateway.initServiceInitContainer.resources | nindent 12 }}
-            {{- end }}
+          resources: {{ toYaml .Values.meshGateway.initServiceInitContainer.resources | nindent 12 }}
           {{- end }}
       containers:
         - name: mesh-gateway

--- a/charts/consul/test/unit/mesh-gateway-deployment.bats
+++ b/charts/consul/test/unit/mesh-gateway-deployment.bats
@@ -449,9 +449,9 @@ key2: value2' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.initContainers[1].resources' | tee /dev/stderr)
 
-  [ $(echo "${actual}" | yq -r '.requests.memory') = "25Mi" ]
+  [ $(echo "${actual}" | yq -r '.requests.memory') = "50Mi" ]
   [ $(echo "${actual}" | yq -r '.requests.cpu') = "50m" ]
-  [ $(echo "${actual}" | yq -r '.limits.memory') = "150Mi" ]
+  [ $(echo "${actual}" | yq -r '.limits.memory') = "50Mi" ]
   [ $(echo "${actual}" | yq -r '.limits.cpu') = "50m" ]
 }
 

--- a/charts/consul/test/unit/mesh-gateway-deployment.bats
+++ b/charts/consul/test/unit/mesh-gateway-deployment.bats
@@ -447,7 +447,7 @@ key2: value2' \
       --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.initServiceInitContainer[0].resources' | tee /dev/stderr)
+      yq -r '.spec.template.spec.initContainers[1].resources' | tee /dev/stderr)
 
   [ $(echo "${actual}" | yq -r '.requests.memory') = "25Mi" ]
   [ $(echo "${actual}" | yq -r '.requests.cpu') = "50m" ]
@@ -466,7 +466,7 @@ key2: value2' \
       --set 'meshGateway.initServiceInitContainer.resources.limits.memory=memory2' \
       --set 'meshGateway.initServiceInitContainer.resources.limits.cpu=cpu2' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.initServiceInitContainer[0].resources' | tee /dev/stderr)
+      yq -r '.spec.template.spec.initContainers[1].resources' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.requests.memory' | tee /dev/stderr)
   [ "${actual}" = "memory" ]

--- a/charts/consul/test/unit/mesh-gateway-deployment.bats
+++ b/charts/consul/test/unit/mesh-gateway-deployment.bats
@@ -438,6 +438,50 @@ key2: value2' \
 }
 
 #--------------------------------------------------------------------
+# service-init container resources
+
+@test "meshGateway/Deployment: init service-init container has default resources" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initServiceInitContainer[0].resources' | tee /dev/stderr)
+
+  [ $(echo "${actual}" | yq -r '.requests.memory') = "25Mi" ]
+  [ $(echo "${actual}" | yq -r '.requests.cpu') = "50m" ]
+  [ $(echo "${actual}" | yq -r '.limits.memory') = "150Mi" ]
+  [ $(echo "${actual}" | yq -r '.limits.cpu') = "50m" ]
+}
+
+@test "meshGateway/Deployment: init service-init container resources can be set" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/mesh-gateway-deployment.yaml \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'meshGateway.initServiceInitContainer.resources.requests.memory=memory' \
+      --set 'meshGateway.initServiceInitContainer.resources.requests.cpu=cpu' \
+      --set 'meshGateway.initServiceInitContainer.resources.limits.memory=memory2' \
+      --set 'meshGateway.initServiceInitContainer.resources.limits.cpu=cpu2' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initServiceInitContainer[0].resources' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.requests.memory' | tee /dev/stderr)
+  [ "${actual}" = "memory" ]
+
+  local actual=$(echo $object | yq -r '.requests.cpu' | tee /dev/stderr)
+  [ "${actual}" = "cpu" ]
+
+  local actual=$(echo $object | yq -r '.limits.memory' | tee /dev/stderr)
+  [ "${actual}" = "memory2" ]
+
+  local actual=$(echo $object | yq -r '.limits.cpu' | tee /dev/stderr)
+  [ "${actual}" = "cpu2" ]
+}
+
+#--------------------------------------------------------------------
 # consul sidecar resources
 
 @test "meshGateway/Deployment: consul sidecar has default resources" {

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2015,10 +2015,10 @@ meshGateway:
   initServiceInitContainer:
     resources:
       requests:
-        memory: "25Mi"
+        memory: "50Mi"
         cpu: "50m"
       limits:
-        memory: "150Mi"
+        memory: "50Mi"
         cpu: "50m"
 
   # By default, we set an anti-affinity so that two gateway pods won't be

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2009,6 +2009,18 @@ meshGateway:
         memory: "150Mi"
         cpu: "50m"
 
+  # Resource settings for the `service-init` init container.
+  # @recurse: false
+  # @type: map
+  initServiceInitContainer:
+    resources:
+      requests:
+        memory: "25Mi"
+        cpu: "50m"
+      limits:
+        memory: "150Mi"
+        cpu: "50m"
+
   # By default, we set an anti-affinity so that two gateway pods won't be
   # on the same node. NOTE: Gateways require that Consul client agents are
   # also running on the nodes alongside each gateway pod.


### PR DESCRIPTION
Changes proposed in this PR:
- Congiure resource requests and limits for the service init container on the mesh gateway deployment. 

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

