### PR TITLE
Fix bug where webhookconfig would not be updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ BUG FIXES:
     then on subsequent re-runs of server-acl-init the tokens are never set. [[GH-825](https://github.com/hashicorp/consul-k8s/issues/825)]
   * ACLs: Fix issue where if the number of Consul servers is increased, the new servers are never provisioned
     an ACL token. [[GH-677](https://github.com/hashicorp/consul-k8s/issues/677)]
+  * Fix issue where after a `helm upgrade`, users would see `x509: certificate signed by unknown authority.`
+    errors when modifying config entry resources. [[GH-837](https://github.com/hashicorp/consul-k8s/pull/837)]
 
 ## 0.36.0 (November 02, 2021)
 

--- a/charts/consul/templates/controller-mutatingwebhookconfiguration.yaml
+++ b/charts/consul/templates/controller-mutatingwebhookconfiguration.yaml
@@ -12,7 +12,6 @@ metadata:
     component: controller
 webhooks:
 - clientConfig:
-    caBundle: Cg==
     service:
       name: {{ template "consul.fullname" . }}-controller-webhook
       namespace: {{ .Release.Namespace }}
@@ -34,7 +33,6 @@ webhooks:
       - proxydefaults
   sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: {{ template "consul.fullname" . }}-controller-webhook
       namespace: {{ .Release.Namespace }}
@@ -56,7 +54,6 @@ webhooks:
       - meshes
   sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: {{ template "consul.fullname" . }}-controller-webhook
       namespace: {{ .Release.Namespace }}
@@ -78,7 +75,6 @@ webhooks:
     - servicedefaults
   sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: {{ template "consul.fullname" . }}-controller-webhook
       namespace: {{ .Release.Namespace }}
@@ -100,7 +96,6 @@ webhooks:
     - serviceresolvers
   sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: {{ template "consul.fullname" . }}-controller-webhook
       namespace: {{ .Release.Namespace }}
@@ -122,7 +117,6 @@ webhooks:
     - servicerouters
   sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: {{ template "consul.fullname" . }}-controller-webhook
       namespace: {{ .Release.Namespace }}
@@ -144,7 +138,6 @@ webhooks:
     - servicesplitters
   sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: {{ template "consul.fullname" . }}-controller-webhook
       namespace: {{ .Release.Namespace }}
@@ -166,7 +159,6 @@ webhooks:
     - serviceintentions
   sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: {{ template "consul.fullname" . }}-controller-webhook
       namespace: {{ .Release.Namespace }}
@@ -188,7 +180,6 @@ webhooks:
       - ingressgateways
   sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: {{ template "consul.fullname" . }}-controller-webhook
       namespace: {{ .Release.Namespace }}

--- a/control-plane/subcommand/webhook-cert-manager/command_test.go
+++ b/control-plane/subcommand/webhook-cert-manager/command_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/webhook-cert-manager/mocks"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/mitchellh/cli"
@@ -482,6 +483,105 @@ func TestRun_SecretUpdates(t *testing.T) {
 		require.NotEqual(r, secret1.Data[v1.TLSPrivateKeyKey], key)
 		require.Equal(r, deploymentName, secret1.OwnerReferences[0].Name)
 		require.Equal(r, uid, secret1.OwnerReferences[0].UID)
+	})
+}
+
+// Test that when the MutatingWebhookConfiguration is modified, that we correctly
+// reset it to the expected CA bundle.
+func TestRun_WebhookConfigModified(t *testing.T) {
+	t.Parallel()
+
+	deploymentName := "deployment"
+	deploymentNamespace := "deploy-ns"
+	webhook1ConfigName := "webhookOne"
+	webhook2ConfigName := "webhookTwo"
+	caBundle1 := []byte("bootstrapped-CA1")
+	caBundle2 := []byte("bootstrapped-CA2")
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: deploymentNamespace,
+			UID:       types.UID("this-is-a-uid"),
+		},
+	}
+
+	initialWebhook1Config := &admissionv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: webhook1ConfigName,
+		},
+		Webhooks: []admissionv1.MutatingWebhook{
+			{
+				Name: "webhook1-under-test",
+				ClientConfig: admissionv1.WebhookClientConfig{
+					CABundle: caBundle1,
+				},
+			},
+		},
+	}
+	initialWebhook2Config := &admissionv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: webhook2ConfigName,
+		},
+		Webhooks: []admissionv1.MutatingWebhook{
+			{
+				Name: "webhook2-under-test",
+				ClientConfig: admissionv1.WebhookClientConfig{
+					CABundle: caBundle2,
+				},
+			},
+		},
+	}
+
+	// The k8s cluster will start with the two webhook configs and the deployment.
+	k8s := fake.NewSimpleClientset(initialWebhook1Config, initialWebhook2Config, deployment)
+	ctx := context.Background()
+
+	// We don't want the certs to expire. This test is only checking if
+	// the MutatingWebhookConfiguration is modified that it gets reset.
+	certExpiry := 1 * time.Hour
+
+	// Start the command.
+	cmd := Command{
+		UI:         cli.NewMockUi(),
+		clientset:  k8s,
+		certExpiry: &certExpiry,
+	}
+
+	configFile := common.WriteTempFile(t, configFile)
+	exitCh := runCommandAsynchronously(&cmd, []string{
+		"-config-file", configFile,
+		"-deployment-name", deploymentName,
+		"-deployment-namespace", deploymentNamespace,
+	})
+	defer stopCommand(t, &cmd, exitCh)
+
+	// First, check that the mutatingwebhookconfiguration contents are updated when the cert-manager starts.
+	timer := &retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}
+	retry.RunWith(timer, t, func(r *retry.R) {
+		webhookConfig1, err := k8s.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, webhook1ConfigName, metav1.GetOptions{})
+		require.NoError(r, err)
+		require.NotEqual(r, webhookConfig1.Webhooks[0].ClientConfig.CABundle, caBundle1)
+
+		webhookConfig2, err := k8s.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, webhook2ConfigName, metav1.GetOptions{})
+		require.NoError(r, err)
+		require.NotEqual(r, webhookConfig2.Webhooks[0].ClientConfig.CABundle, caBundle2)
+	})
+
+	// Now, edit the mutatingwebhookconfigurations and reset the caBundle fields.
+	k8s.AdmissionregistrationV1().MutatingWebhookConfigurations().Update(ctx, initialWebhook1Config, metav1.UpdateOptions{})
+	k8s.AdmissionregistrationV1().MutatingWebhookConfigurations().Update(ctx, initialWebhook2Config, metav1.UpdateOptions{})
+
+	// Check that both mutatingwebhookconfigurations have their caBundle fields reset.
+	timer = &retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}
+	retry.RunWith(timer, t, func(r *retry.R) {
+		webhookConfig1, err := k8s.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, webhook1ConfigName, metav1.GetOptions{})
+		require.NoError(r, err)
+		require.NotEqual(r, webhookConfig1.Webhooks[0].ClientConfig.CABundle, caBundle1)
+
+		webhookConfig2, err := k8s.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, webhook2ConfigName, metav1.GetOptions{})
+		require.NoError(r, err)
+		require.NotEqual(r, webhookConfig2.Webhooks[0].ClientConfig.CABundle, caBundle2)
 	})
 }
 


### PR DESCRIPTION
Fixes an issue where if the webhookconfiguration is updated after the
webhook cert manager starts, then it is never reset to the correct
configuration until the manager is restarted or the certificate expires.

The issue was occurring because in the loop where we check the
webhookconfiguration we are only checking the webhookconfiguration of
the last updated certificate bundle. If there are multiple webhook
configurations then we are only watching a single one at a time since
the loop always operates on one bundle.

The fix is for each webhook to run its own loop.

In addition, the reason this was causing issues is because during a helm
upgrade we were resetting the webhookconfiguration's caBundle fields.
I've removed the caBundle setting (which already didn't exist in the
connect injector's webhook config) so that during a helm upgrade it
doesn't overwrite that field.

Fixes https://github.com/hashicorp/consul-k8s/issues/808

How I've tested this PR:
* unit tests (the test I added used to fail)
* manual test: install Consul and then edit both the connect inject webhook config and the controller webhook config and set caBundle to `""`. Wait a couple seconds. Now get the configs. Only _one_ will have been reset properly. Now do the same with this image (`ghcr.io/lkysow/consul-k8s-dev:nov03-3`)

How I expect reviewers to test this PR:
* code/manual testing if interested

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

