### PR TITLE
Standardize resource names across the helm chart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
         type: string
       consul-k8s-image:
         type: string
-        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s-control-plane:latest"
+        default: "ashwinvenkatesh/consul-k8s@sha256:33f14b9acffd2d403b45da9bb2330b84bb103caa7a700cda7619416f33d47f1a"
       go-path:
         type: string
         default: "/home/circleci/.go_workspace"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## UNRELEASED
 
+BREAKING CHANGES:
+* Helm
+  * Some Consul components from the Helm chart have been renamed to ensure consistency in naming across the components.
+  This will not be a breaking change if Consul components are not referred to by name externally. Check the PR for the list of renamed components. [[GH-993](https://github.com/hashicorp/consul-k8s/pull/985)]
+
 FEATURES:
 * Helm
   * Support Envoy 1.20.1. [[GH-958](https://github.com/hashicorp/consul-k8s/pull/958)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ IMPROVEMENTS:
   * Support `ui.dashboardURLTemplates.service` value for setting [dashboard URL templates](https://www.consul.io/docs/agent/options#ui_config_dashboard_url_templates_service). [[GH-937](https://github.com/hashicorp/consul-k8s/pull/937)]
   * Allow using dash-separated names for config entries when using `kubectl`. [[GH-965](https://github.com/hashicorp/consul-k8s/pull/965)]
   * Support Pod Security Policies with Vault integration. [[GH-985](https://github.com/hashicorp/consul-k8s/pull/985)]
+  * Rename Consul resources to remove resource kind suffixes from the resource names to standardize resource names across the Helm chart. [[GH-993](https://github.com/hashicorp/consul-k8s/pull/985)]
 * CLI
   * Show a diff when upgrading a Consul installation on Kubernetes [[GH-934](https://github.com/hashicorp/consul-k8s/pull/934)]
 * Control Plane

--- a/charts/consul/templates/connect-inject-authmethod-clusterrole.yaml
+++ b/charts/consul/templates/connect-inject-authmethod-clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-authmethod-role
+  name: {{ template "consul.fullname" . }}-connect-injector-authmethod
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/connect-inject-authmethod-clusterrole.yaml
+++ b/charts/consul/templates/connect-inject-authmethod-clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-authmethod
+  name: {{ template "consul.fullname" . }}-connect-injector
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/connect-inject-authmethod-clusterrolebinding.yaml
+++ b/charts/consul/templates/connect-inject-authmethod-clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-authmethod-authdelegator
+  name: {{ template "consul.fullname" . }}-connect-injector-authdelegator
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -16,13 +16,13 @@ roleRef:
   name: "system:auth-delegator"
 subjects:
   - kind: ServiceAccount
-    name: {{ template "consul.fullname" . }}-connect-injector-authmethod
+    name: {{ template "consul.fullname" . }}-connect-injector
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-authmethod-serviceaccount
+  name: {{ template "consul.fullname" . }}-connect-injector
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -31,10 +31,10 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "consul.fullname" . }}-connect-injector-authmethod
+  name: {{ template "consul.fullname" . }}-connect-injector
 subjects:
   - kind: ServiceAccount
-    name: {{ template "consul.fullname" . }}-connect-injector-authmethod
+    name: {{ template "consul.fullname" . }}-connect-injector
     namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/connect-inject-authmethod-clusterrolebinding.yaml
+++ b/charts/consul/templates/connect-inject-authmethod-clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-authmethod-authdelegator-role-binding
+  name: {{ template "consul.fullname" . }}-connect-injector-authmethod-authdelegator
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -16,13 +16,13 @@ roleRef:
   name: "system:auth-delegator"
 subjects:
   - kind: ServiceAccount
-    name: {{ template "consul.fullname" . }}-connect-injector-authmethod-svc-account
+    name: {{ template "consul.fullname" . }}-connect-injector-authmethod
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-authmethod-serviceaccount-role-binding
+  name: {{ template "consul.fullname" . }}-connect-injector-authmethod-serviceaccount
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -31,10 +31,10 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "consul.fullname" . }}-connect-injector-authmethod-role
+  name: {{ template "consul.fullname" . }}-connect-injector-authmethod
 subjects:
   - kind: ServiceAccount
-    name: {{ template "consul.fullname" . }}-connect-injector-authmethod-svc-account
+    name: {{ template "consul.fullname" . }}-connect-injector-authmethod
     namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/connect-inject-authmethod-serviceaccount.yaml
+++ b/charts/consul/templates/connect-inject-authmethod-serviceaccount.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-authmethod-svc-account
+  name: {{ template "consul.fullname" . }}-connect-injector-authmethod
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}

--- a/charts/consul/templates/connect-inject-authmethod-serviceaccount.yaml
+++ b/charts/consul/templates/connect-inject-authmethod-serviceaccount.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-authmethod
+  name: {{ template "consul.fullname" . }}-connect-injector
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}

--- a/charts/consul/templates/connect-inject-clusterrole.yaml
+++ b/charts/consul/templates/connect-inject-clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-webhook
+  name: {{ template "consul.fullname" . }}-connect-injector
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -30,7 +30,7 @@ rules:
 - apiGroups: ["policy"]
   resources: ["podsecuritypolicies"]
   resourceNames:
-  - {{ template "consul.fullname" . }}-connect-injector-webhook
+  - {{ template "consul.fullname" . }}-connect-injector
   verbs:
   - use
 {{- end }}

--- a/charts/consul/templates/connect-inject-clusterrolebinding.yaml
+++ b/charts/consul/templates/connect-inject-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-webhook-admin-role-binding
+  name: {{ template "consul.fullname" . }}-connect-injector
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -12,9 +12,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "consul.fullname" . }}-connect-injector-webhook
+  name: {{ template "consul.fullname" . }}-connect-injector
 subjects:
 - kind: ServiceAccount
-  name: {{ template "consul.fullname" . }}-connect-injector-webhook-svc-account
+  name: {{ template "consul.fullname" . }}-connect-injector
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -13,7 +13,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-webhook-deployment
+  name: {{ template "consul.fullname" . }}-connect-injector
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
@@ -50,7 +50,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "consul.fullname" . }}-connect-injector-webhook-svc-account
+      serviceAccountName: {{ template "consul.fullname" . }}-connect-injector
       containers:
         - name: sidecar-injector
           image: "{{ default .Values.global.imageK8S .Values.connectInject.image }}"

--- a/charts/consul/templates/connect-inject-leader-election-rolebinding.yaml
+++ b/charts/consul/templates/connect-inject-leader-election-rolebinding.yaml
@@ -16,6 +16,6 @@ roleRef:
   name: {{ template "consul.fullname" . }}-connect-inject-leader-election
 subjects:
 - kind: ServiceAccount
-  name: {{ template "consul.fullname" . }}-connect-injector-webhook-svc-account
+  name: {{ template "consul.fullname" . }}-connect-injector
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/consul/templates/connect-inject-mutatingwebhookconfiguration.yaml
+++ b/charts/consul/templates/connect-inject-mutatingwebhookconfiguration.yaml
@@ -3,7 +3,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-cfg
+  name: {{ template "consul.fullname" . }}-connect-injector
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
@@ -26,7 +26,7 @@ webhooks:
     - "v1"
     clientConfig:
       service:
-        name: {{ template "consul.fullname" . }}-connect-injector-svc
+        name: {{ template "consul.fullname" . }}-connect-injector
         namespace: {{ .Release.Namespace }}
         path: "/mutate"
     rules:

--- a/charts/consul/templates/connect-inject-podsecuritypolicy.yaml
+++ b/charts/consul/templates/connect-inject-podsecuritypolicy.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-webhook
+  name: {{ template "consul.fullname" . }}-connect-injector
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}

--- a/charts/consul/templates/connect-inject-service.yaml
+++ b/charts/consul/templates/connect-inject-service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-svc
+  name: {{ template "consul.fullname" . }}-connect-injector
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}

--- a/charts/consul/templates/connect-inject-serviceaccount.yaml
+++ b/charts/consul/templates/connect-inject-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "consul.fullname" . }}-connect-injector-webhook-svc-account
+  name: {{ template "consul.fullname" . }}-connect-injector
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}

--- a/charts/consul/templates/controller-mutatingwebhookconfiguration.yaml
+++ b/charts/consul/templates/controller-mutatingwebhookconfiguration.yaml
@@ -2,7 +2,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: {{ template "consul.fullname" . }}-controller-mutating-webhook-configuration
+  name: {{ template "consul.fullname" . }}-controller
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}

--- a/charts/consul/templates/enterprise-license-job.yaml
+++ b/charts/consul/templates/enterprise-license-job.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "consul.fullname" . }}-license
+  name: {{ template "consul.fullname" . }}-enterprise-license
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{.Release.Service | quote }}

--- a/charts/consul/templates/partition-init-role.yaml
+++ b/charts/consul/templates/partition-init-role.yaml
@@ -26,7 +26,7 @@ rules:
     resources:
       - serviceaccounts
     resourceNames:
-      - {{ template "consul.fullname" . }}-connect-injector-authmethod
+      - {{ template "consul.fullname" . }}-connect-injector
     verbs:
       - get
 {{- end }}

--- a/charts/consul/templates/partition-init-role.yaml
+++ b/charts/consul/templates/partition-init-role.yaml
@@ -26,7 +26,7 @@ rules:
     resources:
       - serviceaccounts
     resourceNames:
-      - {{ template "consul.fullname" . }}-connect-injector-authmethod-svc-account
+      - {{ template "consul.fullname" . }}-connect-injector-authmethod
     verbs:
       - get
 {{- end }}

--- a/charts/consul/templates/partition-service.yaml
+++ b/charts/consul/templates/partition-service.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "consul.fullname" . }}-partition-service
+  name: {{ template "consul.fullname" . }}-partition
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}

--- a/charts/consul/templates/server-acl-init-role.yaml
+++ b/charts/consul/templates/server-acl-init-role.yaml
@@ -24,7 +24,7 @@ rules:
     resources:
       - serviceaccounts
     resourceNames:
-      - {{ template "consul.fullname" . }}-connect-injector-authmethod
+      - {{ template "consul.fullname" . }}-connect-injector
     verbs:
       - get
 {{- end }}

--- a/charts/consul/templates/server-acl-init-role.yaml
+++ b/charts/consul/templates/server-acl-init-role.yaml
@@ -24,7 +24,7 @@ rules:
     resources:
       - serviceaccounts
     resourceNames:
-      - {{ template "consul.fullname" . }}-connect-injector-authmethod-svc-account
+      - {{ template "consul.fullname" . }}-connect-injector-authmethod
     verbs:
       - get
 {{- end }}

--- a/charts/consul/templates/ui-ingress.yaml
+++ b/charts/consul/templates/ui-ingress.yaml
@@ -12,7 +12,7 @@ apiVersion: networking.k8s.io/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ template "consul.fullname" . }}-ingress
+  name: {{ template "consul.fullname" . }}-ui
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}

--- a/charts/consul/templates/webhook-cert-manager-clusterrole.yaml
+++ b/charts/consul/templates/webhook-cert-manager-clusterrole.yaml
@@ -45,7 +45,7 @@ rules:
   resources:
   - podsecuritypolicies
   resourceNames:
-  - {{ template "consul.fullname" . }}-connect-injector-webhook
+  - {{ template "consul.fullname" . }}-connect-injector
   verbs:
   - use
 {{- end }}

--- a/charts/consul/templates/webhook-cert-manager-configmap.yaml
+++ b/charts/consul/templates/webhook-cert-manager-configmap.yaml
@@ -15,19 +15,19 @@ data:
     [
     {{- if .Values.connectInject.enabled }}
       {
-        "name": "{{ template "consul.fullname" . }}-connect-injector-cfg",
+        "name": "{{ template "consul.fullname" . }}-connect-injector",
         "tlsAutoHosts": [
-          "{{ template "consul.fullname" . }}-connect-injector-svc",
-          "{{ template "consul.fullname" . }}-connect-injector-svc.{{ .Release.Namespace }}",
-          "{{ template "consul.fullname" . }}-connect-injector-svc.{{ .Release.Namespace }}.svc",
-          "{{ template "consul.fullname" . }}-connect-injector-svc.{{ .Release.Namespace }}.svc.cluster.local"
+          "{{ template "consul.fullname" . }}-connect-injector",
+          "{{ template "consul.fullname" . }}-connect-injector.{{ .Release.Namespace }}",
+          "{{ template "consul.fullname" . }}-connect-injector.{{ .Release.Namespace }}.svc",
+          "{{ template "consul.fullname" . }}-connect-injector.{{ .Release.Namespace }}.svc.cluster.local"
         ],
         "secretName": "{{ template "consul.fullname" . }}-connect-inject-webhook-cert",
         "secretNamespace": "{{ .Release.Namespace }}"
       }{{- if and .Values.controller.enabled }},{{- end }}{{- end }}
     {{- if and .Values.controller.enabled }}
       {
-        "name": "{{ template "consul.fullname" . }}-controller-mutating-webhook-configuration",
+        "name": "{{ template "consul.fullname" . }}-controller",
         "tlsAutoHosts": [
           "{{ template "consul.fullname" . }}-controller-webhook",
           "{{ template "consul.fullname" . }}-controller-webhook.{{ .Release.Namespace }}",

--- a/charts/consul/test/unit/webhook-cert-manager-configmap.bats
+++ b/charts/consul/test/unit/webhook-cert-manager-configmap.bats
@@ -52,7 +52,7 @@ load _helpers
   local actual=$(echo $cfg | jq '. | length == 1')
   [ "${actual}" = "true" ]
 
-  local actual=$(echo $cfg | jq '.[0].name | contains("controller-mutating-webhook-configuration")')
+  local actual=$(echo $cfg | jq '.[0].name | contains("controller")')
   [ "${actual}" = "true" ]
 }
 
@@ -68,7 +68,7 @@ load _helpers
   local actual=$(echo $cfg | jq '. | length == 1')
   [ "${actual}" = "true" ]
 
-  local actual=$(echo $cfg | jq '.[0].name | contains("controller-mutating-webhook-configuration")')
+  local actual=$(echo $cfg | jq '.[0].name | contains("controller")')
   [ "${actual}" = "false" ]
 }
 
@@ -85,9 +85,9 @@ load _helpers
   local actual=$(echo $cfg | jq '. | length == 2')
   [ "${actual}" = "true" ]
 
-  local actual=$(echo $cfg | jq '.[0].name | contains("connect-injector-cfg")')
+  local actual=$(echo $cfg | jq '.[0].name | contains("connect-injector")')
   [ "${actual}" = "true" ]
 
-  local actual=$(echo $cfg | jq '.[1].name | contains("controller-mutating-webhook-configuration")')
+  local actual=$(echo $cfg | jq '.[1].name | contains("controller")')
   [ "${actual}" = "true" ]
 }

--- a/control-plane/subcommand/server-acl-init/command_test.go
+++ b/control-plane/subcommand/server-acl-init/command_test.go
@@ -2265,7 +2265,7 @@ func getBootToken(t *testing.T, k8s *fake.Clientset, prefix string, k8sNamespace
 func setUpK8sServiceAccount(t *testing.T, k8s *fake.Clientset, namespace string) (string, string) {
 	// Create ServiceAccount for the kubernetes auth method if it doesn't exist,
 	// otherwise, do nothing.
-	serviceAccountName := resourcePrefix + "-connect-injector-authmethod"
+	serviceAccountName := resourcePrefix + "-connect-injector"
 	sa, _ := k8s.CoreV1().ServiceAccounts(namespace).Get(context.Background(), serviceAccountName, metav1.GetOptions{})
 	if sa == nil {
 		// Create a service account that references two secrets.
@@ -2282,7 +2282,7 @@ func setUpK8sServiceAccount(t *testing.T, k8s *fake.Clientset, namespace string)
 						Name: resourcePrefix + "-some-other-secret",
 					},
 					{
-						Name: resourcePrefix + "-connect-injector-authmethod",
+						Name: resourcePrefix + "-connect-injector",
 					},
 				},
 			},
@@ -2297,7 +2297,7 @@ func setUpK8sServiceAccount(t *testing.T, k8s *fake.Clientset, namespace string)
 	require.NoError(t, err)
 
 	// Create a Kubernetes secret if it doesn't exist, otherwise update it
-	secretName := resourcePrefix + "-connect-injector-authmethod"
+	secretName := resourcePrefix + "-connect-injector"
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   secretName,

--- a/control-plane/subcommand/server-acl-init/command_test.go
+++ b/control-plane/subcommand/server-acl-init/command_test.go
@@ -2265,7 +2265,7 @@ func getBootToken(t *testing.T, k8s *fake.Clientset, prefix string, k8sNamespace
 func setUpK8sServiceAccount(t *testing.T, k8s *fake.Clientset, namespace string) (string, string) {
 	// Create ServiceAccount for the kubernetes auth method if it doesn't exist,
 	// otherwise, do nothing.
-	serviceAccountName := resourcePrefix + "-connect-injector-authmethod-svc-account"
+	serviceAccountName := resourcePrefix + "-connect-injector-authmethod"
 	sa, _ := k8s.CoreV1().ServiceAccounts(namespace).Get(context.Background(), serviceAccountName, metav1.GetOptions{})
 	if sa == nil {
 		// Create a service account that references two secrets.
@@ -2282,7 +2282,7 @@ func setUpK8sServiceAccount(t *testing.T, k8s *fake.Clientset, namespace string)
 						Name: resourcePrefix + "-some-other-secret",
 					},
 					{
-						Name: resourcePrefix + "-connect-injector-authmethod-svc-account",
+						Name: resourcePrefix + "-connect-injector-authmethod",
 					},
 				},
 			},
@@ -2297,7 +2297,7 @@ func setUpK8sServiceAccount(t *testing.T, k8s *fake.Clientset, namespace string)
 	require.NoError(t, err)
 
 	// Create a Kubernetes secret if it doesn't exist, otherwise update it
-	secretName := resourcePrefix + "-connect-injector-authmethod-svc-account"
+	secretName := resourcePrefix + "-connect-injector-authmethod"
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   secretName,

--- a/control-plane/subcommand/server-acl-init/connect_inject.go
+++ b/control-plane/subcommand/server-acl-init/connect_inject.go
@@ -139,7 +139,7 @@ func (c *Command) configureConnectInjectAuthMethod(consulClient *api.Client) err
 func (c *Command) createAuthMethodTmpl(authMethodName string) (api.ACLAuthMethod, error) {
 	// Get the Secret name for the auth method ServiceAccount.
 	var authMethodServiceAccount *apiv1.ServiceAccount
-	saName := c.withPrefix("connect-injector-authmethod-svc-account")
+	saName := c.withPrefix("connect-injector-authmethod")
 	err := c.untilSucceeds(fmt.Sprintf("getting %s ServiceAccount", saName),
 		func() error {
 			var err error

--- a/control-plane/subcommand/server-acl-init/connect_inject.go
+++ b/control-plane/subcommand/server-acl-init/connect_inject.go
@@ -139,7 +139,7 @@ func (c *Command) configureConnectInjectAuthMethod(consulClient *api.Client) err
 func (c *Command) createAuthMethodTmpl(authMethodName string) (api.ACLAuthMethod, error) {
 	// Get the Secret name for the auth method ServiceAccount.
 	var authMethodServiceAccount *apiv1.ServiceAccount
-	saName := c.withPrefix("connect-injector-authmethod")
+	saName := c.withPrefix("connect-injector")
 	err := c.untilSucceeds(fmt.Sprintf("getting %s ServiceAccount", saName),
 		func() error {
 			var err error

--- a/control-plane/subcommand/server-acl-init/connect_inject_test.go
+++ b/control-plane/subcommand/server-acl-init/connect_inject_test.go
@@ -30,8 +30,8 @@ func TestCommand_createAuthMethodTmpl_SecretNotFound(t *testing.T) {
 		ctx:                ctx,
 	}
 
-	serviceAccountName := resourcePrefix + "-connect-injector-authmethod"
-	secretName := resourcePrefix + "-connect-injector-authmethod"
+	serviceAccountName := resourcePrefix + "-connect-injector"
+	secretName := resourcePrefix + "-connect-injector"
 
 	// Create a service account referencing secretName
 	sa, _ := k8s.CoreV1().ServiceAccounts(ns).Get(ctx, serviceAccountName, metav1.GetOptions{})
@@ -65,5 +65,5 @@ func TestCommand_createAuthMethodTmpl_SecretNotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = cmd.createAuthMethodTmpl("test")
-	require.EqualError(t, err, "found no secret of type 'kubernetes.io/service-account-token' associated with the release-name-consul-connect-injector-authmethod service account")
+	require.EqualError(t, err, "found no secret of type 'kubernetes.io/service-account-token' associated with the release-name-consul-connect-injector service account")
 }

--- a/control-plane/subcommand/server-acl-init/connect_inject_test.go
+++ b/control-plane/subcommand/server-acl-init/connect_inject_test.go
@@ -30,8 +30,8 @@ func TestCommand_createAuthMethodTmpl_SecretNotFound(t *testing.T) {
 		ctx:                ctx,
 	}
 
-	serviceAccountName := resourcePrefix + "-connect-injector-authmethod-svc-account"
-	secretName := resourcePrefix + "-connect-injector-authmethod-svc-account"
+	serviceAccountName := resourcePrefix + "-connect-injector-authmethod"
+	secretName := resourcePrefix + "-connect-injector-authmethod"
 
 	// Create a service account referencing secretName
 	sa, _ := k8s.CoreV1().ServiceAccounts(ns).Get(ctx, serviceAccountName, metav1.GetOptions{})
@@ -65,5 +65,5 @@ func TestCommand_createAuthMethodTmpl_SecretNotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = cmd.createAuthMethodTmpl("test")
-	require.EqualError(t, err, "found no secret of type 'kubernetes.io/service-account-token' associated with the release-name-consul-connect-injector-authmethod-svc-account service account")
+	require.EqualError(t, err, "found no secret of type 'kubernetes.io/service-account-token' associated with the release-name-consul-connect-injector-authmethod service account")
 }


### PR DESCRIPTION
Changes proposed in this PR:
- Rename helm resources that have redundant resource-name suffixes.
- Update `server-acl-init` as the secret name was hard-coded to use the `-svc-aaccount` suffix.

How I've tested this PR:
- Pipelines.

How I expect reviewers to test this PR:
- 👀 

Checklist:
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

