### PR TITLE
Add configuration for the vault Connect CA provider

### DIFF
--- a/acceptance/framework/helpers/helpers.go
+++ b/acceptance/framework/helpers/helpers.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/gruntwork-io/terratest/modules/helm"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
 
 	terratestk8s "github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
@@ -85,6 +86,7 @@ func WaitForAllPodsToBeReady(t *testing.T, client kubernetes.Interface, namespac
 	retry.RunWith(counter, t, func(r *retry.R) {
 		pods, err := client.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: podLabelSelector})
 		require.NoError(r, err)
+		require.NotEmpty(t, pods.Items)
 
 		var notReadyPods []string
 		for _, pod := range pods.Items {

--- a/acceptance/framework/helpers/helpers.go
+++ b/acceptance/framework/helpers/helpers.go
@@ -86,7 +86,7 @@ func WaitForAllPodsToBeReady(t *testing.T, client kubernetes.Interface, namespac
 	retry.RunWith(counter, t, func(r *retry.R) {
 		pods, err := client.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: podLabelSelector})
 		require.NoError(r, err)
-		require.NotEmpty(t, pods.Items)
+		require.NotEmpty(r, pods.Items)
 
 		var notReadyPods []string
 		for _, pod := range pods.Items {

--- a/acceptance/tests/fixtures/bases/intention/intention.yaml
+++ b/acceptance/tests/fixtures/bases/intention/intention.yaml
@@ -1,0 +1,10 @@
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceIntentions
+metadata:
+  name: client-to-server
+spec:
+  destination:
+    name: static-server
+  sources:
+    - name: static-client
+      action: allow

--- a/acceptance/tests/fixtures/bases/intention/kustomization.yaml
+++ b/acceptance/tests/fixtures/bases/intention/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - intention.yaml

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -20,6 +20,8 @@ path "consul/data/secret/gossip" {
   capabilities = ["read"]
 }`
 
+	// connectCAPolicy allows Consul to bootstrap all certificates for the service mesh in Vault.
+	// Adapted from https://www.consul.io/docs/connect/ca/vault#consul-managed-pki-paths.
 	connectCARules = `
 path "/sys/mounts" {
   capabilities = [ "read" ]

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -138,6 +138,7 @@ func TestVault(t *testing.T) {
 
 	// Confirm that the Vault Connect CA has been bootstrapped correctly.
 	caConfig, _, err := consulClient.Connect().CAGetConfig(nil)
+	require.NoError(t, err)
 	require.Equal(t, caConfig.Provider, "vault")
 
 	// Deploy two services and check that they can talk to each other.

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -15,14 +15,14 @@ import (
 )
 
 const (
-	gossipRules = `
+	gossipPolicy = `
 path "consul/data/secret/gossip" {
   capabilities = ["read"]
 }`
 
 	// connectCAPolicy allows Consul to bootstrap all certificates for the service mesh in Vault.
 	// Adapted from https://www.consul.io/docs/connect/ca/vault#consul-managed-pki-paths.
-	connectCARules = `
+	connectCAPolicy = `
 path "/sys/mounts" {
   capabilities = [ "read" ]
 }
@@ -65,10 +65,10 @@ func TestVault(t *testing.T) {
 
 	// Create the Vault Policy for the gossip key.
 	logger.Log(t, "Creating policies")
-	err := vaultClient.Sys().PutPolicy("consul-gossip", gossipRules)
+	err := vaultClient.Sys().PutPolicy("consul-gossip", gossipPolicy)
 	require.NoError(t, err)
 
-	err = vaultClient.Sys().PutPolicy("connect-ca", connectCARules)
+	err = vaultClient.Sys().PutPolicy("connect-ca", connectCAPolicy)
 	require.NoError(t, err)
 
 	// Create the Auth Roles for consul-server and consul-client.

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -72,6 +72,11 @@ func TestVault(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the Auth Roles for consul-server and consul-client.
+	// Auth roles bind policies to Kubernetes service accounts, which
+	// then enables the Vault agent init container to call 'vault login'
+	// with the Kubernetes auth method to obtain a Vault token.
+	// Please see https://www.vaultproject.io/docs/auth/kubernetes#configuration
+	// for more details.
 	logger.Log(t, "Creating the consul-server and consul-client roles")
 	params := map[string]interface{}{
 		"bound_service_account_names":      consulClientServiceAccountName,

--- a/charts/consul/templates/server-config-configmap.yaml
+++ b/charts/consul/templates/server-config-configmap.yaml
@@ -11,6 +11,31 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 data:
+  {{- with .Values.global.secretsBackend.vault }}
+  {{- if .connectCA }}
+  connect-ca-config.json: |
+    {
+      "connect": [
+        {
+          "ca_config": [
+            {
+              "address": "{{ .connectCA.address }}",
+              "intermediate_pki_path": "{{ .connectCA.intermediatePKIPath }}",
+              "root_pki_path": "{{ .connectCA.rootPKIPath }}",
+              "auth_method": {
+                "type": "kubernetes",
+                "params": {
+                  "role": "{{.consulServerRole}}"
+                }
+              }
+            }
+          ],
+          "ca_provider": "vault"
+        }
+      ]
+    }
+    {{- end }}
+  {{- end }}
   extra-from-values.json: |-
 {{ tpl .Values.server.extraConfig . | trimAll "\"" | indent 4 }}
   {{- if .Values.global.acls.manageSystemACLs }}

--- a/charts/consul/templates/server-config-configmap.yaml
+++ b/charts/consul/templates/server-config-configmap.yaml
@@ -11,8 +11,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 data:
+  {{- $vaultConnectCAEnabled := and .Values.global.secretsBackend.vault.connectCA.address .Values.global.secretsBackend.vault.connectCA.rootPKIPath .Values.global.secretsBackend.vault.connectCA.intermediatePKIPath -}}
+  {{- if and .Values.global.secretsBackend.vault.enabled $vaultConnectCAEnabled }}
   {{- with .Values.global.secretsBackend.vault }}
-  {{- if .connectCA }}
   connect-ca-config.json: |
     {
       "connect": [
@@ -34,7 +35,11 @@ data:
         }
       ]
     }
-    {{- end }}
+  {{- if .connectCA.additionalConfig }}
+  additional-connect-ca-config.json: |
+{{ tpl .connectCA.additionalConfig $ | trimAll "\"" | indent 4 }}
+  {{- end }}
+  {{- end }}
   {{- end }}
   extra-from-values.json: |-
 {{ tpl .Values.server.extraConfig . | trimAll "\"" | indent 4 }}

--- a/charts/consul/test/unit/server-config-configmap.bats
+++ b/charts/consul/test/unit/server-config-configmap.bats
@@ -179,3 +179,230 @@ load _helpers
       yq -r '.data["acl-config.json"]' | yq -r '.acl.enable_token_replication' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# Vault Connect CA
+
+@test "server/ConfigMap: doesn't add connect CA config by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      . | tee /dev/stderr |
+      yq '.data["connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      . | tee /dev/stderr |
+      yq '.data["additional-connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ConfigMap: doesn't add connect CA config when vault is enabled but vault address, root and int PKI paths are not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      . | tee /dev/stderr |
+      yq '.data["connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      . | tee /dev/stderr |
+      yq '.data["additional-connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ConfigMap: doesn't add connect CA config when vault is enabled and vault address is set, but root and int PKI paths are not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.connectCA.address=example.com' \
+      . | tee /dev/stderr |
+      yq '.data["connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.connectCA.address=example.com' \
+      . | tee /dev/stderr |
+      yq '.data["additional-connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ConfigMap: doesn't add connect CA config when vault is enabled and root pki path is set, but vault address and int PKI paths are not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.connectCA.rootPKIPath=root' \
+      . | tee /dev/stderr |
+      yq '.data["connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.connectCA.rootPKIPath=root' \
+      . | tee /dev/stderr |
+      yq '.data["additional-connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ConfigMap: doesn't add connect CA config when vault is enabled and int path is set, but vault address and root PKI paths are not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.connectCA.intermediatePKIPath=int' \
+      . | tee /dev/stderr |
+      yq '.data["connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.connectCA.intermediatePKIPath=int' \
+      . | tee /dev/stderr |
+      yq '.data["additional-connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ConfigMap: doesn't add connect CA config when vault is enabled and root and int paths are set, but vault address is not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.connectCA.rootPKIPath=root' \
+      --set 'global.secretsBackend.vault.connectCA.intermediatePKIPath=int' \
+      . | tee /dev/stderr |
+      yq '.data["connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.connectCA.rootPKIPath=root' \
+      --set 'global.secretsBackend.vault.connectCA.intermediatePKIPath=int' \
+      . | tee /dev/stderr |
+      yq '.data["additional-connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ConfigMap: doesn't add connect CA config when vault is enabled and root path and address are set, but int path is not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.connectCA.rootPKIPath=root' \
+      --set 'global.secretsBackend.vault.connectCA.address=example.com' \
+      . | tee /dev/stderr |
+      yq '.data["connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.connectCA.rootPKIPath=root' \
+      --set 'global.secretsBackend.vault.connectCA.address=example.com' \
+      . | tee /dev/stderr |
+      yq '.data["additional-connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ConfigMap: doesn't add connect CA config when vault is enabled and int path and address are set, but root path is not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.connectCA.intPKIPath=int' \
+      --set 'global.secretsBackend.vault.connectCA.address=example.com' \
+      . | tee /dev/stderr |
+      yq '.data["connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.connectCA.intPKIPath=int' \
+      --set 'global.secretsBackend.vault.connectCA.address=example.com' \
+      . | tee /dev/stderr |
+      yq '.data["additional-connect-ca-config.json"] | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ConfigMap: adds connect CA config when vault is enabled and connect CA are configured" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.connectCA.address=example.com' \
+      --set 'global.secretsBackend.vault.connectCA.rootPKIPath=root' \
+      --set 'global.secretsBackend.vault.connectCA.intermediatePKIPath=int' \
+      . | tee /dev/stderr |
+      yq '.data["connect-ca-config.json"]' | tee /dev/stderr)
+  [ "${actual}" = '"{\n  \"connect\": [\n    {\n      \"ca_config\": [\n        {\n          \"address\": \"example.com\",\n          \"intermediate_pki_path\": \"int\",\n          \"root_pki_path\": \"root\",\n          \"auth_method\": {\n            \"type\": \"kubernetes\",\n            \"params\": {\n              \"role\": \"foo\"\n            }\n          }\n        }\n      ],\n      \"ca_provider\": \"vault\"\n    }\n  ]\n}\n"' ]
+
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.connectCA.address=example.com' \
+      --set 'global.secretsBackend.vault.connectCA.rootPKIPath=root' \
+      --set 'global.secretsBackend.vault.connectCA.intermediatePKIPath=int' \
+      . | tee /dev/stderr |
+      yq '.data["additional-connect-ca-config.json"]' | tee /dev/stderr)
+  [ "${actual}" = '"{}\n"' ]
+}
+
+@test "server/ConfigMap: can set additional connect CA config" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.connectCA.address=example.com' \
+      --set 'global.secretsBackend.vault.connectCA.rootPKIPath=root' \
+      --set 'global.secretsBackend.vault.connectCA.intermediatePKIPath=int' \
+      --set 'global.secretsBackend.vault.connectCA.additionalConfig="{\"hello\": \"world\"}"' \
+      . | tee /dev/stderr |
+      yq '.data["additional-connect-ca-config.json"]' | tee /dev/stderr)
+  [ "${actual}" = '"{\"hello\": \"world\"}\n"' ]
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -155,7 +155,7 @@ global:
       # Configuration for the Vault Connect CA provider.
       # The provider will be configured to use the Vault Kubernetes auth method
       # and therefore requires the role provided by `consulServerRole`
-      # needs to have permissions to the root and intermediate PKI paths.
+      # to have permissions to the root and intermediate PKI paths.
       # Please see https://www.consul.io/docs/connect/ca/vault#vault-acl-policies
       # for information on how to configure the Vault policies.
       connectCA:

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -173,6 +173,19 @@ global:
         # Additional Connect CA configuration in JSON format.
         # Please see https://www.consul.io/docs/connect/ca/vault#common-ca-config-options
         # for additional configuration options.
+        #
+        # Example:
+        #
+        # ```yaml
+        # additionalConfig: |
+        #   {
+        #     "connect": [{
+        #       "ca_config": [{
+        #            "leaf_cert_ttl": "36h"
+        #         }]
+        #     }]
+        #   }
+        # ```
         additionalConfig: |
           {}
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -154,7 +154,7 @@ global:
 
       # Configuration for the Vault Connect CA provider.
       # The provider will be configured to use the Vault Kubernetes auth method
-      # and therefore requires the role provided by `consulServerRole`
+      # and therefore requires the role provided by `global.secretsBackend.vault.consulServerRole`
       # to have permissions to the root and intermediate PKI paths.
       # Please see https://www.consul.io/docs/connect/ca/vault#vault-acl-policies
       # for information on how to configure the Vault policies.

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -152,6 +152,30 @@ global:
       # and check the name of `metadata.name`.
       consulClientRole: ""
 
+      # Configuration for the Vault Connect CA provider.
+      # The provider will be configured to use the Vault Kubernetes auth method
+      # and therefore requires the role provided by `consulServerRole`
+      # needs to have permissions to the root and intermediate PKI paths.
+      # Please see https://www.consul.io/docs/connect/ca/vault#vault-acl-policies
+      # for information on how to configure the Vault policies.
+      connectCA:
+        # The address of the Vault server.
+        address: ""
+
+        # The path to a PKI secrets engine for the root certificate.
+        # Please see https://www.consul.io/docs/connect/ca/vault#rootpkipath.
+        rootPKIPath: ""
+
+        # The path to a PKI secrets engine for the generated intermediate certificate.
+        # Please see https://www.consul.io/docs/connect/ca/vault#intermediatepkipath.
+        intermediatePKIPath: ""
+
+        # Additional Connect CA configuration in JSON format.
+        # Please see https://www.consul.io/docs/connect/ca/vault#common-ca-config-options
+        # for additional configuration options.
+        additionalConfig: |
+          {}
+
   # Configures Consul's gossip encryption key.
   # (see `-encrypt` (https://consul.io/docs/agent/options#_encrypt)).
   # By default, gossip encryption is not enabled. The gossip encryption key may be set automatically or manually.


### PR DESCRIPTION
Changes proposed in this PR:
- Adds helm values to configure vault connect ca provider
- Uses k8s auth method to configure connect CA provider in consul (hashicorp/consul#11573)
- This PR does not work if vault is configured with TLS (this change will come as a separate PR)

How I've tested this PR:
acceptance tests

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

