### PR TITLE
[Helm] Add support for ingressClassName

### DIFF
--- a/charts/consul/templates/ui-ingress.yaml
+++ b/charts/consul/templates/ui-ingress.yaml
@@ -5,7 +5,7 @@
 This is because while networks.k8s.io/v1 was introduced in Kubernetes v1.15+, the Ingress resource was
 promoted to v1 only in Kubernetes v1.19+. This ensures the correct API version is chosen that supports
 the Ingress resource. */}}
-{{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "19" ) }}
+{{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -25,9 +25,12 @@ metadata:
     {{ tpl .Values.ui.ingress.annotations . | nindent 4 | trim }}
   {{- end }}
 spec:
+  {{- if and .Values.ui.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ui.ingress.className }}
+  {{- end }}
   rules:
   {{ $global := .Values.global }}
-  {{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "19" ) }}
+  {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
   {{- range .Values.ui.ingress.hosts }}
   - host: {{ .host | quote }}
     http:

--- a/charts/consul/test/unit/ui-ingress.bats
+++ b/charts/consul/test/unit/ui-ingress.bats
@@ -228,3 +228,25 @@ load _helpers
     yq -r '.spec.rules[0].http.paths[0].pathType' | tee /dev/stderr)
   [ "${actual}" = "ImplementationSpecific" ]
 }
+
+#--------------------------------------------------------------------
+# ingressClassName
+
+@test "ui/Ingress: no ingressClassName by default" {
+  local actual=$(helm template \
+    -s templates/ui-ingress.yaml  \
+    --set 'ui.ingress.enabled=true' \
+    . | tee /dev/stderr |
+    yq -r '.spec.ingressClassName' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "ui/Ingress: no ingressClassName by default" {
+  local actual=$(helm template \
+    -s templates/ui-ingress.yaml  \
+    --set 'ui.ingress.enabled=true' \
+    --set 'ui.ingress.ingressClassName=nginx' \
+    . | tee /dev/stderr |
+    yq -r '.spec.ingressClassName' | tee /dev/stderr)
+  [ "${actual}" = "nginx" ]
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1214,7 +1214,8 @@ ui:
   ingress:
     # This will create an Ingress resource for the Consul UI.
     # @type: boolean
-    enabled: false
+    enabled: true
+    className: ""
 
     # pathType override - see: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
     pathType: Prefix


### PR DESCRIPTION
Signed-off-by: Niklas Wagner <n.wagner@finatix.de>

Changes proposed in this PR:
- Add support for ingressClassName within the Helm Chart.

How I've tested this PR:
- I run the `helm template` comannd locally with ingressClassName enabled and without it.
- I've added test, hopefully they run just fine - cannot test them locally.


How I expect reviewers to test this PR:
- Set `ui.ingress.className` and you should see the ingressClassName field within the Ingress object.


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

