### PR TITLE
Prototype: Automatically Selecting Endpoint Services

### DIFF
--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -128,8 +128,8 @@ const (
 	// webhook/handler.
 	annotationOriginalPod = "consul.hashicorp.com/original-pod"
 
-	// annotationEndpointServiceName is the name of the service which should be used by the Endpoints Controller.
-	annotationEndpointServiceName = "consul.hashicorp.com/endpoint-service-name"
+	// annotationKubernetesService is the name of the service which should be used by the Endpoints Controller.
+	annotationKubernetesService = "consul.hashicorp.com/kubernetes-service"
 
 	// labelServiceIgnore is a label that can be added to a service to prevent it from being
 	// registered with Consul.

--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -128,6 +128,9 @@ const (
 	// webhook/handler.
 	annotationOriginalPod = "consul.hashicorp.com/original-pod"
 
+	// annotationConnectServiceSelector is the name of the service which should be used by the Endpoints Controller.
+	annotationConnectServiceSelector = "consul.hashicorp.com/connect-service-selector"
+
 	// labelServiceIgnore is a label that can be added to a service to prevent it from being
 	// registered with Consul.
 	labelServiceIgnore = "consul.hashicorp.com/service-ignore"

--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -128,8 +128,8 @@ const (
 	// webhook/handler.
 	annotationOriginalPod = "consul.hashicorp.com/original-pod"
 
-	// annotationConnectServiceSelector is the name of the service which should be used by the Endpoints Controller.
-	annotationConnectServiceSelector = "consul.hashicorp.com/connect-service-selector"
+	// annotationEndpointServiceName is the name of the service which should be used by the Endpoints Controller.
+	annotationEndpointServiceName = "consul.hashicorp.com/endpoint-service-name"
 
 	// labelServiceIgnore is a label that can be added to a service to prevent it from being
 	// registered with Consul.

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -159,7 +159,7 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// If the endpoints object has the annotation "consul.hashicorp.com/endpoint-service-name" with a value that does not match
 	// the name of the service, deregister all instances in Consul for this service.
-	if endpointSvcName, hasAnno := serviceEndpoints.Annotations[annotationEndpointServiceName]; hasAnno && endpointSvcName != serviceEndpoints.Name {
+	if endpointSvcName, hasAnno := serviceEndpoints.Annotations[annotationKubernetesService]; hasAnno && endpointSvcName != serviceEndpoints.Name {
 		// We always deregister the service to handle the case where a user has registered the service, then added the label later.
 		r.Log.Info("Ignoring endpoint because of selector", "name", req.Name, "namespace", req.Namespace)
 		err = r.deregisterServiceOnAllAgents(ctx, req.Name, req.Namespace, nil, endpointPods)

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -2762,7 +2762,7 @@ func TestReconcileIgnoresServiceIgnoreLabel(t *testing.T) {
 
 	for name, tt := range cases {
 		t.Run(name, func(t *testing.T) {
-			// Set up the fake Kubernetes client with an k8sEndpoint, pod, consul client, and the default namespace.
+			// Set up the fake Kubernetes client with an endpoint, pod, consul client, and the default namespace.
 			k8sEndpoint := &corev1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      serviceName,

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -2881,13 +2881,13 @@ func TestReconcileHandlesServiceAutoSelection(t *testing.T) {
 		},
 		"With annotation which matches the service name the service is registered as a Consul endpoint": {
 			annotations: map[string]string{
-				"consul.hashicorp.com/endpoint-service-name": serviceName,
+				annotationEndpointServiceName: serviceName,
 			},
 			expectedNumSvcInstances: 1,
 		},
 		"With annotion which does not match the service name the service is not registered as a Consul endpoint": {
 			annotations: map[string]string{
-				"consul.hashicorp.com/endpoint-service-name": "other-service",
+				annotationEndpointServiceName: "other-service",
 			},
 			expectedNumSvcInstances: 0,
 		},

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -2881,13 +2881,13 @@ func TestReconcileHandlesServiceAutoSelection(t *testing.T) {
 		},
 		"With annotation which matches the service name the service is registered as a Consul endpoint": {
 			annotations: map[string]string{
-				annotationEndpointServiceName: serviceName,
+				annotationKubernetesService: serviceName,
 			},
 			expectedNumSvcInstances: 1,
 		},
 		"With annotion which does not match the service name the service is not registered as a Consul endpoint": {
 			annotations: map[string]string{
-				annotationEndpointServiceName: "other-service",
+				annotationKubernetesService: "other-service",
 			},
 			expectedNumSvcInstances: 0,
 		},


### PR DESCRIPTION
Prototype implementation of MiniRFC [Automatically Selecting Endpoint Services](https://docs.google.com/document/d/1Of3Q8Q5tc1ZHmBrhdrazNVkwUQLv16tr-iO5Kgks-yk/edit#heading=h.8zwoqbrp52v4).

## Changes proposed in this PR
- Endpoints Controller will check for the annotation or label `consul.hashicorp.com/connect-service-selector`. If it exists and does not match the name of the service being reconciled, the endpoint will be deregistered (a no-op for endpoints which were never registered).

## How I've tested this PR

I added a test "TestReconcileHandlesServiceAutoSelection" which tests 3 scenarios with a service named `"test-service"`.

| Annotations | Endpoints created |
| :-- | :-- |
| `None` | 1 |
| `consul.hashicorp.com/endpoint-service-name: "test-service"` | 1 |
| `consul.hashicorp.com/endpoint-service-name: "other-service"` | 0 |


1. A service exists without any annotations -> an endpoint is generated
2. A service exists with the annotation `consul.hashicorp.com/endpoint-service-name` set to the name of the service -> an endpoint is generated
3. A service exists with the annotation `consul.hashicorp.com/endpoint-service-name` set to "other service" -> no endpoint is generated

## How I expect reviewers to test this PR


## Checklist
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

