### PR TITLE
cli: bump golang.org/x/sys dependency

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/posener/complete v1.1.1
 	github.com/stretchr/testify v1.7.0
 	go.starlark.net v0.0.0-20200707032745-474f21a9602d // indirect
+	golang.org/x/sys v0.0.0-20211013075003-97ac67df715c // indirect
 	google.golang.org/grpc v1.33.1 // indirect
 	helm.sh/helm/v3 v3.6.1
 	k8s.io/api v0.21.2

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -957,8 +957,9 @@ golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 h1:dXfMednGJh/SUUFjTLsWJz3P+TQt9qnR11GgeI3vWKs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20211013075003-97ac67df715c h1:taxlMj0D/1sOAuv/CbSD+MMDof2vbyPTqz5FNYKpXt8=
+golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=


### PR DESCRIPTION
See https://github.com/golang/go/issues/46763. The CLI would error at
runtime after being compiled with go 1.17, unless the x/sys dependency
is bumped.

How I've tested this PR:
- upgraded to go 1.17.2
- Ran `go build . -o consul-k8s` 
- `./consul-k8s version`
How I expect reviewers to test this PR:
- build and run the cli like above with go 1.17.x and check that it works


Checklist:
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

