### PR TITLE
chart: bump to envoy 1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## UNRELEASED
 
+FEATURES:
 * Helm
   * Support Envoy 1.20.1. [[GH-935](https://github.com/hashicorp/consul-k8s/pull/958)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## UNRELEASED
+
+* Helm
+  * Support Envoy 1.20.1. [[GH-935](https://github.com/hashicorp/consul-k8s/pull/958)]
+
 IMPROVEMENTS:
 * Helm
   * Allow customization of `terminationGracePeriodSeconds` on the ingress gateways. [[GH-947](https://github.com/hashicorp/consul-k8s/pull/947)] 

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -17,7 +17,7 @@ annotations:
     - name: consul-k8s-control-plane
       image: hashicorp/consul-k8s-control-plane:0.39.0
     - name: envoy
-      image: envoyproxy/envoy-alpine:v1.20.0
+      image: envoyproxy/envoy-alpine:v1.20.1
   artifacthub.io/license: MPL-2.0
   artifacthub.io/links: |
     - name: Documentation

--- a/charts/consul/test/unit/ingress-gateways-deployment.bats
+++ b/charts/consul/test/unit/ingress-gateways-deployment.bats
@@ -83,7 +83,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "envoyproxy/envoy-alpine:v1.20.0" ]
+  [ "${actual}" = "envoyproxy/envoy-alpine:v1.20.1" ]
 }
 
 @test "ingressGateways/Deployment: envoy image can be set using the global value" {

--- a/charts/consul/test/unit/mesh-gateway-deployment.bats
+++ b/charts/consul/test/unit/mesh-gateway-deployment.bats
@@ -335,7 +335,7 @@ key2: value2' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "envoyproxy/envoy-alpine:v1.20.0" ]
+  [ "${actual}" = "envoyproxy/envoy-alpine:v1.20.1" ]
 }
 
 @test "meshGateway/Deployment: setting meshGateway.imageEnvoy fails" {

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -83,7 +83,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "envoyproxy/envoy-alpine:v1.20.0" ]
+  [ "${actual}" = "envoyproxy/envoy-alpine:v1.20.1" ]
 }
 
 @test "terminatingGateways/Deployment: envoy image can be set using the global value" {

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -444,7 +444,7 @@ global:
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
   # See https://www.consul.io/docs/connect/proxies/envoy for full compatibility matrix between Consul and Envoy.
   # @default: envoyproxy/envoy-alpine:<latest supported version>
-  imageEnvoy: "envoyproxy/envoy-alpine:v1.20.0"
+  imageEnvoy: "envoyproxy/envoy-alpine:v1.20.1"
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.


### PR DESCRIPTION
Changes proposed in this PR:
- Bump chart.yaml and values.yaml to point to Envoy 1.20.1
- Depends on merging of Core PR: https://github.com/hashicorp/consul/pull/11895 

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

