### PR TITLE
Setup and run partitions tests on EKS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ commands:
                           ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -enable-multi-cluster \
                           -debug-directory="$TEST_RESULTS/debug" \
+                          -run TestPartitions \
                           -consul-k8s-image=<< parameters.consul-k8s-image >>
                     then
                       echo "Tests in ${pkg} failed, aborting early"
@@ -134,6 +135,7 @@ commands:
                       -enable-multi-cluster \
                       ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -debug-directory="$TEST_RESULTS/debug" \
+                      -run TestPartitions \
                       -consul-k8s-image=<< parameters.consul-k8s-image >>
 
 jobs:
@@ -764,7 +766,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig"
+          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-transparent-proxy
 
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,6 @@ commands:
                           ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -enable-multi-cluster \
                           -debug-directory="$TEST_RESULTS/debug" \
-                          -run TestPartitions \
                           -consul-k8s-image=<< parameters.consul-k8s-image >>
                     then
                       echo "Tests in ${pkg} failed, aborting early"
@@ -135,7 +134,6 @@ commands:
                       -enable-multi-cluster \
                       ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -debug-directory="$TEST_RESULTS/debug" \
-                      -run TestPartitions \
                       -consul-k8s-image=<< parameters.consul-k8s-image >>
 
 jobs:
@@ -971,10 +969,6 @@ workflows:
             - unit-test-helm-templates
             - unit-acceptance-framework
             - unit-cli
-      - cleanup-eks-resources
-      - acceptance-eks-1-19:
-          requires:
-            - cleanup-eks-resources
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,6 @@ commands:
                           ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -enable-multi-cluster \
                           -debug-directory="$TEST_RESULTS/debug" \
-                          -run TestPartitions \
                           -consul-k8s-image=<< parameters.consul-k8s-image >>
                     then
                       echo "Tests in ${pkg} failed, aborting early"
@@ -135,7 +134,6 @@ commands:
                       -enable-multi-cluster \
                       ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -debug-directory="$TEST_RESULTS/debug" \
-                      -run TestPartitions \
                       -consul-k8s-image=<< parameters.consul-k8s-image >>
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -972,7 +972,7 @@ workflows:
             - unit-acceptance-framework
             - unit-cli
       - cleanup-eks-resources
-      - acceptance-eks-1-18:
+      - acceptance-eks-1-19:
           requires:
             - cleanup-eks-resources
   nightly-acceptance-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ commands:
                           ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -enable-multi-cluster \
                           -debug-directory="$TEST_RESULTS/debug" \
+                          -run TestPartitions \
                           -consul-k8s-image=<< parameters.consul-k8s-image >>
                     then
                       echo "Tests in ${pkg} failed, aborting early"
@@ -134,6 +135,7 @@ commands:
                       -enable-multi-cluster \
                       ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -debug-directory="$TEST_RESULTS/debug" \
+                      -run TestPartitions \
                       -consul-k8s-image=<< parameters.consul-k8s-image >>
 
 jobs:
@@ -764,7 +766,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-transparent-proxy
+          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig"
 
       - store_test_results:
           path: /tmp/test-results
@@ -775,7 +777,7 @@ jobs:
           name: terraform destroy
           working_directory: *eks-terraform-path
           command: |
-            terraform destroy -auto-approve
+            terraform destroy -var cluster_count=2 -auto-approve
           when: always
 
       - slack/status:
@@ -969,6 +971,10 @@ workflows:
             - unit-test-helm-templates
             - unit-acceptance-framework
             - unit-cli
+      - cleanup-eks-resources
+      - acceptance-eks-1-18:
+          requires:
+            - cleanup-eks-resources
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/acceptance/tests/partitions/partitions_test.go
+++ b/acceptance/tests/partitions/partitions_test.go
@@ -32,9 +32,9 @@ func TestPartitions(t *testing.T) {
 		t.Skipf("skipping this test because -enable-enterprise is not set")
 	}
 
-	if !cfg.UseKind {
-		t.Skipf("skipping this test because Admin Partition tests are only supported in Kind for now")
-	}
+	//if !cfg.UseKind {
+	//	t.Skipf("skipping this test because Admin Partition tests are only supported in Kind for now")
+	//}
 
 	const defaultPartition = "default"
 	const secondaryPartition = "secondary"
@@ -51,36 +51,36 @@ func TestPartitions(t *testing.T) {
 			false,
 			false,
 		},
-		{
-			"default namespace; secure",
-			defaultNamespace,
-			false,
-			true,
-		},
-		{
-			"single destination namespace",
-			staticServerNamespace,
-			false,
-			false,
-		},
-		{
-			"single destination namespace; secure",
-			staticServerNamespace,
-			false,
-			true,
-		},
-		{
-			"mirror k8s namespaces",
-			staticServerNamespace,
-			true,
-			false,
-		},
-		{
-			"mirror k8s namespaces; secure",
-			staticServerNamespace,
-			true,
-			true,
-		},
+		//{
+		//	"default namespace; secure",
+		//	defaultNamespace,
+		//	false,
+		//	true,
+		//},
+		//{
+		//	"single destination namespace",
+		//	staticServerNamespace,
+		//	false,
+		//	false,
+		//},
+		//{
+		//	"single destination namespace; secure",
+		//	staticServerNamespace,
+		//	false,
+		//	true,
+		//},
+		//{
+		//	"mirror k8s namespaces",
+		//	staticServerNamespace,
+		//	true,
+		//	false,
+		//},
+		//{
+		//	"mirror k8s namespaces; secure",
+		//	staticServerNamespace,
+		//	true,
+		//	true,
+		//},
 	}
 
 	for _, c := range cases {
@@ -168,11 +168,11 @@ func TestPartitions(t *testing.T) {
 			var partitionSvcIP string
 			if !cfg.UseKind {
 				// Get the IP of the partition service to configure the external server address in the values file for the workload cluster.
-				partitionSecretName := fmt.Sprintf("%s-partition-secret", releaseName)
+				partitionServiceName := fmt.Sprintf("%s-consul-partition-service", releaseName)
 				logger.Logf(t, "retrieving partition service to determine external IP for servers")
-				partitionsSvc, err := serverClusterContext.KubernetesClient(t).CoreV1().Services(serverClusterContext.KubectlOptions(t).Namespace).Get(ctx, partitionSecretName, metav1.GetOptions{})
+				partitionsSvc, err := serverClusterContext.KubernetesClient(t).CoreV1().Services(serverClusterContext.KubectlOptions(t).Namespace).Get(ctx, partitionServiceName, metav1.GetOptions{})
 				require.NoError(t, err)
-				partitionSvcIP = partitionsSvc.Status.LoadBalancer.Ingress[0].IP
+				partitionSvcIP = partitionsSvc.Status.LoadBalancer.Ingress[0].Hostname
 			} else {
 				nodeList, err := serverClusterContext.KubernetesClient(t).CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 				require.NoError(t, err)
@@ -258,7 +258,7 @@ func TestPartitions(t *testing.T) {
 			// Ensure consul client are created.
 			agentPodList, err := clientClusterContext.KubernetesClient(t).CoreV1().Pods(clientClusterContext.KubectlOptions(t).Namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=consul,component=client"})
 			require.NoError(t, err)
-			require.Len(t, agentPodList.Items, 1)
+			//require.Len(t, agentPodList.Items, 1)
 
 			output, err := k8s.RunKubectlAndGetOutputE(t, clientClusterContext.KubectlOptions(t), "logs", agentPodList.Items[0].Name, "-n", clientClusterContext.KubectlOptions(t).Namespace)
 			require.NoError(t, err)

--- a/acceptance/tests/partitions/partitions_test.go
+++ b/acceptance/tests/partitions/partitions_test.go
@@ -51,12 +51,12 @@ func TestPartitions(t *testing.T) {
 			false,
 			false,
 		},
-		//{
-		//	"default namespace; secure",
-		//	defaultNamespace,
-		//	false,
-		//	true,
-		//},
+		{
+			"default namespace; secure",
+			defaultNamespace,
+			false,
+			true,
+		},
 		//{
 		//	"single destination namespace",
 		//	staticServerNamespace,
@@ -181,13 +181,16 @@ func TestPartitions(t *testing.T) {
 			}
 
 			var k8sAuthMethodHost string
-			if cfg.UseKind {
-				// The Kubernetes AuthMethod IP for Kind is read from the endpoint for the Kubernetes service. On other clouds,
-				// this can be identified by reading the cluster config.
-				kubernetesEndpoint, err := clientClusterContext.KubernetesClient(t).CoreV1().Endpoints(defaultNamespace).Get(ctx, "kubernetes", metav1.GetOptions{})
-				require.NoError(t, err)
-				k8sAuthMethodHost = fmt.Sprintf("%s:%d", kubernetesEndpoint.Subsets[0].Addresses[0].IP, kubernetesEndpoint.Subsets[0].Ports[0].Port)
-			}
+			//if cfg.UseKind {
+			//	// The Kubernetes AuthMethod IP for Kind is read from the endpoint for the Kubernetes service. On other clouds,
+			//	// this can be identified by reading the cluster config.
+			//	kubernetesEndpoint, err := clientClusterContext.KubernetesClient(t).CoreV1().Endpoints(defaultNamespace).Get(ctx, "kubernetes", metav1.GetOptions{})
+			//	require.NoError(t, err)
+			//	k8sAuthMethodHost = fmt.Sprintf("%s:%d", kubernetesEndpoint.Subsets[0].Addresses[0].IP, kubernetesEndpoint.Subsets[0].Ports[0].Port)
+			//}
+			kubernetesEndpoint, err := clientClusterContext.KubernetesClient(t).CoreV1().Endpoints(defaultNamespace).Get(ctx, "kubernetes", metav1.GetOptions{})
+			require.NoError(t, err)
+			k8sAuthMethodHost = fmt.Sprintf("%s:%d", kubernetesEndpoint.Subsets[0].Addresses[0].IP, kubernetesEndpoint.Subsets[0].Ports[0].Port)
 
 			// Create client cluster.
 			clientHelmValues := map[string]string{

--- a/acceptance/tests/partitions/partitions_test.go
+++ b/acceptance/tests/partitions/partitions_test.go
@@ -32,10 +32,6 @@ func TestPartitions(t *testing.T) {
 		t.Skipf("skipping this test because -enable-enterprise is not set")
 	}
 
-	//if !cfg.UseKind {
-	//	t.Skipf("skipping this test because Admin Partition tests are only supported in Kind for now")
-	//}
-
 	const defaultPartition = "default"
 	const secondaryPartition = "secondary"
 	const defaultNamespace = "default"
@@ -181,13 +177,7 @@ func TestPartitions(t *testing.T) {
 			}
 
 			var k8sAuthMethodHost string
-			//if cfg.UseKind {
-			//	// The Kubernetes AuthMethod IP for Kind is read from the endpoint for the Kubernetes service. On other clouds,
-			//	// this can be identified by reading the cluster config.
-			//	kubernetesEndpoint, err := clientClusterContext.KubernetesClient(t).CoreV1().Endpoints(defaultNamespace).Get(ctx, "kubernetes", metav1.GetOptions{})
-			//	require.NoError(t, err)
-			//	k8sAuthMethodHost = fmt.Sprintf("%s:%d", kubernetesEndpoint.Subsets[0].Addresses[0].IP, kubernetesEndpoint.Subsets[0].Ports[0].Port)
-			//}
+			// The Kubernetes AuthMethod IP for Kind is read from the endpoint for the Kubernetes service.
 			kubernetesEndpoint, err := clientClusterContext.KubernetesClient(t).CoreV1().Endpoints(defaultNamespace).Get(ctx, "kubernetes", metav1.GetOptions{})
 			require.NoError(t, err)
 			k8sAuthMethodHost = fmt.Sprintf("%s:%d", kubernetesEndpoint.Subsets[0].Addresses[0].IP, kubernetesEndpoint.Subsets[0].Ports[0].Port)
@@ -261,7 +251,6 @@ func TestPartitions(t *testing.T) {
 			// Ensure consul client are created.
 			agentPodList, err := clientClusterContext.KubernetesClient(t).CoreV1().Pods(clientClusterContext.KubectlOptions(t).Namespace).List(ctx, metav1.ListOptions{LabelSelector: "app=consul,component=client"})
 			require.NoError(t, err)
-			//require.Len(t, agentPodList.Items, 1)
 
 			output, err := k8s.RunKubectlAndGetOutputE(t, clientClusterContext.KubectlOptions(t), "logs", agentPodList.Items[0].Name, "-n", clientClusterContext.KubectlOptions(t).Namespace)
 			require.NoError(t, err)

--- a/acceptance/tests/partitions/partitions_test.go
+++ b/acceptance/tests/partitions/partitions_test.go
@@ -57,30 +57,30 @@ func TestPartitions(t *testing.T) {
 			false,
 			true,
 		},
-		//{
-		//	"single destination namespace",
-		//	staticServerNamespace,
-		//	false,
-		//	false,
-		//},
-		//{
-		//	"single destination namespace; secure",
-		//	staticServerNamespace,
-		//	false,
-		//	true,
-		//},
-		//{
-		//	"mirror k8s namespaces",
-		//	staticServerNamespace,
-		//	true,
-		//	false,
-		//},
-		//{
-		//	"mirror k8s namespaces; secure",
-		//	staticServerNamespace,
-		//	true,
-		//	true,
-		//},
+		{
+			"single destination namespace",
+			staticServerNamespace,
+			false,
+			false,
+		},
+		{
+			"single destination namespace; secure",
+			staticServerNamespace,
+			false,
+			true,
+		},
+		{
+			"mirror k8s namespaces",
+			staticServerNamespace,
+			true,
+			false,
+		},
+		{
+			"mirror k8s namespaces; secure",
+			staticServerNamespace,
+			true,
+			true,
+		},
 	}
 
 	for _, c := range cases {

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -90,7 +90,7 @@ data "aws_eks_cluster_auth" "cluster" {
 }
 
 # The following resources are only applied when cluster_count=2 to set up vpc peering and the appropriate routes and
-# security groups so traffic between vpcs is allowed. There is validation to ensure cluster_count can be 1 or 2.
+# security groups so traffic between VPCs is allowed. There is validation to ensure cluster_count can be 1 or 2.
 
 # Each EKS cluster needs to allow ingress traffic from the other VPC.
 resource "aws_security_group_rule" "allowingressfrom1-0" {

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -89,9 +89,8 @@ data "aws_eks_cluster_auth" "cluster" {
   name  = module.eks[count.index].cluster_id
 }
 
-# The following resources are meant to apply when cluster_count=2 to set up vpc peering and the appropriate routes and
-# security groups so traffic between vpc's is allowed. Since the pipeline only ever deploys with a cluster_count of 2,
-# these resources are hardcoded to work in an environment with 2 clusters.
+# The following resources are only applied when cluster_count=2 to set up vpc peering and the appropriate routes and
+# security groups so traffic between vpcs is allowed. There is validation to ensure cluster_count can be 1 or 2.
 
 # Each EKS cluster needs to allow ingress traffic from the other VPC.
 resource "aws_security_group_rule" "allowingressfrom1-0" {

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -15,6 +15,8 @@ resource "random_id" "suffix" {
 
 data "aws_availability_zones" "available" {}
 
+data "aws_caller_identity" "caller" {}
+
 resource "random_string" "suffix" {
   length  = 8
   special = false
@@ -23,13 +25,13 @@ resource "random_string" "suffix" {
 module "vpc" {
   count   = var.cluster_count
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.47.0"
+  version = "3.11.0"
 
   name                 = "consul-k8s-${random_id.suffix[count.index].dec}"
-  cidr                 = "10.0.0.0/16"
+  cidr                 = format("10.%s.0.0/16", count.index)
   azs                  = data.aws_availability_zones.available.names
-  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  private_subnets      = [format("10.%s.1.0/24", count.index), format("10.%s.2.0/24", count.index), format("10.%s.3.0/24", count.index)]
+  public_subnets       = [format("10.%s.4.0/24", count.index), format("10.%s.5.0/24", count.index), format("10.%s.6.0/24", count.index)]
   enable_nat_gateway   = true
   single_nat_gateway   = true
   enable_dns_hostnames = true
@@ -84,4 +86,77 @@ data "aws_eks_cluster" "cluster" {
 data "aws_eks_cluster_auth" "cluster" {
   count = var.cluster_count
   name  = module.eks[count.index].cluster_id
+}
+
+resource "aws_security_group_rule" "allowingressfrom1-0" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = [module.vpc[1].vpc_cidr_block]
+  security_group_id = module.eks[0].cluster_primary_security_group_id
+}
+
+resource "aws_security_group_rule" "allowingressfrom0-1" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = [module.vpc[0].vpc_cidr_block]
+  security_group_id = module.eks[1].cluster_primary_security_group_id
+}
+
+# Requester's side of the connection.
+resource "aws_vpc_peering_connection" "peer" {
+  vpc_id        = module.vpc[0].vpc_id
+  peer_vpc_id   = module.vpc[1].vpc_id
+  peer_owner_id = data.aws_caller_identity.caller.account_id
+  peer_region   = var.region
+  auto_accept   = false
+
+  tags = {
+    Side = "Requester"
+  }
+}
+
+# Accepter's side of the connection.
+resource "aws_vpc_peering_connection_accepter" "peer" {
+  vpc_peering_connection_id = aws_vpc_peering_connection.peer.id
+  auto_accept               = true
+
+  tags = {
+    Side = "Accepter"
+  }
+}
+
+# Get the route table ids that are associated with eks cluster 0
+data "aws_route_tables" "rtseks0" {
+  vpc_id = module.vpc[0].vpc_id
+
+  filter {
+    name   = "tag:Name"
+    values = [format("%s-*", module.eks[0].cluster_id)]
+  }
+}
+# Get the route table ids that are associated with eks cluster 1
+data "aws_route_tables" "rtseks1" {
+  vpc_id = module.vpc[1].vpc_id
+
+  filter {
+    name   = "tag:Name"
+    values = [format("%s-*", module.eks[1].cluster_id)]
+  }
+}
+
+resource "aws_route" "peering0" {
+  count                     = 2 # we know its the public and private route tables
+  route_table_id            = tolist(data.aws_route_tables.rtseks0.ids)[count.index]
+  destination_cidr_block    = module.vpc[1].vpc_cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.peer.id
+}
+resource "aws_route" "peering1" {
+  count                     = 2
+  route_table_id            = tolist(data.aws_route_tables.rtseks1.ids)[count.index]
+  destination_cidr_block    = module.vpc[0].vpc_cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.peer.id
 }

--- a/charts/consul/test/terraform/eks/variables.tf
+++ b/charts/consul/test/terraform/eks/variables.tf
@@ -6,6 +6,13 @@ variable "region" {
 variable "cluster_count" {
   default     = 1
   description = "The number of Kubernetes clusters to create."
+  // We currently cannot support more than 2 cluster
+  // because setting up peering is more complicated if cluster count is
+  // more than two.
+  validation {
+    condition     = var.cluster_count < 3 && var.cluster_count > 0
+    error_message = "The cluster_count value must be 1 or 2."
+  }
 }
 
 variable "role_arn" {


### PR DESCRIPTION
Changes proposed in this PR:
- Run partitions tests on EKS
- For cross partition communication, the networking setup needs to be such that the node ips of all clients need to be able to talk with the node ips of all servers and vice versa (traffic should be routeable and allowed). Clients across partitions do not need to be able to route to each other.
- To make this work on EKS, the terraform has been modified to:
  - Set up a 2 clusters in 2 VPCs without overlapping IPs
  - Set up peering between those VPCs
  - Add security group ingress rules to each set of nodes' security group, to allow all TCP traffic from the other VPC
  - Add route table entries such that traffic going to the other VPC is routed through the peer
- A few tweaks to partitions acceptance tests so that they pass
- Outside of this PR, I added permissions to the ci role used for helm tests to be able to do anything on EC2 (ec2*) using the aws cli: 
```
aws iam put-role-policy --role-name service-circleci-consul-helm-tests --policy-name CircleCIManageEC2 --policy-document file://ec2policy.json
```
where ec2policy.json looks like this:
```
{
   "Version": "2012-10-17",
   "Statement": [
    {
      "Effect": "Allow",
      "Action": "ec2:*",
      "Resource": "*"
    }
   ]
}
```

How I've tested this PR:
- Running EKS acceptance tests in the pipeline: https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/3871/workflows/854039f8-5c8c-4b29-8e43-6a45445025c3 (without tproxy)
- EKS acc tests with tproxy passes here: https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/3875/workflows/7b4c2445-4848-44f9-b3e0-01fca56cd9e2/jobs/34507

How I expect reviewers to test this PR:
- Review-- I'd like especially like feedback on:
  - ~This currently relies on always deploying 2 clusters, and isn't conditional on any variables for whether to set up the peering. Since the pipeline always deploys 2 clusters, I thought this could be alright. We could even turn cluster_count from a var to a local, to make it clearer the config is meant for deploying 2 clusters. In a case where someone wants to deploy 1 cluster, they'd need to remove the config from line 92 down, and change the local cluster_count to 1.~ Edited to work with cluster_count = 1 or 2.

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

