### PR TITLE
Re-enable streaming for clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ BREAKING CHANGES:
   ```yaml
   client:
     extraConfig: |
-      {use_streaming_backend": false}
+      {"use_streaming_backend": false}
   ```
   
   [[GH-851](https://github.com/hashicorp/consul-k8s/pull/851)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 ## UNRELEASED
 
-FEATURES:
-* Helm Chart
-  * Add support for Consul services to utilize Consul DNS for service discovery. Set `dns.enableRedirection` to allow services to
-    use Consul DNS via the Consul DNS Service. [[GH-833](https://github.com/hashicorp/consul-k8s/pull/833)]
-* Control Plane
-  * Connect: Allow services using Connect to utilize Consul DNS to perform service discovery. [[GH-833](https://github.com/hashicorp/consul-k8s/pull/833)]
-  
 BREAKING CHANGES:
 * Previously [UI metrics](https://www.consul.io/docs/connect/observability/ui-visualization) would be enabled when
   `global.metrics=false` and `ui.metrics.enabled=-`. If you are no longer seeing UI metrics,
@@ -14,6 +7,24 @@ BREAKING CHANGES:
 * The `enterpriseLicense` section of the values file has been migrated from being under the `server` stanza to being
   under the `global` stanza. Migrating the contents of `server.enterpriseLicense` to `global.enterpriseLicense` will
   ensure the license job works. [[GH-856](https://github.com/hashicorp/consul-k8s/pull/856)]
+* Consul [streaming](https://www.consul.io/docs/agent/options#use_streaming_backend) is re-enabled by default.
+  Streaming is broken when using multi-DC federation and Consul versions 1.10.0, 1.10.1, 1.10.2.
+  If you are using those versions and multi-DC federation, you must upgrade to Consul >= 1.10.3 or set:
+
+  ```yaml
+  client:
+    extraConfig: |
+      {use_streaming_backend": false}
+  ```
+  
+  [[GH-851](https://github.com/hashicorp/consul-k8s/pull/851)]
+
+FEATURES:
+* Helm Chart
+  * Add support for Consul services to utilize Consul DNS for service discovery. Set `dns.enableRedirection` to allow services to
+    use Consul DNS via the Consul DNS Service. [[GH-833](https://github.com/hashicorp/consul-k8s/pull/833)]
+* Control Plane
+  * Connect: Allow services using Connect to utilize Consul DNS to perform service discovery. [[GH-833](https://github.com/hashicorp/consul-k8s/pull/833)]
 
 IMPROVEMENTS:
 * Control Plane
@@ -28,6 +39,7 @@ IMPROVEMENTS:
   * Update Consul version to 1.10.4. [[GH-861](https://github.com/hashicorp/consul-k8s/pull/861)]
   * Update Service Router, Service Splitter and Ingress Gateway CRD with support for RequestHeaders and ResponseHeaders. [[GH-863](https://github.com/hashicorp/consul-k8s/pull/863)]
   * Update Ingress Gateway CRD with partition support for the IngressService and TLS Config. [[GH-863](https://github.com/hashicorp/consul-k8s/pull/863)]
+  * Re-enable streaming for Consul clients. [[GH-851](https://github.com/hashicorp/consul-k8s/pull/851)]
 
 BUG FIXES:
 * Control Plane

--- a/charts/consul/templates/client-config-configmap.yaml
+++ b/charts/consul/templates/client-config-configmap.yaml
@@ -25,8 +25,7 @@ data:
        in the UI. */}}
   config.json: |-
     {
-      "check_update_interval": "0s",
-      "use_streaming_backend": false
+      "check_update_interval": "0s"
     }
   {{- end }}
 {{- end }}

--- a/charts/consul/templates/create-federation-secret-job.yaml
+++ b/charts/consul/templates/create-federation-secret-job.yaml
@@ -114,8 +114,7 @@ spec:
               mountPath: /consul/tls/client/ca
               readOnly: true
             {{- end }}
-            {{- if (or .Values.global.gossipEncryption.autoGenerate 
-                       (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey)) }}
+            {{- if (or .Values.global.gossipEncryption.autoGenerate (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey)) }}
             - name: gossip-encryption-key
               mountPath: /consul/gossip
               readOnly: true
@@ -127,8 +126,7 @@ spec:
                 consul-k8s-control-plane create-federation-secret \
                   -log-level={{ .Values.global.logLevel }} \
                   -log-json={{ .Values.global.logJSON }} \
-                  {{- if (or .Values.global.gossipEncryption.autoGenerate (and
-                             .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey)) }}
+                  {{- if (or .Values.global.gossipEncryption.autoGenerate (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey)) }}
                   -gossip-key-file=/consul/gossip/gossip.key \
                   {{- end }}
                   {{- if .Values.global.acls.createReplicationToken }}

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -569,7 +569,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 1b0252854bdef3197902ee928716ebd691ef39b173a19ad0d4e883ddb0443b88 ]
+  [ "${actual}" = b0be8c9b3ae8692a4e393b93976c55988e95cb9d9dae96fbd8626f3f5b6c404b ]
 }
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
Changes proposed in this PR:
- re-enable streaming since these issues were fixed in Consul 1.10.3 (https://github.com/hashicorp/consul/issues/11086, https://github.com/hashicorp/consul/issues/10796)
- fix `Error: parse error at (consul/templates/create-federation-secret-job.yaml:129): unclosed action` error with Helm <3.5.3

How I've tested this PR:
- acceptance tests

How I expect reviewers to test this PR:
- code

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

