### PR TITLE
Add ingressClassName for UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ IMPROVEMENTS:
   * Add support for labeling a Kubernetes service with `consul.hashicorp.com/service-ignore` to prevent services from being registered in Consul. [[GH-858](https://github.com/hashicorp/consul-k8s/pull/858)]
 * Helm Chart
   * Fail an installation/upgrade if WAN federation and Admin Partitions are both enabled. [[GH-892](https://github.com/hashicorp/consul-k8s/issues/892)]
+  * Add support for setting `ingressClassName` for UI. [[GH-909](https://github.com/hashicorp/consul-k8s/pull/909)]
 
 BUG FIXES:
 * Control Plane:

--- a/charts/consul/templates/ui-ingress.yaml
+++ b/charts/consul/templates/ui-ingress.yaml
@@ -5,7 +5,7 @@
 This is because while networks.k8s.io/v1 was introduced in Kubernetes v1.15+, the Ingress resource was
 promoted to v1 only in Kubernetes v1.19+. This ensures the correct API version is chosen that supports
 the Ingress resource. */}}
-{{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "19" ) }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -25,12 +25,12 @@ metadata:
     {{ tpl .Values.ui.ingress.annotations . | nindent 4 | trim }}
   {{- end }}
 spec:
-  {{- if and .Values.ui.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ui.ingress.className }}
+  {{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "18" ) }}
+  ingressClassName: {{ .Values.ui.ingress.ingressClassName }}
   {{- end }}
   rules:
   {{ $global := .Values.global }}
-  {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "19" ) }}
   {{- range .Values.ui.ingress.hosts }}
   - host: {{ .host | quote }}
     http:

--- a/charts/consul/templates/ui-ingress.yaml
+++ b/charts/consul/templates/ui-ingress.yaml
@@ -5,7 +5,7 @@
 This is because while networks.k8s.io/v1 was introduced in Kubernetes v1.15+, the Ingress resource was
 promoted to v1 only in Kubernetes v1.19+. This ensures the correct API version is chosen that supports
 the Ingress resource. */}}
-{{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "19" ) }}
+{{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -25,9 +25,12 @@ metadata:
     {{ tpl .Values.ui.ingress.annotations . | nindent 4 | trim }}
   {{- end }}
 spec:
+  {{- if and .Values.ui.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ui.ingress.className }}
+  {{- end }}
   rules:
   {{ $global := .Values.global }}
-  {{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "19" ) }}
+  {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
   {{- range .Values.ui.ingress.hosts }}
   - host: {{ .host | quote }}
     http:

--- a/charts/consul/test/unit/ui-ingress.bats
+++ b/charts/consul/test/unit/ui-ingress.bats
@@ -59,59 +59,59 @@ load _helpers
   [ "${actual}" = "foo.com" ]
 }
 
-@test "ui/Ingress: exposes single port 80 when global.tls.enabled=false" {
-# todo: test for Kube versions < 1.19 when helm supports --kube-version flag (https://github.com/helm/helm/pull/9040)
-#  local actual=$(helm template \
-#      -s templates/ui-ingress.yaml  \
-#      --set 'ui.ingress.enabled=true' \
-#      --set 'global.tls.enabled=false' \
-#      --set 'ui.ingress.hosts[0].host=foo.com' \
-#      --kube-version "1.18" \
-#      . | tee /dev/stderr |
-#      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
+@test "ui/Ingress: exposes single port 80 when global.tls.enabled=false when Kube version < 1.19" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/ui-ingress.yaml  \
+      --set 'ui.ingress.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      --set 'ui.ingress.hosts[0].host=foo.com' \
+      --kube-version "1.18" \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
+  [ "${actual}" = "80" ]
+}
+
+@test "ui/Ingress: exposes single port 80 when global.tls.enabled=false when Kube version >= 1.19" {
   cd `chart_dir`
   local actual=$(helm template \
      -s templates/ui-ingress.yaml  \
      --set 'ui.ingress.enabled=true' \
      --set 'global.tls.enabled=false' \
      --set 'ui.ingress.hosts[0].host=foo.com' \
+     --kube-version "1.19" \
      . | tee /dev/stderr |
      yq -r '.spec.rules[0].http.paths[0].backend.service.port.number' | tee /dev/stderr)
   [ "${actual}" = "80" ]
 }
 
-@test "ui/Ingress: exposes single port 443 when global.tls.enabled=true and global.tls.httpsOnly=true" {
-# todo: test for Kube versions < 1.19 when helm supports --kube-version flag (https://github.com/helm/helm/pull/9040)
-#  local actual=$(helm template \
-#      -s templates/ui-ingress.yaml  \
-#      --set 'ui.ingress.enabled=true' \
-#      --set 'global.tls.enabled=true' \
-#      --set 'ui.ingress.hosts[0].host=foo.com' \
-#      --kube-version "1.18" \
-#      . | tee /dev/stderr |
-#      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
+@test "ui/Ingress: exposes single port 443 when global.tls.enabled=true and global.tls.httpsOnly=true when Kube version < 1.19" {
+  cd `chart_dir`
+  local actual=$(helm template \
+    -s templates/ui-ingress.yaml  \
+    --set 'ui.ingress.enabled=true' \
+    --set 'global.tls.enabled=true' \
+    --set 'ui.ingress.hosts[0].host=foo.com' \
+    --kube-version "1.18" \
+    . | tee /dev/stderr |
+    yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
+  [ "${actual}" = "443" ]
+}
+
+@test "ui/Ingress: exposes single port 443 when global.tls.enabled=true and global.tls.httpsOnly=true when Kube version >= 1.19" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
       --set 'global.tls.enabled=true' \
       --set 'ui.ingress.hosts[0].host=foo.com' \
+      --kube-version "1.19" \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[0].backend.service.port.number' | tee /dev/stderr)
   [ "${actual}" = "443" ]
 }
 
-@test "ui/Ingress: exposes the port 80 when global.tls.enabled=true and global.tls.httpsOnly=false" {
-# todo: test for Kube versions < 1.19 when helm supports --kube-version flag (https://github.com/helm/helm/pull/9040)
-#  local actual=$(helm template \
-#      -s templates/ui-ingress.yaml  \
-#      --set 'ui.ingress.enabled=true' \
-#      --set 'global.tls.enabled=true' \
-#      --set 'global.tls.httpsOnly=false' \
-#      --set 'ui.ingress.hosts[0].host=foo.com' \
-#      --kube-version "1.18" \
-#      . | tee /dev/stderr |
-#      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
+@test "ui/Ingress: exposes the port 80 when global.tls.enabled=true and global.tls.httpsOnly=false when Kube version < 1.19" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
@@ -119,22 +119,41 @@ load _helpers
       --set 'global.tls.enabled=true' \
       --set 'global.tls.httpsOnly=false' \
       --set 'ui.ingress.hosts[0].host=foo.com' \
+      --kube-version "1.18" \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
+  [ "${actual}" = "80" ]
+}
+
+@test "ui/Ingress: exposes the port 80 when global.tls.enabled=true and global.tls.httpsOnly=false when Kube version >= 1.19" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/ui-ingress.yaml  \
+      --set 'ui.ingress.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.httpsOnly=false' \
+      --set 'ui.ingress.hosts[0].host=foo.com' \
+      --kube-version "1.19" \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[0].backend.service.port.number' | tee /dev/stderr)
   [ "${actual}" = "80" ]
 }
 
-@test "ui/Ingress: exposes the port 443 when global.tls.enabled=true and global.tls.httpsOnly=false" {
-# todo: test for Kube versions < 1.19 when helm supports --kube-version flag (https://github.com/helm/helm/pull/9040)
-#  local actual=$(helm template \
-#      -s templates/ui-ingress.yaml  \
-#      --set 'ui.ingress.enabled=true' \
-#      --set 'global.tls.enabled=true' \
-#      --set 'global.tls.httpsOnly=false' \
-#      --set 'ui.ingress.hosts[0].host=foo.com' \
-#      --kube-version "1.18" \
-#      . | tee /dev/stderr |
-#      yq -r '.spec.rules[0].http.paths[1].backend.servicePort' | tee /dev/stderr)
+@test "ui/Ingress: exposes the port 443 when global.tls.enabled=true and global.tls.httpsOnly=false when Kube version < 1.19" {
+  cd `chart_dir`
+  local actual=$(helm template \
+    -s templates/ui-ingress.yaml  \
+    --set 'ui.ingress.enabled=true' \
+    --set 'global.tls.enabled=true' \
+    --set 'global.tls.httpsOnly=false' \
+    --set 'ui.ingress.hosts[0].host=foo.com' \
+    --kube-version "1.18" \
+    . | tee /dev/stderr |
+    yq -r '.spec.rules[0].http.paths[1].backend.servicePort' | tee /dev/stderr)
+  [ "${actual}" = "443" ]
+}
+
+@test "ui/Ingress: exposes the port 443 when global.tls.enabled=true and global.tls.httpsOnly=false when Kube version >= 1.19" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
@@ -142,6 +161,7 @@ load _helpers
       --set 'global.tls.enabled=true' \
       --set 'global.tls.httpsOnly=false' \
       --set 'ui.ingress.hosts[0].host=foo.com' \
+      --kube-version "1.19" \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[1].backend.service.port.number' | tee /dev/stderr)
   [ "${actual}" = "443" ]
@@ -239,6 +259,7 @@ load _helpers
 # ingressClassName
 
 @test "ui/Ingress: no ingressClassName by default" {
+  cd `chart_dir`
   local actual=$(helm template \
     -s templates/ui-ingress.yaml  \
     --set 'ui.ingress.enabled=true' \
@@ -247,7 +268,8 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
-@test "ui/Ingress: no ingressClassName by default" {
+@test "ui/Ingress: can set ingressClassName" {
+  cd `chart_dir`
   local actual=$(helm template \
     -s templates/ui-ingress.yaml  \
     --set 'ui.ingress.enabled=true' \
@@ -256,3 +278,16 @@ load _helpers
     yq -r '.spec.ingressClassName' | tee /dev/stderr)
   [ "${actual}" = "nginx" ]
 }
+
+@test "ui/Ingress: cannot set ingressClassName for Kube version < 1.18" {
+  cd `chart_dir`
+  local actual=$(helm template \
+    -s templates/ui-ingress.yaml  \
+    --set 'ui.ingress.enabled=true' \
+    --set 'ui.ingress.ingressClassName=nginx' \
+    --kube-version "1.17" \
+    . | tee /dev/stderr |
+    yq -r '.spec.ingressClassName' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+

--- a/charts/consul/test/unit/ui-ingress.bats
+++ b/charts/consul/test/unit/ui-ingress.bats
@@ -234,3 +234,25 @@ load _helpers
     yq -r '.spec.rules[0].http.paths[0].pathType' | tee /dev/stderr)
   [ "${actual}" = "ImplementationSpecific" ]
 }
+
+#--------------------------------------------------------------------
+# ingressClassName
+
+@test "ui/Ingress: no ingressClassName by default" {
+  local actual=$(helm template \
+    -s templates/ui-ingress.yaml  \
+    --set 'ui.ingress.enabled=true' \
+    . | tee /dev/stderr |
+    yq -r '.spec.ingressClassName' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "ui/Ingress: no ingressClassName by default" {
+  local actual=$(helm template \
+    -s templates/ui-ingress.yaml  \
+    --set 'ui.ingress.enabled=true' \
+    --set 'ui.ingress.ingressClassName=nginx' \
+    . | tee /dev/stderr |
+    yq -r '.spec.ingressClassName' | tee /dev/stderr)
+  [ "${actual}" = "nginx" ]
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1220,7 +1220,8 @@ ui:
   ingress:
     # This will create an Ingress resource for the Consul UI.
     # @type: boolean
-    enabled: false
+    enabled: true
+    className: ""
 
     # pathType override - see: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
     pathType: Prefix

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1220,8 +1220,10 @@ ui:
   ingress:
     # This will create an Ingress resource for the Consul UI.
     # @type: boolean
-    enabled: true
-    className: ""
+    enabled: false
+
+    # Optionally set the ingressClassName.
+    ingressClassName: ""
 
     # pathType override - see: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
     pathType: Prefix


### PR DESCRIPTION
Work based on existing PR: https://github.com/hashicorp/consul-k8s/pull/780

Closes #897

Changes proposed in this PR:
- Add support for ingressClassName
- Test ingress UI with different Kube versions

How I've tested this PR:

Bats!

How I expect reviewers to test this PR:

Bats!

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

