### PR TITLE
Add annotation to mount connect inject volume to other containers

### DIFF
--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -16,6 +16,12 @@ const (
 	// be set to a truthy or falsy value, as parseable by strconv.ParseBool
 	annotationInject = "consul.hashicorp.com/connect-inject"
 
+	// annotationInjectMountVolumes is the key of the annotation that controls whether
+	// the data volume that connect inject uses to store data including the Consul ACL token
+	// is mounted to other containers in the pod. It is a comma-separated list of container names
+	// to mount the volume on. It will be mounted at the path `/consul/connect-inject`
+	annotationInjectMountVolumes = "consul.hashicorp.com/connect-inject-mount-volume"
+
 	// annotationService is the name of the service to proxy. This defaults
 	// to the name of the first container.
 	annotationService = "consul.hashicorp.com/connect-service"

--- a/control-plane/connect-inject/handler.go
+++ b/control-plane/connect-inject/handler.go
@@ -355,7 +355,7 @@ func (h *Handler) overwriteProbes(ns corev1.Namespace, pod *corev1.Pod) error {
 	return nil
 }
 
-func (h *Handler) injectVolumeMount(pod corev1.Pod) error {
+func (h *Handler) injectVolumeMount(pod corev1.Pod) {
 	containersToInject := splitCommaSeparatedItemsFromAnnotation(annotationInjectMountVolumes, pod)
 
 	for index, container := range pod.Spec.Containers {
@@ -366,8 +366,6 @@ func (h *Handler) injectVolumeMount(pod corev1.Pod) error {
 			})
 		}
 	}
-
-	return nil
 }
 
 func (h *Handler) shouldInject(pod corev1.Pod, namespace string) (bool, error) {


### PR DESCRIPTION
Changes proposed in this PR:
- Add annotation to mount connect inject volume to other containers

Discussion in https://github.com/hashicorp/consul-k8s/issues/761
Fixes https://github.com/hashicorp/consul-k8s/issues/761

How I've tested this PR: Unit tests and manual tests

How I expect reviewers to test this PR: Manually add annotation to pods and see if volume gets mounted.


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added (*HashiCorp engineers only, community PRs should not add a changelog entry*)

