### PR TITLE
Bump k8s versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -488,7 +488,7 @@ jobs:
       - checkout
       - install-prereqs
       - create-kind-clusters:
-          version: "v1.21.2"
+          version: "v1.22.4"
       - restore_cache:
           keys:
             - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
@@ -520,7 +520,7 @@ jobs:
       - checkout
       - install-prereqs
       - create-kind-clusters:
-          version: "v1.21.2"
+          version: "v1.22.4"
       - restore_cache:
           keys:
             - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
@@ -600,7 +600,7 @@ jobs:
   ########################
   # ACCEPTANCE TESTS
   ########################
-  acceptance-gke-1-19:
+  acceptance-gke-1-20:
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -666,7 +666,7 @@ jobs:
           fail_only: true
           failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-aks-1-20:
+  acceptance-aks-1-21:
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -721,7 +721,7 @@ jobs:
           fail_only: true
           failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-eks-1-18:
+  acceptance-eks-1-19:
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -835,7 +835,7 @@ jobs:
           fail_only: true
           failure_message: "OpenShift acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-kind-1-22:
+  acceptance-kind-1-23:
     environment:
       - TEST_RESULTS: /tmp/test-results
     machine:
@@ -845,7 +845,7 @@ jobs:
       - checkout
       - install-prereqs
       - create-kind-clusters:
-          version: "v1.22.1"
+          version: "v1.23.0"
       - restore_cache:
           keys:
             - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
@@ -985,26 +985,13 @@ workflows:
 #      - acceptance-openshift:
 #          requires:
 #          - cleanup-azure-resources
-      - acceptance-gke-1-19:
+      - acceptance-gke-1-20:
           requires:
             - cleanup-gcp-resources
-      - acceptance-eks-1-18:
+      - acceptance-eks-1-19:
           requires:
             - cleanup-eks-resources
-      - acceptance-aks-1-20:
+      - acceptance-aks-1-21:
           requires:
             - cleanup-azure-resources
-      - acceptance-kind-1-22
-#  update-helm-charts-index: <-- Disable until we can figure out a release workflow. We currently don't want it to trigger on a tag because the tag is pushed by the eco-releases pipeline.
-#    jobs:
-#      - helm-chart-pipeline-approval:
-#          type: approval
-#      - update-helm-charts-index:
-#          requires:
-#            - helm-chart-pipeline-approval
-#          context: helm-charts-trigger-consul
-#          filters:
-#            tags:
-#              only: /^v.*/
-#            branches:
-#              ignore: /.*/
+      - acceptance-kind-1-23

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ use Consul with Kubernetes, please see the
 
 ### Prerequisites
   * **Helm 3.2+** (Helm 2 is not supported)
-  * **Kubernetes 1.18+** - This is the earliest version of Kubernetes tested.
-    It is possible that this chart works with earlier versions but it is
+  * **Kubernetes 1.19+** - This is the earliest version of Kubernetes tested.
+    It is possible that this chart works with earlier versions, but it is
     untested.
 
 ### Usage

--- a/charts/consul/test/terraform/aks/main.tf
+++ b/charts/consul/test/terraform/aks/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   location            = azurerm_resource_group.default[count.index].location
   resource_group_name = azurerm_resource_group.default[count.index].name
   dns_prefix          = "consul-k8s-${random_id.suffix[count.index].dec}"
-  kubernetes_version  = "1.20.9"
+  kubernetes_version  = "1.21.7"
 
   default_node_pool {
     name            = "default"

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -54,7 +54,7 @@ module "eks" {
   version = "17.20.0"
 
   cluster_name    = "consul-k8s-${random_id.suffix[count.index].dec}"
-  cluster_version = "1.18"
+  cluster_version = "1.19"
   subnets         = module.vpc[count.index].private_subnets
 
   vpc_id = module.vpc[count.index].vpc_id

--- a/charts/consul/test/terraform/gke/main.tf
+++ b/charts/consul/test/terraform/gke/main.tf
@@ -10,7 +10,7 @@ resource "random_id" "suffix" {
 
 data "google_container_engine_versions" "main" {
   location       = var.zone
-  version_prefix = "1.19."
+  version_prefix = "1.20."
 }
 
 resource "google_container_cluster" "cluster" {


### PR DESCRIPTION
Changes proposed in this PR:
- Kubernetes 1.23 is now released so we need to bump our tested versions

How I've tested this PR:
[Ran tests](https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/3860/workflows/6e5921c5-3d9f-44ed-89f3-a2d65c438657)

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

