### PR TITLE
Controller acls reenabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
         type: string
       consul-k8s-image:
         type: string
-        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s-control-plane:latest"
+        default: "ashwinvenkatesh/consul-k8s@sha256:e777b8f2dab5ffc10e08febc16ccf4403c4feb62465c5bdc1ac6855a6b995acb"
       go-path:
         type: string
         default: "/home/circleci/.go_workspace"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
         type: string
       consul-k8s-image:
         type: string
-        default: "ashwinvenkatesh/consul-k8s@sha256:e777b8f2dab5ffc10e08febc16ccf4403c4feb62465c5bdc1ac6855a6b995acb"
+        default: "ashwinvenkatesh/consul-k8s@sha256:89a7056425d3f3d9ce3a214239046f8986d1ed06583bad22122ed36c3995c306"
       go-path:
         type: string
         default: "/home/circleci/.go_workspace"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
         type: string
       consul-k8s-image:
         type: string
-        default: "ashwinvenkatesh/consul-k8s@sha256:89a7056425d3f3d9ce3a214239046f8986d1ed06583bad22122ed36c3995c306"
+        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s-control-plane:latest"
       go-path:
         type: string
         default: "/home/circleci/.go_workspace"

--- a/acceptance/tests/controller/controller_namespaces_test.go
+++ b/acceptance/tests/controller/controller_namespaces_test.go
@@ -74,7 +74,7 @@ func TestControllerNamespaces(t *testing.T) {
 			ctx := suite.Environment().DefaultContext(t)
 
 			helmValues := map[string]string{
-				"global.image": "ashwinvenkatesh/consul@sha256:7426f47fa7065e38a2488042be66325aa37cda17a3bc15e58178104ff4619c1b",
+				"global.image": "ashwinvenkatesh/consul@sha256:70c8ba1c8c7c092e34473f4d45f08f148bf52f372bce830babfdd7dbfc1ce5d4",
 
 				"global.enableConsulNamespaces":  "true",
 				"global.adminPartitions.enabled": "true",

--- a/acceptance/tests/partitions/partitions_test.go
+++ b/acceptance/tests/partitions/partitions_test.go
@@ -97,7 +97,7 @@ func TestPartitionsWithoutMesh(t *testing.T) {
 
 			serverHelmValues := map[string]string{
 				"global.datacenter": "dc1",
-				"global.image":      "hashicorp/consul-enterprise:1.11.0-ent-beta1",
+				"global.image":      "ashwinvenkatesh/consul@sha256:70c8ba1c8c7c092e34473f4d45f08f148bf52f372bce830babfdd7dbfc1ce5d4",
 
 				"global.adminPartitions.enabled": "true",
 				"global.enableConsulNamespaces":  "true",
@@ -186,7 +186,7 @@ func TestPartitionsWithoutMesh(t *testing.T) {
 			// Create client cluster.
 			clientHelmValues := map[string]string{
 				"global.datacenter": "dc1",
-				"global.image":      "hashicorp/consul-enterprise:1.11.0-ent-beta1",
+				"global.image":      "ashwinvenkatesh/consul@sha256:70c8ba1c8c7c092e34473f4d45f08f148bf52f372bce830babfdd7dbfc1ce5d4",
 				"global.enabled":    "false",
 
 				"global.tls.enabled":           "true",
@@ -523,7 +523,7 @@ func TestPartitionsWithMesh(t *testing.T) {
 
 			serverHelmValues := map[string]string{
 				"global.datacenter": "dc1",
-				"global.image":      "ashwinvenkatesh/consul@sha256:e321bd719da2c2284c358846163d2b48e8fc27822ae5caba4b22c397c6e09356",
+				"global.image":      "ashwinvenkatesh/consul@sha256:70c8ba1c8c7c092e34473f4d45f08f148bf52f372bce830babfdd7dbfc1ce5d4",
 				"global.imageK8S":   "ashwinvenkatesh/consul-k8s@sha256:e777b8f2dab5ffc10e08febc16ccf4403c4feb62465c5bdc1ac6855a6b995acb",
 
 				"global.adminPartitions.enabled": "true",
@@ -620,7 +620,7 @@ func TestPartitionsWithMesh(t *testing.T) {
 			// Create client cluster.
 			clientHelmValues := map[string]string{
 				"global.datacenter": "dc1",
-				"global.image":      "ashwinvenkatesh/consul@sha256:e321bd719da2c2284c358846163d2b48e8fc27822ae5caba4b22c397c6e09356",
+				"global.image":      "ashwinvenkatesh/consul@sha256:70c8ba1c8c7c092e34473f4d45f08f148bf52f372bce830babfdd7dbfc1ce5d4",
 				"global.imageK8S":   "ashwinvenkatesh/consul-k8s@sha256:e777b8f2dab5ffc10e08febc16ccf4403c4feb62465c5bdc1ac6855a6b995acb",
 				"global.enabled":    "false",
 

--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -335,6 +335,7 @@ func (c *Command) controllerRules() (string, error) {
 {{- if .EnablePartitions }}
 partition "{{ .PartitionName }}" {
   mesh = "write"
+  acl = "write"
 {{- else }}
   operator = "write"
 {{- end }}

--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -229,6 +229,9 @@ partition "{{ .PartitionName }}" {
 	return c.renderGatewayRules(terminatingGatewayRulesTpl, name, namespace)
 }
 
+// acl = "write" is required when creating namespace with a default policy.
+// Attaching a default ACL policy to a namespace requires acl = "write" in the
+// namespace that the policy is defined in, which in our case is "default".
 func (c *Command) syncRules() (string, error) {
 	syncRulesTpl := `
   node "{{ .SyncConsulNodeName }}" {
@@ -236,6 +239,7 @@ func (c *Command) syncRules() (string, error) {
   }
 {{- if .EnableNamespaces }}
 operator = "write"
+acl = "write"
 {{- if .SyncEnableNSMirroring }}
 namespace_prefix "{{ .SyncNSMirroringPrefix }}" {
 {{- else }}
@@ -330,6 +334,9 @@ partition "default" {
 }
 
 // policy = "write" is required when creating namespaces within a partition.
+// acl = "write" is required when creating namespace with a default policy.
+// Attaching a default ACL policy to a namespace requires acl = "write" in the
+// namespace that the policy is defined in, which in our case is "default".
 func (c *Command) controllerRules() (string, error) {
 	controllerRules := `
 {{- if .EnablePartitions }}
@@ -338,6 +345,7 @@ partition "{{ .PartitionName }}" {
   acl = "write"
 {{- else }}
   operator = "write"
+  acl = "write"
 {{- end }}
 {{- if .EnableNamespaces }}
 {{- if .InjectEnableNSMirroring }}

--- a/control-plane/subcommand/server-acl-init/rules_test.go
+++ b/control-plane/subcommand/server-acl-init/rules_test.go
@@ -827,6 +827,7 @@ func TestControllerRules(t *testing.T) {
 			Expected: `
 partition "part-1" {
   mesh = "write"
+  acl = "write"
   namespace "consul" {
     policy = "write"
     service_prefix "" {
@@ -845,6 +846,7 @@ partition "part-1" {
 			Expected: `
 partition "part-1" {
   mesh = "write"
+  acl = "write"
   namespace_prefix "" {
     policy = "write"
     service_prefix "" {
@@ -864,6 +866,7 @@ partition "part-1" {
 			Expected: `
 partition "part-1" {
   mesh = "write"
+  acl = "write"
   namespace_prefix "prefix-" {
     policy = "write"
     service_prefix "" {

--- a/control-plane/subcommand/server-acl-init/rules_test.go
+++ b/control-plane/subcommand/server-acl-init/rules_test.go
@@ -477,6 +477,7 @@ func TestSyncRules(t *testing.T) {
     policy = "write"
   }
 operator = "write"
+acl = "write"
 namespace "sync-namespace" {
   node_prefix "" {
     policy = "read"
@@ -496,6 +497,7 @@ namespace "sync-namespace" {
     policy = "write"
   }
 operator = "write"
+acl = "write"
 namespace "sync-namespace" {
   node_prefix "" {
     policy = "read"
@@ -515,6 +517,7 @@ namespace "sync-namespace" {
     policy = "write"
   }
 operator = "write"
+acl = "write"
 namespace_prefix "" {
   node_prefix "" {
     policy = "read"
@@ -534,6 +537,7 @@ namespace_prefix "" {
     policy = "write"
   }
 operator = "write"
+acl = "write"
 namespace_prefix "" {
   node_prefix "" {
     policy = "read"
@@ -554,6 +558,7 @@ namespace_prefix "" {
     policy = "write"
   }
 operator = "write"
+acl = "write"
 namespace_prefix "prefix-" {
   node_prefix "" {
     policy = "read"
@@ -574,6 +579,7 @@ namespace_prefix "prefix-" {
     policy = "write"
   }
 operator = "write"
+acl = "write"
 namespace_prefix "prefix-" {
   node_prefix "" {
     policy = "read"
@@ -773,6 +779,7 @@ func TestControllerRules(t *testing.T) {
 			Name: "namespaces=disabled, partitions=disabled",
 			Expected: `
   operator = "write"
+  acl = "write"
     service_prefix "" {
       policy = "write"
       intentions = "write"
@@ -784,6 +791,7 @@ func TestControllerRules(t *testing.T) {
 			DestConsulNS:     "consul",
 			Expected: `
   operator = "write"
+  acl = "write"
   namespace "consul" {
     service_prefix "" {
       policy = "write"
@@ -797,6 +805,7 @@ func TestControllerRules(t *testing.T) {
 			Mirroring:        true,
 			Expected: `
   operator = "write"
+  acl = "write"
   namespace_prefix "" {
     service_prefix "" {
       policy = "write"
@@ -811,6 +820,7 @@ func TestControllerRules(t *testing.T) {
 			MirroringPrefix:  "prefix-",
 			Expected: `
   operator = "write"
+  acl = "write"
   namespace_prefix "prefix-" {
     service_prefix "" {
       policy = "write"


### PR DESCRIPTION
This reverts commit 28a637d2f129c9c1fdbe636bb3080852cd41eab6.

Changes proposed in this PR:
- Revert commit that adds ACL write

How I've tested this PR:
- Acceptance tests

How I expect reviewers to test this PR:
- Acceptance tests results. (vs acceptance test results on main)


