### PR TITLE
Tweak sidecar resources comment to render in consul-helm docs

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -429,7 +429,6 @@ global:
 
   # For connect-injected pods, the consul sidecar is responsible for metrics merging. For ingress/mesh/terminating
   # gateways, it additionally ensures the Consul services are always registered with their local Consul client.
-  # @recurse: false
   # @type: map
   consulSidecarContainer:
     # Set default resources for consul sidecar. If null, that resource won't
@@ -440,6 +439,7 @@ global:
     # - `consul.hashicorp.com/consul-sidecar-cpu-request`
     # - `consul.hashicorp.com/consul-sidecar-memory-limit`
     # - `consul.hashicorp.com/consul-sidecar-memory-request`
+    # @recurse: false
     # @type: map
     resources:
       requests:


### PR DESCRIPTION
Changes proposed in this PR:
-allow resources to show up in helm docs, but don't recurse further

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

