### PR TITLE
Support commas in tag annotation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ IMPROVEMENTS:
 * Control Plane
   * Support the value `$POD_NAME` for the annotation `consul.hashicorp.com/service-meta-*` that will now be interpolated and set to the pod's name in the service's metadata. [[GH-982](https://github.com/hashicorp/consul-k8s/pull/982)]
   * Allow managing Consul sidecar resources via annotations. [[GH-956](https://github.com/hashicorp/consul-k8s/pull/956)]
+  * Support using a backslash to escape commas in `consul.hashicorp.com/service-tags` annotation. [[GH-983](https://github.com/hashicorp/consul-k8s/pull/983)]
 
 BUG FIXES:
 * Helm

--- a/control-plane/catalog/to-consul/resource.go
+++ b/control-plane/catalog/to-consul/resource.go
@@ -434,10 +434,8 @@ func (t *ServiceResource) generateRegistrations(key string) {
 	}
 
 	// Parse any additional tags
-	if tags, ok := svc.Annotations[annotationServiceTags]; ok {
-		for _, t := range strings.Split(tags, ",") {
-			baseService.Tags = append(baseService.Tags, strings.TrimSpace(t))
-		}
+	if rawTags, ok := svc.Annotations[annotationServiceTags]; ok {
+		baseService.Tags = append(baseService.Tags, parseTags(rawTags)...)
 	}
 
 	// Parse any additional meta
@@ -772,4 +770,54 @@ func (t *ServiceResource) addPrefixAndK8SNamespace(name, namespace string) strin
 	}
 
 	return name
+}
+
+// parseTags parses the tags annotation into a slice of tags.
+// Tags are split on commas (except for escaped commas "\,").
+func parseTags(tagsAnno string) []string {
+
+	// This algorithm parses the tagsAnno string into a slice of strings.
+	// Ideally we'd just split on commas but since Consul tags support commas,
+	// we allow users to escape commas so they're included in the tag, e.g.
+	// the annotation "tag\,with\,commas\,,tag2" will become the tags:
+	// ["tag,with,commas", "tag2"].
+
+	var tags []string
+	// nextTag is built up char by char until we see a comma. Then we
+	// append it to tags.
+	var nextTag string
+
+	for _, runeChar := range tagsAnno {
+		runeStr := fmt.Sprintf("%c", runeChar)
+
+		// Not a comma, just append to nextTag.
+		if runeStr != "," {
+			nextTag += runeStr
+			continue
+		}
+
+		// Reached a comma but there's nothing in nextTag,
+		// skip. (e.g. "a,,b" => ["a", "b"])
+		if len(nextTag) == 0 {
+			continue
+		}
+
+		// Check if the comma was escaped comma, e.g. "a\,b".
+		if string(nextTag[len(nextTag)-1]) == `\` {
+			// Replace the backslash with a comma.
+			nextTag = nextTag[0:len(nextTag)-1] + ","
+			continue
+		}
+
+		// Non-escaped comma. We're ready to push nextTag onto tags and reset nextTag.
+		tags = append(tags, strings.TrimSpace(nextTag))
+		nextTag = ""
+	}
+
+	// We're done the loop but nextTag still contains the last tag.
+	if len(nextTag) > 0 {
+		tags = append(tags, strings.TrimSpace(nextTag))
+	}
+
+	return tags
 }

--- a/control-plane/catalog/to-consul/resource.go
+++ b/control-plane/catalog/to-consul/resource.go
@@ -779,7 +779,7 @@ func parseTags(tagsAnno string) []string {
 	// This algorithm parses the tagsAnno string into a slice of strings.
 	// Ideally we'd just split on commas but since Consul tags support commas,
 	// we allow users to escape commas so they're included in the tag, e.g.
-	// the annotation "tag\,with\,commas\,,tag2" will become the tags:
+	// the annotation "tag\,with\,commas,tag2" will become the tags:
 	// ["tag,with,commas", "tag2"].
 
 	var tags []string


### PR DESCRIPTION
Commas can be set by escaping with backslash. Fixes https://github.com/hashicorp/consul-k8s/issues/719

Example:

	annotation: "this,supports,commas\,now"

Becomes:

	["this", "supports", "commas,now"]

How I've tested this PR:
* unit tests

How I expect reviewers to test this PR:
* code

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

