### PR TITLE
Always set server acl tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## UNRELEASED
 
+BUG FIXES:
+* Control Plane
+  * ACLs: Fix issue where if one or more servers fail to have their ACL tokens set on the initial run of server-acl-init
+    then on subsequent re-runs of server-acl-init the tokens are never set. [[GH-825](https://github.com/hashicorp/consul-k8s/issues/825)]
+  * ACLs: Fix issue where if the number of Consul servers is increased, the new servers are never provisioned
+    an ACL token. [[GH-677](https://github.com/hashicorp/consul-k8s/issues/677)]
+
 ## 0.36.0 (November 02, 2021)
 
 BREAKING CHANGES:

--- a/control-plane/subcommand/server-acl-init/servers.go
+++ b/control-plane/subcommand/server-acl-init/servers.go
@@ -5,17 +5,53 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/consul-k8s/control-plane/consul"
-	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
 	"github.com/hashicorp/consul/api"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/hashicorp/consul-k8s/control-plane/consul"
+	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
 )
 
 // bootstrapServers bootstraps ACLs and ensures each server has an ACL token.
-func (c *Command) bootstrapServers(serverAddresses []string, bootTokenSecretName, scheme string) (string, error) {
+// If bootstrapToken is not empty then ACLs are already bootstrapped.
+func (c *Command) bootstrapServers(serverAddresses []string, bootstrapToken, bootTokenSecretName, scheme string) (string, error) {
 	// Pick the first server address to connect to for bootstrapping and set up connection.
 	firstServerAddr := fmt.Sprintf("%s:%d", serverAddresses[0], c.flagServerPort)
+
+	if bootstrapToken == "" {
+		var err error
+		bootstrapToken, err = c.bootstrapACLs(firstServerAddr, scheme, bootTokenSecretName)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// Override our original client with a new one that has the bootstrap token
+	// set.
+	consulClient, err := consul.NewClient(&api.Config{
+		Address: firstServerAddr,
+		Scheme:  scheme,
+		Token:   bootstrapToken,
+		TLSConfig: api.TLSConfig{
+			Address: c.flagConsulTLSServerName,
+			CAFile:  c.flagConsulCACert,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("creating Consul client for address %s: %s", firstServerAddr, err)
+	}
+
+	// Create new tokens for each server and apply them.
+	if err := c.setServerTokens(consulClient, serverAddresses, bootstrapToken, scheme); err != nil {
+		return "", err
+	}
+	return bootstrapToken, nil
+}
+
+// bootstrapACLs makes the ACL bootstrap API call and writes the bootstrap token
+// to a kube secret.
+func (c *Command) bootstrapACLs(firstServerAddr string, scheme string, bootTokenSecretName string) (string, error) {
 	consulClient, err := consul.NewClient(&api.Config{
 		Address: firstServerAddr,
 		Scheme:  scheme,
@@ -29,13 +65,13 @@ func (c *Command) bootstrapServers(serverAddresses []string, bootTokenSecretName
 	}
 
 	// Call bootstrap ACLs API.
-	var bootstrapToken []byte
+	var bootstrapToken string
 	var unrecoverableErr error
 	err = c.untilSucceeds("bootstrapping ACLs - PUT /v1/acl/bootstrap",
 		func() error {
 			bootstrapResp, _, err := consulClient.ACL().Bootstrap()
 			if err == nil {
-				bootstrapToken = []byte(bootstrapResp.SecretID)
+				bootstrapToken = bootstrapResp.SecretID
 				return nil
 			}
 
@@ -69,36 +105,13 @@ func (c *Command) bootstrapServers(serverAddresses []string, bootTokenSecretName
 					Name: bootTokenSecretName,
 				},
 				Data: map[string][]byte{
-					common.ACLTokenSecretKey: bootstrapToken,
+					common.ACLTokenSecretKey: []byte(bootstrapToken),
 				},
 			}
 			_, err := c.clientset.CoreV1().Secrets(c.flagK8sNamespace).Create(c.ctx, secret, metav1.CreateOptions{})
 			return err
 		})
-	if err != nil {
-		return "", err
-	}
-
-	// Override our original client with a new one that has the bootstrap token
-	// set.
-	consulClient, err = consul.NewClient(&api.Config{
-		Address: firstServerAddr,
-		Scheme:  scheme,
-		Token:   string(bootstrapToken),
-		TLSConfig: api.TLSConfig{
-			Address: c.flagConsulTLSServerName,
-			CAFile:  c.flagConsulCACert,
-		},
-	})
-	if err != nil {
-		return "", fmt.Errorf("creating Consul client for address %s: %s", firstServerAddr, err)
-	}
-
-	// Create new tokens for each server and apply them.
-	if err := c.setServerTokens(consulClient, serverAddresses, string(bootstrapToken), scheme); err != nil {
-		return "", err
-	}
-	return string(bootstrapToken), nil
+	return bootstrapToken, err
 }
 
 // setServerTokens creates policies and associated ACL token for each server
@@ -109,9 +122,14 @@ func (c *Command) setServerTokens(consulClient *api.Client, serverAddresses []st
 		return err
 	}
 
+	existingTokens, _, err := consulClient.ACL().TokenList(nil)
+	if err != nil {
+		return err
+	}
+
 	// Create agent token for each server agent.
 	for _, host := range serverAddresses {
-		var token *api.ACLToken
+		var tokenSecretID string
 
 		// We create a new client for each server because we need to call each
 		// server specifically.
@@ -128,26 +146,44 @@ func (c *Command) setServerTokens(consulClient *api.Client, serverAddresses []st
 			return err
 		}
 
-		// Create token for the server
-		err = c.untilSucceeds(fmt.Sprintf("creating server token for %s - PUT /v1/acl/token", host),
-			func() error {
-				tokenReq := api.ACLToken{
-					Description: fmt.Sprintf("Server Token for %s", host),
-					Policies:    []*api.ACLTokenPolicyLink{{Name: agentPolicy.Name}},
+		tokenDescription := fmt.Sprintf("Server Token for %s", host)
+
+		// Check if the token was already created. We're matching on the description
+		// since that's the only part that's unique.
+		for _, t := range existingTokens {
+			if len(t.Policies) == 1 && t.Policies[0].Name == agentPolicy.Name {
+				if t.Description == tokenDescription {
+					tokenSecretID = t.SecretID
+					break
 				}
-				var err error
-				token, _, err = serverClient.ACL().TokenCreate(&tokenReq, nil)
-				return err
-			})
-		if err != nil {
-			return err
+			}
 		}
 
-		// Pass out agent tokens to servers.
-		// Update token.
+		// Create token for the server if it doesn't already exist.
+		if tokenSecretID == "" {
+			err = c.untilSucceeds(fmt.Sprintf("creating server token for %s - PUT /v1/acl/token", host),
+				func() error {
+					tokenReq := api.ACLToken{
+						Description: tokenDescription,
+						Policies:    []*api.ACLTokenPolicyLink{{Name: agentPolicy.Name}},
+					}
+					token, _, err := serverClient.ACL().TokenCreate(&tokenReq, nil)
+					if err != nil {
+						return err
+					}
+					tokenSecretID = token.SecretID
+					return nil
+				})
+			if err != nil {
+				return err
+			}
+		}
+
+		// Pass out agent tokens to servers. It's okay to make this API call
+		// even if the server already has a token since the call is idempotent.
 		err = c.untilSucceeds(fmt.Sprintf("updating server token for %s - PUT /v1/agent/token/agent", host),
 			func() error {
-				_, err := serverClient.Agent().UpdateAgentACLToken(token.SecretID, nil)
+				_, err := serverClient.Agent().UpdateAgentACLToken(tokenSecretID, nil)
 				return err
 			})
 		if err != nil {


### PR DESCRIPTION
If server-acl-init is re-run, ensure that server ACL tokens have been
created for each server and call the update token API for each server
again.

This ensures that if server-acl-init fails to pass out tokens to every
server that when it is re-run it won't assume that every server has a
token.

In addition this fixes a long-standing issue where if you increase your number of servers the new servers never get ACL tokens provisioned.

Fixes #825, #677

How I've tested this PR:

1. Brough up cluster with 3 servers:
  
    ```yaml
    global:
      imageK8S: ghcr.io/lkysow/consul-k8s-dev:nov02-2
      acls:
        manageSystemACLs: true
    server:
      replicas: 3
    ```

1. Then updated to 5 servers and ran helm upgrade.
1. Confirmed that there are no "Coordinate update" errors in logs of new servers. This would indicate they didn't have an ACL token set.
1. Confirmed that there are still only 5 server tokens (so it didn't re-create tokens)

How I expect reviewers to test this PR:
* code

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

