### PR TITLE
Prevent using reserved names for ns's/partitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ BUG FIXES:
     an ACL token. [[GH-677](https://github.com/hashicorp/consul-k8s/issues/677)]
   * Fix issue where after a `helm upgrade`, users would see `x509: certificate signed by unknown authority.`
     errors when modifying config entry resources. [[GH-837](https://github.com/hashicorp/consul-k8s/pull/837)]
+* Helm Chart
+  * **(Consul Enterprise only)** Error on Helm install if a reserved name is used for the admin partition name or a
+    Consul destination namespace for connect or catalog sync. [[GH-846](https://github.com/hashicorp/consul-k8s/pull/846)]
 
 ## 0.36.0 (November 02, 2021)
 

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -119,3 +119,21 @@ This template is for an init container.
       memory: "50Mi"
       cpu: "50m"
 {{- end -}}
+
+{{/*
+Fails when a reserved name is passed in. This should be used to test against
+Consul namespaces and partition names.
+This template accepts an array that contains two elements. The first element
+is the name that's being checked and the second is the name of the values.yaml
+key that's setting the name.
+
+Usage: {{ template "consul.reservedNamesFailer" (list .Values.key "key") }}
+
+*/}}
+{{- define "consul.reservedNamesFailer" -}}
+{{- $name := index . 0 -}}
+{{- $key := index . 1 -}}
+{{- if or (eq "system" $name) (eq "universal" $name) (eq "consul" $name) (eq "operator" $name) (eq "root" $name) }}
+{{- fail (cat "The name" $name "set for key" $key "is reserved by Consul for future use." ) }}
+{{- end }}
+{{- end -}}

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -8,6 +8,7 @@
 {{- if .Values.connectInject.centralConfig }}{{ if .Values.connectInject.centralConfig.proxyDefaults }}{{- if ne (trim .Values.connectInject.centralConfig.proxyDefaults) `{}` }}{{ fail "connectInject.centralConfig.proxyDefaults is no longer supported; instead you must migrate to CRDs (see www.consul.io/docs/k8s/crds/upgrade-to-crds)" }}{{ end }}{{ end }}{{ end -}}
 {{- if .Values.connectInject.imageEnvoy }}{{ fail "connectInject.imageEnvoy must be specified in global.imageEnvoy" }}{{ end }}
 {{- if .Values.global.lifecycleSidecarContainer }}{{ fail "global.lifecycleSidecarContainer has been renamed to global.consulSidecarContainer. Please set values using global.consulSidecarContainer." }}{{ end }}
+{{- template "consul.reservedNamesFailer" (list .Values.connectInject.consulNamespaces.consulDestinationNamespace "connectInject.consulNamespaces.consulDestinationNamespace") }}
 # The deployment for running the Connect sidecar injector
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/consul/templates/partition-init-job.yaml
+++ b/charts/consul/templates/partition-init-job.yaml
@@ -1,5 +1,6 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (and .Values.global.adminPartitions.enabled (not $serverEnabled)) }}
+{{- template "consul.reservedNamesFailer" (list .Values.global.adminPartitions.name "global.adminPartitions.name") }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/consul/templates/sync-catalog-deployment.yaml
+++ b/charts/consul/templates/sync-catalog-deployment.yaml
@@ -1,5 +1,6 @@
 {{- $clientEnabled := (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
+{{- template "consul.reservedNamesFailer" (list .Values.syncCatalog.consulNamespaces.consulDestinationNamespace "syncCatalog.consulNamespaces.consulDestinationNamespace") }}
 # The deployment for running the sync-catalog pod
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -1513,3 +1513,40 @@ EOF
 
   [ "${actual}" = "3" ]
 }
+
+#--------------------------------------------------------------------
+# consulDestinationNamespace reserved name
+
+@test "connectInject/Deployment: fails when consulDestinationNamespace=system" {
+  reservedNameTest "system"
+}
+
+@test "connectInject/Deployment: fails when consulDestinationNamespace=universal" {
+  reservedNameTest "universal"
+}
+
+@test "connectInject/Deployment: fails when consulDestinationNamespace=consul" {
+  reservedNameTest "consul"
+}
+
+@test "connectInject/Deployment: fails when consulDestinationNamespace=operator" {
+  reservedNameTest "operator"
+}
+
+@test "connectInject/Deployment: fails when consulDestinationNamespace=root" {
+  reservedNameTest "root"
+}
+
+# reservedNameTest is a helper function that tests if certain Consul destination
+# namespace names fail because the name is reserved.
+reservedNameTest() {
+  cd `chart_dir`
+  local -r name="$1"
+		run helm template \
+				-s templates/connect-inject-deployment.yaml  \
+				--set 'connectInject.enabled=true' \
+				--set "connectInject.consulNamespaces.consulDestinationNamespace=$name" .
+
+		[ "$status" -eq 1 ]
+		[[ "$output" =~ "The name $name set for key connectInject.consulNamespaces.consulDestinationNamespace is reserved by Consul for future use" ]]
+}

--- a/charts/consul/test/unit/sync-catalog-deployment.bats
+++ b/charts/consul/test/unit/sync-catalog-deployment.bats
@@ -978,3 +978,39 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+#--------------------------------------------------------------------
+# consulDestinationNamespace reserved name
+
+@test "syncCatalog/Deployment: fails when consulDestinationNamespace=system" {
+  reservedNameTest "system"
+}
+
+@test "syncCatalog/Deployment: fails when consulDestinationNamespace=universal" {
+  reservedNameTest "universal"
+}
+
+@test "syncCatalog/Deployment: fails when consulDestinationNamespace=consul" {
+  reservedNameTest "consul"
+}
+
+@test "syncCatalog/Deployment: fails when consulDestinationNamespace=operator" {
+  reservedNameTest "operator"
+}
+
+@test "syncCatalog/Deployment: fails when consulDestinationNamespace=root" {
+  reservedNameTest "root"
+}
+
+# reservedNameTest is a helper function that tests if certain Consul destination
+# namespace names fail because the name is reserved.
+reservedNameTest() {
+  cd `chart_dir`
+  local -r name="$1"
+		run helm template \
+				-s templates/sync-catalog-deployment.yaml  \
+				--set 'syncCatalog.enabled=true' \
+				--set "syncCatalog.consulNamespaces.consulDestinationNamespace=$name" .
+
+		[ "$status" -eq 1 ]
+		[[ "$output" =~ "The name $name set for key syncCatalog.consulNamespaces.consulDestinationNamespace is reserved by Consul for future use" ]]
+}


### PR DESCRIPTION
Some names are reserved by Consul and can't be used for namespaces or
partitions. Catching this early before the helm install is a better UX
than having the install fail (in the case of partitions) or succeed (in
the case of namespaces) and then fail during syncing or injection.

This code uses some tricks:
1. The code for failing on reserved names is extracted into a helper template so it can be re-used in other templates
2. The test code uses a helper function so there's less duplication in the tests

Fixes https://github.com/hashicorp/consul-k8s/issues/593


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)