### PR TITLE
Create anonymous-policy and token from non-default partitions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
         type: string
       consul-k8s-image:
         type: string
-        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s-control-plane:latest"
+        default: "ashwinvenkatesh/consul-k8s@sha256:9b46fae446fcf99c715d9063231857eef5525830f2cd3cdcb46266c84db11deb"
       go-path:
         type: string
         default: "/home/circleci/.go_workspace"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
         type: string
       consul-k8s-image:
         type: string
-        default: "ashwinvenkatesh/consul-k8s@sha256:9b46fae446fcf99c715d9063231857eef5525830f2cd3cdcb46266c84db11deb"
+        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s-control-plane:latest"
       go-path:
         type: string
         default: "/home/circleci/.go_workspace"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ IMPROVEMENTS:
 BUG FIXES:
 * Helm
   * Add `PodDisruptionBudget` Kind when checking for existing versions so that `helm template` can generate the right version. [[GH-923](https://github.com/hashicorp/consul-k8s/pull/923)]
+* Control Plane
+  * Admin Partitions **(Consul Enterprise only)**: Create anonymous-policy and anonymous-token from non-default partitions to support DNS queries when the default partition is on a VM. [[GH-966](https://github.com/hashicorp/consul-k8s/pull/966)]
 
 ## 0.39.0 (December 15, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ BUG FIXES:
 * Helm
   * Add `PodDisruptionBudget` Kind when checking for existing versions so that `helm template` can generate the right version. [[GH-923](https://github.com/hashicorp/consul-k8s/pull/923)]
 * Control Plane
-  * Admin Partitions **(Consul Enterprise only)**: Create anonymous-policy and anonymous-token from non-default partitions to support DNS queries when the default partition is on a VM. [[GH-966](https://github.com/hashicorp/consul-k8s/pull/966)]
+  * Admin Partitions **(Consul Enterprise only)**: Attach anonymous-policy to the anonymous token from non-default partitions to support DNS queries when the default partition is on a VM. [[GH-966](https://github.com/hashicorp/consul-k8s/pull/966)]
 
 ## 0.39.0 (December 15, 2021)
 

--- a/control-plane/connect-inject/endpoints_controller_ent_test.go
+++ b/control-plane/connect-inject/endpoints_controller_ent_test.go
@@ -1180,7 +1180,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 				consul, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 					if tt.enableACLs {
 						c.ACL.Enabled = true
-						c.ACL.Tokens.Master = adminToken
+						c.ACL.Tokens.InitialManagement = adminToken
 					}
 					c.NodeName = nodeName
 				})
@@ -1514,7 +1514,7 @@ func TestReconcileDeleteEndpointWithNamespaces(t *testing.T) {
 				consul, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 					if tt.enableACLs {
 						c.ACL.Enabled = true
-						c.ACL.Tokens.Master = adminToken
+						c.ACL.Tokens.InitialManagement = adminToken
 					}
 					c.NodeName = nodeName
 				})

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -127,7 +127,7 @@ func TestProcessUpstreamsTLSandACLs(t *testing.T) {
 	consul, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 		c.ACL.Enabled = true
 		c.ACL.DefaultPolicy = "deny"
-		c.ACL.Tokens.Master = masterToken
+		c.ACL.Tokens.InitialManagement = masterToken
 		c.CAFile = caFile
 		c.CertFile = certFile
 		c.KeyFile = keyFile
@@ -2340,7 +2340,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			consul, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 				if tt.enableACLs {
 					c.ACL.Enabled = tt.enableACLs
-					c.ACL.Tokens.Master = adminToken
+					c.ACL.Tokens.InitialManagement = adminToken
 				}
 				c.NodeName = nodeName
 			})
@@ -2627,7 +2627,7 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 			consul, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 				if tt.enableACLs {
 					c.ACL.Enabled = true
-					c.ACL.Tokens.Master = adminToken
+					c.ACL.Tokens.InitialManagement = adminToken
 				}
 				c.NodeName = nodeName
 			})

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -129,4 +129,6 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
+replace github.com/hashicorp/consul/sdk v0.9.0 => github.com/hashicorp/consul/sdk v0.4.1-0.20220120214936-7568f3a102a8
+
 go 1.17

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -300,9 +300,9 @@ github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBt
 github.com/hashicorp/consul/api v1.12.0 h1:k3y1FYv6nuKyNTqj6w9gXOx5r5CfLj/k/euUeBXj1OY=
 github.com/hashicorp/consul/api v1.12.0/go.mod h1:6pVBMo0ebnYdt2S3H87XhekM/HHrUoTD2XXb/VrZVy0=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/consul/sdk v0.4.1-0.20220120214936-7568f3a102a8 h1:1O/CANaJGcL6urr47PLoPZ0oQcGLUlGpYoRLYAYFSDs=
+github.com/hashicorp/consul/sdk v0.4.1-0.20220120214936-7568f3a102a8/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
-github.com/hashicorp/consul/sdk v0.9.0 h1:NGSHAU7X3yDCjo8WBUbNOtD3BSqv8u0vu3+zNxgmxQI=
-github.com/hashicorp/consul/sdk v0.9.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/control-plane/namespaces/namespaces_test.go
+++ b/control-plane/namespaces/namespaces_test.go
@@ -33,7 +33,7 @@ func TestEnsureExists_AlreadyExists(tt *testing.T) {
 			consul, err := testutil.NewTestServerConfigT(t, func(cfg *testutil.TestServerConfig) {
 				cfg.ACL.Enabled = c.ACLsEnabled
 				cfg.ACL.DefaultPolicy = "deny"
-				cfg.ACL.Tokens.Master = masterToken
+				cfg.ACL.Tokens.InitialManagement = masterToken
 			})
 			req.NoError(err)
 			defer consul.Stop()
@@ -104,7 +104,7 @@ func TestEnsureExists_CreatesNS(tt *testing.T) {
 			consul, err := testutil.NewTestServerConfigT(t, func(cfg *testutil.TestServerConfig) {
 				cfg.ACL.Enabled = c.ACLsEnabled
 				cfg.ACL.DefaultPolicy = "deny"
-				cfg.ACL.Tokens.Master = masterToken
+				cfg.ACL.Tokens.InitialManagement = masterToken
 			})
 			req.NoError(err)
 			defer consul.Stop()

--- a/control-plane/subcommand/connect-init/command_ent_test.go
+++ b/control-plane/subcommand/connect-init/command_ent_test.go
@@ -136,7 +136,7 @@ func TestRun_ServicePollingWithACLsAndTLSWithNamespaces(t *testing.T) {
 				if c.acls {
 					cfg.ACL.Enabled = true
 					cfg.ACL.DefaultPolicy = "deny"
-					cfg.ACL.Tokens.Master = masterToken
+					cfg.ACL.Tokens.InitialManagement = masterToken
 				}
 				if c.tls {
 					caFile, certFile, keyFile = test.GenerateServerCerts(t)

--- a/control-plane/subcommand/connect-init/command_test.go
+++ b/control-plane/subcommand/connect-init/command_test.go
@@ -122,7 +122,7 @@ func TestRun_ServicePollingWithACLsAndTLS(t *testing.T) {
 			server, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 				c.ACL.Enabled = true
 				c.ACL.DefaultPolicy = "deny"
-				c.ACL.Tokens.Master = masterToken
+				c.ACL.Tokens.InitialManagement = masterToken
 				if tt.tls {
 					caFile, certFile, keyFile = test.GenerateServerCerts(t)
 					c.CAFile = caFile

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -451,7 +451,21 @@ func (c *Command) Run(args []string) int {
 	}
 
 	if c.createAnonymousPolicy(isPrimary) {
-		err := c.configureAnonymousPolicy(consulClient)
+		// When the default partition is in a VM, the anonymous policy does not allow cross-partition
+		// DNS lookups. The anonymous policy in the default partition needs to be updated in order to
+		// support this use-case. Creating a separate anonymous token client that updates the anonymous
+		// policy and token in the default partition ensures this works.
+		anonTokenConfig := clientConfig
+		if c.flagEnablePartitions {
+			anonTokenConfig.Partition = consulDefaultPartition
+		}
+		anonTokenClient, err := consul.NewClient(anonTokenConfig)
+		if err != nil {
+			c.log.Error(err.Error())
+			return 1
+		}
+
+		err = c.configureAnonymousPolicy(anonTokenClient)
 		if err != nil {
 			c.log.Error(err.Error())
 			return 1
@@ -793,12 +807,6 @@ type Config struct {
 // createAnonymousPolicy returns whether we should create a policy for the
 // anonymous ACL token, i.e. queries without ACL tokens.
 func (c *Command) createAnonymousPolicy(isPrimary bool) bool {
-	// Don't try to create the anonymous policy in non-default partitions because
-	// non-default partitions will use the anonymous policy from the default
-	// partition.
-	if c.flagEnablePartitions && c.flagPartitionName != "default" {
-		return false
-	}
 	// If isPrimary is not set then we're in a secondary DC.
 	// In this case we assume that the primary datacenter has already created
 	// the anonymous policy and attached it to the anonymous token.

--- a/control-plane/subcommand/server-acl-init/command_ent_test.go
+++ b/control-plane/subcommand/server-acl-init/command_ent_test.go
@@ -208,7 +208,7 @@ func TestRun_ConnectInject_NamespaceMirroring(t *testing.T) {
 	}
 }
 
-// Test that the anonymous token is created in the default partition from
+// Test that the anonymous token policy is created in the default partition from
 // a non-default partition.
 func TestRun_AnonymousToken_CreatedFromNonDefaultPartition(t *testing.T) {
 	bootToken := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"

--- a/control-plane/subcommand/server-acl-init/command_test.go
+++ b/control-plane/subcommand/server-acl-init/command_test.go
@@ -2108,7 +2108,7 @@ func completeBootstrappedSetup(t *testing.T, masterToken string) (*fake.Clientse
 
 	svr, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 		c.ACL.Enabled = true
-		c.ACL.Tokens.Master = masterToken
+		c.ACL.Tokens.InitialManagement = masterToken
 	})
 	require.NoError(t, err)
 	svr.WaitForActiveCARoot(t)
@@ -2153,7 +2153,7 @@ func replicatedSetup(t *testing.T, bootToken string) (*fake.Clientset, *api.Clie
 	primarySvr, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 		c.ACL.Enabled = true
 		if bootToken != "" {
-			c.ACL.Tokens.Master = bootToken
+			c.ACL.Tokens.InitialManagement = bootToken
 		}
 	})
 	require.NoError(t, err)

--- a/control-plane/subcommand/server-acl-init/create_or_update_test.go
+++ b/control-plane/subcommand/server-acl-init/create_or_update_test.go
@@ -30,7 +30,7 @@ func TestCreateOrUpdateACLPolicy_ErrorsIfDescriptionDoesNotMatch(t *testing.T) {
 	bootToken := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 	svr, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 		c.ACL.Enabled = true
-		c.ACL.Tokens.Master = bootToken
+		c.ACL.Tokens.InitialManagement = bootToken
 	})
 	require.NoError(err)
 	svr.WaitForLeader(t)


### PR DESCRIPTION
Changes proposed in this PR:
- Ensure the anonymous token in the default partition is updated to support cross-partition DNS resolution even if the server-acl-init is running in a non-default partition. This ensures DNS lookups work even if the default partition is on VMs and hence does not have the requisite policy required to do the same.
- Update SDK to the latest version that update which updates ACL.Tokens.Master to ACL.Tokens.InitialManagement

How I've tested this PR:
- Acceptance tests don't break
- Tested on HCP with help from the cloud team.

How I expect reviewers to test this PR:
- 👀 

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

