### PR TITLE
When set_dev_mode is called, also set for CLI

### DIFF
--- a/control-plane/build-support/functions/10-util.sh
+++ b/control-plane/build-support/functions/10-util.sh
@@ -795,8 +795,13 @@ function set_dev_mode {
    local sdir="$1"
    local vers="$(parse_version "${sdir}" false false)"
 
-   status_stage "==> Setting VersionPreRelease back to 'dev'"
+   status_stage "==> Setting VersionPreRelease back to 'dev' for Control Plane"
    update_version "${sdir}/version/version.go" "${vers}" dev || return 1
+
+   # This function has been modified for Consul-K8s monorepo. It now sets dev mode
+   # for the CLI module as well.
+   status_stage "==> Setting VersionPreRelease back to 'dev' for CLI"
+   update_version "${sdir}/../cli/version/version.go" "${vers}" dev || return 1
 
    status_stage "==> Adding new UNRELEASED label in CHANGELOG.md"
    add_unreleased_to_changelog "${sdir}/.." || return 1

--- a/control-plane/build-support/functions/10-util.sh
+++ b/control-plane/build-support/functions/10-util.sh
@@ -862,7 +862,7 @@ function commit_dev_mode {
    pushd "$1" > /dev/null
 
    status "Staging CHANGELOG.md and version_*.go files"
-   git add CHANGELOG.md && git add control-plane/version/version*.go
+   git add CHANGELOG.md && git add */version/version*.go
    ret=$?
 
    if test ${ret} -eq 0

--- a/control-plane/build-support/scripts/dev.sh
+++ b/control-plane/build-support/scripts/dev.sh
@@ -84,6 +84,7 @@ function main {
       esac
    done
 
+   # Set dev mode for both CLI and Control Plane modules
    set_dev_mode "${sdir}" || return 1
 
 
@@ -91,6 +92,7 @@ function main {
    then
       status_stage "==> Commiting Dev Mode Changes"
       # Currently ${sdir} is consul-k8s/control-plane, but for git functions we should be in top-level, so we pass in "${sdir}/..".
+      # This will commit `version.go` for both CLI and Control Plane modules as well as the CHANGELOG.md.
       commit_dev_mode "${sdir}/.." || return 1
 
       if is_set "${do_push}"


### PR DESCRIPTION
Changes proposed in this PR:
- When `set_dev_mode` is called in build-scripts, set CLI to dev mode as well.

How I've tested this PR:
- We (@ndhanushkodi and I) ran `make dev-tree` from `/control-plane` and saw that the correct files were modified and committed.

How I expect reviewers to test this PR:
- You may also run `make dev-tree`.

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

