### PR TITLE
chart: Squash conditional to one liner for gossip encryption key volume mount

### DIFF
--- a/charts/consul/templates/create-federation-secret-job.yaml
+++ b/charts/consul/templates/create-federation-secret-job.yaml
@@ -114,7 +114,7 @@ spec:
               mountPath: /consul/tls/client/ca
               readOnly: true
             {{- end }}
-            {{- if (or .Values.global.gossipEncryption.autoGenerate (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey)) }}
+            {{- if (or .Values.global.gossipEncryption.autoGenerate (and .Values.global.gossipEncryption.secretName  .Values.global.gossipEncryption.secretKey)) }}
             - name: gossip-encryption-key
               mountPath: /consul/gossip
               readOnly: true

--- a/charts/consul/templates/create-federation-secret-job.yaml
+++ b/charts/consul/templates/create-federation-secret-job.yaml
@@ -114,8 +114,7 @@ spec:
               mountPath: /consul/tls/client/ca
               readOnly: true
             {{- end }}
-            {{- if (or .Values.global.gossipEncryption.autoGenerate 
-                       (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey)) }}
+            {{- if (or .Values.global.gossipEncryption.autoGenerate (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey)) }}
             - name: gossip-encryption-key
               mountPath: /consul/gossip
               readOnly: true


### PR DESCRIPTION
Changes proposed in this PR:
- For Helm CLI 3.5.0 the following error occurs 

  ```
  helm template \
        -s templates/client-daemonset.yaml  \
        .
  Error: parse error at (consul/templates/create-federation-secret-job.yaml:117): unclosed action
  ```
  
  By squashing the conditional in that line and subsequent line in one line, it should fix that issue. This is resolved in Helm 3.5.4+ but this is raised so 3.5.4+ is not explicitly required. 

How I've tested this PR:

  helm install
  ```
  helm install consul --create-namespace -n consul -f ./values.dev.yaml ./charts/consul
  ```
  
  values.dev.yaml
  ```
  global:
    name: consul
    datacenter: dc1
    image: hashicorp/consul:1.10.4
    imageK8S: hashicorp/consul-k8s-control-plane:0.37.0
    tls: 
      enabled: true
    acls: 
      manageSystemACLs: true
      createReplicationToken: true
    federation: 
      enabled: true
      createFederationSecret: true
    gossipEncryption:
      autoGenerate: true
  server:
    replicas: 1
  ui:
    enabled: true
    service:
      enabled: true
  connectInject:
    enabled: true
  controller:
    enabled: true
  meshGateway:
    enabled: true
  ```

  Inspect contents of federation secret
  ```
❯ cat consul-federation-secret.yaml
apiVersion: v1
data:
  caCert: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURRakNDQXVpZ0F3SUJBZ0lVTWZpKzNoMHRJVVBrMHMxWXJITFBob0dicFVvd0NnWUlLb1pJemowRUF3SXcKZ1pFeEN6QUpCZ05WQkFZVEFsVlRNUXN3Q1FZRFZRUUlFd0pEUVRFV01CUUdBMVVFQnhNTlUyRnVJRVp5WVc1agphWE5qYnpFYU1CZ0dBMVVFQ1JNUk1UQXhJRk5sWTI5dVpDQlRkSEpsWlhReERqQU1CZ05WQkJFVEJUazBNVEExCk1SY3dGUVlEVlFRS0V3NUlZWE5vYVVOdmNuQWdTVzVqTGpFWU1CWUdBMVVFQXhNUFEyOXVjM1ZzSUVGblpXNTAKSUVOQk1CNFhEVEl4TVRFeE9UQTFOVFUxTTFvWERUTXhNVEV4TnpBMU5UWTFNMW93Z1pFeEN6QUpCZ05WQkFZVApBbFZUTVFzd0NRWURWUVFJRXdKRFFURVdNQlFHQTFVRUJ4TU5VMkZ1SUVaeVlXNWphWE5qYnpFYU1CZ0dBMVVFCkNSTVJNVEF4SUZObFkyOXVaQ0JUZEhKbFpYUXhEakFNQmdOVkJCRVRCVGswTVRBMU1SY3dGUVlEVlFRS0V3NUkKWVhOb2FVTnZjbkFnU1c1akxqRVlNQllHQTFVRUF4TVBRMjl1YzNWc0lFRm5aVzUwSUVOQk1Ga3dFd1lIS29aSQp6ajBDQVFZSUtvWkl6ajBEQVFjRFFnQUVPTUphU2F0ZHEzY3hITUNyL3BFY05naTgvUGYzdTQ4RTV6M09qSVhSClFjZUNRd2YrUk1iVzd5T09GalltNzZCRWtxQzFVUWtNL0lqNFcvSE5ud3ROanFPQ0FSb3dnZ0VXTUE0R0ExVWQKRHdFQi93UUVBd0lCaGpBZEJnTlZIU1VFRmpBVUJnZ3JCZ0VGQlFjREFRWUlLd1lCQlFVSEF3SXdEd1lEVlIwVApBUUgvQkFVd0F3RUIvekJvQmdOVkhRNEVZUVJmWkRRNk5URTZOV002WVRZNk5tVTZObUU2WVdZNlpETTZPVEE2ClptVTZObVE2TkRjNk1UZzZaamM2WWpjNk9UYzZabVU2WVdVNllUWTZOamc2WkdRNk5XUTZNams2TlRrNk5qSTYKTURrNk16VTZNVGc2T0dFNk56VTZZVGs2T0RVd2FnWURWUjBqQkdNd1lZQmZaRFE2TlRFNk5XTTZZVFk2Tm1VNgpObUU2WVdZNlpETTZPVEE2Wm1VNk5tUTZORGM2TVRnNlpqYzZZamM2T1RjNlptVTZZV1U2WVRZNk5qZzZaR1E2Ck5XUTZNams2TlRrNk5qSTZNRGs2TXpVNk1UZzZPR0U2TnpVNllUazZPRFV3Q2dZSUtvWkl6ajBFQXdJRFNBQXcKUlFJZ0ZEcUpPNks2d0lnZnY4cDFOMG9Yd1FSdDAvcmpBUHUvQnRabUN6VHAxU0lDSVFDbFl3dXNaSytZUVZwWQpENG0rTGlpbjdoRVkzQk5kcXJ2UnFDbHBFRzNweXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
  caKey: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUpQTG02Zk14RFhqVkE5MEEvT0tYejl6a3ZCOEU4UmRNVWNOS1Q2TzVpVXdvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFT01KYVNhdGRxM2N4SE1Dci9wRWNOZ2k4L1BmM3U0OEU1ejNPaklYUlFjZUNRd2YrUk1iVwo3eU9PRmpZbTc2QkVrcUMxVVFrTS9JajRXL0hObnd0TmpnPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
  gossipEncryptionKey: S1FNclVDZHRONUwyY2pnSnYwYjNMK1B0SnZHV3hhbTR4OUoxSUk4a2gyZz0=
  replicationToken: MmFmMjFkMTMtN2JmZi1iOThhLTQxMTQtM2Q0Y2NhY2ZmMzMy
  serverConfigJSON: eyJwcmltYXJ5X2RhdGFjZW50ZXIiOiJkYzEiLCJwcmltYXJ5X2dhdGV3YXlzIjpbIjM1LjIwMy4xNzAuMTkwOjQ0MyJdfQ==
kind: Secret
metadata:
  creationTimestamp: "2021-11-19T05:50:31Z"
  name: consul-federation
  namespace: consul
  resourceVersion: "6078"
  uid: 371a8055-f3af-471d-894b-07d6c8e61530
type: Opaque
```

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

