### PR TITLE
adding Kind to ApiVersion

### DIFF
--- a/charts/consul/templates/server-disruptionbudget.yaml
+++ b/charts/consul/templates/server-disruptionbudget.yaml
@@ -1,7 +1,7 @@
 {{- if (and .Values.server.disruptionBudget.enabled (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled))) }}
 # PodDisruptionBudget to prevent degrading the server cluster through
 # voluntary cluster changes.
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/charts/consul/test/unit/server-disruptionbudget.bats
+++ b/charts/consul/test/unit/server-disruptionbudget.bats
@@ -127,7 +127,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-disruptionbudget.yaml \
-      --api-versions 'policy/v1' \
+      --api-versions 'policy/v1/PodDisruptionBudget' \
       . | tee /dev/stderr |
       yq -r '.apiVersion' | tee /dev/stderr)
   [ "${actual}" = "policy/v1" ]


### PR DESCRIPTION
Changes proposed in this PR:
New version of consul helm chart is using apiVersion of "policy/v1" and deprecated "v1beata1" causing errors similar to below issues with cortex and argocd. Used the workaround mentioned to use Kind with apiVersion and that works.
https://github.com/cortexproject/cortex-helm-chart/pull/277
https://github.com/argoproj/argo-cd/issues/7291

How I've tested this PR:
Tested locally against the new version of consul 1.10.4 with helm chart 0.37.0 and had issues with PBD not syncing up in argocd and complaining about apiversion.

How I expect reviewers to test this PR:
Create a release version and test it.

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

