### PR TITLE
Add partitions test to GKE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ commands:
                           ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -enable-multi-cluster \
                           -debug-directory="$TEST_RESULTS/debug" \
+                          -run TestPartitions \
                           -consul-k8s-image=<< parameters.consul-k8s-image >>
                     then
                       echo "Tests in ${pkg} failed, aborting early"
@@ -134,6 +135,7 @@ commands:
                       -enable-multi-cluster \
                       ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -debug-directory="$TEST_RESULTS/debug" \
+                      -run TestPartitions \
                       -consul-k8s-image=<< parameters.consul-k8s-image >>
 
 jobs:
@@ -764,7 +766,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig"
+          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-transparent-proxy
 
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,6 @@ commands:
                           ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -enable-multi-cluster \
                           -debug-directory="$TEST_RESULTS/debug" \
-                          -run TestPartitions \
                           -consul-k8s-image=<< parameters.consul-k8s-image >>
                     then
                       echo "Tests in ${pkg} failed, aborting early"
@@ -135,7 +134,6 @@ commands:
                       -enable-multi-cluster \
                       ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -debug-directory="$TEST_RESULTS/debug" \
-                      -run TestPartitions \
                       -consul-k8s-image=<< parameters.consul-k8s-image >>
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -664,9 +664,9 @@ jobs:
             terraform destroy -var project=${CLOUDSDK_CORE_PROJECT} -auto-approve
           when: always
 
-      - slack/status:
-          fail_only: true
-          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-21:
     environment:
@@ -971,7 +971,6 @@ workflows:
             - unit-test-helm-templates
             - unit-acceptance-framework
             - unit-cli
-      - cleanup-gcp-resources
       - acceptance-gke-1-20
   nightly-acceptance-tests:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -972,7 +972,7 @@ workflows:
             - unit-acceptance-framework
             - unit-cli
       - cleanup-eks-resources
-      - acceptance-eks-1-18:
+      - acceptance-eks-1-19:
           requires:
             - cleanup-eks-resources
   nightly-acceptance-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ commands:
                           ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -enable-multi-cluster \
                           -debug-directory="$TEST_RESULTS/debug" \
+                          -run TestPartitions \
                           -consul-k8s-image=<< parameters.consul-k8s-image >>
                     then
                       echo "Tests in ${pkg} failed, aborting early"
@@ -134,6 +135,7 @@ commands:
                       -enable-multi-cluster \
                       ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -debug-directory="$TEST_RESULTS/debug" \
+                      -run TestPartitions \
                       -consul-k8s-image=<< parameters.consul-k8s-image >>
 
 jobs:
@@ -764,7 +766,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-transparent-proxy
+          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig"
 
       - store_test_results:
           path: /tmp/test-results
@@ -969,6 +971,10 @@ workflows:
             - unit-test-helm-templates
             - unit-acceptance-framework
             - unit-cli
+      - cleanup-eks-resources
+      - acceptance-eks-1-18:
+          requires:
+            - cleanup-eks-resources
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -971,8 +971,8 @@ workflows:
             - unit-test-helm-templates
             - unit-acceptance-framework
             - unit-cli
-      - cleanup-eks-resources
-      - acceptance-aks-1-21
+      - cleanup-gcp-resources
+      - acceptance-gke-1-20
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,6 @@ commands:
                           ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -enable-multi-cluster \
                           -debug-directory="$TEST_RESULTS/debug" \
-                          -run TestPartitions \
                           -consul-k8s-image=<< parameters.consul-k8s-image >>
                     then
                       echo "Tests in ${pkg} failed, aborting early"
@@ -135,7 +134,6 @@ commands:
                       -enable-multi-cluster \
                       ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -debug-directory="$TEST_RESULTS/debug" \
-                      -run TestPartitions \
                       -consul-k8s-image=<< parameters.consul-k8s-image >>
 
 jobs:
@@ -664,9 +662,9 @@ jobs:
             terraform destroy -var project=${CLOUDSDK_CORE_PROJECT} -auto-approve
           when: always
 
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-21:
     environment:
@@ -719,9 +717,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-eks-1-19:
     environment:
@@ -971,7 +969,6 @@ workflows:
             - unit-test-helm-templates
             - unit-acceptance-framework
             - unit-cli
-      - acceptance-gke-1-20
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -719,9 +719,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-      - slack/status:
-          fail_only: true
-          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-eks-1-19:
     environment:
@@ -972,9 +972,7 @@ workflows:
             - unit-acceptance-framework
             - unit-cli
       - cleanup-eks-resources
-      - acceptance-eks-1-19:
-          requires:
-            - cleanup-eks-resources
+      - acceptance-aks-1-21
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/acceptance/tests/partitions/partitions_test.go
+++ b/acceptance/tests/partitions/partitions_test.go
@@ -169,7 +169,7 @@ func TestPartitions(t *testing.T) {
 
 				// It can take some time for the load balancers to be ready and have an IP/Hostname.
 				// Wait for 2 minutes before failing.
-				retry.RunWith(&retry.Counter{Wait: 1 * time.Second, Count: 120}, t, func(r *retry.R) {
+				retry.RunWith(&retry.Counter{Wait: 1 * time.Second, Count: 300}, t, func(r *retry.R) {
 					require.NotZero(r, len(partitionsSvc.Status.LoadBalancer.Ingress))
 					// On AWS, load balancers have a hostname for ingress, while on Azure and GCP
 					// load balancers have IPs.

--- a/acceptance/tests/partitions/partitions_test.go
+++ b/acceptance/tests/partitions/partitions_test.go
@@ -164,13 +164,13 @@ func TestPartitions(t *testing.T) {
 				// Get the IP of the partition service to configure the external server address in the values file for the clients cluster.
 				partitionServiceName := fmt.Sprintf("%s-consul-partition-service", releaseName)
 				logger.Logf(t, "retrieving partition service to determine external address for servers")
-				partitionsSvc, err := serverClusterContext.KubernetesClient(t).CoreV1().Services(serverClusterContext.KubectlOptions(t).Namespace).Get(ctx, partitionServiceName, metav1.GetOptions{})
-				require.NoError(t, err)
 
 				// It can take some time for the load balancers to be ready and have an IP/Hostname.
-				// Wait for 2 minutes before failing.
-				retry.RunWith(&retry.Counter{Wait: 1 * time.Second, Count: 300}, t, func(r *retry.R) {
-					require.NotZero(r, len(partitionsSvc.Status.LoadBalancer.Ingress))
+				// Wait for 60 seconds before failing.
+				retry.RunWith(&retry.Counter{Wait: 1 * time.Second, Count: 60}, t, func(r *retry.R) {
+					partitionsSvc, err := serverClusterContext.KubernetesClient(t).CoreV1().Services(serverClusterContext.KubectlOptions(t).Namespace).Get(ctx, partitionServiceName, metav1.GetOptions{})
+					require.NoError(t, err)
+					require.NotEmpty(r, partitionsSvc.Status.LoadBalancer.Ingress)
 					// On AWS, load balancers have a hostname for ingress, while on Azure and GCP
 					// load balancers have IPs.
 					if partitionsSvc.Status.LoadBalancer.Ingress[0].Hostname != "" {

--- a/charts/consul/templates/server-podsecuritypolicy.yaml
+++ b/charts/consul/templates/server-podsecuritypolicy.yaml
@@ -27,6 +27,15 @@ spec:
     - 'downwardAPI'
     - 'persistentVolumeClaim'
   hostNetwork: false
+  hostPorts:
+  {{- if .Values.server.exposeGossipAndRPCPorts }}
+  - min: 8300
+    max: 8300
+  - min: {{ .Values.server.ports.serflan.port }}
+    max: {{ .Values.server.ports.serflan.port }}
+  - min: 8302
+    max: 8302
+  {{- end }}
   hostIPC: false
   hostPID: false
   runAsUser:

--- a/charts/consul/test/terraform/gke/main.tf
+++ b/charts/consul/test/terraform/gke/main.tf
@@ -38,7 +38,7 @@ resource "google_compute_firewall" "firewall-rules" {
   project     = var.project
   name        = "consul-k8s-acceptance-firewall-${random_id.suffix[count.index].dec}"
   network     = "default"
-  description = "Creates firewall rule targeting tagged instances"
+  description = "Creates firewall rule allowing traffic from nodes and pods of the ${random_id.suffix[count.index == 0 ? 1 : 0].dec} Kubernetes cluster."
 
   count = var.cluster_count > 1 ? var.cluster_count : 0
 

--- a/charts/consul/test/terraform/gke/variables.tf
+++ b/charts/consul/test/terraform/gke/variables.tf
@@ -19,6 +19,14 @@ variable "init_cli" {
 variable "cluster_count" {
   default     = 1
   description = "The number of Kubernetes clusters to create."
+
+  // We currently cannot support more than 2 cluster
+  // because setting up peering is more complicated if cluster count is
+  // more than two.
+  validation {
+    condition     = var.cluster_count < 3 && var.cluster_count > 0
+    error_message = "The cluster_count value must be 1 or 2."
+  }
 }
 
 variable "labels" {

--- a/charts/consul/test/unit/server-podsecuritypolicy.bats
+++ b/charts/consul/test/unit/server-podsecuritypolicy.bats
@@ -27,3 +27,29 @@ load _helpers
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# server.exposeGossipAndRPCPorts
+
+@test "server/PodSecurityPolicy: hostPort 8300, 8301 and 8302 allowed when exposeGossipAndRPCPorts=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-podsecuritypolicy.yaml  \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'server.exposeGossipAndRPCPorts=true' \
+      . | tee /dev/stderr |
+      yq -c '.spec.hostPorts' | tee /dev/stderr)
+  [ "${actual}" = '[{"min":8300,"max":8300},{"min":8301,"max":8301},{"min":8302,"max":8302}]' ]
+}
+
+@test "server/PodSecurityPolicy: hostPort 8300, server.ports.serflan.port and 8302 allowed when exposeGossipAndRPCPorts=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-podsecuritypolicy.yaml  \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'server.exposeGossipAndRPCPorts=true' \
+      --set 'server.ports.serflan.port=8333' \
+      . | tee /dev/stderr |
+      yq -c '.spec.hostPorts' | tee /dev/stderr)
+  [ "${actual}" = '[{"min":8300,"max":8300},{"min":8333,"max":8333},{"min":8302,"max":8302}]' ]
+}


### PR DESCRIPTION
Changes proposed in this PR:
- Update GKE terraform templates for partitions tests
  - we create firewall rules that allow nodes and pods from each cluster to reach the nodes of the other.
- Update server podsercuritypolicy to allow hostports on specific ports if `server.exportGossipAndRPCPorts` is set to `true`

How I've tested this PR:
- ran tests: https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/3926/workflows/1aeed2ff-40b4-4a7a-99cb-f84f751048a0

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

