### PR TITLE
[charts/consul] - Enable terminationGracePeriodSeconds customization on ingressGateway

### DIFF
--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -88,7 +88,7 @@ spec:
       tolerations:
         {{ tpl (default $defaults.tolerations .tolerations) $root | nindent 8 | trim }}
       {{- end }}
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: {{ default $defaults.terminationGracePeriodSeconds .terminationGracePeriodSeconds }}
       serviceAccountName: {{ template "consul.fullname" $root }}-{{ .name }}
       volumes:
         - name: consul-bin

--- a/charts/consul/test/unit/ingress-gateways-deployment.bats
+++ b/charts/consul/test/unit/ingress-gateways-deployment.bats
@@ -1610,3 +1610,29 @@ EOF
   local actual=$(echo $object | yq -r '.metadata.annotations."vault.hashicorp.com/ca-cert"')
   [ "${actual}" = "/vault/custom/tls.crt" ]
 }
+
+#--------------------------------------------------------------------
+# terminationGracePeriodSeconds
+
+@test "ingressGateways/Deployment: terminationGracePeriodSeconds defaults to 10" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.terminationGracePeriodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "10" ]
+}
+
+@test "ingressGateways/Deployment: terminationGracePeriodSeconds set defaults to 30" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.terminationGracePeriodSeconds=30' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.terminationGracePeriodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "30" ]
+}

--- a/charts/consul/test/unit/ingress-gateways-deployment.bats
+++ b/charts/consul/test/unit/ingress-gateways-deployment.bats
@@ -1614,7 +1614,7 @@ EOF
 #--------------------------------------------------------------------
 # terminationGracePeriodSeconds
 
-@test "ingressGateways/Deployment: terminationGracePeriodSeconds defaults to 10" {
+@test "ingressGateways/Deployment: can set terminationGracePeriodSeconds through defaults" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/ingress-gateways-deployment.yaml  \
@@ -1625,12 +1625,15 @@ EOF
   [ "${actual}" = "10" ]
 }
 
-@test "ingressGateways/Deployment: terminationGracePeriodSeconds set defaults to 30" {
+@test "ingressGateways/Deployment: can set terminationGracePeriodSeconds through specific gateway overriding defaults" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/ingress-gateways-deployment.yaml  \
       --set 'ingressGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.replicas=3' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'ingressGateways.gateways[0].replicas=12' \
       --set 'ingressGateways.defaults.terminationGracePeriodSeconds=30' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.terminationGracePeriodSeconds' | tee /dev/stderr)

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2304,7 +2304,7 @@ ingressGateways:
     # Optional priorityClassName.
     priorityClassName: ""
 
-    # Amount of seconds to wait before killing the pod
+    # Amount of seconds to wait for graceful termination before killing the pod.
     terminationGracePeriodSeconds: 10
 
     # Annotations to apply to the ingress gateway deployment. Annotations defined

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2304,6 +2304,9 @@ ingressGateways:
     # Optional priorityClassName.
     priorityClassName: ""
 
+    # Amount of seconds to wait before killing the pod
+    terminationGracePeriodSeconds: 10
+
     # Annotations to apply to the ingress gateway deployment. Annotations defined
     # here will be applied to all ingress gateway deployments in addition to any
     # annotations defined for a specific gateway in `ingressGateways.gateways`.


### PR DESCRIPTION
Signed-off-by: Lord-Y <Lord-Y@users.noreply.github.com>

Changes proposed in this PR:
- Enable terminationGracePeriodSeconds customization

How I've tested this PR:

Yes:

```bash
...
.......
 ✓ ingressGateways/Deployment: namespace command flag is specified through defaults
 ✓ ingressGateways/Deployment: namespace command flag is specified through specific gateway overriding defaults
 ✓ ingressGateways/Deployment: partition command flag is not present by default
 ✓ ingressGateways/Deployment: partition command flag is specified through partition name
 ✓ ingressGateways/Deployment: fails if admin partitions are enabled but namespaces aren't
 ✓ ingressGateways/Deployment: multiple gateways
 ✓ ingressGateway/Deployment: vault tls annotations are set when tls is enabled
 ✓ ingressGateway/Deployment: vault CA is not configured by default
 ✓ ingressGateway/Deployment: vault CA is not configured when secretName is set but secretKey is not
 ✓ ingressGateway/Deployment: vault CA is not configured when secretKey is set but secretName is not
 ✓ ingressGateway/Deployment: vault CA is configured when both secretName and secretKey are set
 ✓ ingressGateways/Deployment: terminationGracePeriodSeconds defaults to 10
 ✓ ingressGateways/Deployment: terminationGracePeriodSeconds set defaults to 30

91 tests, 0 failures
```

How I expect reviewers to test this PR:

Checklist:
- [x] Tests added

