### PR TITLE
Support annotation service-tags: $POD_NAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ FEATURES:
 
 IMPROVEMENTS:
 * Control Plane
-  * Bump `consul-k8s-control-plane` UBI images for OpenShift to use base image `ubi-minimal:8.5`: [[GH-922](https://github.com/hashicorp/consul-k8s/pull/922)]
+  * Bump `consul-k8s-control-plane` UBI images for OpenShift to use base image `ubi-minimal:8.5`. [[GH-922](https://github.com/hashicorp/consul-k8s/pull/922)]
+  * Support the value `$POD_NAME` for the annotation `consul.hashicorp.com/service-tags` that will now be interpolated and set to the pod name. [[GH-931](https://github.com/hashicorp/consul-k8s/pull/931)]
  
 
 ## 0.38.0 (December 08, 2021)

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -886,8 +886,8 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 				pod1.Annotations[annotationService] = "different-consul-svc-name"
 				pod1.Annotations[fmt.Sprintf("%sname", annotationMeta)] = "abc"
 				pod1.Annotations[fmt.Sprintf("%sversion", annotationMeta)] = "2"
-				pod1.Annotations[annotationTags] = "abc,123"
-				pod1.Annotations[annotationConnectTags] = "def,456"
+				pod1.Annotations[annotationTags] = "abc,123,$POD_NAME"
+				pod1.Annotations[annotationConnectTags] = "def,456,$POD_NAME"
 				pod1.Annotations[annotationUpstreams] = "upstream1:1234"
 				pod1.Annotations[annotationEnableMetrics] = "true"
 				pod1.Annotations[annotationPrometheusScrapePort] = "12345"
@@ -930,7 +930,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 						MetaKeyKubeNS:          "default",
 						MetaKeyManagedBy:       managedByValue,
 					},
-					ServiceTags: []string{"abc", "123", "def", "456"},
+					ServiceTags: []string{"abc", "123", "pod1", "def", "456", "pod1"},
 				},
 			},
 			expectedProxySvcInstances: []*api.CatalogService{
@@ -963,7 +963,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 						MetaKeyKubeNS:          "default",
 						MetaKeyManagedBy:       managedByValue,
 					},
-					ServiceTags: []string{"abc", "123", "def", "456"},
+					ServiceTags: []string{"abc", "123", "pod1", "def", "456", "pod1"},
 				},
 			},
 			expectedAgentHealthChecks: []*api.AgentCheck{


### PR DESCRIPTION
Support the annotation

```
consul.hashicorp.com/service-tags: $POD_NAME
```

Where $POD_NAME will be replaced with the Pod's name.

This mimics support we had before the endpoints controller
where environment variable were interpolated for tags.

This PR only supports $POD_NAME for now because it's the only
environment variable we've been asked to support.

How I've tested this PR: unit tests

How I expect reviewers to test this PR: code

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

