### PR TITLE
cli: improve secure preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BREAKING CHANGES:
 * Helm Chart
   * The `kube-system` and `local-path-storage` namespaces are now _excluded_ from connect injection by default on Kubernetes versions >= 1.21. If you wish to enable injection on those namespaces, set `connectInject.namespaceSelector` to `null`. [[GH-726](https://github.com/hashicorp/consul-k8s/pull/726)]
+
 IMPROVEMENTS:
 * Helm Chart
   * Automatic retry for `gossip-encryption-autogenerate-job` on failure [[GH-789](https://github.com/hashicorp/consul-k8s/pull/789)]
@@ -10,7 +11,9 @@ IMPROVEMENTS:
 * CLI
   * Add `status` command. [[GH-768](https://github.com/hashicorp/consul-k8s/pull/768)]
   * Add `-verbose`, `-v` flag to the `consul-k8s install` command, which outputs all logs emitted from the installation. By default, verbose is set to `false` to hide logs that show resources are not ready. [[GH-810](https://github.com/hashicorp/consul-k8s/pull/810)]
-  * Add Prometheus deployment and Consul K8s metrics integration with demo preset when installing via `-preset=demo`. [[GH-809](https://github.com/hashicorp/consul-k8s/pull/809)]
+  * Set `prometheus.enabled` to true and enable all metrics for Consul K8s when installing via the `demo` preset. [[GH-809](https://github.com/hashicorp/consul-k8s/pull/809)]
+  * Set `controller.enabled` to `true` when installing via the `demo` preset. [[GH818](https://github.com/hashicorp/consul-k8s/pull/818)]
+  * Set `global.gossipEncryption.autoGenerate` to `true` and `global.tls.enableAutoEncrypt` to `true` when installing via the `secure` preset. [[GH818](https://github.com/hashicorp/consul-k8s/pull/818)]
 
 ## 0.35.0 (October 19, 2021)
 

--- a/cli/cmd/install/presets.go
+++ b/cli/cmd/install/presets.go
@@ -39,7 +39,6 @@ var secure = `
 global:
   name: consul
   enabled: true
-  datacenter: dc1
   gossipEncryption:
     autoGenerate: true 
   tls:

--- a/cli/cmd/install/presets.go
+++ b/cli/cmd/install/presets.go
@@ -27,6 +27,8 @@ connectInject:
     enableGatewayMetrics: true
 server:
   replicas: 1
+controller:
+  enabled: true
 ui: 
   enabled: true
   service:

--- a/cli/cmd/install/presets.go
+++ b/cli/cmd/install/presets.go
@@ -38,7 +38,6 @@ prometheus:
 var secure = `
 global:
   name: consul
-  enabled: true
   gossipEncryption:
     autoGenerate: true 
   tls:

--- a/cli/cmd/install/presets.go
+++ b/cli/cmd/install/presets.go
@@ -27,7 +27,6 @@ connectInject:
     enableGatewayMetrics: true
 server:
   replicas: 1
-  bootstrapExpect: 1
 ui: 
   enabled: true
   service:

--- a/cli/cmd/install/presets.go
+++ b/cli/cmd/install/presets.go
@@ -42,8 +42,6 @@ global:
   datacenter: dc1
   gossipEncryption:
     autoGenerate: true 
-    secretName: "consul-gossip-encryption-key"
-    secretKey: "key"
   tls:
     enabled: true
     enableAutoEncrypt: true

--- a/cli/cmd/install/presets.go
+++ b/cli/cmd/install/presets.go
@@ -13,7 +13,6 @@ var presets = map[string]interface{}{
 	PresetSecure: convert(secure),
 }
 
-// TODO: enable prometheus in demo installation
 var demo = `
 global:
   name: consul
@@ -40,15 +39,23 @@ prometheus:
 var secure = `
 global:
   name: consul
-  acls:
-    manageSystemACLs: true
+  enabled: true
+  datacenter: dc1
+  gossipEncryption:
+    autoGenerate: true 
+    secretName: "consul-gossip-encryption-key"
+    secretKey: "key"
   tls:
     enabled: true
-connectInject:
-  enabled: true
+    enableAutoEncrypt: true
+  acls:
+    manageSystemACLs: true
 server:
   replicas: 1
-  bootstrapExpect: 1
+connectInject:
+  enabled: true
+controller:
+  enabled: true
 `
 
 var globalNameConsul = `


### PR DESCRIPTION
Changes proposed in this PR:
- Enable `gossipEncryption` generation and `autoEncrypt` in the `secure` preset. 
- Remove `server.bootstrapExpect` from demo preset since it defaults to `server.replicas` as defined in our [docs](https://www.consul.io/docs/k8s/helm#v-server-bootstrapexpect)
- Add `controller.enabled` to `true` to demo preset. 

How I've tested this PR:

```
❯ consul-k8s install -preset=secure

==> Pre-Install Checks
No existing installations found.
 ✓ No previous persistent volume claims found
 ✓ No previous secrets found

==> Consul Installation Summary
    Installation name: consul
    Namespace: consul
    Overrides:
    connectInject:
      enabled: true
    controller:
      enabled: true
    global:
      acls:
        manageSystemACLs: true
      gossipEncryption:
        autoGenerate: true
      name: consul
      tls:
        enableAutoEncrypt: true
        enabled: true
    server:
      replicas: 1

    Proceed with installation? (y/N) y

==> Running Installation
 ✓ Downloaded charts
 --> creating 1 resource(s)
 --> Starting delete for "consul-gossip-encryption-autogenerate" PodSecurityPolicy
 --> podsecuritypolicies.policy "consul-gossip-encryption-autogenerate" not found
 --> creating 1 resource(s)
 --> Starting delete for "consul-gossip-encryption-autogenerate" ServiceAccount
 --> serviceaccounts "consul-gossip-encryption-autogenerate" not found
 --> creating 1 resource(s)
 --> Starting delete for "consul-gossip-encryption-autogenerate" Role
 --> roles.rbac.authorization.k8s.io "consul-gossip-encryption-autogenerate" not found
 --> creating 1 resource(s)
 --> Starting delete for "consul-gossip-encryption-autogenerate" RoleBinding
 --> rolebindings.rbac.authorization.k8s.io "consul-gossip-encryption-autogenerate" not found
 --> creating 1 resource(s)
 --> Starting delete for "consul-tls-init" ServiceAccount
 --> serviceaccounts "consul-tls-init" not found
 --> creating 1 resource(s)
 --> Starting delete for "consul-tls-init" Role
 --> roles.rbac.authorization.k8s.io "consul-tls-init" not found
 --> creating 1 resource(s)
 --> Starting delete for "consul-tls-init" RoleBinding
 --> rolebindings.rbac.authorization.k8s.io "consul-tls-init" not found
 --> creating 1 resource(s)
 --> Starting delete for "consul-gossip-encryption-autogenerate" Job
 --> jobs.batch "consul-gossip-encryption-autogenerate" not found
 --> creating 1 resource(s)
 --> Watching for changes to Job consul-gossip-encryption-autogenerate with timeout of 10m0s
 --> Add/Modify event for consul-gossip-encryption-autogenerate: ADDED
 --> consul-gossip-encryption-autogenerate: Jobs active: 0, jobs failed: 0, jobs succeeded: 0
 --> Add/Modify event for consul-gossip-encryption-autogenerate: MODIFIED
 --> consul-gossip-encryption-autogenerate: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
 --> Add/Modify event for consul-gossip-encryption-autogenerate: MODIFIED
 --> consul-gossip-encryption-autogenerate: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
 --> Add/Modify event for consul-gossip-encryption-autogenerate: MODIFIED
 --> Starting delete for "consul-tls-init" Job
 --> jobs.batch "consul-tls-init" not found
 --> creating 1 resource(s)
 --> Watching for changes to Job consul-tls-init with timeout of 10m0s
 --> Add/Modify event for consul-tls-init: ADDED
 --> consul-tls-init: Jobs active: 0, jobs failed: 0, jobs succeeded: 0
 --> Add/Modify event for consul-tls-init: MODIFIED
 --> consul-tls-init: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
 --> Add/Modify event for consul-tls-init: MODIFIED
 --> Starting delete for "consul-gossip-encryption-autogenerate" Job
 --> Starting delete for "consul-tls-init" Job
 --> creating 56 resource(s)
 --> beginning wait for 56 resources with timeout of 10m0s
 --> creating 1 resource(s)
 --> Watching for changes to Job consul-server-acl-init-cleanup with timeout of 10m0s
 --> Add/Modify event for consul-server-acl-init-cleanup: ADDED
 --> consul-server-acl-init-cleanup: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
 --> Add/Modify event for consul-server-acl-init-cleanup: MODIFIED
 --> Starting delete for "consul-server-acl-init-cleanup" Job
 ✓ Consul installed into namespace "consul"

~/projects/consul-k8s/cli david-yu-cli-secure-preset 1m 49s
❯ k get pods -n consul
NAME                                                          READY   STATUS    RESTARTS   AGE
consul-4258h                                                  1/1     Running   0          66s
consul-connect-injector-webhook-deployment-668cd47898-56zjg   1/1     Running   0          66s
consul-connect-injector-webhook-deployment-668cd47898-p9lpj   1/1     Running   0          65s
consul-controller-76bf96646d-58lkh                            1/1     Running   0          66s
consul-ptqfw                                                  1/1     Running   0          66s
consul-q2tbp                                                  1/1     Running   0          66s
consul-server-0                                               1/1     Running   0          64s
consul-webhook-cert-manager-6d8cf874cc-xlh7c                  1/1     Running   0          66s

❯ k exec -it consul-server-0 -n consul -- /bin/sh
/ $ echo $GOSSIP_KEY
fdZ10GVbUjCntfZDipXBot+mxLzAMssfopf0+kPRY4c=
```

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

