### PR TITLE
CHANGELOG: remove duplicate entry for CLI on 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ IMPROVEMENTS:
   * Set `prometheus.enabled` to true and enable all metrics for Consul K8s when installing via the `demo` preset. [[GH-809](https://github.com/hashicorp/consul-k8s/pull/809)]
   * Set `controller.enabled` to `true` when installing via the `demo` preset. [[GH818](https://github.com/hashicorp/consul-k8s/pull/818)]
   * Set `global.gossipEncryption.autoGenerate` to `true` and `global.tls.enableAutoEncrypt` to `true` when installing via the `secure` preset. [[GH818](https://github.com/hashicorp/consul-k8s/pull/818)]
-  * Add Prometheus deployment and Consul K8s metrics integration with demo preset when installing via `-preset=demo`. [[GH-809](https://github.com/hashicorp/consul-k8s/pull/809)]
 * Control Plane
   * Add support for partition-exports config entry as a Custom Resource Definition to help manage cross-partition networking. [[GH-802](https://github.com/hashicorp/consul-k8s/pull/802)]
 

--- a/README.md
+++ b/README.md
@@ -94,4 +94,4 @@ file. These are also fully documented directly on the
 # Tutorials
 
 You can find examples and complete tutorials on how to deploy Consul on 
-Kubernetes using Helm on the [HashiCorp Learn website](https://learn.hashicorp.com/consul).
+Kubernetes using Helm on the [HashiCorp Learn website](https://learn.hashicorp.com/collections/consul/kubernetes).


### PR DESCRIPTION
Changes proposed in this PR:
- Remove duplicate entry referencing enabling metrics and Prometheus integration. 
- Change link at bottom of README to go to https://learn.hashicorp.com/collections/consul/kubernetes instead of the main Consul learn guide landing page. 

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

