### PR TITLE
cli: allow enterprise images to be named without the string "-ent"

### DIFF
--- a/cli/cmd/install/install_test.go
+++ b/cli/cmd/install/install_test.go
@@ -203,24 +203,19 @@ func TestCheckValidEnterprise(t *testing.T) {
 		},
 	}
 
-	// Enterprise secret and image are valid.
+	// Enterprise secret is valid.
 	c.kubernetes.CoreV1().Secrets("consul").Create(context.Background(), secret, metav1.CreateOptions{})
-	err := c.checkValidEnterprise(secret.Name, "consul-enterprise:-ent")
+	err := c.checkValidEnterprise(secret.Name)
 	require.NoError(t, err)
 
-	// Enterprise secret provided but not an enterprise image.
-	err = c.checkValidEnterprise(secret.Name, "consul:")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "enterprise Consul image is not provided")
-
 	// Enterprise secret does not exist.
-	err = c.checkValidEnterprise("consul-unrelated-secret", "consul-enterprise:-ent")
+	err = c.checkValidEnterprise("consul-unrelated-secret")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "please make sure that the secret exists")
 
 	// Enterprise secret exists in a different namespace.
 	c.kubernetes.CoreV1().Secrets("unrelated").Create(context.Background(), secret2, metav1.CreateOptions{})
-	err = c.checkValidEnterprise(secret2.Name, "consul-enterprise:-ent")
+	err = c.checkValidEnterprise(secret2.Name)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "please make sure that the secret exists")
 }


### PR DESCRIPTION
In a case where users might have a Consul enterprise image that may not
contain the string "-ent" in the name, we don't want to fail the
installation. This is a fairly common case, so we've removed the check.

How I've tested this PR:
unit tests

How I expect reviewers to test this PR:
👀 


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

