### PR TITLE
Set extra volumes and env vars for sync catalog deployment

### DIFF
--- a/charts/consul/templates/sync-catalog-deployment.yaml
+++ b/charts/consul/templates/sync-catalog-deployment.yaml
@@ -33,8 +33,9 @@ spec:
         "consul.hashicorp.com/connect-inject": "false"
     spec:
       serviceAccountName: {{ template "consul.fullname" . }}-sync-catalog
-      {{- if .Values.global.tls.enabled }}
+      {{- if or .Values.global.tls.enabled .Values.syncCatalog.extraVolumes }}
       volumes:
+      {{- if .Values.global.tls.enabled }}
       {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
       - name: consul-ca-cert
         secret:
@@ -51,6 +52,23 @@ spec:
       - name: consul-auto-encrypt-ca-cert
         emptyDir:
           medium: "Memory"
+      {{- end }}
+      {{- end }}
+      {{- range .Values.syncCatalog.extraVolumes }}
+      - name: userconfig-{{ .name }}
+        {{ .type }}:
+          {{- if (eq .type "configMap") }}
+          name: {{ .name }}
+          {{- else if (eq .type "secret") }}
+          secretName: {{ .name }}
+          {{- end }}
+          {{- with .items }}
+          items:
+          {{- range . }}
+          - key: {{ .key }}
+            path: {{ .path }}
+          {{- end }}
+          {{- end }}
       {{- end }}
       {{- end }}
       containers:
@@ -98,8 +116,10 @@ spec:
               value: http://{{ template "consul.fullname" . }}-server:8500
             {{- end }}
             {{- end }}
-          {{- if .Values.global.tls.enabled }}
+          {{- include "consul.extraEnvironmentVars" .Values.syncCatalog | nindent 12 }}
+          {{- if or .Values.global.tls.enabled .Values.syncCatalog.extraVolumes}}
           volumeMounts:
+            {{- if .Values.global.tls.enabled }}
             {{- if (and .Values.global.tls.enableAutoEncrypt $clientEnabled) }}
             - name: consul-auto-encrypt-ca-cert
             {{- else }}
@@ -107,6 +127,12 @@ spec:
             {{- end }}
               mountPath: /consul/tls/ca
               readOnly: true
+            {{- end }}
+            {{- range .Values.syncCatalog.extraVolumes }}
+            - name: userconfig-{{ .name }}
+              readOnly: true
+              mountPath: /consul/userconfig/{{ .name }}
+            {{- end }}
           {{- end }}
           command:
             - "/bin/sh"

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1496,6 +1496,26 @@ syncCatalog:
   # @type: map
   extraLabels: null
 
+  # A list of extra volumes to mount. These will be exposed to Consul in the path `/consul/userconfig/<name>/`.
+  #
+  # Example:
+  #
+  # ```yaml
+  # extraVolumes:
+  #   - type: secret
+  #     name: my-secret
+  #     items: # optional items array
+  #       - key: key
+  #         path: path # secret will now mount to /consul/userconfig/my-secret/path
+  # ```
+  # @type: array<map>
+  extraVolumes: []
+
+  # A set of extra environment variables to set within the sync catalog container.
+  # These can be used to configure custom Consul parameters.
+  # @type: map
+  extraEnvironmentVars: {}
+
 # Configures the automatic Connect sidecar injector.
 connectInject:
   # True if you want to enable connect injection. Set to "-" to inherit from


### PR DESCRIPTION
Changes proposed in this PR:
- Add the possibility to specify extra volumes and extra environment variables to sync-catalog pods.

How I've tested this PR:
- Unit tests (`sync-catalog-deployment.bats`)

How I expect reviewers to test this PR:
- Run the `sync-catalog-deployment` unit tests

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)