### PR TITLE
Make sure vault integration works with PSPs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -648,7 +648,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-pod-security-policies -enable-transparent-proxy
+          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-pod-security-policies -enable-transparent-proxy -run TestVault
 
       - store_test_results:
           path: /tmp/test-results
@@ -969,6 +969,7 @@ workflows:
             - unit-test-helm-templates
             - unit-acceptance-framework
             - unit-cli
+      - acceptance-gke-1-20
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -648,7 +648,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-pod-security-policies -enable-transparent-proxy -run TestVault
+          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-pod-security-policies -enable-transparent-proxy
 
       - store_test_results:
           path: /tmp/test-results
@@ -969,7 +969,6 @@ workflows:
             - unit-test-helm-templates
             - unit-acceptance-framework
             - unit-cli
-      - acceptance-gke-1-20
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ IMPROVEMENTS:
   * Allow customization of `terminationGracePeriodSeconds` on the ingress gateways. [[GH-947](https://github.com/hashicorp/consul-k8s/pull/947)]
   * Support `ui.dashboardURLTemplates.service` value for setting [dashboard URL templates](https://www.consul.io/docs/agent/options#ui_config_dashboard_url_templates_service). [[GH-937](https://github.com/hashicorp/consul-k8s/pull/937)]
   * Allow using dash-separated names for config entries when using `kubectl`. [[GH-965](https://github.com/hashicorp/consul-k8s/pull/965)]
+  * Support Pod Security Policies with Vault integration. [[GH-985](https://github.com/hashicorp/consul-k8s/pull/985)]
 * Control Plane
   * Support the value `$POD_NAME` for the annotation `consul.hashicorp.com/service-meta-pod_name` that will now be interpolated and set to the pod name in the service's metadata. [[GH-982](https://github.com/hashicorp/consul-k8s/pull/982)]
 

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -57,9 +57,6 @@ path "pki/cert/ca" {
 // It then configures Consul to use vault as the backend and checks that it works.
 func TestVault(t *testing.T) {
 	cfg := suite.Config()
-	if cfg.EnablePodSecurityPolicies {
-		t.Skipf("skipping this test because PSPs don't yet work with the acceptance test Vault installation")
-	}
 	ctx := suite.Environment().DefaultContext(t)
 	ns := ctx.KubectlOptions(t).Namespace
 

--- a/charts/consul/templates/server-acl-init-podsecuritypolicy.yaml
+++ b/charts/consul/templates/server-acl-init-podsecuritypolicy.yaml
@@ -18,6 +18,7 @@ spec:
   # Allow core volume types.
   volumes:
     - 'secret'
+    - 'emptyDir'
   allowPrivilegeEscalation: false
   # This is redundant with non-root + disallow privilege escalation,
   # but we can provide it for defense in depth.

--- a/charts/consul/test/terraform/gke/main.tf
+++ b/charts/consul/test/terraform/gke/main.tf
@@ -25,7 +25,8 @@ resource "google_container_cluster" "cluster" {
   min_master_version = data.google_container_engine_versions.main.latest_master_version
   node_version       = data.google_container_engine_versions.main.latest_master_version
   node_config {
-    tags = ["consul-k8s-${random_id.suffix[count.index].dec}"]
+    tags         = ["consul-k8s-${random_id.suffix[count.index].dec}"]
+    machine_type = "e2-standard-4"
   }
   pod_security_policy_config {
     enabled = true


### PR DESCRIPTION
Changes proposed in this PR:
- Update server-acl-init PSP to have access to mount emptyDir volumes for the vault injector
- Scale up gke cluster so accommodate for everything we're installing in the vault test

How I've tested this PR:
acceptance tests: https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/4015/workflows/87c78757-4c96-4641-a2f0-d535bbe567fc/jobs/36509

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

