### PR TITLE
add a makefile target for parallel bats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,7 @@ copy-crds-to-chart:
 # Deletes AWS resources left behind after failed acceptance tests.
 ci.aws-acceptance-test-cleanup:
 	@cd hack/aws-acceptance-test-cleanup; go run ./... -auto-approve
+
+# Run bats tests in parallel from the root of the repository.
+bats-tests:
+	 bats --jobs 4 charts/consul/test/unit


### PR DESCRIPTION
Changes proposed in this PR:
- Adds a makefile target to run bats tests in parallel. This shaves off about 5 minutes from a full run of the bats tests.
- This is the same command we run in CI.

How I've tested this PR:
`make bats-tests` passes.

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

