### PR TITLE
Create federation secret with default `consul-gossip-encryption-key` secret when global.gossipEncryption.autoGenerate is set to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ BUG FIXES:
   * **(Consul Enterprise only)** Error on Helm install if a reserved name is used for the admin partition name or a
     Consul destination namespace for connect or catalog sync. [[GH-846](https://github.com/hashicorp/consul-k8s/pull/846)]
   * Truncate Persistent Volume Claim names when namespace names are too long. [[GH-799](https://github.com/hashicorp/consul-k8s/pull/799)]
+  * Populate the federation secret with the generated Gossip key when `global.gossipEncryption.autoGenerate` is set to true. [[GH-854](https://github.com/hashicorp/consul-k8s/pull/854)]
 
 ## 0.36.0 (November 02, 2021)
 

--- a/charts/consul/templates/create-federation-secret-job.yaml
+++ b/charts/consul/templates/create-federation-secret-job.yaml
@@ -68,6 +68,13 @@ spec:
             items:
               - key: {{ .Values.global.gossipEncryption.secretKey }}
                 path: gossip.key
+        {{- else if .Values.global.gossipEncryption.autoGenerate }}
+        - name: gossip-encryption-key
+          secret:
+            secretName: consul-gossip-encryption-key
+            items:
+              - key: key
+                path: gossip.key
         {{- end }}
 
       {{- if .Values.global.tls.enableAutoEncrypt }}
@@ -107,7 +114,8 @@ spec:
               mountPath: /consul/tls/client/ca
               readOnly: true
             {{- end }}
-            {{- if (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey) }}
+            {{- if (or (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey)
+                       .Values.global.gossipEncryption.autoGenerate) }}
             - name: gossip-encryption-key
               mountPath: /consul/gossip
               readOnly: true

--- a/charts/consul/templates/create-federation-secret-job.yaml
+++ b/charts/consul/templates/create-federation-secret-job.yaml
@@ -114,8 +114,8 @@ spec:
               mountPath: /consul/tls/client/ca
               readOnly: true
             {{- end }}
-            {{- if (or (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey)
-                       .Values.global.gossipEncryption.autoGenerate) }}
+            {{- if (or .Values.global.gossipEncryption.autoGenerate 
+                       (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey)) }}
             - name: gossip-encryption-key
               mountPath: /consul/gossip
               readOnly: true
@@ -127,7 +127,8 @@ spec:
                 consul-k8s-control-plane create-federation-secret \
                   -log-level={{ .Values.global.logLevel }} \
                   -log-json={{ .Values.global.logJSON }} \
-                  {{- if (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey) }}
+                  {{- if (or .Values.global.gossipEncryption.autoGenerate (and
+                             .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey)) }}
                   -gossip-key-file=/consul/gossip/gossip.key \
                   {{- end }}
                   {{- if .Values.global.acls.createReplicationToken }}


### PR DESCRIPTION
Changes proposed in this PR:
- Check to see whether autoGenerate is set to true and use default secret name and secret key to export out gossipEncryptionKey for consul federation secret. Previously the generated gossip encryption key was not exported when setting `autoGenerate` to true. 

How I've tested this PR:

```
global:
  name: consul
  datacenter: dc1
  image: hashicorp/consul:1.10.3
  tls: 
    enabled: true
  acls: 
    manageSystemACLs: true
    createReplicationToken: true
  federation: 
    enabled: true
    createFederationSecret: true
  gossipEncryption:
    autoGenerate: true
server:
  replicas: 1
ui:
  enabled: true
  service:
    enabled: true
connectInject:
  enabled: true
controller:
  enabled: true
meshGateway:
  enabled: true
```

Export out consul-federation secret
```
kubectl get secret consul-federation -o yaml > consul-federation-secret.yaml
```

Inspect contents of federation secret
```
> cat consul-federation-secret.yaml
apiVersion: v1
data:
  caCert: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURRekNDQXVpZ0F3SUJBZ0lVWmdhSGU1MGo1NU1mK0gwZmc5eXRKTnBxQ2Nrd0NnWUlLb1pJemowRUF3SXcKZ1pFeEN6QUpCZ05WQkFZVEFsVlRNUXN3Q1FZRFZRUUlFd0pEUVRFV01CUUdBMVVFQnhNTlUyRnVJRVp5WVc1agphWE5qYnpFYU1CZ0dBMVVFQ1JNUk1UQXhJRk5sWTI5dVpDQlRkSEpsWlhReERqQU1CZ05WQkJFVEJUazBNVEExCk1SY3dGUVlEVlFRS0V3NUlZWE5vYVVOdmNuQWdTVzVqTGpFWU1CWUdBMVVFQXhNUFEyOXVjM1ZzSUVGblpXNTAKSUVOQk1CNFhEVEl4TVRFeE1EQTBORGswTmxvWERUTXhNVEV3T0RBME5UQTBObG93Z1pFeEN6QUpCZ05WQkFZVApBbFZUTVFzd0NRWURWUVFJRXdKRFFURVdNQlFHQTFVRUJ4TU5VMkZ1SUVaeVlXNWphWE5qYnpFYU1CZ0dBMVVFCkNSTVJNVEF4SUZObFkyOXVaQ0JUZEhKbFpYUXhEakFNQmdOVkJCRVRCVGswTVRBMU1SY3dGUVlEVlFRS0V3NUkKWVhOb2FVTnZjbkFnU1c1akxqRVlNQllHQTFVRUF4TVBRMjl1YzNWc0lFRm5aVzUwSUVOQk1Ga3dFd1lIS29aSQp6ajBDQVFZSUtvWkl6ajBEQVFjRFFnQUVkbmk1cUI3dTBxMk40dldBRjVaVTNpeXVTS2JrTWxNV2FObmt3VVNWCmRMZjJ0bHc2VlNNelAyelQ5Smx6WDAxTVBzZnZSaTRrVGxaN1pEM0VNcW93QjZPQ0FSb3dnZ0VXTUE0R0ExVWQKRHdFQi93UUVBd0lCaGpBZEJnTlZIU1VFRmpBVUJnZ3JCZ0VGQlFjREFRWUlLd1lCQlFVSEF3SXdEd1lEVlIwVApBUUgvQkFVd0F3RUIvekJvQmdOVkhRNEVZUVJmTm1RNk16TTZPR1U2WkRrNllUTTZZVFE2TW1FNk1HTTZOekE2Ck5XSTZNMk02TjJZNlpUSTZOamc2T0dJNllUTTZaakE2WVRFNk1UZzZNVE02WTJZNk1HTTZZV1E2WlRVNlpqVTYKTVRjNlpUazZPREU2TlRjNll6RTZNMkU2T1dJd2FnWURWUjBqQkdNd1lZQmZObVE2TXpNNk9HVTZaRGs2WVRNNgpZVFE2TW1FNk1HTTZOekE2TldJNk0yTTZOMlk2WlRJNk5qZzZPR0k2WVRNNlpqQTZZVEU2TVRnNk1UTTZZMlk2Ck1HTTZZV1E2WlRVNlpqVTZNVGM2WlRrNk9ERTZOVGM2WXpFNk0yRTZPV0l3Q2dZSUtvWkl6ajBFQXdJRFNRQXcKUmdJaEFOTkdmNGNCYTkrOXFUSTBjeXF4MHc2T0kwYUFLblEwS3pvSjdCdUl1Q1hYQWlFQXZmN053OVI4clhORwpabVNYazNBSTJwQ1hXWmY4QUt5cGk1Z2VLSHAycjBNPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
  caKey: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUtoWExJL1RaYkhkZzRYdXFWTjhYMTdJOU4yVGx4K3NUTGpDWk8zcHA5K3NvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFZG5pNXFCN3UwcTJONHZXQUY1WlUzaXl1U0tia01sTVdhTm5rd1VTVmRMZjJ0bHc2VlNNegpQMnpUOUpselgwMU1Qc2Z2Umk0a1RsWjdaRDNFTXFvd0J3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
  gossipEncryptionKey: eUxlLzdGRTZJU3ZBUi8rTS9BM2NzK2NPR25Bbm1tdDJiNGo5eDZxRmw3az0=
  replicationToken: MjZlMGY0MmYtZTdlMy1jYjBmLTVkNzctNDY4YjNhNTZjMDYy
  serverConfigJSON: eyJwcmltYXJ5X2RhdGFjZW50ZXIiOiJkYzEiLCJwcmltYXJ5X2dhdGV3YXlzIjpbIjM0LjEwNS4xMTAuNzE6NDQzIl19
kind: Secret
metadata:
  creationTimestamp: "2021-11-10T04:51:44Z"
  name: consul-federation
  namespace: consul
  resourceVersion: "16343"
  uid: 2b145443-8361-4dd3-abbb-dfd5cc0c3404
type: Opaque
```

How I expect reviewers to test this PR:

Manually, I'm not sure how to automate it. 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

