### PR TITLE
Fix unit tests to work with consul 1.11

### DIFF
--- a/control-plane/subcommand/server-acl-init/command_test.go
+++ b/control-plane/subcommand/server-acl-init/command_test.go
@@ -2103,7 +2103,6 @@ func replicatedSetup(t *testing.T, bootToken string) (*fake.Clientset, *api.Clie
 		}
 	})
 	require.NoError(t, err)
-	secondarySvr.WaitForLeader(t)
 
 	// Our consul client will use the secondary dc.
 	clientToken := bootToken
@@ -2126,6 +2125,8 @@ func replicatedSetup(t *testing.T, bootToken string) (*fake.Clientset, *api.Clie
 	// WAN join primary to the secondary
 	err = consul.Agent().Join(secondarySvr.WANAddr, true)
 	require.NoError(t, err)
+
+	secondarySvr.WaitForLeader(t)
 
 	// Overwrite consul client, pointing it to the secondary DC
 	consul, err = api.NewClient(&api.Config{


### PR DESCRIPTION
Previously, WaitForLeader would work because it relied on legacy ACLs
not erroring out before WAN joining the cluster.
But this is not longer the case, and so we need to WAN join first
and wait for ACL replication to finish before calling WaitForLeader.

How I've tested this PR:
- ran unit tests in CI

How I expect reviewers to test this PR:
- 👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

