### PR TITLE
Move make targets to top-level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,91 @@
-# Generate Helm reference docs from values.yaml and update Consul website.
-# Usage: make gen-docs consul=<path-to-consul-repo>
-gen-docs:
+# ===========> Helm Targets
+
+gen-helm-docs: ## Generate Helm reference docs from values.yaml and update Consul website. Usage: make gen-helm-docs consul=<path-to-consul-repo>.
 	@cd hack/helm-reference-gen; go run ./... $(consul)
 
-# Copy generated CRD YAML into charts/consul.
-# Usage: make copy-crds-to-chart
-copy-crds-to-chart:
+copy-crds-to-chart: ## Copy generated CRD YAML into charts/consul. Usage: make copy-crds-to-chart
 	@cd hack/copy-crds-to-chart; go run ./...
 
-# Deletes AWS resources left behind after failed acceptance tests.
-ci.aws-acceptance-test-cleanup:
+bats-tests: ## Run Helm chart bats tests.
+	 bats --jobs 4 charts/consul/test/unit
+
+
+
+
+# ===========> Control Plane Targets
+
+control-plane-dev: ## Build consul-k8s-control-plane binary.
+	@$(SHELL) $(CURDIR)/control-plane/build-support/scripts/build-local.sh -o $(GOOS) -a $(GOARCH)
+
+control-plane-dev-docker: ## Build consul-k8s-control-plane dev Docker image.
+	@$(SHELL) $(CURDIR)/control-plane/build-support/scripts/build-local.sh -o linux -a amd64
+	@docker build -t '$(DEV_IMAGE)' \
+       --build-arg 'GIT_COMMIT=$(GIT_COMMIT)' \
+       --build-arg 'GIT_DIRTY=$(GIT_DIRTY)' \
+       --build-arg 'GIT_DESCRIBE=$(GIT_DESCRIBE)' \
+       -f $(CURDIR)/build-support/docker/Dev.dockerfile $(CURDIR)
+
+control-plane-test: ## Run go test for the control plane.
+	cd control-plane; go test ./...
+
+control-plane-ent-test: ## Run go test with Consul enterprise tests. The consul binary in your PATH must be Consul Enterprise.
+	cd control-plane; go test ./... -tags=enterprise
+
+control-plane-cov: ## Run go test with code coverage.
+	cd control-plane; go test ./... -coverprofile=coverage.out; go tool cover -html=coverage.out
+
+control-plane-clean: ## Delete bin and pkg dirs.
+	@rm -rf \
+		$(CURDIR)/control-plane/bin \
+		$(CURDIR)/control-plane/pkg
+
+ctrl-generate: get-controller-gen ## Run CRD code generation.
+	cd control-plane; $(CONTROLLER_GEN) object:headerFile="build-support/controller/boilerplate.go.txt" paths="./..."
+
+
+
+
+# ===========> Shared Targets
+
+help: ## Show targets and their descriptions.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+ctrl-manifests: get-controller-gen ## Generate CRD manifests.
+	cd control-plane; $(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	make copy-crds-to-chart
+
+get-controller-gen: ## Download controller-gen program needed for operator SDK.
+ifeq (, $(shell which controller-gen))
+	@{ \
+	set -e ;\
+	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
+	cd $$CONTROLLER_GEN_TMP_DIR ;\
+	go mod init tmp ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0 ;\
+	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
+	}
+CONTROLLER_GEN=$(shell go env GOPATH)/bin/controller-gen
+else
+CONTROLLER_GEN=$(shell which controller-gen)
+endif
+
+# ===========> CI Targets
+
+ci.aws-acceptance-test-cleanup: ## Deletes AWS resources left behind after failed acceptance tests.
 	@cd hack/aws-acceptance-test-cleanup; go run ./... -auto-approve
 
-# Run bats tests in parallel from the root of the repository.
-bats-tests:
-	 bats --jobs 4 charts/consul/test/unit
+
+
+
+# ===========> Makefile config
+
+.DEFAULT_GOAL := help
+.PHONY: gen-helm-docs copy-crds-to-chart bats-tests help ci.aws-acceptance-test-cleanup
+SHELL = bash
+GOOS?=$(shell go env GOOS)
+GOARCH?=$(shell go env GOARCH)
+DEV_IMAGE?=consul-k8s-control-plane-dev
+GIT_COMMIT?=$(shell git rev-parse --short HEAD)
+GIT_DIRTY?=$(shell test -n "`git status --porcelain`" && echo "+CHANGES" || true)
+GIT_DESCRIBE?=$(shell git describe --tags --always)
+CRD_OPTIONS ?= "crd:trivialVersions=true,allowDangerousTypes=true"

--- a/charts/consul/Makefile
+++ b/charts/consul/Makefile
@@ -1,6 +1,0 @@
-TEST_IMAGE?=consul-helm-test
-
-test-docker:
-	@docker build --rm -t '$(TEST_IMAGE)' -f $(CURDIR)/test/docker/Test.dockerfile $(CURDIR)
-
-.PHONY: test-docker

--- a/control-plane/Makefile
+++ b/control-plane/Makefile
@@ -1,8 +1,8 @@
 SHELL = bash
 
-GOOS?=$(shell go env GOOS)
-GOARCH?=$(shell go env GOARCH)
-DEV_IMAGE?=consul-k8s-control-plane-dev
+################
+# CI Variables #
+################
 GIT_COMMIT?=$(shell git rev-parse --short HEAD)
 GIT_DIRTY?=$(shell test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 GIT_DESCRIBE?=$(shell git describe --tags --always)
@@ -18,82 +18,14 @@ export GIT_COMMIT
 export GIT_DIRTY
 export GIT_DESCRIBE
 
-CRD_OPTIONS ?= "crd:trivialVersions=true,allowDangerousTypes=true"
-
-################
-# CI Variables #
-################
 CI_DEV_DOCKER_NAMESPACE?=hashicorpdev
 CI_DEV_DOCKER_IMAGE_NAME?=consul-k8s-control-plane
 CI_DEV_DOCKER_WORKDIR?=.
 CONSUL_K8S_IMAGE_VERSION?=latest
 ################
 
-dev:
-	@$(SHELL) $(CURDIR)/build-support/scripts/build-local.sh -o $(GOOS) -a $(GOARCH)
-
-dev-docker:
-	@$(SHELL) $(CURDIR)/build-support/scripts/build-local.sh -o linux -a amd64
-	@docker build -t '$(DEV_IMAGE)' --build-arg 'GIT_COMMIT=$(GIT_COMMIT)' --build-arg 'GIT_DIRTY=$(GIT_DIRTY)' --build-arg 'GIT_DESCRIBE=$(GIT_DESCRIBE)' -f $(CURDIR)/build-support/docker/Dev.dockerfile $(CURDIR)
-
-dev-tree:
+ci.dev-tree:
 	@$(SHELL) $(CURDIR)/build-support/scripts/dev.sh $(DEV_PUSH_ARG)
-
-test:
-	go test ./...
-
-# requires a consul enterprise binary on the path
-ent-test:
-	go test ./... -tags=enterprise
-
-cov:
-	go test ./... -coverprofile=coverage.out
-	go tool cover -html=coverage.out
-
-clean:
-	@rm -rf \
-		$(CURDIR)/bin \
-		$(CURDIR)/pkg
-
-# Generate manifests e.g. CRD, RBAC etc.
-ctrl-manifests: get-controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-
-# Generate code
-ctrl-generate: get-controller-gen
-	$(CONTROLLER_GEN) object:headerFile="build-support/controller/boilerplate.go.txt" paths="./..."
-
-# find or download controller-gen
-# download controller-gen if necessary
-get-controller-gen:
-ifeq (, $(shell which controller-gen))
-	@{ \
-	set -e ;\
-	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$CONTROLLER_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0 ;\
-	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
-	}
-CONTROLLER_GEN=$(GOBIN)/controller-gen
-else
-CONTROLLER_GEN=$(shell which controller-gen)
-endif
-
-get-kustomize:
-ifeq (, $(shell which kustomize))
-	@{ \
-	set -e ;\
-	KUSTOMIZE_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$KUSTOMIZE_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4 ;\
-	rm -rf $$KUSTOMIZE_GEN_TMP_DIR ;\
-	}
-KUSTOMIZE=$(GOBIN)/kustomize
-else
-KUSTOMIZE=$(shell which kustomize)
-endif
 
 # In CircleCI, the linux binary will be attached from a previous step at pkg/bin/linux_amd64/. This make target
 # should only run in CI and not locally.
@@ -114,13 +46,5 @@ ifeq ($(CIRCLE_BRANCH), main)
 	@docker tag $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT) $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
 	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
 endif
-ifeq ($(CIRCLE_BRANCH), crd-controller-base)
-	@docker tag $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT) $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):crd-controller-base-latest
-	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):crd-controller-base-latest
-endif
-ifeq ($(CIRCLE_BRANCH), monorepo)
-	@docker tag $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT) $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):monorepo
-	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):monorepo
-endif
 
-.PHONY: all bin clean dev dist docker-images go-build-image test tools ci.dev-docker
+.PHONY: ci.dev-tree ci.dev-docker


### PR DESCRIPTION
* Move make targets from control-plane Makefile to top-level Makefile
* leave targets that are needed for CI
* remove charts/consul/Makefile because its test-docker target was never
  used
* add help text to all Makefile targets. You can see the help by running
  `make` or `make help`
* Add `control-plane-` prefix to control plane targets
* Modify targets that download Go tools to use `go install` instead of
  `go get` because using go get to download tools is deprecated
* modify the `ctrl-gen` target to also copy the generated CRDs to the chart

How I've tested this PR:
* ran each make target

How I expect reviewers to test this PR:
* code
