### PR TITLE
control-plane: Add possibility to manage consul sidecar resources with annotations

### DIFF
--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -201,16 +201,16 @@ spec:
                 {{- if .Values.global.consulSidecarContainer }}
                 {{- $consulSidecarResources := .Values.global.consulSidecarContainer.resources }}
                 {{- if not (kindIs "invalid" $consulSidecarResources.limits.memory) }}
-                -consul-sidecar-memory-limit={{ $consulSidecarResources.limits.memory }} \
+                -default-consul-sidecar-memory-limit={{ $consulSidecarResources.limits.memory }} \
                 {{- end }}
                 {{- if not (kindIs "invalid" $consulSidecarResources.requests.memory) }}
-                -consul-sidecar-memory-request={{ $consulSidecarResources.requests.memory }} \
+                -default-consul-sidecar-memory-request={{ $consulSidecarResources.requests.memory }} \
                 {{- end }}
                 {{- if not (kindIs "invalid" $consulSidecarResources.limits.cpu) }}
-                -consul-sidecar-cpu-limit={{ $consulSidecarResources.limits.cpu }} \
+                -default-consul-sidecar-cpu-limit={{ $consulSidecarResources.limits.cpu }} \
                 {{- end }}
                 {{- if not (kindIs "invalid" $consulSidecarResources.requests.cpu) }}
-                -consul-sidecar-cpu-request={{ $consulSidecarResources.requests.cpu }} \
+                -default-consul-sidecar-cpu-request={{ $consulSidecarResources.requests.cpu }} \
                 {{- end }}
                 {{- end }}
           startupProbe:

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -1165,19 +1165,19 @@ EOF
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-memory-request=25Mi"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-memory-request=25Mi"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-cpu-request=20m"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-cpu-request=20m"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-memory-limit=50Mi"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-memory-limit=50Mi"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-cpu-limit=20m"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-cpu-limit=20m"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
@@ -1194,19 +1194,19 @@ EOF
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-memory-request=100Mi"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-memory-request=100Mi"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-cpu-request=100m"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-cpu-request=100m"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-memory-limit=200Mi"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-memory-limit=200Mi"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-cpu-limit=200m"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-cpu-limit=200m"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
@@ -1223,19 +1223,19 @@ EOF
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-memory-request=0"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-memory-request=0"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-cpu-request=0"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-cpu-request=0"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-memory-limit=0"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-memory-limit=0"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-cpu-limit=0"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-cpu-limit=0"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
@@ -1252,19 +1252,19 @@ EOF
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-memory-request"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-memory-request"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-cpu-request"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-cpu-request"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-memory-limit"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-memory-limit"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-cpu-limit"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-cpu-limit"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
@@ -1278,19 +1278,19 @@ EOF
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-memory-request"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-memory-request"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-cpu-request"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-cpu-request"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-memory-limit"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-memory-limit"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-consul-sidecar-cpu-limit"))' | tee /dev/stderr)
+    yq 'any(contains("-default-consul-sidecar-cpu-limit"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 

--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -69,6 +69,12 @@ const (
 	annotationSidecarProxyMemoryLimit   = "consul.hashicorp.com/sidecar-proxy-memory-limit"
 	annotationSidecarProxyMemoryRequest = "consul.hashicorp.com/sidecar-proxy-memory-request"
 
+	// annotations for consul sidecar resource limits.
+	annotationConsulSidecarCPULimit      = "consul.hashicorp.com/consul-sidecar-cpu-limit"
+	annotationConsulSidecarCPURequest    = "consul.hashicorp.com/consul-sidecar-cpu-request"
+	annotationConsulSidecarMemoryLimit   = "consul.hashicorp.com/consul-sidecar-memory-limit"
+	annotationConsulSidecarMemoryRequest = "consul.hashicorp.com/consul-sidecar-memory-request"
+
 	// annotations for metrics to configure where Prometheus scrapes
 	// metrics from, whether to run a merged metrics endpoint on the consul
 	// sidecar, and configure the connect service metrics.

--- a/control-plane/connect-inject/consul_sidecar.go
+++ b/control-plane/connect-inject/consul_sidecar.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // consulSidecar starts the consul-sidecar command to only run
@@ -12,6 +13,11 @@ import (
 // need to keep services registered as this is handled in the endpoints-controller.
 func (h *Handler) consulSidecar(pod corev1.Pod) (corev1.Container, error) {
 	metricsPorts, err := h.MetricsConfig.mergedMetricsServerConfiguration(pod)
+	if err != nil {
+		return corev1.Container{}, err
+	}
+
+	resources, err := h.consulSidecarResources(pod)
 	if err != nil {
 		return corev1.Container{}, err
 	}
@@ -38,6 +44,72 @@ func (h *Handler) consulSidecar(pod corev1.Pod) (corev1.Container, error) {
 			},
 		},
 		Command:   command,
-		Resources: h.ConsulSidecarResources,
+		Resources: resources,
 	}, nil
+}
+
+func (h *Handler) consulSidecarResources(pod corev1.Pod) (corev1.ResourceRequirements, error) {
+	resources := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{},
+		Requests: corev1.ResourceList{},
+	}
+	// zeroQuantity is used for comparison to see if a quantity was explicitly
+	// set.
+	var zeroQuantity resource.Quantity
+
+	// NOTE: We only want to set the limit/request if the default or annotation
+	// was explicitly set. If it's not explicitly set, it will be the zero value
+	// which would show up in the pod spec as being explicitly set to zero if we
+	// set that key, e.g. "cpu" to zero.
+	// We want it to not show up in the pod spec at all if if it's not explicitly
+	// set so that users aren't wondering why it's set to 0 when they didn't specify
+	// a request/limit. If they have explicitly set it to 0 then it will be set
+	// to 0 in the pod spec because we're doing a comparison to the zero-valued
+	// struct.
+
+	// CPU Limit.
+	if anno, ok := pod.Annotations[annotationConsulSidecarCPULimit]; ok {
+		cpuLimit, err := resource.ParseQuantity(anno)
+		if err != nil {
+			return corev1.ResourceRequirements{}, fmt.Errorf("parsing annotation %s:%q: %s", annotationConsulSidecarCPULimit, anno, err)
+		}
+		resources.Limits[corev1.ResourceCPU] = cpuLimit
+	} else if h.DefaultConsulSidecarResources.Limits[corev1.ResourceCPU] != zeroQuantity {
+		resources.Limits[corev1.ResourceCPU] = h.DefaultConsulSidecarResources.Limits[corev1.ResourceCPU]
+	}
+
+	// CPU Request.
+	if anno, ok := pod.Annotations[annotationConsulSidecarCPURequest]; ok {
+		cpuRequest, err := resource.ParseQuantity(anno)
+		if err != nil {
+			return corev1.ResourceRequirements{}, fmt.Errorf("parsing annotation %s:%q: %s", annotationConsulSidecarCPURequest, anno, err)
+		}
+		resources.Requests[corev1.ResourceCPU] = cpuRequest
+	} else if h.DefaultConsulSidecarResources.Requests[corev1.ResourceCPU] != zeroQuantity {
+		resources.Requests[corev1.ResourceCPU] = h.DefaultConsulSidecarResources.Requests[corev1.ResourceCPU]
+	}
+
+	// Memory Limit.
+	if anno, ok := pod.Annotations[annotationConsulSidecarMemoryLimit]; ok {
+		memoryLimit, err := resource.ParseQuantity(anno)
+		if err != nil {
+			return corev1.ResourceRequirements{}, fmt.Errorf("parsing annotation %s:%q: %s", annotationConsulSidecarMemoryLimit, anno, err)
+		}
+		resources.Limits[corev1.ResourceMemory] = memoryLimit
+	} else if h.DefaultConsulSidecarResources.Limits[corev1.ResourceMemory] != zeroQuantity {
+		resources.Limits[corev1.ResourceMemory] = h.DefaultConsulSidecarResources.Limits[corev1.ResourceMemory]
+	}
+
+	// Memory Request.
+	if anno, ok := pod.Annotations[annotationConsulSidecarMemoryRequest]; ok {
+		memoryRequest, err := resource.ParseQuantity(anno)
+		if err != nil {
+			return corev1.ResourceRequirements{}, fmt.Errorf("parsing annotation %s:%q: %s", annotationConsulSidecarMemoryRequest, anno, err)
+		}
+		resources.Requests[corev1.ResourceMemory] = memoryRequest
+	} else if h.DefaultConsulSidecarResources.Requests[corev1.ResourceMemory] != zeroQuantity {
+		resources.Requests[corev1.ResourceMemory] = h.DefaultConsulSidecarResources.Requests[corev1.ResourceMemory]
+	}
+
+	return resources, nil
 }

--- a/control-plane/connect-inject/consul_sidecar_test.go
+++ b/control-plane/connect-inject/consul_sidecar_test.go
@@ -6,6 +6,7 @@ import (
 	logrtest "github.com/go-logr/logr/testing"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -42,4 +43,301 @@ func TestConsulSidecar_MetricsFlags(t *testing.T) {
 	require.Contains(t, container.Command, "-merged-metrics-port=20100")
 	require.Contains(t, container.Command, "-service-metrics-port=8080")
 	require.Contains(t, container.Command, "-service-metrics-path=/metrics")
+}
+
+func TestHandlerConsulSidecar_Resources(t *testing.T) {
+	mem1 := resource.MustParse("100Mi")
+	mem2 := resource.MustParse("200Mi")
+	cpu1 := resource.MustParse("100m")
+	cpu2 := resource.MustParse("200m")
+	zero := resource.MustParse("0")
+
+	cases := map[string]struct {
+		handler      Handler
+		annotations  map[string]string
+		expResources corev1.ResourceRequirements
+		expErr       string
+	}{
+		"no defaults, no annotations": {
+			handler: Handler{
+				Log:            logrtest.TestLogger{T: t},
+				ImageConsulK8S: "hashicorp/consul-k8s:9.9.9",
+				MetricsConfig: MetricsConfig{
+					DefaultEnableMetrics:        true,
+					DefaultEnableMetricsMerging: true,
+				},
+			},
+			annotations: map[string]string{
+				annotationMergedMetricsPort:  "20100",
+				annotationServiceMetricsPort: "8080",
+				annotationServiceMetricsPath: "/metrics",
+			},
+			expResources: corev1.ResourceRequirements{
+				Limits:   corev1.ResourceList{},
+				Requests: corev1.ResourceList{},
+			},
+		},
+		"all defaults, no annotations": {
+			handler: Handler{
+				Log:            logrtest.TestLogger{T: t},
+				ImageConsulK8S: "hashicorp/consul-k8s:9.9.9",
+				MetricsConfig: MetricsConfig{
+					DefaultEnableMetrics:        true,
+					DefaultEnableMetricsMerging: true,
+				},
+				DefaultConsulSidecarResources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    cpu1,
+						corev1.ResourceMemory: mem1,
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    cpu2,
+						corev1.ResourceMemory: mem2,
+					},
+				},
+			},
+			annotations: map[string]string{
+				annotationMergedMetricsPort:  "20100",
+				annotationServiceMetricsPort: "8080",
+				annotationServiceMetricsPath: "/metrics",
+			},
+			expResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    cpu2,
+					corev1.ResourceMemory: mem2,
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    cpu1,
+					corev1.ResourceMemory: mem1,
+				},
+			},
+		},
+		"no defaults, all annotations": {
+			handler: Handler{
+				Log:            logrtest.TestLogger{T: t},
+				ImageConsulK8S: "hashicorp/consul-k8s:9.9.9",
+				MetricsConfig: MetricsConfig{
+					DefaultEnableMetrics:        true,
+					DefaultEnableMetricsMerging: true,
+				},
+			},
+			annotations: map[string]string{
+				annotationMergedMetricsPort:          "20100",
+				annotationServiceMetricsPort:         "8080",
+				annotationServiceMetricsPath:         "/metrics",
+				annotationConsulSidecarCPURequest:    "100m",
+				annotationConsulSidecarMemoryRequest: "100Mi",
+				annotationConsulSidecarCPULimit:      "200m",
+				annotationConsulSidecarMemoryLimit:   "200Mi",
+			},
+			expResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    cpu2,
+					corev1.ResourceMemory: mem2,
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    cpu1,
+					corev1.ResourceMemory: mem1,
+				},
+			},
+		},
+		"annotations override defaults": {
+			handler: Handler{
+				Log:            logrtest.TestLogger{T: t},
+				ImageConsulK8S: "hashicorp/consul-k8s:9.9.9",
+				MetricsConfig: MetricsConfig{
+					DefaultEnableMetrics:        true,
+					DefaultEnableMetricsMerging: true,
+				},
+				DefaultConsulSidecarResources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    zero,
+						corev1.ResourceMemory: zero,
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    zero,
+						corev1.ResourceMemory: zero,
+					},
+				},
+			},
+			annotations: map[string]string{
+				annotationMergedMetricsPort:          "20100",
+				annotationServiceMetricsPort:         "8080",
+				annotationServiceMetricsPath:         "/metrics",
+				annotationConsulSidecarCPURequest:    "100m",
+				annotationConsulSidecarMemoryRequest: "100Mi",
+				annotationConsulSidecarCPULimit:      "200m",
+				annotationConsulSidecarMemoryLimit:   "200Mi",
+			},
+			expResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    cpu2,
+					corev1.ResourceMemory: mem2,
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    cpu1,
+					corev1.ResourceMemory: mem1,
+				},
+			},
+		},
+		"defaults set to zero, no annotations": {
+			handler: Handler{
+				Log:            logrtest.TestLogger{T: t},
+				ImageConsulK8S: "hashicorp/consul-k8s:9.9.9",
+				MetricsConfig: MetricsConfig{
+					DefaultEnableMetrics:        true,
+					DefaultEnableMetricsMerging: true,
+				},
+				DefaultConsulSidecarResources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    zero,
+						corev1.ResourceMemory: zero,
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    zero,
+						corev1.ResourceMemory: zero,
+					},
+				},
+			},
+			annotations: map[string]string{
+				annotationMergedMetricsPort:  "20100",
+				annotationServiceMetricsPort: "8080",
+				annotationServiceMetricsPath: "/metrics",
+			},
+			expResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    zero,
+					corev1.ResourceMemory: zero,
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    zero,
+					corev1.ResourceMemory: zero,
+				},
+			},
+		},
+		"annotations set to 0": {
+			handler: Handler{
+				Log:            logrtest.TestLogger{T: t},
+				ImageConsulK8S: "hashicorp/consul-k8s:9.9.9",
+				MetricsConfig: MetricsConfig{
+					DefaultEnableMetrics:        true,
+					DefaultEnableMetricsMerging: true,
+				},
+			},
+			annotations: map[string]string{
+				annotationMergedMetricsPort:          "20100",
+				annotationServiceMetricsPort:         "8080",
+				annotationServiceMetricsPath:         "/metrics",
+				annotationConsulSidecarCPURequest:    "0",
+				annotationConsulSidecarMemoryRequest: "0",
+				annotationConsulSidecarCPULimit:      "0",
+				annotationConsulSidecarMemoryLimit:   "0",
+			},
+			expResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    zero,
+					corev1.ResourceMemory: zero,
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    zero,
+					corev1.ResourceMemory: zero,
+				},
+			},
+		},
+		"invalid cpu request": {
+			handler: Handler{
+				Log:            logrtest.TestLogger{T: t},
+				ImageConsulK8S: "hashicorp/consul-k8s:9.9.9",
+				MetricsConfig: MetricsConfig{
+					DefaultEnableMetrics:        true,
+					DefaultEnableMetricsMerging: true,
+				},
+			},
+			annotations: map[string]string{
+				annotationMergedMetricsPort:       "20100",
+				annotationServiceMetricsPort:      "8080",
+				annotationServiceMetricsPath:      "/metrics",
+				annotationConsulSidecarCPURequest: "invalid",
+			},
+			expErr: "parsing annotation consul.hashicorp.com/consul-sidecar-cpu-request:\"invalid\": quantities must match the regular expression",
+		},
+		"invalid cpu limit": {
+			handler: Handler{
+				Log:            logrtest.TestLogger{T: t},
+				ImageConsulK8S: "hashicorp/consul-k8s:9.9.9",
+				MetricsConfig: MetricsConfig{
+					DefaultEnableMetrics:        true,
+					DefaultEnableMetricsMerging: true,
+				},
+			},
+			annotations: map[string]string{
+				annotationMergedMetricsPort:     "20100",
+				annotationServiceMetricsPort:    "8080",
+				annotationServiceMetricsPath:    "/metrics",
+				annotationConsulSidecarCPULimit: "invalid",
+			},
+			expErr: "parsing annotation consul.hashicorp.com/consul-sidecar-cpu-limit:\"invalid\": quantities must match the regular expression",
+		},
+		"invalid memory request": {
+			handler: Handler{
+				Log:            logrtest.TestLogger{T: t},
+				ImageConsulK8S: "hashicorp/consul-k8s:9.9.9",
+				MetricsConfig: MetricsConfig{
+					DefaultEnableMetrics:        true,
+					DefaultEnableMetricsMerging: true,
+				},
+			},
+			annotations: map[string]string{
+				annotationMergedMetricsPort:          "20100",
+				annotationServiceMetricsPort:         "8080",
+				annotationServiceMetricsPath:         "/metrics",
+				annotationConsulSidecarMemoryRequest: "invalid",
+			},
+			expErr: "parsing annotation consul.hashicorp.com/consul-sidecar-memory-request:\"invalid\": quantities must match the regular expression",
+		},
+		"invalid memory limit": {
+			handler: Handler{
+				Log:            logrtest.TestLogger{T: t},
+				ImageConsulK8S: "hashicorp/consul-k8s:9.9.9",
+				MetricsConfig: MetricsConfig{
+					DefaultEnableMetrics:        true,
+					DefaultEnableMetricsMerging: true,
+				},
+			},
+			annotations: map[string]string{
+				annotationMergedMetricsPort:        "20100",
+				annotationServiceMetricsPort:       "8080",
+				annotationServiceMetricsPath:       "/metrics",
+				annotationConsulSidecarMemoryLimit: "invalid",
+			},
+			expErr: "parsing annotation consul.hashicorp.com/consul-sidecar-memory-limit:\"invalid\": quantities must match the regular expression",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(tt *testing.T) {
+			require := require.New(tt)
+			pod := corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: c.annotations,
+				},
+
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "web",
+						},
+					},
+				},
+			}
+			container, err := c.handler.consulSidecar(pod)
+			if c.expErr != "" {
+				require.NotNil(err)
+				require.Contains(err.Error(), c.expErr)
+			} else {
+				require.NoError(err)
+				require.Equal(c.expResources, container.Resources)
+			}
+		})
+	}
 }

--- a/control-plane/connect-inject/handler.go
+++ b/control-plane/connect-inject/handler.go
@@ -123,7 +123,7 @@ type Handler struct {
 
 	// Resource settings for Consul sidecar. All of these fields
 	// will be populated by the defaults provided in the initial flags.
-	ConsulSidecarResources corev1.ResourceRequirements
+	DefaultConsulSidecarResources corev1.ResourceRequirements
 
 	// EnableTransparentProxy enables transparent proxy mode.
 	// This means that the injected init container will apply traffic redirection rules

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -77,10 +77,10 @@ type Command struct {
 	flagDefaultPrometheusScrapePath string
 
 	// Consul sidecar resource settings.
-	flagConsulSidecarCPULimit      string
-	flagConsulSidecarCPURequest    string
-	flagConsulSidecarMemoryLimit   string
-	flagConsulSidecarMemoryRequest string
+	flagDefaultConsulSidecarCPULimit      string
+	flagDefaultConsulSidecarCPURequest    string
+	flagDefaultConsulSidecarMemoryLimit   string
+	flagDefaultConsulSidecarMemoryRequest string
 
 	// Init container resource settings.
 	flagInitContainerCPULimit      string
@@ -197,10 +197,10 @@ func (c *Command) init() {
 	c.flagSet.StringVar(&c.flagInitContainerMemoryLimit, "init-container-memory-limit", "150Mi", "Init container memory limit.")
 
 	// Consul sidecar resource setting flags.
-	c.flagSet.StringVar(&c.flagConsulSidecarCPURequest, "consul-sidecar-cpu-request", "20m", "Consul sidecar CPU request.")
-	c.flagSet.StringVar(&c.flagConsulSidecarCPULimit, "consul-sidecar-cpu-limit", "20m", "Consul sidecar CPU limit.")
-	c.flagSet.StringVar(&c.flagConsulSidecarMemoryRequest, "consul-sidecar-memory-request", "25Mi", "Consul sidecar memory request.")
-	c.flagSet.StringVar(&c.flagConsulSidecarMemoryLimit, "consul-sidecar-memory-limit", "50Mi", "Consul sidecar memory limit.")
+	c.flagSet.StringVar(&c.flagDefaultConsulSidecarCPURequest, "default-consul-sidecar-cpu-request", "20m", "Default consul sidecar CPU request.")
+	c.flagSet.StringVar(&c.flagDefaultConsulSidecarCPULimit, "default-consul-sidecar-cpu-limit", "20m", "Default consul sidecar CPU limit.")
+	c.flagSet.StringVar(&c.flagDefaultConsulSidecarMemoryRequest, "default-consul-sidecar-memory-request", "25Mi", "Default consul sidecar memory request.")
+	c.flagSet.StringVar(&c.flagDefaultConsulSidecarMemoryLimit, "default-consul-sidecar-memory-limit", "50Mi", "Default consul sidecar memory limit.")
 
 	c.http = &flags.HTTPFlags{}
 
@@ -453,38 +453,38 @@ func (c *Command) Run(args []string) int {
 
 	mgr.GetWebhookServer().Register("/mutate",
 		&webhook.Admission{Handler: &connectinject.Handler{
-			Clientset:                  c.clientset,
-			ConsulClient:               c.consulClient,
-			ImageConsul:                c.flagConsulImage,
-			ImageEnvoy:                 c.flagEnvoyImage,
-			EnvoyExtraArgs:             c.flagEnvoyExtraArgs,
-			ImageConsulK8S:             c.flagConsulK8sImage,
-			RequireAnnotation:          !c.flagDefaultInject,
-			AuthMethod:                 c.flagACLAuthMethod,
-			ConsulCACert:               string(consulCACert),
-			DefaultProxyCPURequest:     sidecarProxyCPURequest,
-			DefaultProxyCPULimit:       sidecarProxyCPULimit,
-			DefaultProxyMemoryRequest:  sidecarProxyMemoryRequest,
-			DefaultProxyMemoryLimit:    sidecarProxyMemoryLimit,
-			MetricsConfig:              metricsConfig,
-			InitContainerResources:     initResources,
-			ConsulSidecarResources:     consulSidecarResources,
-			ConsulPartition:            c.http.Partition(),
-			AllowK8sNamespacesSet:      allowK8sNamespaces,
-			DenyK8sNamespacesSet:       denyK8sNamespaces,
-			EnableNamespaces:           c.flagEnableNamespaces,
-			ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
-			EnableK8SNSMirroring:       c.flagEnableK8SNSMirroring,
-			K8SNSMirroringPrefix:       c.flagK8SNSMirroringPrefix,
-			CrossNamespaceACLPolicy:    c.flagCrossNamespaceACLPolicy,
-			EnableTransparentProxy:     c.flagDefaultEnableTransparentProxy,
-			TProxyOverwriteProbes:      c.flagTransparentProxyDefaultOverwriteProbes,
-			EnableConsulDNS:            c.flagEnableConsulDNS,
-			ResourcePrefix:             c.flagResourcePrefix,
-			EnableOpenShift:            c.flagEnableOpenShift,
-			Log:                        ctrl.Log.WithName("handler").WithName("connect"),
-			LogLevel:                   c.flagLogLevel,
-			LogJSON:                    c.flagLogJSON,
+			Clientset:                     c.clientset,
+			ConsulClient:                  c.consulClient,
+			ImageConsul:                   c.flagConsulImage,
+			ImageEnvoy:                    c.flagEnvoyImage,
+			EnvoyExtraArgs:                c.flagEnvoyExtraArgs,
+			ImageConsulK8S:                c.flagConsulK8sImage,
+			RequireAnnotation:             !c.flagDefaultInject,
+			AuthMethod:                    c.flagACLAuthMethod,
+			ConsulCACert:                  string(consulCACert),
+			DefaultProxyCPURequest:        sidecarProxyCPURequest,
+			DefaultProxyCPULimit:          sidecarProxyCPULimit,
+			DefaultProxyMemoryRequest:     sidecarProxyMemoryRequest,
+			DefaultProxyMemoryLimit:       sidecarProxyMemoryLimit,
+			MetricsConfig:                 metricsConfig,
+			InitContainerResources:        initResources,
+			DefaultConsulSidecarResources: consulSidecarResources,
+			ConsulPartition:               c.http.Partition(),
+			AllowK8sNamespacesSet:         allowK8sNamespaces,
+			DenyK8sNamespacesSet:          denyK8sNamespaces,
+			EnableNamespaces:              c.flagEnableNamespaces,
+			ConsulDestinationNamespace:    c.flagConsulDestinationNamespace,
+			EnableK8SNSMirroring:          c.flagEnableK8SNSMirroring,
+			K8SNSMirroringPrefix:          c.flagK8SNSMirroringPrefix,
+			CrossNamespaceACLPolicy:       c.flagCrossNamespaceACLPolicy,
+			EnableTransparentProxy:        c.flagDefaultEnableTransparentProxy,
+			TProxyOverwriteProbes:         c.flagTransparentProxyDefaultOverwriteProbes,
+			EnableConsulDNS:               c.flagEnableConsulDNS,
+			ResourcePrefix:                c.flagResourcePrefix,
+			EnableOpenShift:               c.flagEnableOpenShift,
+			Log:                           ctrl.Log.WithName("handler").WithName("connect"),
+			LogLevel:                      c.flagLogLevel,
+			LogJSON:                       c.flagLogJSON,
 		}})
 
 	if err := mgr.Start(ctx); err != nil {
@@ -548,36 +548,36 @@ func (c *Command) parseAndValidateResourceFlags() (corev1.ResourceRequirements, 
 	var consulSidecarCPULimit, consulSidecarCPURequest, consulSidecarMemoryLimit, consulSidecarMemoryRequest resource.Quantity
 
 	// Parse and validate the Consul sidecar resources
-	consulSidecarCPURequest, err = resource.ParseQuantity(c.flagConsulSidecarCPURequest)
+	consulSidecarCPURequest, err = resource.ParseQuantity(c.flagDefaultConsulSidecarCPURequest)
 	if err != nil {
 		return corev1.ResourceRequirements{}, corev1.ResourceRequirements{},
-			fmt.Errorf("-consul-sidecar-cpu-request '%s' is invalid: %s", c.flagConsulSidecarCPURequest, err)
+			fmt.Errorf("-default-consul-sidecar-cpu-request '%s' is invalid: %s", c.flagDefaultConsulSidecarCPURequest, err)
 	}
-	consulSidecarCPULimit, err = resource.ParseQuantity(c.flagConsulSidecarCPULimit)
+	consulSidecarCPULimit, err = resource.ParseQuantity(c.flagDefaultConsulSidecarCPULimit)
 	if err != nil {
 		return corev1.ResourceRequirements{}, corev1.ResourceRequirements{},
-			fmt.Errorf("-consul-sidecar-cpu-limit '%s' is invalid: %s", c.flagConsulSidecarCPULimit, err)
+			fmt.Errorf("-default-consul-sidecar-cpu-limit '%s' is invalid: %s", c.flagDefaultConsulSidecarCPULimit, err)
 	}
 	if consulSidecarCPULimit.Value() != 0 && consulSidecarCPURequest.Cmp(consulSidecarCPULimit) > 0 {
 		return corev1.ResourceRequirements{}, corev1.ResourceRequirements{}, fmt.Errorf(
-			"request must be <= limit: -consul-sidecar-cpu-request value of %q is greater than the -consul-sidecar-cpu-limit value of %q",
-			c.flagConsulSidecarCPURequest, c.flagConsulSidecarCPULimit)
+			"request must be <= limit: -default-consul-sidecar-cpu-request value of %q is greater than the -default-consul-sidecar-cpu-limit value of %q",
+			c.flagDefaultConsulSidecarCPURequest, c.flagDefaultConsulSidecarCPULimit)
 	}
 
-	consulSidecarMemoryRequest, err = resource.ParseQuantity(c.flagConsulSidecarMemoryRequest)
+	consulSidecarMemoryRequest, err = resource.ParseQuantity(c.flagDefaultConsulSidecarMemoryRequest)
 	if err != nil {
 		return corev1.ResourceRequirements{}, corev1.ResourceRequirements{},
-			fmt.Errorf("-consul-sidecar-memory-request '%s' is invalid: %s", c.flagConsulSidecarMemoryRequest, err)
+			fmt.Errorf("-default-consul-sidecar-memory-request '%s' is invalid: %s", c.flagDefaultConsulSidecarMemoryRequest, err)
 	}
-	consulSidecarMemoryLimit, err = resource.ParseQuantity(c.flagConsulSidecarMemoryLimit)
+	consulSidecarMemoryLimit, err = resource.ParseQuantity(c.flagDefaultConsulSidecarMemoryLimit)
 	if err != nil {
 		return corev1.ResourceRequirements{}, corev1.ResourceRequirements{},
-			fmt.Errorf("-consul-sidecar-memory-limit '%s' is invalid: %s", c.flagConsulSidecarMemoryLimit, err)
+			fmt.Errorf("-default-consul-sidecar-memory-limit '%s' is invalid: %s", c.flagDefaultConsulSidecarMemoryLimit, err)
 	}
 	if consulSidecarMemoryLimit.Value() != 0 && consulSidecarMemoryRequest.Cmp(consulSidecarMemoryLimit) > 0 {
 		return corev1.ResourceRequirements{}, corev1.ResourceRequirements{}, fmt.Errorf(
-			"request must be <= limit: -consul-sidecar-memory-request value of %q is greater than the -consul-sidecar-memory-limit value of %q",
-			c.flagConsulSidecarMemoryRequest, c.flagConsulSidecarMemoryLimit)
+			"request must be <= limit: -default-consul-sidecar-memory-request value of %q is greater than the -default-consul-sidecar-memory-limit value of %q",
+			c.flagDefaultConsulSidecarMemoryRequest, c.flagDefaultConsulSidecarMemoryLimit)
 	}
 
 	// Put into corev1.ResourceRequirements form

--- a/control-plane/subcommand/inject-connect/command_test.go
+++ b/control-plane/subcommand/inject-connect/command_test.go
@@ -127,37 +127,37 @@ func TestRun_FlagValidation(t *testing.T) {
 		},
 		{
 			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
-				"-consul-sidecar-cpu-limit=unparseable"},
-			expErr: "-consul-sidecar-cpu-limit 'unparseable' is invalid",
+				"-default-consul-sidecar-cpu-limit=unparseable"},
+			expErr: "-default-consul-sidecar-cpu-limit 'unparseable' is invalid",
 		},
 		{
 			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
-				"-consul-sidecar-cpu-request=unparseable"},
-			expErr: "-consul-sidecar-cpu-request 'unparseable' is invalid",
+				"-default-consul-sidecar-cpu-request=unparseable"},
+			expErr: "-default-consul-sidecar-cpu-request 'unparseable' is invalid",
 		},
 		{
 			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
-				"-consul-sidecar-memory-limit=unparseable"},
-			expErr: "-consul-sidecar-memory-limit 'unparseable' is invalid",
+				"-default-consul-sidecar-memory-limit=unparseable"},
+			expErr: "-default-consul-sidecar-memory-limit 'unparseable' is invalid",
 		},
 		{
 			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
-				"-consul-sidecar-memory-request=unparseable"},
-			expErr: "-consul-sidecar-memory-request 'unparseable' is invalid",
+				"-default-consul-sidecar-memory-request=unparseable"},
+			expErr: "-default-consul-sidecar-memory-request 'unparseable' is invalid",
 		},
 		{
 			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
-				"-consul-sidecar-memory-request=50Mi",
-				"-consul-sidecar-memory-limit=25Mi",
+				"-default-consul-sidecar-memory-request=50Mi",
+				"-default-consul-sidecar-memory-limit=25Mi",
 			},
-			expErr: "request must be <= limit: -consul-sidecar-memory-request value of \"50Mi\" is greater than the -consul-sidecar-memory-limit value of \"25Mi\"",
+			expErr: "request must be <= limit: -default-consul-sidecar-memory-request value of \"50Mi\" is greater than the -default-consul-sidecar-memory-limit value of \"25Mi\"",
 		},
 		{
 			flags: []string{"-consul-k8s-image", "foo", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
-				"-consul-sidecar-cpu-request=50m",
-				"-consul-sidecar-cpu-limit=25m",
+				"-default-consul-sidecar-cpu-request=50m",
+				"-default-consul-sidecar-cpu-limit=25m",
 			},
-			expErr: "request must be <= limit: -consul-sidecar-cpu-request value of \"50m\" is greater than the -consul-sidecar-cpu-limit value of \"25m\"",
+			expErr: "request must be <= limit: -default-consul-sidecar-cpu-request value of \"50m\" is greater than the -default-consul-sidecar-cpu-limit value of \"25m\"",
 		},
 		{
 			flags: []string{"-consul-k8s-image", "hashicorp/consul-k8s", "-consul-image", "foo", "-envoy-image", "envoy:1.16.0",
@@ -199,10 +199,10 @@ func TestRun_ResourceLimitDefaults(t *testing.T) {
 	require.Equal(t, cmd.flagInitContainerMemoryLimit, "150Mi")
 
 	// Consul sidecar container defaults
-	require.Equal(t, cmd.flagConsulSidecarCPURequest, "20m")
-	require.Equal(t, cmd.flagConsulSidecarCPULimit, "20m")
-	require.Equal(t, cmd.flagConsulSidecarMemoryRequest, "25Mi")
-	require.Equal(t, cmd.flagConsulSidecarMemoryLimit, "50Mi")
+	require.Equal(t, cmd.flagDefaultConsulSidecarCPURequest, "20m")
+	require.Equal(t, cmd.flagDefaultConsulSidecarCPULimit, "20m")
+	require.Equal(t, cmd.flagDefaultConsulSidecarMemoryRequest, "25Mi")
+	require.Equal(t, cmd.flagDefaultConsulSidecarMemoryLimit, "50Mi")
 }
 
 func TestRun_ValidationConsulHTTPAddr(t *testing.T) {


### PR DESCRIPTION
Hi

We are currently migrating our metrics polling to use merged metrics and we have one issue.
Some of our pods return lots of metrics (~150k) and the consul sidecar get OOM killed.
We bump the memory of the sidecar but dont want to waste memory where we dont need it.

Changes proposed in this PR:
- default resources are set via flags of the injector
- can be overriden with annotations on pods

I renamed the injector flags to mirror the envoy sidecar configuration.
The code is heavily inspired by envoy sidecar configuration but i kept the `consulSidecarResources` object in the subcommand.
If you want that i replicate the envoy stuff and split the resources into 4 vars when passing the settings to the handler, i can do it.

I am open to any ideas / modifications :)

How I've tested this PR:
- Added tests
- Run the tests ( control-plane and charts )

How I expect reviewers to test this PR:
¯\\_(ツ)_/¯

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

