### PR TITLE
Fix incorrect CRD field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+BREAKING CHANGES:
+* Helm
+  * Rename fields of IngressGateway CRD to fix incorrect names (`gatewayTLSConfig` => `tls`, `gatewayServiceTLSConfig` => `tls`, `gatewayTLSSDSConfig` => `sds`). [[GH-1017](https://github.com/hashicorp/consul-k8s/pull/1017)]
+
 ## 0.40.0 (January 27, 2022)
 
 BREAKING CHANGES:

--- a/charts/consul/templates/crd-ingressgateways.yaml
+++ b/charts/consul/templates/crd-ingressgateways.yaml
@@ -64,14 +64,14 @@ spec:
                   description: IngressListener manages the configuration for a listener
                     on a specific port.
                   properties:
-                    gatewayTLSConfig:
+                    tls:
                       description: TLS config for this listener.
                       properties:
                         enabled:
                           description: Indicates that TLS should be enabled for this
                             gateway service.
                           type: boolean
-                        gatewayTLSSDSConfig:
+                        sds:
                           description: SDS allows configuring TLS certificate from
                             an SDS service.
                           properties:
@@ -103,11 +103,11 @@ spec:
                         description: IngressService manages configuration for services
                           that are exposed to ingress traffic.
                         properties:
-                          gatewayServiceTLSConfig:
+                          tls:
                             description: TLS allows specifying some TLS configuration
                               per listener.
                             properties:
-                              gatewayTLSSDSConfig:
+                              sds:
                                 description: SDS allows configuring TLS certificate
                                   from an SDS service.
                                 properties:
@@ -212,7 +212,7 @@ spec:
                     description: Indicates that TLS should be enabled for this gateway
                       service.
                     type: boolean
-                  gatewayTLSSDSConfig:
+                  sds:
                     description: SDS allows configuring TLS certificate from an SDS
                       service.
                     properties:

--- a/control-plane/api/v1alpha1/ingressgateway_types.go
+++ b/control-plane/api/v1alpha1/ingressgateway_types.go
@@ -64,12 +64,12 @@ type GatewayTLSConfig struct {
 	Enabled bool `json:"enabled"`
 
 	// SDS allows configuring TLS certificate from an SDS service.
-	SDS *GatewayTLSSDSConfig `json:"gatewayTLSSDSConfig,omitempty"`
+	SDS *GatewayTLSSDSConfig `json:"sds,omitempty"`
 }
 
 type GatewayServiceTLSConfig struct {
 	// SDS allows configuring TLS certificate from an SDS service.
-	SDS *GatewayTLSSDSConfig `json:"gatewayTLSSDSConfig,omitempty"`
+	SDS *GatewayTLSSDSConfig `json:"sds,omitempty"`
 }
 
 type GatewayTLSSDSConfig struct {
@@ -89,7 +89,7 @@ type IngressListener struct {
 	Protocol string `json:"protocol,omitempty"`
 
 	// TLS config for this listener.
-	TLS *GatewayTLSConfig `json:"gatewayTLSConfig,omitempty"`
+	TLS *GatewayTLSConfig `json:"tls,omitempty"`
 
 	// Services declares the set of services to which the listener forwards
 	// traffic.
@@ -134,7 +134,7 @@ type IngressService struct {
 	Partition string `json:"partition,omitempty"`
 
 	// TLS allows specifying some TLS configuration per listener.
-	TLS *GatewayServiceTLSConfig `json:"gatewayServiceTLSConfig,omitempty"`
+	TLS *GatewayServiceTLSConfig `json:"tls,omitempty"`
 
 	// Allow HTTP header manipulation to be configured.
 	RequestHeaders  *HTTPHeaderModifiers `json:"requestHeaders,omitempty"`

--- a/control-plane/config/crd/bases/consul.hashicorp.com_ingressgateways.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_ingressgateways.yaml
@@ -58,14 +58,14 @@ spec:
                   description: IngressListener manages the configuration for a listener
                     on a specific port.
                   properties:
-                    gatewayTLSConfig:
+                    tls:
                       description: TLS config for this listener.
                       properties:
                         enabled:
                           description: Indicates that TLS should be enabled for this
                             gateway service.
                           type: boolean
-                        gatewayTLSSDSConfig:
+                        sds:
                           description: SDS allows configuring TLS certificate from
                             an SDS service.
                           properties:
@@ -97,11 +97,11 @@ spec:
                         description: IngressService manages configuration for services
                           that are exposed to ingress traffic.
                         properties:
-                          gatewayServiceTLSConfig:
+                          tls:
                             description: TLS allows specifying some TLS configuration
                               per listener.
                             properties:
-                              gatewayTLSSDSConfig:
+                              sds:
                                 description: SDS allows configuring TLS certificate
                                   from an SDS service.
                                 properties:
@@ -206,7 +206,7 @@ spec:
                     description: Indicates that TLS should be enabled for this gateway
                       service.
                     type: boolean
-                  gatewayTLSSDSConfig:
+                  sds:
                     description: SDS allows configuring TLS certificate from an SDS
                       service.
                     properties:


### PR DESCRIPTION
gatewayTLSConfig => tls
gatewayTLSSDSConfig => sds

How I've tested this PR:
- `s/old/new/g`

How I expect reviewers to test this PR:
- code

Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

