### PR TITLE
Allow API Gateway controller to update k8s Deployments + Services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BUG FIXES:
 * API Gateway
   * Fix issue where if the API gateway controller pods restarted, gateway pods would become disconnected from the secret discovery service. [[GH-1007](https://github.com/hashicorp/consul-k8s/pull/1007)]
+  * Fix issue where the API gateway controller could not update existing Deployments or Services. [[GH-1014](https://github.com/hashicorp/consul-k8s/pull/1014)]
 
 ## 0.40.0 (January 27, 2022)
 

--- a/charts/consul/templates/api-gateway-controller-clusterrole.yaml
+++ b/charts/consul/templates/api-gateway-controller-clusterrole.yaml
@@ -34,6 +34,7 @@ rules:
   - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - coordination.k8s.io

--- a/charts/consul/templates/api-gateway-controller-clusterrole.yaml
+++ b/charts/consul/templates/api-gateway-controller-clusterrole.yaml
@@ -94,6 +94,7 @@ rules:
   - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ""


### PR DESCRIPTION
The k8s client abstraction in consul-api-gateway [expects](https://github.com/hashicorp/consul-api-gateway/blob/c82e707fb30bebf1a88980568e0f67e318f65496/internal/k8s/gatewayclient/gatewayclient.go#L67-L68) to be able to create **or update** k8s `Deployments` and `Services`; however, the `ClusterRole` as defined today does not allow for updates to these resources. This prevents the Consul API Gateway controller from successfully installing a new gateway to the cluster.

Changes proposed in this PR:
- Modify `ClusterRole` to allow controller to update k8s `Deployment`
- Modify `ClusterRole` to allow controller to update k8s `Service`

How I've tested this PR:
Applied changes to deployment on GKE

How I expect reviewers to test this PR:
Follow the [Learn tutorial](https://learn.hashicorp.com/tutorials/consul/kubernetes-api-gateway) for Consul API Gateway; however, the Consul Helm chart install needs to use the branch in this PR.

I believe the easiest way to do that is to check this branch out locally and `$ helm install ...` from there (replacing `$ helm install --values consul/config.yaml consul hashicorp/consul --version "0.40.0"` with the following):
```shell
# git checkout the branch from this PR locally
...
$ helm install --values consul/config.yaml consul <path/to>/consul-k8s/charts/consul
```

Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

