### PR TITLE
CLI Upgrade Command (fixed PR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ FEATURES:
 
 FEATURES:
 * CLI
-   * Add `upgrade` command to modify Consul installation on Kubernetes. [[GH-898](https://github.com/hashicorp/consul-k8s/pull/898)]
+   * **BETA** Add `upgrade` command to modify Consul installation on Kubernetes. [[GH-898](https://github.com/hashicorp/consul-k8s/pull/898)]
 
 IMPROVEMENTS:
 * CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ FEATURES:
 * Helm
   * Rename `PartitionExports` CRD to `ExportedServices`. [[GH-902](https://github.com/hashicorp/consul-k8s/pull/902)]
 
+FEATURES:
+* CLI
+   * Add `upgrade` command to modify Consul installation on Kubernetes. [[GH-898](https://github.com/hashicorp/consul-k8s/pull/898)]
+
 IMPROVEMENTS:
 * CLI
   * Pre-check in the `install` command to verify the correct license secret exists when using an enterprise Consul image. [[GH-875](https://github.com/hashicorp/consul-k8s/pull/875)]

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/consul-k8s/cli/cmd/common"
 	"github.com/hashicorp/consul-k8s/cli/cmd/common/flag"
 	"github.com/hashicorp/consul-k8s/cli/cmd/common/terminal"
+	"github.com/hashicorp/consul-k8s/cli/config"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	helmCLI "helm.sh/helm/v3/pkg/cli"
@@ -82,7 +83,7 @@ type Command struct {
 func (c *Command) init() {
 	// Store all the possible preset values in 'presetList'. Printed in the help message.
 	var presetList []string
-	for name := range Presets {
+	for name := range config.Presets {
 		presetList = append(presetList, name)
 	}
 
@@ -313,7 +314,7 @@ func (c *Command) Run(args []string) int {
 	// Without informing the user, default global.name to consul if it hasn't been set already. We don't allow setting
 	// the release name, and since that is hardcoded to "consul", setting global.name to "consul" makes it so resources
 	// aren't double prefixed with "consul-consul-...".
-	vals = MergeMaps(Convert(GlobalNameConsul), vals)
+	vals = MergeMaps(config.Convert(config.GlobalNameConsul), vals)
 
 	// Dry Run should exit here, no need to actual locate/download the charts.
 	if c.flagDryRun {
@@ -454,7 +455,7 @@ func (c *Command) mergeValuesFlagsWithPrecedence(settings *helmCLI.EnvSettings) 
 	}
 	if c.flagPreset != defaultPreset {
 		// Note the ordering of the function call, presets have lower precedence than set vals.
-		presetMap := Presets[c.flagPreset].(map[string]interface{})
+		presetMap := config.Presets[c.flagPreset].(map[string]interface{})
 		vals = MergeMaps(presetMap, vals)
 	}
 	return vals, err
@@ -492,7 +493,7 @@ func (c *Command) validateFlags(args []string) error {
 	if len(c.flagValueFiles) != 0 && c.flagPreset != defaultPreset {
 		return fmt.Errorf("Cannot set both -%s and -%s", flagNameConfigFile, flagNamePreset)
 	}
-	if _, ok := Presets[c.flagPreset]; c.flagPreset != defaultPreset && !ok {
+	if _, ok := config.Presets[c.flagPreset]; c.flagPreset != defaultPreset && !ok {
 		return fmt.Errorf("'%s' is not a valid preset", c.flagPreset)
 	}
 	if !validLabel(c.flagNamespace) {

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"time"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-
 	consulChart "github.com/hashicorp/consul-k8s/charts"
 	"github.com/hashicorp/consul-k8s/cli/cmd/common"
 	"github.com/hashicorp/consul-k8s/cli/cmd/common/flag"
@@ -20,6 +18,7 @@ import (
 	helmCLI "helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/getter"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"

--- a/cli/cmd/install/presets.go
+++ b/cli/cmd/install/presets.go
@@ -7,35 +7,46 @@ const (
 	PresetSecure = "secure"
 )
 
-// presets is a map of pre-configured helm values.
-var presets = map[string]interface{}{
-	PresetDemo:   convert(demo),
-	PresetSecure: convert(secure),
+// Presets is a map of pre-configured helm values.
+var Presets = map[string]interface{}{
+	PresetDemo:   Convert(demo),
+	PresetSecure: Convert(secure),
 }
 
 var demo = `
 global:
   name: consul
-  metrics:
-    enabled: true
-    enableAgentMetrics: true
 connectInject:
   enabled: true
-  metrics: 
-    defaultEnabled: true
-    defaultEnableMerging: true
-    enableGatewayMetrics: true
 server:
   replicas: 1
-controller:
-  enabled: true
-ui: 
-  enabled: true
-  service:
-    enabled: true
-prometheus:
-  enabled: true
+  bootstrapExpect: 1
 `
+
+// TODO: I don't know why the following hangs for me.
+//var demo = `
+//global:
+//  name: consul
+//  metrics:
+//    enabled: true
+//    enableAgentMetrics: true
+//connectInject:
+//  enabled: true
+//  metrics:
+//    defaultEnabled: true
+//    defaultEnableMerging: true
+//    enableGatewayMetrics: true
+//server:
+//  replicas: 1
+//controller:
+//  enabled: true
+//ui:
+//  enabled: true
+//  service:
+//    enabled: true
+//prometheus:
+//  enabled: true
+//`
 
 var secure = `
 global:
@@ -55,13 +66,13 @@ controller:
   enabled: true
 `
 
-var globalNameConsul = `
+var GlobalNameConsul = `
 global:
   name: consul
 `
 
 // convert is a helper function that converts a YAML string to a map.
-func convert(s string) map[string]interface{} {
+func Convert(s string) map[string]interface{} {
 	var m map[string]interface{}
 	_ = yaml.Unmarshal([]byte(s), &m)
 	return m

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -238,6 +238,7 @@ func (c *Command) Run(args []string) int {
 	// Note the logic here, common's CheckForInstallations function returns an error if
 	// the release is not found. In `upgrade` we should indeed error if a user doesn't currently have a release.
 	if name, ns, err := common.CheckForInstallations(settings, uiLogger); err != nil {
+		// TODO: Don't just error, install.
 		c.UI.Output(fmt.Sprintf("could not find existing Consul installation - run `consul-k8s install`"))
 		return 1
 	} else {
@@ -446,4 +447,14 @@ func (c *Command) mergeValuesFlagsWithPrecedence(settings *helmCLI.EnvSettings) 
 		vals = install.MergeMaps(presetMap, vals)
 	}
 	return vals, err
+}
+
+func (c *Command) Help() string {
+	c.once.Do(c.init)
+	s := "Usage: consul-k8s upgrade [flags]" + "\n" + "Upgrade Consul from an existing installation." + "\n"
+	return s + "\n" + c.help
+}
+
+func (c *Command) Synopsis() string {
+	return "Upgrade Consul on Kubernetes."
 }

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -9,20 +9,16 @@ import (
 	"time"
 
 	consulChart "github.com/hashicorp/consul-k8s/charts"
-	"helm.sh/helm/v3/pkg/chart/loader"
-
-	"helm.sh/helm/v3/pkg/action"
-	"helm.sh/helm/v3/pkg/cli/values"
-	"helm.sh/helm/v3/pkg/getter"
-
-	"github.com/hashicorp/consul-k8s/cli/cmd/common/terminal"
-	"github.com/hashicorp/consul-k8s/cli/config"
-	helmCLI "helm.sh/helm/v3/pkg/cli"
-
-	"github.com/hashicorp/consul-k8s/cli/cmd/install"
-
 	"github.com/hashicorp/consul-k8s/cli/cmd/common"
 	"github.com/hashicorp/consul-k8s/cli/cmd/common/flag"
+	"github.com/hashicorp/consul-k8s/cli/cmd/common/terminal"
+	"github.com/hashicorp/consul-k8s/cli/cmd/install"
+	"github.com/hashicorp/consul-k8s/cli/config"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	helmCLI "helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/cli/values"
+	"helm.sh/helm/v3/pkg/getter"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
 )

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -174,8 +174,6 @@ func (c *Command) init() {
 
 func (c *Command) Run(args []string) int {
 	c.once.Do(c.init)
-
-	// The logger is initialized in main with the name cli. Here, we reset the name to install so log lines would be prefixed with install.
 	c.Log.ResetNamed("upgrade")
 
 	defer common.CloseWithError(c.BaseCommand)
@@ -259,7 +257,6 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// Print out the upgrade summary.
-	// TODO: Fix this to show the diff between existing and proposed install rather than overrides.
 	if !c.flagAutoApprove {
 		c.UI.Output("Consul Upgrade Summary", terminal.WithHeaderStyle())
 		c.UI.Output("Installation name: %s", common.DefaultReleaseName, terminal.WithInfoStyle())
@@ -272,11 +269,10 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
-	// TODO: Fix this! We are just going to comment this in, because we do want to set global.name to consul if not set already.
-	//// Without informing the user, default global.name to consul if it hasn't been set already. We don't allow setting
-	//// the release name, and since that is hardcoded to "consul", setting global.name to "consul" makes it so resources
-	//// aren't double prefixed with "consul-consul-...".
-	//vals = install.MergeMaps(install.Convert(install.GlobalNameConsul), vals)
+	// Without informing the user, default global.name to consul if it hasn't been set already. We don't allow setting
+	// the release name, and since that is hardcoded to "consul", setting global.name to "consul" makes it so resources
+	// aren't double prefixed with "consul-consul-...".
+	vals = install.MergeMaps(install.Convert(install.GlobalNameConsul), vals)
 
 	if !c.flagAutoApprove && !c.flagDryRun {
 		confirmation, err := c.UI.Input(&terminal.Input{
@@ -310,7 +306,6 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// Setup the upgrade action.
-	// TODO: So many things to add here. (Could add upgrade.<> features)
 	upgrade := action.NewUpgrade(actionConfig)
 	upgrade.Namespace = foundNamespace
 	upgrade.DryRun = c.flagDryRun
@@ -362,8 +357,7 @@ func (c *Command) Run(args []string) int {
 }
 
 // TODO: Make sure the following function is consistent.
-// TODO: Move these functions to common?
-// validateFlags is a helper function that performs sanity checks on the user's provided flags.
+// validateFlags checks that the user's provided flags are valid.
 func (c *Command) validateFlags(args []string) error {
 	if err := c.set.Parse(args); err != nil {
 		return err
@@ -372,7 +366,7 @@ func (c *Command) validateFlags(args []string) error {
 		return errors.New("should have no non-flag arguments")
 	}
 	if len(c.flagValueFiles) != 0 && c.flagPreset != defaultPreset {
-		return fmt.Errorf("Cannot set both -%s and -%s", flagNameConfigFile, flagNamePreset)
+		return fmt.Errorf("cannot set both -%s and -%s", flagNameConfigFile, flagNamePreset)
 	}
 	if _, ok := install.Presets[c.flagPreset]; c.flagPreset != defaultPreset && !ok {
 		return fmt.Errorf("'%s' is not a valid preset", c.flagPreset)
@@ -385,7 +379,7 @@ func (c *Command) validateFlags(args []string) error {
 	if len(c.flagValueFiles) != 0 {
 		for _, filename := range c.flagValueFiles {
 			if _, err := os.Stat(filename); err != nil && os.IsNotExist(err) {
-				return fmt.Errorf("File '%s' does not exist.", filename)
+				return fmt.Errorf("file '%s' does not exist", filename)
 			}
 		}
 	}
@@ -397,8 +391,7 @@ func (c *Command) validateFlags(args []string) error {
 }
 
 // TODO: Make sure the following function is consistent.
-// TODO: Move these functions to common?
-// validLabel is a helper function that checks if a string follows RFC 1123 labels.
+// validLabel checks if a string follows RFC 1123 labels.
 func validLabel(s string) bool {
 	for i, c := range s {
 		alphanum := ('a' <= c && c <= 'z') || ('0' <= c && c <= '9')
@@ -413,7 +406,6 @@ func validLabel(s string) bool {
 	return true
 }
 
-// TODO: Move these functions to common?
 // mergeValuesFlagsWithPrecedence is responsible for merging all the values to determine the values file for the
 // installation based on the following precedence order from lowest to highest:
 // 1. -preset

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -51,6 +51,9 @@ const (
 
 	flagNameWait = "wait"
 	defaultWait  = true
+	// action/upgrade
+	// --install, --reset-values vs --reuse-values,
+	// atomic
 )
 
 type Command struct {
@@ -256,6 +259,7 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// Print out the upgrade summary.
+	// TODO: Fix this to show the diff between existing and proposed install rather than overrides.
 	if !c.flagAutoApprove {
 		c.UI.Output("Consul Upgrade Summary", terminal.WithHeaderStyle())
 		c.UI.Output("Installation name: %s", common.DefaultReleaseName, terminal.WithInfoStyle())
@@ -268,7 +272,7 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
-	// TODO: Fix this!
+	// TODO: Fix this! We are just going to comment this in, because we do want to set global.name to consul if not set already.
 	//// Without informing the user, default global.name to consul if it hasn't been set already. We don't allow setting
 	//// the release name, and since that is hardcoded to "consul", setting global.name to "consul" makes it so resources
 	//// aren't double prefixed with "consul-consul-...".
@@ -306,7 +310,7 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// Setup the upgrade action.
-	// TODO: So many things to add here.
+	// TODO: So many things to add here. (Could add upgrade.<> features)
 	upgrade := action.NewUpgrade(actionConfig)
 	upgrade.Namespace = foundNamespace
 	upgrade.DryRun = c.flagDryRun

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -16,6 +16,7 @@ import (
 	"helm.sh/helm/v3/pkg/getter"
 
 	"github.com/hashicorp/consul-k8s/cli/cmd/common/terminal"
+	"github.com/hashicorp/consul-k8s/cli/config"
 	helmCLI "helm.sh/helm/v3/pkg/cli"
 
 	"github.com/hashicorp/consul-k8s/cli/cmd/install"
@@ -73,7 +74,6 @@ type Command struct {
 	timeoutDuration     time.Duration
 	flagVerbose         bool
 	flagWait            bool
-	flagInstall         bool
 
 	flagKubeConfig  string
 	flagKubeContext string
@@ -85,7 +85,7 @@ type Command struct {
 func (c *Command) init() {
 	// Store all the possible preset values in 'presetList'. Printed in the help message.
 	var presetList []string
-	for name := range install.Presets {
+	for name := range config.Presets {
 		presetList = append(presetList, name)
 	}
 
@@ -277,7 +277,7 @@ func (c *Command) Run(args []string) int {
 	// Without informing the user, default global.name to consul if it hasn't been set already. We don't allow setting
 	// the release name, and since that is hardcoded to "consul", setting global.name to "consul" makes it so resources
 	// aren't double prefixed with "consul-consul-...".
-	vals = install.MergeMaps(install.Convert(install.GlobalNameConsul), vals)
+	vals = install.MergeMaps(config.Convert(config.GlobalNameConsul), vals)
 
 	if !c.flagAutoApprove && !c.flagDryRun {
 		confirmation, err := c.UI.Input(&terminal.Input{
@@ -372,7 +372,7 @@ func (c *Command) validateFlags(args []string) error {
 	if len(c.flagValueFiles) != 0 && c.flagPreset != defaultPreset {
 		return fmt.Errorf("cannot set both -%s and -%s", flagNameConfigFile, flagNamePreset)
 	}
-	if _, ok := install.Presets[c.flagPreset]; c.flagPreset != defaultPreset && !ok {
+	if _, ok := config.Presets[c.flagPreset]; c.flagPreset != defaultPreset && !ok {
 		return fmt.Errorf("'%s' is not a valid preset", c.flagPreset)
 	}
 	if !validLabel(c.flagNamespace) {
@@ -436,7 +436,7 @@ func (c *Command) mergeValuesFlagsWithPrecedence(settings *helmCLI.EnvSettings) 
 	}
 	if c.flagPreset != defaultPreset {
 		// Note the ordering of the function call, presets have lower precedence than set vals.
-		presetMap := install.Presets[c.flagPreset].(map[string]interface{})
+		presetMap := config.Presets[c.flagPreset].(map[string]interface{})
 		vals = install.MergeMaps(presetMap, vals)
 	}
 	return vals, err

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -93,19 +93,19 @@ func (c *Command) init() {
 		Name:    flagNameDryRun,
 		Target:  &c.flagDryRun,
 		Default: defaultDryRun,
-		Usage:   "Run pre-install checks and display summary of installation.",
+		Usage:   "Run pre-upgrade checks and display summary of upgrade.",
 	})
 	f.StringSliceVar(&flag.StringSliceVar{
 		Name:    flagNameConfigFile,
 		Aliases: []string{"f"},
 		Target:  &c.flagValueFiles,
-		Usage:   "Path to a file to customize the installation, such as Consul Helm chart values file. Can be specified multiple times.",
+		Usage:   "Path to a file to customize the upgrade, such as Consul Helm chart values file. Can be specified multiple times.",
 	})
 	f.StringVar(&flag.StringVar{
 		Name:    flagNamePreset,
 		Target:  &c.flagPreset,
 		Default: defaultPreset,
-		Usage:   fmt.Sprintf("Use an installation preset, one of %s. Defaults to none", strings.Join(presetList, ", ")),
+		Usage:   fmt.Sprintf("Use an upgrade preset, one of %s. Defaults to none", strings.Join(presetList, ", ")),
 	})
 	f.StringSliceVar(&flag.StringSliceVar{
 		Name:   flagNameSetValues,
@@ -127,20 +127,20 @@ func (c *Command) init() {
 		Name:    flagNameTimeout,
 		Target:  &c.flagTimeout,
 		Default: defaultTimeout,
-		Usage:   "Timeout to wait for installation to be ready.",
+		Usage:   "Timeout to wait for upgrade to be ready.",
 	})
 	f.BoolVar(&flag.BoolVar{
 		Name:    flagNameVerbose,
 		Aliases: []string{"v"},
 		Target:  &c.flagVerbose,
 		Default: defaultVerbose,
-		Usage:   "Output verbose logs from the install command with the status of resources being installed.",
+		Usage:   "Output verbose logs from the upgrade command with the status of resources being upgraded.",
 	})
 	f.BoolVar(&flag.BoolVar{
 		Name:    flagNameWait,
 		Target:  &c.flagWait,
 		Default: defaultWait,
-		Usage:   "Determines whether to wait for resources in installation to be ready before exiting command.",
+		Usage:   "Determines whether to wait for resources in upgrade to be ready before exiting command.",
 	})
 
 	f = c.set.NewSet("Global Options")
@@ -228,7 +228,7 @@ func (c *Command) Run(args []string) int {
 		c.UI.Output("could not find existing Consul installation - run `consul-k8s install`")
 		return 1
 	} else {
-		c.UI.Output("Existing installation found.", terminal.WithSuccessStyle())
+		c.UI.Output("Existing installation found to be upgraded.", terminal.WithSuccessStyle())
 		c.UI.Output("Name: %s", name, terminal.WithInfoStyle())
 		c.UI.Output("Namespace: %s", ns, terminal.WithInfoStyle())
 
@@ -310,7 +310,7 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	// Create a *chart.Chart object from the files to run the installation from.
+	// Create a *chart.Chart object from the files to run the upgrade from.
 	chart, err := loader.LoadFiles(chartFiles)
 	if err != nil {
 		c.UI.Output(err.Error(), terminal.WithErrorStyle())
@@ -375,13 +375,13 @@ func (c *Command) validateFlags(args []string) error {
 	}
 
 	if c.flagDryRun {
-		c.UI.Output("Performing dry run installation.", terminal.WithInfoStyle())
+		c.UI.Output("Performing dry run upgrade.", terminal.WithInfoStyle())
 	}
 	return nil
 }
 
 // mergeValuesFlagsWithPrecedence is responsible for merging all the values to determine the values file for the
-// installation based on the following precedence order from lowest to highest:
+// upgrade based on the following precedence order from lowest to highest:
 // 1. -preset
 // 2. -f values-file
 // 3. -set

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -238,6 +238,7 @@ func (c *Command) Run(args []string) int {
 	// Note the logic here, common's CheckForInstallations function returns an error if
 	// the release is not found. In `upgrade` we should indeed error if a user doesn't currently have a release.
 	if name, ns, err := common.CheckForInstallations(settings, uiLogger); err != nil {
+		// TODO: Don't just error, install.
 		c.UI.Output(fmt.Sprintf("could not find existing Consul installation - run `consul-k8s install`"))
 		return 1
 	} else {

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -42,9 +42,6 @@ const (
 	flagNameAutoApprove = "auto-approve"
 	defaultAutoApprove  = false
 
-	flagNamespace    = "namespace"
-	defaultNamespace = "consul"
-
 	flagNameTimeout = "timeout"
 	defaultTimeout  = "10m"
 
@@ -65,7 +62,6 @@ type Command struct {
 	flagPreset          string
 	flagDryRun          bool
 	flagAutoApprove     bool
-	flagNamespace       string
 	flagValueFiles      []string
 	flagSetStringValues []string
 	flagSetValues       []string
@@ -293,7 +289,7 @@ func (c *Command) Run(args []string) int {
 	if !c.flagDryRun {
 		c.UI.Output("Running Upgrade", terminal.WithHeaderStyle())
 	} else {
-		c.UI.Output("Performing Dry Upgrade", terminal.WithHeaderStyle())
+		c.UI.Output("Performing Dry Run Upgrade", terminal.WithHeaderStyle())
 	}
 
 	// Setup action configuration for Helm Go SDK function calls.
@@ -324,9 +320,9 @@ func (c *Command) Run(args []string) int {
 		c.UI.Output(err.Error(), terminal.WithErrorStyle())
 		return 1
 	}
-	c.UI.Output("Downloaded charts", terminal.WithSuccessStyle())
+	c.UI.Output("Loaded charts", terminal.WithSuccessStyle())
 
-	// Run the install.
+	// Run the upgrade. Note that the dry run config is passed into the upgrade action, so upgrade.Run is called even during a dry run.
 	re, err := upgrade.Run(common.DefaultReleaseName, chart, vals)
 	if err != nil {
 		c.UI.Output(err.Error(), terminal.WithErrorStyle())

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -51,9 +51,6 @@ const (
 
 	flagNameWait = "wait"
 	defaultWait  = true
-	// action/upgrade
-	// --install, --reset-values vs --reuse-values,
-	// atomic
 )
 
 type Command struct {
@@ -64,6 +61,7 @@ type Command struct {
 	set *flag.Sets
 
 	flagPreset          string
+	flagNamespace       string
 	flagDryRun          bool
 	flagAutoApprove     bool
 	flagValueFiles      []string
@@ -108,6 +106,12 @@ func (c *Command) init() {
 		Aliases: []string{"f"},
 		Target:  &c.flagValueFiles,
 		Usage:   "Path to a file to customize the installation, such as Consul Helm chart values file. Can be specified multiple times.",
+	})
+	f.StringVar(&flag.StringVar{
+		Name:    flagNameNamespace,
+		Target:  &c.flagNamespace,
+		Default: common.DefaultReleaseNamespace,
+		Usage:   "Namespace for the Consul installation.",
 	})
 	f.StringVar(&flag.StringVar{
 		Name:    flagNamePreset,
@@ -233,17 +237,13 @@ func (c *Command) Run(args []string) int {
 
 	// Note the logic here, common's CheckForInstallations function returns an error if
 	// the release is not found. In `upgrade` we should indeed error if a user doesn't currently have a release.
-	foundNamespace := ""
 	if name, ns, err := common.CheckForInstallations(settings, uiLogger); err != nil {
-		// TODO: Don't just error, install.
 		c.UI.Output(fmt.Sprintf("could not find existing Consul installation - run `consul-k8s install`"))
 		return 1
 	} else {
 		c.UI.Output("Existing installation found.", terminal.WithSuccessStyle())
 		c.UI.Output("Name: %s", name, terminal.WithInfoStyle())
 		c.UI.Output("Namespace: %s", ns, terminal.WithInfoStyle())
-
-		foundNamespace = ns
 	}
 
 	// Handle preset, value files, and set values logic.
@@ -259,11 +259,10 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// Print out the upgrade summary.
-	// TODO: Fix this to show the diff between existing and proposed install rather than overrides.
 	if !c.flagAutoApprove {
 		c.UI.Output("Consul Upgrade Summary", terminal.WithHeaderStyle())
 		c.UI.Output("Installation name: %s", common.DefaultReleaseName, terminal.WithInfoStyle())
-		c.UI.Output("Namespace: %s", foundNamespace, terminal.WithInfoStyle())
+		c.UI.Output("Namespace: %s", c.flagNamespace, terminal.WithInfoStyle())
 
 		if len(vals) == 0 {
 			c.UI.Output("Overrides: "+string(valuesYaml), terminal.WithInfoStyle())
@@ -272,11 +271,10 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
-	// TODO: Fix this! We are just going to comment this in, because we do want to set global.name to consul if not set already.
-	//// Without informing the user, default global.name to consul if it hasn't been set already. We don't allow setting
-	//// the release name, and since that is hardcoded to "consul", setting global.name to "consul" makes it so resources
-	//// aren't double prefixed with "consul-consul-...".
-	//vals = install.MergeMaps(install.Convert(install.GlobalNameConsul), vals)
+	// Without informing the user, default global.name to consul if it hasn't been set already. We don't allow setting
+	// the release name, and since that is hardcoded to "consul", setting global.name to "consul" makes it so resources
+	// aren't double prefixed with "consul-consul-...".
+	vals = install.MergeMaps(install.Convert(install.GlobalNameConsul), vals)
 
 	if !c.flagAutoApprove && !c.flagDryRun {
 		confirmation, err := c.UI.Input(&terminal.Input{
@@ -303,16 +301,16 @@ func (c *Command) Run(args []string) int {
 
 	// Setup action configuration for Helm Go SDK function calls.
 	actionConfig := new(action.Configuration)
-	actionConfig, err = common.InitActionConfig(actionConfig, foundNamespace, settings, uiLogger)
+	actionConfig, err = common.InitActionConfig(actionConfig, c.flagNamespace, settings, uiLogger)
 	if err != nil {
 		c.UI.Output(err.Error(), terminal.WithErrorStyle())
 		return 1
 	}
 
 	// Setup the upgrade action.
-	// TODO: So many things to add here. (Could add upgrade.<> features)
+	// TODO: So many things to add here.
 	upgrade := action.NewUpgrade(actionConfig)
-	upgrade.Namespace = foundNamespace
+	upgrade.Namespace = c.flagNamespace
 	upgrade.DryRun = c.flagDryRun
 	upgrade.Wait = c.flagWait
 	upgrade.Timeout = c.timeoutDuration
@@ -341,6 +339,8 @@ func (c *Command) Run(args []string) int {
 
 	// Dry Run should exit here, printing the release's config.
 	if c.flagDryRun {
+		c.UI.Output("Dry run complete - upgrade can proceed.", terminal.WithInfoStyle())
+
 		configYaml, err := yaml.Marshal(re.Config)
 		if err != nil {
 			c.UI.Output(err.Error(), terminal.WithErrorStyle())
@@ -352,11 +352,11 @@ func (c *Command) Run(args []string) int {
 		} else {
 			c.UI.Output("Config:"+"\n"+string(configYaml), terminal.WithInfoStyle())
 		}
-		c.UI.Output("Dry run complete - upgrade can proceed.", terminal.WithSuccessStyle())
+
 		return 0
 	}
 
-	c.UI.Output("Upgraded Consul into namespace %q", foundNamespace, terminal.WithSuccessStyle())
+	c.UI.Output("Upgraded Consul into namespace %q", c.flagNamespace, terminal.WithSuccessStyle())
 
 	return 0
 }
@@ -376,6 +376,10 @@ func (c *Command) validateFlags(args []string) error {
 	}
 	if _, ok := install.Presets[c.flagPreset]; c.flagPreset != defaultPreset && !ok {
 		return fmt.Errorf("'%s' is not a valid preset", c.flagPreset)
+	}
+	if !validLabel(c.flagNamespace) {
+		return fmt.Errorf("'%s' is an invalid namespace. Namespaces follow the RFC 1123 label convention and must "+
+			"consist of a lower case alphanumeric character or '-' and must start/end with an alphanumeric", c.flagNamespace)
 	}
 	duration, err := time.ParseDuration(c.flagTimeout)
 	if err != nil {

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -51,6 +51,9 @@ const (
 
 	flagNameWait = "wait"
 	defaultWait  = true
+	// action/upgrade
+	// --install, --reset-values vs --reuse-values,
+	// atomic
 )
 
 type Command struct {
@@ -256,7 +259,7 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// Print out the upgrade summary.
-	// TODO: Fix this, it's just incorrect.
+	// TODO: Fix this to show the diff between existing and proposed install rather than overrides.
 	if !c.flagAutoApprove {
 		c.UI.Output("Consul Upgrade Summary", terminal.WithHeaderStyle())
 		c.UI.Output("Installation name: %s", common.DefaultReleaseName, terminal.WithInfoStyle())
@@ -269,7 +272,7 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
-	// TODO: Fix this!
+	// TODO: Fix this! We are just going to comment this in, because we do want to set global.name to consul if not set already.
 	//// Without informing the user, default global.name to consul if it hasn't been set already. We don't allow setting
 	//// the release name, and since that is hardcoded to "consul", setting global.name to "consul" makes it so resources
 	//// aren't double prefixed with "consul-consul-...".
@@ -307,7 +310,7 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// Setup the upgrade action.
-	// TODO: So many things to add here.
+	// TODO: So many things to add here. (Could add upgrade.<> features)
 	upgrade := action.NewUpgrade(actionConfig)
 	upgrade.Namespace = foundNamespace
 	upgrade.DryRun = c.flagDryRun

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -61,7 +61,6 @@ type Command struct {
 	set *flag.Sets
 
 	flagPreset          string
-	flagNamespace       string
 	flagDryRun          bool
 	flagAutoApprove     bool
 	flagValueFiles      []string
@@ -106,12 +105,6 @@ func (c *Command) init() {
 		Aliases: []string{"f"},
 		Target:  &c.flagValueFiles,
 		Usage:   "Path to a file to customize the installation, such as Consul Helm chart values file. Can be specified multiple times.",
-	})
-	f.StringVar(&flag.StringVar{
-		Name:    flagNameNamespace,
-		Target:  &c.flagNamespace,
-		Default: common.DefaultReleaseNamespace,
-		Usage:   "Namespace for the Consul installation.",
 	})
 	f.StringVar(&flag.StringVar{
 		Name:    flagNamePreset,
@@ -237,6 +230,7 @@ func (c *Command) Run(args []string) int {
 
 	// Note the logic here, common's CheckForInstallations function returns an error if
 	// the release is not found. In `upgrade` we should indeed error if a user doesn't currently have a release.
+	foundNamespace := ""
 	if name, ns, err := common.CheckForInstallations(settings, uiLogger); err != nil {
 		// TODO: Don't just error, install.
 		c.UI.Output(fmt.Sprintf("could not find existing Consul installation - run `consul-k8s install`"))
@@ -245,6 +239,8 @@ func (c *Command) Run(args []string) int {
 		c.UI.Output("Existing installation found.", terminal.WithSuccessStyle())
 		c.UI.Output("Name: %s", name, terminal.WithInfoStyle())
 		c.UI.Output("Namespace: %s", ns, terminal.WithInfoStyle())
+
+		foundNamespace = ns
 	}
 
 	// Handle preset, value files, and set values logic.
@@ -263,7 +259,7 @@ func (c *Command) Run(args []string) int {
 	if !c.flagAutoApprove {
 		c.UI.Output("Consul Upgrade Summary", terminal.WithHeaderStyle())
 		c.UI.Output("Installation name: %s", common.DefaultReleaseName, terminal.WithInfoStyle())
-		c.UI.Output("Namespace: %s", c.flagNamespace, terminal.WithInfoStyle())
+		c.UI.Output("Namespace: %s", foundNamespace, terminal.WithInfoStyle())
 
 		if len(vals) == 0 {
 			c.UI.Output("Overrides: "+string(valuesYaml), terminal.WithInfoStyle())
@@ -272,10 +268,11 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
-	// Without informing the user, default global.name to consul if it hasn't been set already. We don't allow setting
-	// the release name, and since that is hardcoded to "consul", setting global.name to "consul" makes it so resources
-	// aren't double prefixed with "consul-consul-...".
-	vals = install.MergeMaps(install.Convert(install.GlobalNameConsul), vals)
+	// TODO: Fix this!
+	//// Without informing the user, default global.name to consul if it hasn't been set already. We don't allow setting
+	//// the release name, and since that is hardcoded to "consul", setting global.name to "consul" makes it so resources
+	//// aren't double prefixed with "consul-consul-...".
+	//vals = install.MergeMaps(install.Convert(install.GlobalNameConsul), vals)
 
 	if !c.flagAutoApprove && !c.flagDryRun {
 		confirmation, err := c.UI.Input(&terminal.Input{
@@ -302,7 +299,7 @@ func (c *Command) Run(args []string) int {
 
 	// Setup action configuration for Helm Go SDK function calls.
 	actionConfig := new(action.Configuration)
-	actionConfig, err = common.InitActionConfig(actionConfig, c.flagNamespace, settings, uiLogger)
+	actionConfig, err = common.InitActionConfig(actionConfig, foundNamespace, settings, uiLogger)
 	if err != nil {
 		c.UI.Output(err.Error(), terminal.WithErrorStyle())
 		return 1
@@ -311,7 +308,7 @@ func (c *Command) Run(args []string) int {
 	// Setup the upgrade action.
 	// TODO: So many things to add here.
 	upgrade := action.NewUpgrade(actionConfig)
-	upgrade.Namespace = c.flagNamespace
+	upgrade.Namespace = foundNamespace
 	upgrade.DryRun = c.flagDryRun
 	upgrade.Wait = c.flagWait
 	upgrade.Timeout = c.timeoutDuration
@@ -340,8 +337,6 @@ func (c *Command) Run(args []string) int {
 
 	// Dry Run should exit here, printing the release's config.
 	if c.flagDryRun {
-		c.UI.Output("Dry run complete - upgrade can proceed.", terminal.WithInfoStyle())
-
 		configYaml, err := yaml.Marshal(re.Config)
 		if err != nil {
 			c.UI.Output(err.Error(), terminal.WithErrorStyle())
@@ -353,11 +348,11 @@ func (c *Command) Run(args []string) int {
 		} else {
 			c.UI.Output("Config:"+"\n"+string(configYaml), terminal.WithInfoStyle())
 		}
-
+		c.UI.Output("Dry run complete - upgrade can proceed.", terminal.WithSuccessStyle())
 		return 0
 	}
 
-	c.UI.Output("Upgraded Consul into namespace %q", c.flagNamespace, terminal.WithSuccessStyle())
+	c.UI.Output("Upgraded Consul into namespace %q", foundNamespace, terminal.WithSuccessStyle())
 
 	return 0
 }
@@ -377,10 +372,6 @@ func (c *Command) validateFlags(args []string) error {
 	}
 	if _, ok := install.Presets[c.flagPreset]; c.flagPreset != defaultPreset && !ok {
 		return fmt.Errorf("'%s' is not a valid preset", c.flagPreset)
-	}
-	if !validLabel(c.flagNamespace) {
-		return fmt.Errorf("'%s' is an invalid namespace. Namespaces follow the RFC 1123 label convention and must "+
-			"consist of a lower case alphanumeric character or '-' and must start/end with an alphanumeric", c.flagNamespace)
 	}
 	duration, err := time.ParseDuration(c.flagTimeout)
 	if err != nil {

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -97,12 +97,6 @@ func (c *Command) init() {
 		Default: defaultAutoApprove,
 		Usage:   "Skip confirmation prompt.",
 	})
-	f.StringVar(&flag.StringVar{
-		Name:    flagNamespace,
-		Target:  &c.flagNamespace,
-		Default: defaultNamespace,
-		Usage:   "Namespace where Consul is installed. Defaults to 'consul'.",
-	})
 	f.BoolVar(&flag.BoolVar{
 		Name:    flagNameDryRun,
 		Target:  &c.flagDryRun,
@@ -375,10 +369,6 @@ func (c *Command) validateFlags(args []string) error {
 	if _, ok := config.Presets[c.flagPreset]; c.flagPreset != defaultPreset && !ok {
 		return fmt.Errorf("'%s' is not a valid preset", c.flagPreset)
 	}
-	if !validLabel(c.flagNamespace) {
-		return fmt.Errorf("'%s' is an invalid namespace. Namespaces follow the RFC 1123 label convention and must "+
-			"consist of a lower case alphanumeric character or '-' and must start/end with an alphanumeric", c.flagNamespace)
-	}
 	duration, err := time.ParseDuration(c.flagTimeout)
 	if err != nil {
 		return fmt.Errorf("unable to parse -%s: %s", flagNameTimeout, err)
@@ -396,21 +386,6 @@ func (c *Command) validateFlags(args []string) error {
 		c.UI.Output("Performing dry run installation.", terminal.WithInfoStyle())
 	}
 	return nil
-}
-
-// validLabel is a helper function that checks if a string follows RFC 1123 labels.
-func validLabel(s string) bool {
-	for i, c := range s {
-		alphanum := ('a' <= c && c <= 'z') || ('0' <= c && c <= '9')
-		// If the character is not the last or first, it can be a dash.
-		if i != 0 && i != (len(s)-1) {
-			alphanum = alphanum || (c == '-')
-		}
-		if !alphanum {
-			return false
-		}
-	}
-	return true
 }
 
 // mergeValuesFlagsWithPrecedence is responsible for merging all the values to determine the values file for the

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -390,22 +390,6 @@ func (c *Command) validateFlags(args []string) error {
 	return nil
 }
 
-// TODO: Make sure the following function is consistent.
-// validLabel checks if a string follows RFC 1123 labels.
-func validLabel(s string) bool {
-	for i, c := range s {
-		alphanum := ('a' <= c && c <= 'z') || ('0' <= c && c <= '9')
-		// If the character is not the last or first, it can be a dash.
-		if i != 0 && i != (len(s)-1) {
-			alphanum = alphanum || (c == '-')
-		}
-		if !alphanum {
-			return false
-		}
-	}
-	return true
-}
-
 // mergeValuesFlagsWithPrecedence is responsible for merging all the values to determine the values file for the
 // installation based on the following precedence order from lowest to highest:
 // 1. -preset

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -41,7 +41,8 @@ const (
 	flagNameAutoApprove = "auto-approve"
 	defaultAutoApprove  = false
 
-	flagNameNamespace = "namespace"
+	flagNamespace    = "namespace"
+	defaultNamespace = "consul"
 
 	flagNameTimeout = "timeout"
 	defaultTimeout  = "10m"
@@ -51,9 +52,9 @@ const (
 
 	flagNameWait = "wait"
 	defaultWait  = true
-	// action/upgrade
-	// --install, --reset-values vs --reuse-values,
-	// atomic
+
+	flagInstall    = "install"
+	defaultInstall = false
 )
 
 type Command struct {
@@ -66,6 +67,7 @@ type Command struct {
 	flagPreset          string
 	flagDryRun          bool
 	flagAutoApprove     bool
+	flagNamespace       string
 	flagValueFiles      []string
 	flagSetStringValues []string
 	flagSetValues       []string
@@ -74,6 +76,7 @@ type Command struct {
 	timeoutDuration     time.Duration
 	flagVerbose         bool
 	flagWait            bool
+	flagInstall         bool
 
 	flagKubeConfig  string
 	flagKubeContext string
@@ -96,6 +99,12 @@ func (c *Command) init() {
 		Target:  &c.flagAutoApprove,
 		Default: defaultAutoApprove,
 		Usage:   "Skip confirmation prompt.",
+	})
+	f.StringVar(&flag.StringVar{
+		Name:    flagNamespace,
+		Target:  &c.flagNamespace,
+		Default: defaultNamespace,
+		Usage:   "Namespace where Consul is installed. Defaults to 'consul'.",
 	})
 	f.BoolVar(&flag.BoolVar{
 		Name:    flagNameDryRun,
@@ -149,6 +158,12 @@ func (c *Command) init() {
 		Target:  &c.flagWait,
 		Default: defaultWait,
 		Usage:   "Determines whether to wait for resources in installation to be ready before exiting command.",
+	})
+	f.BoolVar(&flag.BoolVar{
+		Name:    flagInstall,
+		Target:  &c.flagInstall,
+		Default: defaultInstall,
+		Usage:   "Fall back to installing Consul if not already installed. Defaults to false.",
 	})
 
 	f = c.set.NewSet("Global Options")

--- a/cli/cmd/upgrade/upgrade_test.go
+++ b/cli/cmd/upgrade/upgrade_test.go
@@ -1,0 +1,35 @@
+package upgrade
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/consul-k8s/cli/cmd/common"
+	"github.com/hashicorp/go-hclog"
+)
+
+/* Just using this to play around with the Go debugger. */
+func TestDebugger(t *testing.T) {
+	c := getInitializedCommand(t)
+	c.Run([]string{"-dry-run"})
+}
+
+// getInitializedCommand sets up a command struct for tests.
+func getInitializedCommand(t *testing.T) *Command {
+	t.Helper()
+	log := hclog.New(&hclog.LoggerOptions{
+		Name:   "cli",
+		Level:  hclog.Info,
+		Output: os.Stdout,
+	})
+
+	baseCommand := &common.BaseCommand{
+		Log: log,
+	}
+
+	c := &Command{
+		BaseCommand: baseCommand,
+	}
+	c.init()
+	return c
+}

--- a/cli/cmd/upgrade/upgrade_test.go
+++ b/cli/cmd/upgrade/upgrade_test.go
@@ -11,7 +11,7 @@ import (
 /* Just using this to play around with the Go debugger. */
 func TestDebugger(t *testing.T) {
 	c := getInitializedCommand(t)
-	c.Run([]string{"-dry-run"})
+	c.Run([]string{"-set=\"connectInject.enabled=false\"", "-auto-approve"})
 }
 
 // getInitializedCommand sets up a command struct for tests.

--- a/cli/cmd/upgrade/upgrade_test.go
+++ b/cli/cmd/upgrade/upgrade_test.go
@@ -32,10 +32,6 @@ func TestValidateFlags(t *testing.T) {
 			[]string{"-timeout=invalid-timeout"},
 		},
 		{
-			"Should error on an invalid namespace.",
-			[]string{"-namespace=\" nsWithSpace\""},
-		},
-		{
 			"Should have errored on a non-existant file.",
 			[]string{"-f=\"does_not_exist.txt\""},
 		},

--- a/cli/cmd/upgrade/upgrade_test.go
+++ b/cli/cmd/upgrade/upgrade_test.go
@@ -8,12 +8,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-/* Just using this to play around with the Go debugger. */
-func TestDebugger(t *testing.T) {
-	c := getInitializedCommand(t)
-	c.Run([]string{"-set=\"connectInject.enabled=false\"", "-auto-approve"})
-}
-
 // getInitializedCommand sets up a command struct for tests.
 func getInitializedCommand(t *testing.T) *Command {
 	t.Helper()

--- a/cli/cmd/upgrade/upgrade_test.go
+++ b/cli/cmd/upgrade/upgrade_test.go
@@ -11,7 +11,7 @@ import (
 /* Just using this to play around with the Go debugger. */
 func TestDebugger(t *testing.T) {
 	c := getInitializedCommand(t)
-	c.Run([]string{"-set=\"connectInject.enabled=false\"", "-auto-approve"})
+	c.Run([]string{"-dry-run"})
 }
 
 // getInitializedCommand sets up a command struct for tests.

--- a/cli/cmd/upgrade/upgrade_test.go
+++ b/cli/cmd/upgrade/upgrade_test.go
@@ -8,6 +8,49 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
+// TestValidateFlags tests the validate flags function.
+func TestValidateFlags(t *testing.T) {
+	// The following cases should all error, if they fail to this test fails.
+	testCases := []struct {
+		description string
+		input       []string
+	}{
+		{
+			"Should disallow non-flag arguments.",
+			[]string{"foo", "-auto-approve"},
+		},
+		{
+			"Should disallow specifying both values file AND presets.",
+			[]string{"-f='f.txt'", "-preset=demo"},
+		},
+		{
+			"Should error on invalid presets.",
+			[]string{"-preset=foo"},
+		},
+		{
+			"Should error on invalid timeout.",
+			[]string{"-timeout=invalid-timeout"},
+		},
+		{
+			"Should error on an invalid namespace.",
+			[]string{"-namespace=\" nsWithSpace\""},
+		},
+		{
+			"Should have errored on a non-existant file.",
+			[]string{"-f=\"does_not_exist.txt\""},
+		},
+	}
+
+	for _, testCase := range testCases {
+		c := getInitializedCommand(t)
+		t.Run(testCase.description, func(t *testing.T) {
+			if err := c.validateFlags(testCase.input); err == nil {
+				t.Errorf("Test case should have failed.")
+			}
+		})
+	}
+}
+
 // getInitializedCommand sets up a command struct for tests.
 func getInitializedCommand(t *testing.T) *Command {
 	t.Helper()

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/consul-k8s/cli/cmd/install"
 	"github.com/hashicorp/consul-k8s/cli/cmd/status"
 	"github.com/hashicorp/consul-k8s/cli/cmd/uninstall"
+	"github.com/hashicorp/consul-k8s/cli/cmd/upgrade"
 	cmdversion "github.com/hashicorp/consul-k8s/cli/cmd/version"
 	"github.com/hashicorp/consul-k8s/cli/version"
 	"github.com/hashicorp/go-hclog"
@@ -33,6 +34,11 @@ func initializeCommands(ctx context.Context, log hclog.Logger) (*common.BaseComm
 		},
 		"status": func() (cli.Command, error) {
 			return &status.Command{
+				BaseCommand: baseCommand,
+			}, nil
+		},
+		"upgrade": func() (cli.Command, error) {
+			return &upgrade.Command{
 				BaseCommand: baseCommand,
 			}, nil
 		},

--- a/cli/config/presets.go
+++ b/cli/config/presets.go
@@ -1,4 +1,4 @@
-package install
+package config
 
 import "sigs.k8s.io/yaml"
 
@@ -13,7 +13,7 @@ var Presets = map[string]interface{}{
 	PresetSecure: Convert(secure),
 }
 
-var demo = `
+const demo = `
 global:
   name: consul
 connectInject:
@@ -24,6 +24,7 @@ server:
 `
 
 // TODO: I don't know why the following hangs for me.
+// TODO: This was hanging for Saad. I will look into it.
 //var demo = `
 //global:
 //  name: consul
@@ -48,7 +49,7 @@ server:
 //  enabled: true
 //`
 
-var secure = `
+const secure = `
 global:
   name: consul
   gossipEncryption:
@@ -66,7 +67,7 @@ controller:
   enabled: true
 `
 
-var GlobalNameConsul = `
+const GlobalNameConsul = `
 global:
   name: consul
 `

--- a/cli/config/presets.go
+++ b/cli/config/presets.go
@@ -13,42 +13,32 @@ var Presets = map[string]interface{}{
 	PresetSecure: Convert(secure),
 }
 
+// demo is a preset of common values for setting up Consul.
 const demo = `
 global:
   name: consul
+  metrics:
+    enabled: true
+    enableAgentMetrics: true
 connectInject:
   enabled: true
+  metrics:
+    defaultEnabled: true
+    defaultEnableMerging: true
+    enableGatewayMetrics: true
 server:
   replicas: 1
-  bootstrapExpect: 1
+controller:
+  enabled: true
+ui:
+  enabled: true
+  service:
+    enabled: true
+prometheus:
+  enabled: true
 `
 
-// TODO: I don't know why the following hangs for me.
-// TODO: This was hanging for Saad. I will look into it.
-//var demo = `
-//global:
-//  name: consul
-//  metrics:
-//    enabled: true
-//    enableAgentMetrics: true
-//connectInject:
-//  enabled: true
-//  metrics:
-//    defaultEnabled: true
-//    defaultEnableMerging: true
-//    enableGatewayMetrics: true
-//server:
-//  replicas: 1
-//controller:
-//  enabled: true
-//ui:
-//  enabled: true
-//  service:
-//    enabled: true
-//prometheus:
-//  enabled: true
-//`
-
+// secure is a preset of common values for setting up Consul in a secure manner.
 const secure = `
 global:
   name: consul
@@ -67,6 +57,7 @@ controller:
   enabled: true
 `
 
+// GlobalNameConsul is used to set the global name of an install to consul.
 const GlobalNameConsul = `
 global:
   name: consul


### PR DESCRIPTION
This is a wrap-up of Saad's excellent work on the Upgrade command. There will need to be some refactors following this, but functionality is solid.

Changes proposed in this PR:
- Made an initial try at the consul-k8s upgrade command. Running into issues with the connect-injector webhook not starting on an install?
- Upgrade commit
- First pass at upgrade was successful.
- notes from sync with Saad on what's left
- Made an initial try at the consul-k8s upgrade command. Running into issues with the connect-injector webhook not starting on an install?
- Upgrade commit
- First pass at upgrade was successful.
- notes from sync with Saad on what's left
- Some basic cleanup
- Remove TestDebugger
- Remove validateLabels (unused)
- Add the namespace and install flags
- Add flag test and remove install option

How I've tested this PR:

Checkout an older version of the CLI and compile it.

``` bash
cd cli
git checkout tags/v0.37.0
go build -o consul-k8s-0-37-0
```

Checkout this version and compile it

``` bash
git checkout cli-upgrade
go build -o consul-k8s-latest
```

Install Consul with the older version, optionally include a preset.

``` bash 
./consul-k8s-0-37-0 install [-preset demo]
```

Apply a static server/client pair to the cluster.

<details>
<summary>K8s Config</summary>
<br>

``` yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: static-client
spec:
  replicas: 1
  selector:
    matchLabels:
      app: static-client
  template:
    metadata:
      name: static-client
      labels:
        app: static-client
      annotations:
        "consul.hashicorp.com/connect-inject": "true"
        "consul.hashicorp.com/connect-service-upstreams": "static-server:1234"
    spec:
      containers:
        - name: static-client
          image: docker.mirror.hashicorp.services/curlimages/curl:latest
          command: [ "/bin/sh", "-c", "--" ]
          args: [ "while true; do sleep 30; done;" ]
          env:
          - name: HOST_IP
            valueFrom:
              fieldRef:
                fieldPath: status.hostIP
      serviceAccountName: static-client
      terminationGracePeriodSeconds: 0 # so deletion is quick
---
apiVersion: v1
kind: Service
metadata:
  name: static-client
spec:
  selector:
    app: static-client
  ports:
    - port: 80
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: static-client
---
apiVersion: v1
kind: Service
metadata:
  name: static-server
spec:
  selector:
    app: static-server
  ports:
    - protocol: TCP
      port: 80
      targetPort: 8080
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: static-server
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: static-server
spec:
  replicas: 1
  selector:
    matchLabels:
      app: static-server
  template:
    metadata:
      name: static-server
      labels:
        app: static-server
      annotations:
        'consul.hashicorp.com/connect-inject': 'true'
    spec:
      containers:
        - name: static-server
          image: hashicorp/http-echo:latest
          args:
            - -text="hello world"
            - -listen=:8080
          ports:
            - containerPort: 8080
              name: http
      serviceAccountName: static-server
---
apiVersion: consul.hashicorp.com/v1alpha1
kind: ServiceIntentions
metadata:
  name: static-server
spec:
  destination:
    name: static-server
  sources:
    - name: static-client
      action: allow
```
</details>

Exec into the client pod

``` bash
kubectl exec <client-pod-name> -it /sh
```

In the client pod, cURL the server pod:

``` bash
curl http://localhost:1234
```

You should receive "hello, world" back. Exit the pod.

Now perform the upgrade with the latest version of the CLI, optionally modifying the preset.

``` bash
./consul-k8s-latest upgrade [-preset secure]
```

Exec into the client pod again, cURL the server pod, and ensure that you still receive "hello, world".

How I expect reviewers to test this PR:

You can do what I did above. I believe in you.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)


