### PR TITLE
api-gateway: add node:read policy

### DIFF
--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -154,6 +154,9 @@ namespace_prefix "" {
     policy = "write"
     intentions = "write"
   }
+  node_prefix "" {
+    policy = "read"
+  }
 {{- if .EnableNamespaces }}
 }
 {{- end }}


### PR DESCRIPTION
To avoid silently filtering all nodes when ACLs are enabled and returning an empty set when attempting to map routes to Consul services registered in consul-k8s

**Changes proposed in this PR:**
- Add `node_prefix "" { policy = "read" }` to the API Gateway template

**How I've tested this PR:**
- Manually applying this change fixed an error loop when deploying Consul API Gateway in GKE with ACLs enabled.

**How I expect reviewers to test this PR:**
- Deploy Consul API Gateway via the Helm chart with the following config set
```
global:
  gossipEncryption:
    autoGenerate: true 
  tls:
    enabled: true
    enableAutoEncrypt: true
  acls:
    manageSystemACLs: true
```
- Attempt to apply a route to the gateway - it should fail to attach before this fix, but succeed with this change.

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added

