### PR TITLE
CHANGELOG: typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 FEATURES:
 * Helm
-  * Support Envoy 1.20.1. [[GH-935](https://github.com/hashicorp/consul-k8s/pull/958)]
+  * Support Envoy 1.20.1. [[GH-958](https://github.com/hashicorp/consul-k8s/pull/958)]
 
 IMPROVEMENTS:
 * Helm


### PR DESCRIPTION
typo in changelog link to PR

Changes proposed in this PR:
- Change link name to GH-958 instead of GH-935 (copy and pasta)

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

