### PR TITLE
Support the value `$POD_NAME` for the annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ IMPROVEMENTS:
   * Allow customization of `terminationGracePeriodSeconds` on the ingress gateways. [[GH-947](https://github.com/hashicorp/consul-k8s/pull/947)]
   * Support `ui.dashboardURLTemplates.service` value for setting [dashboard URL templates](https://www.consul.io/docs/agent/options#ui_config_dashboard_url_templates_service). [[GH-937](https://github.com/hashicorp/consul-k8s/pull/937)]
   * Allow using dash-separated names for config entries when using `kubectl`. [[GH-965](https://github.com/hashicorp/consul-k8s/pull/965)]
+* Control Plane
+  * Support the value `$POD_NAME` for the annotation `consul.hashicorp.com/service-meta-pod_name` that will now be interpolated and set to the pod name in the service's metadata. [[GH-982](https://github.com/hashicorp/consul-k8s/pull/982)]
 
 BUG FIXES:
 * Helm

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -413,7 +413,11 @@ func (r *EndpointsController) createServiceRegistrations(pod corev1.Pod, service
 	}
 	for k, v := range pod.Annotations {
 		if strings.HasPrefix(k, annotationMeta) && strings.TrimPrefix(k, annotationMeta) != "" {
-			meta[strings.TrimPrefix(k, annotationMeta)] = v
+			if v == "$POD_NAME" {
+				meta[strings.TrimPrefix(k, annotationMeta)] = pod.Name
+			} else {
+				meta[strings.TrimPrefix(k, annotationMeta)] = v
+			}
 		}
 	}
 	tags := consulTags(pod)

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -886,6 +886,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 				pod1.Annotations[annotationService] = "different-consul-svc-name"
 				pod1.Annotations[fmt.Sprintf("%sname", annotationMeta)] = "abc"
 				pod1.Annotations[fmt.Sprintf("%sversion", annotationMeta)] = "2"
+				pod1.Annotations[fmt.Sprintf("%spod_name", annotationMeta)] = "$POD_NAME"
 				pod1.Annotations[annotationTags] = "abc,123,$POD_NAME"
 				pod1.Annotations[annotationConnectTags] = "def,456,$POD_NAME"
 				pod1.Annotations[annotationUpstreams] = "upstream1:1234"
@@ -925,6 +926,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 					ServiceMeta: map[string]string{
 						"name":                 "abc",
 						"version":              "2",
+						"pod_name":             "pod1",
 						MetaKeyPodName:         "pod1",
 						MetaKeyKubeServiceName: "service-created",
 						MetaKeyKubeNS:          "default",
@@ -958,6 +960,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 					ServiceMeta: map[string]string{
 						"name":                 "abc",
 						"version":              "2",
+						"pod_name":             "pod1",
 						MetaKeyPodName:         "pod1",
 						MetaKeyKubeServiceName: "service-created",
 						MetaKeyKubeNS:          "default",


### PR DESCRIPTION
Changes proposed in this PR:
- Support the annotation `consul.hashicorp.com/service-meta-pod_name: $POD_NAME` where $POD_NAME will be replaced with the Pod's name. This mimics the support we had before the endpoints controller where environment variables were interpolated for tags.
- This PR only supports $POD_NAME for now because it's the only environment variable we've been asked to support.

How I've tested this PR:
- Unit tests.

How I expect reviewers to test this PR:
- Code Review

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

