### PR TITLE
Release.ubi.dockerfile: update to ubi-minimal:8.5

### DIFF
--- a/control-plane/build-support/docker/Release.ubi.dockerfile
+++ b/control-plane/build-support/docker/Release.ubi.dockerfile
@@ -8,7 +8,7 @@
 # We don't rebuild the software because we want the exact checksums and
 # binary signatures to match the software and our builds aren't fully
 # reproducible currently.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
 # NAME and VERSION are the name of the software in releases.hashicorp.com
 # and the version to download. Example: NAME=consul VERSION=1.2.3.


### PR DESCRIPTION
Update to the latest ubi-minimal base image

Changes proposed in this PR:
- Update to UBI Base image to ubi-minimal:8.5 from ubi-minimal:8.4 

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

