### PR TITLE
Do not mount consul-ca-cert to partition init if externalServers.useSystemRoots is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ IMPROVEMENTS:
 * CLI
    * Pre-check in the `install` command to verify the correct license secret exists when using an enterprise Consul image. [[GH-875](https://github.com/hashicorp/consul-k8s/pull/875)]
 
+BUG FIXES:
+* Helm Chart
+  * Admin Partitions **(Consul Enterprise only)**: Do not mount Consul CA certs to partition-init job if `externalServers.useSystemRoots` is `true`. [[GH-885](https://github.com/hashicorp/consul-k8s/pull/885)]
+
 ## 0.37.0 (November 18, 2021)
 
 BREAKING CHANGES:

--- a/charts/consul/templates/partition-init-job.yaml
+++ b/charts/consul/templates/partition-init-job.yaml
@@ -31,6 +31,7 @@ spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-partition-init
       {{- if .Values.global.tls.enabled }}
+      {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
       volumes:
         - name: consul-ca-cert
           secret:
@@ -42,6 +43,7 @@ spec:
             items:
               - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
                 path: tls.crt
+      {{- end }}
       {{- end }}
       containers:
         - name: partition-init-job
@@ -59,10 +61,12 @@ spec:
                   key: {{ .Values.global.acls.bootstrapToken.secretKey }}
             {{- end }}
           {{- if .Values.global.tls.enabled  }}
+          {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
           volumeMounts:
             - name: consul-ca-cert
               mountPath: /consul/tls/ca
               readOnly: true
+          {{- end }}
           {{- end }}
           command:
             - "/bin/sh"
@@ -82,9 +86,8 @@ spec:
 
                 {{- if .Values.global.tls.enabled }}
                 -use-https \
+                {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
                 -consul-ca-cert=/consul/tls/ca/tls.crt \
-                {{- if not .Values.externalServers.enabled }}
-                -server-port=8501 \
                 {{- end }}
                 {{- if .Values.externalServers.tlsServerName }}
                 -consul-tls-server-name={{ .Values.externalServers.tlsServerName }} \

--- a/charts/consul/templates/partition-init-job.yaml
+++ b/charts/consul/templates/partition-init-job.yaml
@@ -1,6 +1,7 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
-{{- if (and .Values.global.adminPartitions.enabled (not $serverEnabled)) }}
+{{- if (and .Values.global.adminPartitions.enabled (not $serverEnabled) (ne .Values.global.adminPartitions.name "default")) }}
 {{- template "consul.reservedNamesFailer" (list .Values.global.adminPartitions.name "global.adminPartitions.name") }}
+{{- if and (not .Values.externalServers.enabled) (ne .Values.global.adminPartitions.name "default") }}{{ fail "externalServers.enabled needs to be true and configured to create a non-default partition." }}{{ end -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -31,7 +32,7 @@ spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-partition-init
       {{- if .Values.global.tls.enabled }}
-      {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
+      {{- if not .Values.externalServers.useSystemRoots }}
       volumes:
         - name: consul-ca-cert
           secret:
@@ -61,7 +62,7 @@ spec:
                   key: {{ .Values.global.acls.bootstrapToken.secretKey }}
             {{- end }}
           {{- if .Values.global.tls.enabled  }}
-          {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
+          {{- if not .Values.externalServers.useSystemRoots }}
           volumeMounts:
             - name: consul-ca-cert
               mountPath: /consul/tls/ca
@@ -72,8 +73,6 @@ spec:
             - "/bin/sh"
             - "-ec"
             - |
-              CONSUL_FULLNAME="{{template "consul.fullname" . }}"
-
               consul-k8s-control-plane partition-init \
                 -log-level={{ .Values.global.logLevel }} \
                 -log-json={{ .Values.global.logJSON }} \
@@ -86,7 +85,7 @@ spec:
 
                 {{- if .Values.global.tls.enabled }}
                 -use-https \
-                {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
+                {{- if not .Values.externalServers.useSystemRoots }}
                 -consul-ca-cert=/consul/tls/ca/tls.crt \
                 {{- end }}
                 {{- if .Values.externalServers.tlsServerName }}

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -1446,6 +1446,8 @@ rollingUpdate:
       --set 'global.adminPartitions.enabled=true' \
       --set 'global.adminPartitions.name=test' \
       --set 'server.enabled=false' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=bar' \
       . | tee /dev/stderr |
       yq -c -r '.spec.template.spec.containers[0].command | join(" ") | contains("partition = \"test\"")' | tee /dev/stderr)
   [ "${actual}" = "true" ]


### PR DESCRIPTION
How I've tested this PR: Compared code to using `useSystemRoots` across the project. Unit tests.

How I expect reviewers to test this PR: 👀 


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

