### PR TITLE
Add - separated names for config entry crds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ IMPROVEMENTS:
 * Helm
   * Allow customization of `terminationGracePeriodSeconds` on the ingress gateways. [[GH-947](https://github.com/hashicorp/consul-k8s/pull/947)]
   * Support `ui.dashboardURLTemplates.service` value for setting [dashboard URL templates](https://www.consul.io/docs/agent/options#ui_config_dashboard_url_templates_service). [[GH-937](https://github.com/hashicorp/consul-k8s/pull/937)]
+  * Allow using dash-separated names for config entries when using `kubectl`. [[GH-965](https://github.com/hashicorp/consul-k8s/pull/965)]
 
 BUG FIXES:
 * Helm

--- a/charts/consul/templates/crd-exportedservices.yaml
+++ b/charts/consul/templates/crd-exportedservices.yaml
@@ -19,6 +19,8 @@ spec:
     kind: ExportedServices
     listKind: ExportedServicesList
     plural: exportedservices
+    shortNames:
+    - exported-services
     singular: exportedservices
   scope: Namespaced
   versions:

--- a/charts/consul/templates/crd-ingressgateways.yaml
+++ b/charts/consul/templates/crd-ingressgateways.yaml
@@ -19,6 +19,8 @@ spec:
     kind: IngressGateway
     listKind: IngressGatewayList
     plural: ingressgateways
+    shortNames:
+    - ingress-gateway
     singular: ingressgateway
   scope: Namespaced
   versions:

--- a/charts/consul/templates/crd-proxydefaults.yaml
+++ b/charts/consul/templates/crd-proxydefaults.yaml
@@ -19,6 +19,8 @@ spec:
     kind: ProxyDefaults
     listKind: ProxyDefaultsList
     plural: proxydefaults
+    shortNames:
+    - proxy-defaults
     singular: proxydefaults
   scope: Namespaced
   versions:

--- a/charts/consul/templates/crd-servicedefaults.yaml
+++ b/charts/consul/templates/crd-servicedefaults.yaml
@@ -19,6 +19,8 @@ spec:
     kind: ServiceDefaults
     listKind: ServiceDefaultsList
     plural: servicedefaults
+    shortNames:
+    - service-defaults
     singular: servicedefaults
   scope: Namespaced
   versions:

--- a/charts/consul/templates/crd-serviceintentions.yaml
+++ b/charts/consul/templates/crd-serviceintentions.yaml
@@ -19,6 +19,8 @@ spec:
     kind: ServiceIntentions
     listKind: ServiceIntentionsList
     plural: serviceintentions
+    shortNames:
+    - service-intentions
     singular: serviceintentions
   scope: Namespaced
   versions:

--- a/charts/consul/templates/crd-serviceresolvers.yaml
+++ b/charts/consul/templates/crd-serviceresolvers.yaml
@@ -19,6 +19,8 @@ spec:
     kind: ServiceResolver
     listKind: ServiceResolverList
     plural: serviceresolvers
+    shortNames:
+    - service-resolver
     singular: serviceresolver
   scope: Namespaced
   versions:

--- a/charts/consul/templates/crd-servicerouters.yaml
+++ b/charts/consul/templates/crd-servicerouters.yaml
@@ -19,6 +19,8 @@ spec:
     kind: ServiceRouter
     listKind: ServiceRouterList
     plural: servicerouters
+    shortNames:
+    - service-router
     singular: servicerouter
   scope: Namespaced
   versions:

--- a/charts/consul/templates/crd-servicesplitters.yaml
+++ b/charts/consul/templates/crd-servicesplitters.yaml
@@ -19,6 +19,8 @@ spec:
     kind: ServiceSplitter
     listKind: ServiceSplitterList
     plural: servicesplitters
+    shortNames:
+    - service-splitter
     singular: servicesplitter
   scope: Namespaced
   versions:

--- a/charts/consul/templates/crd-terminatinggateways.yaml
+++ b/charts/consul/templates/crd-terminatinggateways.yaml
@@ -19,6 +19,8 @@ spec:
     kind: TerminatingGateway
     listKind: TerminatingGatewayList
     plural: terminatinggateways
+    shortNames:
+    - terminating-gateway
     singular: terminatinggateway
   scope: Namespaced
   versions:

--- a/control-plane/api/v1alpha1/exportedservices_types.go
+++ b/control-plane/api/v1alpha1/exportedservices_types.go
@@ -29,6 +29,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
 // +kubebuilder:printcolumn:name="Last Synced",type="date",JSONPath=".status.lastSyncedTime",description="The last successful synced time of the resource with Consul"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
+// +kubebuilder:resource:shortName="exported-services"
 type ExportedServices struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/control-plane/api/v1alpha1/ingressgateway_types.go
+++ b/control-plane/api/v1alpha1/ingressgateway_types.go
@@ -32,6 +32,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
 // +kubebuilder:printcolumn:name="Last Synced",type="date",JSONPath=".status.lastSyncedTime",description="The last successful synced time of the resource with Consul"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
+// +kubebuilder:resource:shortName="ingress-gateway"
 type IngressGateway struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/control-plane/api/v1alpha1/proxydefaults_types.go
+++ b/control-plane/api/v1alpha1/proxydefaults_types.go
@@ -31,6 +31,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
 // +kubebuilder:printcolumn:name="Last Synced",type="date",JSONPath=".status.lastSyncedTime",description="The last successful synced time of the resource with Consul"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
+// +kubebuilder:resource:shortName="proxy-defaults"
 type ProxyDefaults struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/control-plane/api/v1alpha1/servicedefaults_types.go
+++ b/control-plane/api/v1alpha1/servicedefaults_types.go
@@ -29,6 +29,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
 // +kubebuilder:printcolumn:name="Last Synced",type="date",JSONPath=".status.lastSyncedTime",description="The last successful synced time of the resource with Consul"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
+// +kubebuilder:resource:shortName="service-defaults"
 type ServiceDefaults struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/control-plane/api/v1alpha1/serviceintentions_types.go
+++ b/control-plane/api/v1alpha1/serviceintentions_types.go
@@ -29,6 +29,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
 // +kubebuilder:printcolumn:name="Last Synced",type="date",JSONPath=".status.lastSyncedTime",description="The last successful synced time of the resource with Consul"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
+// +kubebuilder:resource:shortName="service-intentions"
 type ServiceIntentions struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/control-plane/api/v1alpha1/serviceresolver_types.go
+++ b/control-plane/api/v1alpha1/serviceresolver_types.go
@@ -27,6 +27,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
 // +kubebuilder:printcolumn:name="Last Synced",type="date",JSONPath=".status.lastSyncedTime",description="The last successful synced time of the resource with Consul"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
+// +kubebuilder:resource:shortName="service-resolver"
 type ServiceResolver struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/control-plane/api/v1alpha1/servicerouter_types.go
+++ b/control-plane/api/v1alpha1/servicerouter_types.go
@@ -30,6 +30,7 @@ const (
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
 // +kubebuilder:printcolumn:name="Last Synced",type="date",JSONPath=".status.lastSyncedTime",description="The last successful synced time of the resource with Consul"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
+// +kubebuilder:resource:shortName="service-router"
 type ServiceRouter struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/control-plane/api/v1alpha1/servicesplitter_types.go
+++ b/control-plane/api/v1alpha1/servicesplitter_types.go
@@ -26,6 +26,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
 // +kubebuilder:printcolumn:name="Last Synced",type="date",JSONPath=".status.lastSyncedTime",description="The last successful synced time of the resource with Consul"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
+// +kubebuilder:resource:shortName="service-splitter"
 type ServiceSplitter struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/control-plane/api/v1alpha1/terminatinggateway_types.go
+++ b/control-plane/api/v1alpha1/terminatinggateway_types.go
@@ -30,6 +30,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
 // +kubebuilder:printcolumn:name="Last Synced",type="date",JSONPath=".status.lastSyncedTime",description="The last successful synced time of the resource with Consul"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
+// +kubebuilder:resource:shortName="terminating-gateway"
 type TerminatingGateway struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/control-plane/config/crd/bases/consul.hashicorp.com_exportedservices.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_exportedservices.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ExportedServices
     listKind: ExportedServicesList
     plural: exportedservices
+    shortNames:
+    - exported-services
     singular: exportedservices
   scope: Namespaced
   versions:

--- a/control-plane/config/crd/bases/consul.hashicorp.com_ingressgateways.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_ingressgateways.yaml
@@ -13,6 +13,8 @@ spec:
     kind: IngressGateway
     listKind: IngressGatewayList
     plural: ingressgateways
+    shortNames:
+    - ingress-gateway
     singular: ingressgateway
   scope: Namespaced
   versions:

--- a/control-plane/config/crd/bases/consul.hashicorp.com_proxydefaults.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_proxydefaults.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ProxyDefaults
     listKind: ProxyDefaultsList
     plural: proxydefaults
+    shortNames:
+    - proxy-defaults
     singular: proxydefaults
   scope: Namespaced
   versions:

--- a/control-plane/config/crd/bases/consul.hashicorp.com_servicedefaults.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_servicedefaults.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ServiceDefaults
     listKind: ServiceDefaultsList
     plural: servicedefaults
+    shortNames:
+    - service-defaults
     singular: servicedefaults
   scope: Namespaced
   versions:

--- a/control-plane/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ServiceIntentions
     listKind: ServiceIntentionsList
     plural: serviceintentions
+    shortNames:
+    - service-intentions
     singular: serviceintentions
   scope: Namespaced
   versions:

--- a/control-plane/config/crd/bases/consul.hashicorp.com_serviceresolvers.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_serviceresolvers.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ServiceResolver
     listKind: ServiceResolverList
     plural: serviceresolvers
+    shortNames:
+    - service-resolver
     singular: serviceresolver
   scope: Namespaced
   versions:

--- a/control-plane/config/crd/bases/consul.hashicorp.com_servicerouters.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_servicerouters.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ServiceRouter
     listKind: ServiceRouterList
     plural: servicerouters
+    shortNames:
+    - service-router
     singular: servicerouter
   scope: Namespaced
   versions:

--- a/control-plane/config/crd/bases/consul.hashicorp.com_servicesplitters.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_servicesplitters.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ServiceSplitter
     listKind: ServiceSplitterList
     plural: servicesplitters
+    shortNames:
+    - service-splitter
     singular: servicesplitter
   scope: Namespaced
   versions:

--- a/control-plane/config/crd/bases/consul.hashicorp.com_terminatinggateways.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_terminatinggateways.yaml
@@ -13,6 +13,8 @@ spec:
     kind: TerminatingGateway
     listKind: TerminatingGatewayList
     plural: terminatinggateways
+    shortNames:
+    - terminating-gateway
     singular: terminatinggateway
   scope: Namespaced
   versions:


### PR DESCRIPTION
For example allow both kubectl get ingressgateways and
kubectl get ingress-gateways.

When specified in .hcl or .json the config entries are dash-separated so
this makes it consistent if someone uses a dash by mistake after reading
our docs.

How I've tested this PR:
- edited a crd in my cluster to match and tested out the aliasname

How I expect reviewers to test this PR:
- make sure I didn't typo or use the wrong name for a config entry
- also review if this is a good idea


Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

