### PR TITLE
Migrate server.enterpriseLicense to global.enterpriseLicense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ BREAKING CHANGES:
 * Previously [UI metrics](https://www.consul.io/docs/connect/observability/ui-visualization) would be enabled when
   `global.metrics=false` and `ui.metrics.enabled=-`. If you are no longer seeing UI metrics,
   set `global.metrics=true` or `ui.metrics.enabled=true`. [[GH-841](https://github.com/hashicorp/consul-k8s/pull/841)]
+* The `enterpriseLicense` section of the values file has been migrated from being under the `server` stanza to being
+  under the `global` stanza. Migrating the contents of `server.enterpriseLicense` to `global.enterpriseLicense` will
+  ensure the license job works. [[GH-856](https://github.com/hashicorp/consul-k8s/pull/856)]
 
 IMPROVEMENTS:
 * Control Plane

--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -66,8 +66,8 @@ func (t *TestConfig) HelmValuesFromConfig() (map[string]string, error) {
 	}
 
 	if t.EnterpriseLicense != "" {
-		setIfNotEmpty(helmValues, "server.enterpriseLicense.secretName", LicenseSecretName)
-		setIfNotEmpty(helmValues, "server.enterpriseLicense.secretKey", LicenseSecretKey)
+		setIfNotEmpty(helmValues, "global.enterpriseLicense.secretName", LicenseSecretName)
+		setIfNotEmpty(helmValues, "global.enterpriseLicense.secretKey", LicenseSecretKey)
 	}
 
 	if t.EnableOpenshift {

--- a/acceptance/framework/config/config_test.go
+++ b/acceptance/framework/config/config_test.go
@@ -61,8 +61,8 @@ func TestConfig_HelmValuesFromConfig(t *testing.T) {
 				EnterpriseLicense: "ent-license",
 			},
 			map[string]string{
-				"server.enterpriseLicense.secretName":           "license",
-				"server.enterpriseLicense.secretKey":            "key",
+				"global.enterpriseLicense.secretName":           "license",
+				"global.enterpriseLicense.secretKey":            "key",
 				"connectInject.transparentProxy.defaultEnabled": "false",
 			},
 		},

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -131,10 +131,10 @@ spec:
         - name: aclconfig
           emptyDir: {}
         {{- else }}
-        {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+        {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload) }}
         - name: consul-license
           secret:
-            secretName: {{ .Values.server.enterpriseLicense.secretName }}
+            secretName: {{ .Values.global.enterpriseLicense.secretName }}
         {{- end }}
         {{- end }}
       containers:
@@ -181,9 +181,9 @@ spec:
                   key: {{ .Values.global.gossipEncryption.secretKey }}
                 {{- end }}
             {{- end }}
-            {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload (not .Values.global.acls.manageSystemACLs)) }}
+            {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload (not .Values.global.acls.manageSystemACLs)) }}
             - name: CONSUL_LICENSE_PATH
-              value: /consul/license/{{ .Values.server.enterpriseLicense.secretKey }}
+              value: /consul/license/{{ .Values.global.enterpriseLicense.secretKey }}
             {{- end }}
             {{- if .Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
@@ -309,7 +309,7 @@ spec:
             - name: aclconfig
               mountPath: /consul/aclconfig
             {{- else }}
-            {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+            {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload) }}
             - name: consul-license
               mountPath: /consul/license
               readOnly: true

--- a/charts/consul/templates/client-snapshot-agent-deployment.yaml
+++ b/charts/consul/templates/client-snapshot-agent-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       {{- if .Values.client.priorityClassName }}
       priorityClassName: {{ .Values.client.priorityClassName | quote }}
       {{- end }}
-      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
+      {{- if (or .Values.global.acls.manageSystemACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload)) }}
       volumes:
         {{- if (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) }}
         - name: snapshot-config
@@ -52,10 +52,10 @@ spec:
         - name: aclconfig
           emptyDir: {}
         {{- else }}
-        {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+        {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload) }}
         - name: consul-license
           secret:
-            secretName: {{ .Values.server.enterpriseLicense.secretName }}
+            secretName: {{ .Values.global.enterpriseLicense.secretName }}
         {{- end }}
         {{- end }}
         {{- if .Values.global.tls.enabled }}
@@ -102,9 +102,9 @@ spec:
                   name: "{{ template "consul.fullname" . }}-client-snapshot-agent-acl-token"
                   key: "token"
             {{- else }}
-            {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+            {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload) }}
             - name: CONSUL_LICENSE_PATH
-              value: /consul/license/{{ .Values.server.enterpriseLicense.secretKey }}
+              value: /consul/license/{{ .Values.global.enterpriseLicense.secretKey }}
             {{- end }}
             {{- end}}
           command:
@@ -123,7 +123,7 @@ spec:
                 {{- if .Values.global.acls.manageSystemACLs }}
                 -config-dir=/consul/aclconfig \
                 {{- end }}
-          {{- if (or .Values.global.acls.manageSystemACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
+          {{- if (or .Values.global.acls.manageSystemACLs .Values.global.tls.enabled (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload)) }}
           volumeMounts:
             {{- if (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) }}
             - name: snapshot-config
@@ -134,7 +134,7 @@ spec:
             - name: aclconfig
               mountPath: /consul/aclconfig
             {{- else }}
-            {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+            {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload) }}
             - name: consul-license
               mountPath: /consul/license
               readOnly: true

--- a/charts/consul/templates/enterprise-license-job.yaml
+++ b/charts/consul/templates/enterprise-license-job.yaml
@@ -1,5 +1,6 @@
+{{- if .Values.server.enterpriseLicense }}{{ fail "server.enterpriseLicense has been moved to global.enterpriseLicense" }}{{ end -}}
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
+{{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey (not .Values.global.enterpriseLicense.enableLicenseAutoload)) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -55,8 +56,8 @@ spec:
             - name: ENTERPRISE_LICENSE
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.server.enterpriseLicense.secretName }}
-                  key: {{ .Values.server.enterpriseLicense.secretKey }}
+                  name: {{ .Values.global.enterpriseLicense.secretName }}
+                  key: {{ .Values.global.enterpriseLicense.secretKey }}
             - name: CONSUL_HTTP_ADDR
               {{- if .Values.global.tls.enabled }}
               value: https://{{ template "consul.fullname" . }}-server:8501

--- a/charts/consul/templates/enterprise-license-podsecuritypolicy.yaml
+++ b/charts/consul/templates/enterprise-license-podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
+{{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey (not .Values.global.enterpriseLicense.enableLicenseAutoload)) }}
 {{- if .Values.global.enablePodSecurityPolicies }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/charts/consul/templates/enterprise-license-role.yaml
+++ b/charts/consul/templates/enterprise-license-role.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
+{{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey (not .Values.global.enterpriseLicense.enableLicenseAutoload)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/consul/templates/enterprise-license-rolebinding.yaml
+++ b/charts/consul/templates/enterprise-license-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
+{{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey (not .Values.global.enterpriseLicense.enableLicenseAutoload)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/consul/templates/enterprise-license-serviceaccount.yaml
+++ b/charts/consul/templates/enterprise-license-serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey (not .Values.server.enterpriseLicense.enableLicenseAutoload)) }}
+{{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey (not .Values.global.enterpriseLicense.enableLicenseAutoload)) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -192,7 +192,7 @@ spec:
                 -acl-binding-rule-selector={{ .Values.connectInject.aclBindingRuleSelector }} \
                 {{- end }}
 
-                {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+                {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey) }}
                 -create-enterprise-license-token=true \
                 {{- end }}
 

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -102,10 +102,10 @@ spec:
             secretName: {{ template "consul.fullname" . }}-server-cert
             {{- end }}
         {{- end }}
-        {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+        {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload) }}
         - name: consul-license
           secret:
-            secretName: {{ .Values.server.enterpriseLicense.secretName }}
+            secretName: {{ .Values.global.enterpriseLicense.secretName }}
         {{- end }}
         {{- range .Values.server.extraVolumes }}
         - name: userconfig-{{ .name }}
@@ -174,9 +174,9 @@ spec:
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- end }}
-            {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+            {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload) }}
             - name: CONSUL_LICENSE_PATH
-              value: /consul/license/{{ .Values.server.enterpriseLicense.secretKey }}
+              value: /consul/license/{{ .Values.global.enterpriseLicense.secretKey }}
             {{- end }}
             {{- if (and .Values.global.acls.replicationToken.secretName .Values.global.acls.replicationToken.secretKey) }}
             - name: ACL_REPLICATION_TOKEN
@@ -276,7 +276,7 @@ spec:
               mountPath: /consul/tls/server
               readOnly: true
             {{- end }}
-            {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey .Values.server.enterpriseLicense.enableLicenseAutoload) }}
+            {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload) }}
             - name: consul-license
               mountPath: /consul/license
               readOnly: true

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -1349,8 +1349,8 @@ rollingUpdate:
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/client-daemonset.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.volumes[] | select(.name == "consul-license")' | tee /dev/stderr)
       [ "${actual}" = '{"name":"consul-license","secret":{"secretName":"foo"}}' ]
@@ -1360,8 +1360,8 @@ rollingUpdate:
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/client-daemonset.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-license")' | tee /dev/stderr)
       [ "${actual}" = '{"name":"consul-license","mountPath":"/consul/license","readOnly":true}' ]
@@ -1371,8 +1371,8 @@ rollingUpdate:
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/client-daemonset.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_LICENSE_PATH")' | tee /dev/stderr)
       [ "${actual}" = '{"name":"CONSUL_LICENSE_PATH","value":"/consul/license/bar"}' ]
@@ -1382,8 +1382,8 @@ rollingUpdate:
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/client-daemonset.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.volumes[] | select(.name == "consul-license")' | tee /dev/stderr)
@@ -1394,8 +1394,8 @@ rollingUpdate:
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/client-daemonset.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-license")' | tee /dev/stderr)
@@ -1406,8 +1406,8 @@ rollingUpdate:
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/client-daemonset.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_LICENSE_PATH")' | tee /dev/stderr)

--- a/charts/consul/test/unit/client-snapshot-agent-deployment.bats
+++ b/charts/consul/test/unit/client-snapshot-agent-deployment.bats
@@ -389,8 +389,8 @@ exec /bin/consul snapshot agent \'
   local actual=$(helm template \
       -s templates/client-snapshot-agent-deployment.yaml  \
       --set 'client.snapshotAgent.enabled=true' \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.volumes[] | select(.name == "consul-license")' | tee /dev/stderr)
       [ "${actual}" = '{"name":"consul-license","secret":{"secretName":"foo"}}' ]
@@ -401,8 +401,8 @@ exec /bin/consul snapshot agent \'
   local actual=$(helm template \
       -s templates/client-snapshot-agent-deployment.yaml  \
       --set 'client.snapshotAgent.enabled=true' \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-license")' | tee /dev/stderr)
       [ "${actual}" = '{"name":"consul-license","mountPath":"/consul/license","readOnly":true}' ]
@@ -413,8 +413,8 @@ exec /bin/consul snapshot agent \'
   local actual=$(helm template \
       -s templates/client-snapshot-agent-deployment.yaml  \
       --set 'client.snapshotAgent.enabled=true' \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_LICENSE_PATH")' | tee /dev/stderr)
       [ "${actual}" = '{"name":"CONSUL_LICENSE_PATH","value":"/consul/license/bar"}' ]
@@ -425,8 +425,8 @@ exec /bin/consul snapshot agent \'
   local actual=$(helm template \
       -s templates/client-snapshot-agent-deployment.yaml  \
       --set 'client.snapshotAgent.enabled=true' \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.volumes[] | select(.name == "consul-license")' | tee /dev/stderr)
@@ -438,8 +438,8 @@ exec /bin/consul snapshot agent \'
   local actual=$(helm template \
       -s templates/client-snapshot-agent-deployment.yaml  \
       --set 'client.snapshotAgent.enabled=true' \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-license")' | tee /dev/stderr)
@@ -451,8 +451,8 @@ exec /bin/consul snapshot agent \'
   local actual=$(helm template \
       -s templates/client-snapshot-agent-deployment.yaml  \
       --set 'client.snapshotAgent.enabled=true' \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_LICENSE_PATH")' | tee /dev/stderr)

--- a/charts/consul/test/unit/enterprise-license-job.bats
+++ b/charts/consul/test/unit/enterprise-license-job.bats
@@ -2,86 +2,99 @@
 
 load _helpers
 
-@test "server/EnterpriseLicense: disabled by default" {
+@test "enterpriseLicense/Job: disabled by default" {
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-job.yaml  \
       .
 }
 
-@test "server/EnterpriseLicense: disabled if autoload is true (default) {
+@test "enterpriseLicense/Job: disabled if autoload is true (default) {
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-job.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       .
 }
 
-@test "server/EnterpriseLicense: disabled when servers are disabled" {
+@test "enterpriseLicense/Job: disabled when servers are disabled" {
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-job.yaml  \
       --set 'server.enabled=false' \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
-@test "server/EnterpriseLicense: disabled when secretName is missing" {
+@test "enterpriseLicense/Job: disabled when secretName is missing" {
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-job.yaml  \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
-@test "server/EnterpriseLicense: disabled when secretKey is missing" {
+@test "enterpriseLicense/Job: disabled when secretKey is missing" {
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-job.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
-@test "server/EnterpriseLicense: enabled when secretName, secretKey is provided and autoload is disabled" {
+@test "enterpriseLicense/Job: enabled when secretName, secretKey is provided and autoload is disabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-job.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-#--------------------------------------------------------------------
-# global.acls.manageSystemACLs
-
-@test "server/EnterpriseLicense: CONSUL_HTTP_TOKEN env variable created when global.acls.manageSystemACLs=true" {
+@test "enterpriseLicense/Job: fail is server.enterpriseLicense is set" {
   cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/enterprise-license-job.yaml \
+  run helm template \
+      -s templates/enterprise-license-job.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
       --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      .
+
+      [ "$status" -eq 1 ]
+      [[ "$output" =~ "server.enterpriseLicense has been moved to global.enterpriseLicense" ]]
+}
+
+#--------------------------------------------------------------------
+# global.acls.manageSystemACLs
+
+@test "enterpriseLicense/Job: CONSUL_HTTP_TOKEN env variable created when global.acls.manageSystemACLs=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/enterprise-license-job.yaml \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "server/EnterpriseLicense: init container is created when global.acls.manageSystemACLs=true" {
+@test "enterpriseLicense/Job: init container is created when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local object=$(helm template \
       -s templates/enterprise-license-job.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.initContainers[0]' | tee /dev/stderr)
@@ -98,104 +111,104 @@ load _helpers
 #--------------------------------------------------------------------
 # global.tls.enabled
 
-@test "server/EnterpriseLicense: no volumes when TLS is disabled" {
+@test "enterpriseLicense/Job: no volumes when TLS is disabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-job.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=false' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.volumes | length' | tee /dev/stderr)
   [ "${actual}" = "0" ]
 }
 
-@test "server/EnterpriseLicense: volumes present when TLS is enabled" {
+@test "enterpriseLicense/Job: volumes present when TLS is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-job.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.volumes | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
 }
 
-@test "server/EnterpriseLicense: no volumes mounted when TLS is disabled" {
+@test "enterpriseLicense/Job: no volumes mounted when TLS is disabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-job.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=false' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].volumeMounts | length' | tee /dev/stderr)
   [ "${actual}" = "0" ]
 }
 
-@test "server/EnterpriseLicense: volumes mounted when TLS is enabled" {
+@test "enterpriseLicense/Job: volumes mounted when TLS is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-job.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].volumeMounts | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
 }
 
-@test "server/EnterpriseLicense: URL is http when TLS is disabled" {
+@test "enterpriseLicense/Job: URL is http when TLS is disabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-job.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=false' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
   [ "${actual}" = "http://RELEASE-NAME-consul-server:8500" ]
 }
 
-@test "server/EnterpriseLicense: URL is https when TLS is enabled" {
+@test "enterpriseLicense/Job: URL is https when TLS is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-job.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
   [ "${actual}" = "https://RELEASE-NAME-consul-server:8501" ]
 }
 
-@test "server/EnterpriseLicense: CA certificate is specified when TLS is enabled" {
+@test "enterpriseLicense/Job: CA certificate is specified when TLS is enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-job.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
   [ "${actual}" = "/consul/tls/ca/tls.crt" ]
 }
 
-@test "server/EnterpriseLicense: can overwrite CA secret with the provided one" {
+@test "enterpriseLicense/Job: can overwrite CA secret with the provided one" {
   cd `chart_dir`
   local ca_cert_volume=$(helm template \
       -s templates/enterprise-license-job.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.caCert.secretName=foo-ca-cert' \
       --set 'global.tls.caCert.secretKey=key' \

--- a/charts/consul/test/unit/enterprise-license-podsecuritypolicy.bats
+++ b/charts/consul/test/unit/enterprise-license-podsecuritypolicy.bats
@@ -13,9 +13,9 @@ load _helpers
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-podsecuritypolicy.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -24,9 +24,9 @@ load _helpers
   assert_empty helm template \
       -s templates/enterprise-license-podsecuritypolicy.yaml  \
       --set 'server.enabled=false' \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -34,8 +34,8 @@ load _helpers
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-podsecuritypolicy.yaml  \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -43,8 +43,8 @@ load _helpers
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-podsecuritypolicy.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -52,9 +52,9 @@ load _helpers
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-podsecuritypolicy.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.enablePodSecurityPolicies=false' \
       .
 }
@@ -63,9 +63,9 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-podsecuritypolicy.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/charts/consul/test/unit/enterprise-license-role.bats
+++ b/charts/consul/test/unit/enterprise-license-role.bats
@@ -13,8 +13,8 @@ load _helpers
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-role.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       .
 }
 
@@ -23,9 +23,9 @@ load _helpers
   assert_empty helm template \
       -s templates/enterprise-license-role.yaml  \
       --set 'server.enabled=false' \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -33,8 +33,8 @@ load _helpers
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-role.yaml  \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -42,8 +42,8 @@ load _helpers
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-role.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -51,9 +51,9 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-role.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -63,9 +63,9 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-role.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       . | tee /dev/stderr |
       yq '.rules | length' | tee /dev/stderr)
   [ "${actual}" = "0" ]
@@ -78,15 +78,14 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-role.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.rules | map(select(.resourceNames[0] == "RELEASE-NAME-consul-enterprise-license-acl-token")) | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
 }
-
 
 #--------------------------------------------------------------------
 # global.enablePodSecurityPolicies
@@ -95,9 +94,9 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-role.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq -r '.rules | map(select(.resources[0] == "podsecuritypolicies")) | length' | tee /dev/stderr)

--- a/charts/consul/test/unit/enterprise-license-rolebinding.bats
+++ b/charts/consul/test/unit/enterprise-license-rolebinding.bats
@@ -13,8 +13,8 @@ load _helpers
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-rolebinding.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       .
 }
 
@@ -23,9 +23,9 @@ load _helpers
   assert_empty helm template \
       -s templates/enterprise-license-rolebinding.yaml  \
       --set 'server.enabled=false' \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -33,8 +33,8 @@ load _helpers
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-rolebinding.yaml  \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -42,8 +42,8 @@ load _helpers
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-rolebinding.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -51,9 +51,9 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-rolebinding.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/charts/consul/test/unit/enterprise-license-serviceaccount.bats
+++ b/charts/consul/test/unit/enterprise-license-serviceaccount.bats
@@ -13,8 +13,8 @@ load _helpers
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-serviceaccount.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       .
 }
 
@@ -23,9 +23,9 @@ load _helpers
   assert_empty helm template \
       -s templates/enterprise-license-serviceaccount.yaml  \
       --set 'server.enabled=false' \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -33,8 +33,8 @@ load _helpers
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-serviceaccount.yaml  \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -42,8 +42,8 @@ load _helpers
   cd `chart_dir`
   assert_empty helm template \
       -s templates/enterprise-license-serviceaccount.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       .
 }
 
@@ -51,9 +51,9 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/enterprise-license-serviceaccount.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -66,9 +66,9 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -s templates/enterprise-license-serviceaccount.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
-      --set 'server.enterpriseLicense.enableLicenseAutoload=false' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.enableLicenseAutoload=false' \
       --set 'global.imagePullSecrets[0].name=my-secret' \
       --set 'global.imagePullSecrets[1].name=my-secret2' \
       . | tee /dev/stderr)

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -204,35 +204,35 @@ load _helpers
 #--------------------------------------------------------------------
 # enterpriseLicense
 
-@test "serverACLInit/Job: ent license acl option enabled with server.enterpriseLicense.secretName and server.enterpriseLicense.secretKey set" {
+@test "serverACLInit/Job: ent license acl option enabled with global.enterpriseLicense.secretName and global.enterpriseLicense.secretKey set" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-create-enterprise-license-token"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInit/Job: ent license acl option disabled missing server.enterpriseLicense.secretName" {
+@test "serverACLInit/Job: ent license acl option disabled missing global.enterpriseLicense.secretName" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-create-enterprise-license-token"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/Job: ent license acl option disabled missing server.enterpriseLicense.secretKey" {
+@test "serverACLInit/Job: ent license acl option disabled missing global.enterpriseLicense.secretKey" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
-      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretName=foo' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-create-enterprise-license-token"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1345,8 +1345,8 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-statefulset.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.volumes[] | select(.name == "consul-license")' | tee /dev/stderr)
       [ "${actual}" = '{"name":"consul-license","secret":{"secretName":"foo"}}' ]
@@ -1356,8 +1356,8 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-statefulset.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-license")' | tee /dev/stderr)
       [ "${actual}" = '{"name":"consul-license","mountPath":"/consul/license","readOnly":true}' ]
@@ -1367,8 +1367,8 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-statefulset.yaml  \
-      --set 'server.enterpriseLicense.secretName=foo' \
-      --set 'server.enterpriseLicense.secretKey=bar' \
+      --set 'global.enterpriseLicense.secretName=foo' \
+      --set 'global.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].env[] | select(.name == "CONSUL_LICENSE_PATH")' | tee /dev/stderr)
       [ "${actual}" = '{"name":"CONSUL_LICENSE_PATH","value":"/consul/license/bar"}' ]

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -262,6 +262,21 @@ global:
       # The key of the Kubernetes secret.
       secretKey: null
 
+  # [Enterprise Only] This value refers to a Kubernetes secret that you have created
+  # that contains your enterprise license. It is required if you are using an
+  # enterprise binary. Defining it here applies it to your cluster once a leader
+  # has been elected. If you are not using an enterprise image or if you plan to
+  # introduce the license key via another route, then set these fields to null.
+  # Note: the job to apply license runs on both Helm installs and upgrades.
+  enterpriseLicense:
+    # The name of the Kubernetes secret that holds the enterprise license.
+    # The secret must be in the same namespace that Consul is installed into.
+    secretName: null
+    # The key within the Kubernetes secret that holds the enterprise license.
+    secretKey: null
+    # Manages license autoload. Required in Consul 1.10.0+, 1.9.7+ and 1.8.12+.
+    enableLicenseAutoload: true
+
   # Configure federation.
   federation:
     # If enabled, this datacenter will be federation-capable. Only federation
@@ -363,21 +378,6 @@ server:
   # of servers.
   # @type: int
   bootstrapExpect: null
-
-  # [Enterprise Only] This value refers to a Kubernetes secret that you have created
-  # that contains your enterprise license. It is required if you are using an
-  # enterprise binary. Defining it here applies it to your cluster once a leader
-  # has been elected. If you are not using an enterprise image or if you plan to
-  # introduce the license key via another route, then set these fields to null.
-  # Note: the job to apply license runs on both Helm installs and upgrades.
-  enterpriseLicense:
-    # The name of the Kubernetes secret that holds the enterprise license.
-    # The secret must be in the same namespace that Consul is installed into.
-    secretName: null
-    # The key within the Kubernetes secret that holds the enterprise license.
-    secretKey: null
-    # Manages license autoload. Required in Consul 1.10.0+, 1.9.7+ and 1.8.12+.
-    enableLicenseAutoload: true
 
   # A Kubernetes secret containing a certificate & key for the server agents to use
   # for TLS communication within the Consul cluster. Cert needs to be provided with


### PR DESCRIPTION
Changes proposed in this PR:
- Migrate the `enterpriseLicense` config from being under the `server` stanza to the `global` stanza.
- This change breaks backwards compatibility but prints an error stating the same. This will not cause existing installations to fail.

How I've tested this PR:
- bats
- Acceptance tests

How I expect reviewers to test this PR:
- code review
- would love to hear thoughts on the breaking nature of the change.

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

