### PR TITLE
Add new value ui.dashboardURLTemplates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 IMPROVEMENTS:
 * Helm
   * Allow customization of `terminationGracePeriodSeconds` on the ingress gateways. [[GH-947](https://github.com/hashicorp/consul-k8s/pull/947)]
+  * Support `ui.dashboardURLTemplates.service` value for setting [dashboard URL templates](https://www.consul.io/docs/agent/options#ui_config_dashboard_url_templates_service). [[GH-937](https://github.com/hashicorp/consul-k8s/pull/937)]
 
 BUG FIXES:
 * Helm

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -295,6 +295,9 @@ spec:
                 {{- end }}
                 {{- if .Values.ui.enabled }}
                 -ui \
+                {{- if .Values.ui.dashboardURLTemplates.service }}
+                -hcl='ui_config { dashboard_url_templates { service = "{{ .Values.ui.dashboardURLTemplates.service }}" } }' \
+                {{- end }}
                 {{- end }}
                 {{- $serverSerfLANPort  := .Values.server.ports.serflan.port -}}
                 {{- range $index := until (.Values.server.replicas | int) }}

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1785,3 +1785,20 @@ load _helpers
     yq -r '.containers[0].volumeMounts[] | select(.name == "consul-ca-key")' | tee /dev/stderr)
   [ "${actual}" = "" ]
 }
+
+#--------------------------------------------------------------------
+# ui.dashboardURLTemplates.service
+
+@test "server/StatefulSet: ui.dashboardURLTemplates.service sets the template" {
+  cd `chart_dir`
+
+  local expected='-hcl='\''ui_config { dashboard_url_templates { service = \"http://localhost:3000/d/WkFEBmF7z/services?orgId=1&var-Service={{Service.Name}}\" } }'
+
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'ui.dashboardURLTemplates.service=http://localhost:3000/d/WkFEBmF7z/services?orgId=1&var-Service={{Service.Name}}' \
+      . | tee /dev/stderr |
+      yq -r ".spec.template.spec.containers[0].command | any(contains(\"$expected\"))" | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1789,6 +1789,17 @@ load _helpers
 #--------------------------------------------------------------------
 # ui.dashboardURLTemplates.service
 
+@test "server/StatefulSet: dashboard_url_templates not set by default" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      . | tee /dev/stderr |
+      yq -r ".spec.template.spec.containers[0].command | any(contains(\"dashboard_url_templates\"))" | tee /dev/stderr)
+
+  [ "${actual}" = "false" ]
+}
+
 @test "server/StatefulSet: ui.dashboardURLTemplates.service sets the template" {
   cd `chart_dir`
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1398,6 +1398,11 @@ ui:
     # @type: string
     baseURL: http://prometheus-server
 
+  # Corresponds to https://www.consul.io/docs/agent/options#ui_config_dashboard_url_templates configuration.
+  dashboardURLTemplates:
+    # Sets https://www.consul.io/docs/agent/options#ui_config_dashboard_url_templates_service.
+    service: ""
+
 # Configure the catalog sync process to sync K8S with Consul
 # services. This can run bidirectional (default) or unidirectionally (Consul
 # to K8S or K8S to Consul only).


### PR DESCRIPTION
This value is used to set Consul's `ui_config.dashboard_url_templates`
config. I'm pulling it out as its own value rather than getting users
to just use `server.extraConfig` because these template strings always
use the characters `{{` and when used within `server.extraConfig`,
users need to escape those characters.

Before:

```yaml
server:
  extraConfig: |
    {
      "ui_config": {
        "dashboard_url_templates": {
          "service": "http://grafana/service/{{ "{{" }}Service.Name}}"
        }
      }
    }
```

Now:

```yaml
ui:
  dashboardURLTemplates:
    service: "http://grafana/service/{{Service.Name}}"
```

How I've tested this PR:
- tests and manual deployment

How I expect reviewers to test this PR:
- code

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
