### PR TITLE
Add configurable preStop delay to Envoy sidecar

### DIFF
--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -69,6 +69,9 @@ const (
 	annotationSidecarProxyMemoryLimit   = "consul.hashicorp.com/sidecar-proxy-memory-limit"
 	annotationSidecarProxyMemoryRequest = "consul.hashicorp.com/sidecar-proxy-memory-request"
 
+	// annotationSidecarProxyPreStopDelay is the number of seconds to delay Envoy Sidecar shutdown
+	annotationSidecarProxyPreStopDelay = "consul.hashicorp.com/sidecar-proxy-prestop-delay"
+
 	// annotations for metrics to configure where Prometheus scrapes
 	// metrics from, whether to run a merged metrics endpoint on the consul
 	// sidecar, and configure the connect service metrics.


### PR DESCRIPTION
Changes proposed in this PR:
- Add a new annotation `consul.hashicorp.com/sidecar-proxy-prestop-delay`
- Pods with this annotation have a [Lifecycle hook](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) added to delay the Envoy proxy sidecar shutdown by the specified number of seconds

Should probably be some validation on the value of the annotation, atm this would allow random command injection to the sidecar container on shutdown

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

Related: #650
