### PR TITLE
aws-acceptance-test-cleanup: Release elastic IPs and delete VPC dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -541,7 +541,7 @@ jobs:
 
   cleanup-eks-resources:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.9.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.10.0
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Changes proposed in this PR:
- Release elastic IPs of NAT gws
- Don't look at deleted nat gateways when confirming they are destroyed
because they can show up in the describe-nat-gateways output for about an 1hr
after being deleted.
- Delete VPC dependencies, like subnets, route tables, internet gateways, and security groups prior to deleting the VPC. AWS API will not delete those for us (only UI does), and so we'll get dependency violation errors trying to delete VPCs. For example, [here](https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/2549/workflows/e3f5e78a-3e2e-4203-b7af-32be048a4626/jobs/15798).

How I've tested this PR:
manually by running `terraform apply -var tags="{\"build_url\": \"iryna-test\"}" -auto-approve` inside `charts/consul/test/terraform/eks` directory and then running `go run ./...` from the `hack/aws-acceptance-test-cleanup` directory.

How I expect reviewers to test this PR:
👀 code review

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

