### PR TITLE
Reenable TestConnectInject_RestartConsulClients

### DIFF
--- a/acceptance/tests/connect/connect_inject_test.go
+++ b/acceptance/tests/connect/connect_inject_test.go
@@ -116,9 +116,6 @@ func TestConnectInject_CleanupKilledPods(t *testing.T) {
 // the services get re-registered and can continue to talk to each other.
 func TestConnectInject_RestartConsulClients(t *testing.T) {
 	cfg := suite.Config()
-	if cfg.EnableTransparentProxy {
-		t.Skip("skipping this test because it's currently flakey when transparent proxy is enabled")
-	}
 	ctx := suite.Environment().DefaultContext(t)
 
 	helmValues := map[string]string{


### PR DESCRIPTION
Changes proposed in this PR:
- We've disabled this test because it was flaky. After running it a >10 times, i didn't see any failures, and so I think we can enable it again.

How I've tested this PR:
ran it multiple times [here](https://app.circleci.com/pipelines/github/hashicorp/consul-k8s?branch=reenable-skipped-test)

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

