### PR TITLE
CONTRIBUTING: small typo for consul-k8s-control-plane binary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@
 
 ### Building and running `consul-k8s-control-plane`
 
-To build and install the control plane binary `consul-k8s` locally, Go version 1.17.0+ is required. 
+To build and install the control plane binary `consul-k8s-control-plane` locally, Go version 1.17.0+ is required. 
 You will also need to install the Docker engine:
 
 - [Docker for Mac](https://docs.docker.com/engine/installation/mac/)
@@ -47,7 +47,7 @@ Change directories into the appropriate folder:
 $ cd control-plane
 ```
 
-To compile the `consul-k8s` binary for your local machine:
+To compile the `consul-k8s-control-plane` binary for your local machine:
 
 ```shell
 $ make dev

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
 
 ## Helm
 
-Within the 'charts/consul' directory is the official HashiCorp Helm chart for installing
+Within the ['charts/consul'](charts/consul) directory is the official HashiCorp Helm chart for installing
 and configuring Consul on Kubernetes. This chart supports multiple use
 cases of Consul on Kubernetes, depending on the values provided.
 


### PR DESCRIPTION
Changes proposed in this PR:
- Renamed consul-k8s to consul-k8s-control-plane where necessary
- Added link back to charts/consul in README.md

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

