### PR TITLE
CONTRIBUTING: change to consul-k8s-control-plane in Contributing 101 and formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to Consul on Kubernetes
 
 1. [Contributing 101](#contributing-101)
+    1. [Building and running `consul-k8s-control-plane`](#building-and-running-consul-k8s-control-plane)
     1. [Running Linters Locally](#running-linters-locally)
     1. [Rebasing Contributions against main](#rebasing-contributions-against-main)
 1. [Creating a new CRD](#creating-a-new-crd)
@@ -22,6 +23,8 @@
 
 
 ## Contributing 101
+
+### Building and running `consul-k8s-control-plane`
 
 To build and install the control plane binary `consul-k8s` locally, Go version 1.11.4+ is required because this repository uses go modules and go 1.11.4 introduced changes to checksumming of modules to correct a symlink problem.
 You will also need to install the Docker engine:
@@ -69,13 +72,28 @@ To create a docker image with your local changes:
 $ make dev-docker
 ```
 
-Create a `values.dev.yaml` file that includes the `global.imageK8s` flag:
+If you'd like to use your docker images in a dev deployment of Consul K8s, you would need to push those images to Docker Hub since 
+deploying off of local images is not supported unless you host your own local Docker registry:
+
+```
+$ docker tag consul-k8s-control-plane-dev <insert-docker-hub-username>/consul-k8s-control-plane-dev
+$ docker push <insert-docker-hub-username>/consul-k8s-control-plane-dev
+Using default tag: latest
+The push refers to repository [docker.io/<hub-username>/consul-k8s-control-plane-dev]
+4c5225fbac5e: Pushed
+737cd00c4260: Pushed
+7a9c7d9855c2: Pushed
+e2eb06d8af82: Pushed
+latest: digest: sha256:0b3e90e0b32da8aba1b11cda6a6a768a5eb4d83664a408d53f1502db8703ef8a size: 1160
+```
+
+Create a `values.dev.yaml` file that includes the `global.imageK8s` flag to point to dev images you just pushed:
 
 ```yaml
 global:
   tls:
     enabled: true
-  imageK8S: consul-k8s-control-plane-dev
+  imageK8S: <insert-docker-hub-username>/consul-k8s-control-plane-dev
 server:
   replicas: 1
 connectInject:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ e2eb06d8af82: Pushed
 latest: digest: sha256:0b3e90e0b32da8aba1b11cda6a6a768a5eb4d83664a408d53f1502db8703ef8a size: 1160
 ```
 
-Create a `values.dev.yaml` file that includes the `global.imageK8s` flag to point to dev images you just pushed:
+Create a `values.dev.yaml` file that includes the `global.imageK8S` flag to point to dev images you just pushed:
 
 ```yaml
 global:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 1. [Contributing 101](#contributing-101)
     1. [Running Linters Locally](#running-linters-locally)
-    2. [Rebasing Contributions against main](#rebasing-contributions-against-main)
+    1. [Rebasing Contributions against main](#rebasing-contributions-against-main)
 1. [Creating a new CRD](#creating-a-new-crd)
     1. [The Structs](#the-structs) 
     1. [Spec Methods](#spec-methods)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,31 @@ To create a docker image with your local changes:
 $ make dev-docker
 ```
 
+Create a `values.dev.yaml` file that includes the `global.imageK8s` flag
+
+```yaml
+global:
+  tls:
+    enabled: true
+  image: hashicorp/consul-k8s-control-plane-dev
+server:
+  replicas: 1
+connectInject:
+  enabled: true
+ui:
+  enabled: true
+  service:
+    enabled: true
+controller:
+  enabled: true
+```
+
+Run a `helm install` from the project root directory to target your dev version of the Helm chart. 
+
+```shell
+helm install consul --create-namespace -n consul -f ./values-dev.yaml ./charts/consul
+```
+
 ### Running linters locally
 [`golangci-lint`](https://golangci-lint.run/) is used in CI to enforce coding and style standards and help catch bugs ahead of time.
 The configuration that CI runs is stored in `.golangci.yml` at the top level of the repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,9 @@
 
 1. [Contributing 101](#contributing-101)
     1. [Building and running `consul-k8s-control-plane`](#building-and-running-consul-k8s-control-plane)
-    1. [Running Linters Locally](#running-linters-locally)
-    1. [Rebasing Contributions against main](#rebasing-contributions-against-main)
+    1. [Building and running the `consul-k8s` CLI](#building-and-running-the-consul-k8s-cli)
+    3. [Running Linters Locally](#running-linters-locally)
+    4. [Rebasing Contributions against main](#rebasing-contributions-against-main)
 1. [Creating a new CRD](#creating-a-new-crd)
     1. [The Structs](#the-structs) 
     1. [Spec Methods](#spec-methods)
@@ -110,6 +111,27 @@ Run a `helm install` from the project root directory to target your dev version 
 
 ```shell
 helm install consul --create-namespace -n consul -f ./values.dev.yaml ./charts/consul
+```
+
+### Building and running the `consul-k8s` CLI
+
+Change directory into the `cli` folder where the golang code resides.
+
+```shell
+cd cli
+```
+
+Build the CLI binary using the following command
+
+```shell
+go build -o bin/consul-k8s
+```
+
+Run the CLI as follows
+
+```shell
+./bin/consul-k8s version
+consul-k8s 0.36.0-dev
 ```
 
 ### Running linters locally

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,13 +69,13 @@ To create a docker image with your local changes:
 $ make dev-docker
 ```
 
-Create a `values.dev.yaml` file that includes the `global.imageK8s` flag
+Create a `values.dev.yaml` file that includes the `global.imageK8s` flag:
 
 ```yaml
 global:
   tls:
     enabled: true
-  image: hashicorp/consul-k8s-control-plane-dev
+  image: consul-k8s-control-plane-dev
 server:
   replicas: 1
 connectInject:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ Create a `values.dev.yaml` file that includes the `global.imageK8s` flag:
 global:
   tls:
     enabled: true
-  image: consul-k8s-control-plane-dev
+  imageK8S: consul-k8s-control-plane-dev
 server:
   replicas: 1
 connectInject:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,22 +3,22 @@
 1. [Contributing 101](#contributing-101)
     1. [Running Linters Locally](#running-linters-locally)
     2. [Rebasing Contributions against main](#rebasing-contributions-against-main)
-3. [Creating a new CRD](#creating-a-new-crd)
+1. [Creating a new CRD](#creating-a-new-crd)
     1. [The Structs](#the-structs) 
-    2. [Spec Methods](#spec-methods)
-    3. [Spec Tests](#spec-tests)
-    4. [Controller](#controller)
-    5. [Webhook](#webhook)
-    6. [Update command.go](#update-commandgo)
-    7. [Generating YAML](#generating-yaml)
-    8. [Updating consul-helm](#updating-consul-helm)
-    9. [Testing a new CRD](#testing-a-new-crd)
-    10. [Update Consul K8s accpetance tests](#update-consul-k8s-acceptance-tests)
+    1. [Spec Methods](#spec-methods)
+    1. [Spec Tests](#spec-tests)
+    1. [Controller](#controller)
+    1. [Webhook](#webhook)
+    1. [Update command.go](#update-commandgo)
+    1. [Generating YAML](#generating-yaml)
+    1. [Updating consul-helm](#updating-consul-helm)
+    1. [Testing a new CRD](#testing-a-new-crd)
+    1. [Update Consul K8s accpetance tests](#update-consul-k8s-acceptance-tests)
 5. [Testing the Helm chart](#testing-the-helm-chart)
-6. [Running the tests](#running-the-tests)
-     1. [Writing Unit tests](#writing-unit-tests)
-     2. [Writing Acceptance tests](#writing-acceptance-tests)
-8. [Helm Reference Docs](#helm-reference-docs)
+    1. [Running the tests](#running-the-tests)
+    1. [Writing Unit tests](#writing-unit-tests)
+    1. [Writing Acceptance tests](#writing-acceptance-tests)
+1. [Helm Reference Docs](#helm-reference-docs)
 
 
 ## Contributing 101
@@ -48,14 +48,8 @@ To compile the `consul-k8s` binary for your local machine:
 $ make dev
 ```
 
-This will compile the `consul-k8s` binary into `bin/consul-k8s` as
+This will compile the `consul-k8s-control-plane` binary into `bin/consul-k8s-control-plane` as
 well as your `$GOPATH` and run the test suite.
-
-Or run the following to generate all binaries:
-
-```shell
-$ make dist
-```
 
 If you just want to run the tests:
 
@@ -445,8 +439,6 @@ The acceptance tests require a Kubernetes cluster with a configured `kubectl`.
   ```bash
   brew install golang
   ```
-  
----
 
 ### Running The Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ controller:
 Run a `helm install` from the project root directory to target your dev version of the Helm chart. 
 
 ```shell
-helm install consul --create-namespace -n consul -f ./values-dev.yaml ./charts/consul
+helm install consul --create-namespace -n consul -f ./values.dev.yaml ./charts/consul
 ```
 
 ### Running linters locally


### PR DESCRIPTION
Changes proposed in this PR:
- Change `consul-k8s` to `consul-k8s-control-plane` in contributing 101
- Remove `make dist` as make target is no longer available
- Add example of running dev Helm chart with images built from dev via `values.dev.yaml`
- Add section for building and running the `consul-k8s` CLI
- Reformat Tests section in TOC

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

