### PR TITLE
cli: Bump to 0.36.0

### DIFF
--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
-	Version = "0.35.0"
+	Version = "0.36.0"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
Changes proposed in this PR:
- Bump CLI to 0.36.0
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

