### PR TITLE
acceptance-tests: add a workaround to mesh gateway tests against kind 1.22

### DIFF
--- a/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -96,6 +96,10 @@ func TestMeshGatewayDefault(t *testing.T) {
 	secondaryConsulCluster := consul.NewHelmCluster(t, secondaryHelmValues, secondaryContext, cfg, releaseName)
 	secondaryConsulCluster.Create(t)
 
+	// workaround
+	k8s.RunKubectl(t, primaryContext.KubectlOptions(t), "rollout", "restart", fmt.Sprintf("sts/%s-consul-server", releaseName))
+	k8s.RunKubectl(t, primaryContext.KubectlOptions(t), "rollout", "status", fmt.Sprintf("sts/%s-consul-server", releaseName))
+
 	primaryClient := primaryConsulCluster.SetupConsulClient(t, false)
 	secondaryClient := secondaryConsulCluster.SetupConsulClient(t, false)
 

--- a/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -96,9 +96,12 @@ func TestMeshGatewayDefault(t *testing.T) {
 	secondaryConsulCluster := consul.NewHelmCluster(t, secondaryHelmValues, secondaryContext, cfg, releaseName)
 	secondaryConsulCluster.Create(t)
 
-	// workaround
-	k8s.RunKubectl(t, primaryContext.KubectlOptions(t), "rollout", "restart", fmt.Sprintf("sts/%s-consul-server", releaseName))
-	k8s.RunKubectl(t, primaryContext.KubectlOptions(t), "rollout", "status", fmt.Sprintf("sts/%s-consul-server", releaseName))
+	if cfg.UseKind {
+		// This is a temporary workaround that seems to fix mesh gateway tests on kind 1.22.x.
+		// TODO (ishustava): we need to investigate this further and remove once we've found the issue.
+		k8s.RunKubectl(t, primaryContext.KubectlOptions(t), "rollout", "restart", fmt.Sprintf("sts/%s-consul-server", releaseName))
+		k8s.RunKubectl(t, primaryContext.KubectlOptions(t), "rollout", "status", fmt.Sprintf("sts/%s-consul-server", releaseName))
+	}
 
 	primaryClient := primaryConsulCluster.SetupConsulClient(t, false)
 	secondaryClient := secondaryConsulCluster.SetupConsulClient(t, false)
@@ -228,6 +231,13 @@ func TestMeshGatewaySecure(t *testing.T) {
 			// Install the secondary consul cluster in the secondary kubernetes context
 			secondaryConsulCluster := consul.NewHelmCluster(t, secondaryHelmValues, secondaryContext, cfg, releaseName)
 			secondaryConsulCluster.Create(t)
+
+			if cfg.UseKind {
+				// This is a temporary workaround that seems to fix mesh gateway tests on kind 1.22.x.
+				// TODO (ishustava): we need to investigate this further and remove once we've found the issue.
+				k8s.RunKubectl(t, primaryContext.KubectlOptions(t), "rollout", "restart", fmt.Sprintf("sts/%s-consul-server", releaseName))
+				k8s.RunKubectl(t, primaryContext.KubectlOptions(t), "rollout", "status", fmt.Sprintf("sts/%s-consul-server", releaseName))
+			}
 
 			primaryClient := primaryConsulCluster.SetupConsulClient(t, true)
 			secondaryClient := secondaryConsulCluster.SetupConsulClient(t, true)


### PR DESCRIPTION
Changes proposed in this PR:
- Currently the tests against kind 1.22 break like [this](https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/3430/workflows/4f84205b-bc1d-4348-9de1-50bff582bc67/jobs/28222/steps). We don't know the underlying issue yet, but this seems to work around this temporarily from testing this locally.

How I've tested this PR:
locally with kind 1.22 clusters

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

