### PR TITLE
Use kube svc dns for api gateway sds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+BUG FIXES:
+* API Gateway
+  * Fix issue where if the API gateway controller pods restarted, gateway pods would become disconnected from the secret discovery service. [[GH-1007](https://github.com/hashicorp/consul-k8s/pull/1007)]
+
 ## 0.40.0 (January 27, 2022)
 
 BREAKING CHANGES:

--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -59,10 +59,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
         {{- if .Values.global.acls.manageSystemACLs }}
         - name: CONSUL_HTTP_TOKEN
           valueFrom:

--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -81,7 +81,7 @@ spec:
           - "-ec"
           - |
             consul-api-gateway server \
-              -sds-server-host $(IP) \
+              -sds-server-host {{ template "consul.fullname" . }}-api-gateway-controller.{{ .Release.Namespace }}.svc \
               -k8s-namespace {{ .Release.Namespace }} \
               -log-level {{ default .Values.global.logLevel .Values.apiGateway.logLevel }} \
         volumeMounts:

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -48,6 +48,17 @@ load _helpers
   [ "${actual}" = "\"bar\"" ]
 }
 
+@test "apiGateway/Deployment: SDS host set correctly" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-controller-deployment.yaml  \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=bar' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | join(" ") | contains("-sds-server-host RELEASE-NAME-consul-api-gateway-controller.default.svc")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 #--------------------------------------------------------------------
 # nodeSelector
 


### PR DESCRIPTION
Previously it was using the pod IP of the controller and then when
gateways were created they were hardcoded to use that pod IP.
This was an issue because if the controller pod dies then there will be
a new pod IP and the gateway will lose its connection to the SDS
service. Instead, this PR changes it to use the kube dns url.

How I've tested this PR:
- bats
- manually deployed gateway following https://learn.hashicorp.com/tutorials/consul/kubernetes-api-gateway and looked at sds url

How I expect reviewers to test this PR:
- code

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

