### PR TITLE
use image 1.11.0-beta2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ executors:
       - image: docker.mirror.hashicorp.services/circleci/golang:1.16
     environment:
       TEST_RESULTS: /tmp/test-results # path to where test results are saved
-      CONSUL_VERSION: 1.11.0-beta1 # Consul's OSS version to use in tests
-      CONSUL_ENT_VERSION: 1.11.0+ent-beta1 # Consul's enterprise version to use in tests
+      CONSUL_VERSION: 1.11.0-beta2 # Consul's OSS version to use in tests
+      CONSUL_ENT_VERSION: 1.11.0+ent-beta2 # Consul's enterprise version to use in tests
 
 control-plane-path : &control-plane-path control-plane
 cli-path : &cli-path cli

--- a/acceptance/tests/controller/controller_namespaces_test.go
+++ b/acceptance/tests/controller/controller_namespaces_test.go
@@ -74,7 +74,7 @@ func TestControllerNamespaces(t *testing.T) {
 			ctx := suite.Environment().DefaultContext(t)
 
 			helmValues := map[string]string{
-				"global.image": "ashwinvenkatesh/consul@sha256:70c8ba1c8c7c092e34473f4d45f08f148bf52f372bce830babfdd7dbfc1ce5d4",
+				"global.image": "hashicorp/consul-enterprise:1.11.0-ent-beta2",
 
 				"global.enableConsulNamespaces":  "true",
 				"global.adminPartitions.enabled": "true",

--- a/acceptance/tests/partitions/partitions_test.go
+++ b/acceptance/tests/partitions/partitions_test.go
@@ -97,7 +97,7 @@ func TestPartitionsWithoutMesh(t *testing.T) {
 
 			serverHelmValues := map[string]string{
 				"global.datacenter": "dc1",
-				"global.image":      "ashwinvenkatesh/consul@sha256:70c8ba1c8c7c092e34473f4d45f08f148bf52f372bce830babfdd7dbfc1ce5d4",
+				"global.image":      "hashicorp/consul-enterprise:1.11.0-ent-beta2",
 
 				"global.adminPartitions.enabled": "true",
 				"global.enableConsulNamespaces":  "true",
@@ -186,7 +186,7 @@ func TestPartitionsWithoutMesh(t *testing.T) {
 			// Create client cluster.
 			clientHelmValues := map[string]string{
 				"global.datacenter": "dc1",
-				"global.image":      "ashwinvenkatesh/consul@sha256:70c8ba1c8c7c092e34473f4d45f08f148bf52f372bce830babfdd7dbfc1ce5d4",
+				"global.image":      "hashicorp/consul-enterprise:1.11.0-ent-beta2",
 				"global.enabled":    "false",
 
 				"global.tls.enabled":           "true",
@@ -523,8 +523,7 @@ func TestPartitionsWithMesh(t *testing.T) {
 
 			serverHelmValues := map[string]string{
 				"global.datacenter": "dc1",
-				"global.image":      "ashwinvenkatesh/consul@sha256:70c8ba1c8c7c092e34473f4d45f08f148bf52f372bce830babfdd7dbfc1ce5d4",
-				"global.imageK8S":   "ashwinvenkatesh/consul-k8s@sha256:e777b8f2dab5ffc10e08febc16ccf4403c4feb62465c5bdc1ac6855a6b995acb",
+				"global.image":      "hashicorp/consul-enterprise:1.11.0-ent-beta2",
 
 				"global.adminPartitions.enabled": "true",
 				"global.enableConsulNamespaces":  "true",
@@ -620,8 +619,7 @@ func TestPartitionsWithMesh(t *testing.T) {
 			// Create client cluster.
 			clientHelmValues := map[string]string{
 				"global.datacenter": "dc1",
-				"global.image":      "ashwinvenkatesh/consul@sha256:70c8ba1c8c7c092e34473f4d45f08f148bf52f372bce830babfdd7dbfc1ce5d4",
-				"global.imageK8S":   "ashwinvenkatesh/consul-k8s@sha256:e777b8f2dab5ffc10e08febc16ccf4403c4feb62465c5bdc1ac6855a6b995acb",
+				"global.image":      "hashicorp/consul-enterprise:1.11.0-ent-beta2",
 				"global.enabled":    "false",
 
 				"global.tls.enabled":           "true",


### PR DESCRIPTION
Changes proposed in this PR:
- Update images across acceptance tests and control plane to use the 1.11.0-beta2 binary

How I've tested this PR:
- pipelines

How I expect reviewers to test this PR:
- 👀 

Checklist:
- [x] Tests added

