### PR TITLE
CHANGELOG: Move go 1.17 bump to UNRELEASED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UNRELEASED
 
+BREAKING CHANGES:
+* Update minimum go version for project to 1.17 [[GH-878](https://github.com/hashicorp/consul-k8s/pull/878)]
+
 IMPROVEMENTS:
 * CLI
    * Pre-check in the `install` command to verify the correct license secret exists when using an enterprise Consul image. [[GH-875](https://github.com/hashicorp/consul-k8s/pull/875)]
@@ -24,7 +27,6 @@ BREAKING CHANGES:
   ```
   
   [[GH-851](https://github.com/hashicorp/consul-k8s/pull/851)]
-* Update minimum go version for project to 1.17 [[GH-878](https://github.com/hashicorp/consul-k8s/pull/878)]
 
 FEATURES:
 * Helm Chart


### PR DESCRIPTION
Changes proposed in this PR:
- Move Go 1.17 release note to correct place. 

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

