### PR TITLE
Change CRD retry-backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,15 @@ FEATURES:
 IMPROVEMENTS:
 * Control Plane
   * Upgrade Docker image Alpine version from 3.13 to 3.14. [[GH-737](https://github.com/hashicorp/consul-k8s/pull/737)]
+  * CRDs: tune failure backoff so invalid config entries are re-synced more quickly. [[GH-788](https://github.com/hashicorp/consul-k8s/pull/788)]
 * Helm Chart
   * Enable adding extra containers to server and client Pods. [[GH-749](https://github.com/hashicorp/consul-k8s/pull/749)]
   * ACL support for Admin Partitions. **(Consul Enterprise only)**
   **BETA** [[GH-766](https://github.com/hashicorp/consul-k8s/pull/766)]
     * This feature now enabled ACL support for Admin Partitions. The server-acl-init job now creates a Partition token. This token
-can be used to bootstrap new partitions as well as manage ACLs in the non-default partitions.
+      can be used to bootstrap new partitions as well as manage ACLs in the non-default partitions.
     * Partition to partition networking is disabled if ACLs are enabled.
     * Documentation for the installation can be found [here](https://github.com/hashicorp/consul-k8s/blob/main/docs/admin-partitions-with-acls.md).
-
 * CLI
   * Add `version` command. [[GH-741](https://github.com/hashicorp/consul-k8s/pull/741)]
   * Add `uninstall` command. [[GH-725](https://github.com/hashicorp/consul-k8s/pull/725)]

--- a/control-plane/controller/ingressgateway_controller.go
+++ b/control-plane/controller/ingressgateway_controller.go
@@ -36,7 +36,5 @@ func (r *IngressGatewayController) UpdateStatus(ctx context.Context, obj client.
 }
 
 func (r *IngressGatewayController) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&consulv1alpha1.IngressGateway{}).
-		Complete(r)
+	return setupWithManager(mgr, &consulv1alpha1.IngressGateway{}, r)
 }

--- a/control-plane/controller/mesh_controller.go
+++ b/control-plane/controller/mesh_controller.go
@@ -36,7 +36,5 @@ func (r *MeshController) UpdateStatus(ctx context.Context, obj client.Object, op
 }
 
 func (r *MeshController) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&consulv1alpha1.Mesh{}).
-		Complete(r)
+	return setupWithManager(mgr, &consulv1alpha1.Mesh{}, r)
 }

--- a/control-plane/controller/proxydefaults_controller.go
+++ b/control-plane/controller/proxydefaults_controller.go
@@ -36,7 +36,5 @@ func (r *ProxyDefaultsController) UpdateStatus(ctx context.Context, obj client.O
 }
 
 func (r *ProxyDefaultsController) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&consulv1alpha1.ProxyDefaults{}).
-		Complete(r)
+	return setupWithManager(mgr, &consulv1alpha1.ProxyDefaults{}, r)
 }

--- a/control-plane/controller/servicedefaults_controller.go
+++ b/control-plane/controller/servicedefaults_controller.go
@@ -36,7 +36,5 @@ func (r *ServiceDefaultsController) UpdateStatus(ctx context.Context, obj client
 }
 
 func (r *ServiceDefaultsController) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&consulv1alpha1.ServiceDefaults{}).
-		Complete(r)
+	return setupWithManager(mgr, &consulv1alpha1.ServiceDefaults{}, r)
 }

--- a/control-plane/controller/serviceintentions_controller.go
+++ b/control-plane/controller/serviceintentions_controller.go
@@ -36,7 +36,5 @@ func (r *ServiceIntentionsController) UpdateStatus(ctx context.Context, obj clie
 }
 
 func (r *ServiceIntentionsController) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&consulv1alpha1.ServiceIntentions{}).
-		Complete(r)
+	return setupWithManager(mgr, &consulv1alpha1.ServiceIntentions{}, r)
 }

--- a/control-plane/controller/serviceresolver_controller.go
+++ b/control-plane/controller/serviceresolver_controller.go
@@ -36,7 +36,5 @@ func (r *ServiceResolverController) UpdateStatus(ctx context.Context, obj client
 }
 
 func (r *ServiceResolverController) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&consulv1alpha1.ServiceResolver{}).
-		Complete(r)
+	return setupWithManager(mgr, &consulv1alpha1.ServiceResolver{}, r)
 }

--- a/control-plane/controller/servicerouter_controller.go
+++ b/control-plane/controller/servicerouter_controller.go
@@ -36,7 +36,5 @@ func (r *ServiceRouterController) UpdateStatus(ctx context.Context, obj client.O
 }
 
 func (r *ServiceRouterController) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&consulv1alpha1.ServiceRouter{}).
-		Complete(r)
+	return setupWithManager(mgr, &consulv1alpha1.ServiceRouter{}, r)
 }

--- a/control-plane/controller/servicesplitter_controller.go
+++ b/control-plane/controller/servicesplitter_controller.go
@@ -36,7 +36,5 @@ func (r *ServiceSplitterController) UpdateStatus(ctx context.Context, obj client
 }
 
 func (r *ServiceSplitterController) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&consulv1alpha1.ServiceSplitter{}).
-		Complete(r)
+	return setupWithManager(mgr, &consulv1alpha1.ServiceSplitter{}, r)
 }

--- a/control-plane/controller/terminatinggateway_controller.go
+++ b/control-plane/controller/terminatinggateway_controller.go
@@ -36,7 +36,5 @@ func (r *TerminatingGatewayController) UpdateStatus(ctx context.Context, obj cli
 }
 
 func (r *TerminatingGatewayController) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&consulv1alpha1.TerminatingGateway{}).
-		Complete(r)
+	return setupWithManager(mgr, &consulv1alpha1.TerminatingGateway{}, r)
 }

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.17.0
 	golang.org/x/sys v0.0.0-20210611083646-a4fc73990273 // indirect
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	golang.org/x/tools v0.1.2 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0
 	k8s.io/api v0.21.1


### PR DESCRIPTION
Previously, if a custom resource failed to sync with Consul, we used the
default retry backoff. This was an exponential backoff starting at 5ms
and maxing out at 1000s (16m).

This backoff was a poor UX for our common error case where one config
entry cannot be applied due to a prerequisite, for example an ingress
gateway entry cannot be applied until the protocol is set to http. The
usual workflow to resolve this would be to look up the error, figure out
the correct ServiceDefaults/ProxyDefaults, and then apply that resource.
Once applied, the user needs to wait fo the ingress gateway (in this
example) resource to be retried. With the default backoff config,
because the user will have taken on the order of minutes to figure out
the correct config, the exponential backoff will now be upwards of
five minutes. The user will have to wait for a long time for the ingress
gateway resource to be retried.

This PR changes the backoff to start out at 200ms and max out at 5s.
This fits our use-case better because the user will have to wait at max
5ms, usually if there's an error, retrying within milliseconds does nothing, so
waiting 200ms to start is fine, and finally, Consul servers can accept
tens of thousands of writes per second so even if there are a ton of
resources retrying every 5s, it won't be an issue.

Fixes https://github.com/hashicorp/consul-k8s/issues/587

How I've tested this PR:

```yaml
# ingress-gateway.yaml
apiVersion: consul.hashicorp.com/v1alpha1
kind: IngressGateway
metadata:
  name: ingress-gateway
spec:
  listeners:
    - port: 8080
      protocol: http
      services:
        - name: frontend
          hosts: ["localhost"]
```

```yaml
# proxy-defaults.yaml
apiVersion: consul.hashicorp.com/v1alpha1
kind: ProxyDefaults
metadata:
  name: global
spec:
  config:
    protocol: http
```

Apply the igw, then the defaults with a small gap in-between, then wait and see how long it takes to retry:

```bash
kubectl apply -f ./ingress-gateway.yaml && sleep 30 && kubectl apply -f ./proxy-defaults.yaml && kubectl get ingressgateway ingress-gateway -w
NAME              SYNCED   LAST SYNCED   AGE
ingress-gateway   False                  33s
ingress-gateway   True     0s            112s
```

See that it takes 80 seconds to re-sync. If we slept for longer then the retry would be even longer, up to 16 minutes!

Now using `ghcr.io/lkysow/consul-k8s-dev:oct17` retry the same:

```yaml
NAME              SYNCED   LAST SYNCED   AGE
ingress-gateway   False                  30s
ingress-gateway   True     0s            35s
```

It re-syncs in 5s!

How I expect reviewers to test this PR:
- can try out the steps above
- I didn't add tests because it is essentially a configuration change. I could possibly add acceptance tests?

Checklist:
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

