### PR TITLE
README.md: change install command and bump to helm CLI 3.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ use Consul with Kubernetes, please see the
 [Consul and Kubernetes documentation](https://www.consul.io/docs/platform/k8s/index.html).
 
 ### Prerequisites
-  * **Helm 3.0+** (Helm 2 is not supported)
+  * **Helm 3.2+** (Helm 2 is not supported)
   * **Kubernetes 1.18+** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is
     untested.
@@ -75,11 +75,12 @@ Detailed installation instructions for Consul on Kubernetes are found [here](htt
 
         $ helm search repo hashicorp/consul
         NAME                CHART VERSION   APP VERSION DESCRIPTION
-        hashicorp/consul    0.33.0          1.10.0      Official HashiCorp Consul Chart
+        hashicorp/consul    0.35.0          1.10.3      Official HashiCorp Consul Chart
 
-3. Now you're ready to install Consul! To install Consul with the default configuration using Helm 3 run:
+3. Now you're ready to install Consul! To install Consul with the default configuration using Helm 3.2 run the following command below.
+   This will create a `consul` Kubernetes namespace if not already present, and install Consul on the dedicated namespace. 
 
-        $ helm install consul hashicorp/consul --set global.name=consul
+        $ helm install consul hashicorp/consul --set global.name=consul --create-namespace -n consul
         NAME: consul
 
 Please see the many options supported in the `values.yaml`


### PR DESCRIPTION
Changes proposed in this PR:
- Change the install command to point users to install on a dedicated `consul` namespace. Helm 3.2+ is required to utilize the `--create-namespace` flag. This ensures the recommended workflows are similar across Helm and Consul-k8s CLI. 

How I've tested this PR:  

Locally as shown below. 

How I expect reviewers to test this PR:

```
❯ helm install consul hashicorp/consul --set global.name=consul --create-namespace -n consul
NAME: consul
LAST DEPLOYED: Thu Oct 28 11:17:21 2021
NAMESPACE: consul
STATUS: deployed
REVISION: 1
NOTES:
Thank you for installing HashiCorp Consul!

Now that you have deployed Consul, you should look over the docs on using
Consul with Kubernetes available here:

https://www.consul.io/docs/platform/k8s/index.html

Your release is named consul.

To learn more about the release, run:

  $ helm status consul
  $ helm get all consul

❯ k get pods -n consul
NAME              READY   STATUS    RESTARTS   AGE
consul-mvfkv      1/1     Running   0          47m
consul-rg4jh      1/1     Running   0          47m
consul-server-0   1/1     Running   0          47m
consul-server-1   1/1     Running   0          47m
consul-server-2   1/1     Running   0          47m
consul-xh2dx      1/1     Running   0          47m
```

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

