### PR TITLE
fix: add license to snapshot-agent

### DIFF
--- a/charts/consul/templates/client-snapshot-agent-deployment.yaml
+++ b/charts/consul/templates/client-snapshot-agent-deployment.yaml
@@ -62,12 +62,11 @@ spec:
         {{- if .Values.global.acls.manageSystemACLs }}
         - name: aclconfig
           emptyDir: {}
-        {{- else }}
+        {{- end }}
         {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload) }}
         - name: consul-license
           secret:
             secretName: {{ .Values.global.enterpriseLicense.secretName }}
-        {{- end }}
         {{- end }}
         {{- if .Values.global.tls.enabled }}
         {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
@@ -112,12 +111,11 @@ spec:
                 secretKeyRef:
                   name: "{{ template "consul.fullname" . }}-client-snapshot-agent-acl-token"
                   key: "token"
-            {{- else }}
+            {{- end }}
             {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload) }}
             - name: CONSUL_LICENSE_PATH
               value: /consul/license/{{ .Values.global.enterpriseLicense.secretKey }}
             {{- end }}
-            {{- end}}
           command:
             - "/bin/sh"
             - "-ec"
@@ -144,12 +142,11 @@ spec:
             {{- if .Values.global.acls.manageSystemACLs }}
             - name: aclconfig
               mountPath: /consul/aclconfig
-            {{- else }}
+            {{- end }}
             {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload) }}
             - name: consul-license
               mountPath: /consul/license
               readOnly: true
-            {{- end }}
             {{- end }}
             {{- if .Values.global.tls.enabled }}
             {{- if .Values.global.tls.enableAutoEncrypt}}


### PR DESCRIPTION
Changes proposed in this PR:
- Add the consul enterprise license to the snapshot agent regardless of `global.acls.manageSystemACLs` 

How I've tested this PR:
helm upgrade with our existing values file

How I expect reviewers to test this PR:

* values:

```yaml
global:
  acls:
    manageSystemACLs: true
  enterpriseLicense:
    enableLicenseAutoload: true
    secretKey: license-key
    secretName: consul-enterprise-license
client:
  snapshotAgent:
    configSecret:
      secretKey: agent_config
      secretName: consul-snapshot-agent
    enabled: true
```

You will need the requisite secrets for `consul-enterprise-license` and `consul-snapshot-agent`.




Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)



Related to ZenDesk Support Ticket # 62914