### PR TITLE
acceptance: include cenkalti/backoff dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -969,6 +969,10 @@ workflows:
             - unit-test-helm-templates
             - unit-acceptance-framework
             - unit-cli
+      - cleanup-gcp-resources
+      - acceptance-gke-1-19:
+          requires:
+            - cleanup-gcp-resources
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/acceptance/framework/vault/vault_cluster.go
+++ b/acceptance/framework/vault/vault_cluster.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	_ "github.com/cenkalti/backoff"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	terratestk8s "github.com/gruntwork-io/terratest/modules/k8s"
 	terratestLogger "github.com/gruntwork-io/terratest/modules/logger"

--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -3,6 +3,7 @@ module github.com/hashicorp/consul-k8s/acceptance
 go 1.17
 
 require (
+	github.com/cenkalti/backoff v2.1.1+incompatible
 	github.com/gruntwork-io/terratest v0.31.2
 	github.com/hashicorp/consul-k8s/control-plane v0.0.0-20211207212234-aea9efea5638
 	github.com/hashicorp/consul/api v1.10.1-0.20211206193229-9b44861ce4bc

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -101,6 +101,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/cenkalti/backoff v2.1.1+incompatible h1:tKJnvO2kl0zmb/jA5UKAt4VoEVw1qxKWjE/Bpp46npY=
+github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
Changes proposed in this PR:
- include cenkalti/backoff as a dot import since cloud acceptance tests were failing like this: https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/3748/workflows/ac988ff0-1095-45ca-8790-f179145ed63e/jobs/32762

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

