### PR TITLE
Ignore services in endpoint controller using `consul.hashicorp.com/service-ignore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ IMPROVEMENTS:
    * Pre-check in the `install` command to verify the correct license secret exists when using an enterprise Consul image. [[GH-875](https://github.com/hashicorp/consul-k8s/pull/875)]
 * Control Plane
    * Add a label "managed-by" to every secret the control-plane creates. Only delete said secrets on an uninstall. [[GH-835](https://github.com/hashicorp/consul-k8s/pull/835)]
-  * Add `consul.hashicorp.com/service-ignore` to prevent services from being registered in Consul. [[GH-858](https://github.com/hashicorp/consul-k8s/pull/858)]
+  * Add  support for labeling a Kubernetes service with `consul.hashicorp.com/service-ignore` to prevent services from being registered in Consul. [[GH-858](https://github.com/hashicorp/consul-k8s/pull/858)]
 
 ## 0.37.0 (November 18, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ IMPROVEMENTS:
    * Pre-check in the `install` command to verify the correct license secret exists when using an enterprise Consul image. [[GH-875](https://github.com/hashicorp/consul-k8s/pull/875)]
 * Control Plane
    * Add a label "managed-by" to every secret the control-plane creates. Only delete said secrets on an uninstall. [[GH-835](https://github.com/hashicorp/consul-k8s/pull/835)]
-  * Add  support for labeling a Kubernetes service with `consul.hashicorp.com/service-ignore` to prevent services from being registered in Consul. [[GH-858](https://github.com/hashicorp/consul-k8s/pull/858)]
+  * Add support for labeling a Kubernetes service with `consul.hashicorp.com/service-ignore` to prevent services from being registered in Consul. [[GH-858](https://github.com/hashicorp/consul-k8s/pull/858)]
 
 ## 0.37.0 (November 18, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ BREAKING CHANGES:
 IMPROVEMENTS:
 * CLI
    * Pre-check in the `install` command to verify the correct license secret exists when using an enterprise Consul image. [[GH-875](https://github.com/hashicorp/consul-k8s/pull/875)]
+* Control Plane
    * Add a label "managed-by" to every secret the control-plane creates. Only delete said secrets on an uninstall. [[GH-835](https://github.com/hashicorp/consul-k8s/pull/835)]
+  * Add `consul.hashicorp.com/service-ignore` to prevent services from being registered in Consul. [[GH-858](https://github.com/hashicorp/consul-k8s/pull/858)]
 
 ## 0.37.0 (November 18, 2021)
 

--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -122,9 +122,9 @@ const (
 	// webhook/handler.
 	annotationOriginalPod = "consul.hashicorp.com/original-pod"
 
-	// labelConnectIgnore is a label that can be added to a service to prevent it from being
+	// labelServiceIgnore is a label that can be added to a service to prevent it from being
 	// registered with Consul.
-	labelConnectIgnore = "consul.hashicorp.com/connect-ignore"
+	labelServiceIgnore = "consul.hashicorp.com/service-ignore"
 
 	// injected is used as the annotation value for annotationInjected.
 	injected = "injected"

--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -122,6 +122,10 @@ const (
 	// webhook/handler.
 	annotationOriginalPod = "consul.hashicorp.com/original-pod"
 
+	// labelConnectIgnore is a label that can be added to a service to prevent it from being
+	// registered with Consul.
+	labelConnectIgnore = "consul.hashicorp.com/connect-ignore"
+
 	// injected is used as the annotation value for annotationInjected.
 	injected = "injected"
 

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -149,7 +149,7 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// If the endpoints object has the label "connect-ignore" set to true, deregister all instances in Consul for this service.
 	// It is possible that the endpoints object has never been registered, in which case deregistration is a no-op.
-	if value, ok := serviceEndpoints.Labels[labelConnectIgnore]; ok && value == "true" {
+	if value, ok := serviceEndpoints.Labels[labelServiceIgnore]; ok && value == "true" {
 		return r.deregisterServiceOnAllAgents(ctx, req.Name, req.Namespace, nil, endpointPods)
 	}
 

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -118,10 +118,14 @@ type EndpointsController struct {
 	context.Context
 }
 
+// Reconcile reads the state of the cluster's service endpoints when a request is received and makes changes
+// to the endpoints based on the state read. Requests are created when the endpoints are created, updated,
+// or deleted.
 func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var errs error
 	var serviceEndpoints corev1.Endpoints
 
+	// Ignore the request if the namespace of the endpoint is not allowed.
 	if shouldIgnore(req.Namespace, r.DenyK8sNamespacesSet, r.AllowK8sNamespacesSet) {
 		return ctrl.Result{}, nil
 	}

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -150,6 +150,7 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 	// If the endpoints object has the label "connect-ignore" set to true, deregister all instances in Consul for this service.
 	// It is possible that the endpoints object has never been registered, in which case deregistration is a no-op.
 	if value, ok := serviceEndpoints.Labels[labelServiceIgnore]; ok && value == "true" {
+		// We always deregister the service to handle the case where a user has registered the service, then added the label later.
 		err = r.deregisterServiceOnAllAgents(ctx, req.Name, req.Namespace, nil, endpointPods)
 		return ctrl.Result{}, err
 	}
@@ -647,11 +648,6 @@ func getHealthCheckStatusReason(healthCheckStatus, podName, podNamespace string)
 	}
 
 	return fmt.Sprintf("Pod \"%s/%s\" is not ready", podNamespace, podName)
-}
-
-// fetchServices returns a list of services from the given k8s client.
-func (r *EndpointsController) fetchServices(ctx context.Context, k8sSvcName, k8sSvcNamespace string) ([]*api.AgentService, error) {
-	return nil, nil
 }
 
 // deregisterServiceOnAllAgents queries all agents for service instances that have the metadata

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -118,8 +118,7 @@ type EndpointsController struct {
 }
 
 // Reconcile reads the state of the cluster's service endpoints when a request is received and makes changes
-// to the endpoints based on the state read. Requests are created when the endpoints are created, updated,
-// or deleted.
+// to the endpoints based on the state read. Reconcile is called when services are created, updated, or deleted.
 func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var errs error
 	var serviceEndpoints corev1.Endpoints

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -149,7 +149,10 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 	// If the endpoints object has the label "connect-ignore" set to true, deregister all instances in Consul for this service.
 	// It is possible that the endpoints object has never been registered, in which case deregistration is a no-op.
 	if value, ok := serviceEndpoints.Labels[labelServiceIgnore]; ok && value == "true" {
-		return r.deregisterServiceOnAllAgents(ctx, req.Name, req.Namespace, nil, endpointPods)
+		if isRegistered() {
+			return r.deregisterServiceOnAllAgents(ctx, req.Name, req.Namespace, nil, endpointPods)
+		}
+		return ctrl.Result{}, nil
 	}
 
 	r.Log.Info("retrieved", "name", serviceEndpoints.Name, "ns", serviceEndpoints.Namespace)
@@ -1018,4 +1021,12 @@ func mapAddresses(addresses corev1.EndpointSubset) map[corev1.EndpointAddress]st
 	}
 
 	return m
+}
+
+// isRegistered checks if the endpoint is registered in Consul.
+func isRegistered() bool {
+	// TODO: Implement this.
+	// _, err := r.consul.Catalog().Service(endpoint.ServiceName, "", nil)
+	// return err == nil
+	return true
 }

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -39,7 +39,6 @@ const (
 	kubernetesSuccessReasonMsg = "Kubernetes health checks passing"
 	envoyPrometheusBindAddr    = "envoy_prometheus_bind_addr"
 	envoySidecarContainer      = "envoy-sidecar"
-	connectIgnoreLabel         = "consul.hashicorp.com/connect-ignore"
 
 	// clusterIPTaggedAddressName is the key for the tagged address to store the service's cluster IP and service port
 	// in Consul. Note: This value should not be changed without a corresponding change in Consul.
@@ -150,7 +149,7 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// If the endpoints object has the label "connect-ignore" set to true, deregister all instances in Consul for this service.
 	// It is possible that the endpoints object has never been registered, in which case deregistration is a no-op.
-	if value, ok := serviceEndpoints.Labels[connectIgnoreLabel]; ok && value == "true" {
+	if value, ok := serviceEndpoints.Labels[labelConnectIgnore]; ok && value == "true" {
 		return r.deregisterServiceOnAllAgents(ctx, req.Name, req.Namespace, nil, endpointPods)
 	}
 

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -199,7 +199,7 @@ func (r *EndpointsController) SetupWithManager(mgr ctrl.Manager) error {
 		).Complete(r)
 }
 
-// registerServicesAndHealthCheck creates Consul registrations for the service and proxy and register them with Consul.
+// registerServicesAndHealthCheck creates Consul registrations for the service and proxy and registers them with Consul.
 // It also upserts a Kubernetes health check for the service based on whether the endpoint address is ready.
 func (r *EndpointsController) registerServicesAndHealthCheck(ctx context.Context, serviceEndpoints corev1.Endpoints, address corev1.EndpointAddress, healthStatus string, endpointAddressMap map[string]bool) error {
 	// Get pod associated with this address.

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -147,7 +147,7 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	// If the endpoints object has the label "connect-ignore" set to true, deregister all instances in Consul for this service.
+	// If the endpoints object has the label "service-ignore" set to true, deregister all instances in Consul for this service.
 	// It is possible that the endpoints object has never been registered, in which case deregistration is a no-op.
 	if value, ok := serviceEndpoints.Labels[labelServiceIgnore]; ok && value == "true" {
 		// We always deregister the service to handle the case where a user has registered the service, then added the label later.

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -1023,9 +1023,3 @@ func mapAddresses(addresses corev1.EndpointSubset) map[corev1.EndpointAddress]st
 
 	return m
 }
-
-// isRegistered checks if the endpoint is registered in Consul.
-func isRegistered() bool {
-
-	return true
-}

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -1011,10 +1011,8 @@ func (r *EndpointsController) consulNamespace(namespace string) string {
 
 // hasBeenInjected checks the value of the status annotation and returns true if the Pod has been injected.
 func hasBeenInjected(pod corev1.Pod) bool {
-	if anno, ok := pod.Annotations[keyInjectStatus]; ok {
-		if anno == injected {
-			return true
-		}
+	if anno, ok := pod.Annotations[keyInjectStatus]; ok && anno == injected {
+		return true
 	}
 	return false
 }

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -147,7 +147,7 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	// If the endpoints object has the label "service-ignore" set to true, deregister all instances in Consul for this service.
+	// If the endpoints object has the label "consul.hashicorp.com/service-ignore" set to true, deregister all instances in Consul for this service.
 	// It is possible that the endpoints object has never been registered, in which case deregistration is a no-op.
 	if value, ok := serviceEndpoints.Labels[labelServiceIgnore]; ok && value == "true" {
 		// We always deregister the service to handle the case where a user has registered the service, then added the label later.

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -152,6 +152,7 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 	// It is possible that the endpoints object has never been registered, in which case deregistration is a no-op.
 	if isLabeledIgnore(serviceEndpoints.Labels) {
 		// We always deregister the service to handle the case where a user has registered the service, then added the label later.
+		r.Log.Info("Ignoring endpoint labeled with `consul.hashicorp.com/service-ignore: \"true\"`", "name", req.Name, "namespace", req.Namespace)
 		err = r.deregisterServiceOnAllAgents(ctx, req.Name, req.Namespace, nil, endpointPods)
 		return ctrl.Result{}, err
 	}

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -117,8 +117,8 @@ type EndpointsController struct {
 	context.Context
 }
 
-// Reconcile reads the state of the cluster's service endpoints when a request is received and makes changes
-// to the endpoints based on the state read. Reconcile is called when services are created, updated, or deleted.
+// Reconcile reads the state of an Endpoints object for a Kubernetes Service and reconciles Consul services which
+// correspond to the Kubernetes Service. These events are driven by changes to the Pods backing the Kube service.
 func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var errs error
 	var serviceEndpoints corev1.Endpoints

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -535,6 +535,87 @@ func TestProcessUpstreams(t *testing.T) {
 	}
 }
 
+// TestReconcileWithServiceIgnore tests the reconcile function with a service that should be ignored.
+func TestReconcileWithServiceIgnore(t *testing.T) {
+	t.Parallel()
+	nodeName := "test-node"
+
+	cases := []struct {
+		name                       string
+		consulSvcName              string
+		k8sObjects                 func() []runtime.Object
+		initialConsulSvcs          []*api.AgentServiceRegistration
+		expectedNumSvcInstances    int
+		expectedConsulSvcInstances []*api.CatalogService
+		expectedProxySvcInstances  []*api.CatalogService
+		expectedAgentHealthChecks  []*api.AgentCheck
+		expErr                     string
+	}{
+		// TODO: Test case where service is registered and should be deregistered.
+		// TODO: Test case where service is not registered and just gets ignored.
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			// The agent pod needs to have the address 127.0.0.1 so when the
+			// code gets the agent pods via the label component=client, and
+			// makes requests against the agent API, it will actually hit the
+			// test server we have on localhost.
+			fakeClientPod := createPod("fake-consul-client", "127.0.0.1", false, true)
+			fakeClientPod.Labels = map[string]string{"component": "client", "app": "consul", "release": "consul"}
+
+			// Add the default namespace.
+			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			// Create fake k8s client
+			k8sObjects := append(tt.k8sObjects(), fakeClientPod, &ns)
+
+			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
+
+			// Create test consul server
+			consul, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
+				c.NodeName = nodeName
+			})
+			require.NoError(t, err)
+			defer consul.Stop()
+			consul.WaitForServiceIntentions(t)
+
+			cfg := &api.Config{
+				Address: consul.HTTPAddr,
+			}
+			consulClient, err := api.NewClient(cfg)
+			require.NoError(t, err)
+			addr := strings.Split(consul.HTTPAddr, ":")
+			consulPort := addr[1]
+
+			// Register service and proxy in consul.
+			for _, svc := range tt.initialConsulSvcs {
+				err = consulClient.Agent().ServiceRegister(svc)
+				require.NoError(t, err)
+			}
+
+			// Create the endpoints controller
+			ep := &EndpointsController{
+				Client:                fakeClient,
+				Log:                   logrtest.TestLogger{T: t},
+				ConsulClient:          consulClient,
+				ConsulPort:            consulPort,
+				ConsulScheme:          "http",
+				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
+				DenyK8sNamespacesSet:  mapset.NewSetWith(),
+				ReleaseName:           "consul",
+				ReleaseNamespace:      "default",
+				ConsulClientCfg:       cfg,
+			}
+			namespacedName := types.NamespacedName{
+				Namespace: "default",
+				Name:      "service-created",
+			}
+
+			_, _ = ep.Reconcile(context.Background(), ctrl.Request{NamespacedName: namespacedName})
+		})
+	}
+}
+
 // TestReconcileCreateEndpoint tests the logic to create service instances in Consul from the addresses in the Endpoints
 // object. The cases test an empty endpoints object, a basic endpoints object with one address, a basic endpoints object
 // with two addresses, and an endpoints object with every possible customization.

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -4761,6 +4761,29 @@ func TestGetTokenMetaFromDescription(t *testing.T) {
 	}
 }
 
+func TestMapAddresses(t *testing.T) {
+	addresses := corev1.EndpointSubset{
+		Addresses: []corev1.EndpointAddress{
+			{Hostname: "host1"},
+			{Hostname: "host2"},
+		},
+		NotReadyAddresses: []corev1.EndpointAddress{
+			{Hostname: "host3"},
+			{Hostname: "host4"},
+		},
+	}
+
+	expected := map[corev1.EndpointAddress]string{
+		{Hostname: "host1"}: api.HealthPassing,
+		{Hostname: "host2"}: api.HealthPassing,
+		{Hostname: "host3"}: api.HealthCritical,
+		{Hostname: "host4"}: api.HealthCritical,
+	}
+
+	actual := mapAddresses(addresses)
+	require.Equal(t, expected, actual)
+}
+
 func createPod(name, ip string, inject bool, managedByEndpointsController bool) *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -2784,7 +2784,7 @@ func TestReconcileIgnoresServiceIgnoreLabel(t *testing.T) {
 			k8sObjects := []runtime.Object{endpoint, pod1, fakeClientPod, &ns}
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
 
-			// Create test Consul server
+			// Create test Consul server.
 			consul, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) { c.NodeName = nodeName })
 			require.NoError(t, err)
 			defer consul.Stop()

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -2719,10 +2719,7 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 
 // TestReconcileIgnoresServiceIgnoreLabel tests that the endpoints controller correctly ignores services
 // with the service-ignore label and deregisters services previously registered if the service-ignore
-// label is added. This is done by running Reconcile twice, once on an initial set of labels, then again
-// on a new set of labels with the service-ignore label. The number of services registered in Consul is
-// checked before updating the labels against the `svcsExpectedBeforeUpdate` and after updating the labels
-// where the expected number of services should be zero.
+// label is added.
 func TestReconcileIgnoresServiceIgnoreLabel(t *testing.T) {
 	t.Parallel()
 	nodeName := "test-node"

--- a/control-plane/subcommand/connect-init/command.go
+++ b/control-plane/subcommand/connect-init/command.go
@@ -177,7 +177,12 @@ func (c *Command) Run(args []string) int {
 			// it is not "lost" to the user at the end of the retries when the pod enters a CrashLoop.
 			if registrationRetryCount%10 == 0 {
 				c.logger.Info("Check to ensure a Kubernetes service has been created for this application." +
-					" If your pod is not starting also check the connect-inject deployment logs.")
+					" If your pod is not starting also check the connect-inject deployment logs." +
+					" Note that only one service may be used to route requests to each pod." +
+					" If you need multiple services to point to the same pod, add the label" +
+					" `consul.hashicorp.com/connect-ignore: \"true\"` to services which should" +
+					" not be used by Consul for handling requests.")
+
 			}
 			return fmt.Errorf("did not find correct number of services: %d", len(serviceList))
 		}

--- a/control-plane/subcommand/connect-init/command.go
+++ b/control-plane/subcommand/connect-init/command.go
@@ -178,7 +178,7 @@ func (c *Command) Run(args []string) int {
 			if registrationRetryCount%10 == 0 {
 				c.logger.Info("Check to ensure a Kubernetes service has been created for this application." +
 					" If your pod is not starting also check the connect-inject deployment logs." +
-					" Note that only one service may be used to route requests to each pod." +
+					"\nNote that only one service may be used to route requests to each pod." +
 					" If you need multiple services to point to the same pod, add the label" +
 					" `consul.hashicorp.com/connect-ignore: \"true\"` to services which should" +
 					" not be used by Consul for handling requests.")

--- a/control-plane/subcommand/connect-init/command.go
+++ b/control-plane/subcommand/connect-init/command.go
@@ -180,7 +180,7 @@ func (c *Command) Run(args []string) int {
 					" If your pod is not starting also check the connect-inject deployment logs." +
 					"\nNote that only one service may be used to route requests to each pod." +
 					" If you need multiple services to point to the same pod, add the label" +
-					" `consul.hashicorp.com/connect-ignore: \"true\"` to services which should" +
+					" `consul.hashicorp.com/service-ignore: \"true\"` to services which should" +
 					" not be used by Consul for handling requests.")
 
 			}

--- a/control-plane/subcommand/connect-init/command.go
+++ b/control-plane/subcommand/connect-init/command.go
@@ -177,13 +177,14 @@ func (c *Command) Run(args []string) int {
 			// it is not "lost" to the user at the end of the retries when the pod enters a CrashLoop.
 			if registrationRetryCount%10 == 0 {
 				c.logger.Info("Check to ensure a Kubernetes service has been created for this application." +
-					" If your pod is not starting also check the connect-inject deployment logs." +
-					"\nNote that only one service may be used to route requests to each pod." +
-					" If you need multiple services to point to the same pod, add the label" +
-					" `consul.hashicorp.com/service-ignore: \"true\"` to services which should" +
-					" not be used by Consul for handling requests.")
-
+					" If your pod is not starting also check the connect-inject deployment logs.")
 			}
+			if len(serviceList) > 2 {
+				c.logger.Error("There are multiple Consul services registered for this pod when there should only be one." +
+					" Check if there are multiple Kubernetes services pointing at this pod and add the label" +
+					" `consul.hashicorp.com/service-ignore: \"true\"` to services which should not be used by Consul for handling requests.")
+			}
+
 			return fmt.Errorf("did not find correct number of services: %d", len(serviceList))
 		}
 		for _, svc := range serviceList {

--- a/control-plane/subcommand/connect-init/command.go
+++ b/control-plane/subcommand/connect-init/command.go
@@ -180,9 +180,9 @@ func (c *Command) Run(args []string) int {
 					" If your pod is not starting also check the connect-inject deployment logs.")
 			}
 			if len(serviceList) > 2 {
-				c.logger.Error("There are multiple Consul services registered for this pod when there should only be one." +
-					" Check if there are multiple Kubernetes services pointing at this pod and add the label" +
-					" `consul.hashicorp.com/service-ignore: \"true\"` to services which should not be used by Consul for handling requests.")
+				c.logger.Error("There are multiple Consul services registered for this pod when there must only be one." +
+					" Check if there are multiple Kubernetes services selecting this pod and add the label" +
+					" `consul.hashicorp.com/service-ignore: \"true\"` to all services except the one used by Consul for handling requests.")
 			}
 
 			return fmt.Errorf("did not find correct number of services: %d", len(serviceList))


### PR DESCRIPTION
> Fixes #592 

Changes proposed in this PR:
- If a service has the label `consul.hashicorp.com/service-ignore: "true"`, it will not be registered by the endpoints controller. If is has been registered before, it will be deregistered.
- If the user does not have the correct number of services registered, they will get a log instructing them to add the "connect ignore" label to services which should not be routed.
- Some comments have been added where it took me time to understand what processes were doing.
- `mapAddresses` function created as a refactor. I spun off reading this "subprocess" in the `Reconcile` method and got sidetracked. I think it makes sense to abstract over it. Feel free to disagree.

How I've tested this PR:
- Unit tests.
- Manual test (detailed below).

How I expect reviewers to test this PR:
- Running the unit tests.
- The manual testing setup I have been using is [here](https://github.com/t-eckert/boilerplates/tree/main/kubernetes/headless-service)
  To test the behavior run the `install` script which will install Consul onto the cluster; create two services, one with the `connect-ignore` label; and create a pod which will come online.

Here is a demo of the change, initially the services are deployed without the `connect-ignore` label on the "headless" service. The pod crashes as `consul-connect-inject-init` cannot register the service. When the label is added to the "headless" service, the pod comes up in a healthy state:

https://user-images.githubusercontent.com/29112081/142670205-671b7d73-0461-4c6b-bb47-69222c379540.mov

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

