### PR TITLE
connect: Avoid making unnecessary calls to Consul in the endpoints controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ IMPROVEMENTS:
   * Support Pod Security Policies with Vault integration. [[GH-985](https://github.com/hashicorp/consul-k8s/pull/985)]
 * Control Plane
   * Support the value `$POD_NAME` for the annotation `consul.hashicorp.com/service-meta-*` that will now be interpolated and set to the pod's name in the service's metadata. [[GH-982](https://github.com/hashicorp/consul-k8s/pull/982)]
+  * Avoid making unnecessary calls to Consul in the endpoints controller to improve application startup time when Consul is down. [[GH-779](https://github.com/hashicorp/consul-k8s/issues/779)]
 
 BUG FIXES:
 * Helm


### PR DESCRIPTION
Fixes #779 
Based on work done in #795 

Changes proposed in this PR:
When Consul client is unavailable, it could slow down events processing in the endpoints controller because we always make *some* calls to consul (because `deregisterServiceOnAllAgents` is called on every `Reconcile`). When we can't reach a Consul client agent, it can take quite long (20-30sec) to process a single event because of the i/o timeout. This could cause your service mesh applications to be stuck in the init phase for longer than you'd expect.

This PR addresses the two cases when making those calls are unnecessary: 
1. When we are processing a service not on the mesh, i.e. when endpoints pods are not injected, we can skip any further processing of that endpoints object.
2. When we are deregistering services on all agents, we can skip agents that are not ready (work proposed in #795). This is OK because when/if an agent becomes ready again, we'll trigger another reconciliation of all services.

How I've tested this PR:
manually with reproduction steps from #779. In my testing I saw a decrease of `consul-connect-inject-init` runtime from ~2min to ~3sec.

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

