### PR TITLE
add cd chart_dir so tests can be run from root level

### DIFF
--- a/charts/consul/test/unit/ui-ingress.bats
+++ b/charts/consul/test/unit/ui-ingress.bats
@@ -69,6 +69,7 @@ load _helpers
 #      --kube-version "1.18" \
 #      . | tee /dev/stderr |
 #      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
+  cd `chart_dir`
   local actual=$(helm template \
      -s templates/ui-ingress.yaml  \
      --set 'ui.ingress.enabled=true' \
@@ -89,6 +90,7 @@ load _helpers
 #      --kube-version "1.18" \
 #      . | tee /dev/stderr |
 #      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
+  cd `chart_dir`
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
@@ -110,6 +112,7 @@ load _helpers
 #      --kube-version "1.18" \
 #      . | tee /dev/stderr |
 #      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
+  cd `chart_dir`
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
@@ -132,6 +135,7 @@ load _helpers
 #      --kube-version "1.18" \
 #      . | tee /dev/stderr |
 #      yq -r '.spec.rules[0].http.paths[1].backend.servicePort' | tee /dev/stderr)
+  cd `chart_dir`
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
@@ -207,6 +211,7 @@ load _helpers
 # pathtype
 
 @test "ui/Ingress: default PathType Prefix" {
+  cd `chart_dir`
   local actual=$(helm template \
     -s templates/ui-ingress.yaml  \
     --set 'ui.ingress.enabled=true' \
@@ -218,6 +223,7 @@ load _helpers
 }
 
 @test "ui/Ingress: set PathType ImplementationSpecific" {
+  cd `chart_dir`
   local actual=$(helm template \
     -s templates/ui-ingress.yaml  \
     --set 'ui.ingress.enabled=true' \


### PR DESCRIPTION
Changes proposed in this PR:
- Add `cd chart_dir` to the ui-ingress tests that were missing it so they can be run cleanly from the root.
-

How I've tested this PR:
run bats test

How I expect reviewers to test this PR:
code review

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

