### PR TITLE
Increase wait time to 10m

### DIFF
--- a/acceptance/framework/helpers/helpers.go
+++ b/acceptance/framework/helpers/helpers.go
@@ -34,10 +34,10 @@ func WaitForAllPodsToBeReady(t *testing.T, client kubernetes.Interface, namespac
 
 	logger.Log(t, "Waiting for pods to be ready.")
 
-	// Wait up to 15m.
+	// Wait up to 10m.
 	// On Azure, volume provisioning can sometimes take close to 5 min,
 	// so we need to give a bit more time for pods to become healthy.
-	counter := &retry.Counter{Count: 180, Wait: 1 * time.Second}
+	counter := &retry.Counter{Count: 600, Wait: 1 * time.Second}
 	retry.RunWith(counter, t, func(r *retry.R) {
 		pods, err := client.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: podLabelSelector})
 		require.NoError(r, err)


### PR DESCRIPTION
The wait time for pods to be ready was accidentally reduced to 3m here (https://github.com/hashicorp/consul-k8s/pull/629/files#diff-4e31c92ae1107b6f5baeb3ac84a55265254d58211a97d2ac12860edcd4414766R40) when the frequency was increased to 1s.

In one of my recent tests AKS took 3m to pull the image which then failed the test.
