### PR TITLE
Add linter info to the contributing guide 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ linters:
   # enables all defaults + the below, `golangci-lint linters` to see the list of active linters.
   enable:
     - gofmt
-    # TODO: re-enable things as we have master cleaned up vs the defaults
+    # TODO: re-enable things as we have main cleaned up vs the defaults
     #- stylecheck
     #- goconst
     #- prealloc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,14 @@ To create a docker image with your local changes:
 $ make dev-docker
 ```
 
+### Running linters locally
+[`golangci-lint`](https://golangci-lint.run/) is used in CI to enforce coding and style standards and help catch bugs ahead of time.
+The configuration that CI runs is stored in `.golangci.yml` at the top level of the repository.
+Please ensure your code passes by running `golangci-lint run` at the top level of the repository and addressing
+any issues prior to submitting a PR.
+
+Version 1.41.1 or higher of [`golangci-lint`](https://github.com/golangci/golangci-lint/releases/tag/v1.41.1) is currently required.
+
 ### Rebasing contributions against main
 
 PRs in this repo are merged using the [`rebase`](https://git-scm.com/docs/git-rebase) method. This keeps


### PR DESCRIPTION
Changes proposed in this PR:
-  During the monorepo/main merge this PR got lost somehow, adding the words back to CONTRIBUTING.md
- https://github.com/hashicorp/consul-k8s/pull/586/files

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

