### PR TITLE
Add support customized IPSans and DNSSans for server-tls server cert for vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 IMPROVEMENTS:
 * Helm
   * Vault: Allow passing arbitrary annotations to the vault agent. [[GH-1015](https://github.com/hashicorp/consul-k8s/pull/1015)]
+  * Vault: Add support customized IPSans and DNSSans for server-tls server cert for vault [GH-1020](https://github.com/hashicorp/consul-k8s/pull/1020)
 
 BUG FIXES:
 * API Gateway

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 IMPROVEMENTS:
 * Helm
   * Vault: Allow passing arbitrary annotations to the vault agent. [[GH-1015](https://github.com/hashicorp/consul-k8s/pull/1015)]
-  * Vault: Add support customized IPSans and DNSSans for server-tls server cert for vault [GH-1020](https://github.com/hashicorp/consul-k8s/pull/1020)
+  * Vault: Add support for customized IP and DNS SANs for server cert in Vault. [[GH-1020](https://github.com/hashicorp/consul-k8s/pull/1020)]
 
 BUG FIXES:
 * API Gateway

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -32,7 +32,7 @@ as well as the global.name setting.
 {{- define "consul.serverTLSCertTemplate" -}}
  |
             {{ "{{" }}- with secret "{{ .Values.server.serverCert.secretName }}" "{{ printf "common_name=server.%s.%s" .Values.global.datacenter .Values.global.domain }}"
-            "ttl=1h" "alt_names={{ include "consul.serverTLSAltNames" . }}{{- range $san := .Values.server.tls.serverAdditionalDNSSANs }},{{ $san }} {{- end -}}" "ip_sans=127.0.0.1{{- range $ipsan := .Values.server.tls.serverAdditionalIPSANs }},{{ $ipsan }} {{- end -}}" -{{ "}}" }}
+            "ttl=1h" "alt_names={{ include "consul.serverTLSAltNames" . }}{{- if .Values.server.tls -}}{{- if .Values.server.tls.serverAdditionalDNSSANs -}}{{- range $san := .Values.server.tls.serverAdditionalDNSSANs }},{{ $san }} {{- end -}}{{- end -}}{{- end -}}" "ip_sans=127.0.0.1{{- if .Values.server.tls -}}{{- if .Values.server.tls.serverAdditionalIPSANs -}}{{- range $ipsan := .Values.server.tls.serverAdditionalIPSANs }},{{ $ipsan }} {{- end -}}{{- end -}}{{- end -}}" -{{ "}}" }}
             {{ "{{" }}- .Data.certificate -{{ "}}" }}
             {{ "{{" }}- end -{{ "}}" }}
 {{- end -}}
@@ -40,7 +40,7 @@ as well as the global.name setting.
 {{- define "consul.serverTLSKeyTemplate" -}}
  |
             {{ "{{" }}- with secret "{{ .Values.server.serverCert.secretName }}" "{{ printf "common_name=server.%s.%s" .Values.global.datacenter .Values.global.domain }}"
-            "ttl=1h" "alt_names={{ include "consul.serverTLSAltNames" . }}{{- range $san := .Values.server.tls.serverAdditionalDNSSANs }},{{ $san }} {{- end -}}" "ip_sans=127.0.0.1{{- range $ipsan := .Values.server.tls.serverAdditionalIPSANs }},{{ $ipsan }} {{- end -}}" -{{ "}}" }}
+            "ttl=1h" "alt_names={{ include "consul.serverTLSAltNames" . }}{{- if .Values.server.tls -}}{{- if .Values.server.tls.serverAdditionalDNSSANs -}}{{- range $san := .Values.server.tls.serverAdditionalDNSSANs }},{{ $san }} {{- end -}}{{- end -}}{{- end -}}" "ip_sans=127.0.0.1{{- if .Values.server.tls -}}{{- if .Values.server.tls.serverAdditionalIPSANs -}}{{- range $ipsan := .Values.server.tls.serverAdditionalIPSANs }},{{ $ipsan }} {{- end -}}{{- end -}}{{- end -}}" -{{ "}}" }}
             {{ "{{" }}- .Data.private_key -{{ "}}" }}
             {{ "{{" }}- end -{{ "}}" }}
 {{- end -}}

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -32,7 +32,7 @@ as well as the global.name setting.
 {{- define "consul.serverTLSCertTemplate" -}}
  |
             {{ "{{" }}- with secret "{{ .Values.server.serverCert.secretName }}" "{{ printf "common_name=server.%s.%s" .Values.global.datacenter .Values.global.domain }}"
-            "ttl=1h" "alt_names={{ include "consul.serverTLSAltNames" . }}" "ip_sans=127.0.0.1" -{{ "}}" }}
+            "ttl=1h" "alt_names={{ include "consul.serverTLSAltNames" . }}{{- range $san := .Values.server.tls.serverAdditionalDNSSANs }},{{ $san }} {{- end -}}" "ip_sans=127.0.0.1{{- range $ipsan := .Values.server.tls.serverAdditionalIPSANs }},{{ $ipsan }} {{- end -}}" -{{ "}}" }}
             {{ "{{" }}- .Data.certificate -{{ "}}" }}
             {{ "{{" }}- end -{{ "}}" }}
 {{- end -}}
@@ -40,7 +40,7 @@ as well as the global.name setting.
 {{- define "consul.serverTLSKeyTemplate" -}}
  |
             {{ "{{" }}- with secret "{{ .Values.server.serverCert.secretName }}" "{{ printf "common_name=server.%s.%s" .Values.global.datacenter .Values.global.domain }}"
-            "ttl=1h" "alt_names={{ include "consul.serverTLSAltNames" . }}" "ip_sans=127.0.0.1" -{{ "}}" }}
+            "ttl=1h" "alt_names={{ include "consul.serverTLSAltNames" . }}{{- range $san := .Values.server.tls.serverAdditionalDNSSANs }},{{ $san }} {{- end -}}" "ip_sans=127.0.0.1{{- range $ipsan := .Values.server.tls.serverAdditionalIPSANs }},{{ $ipsan }} {{- end -}}" -{{ "}}" }}
             {{ "{{" }}- .Data.private_key -{{ "}}" }}
             {{ "{{" }}- end -{{ "}}" }}
 {{- end -}}

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -32,7 +32,7 @@ as well as the global.name setting.
 {{- define "consul.serverTLSCertTemplate" -}}
  |
             {{ "{{" }}- with secret "{{ .Values.server.serverCert.secretName }}" "{{ printf "common_name=server.%s.%s" .Values.global.datacenter .Values.global.domain }}"
-            "ttl=1h" "alt_names={{ include "consul.serverTLSAltNames" . }}{{- if .Values.server.tls -}}{{- if .Values.server.tls.serverAdditionalDNSSANs -}}{{- range $san := .Values.server.tls.serverAdditionalDNSSANs }},{{ $san }} {{- end -}}{{- end -}}{{- end -}}" "ip_sans=127.0.0.1{{- if .Values.server.tls -}}{{- if .Values.server.tls.serverAdditionalIPSANs -}}{{- range $ipsan := .Values.server.tls.serverAdditionalIPSANs }},{{ $ipsan }} {{- end -}}{{- end -}}{{- end -}}" -{{ "}}" }}
+            "ttl=1h" "alt_names={{ include "consul.serverTLSAltNames" . }}" "ip_sans=127.0.0.1{{ include "consul.serverAdditionalIPSANs" . }}" -{{ "}}" }}
             {{ "{{" }}- .Data.certificate -{{ "}}" }}
             {{ "{{" }}- end -{{ "}}" }}
 {{- end -}}
@@ -40,7 +40,7 @@ as well as the global.name setting.
 {{- define "consul.serverTLSKeyTemplate" -}}
  |
             {{ "{{" }}- with secret "{{ .Values.server.serverCert.secretName }}" "{{ printf "common_name=server.%s.%s" .Values.global.datacenter .Values.global.domain }}"
-            "ttl=1h" "alt_names={{ include "consul.serverTLSAltNames" . }}{{- if .Values.server.tls -}}{{- if .Values.server.tls.serverAdditionalDNSSANs -}}{{- range $san := .Values.server.tls.serverAdditionalDNSSANs }},{{ $san }} {{- end -}}{{- end -}}{{- end -}}" "ip_sans=127.0.0.1{{- if .Values.server.tls -}}{{- if .Values.server.tls.serverAdditionalIPSANs -}}{{- range $ipsan := .Values.server.tls.serverAdditionalIPSANs }},{{ $ipsan }} {{- end -}}{{- end -}}{{- end -}}" -{{ "}}" }}
+            "ttl=1h" "alt_names={{ include "consul.serverTLSAltNames" . }}" "ip_sans=127.0.0.1{{ include "consul.serverAdditionalIPSANs" . }}" -{{ "}}" }}
             {{ "{{" }}- .Data.private_key -{{ "}}" }}
             {{ "{{" }}- end -{{ "}}" }}
 {{- end -}}
@@ -48,7 +48,15 @@ as well as the global.name setting.
 {{- define "consul.serverTLSAltNames" -}}
 {{- $name := include "consul.fullname" . -}}
 {{- $ns := .Release.Namespace -}}
-{{ printf "localhost,%s-server,*.%s-server,*.%s-server.%s,*.%s-server.%s.svc,*.server.%s.%s" $name $name $name $ns $name $ns (.Values.global.datacenter ) (.Values.global.domain) }}
+{{ printf "localhost,%s-server,*.%s-server,*.%s-server.%s,*.%s-server.%s.svc,*.server.%s.%s" $name $name $name $ns $name $ns (.Values.global.datacenter ) (.Values.global.domain) }}{{ include "consul.serverAdditionalDNSSANs" . }}
+{{- end -}}
+
+{{- define "consul.serverAdditionalDNSSANs" -}}
+{{- if .Values.global.tls -}}{{- if .Values.global.tls.serverAdditionalDNSSANs -}}{{- range $san := .Values.global.tls.serverAdditionalDNSSANs }},{{ $san }} {{- end -}}{{- end -}}{{- end -}}
+{{- end -}}
+
+{{- define "consul.serverAdditionalIPSANs" -}}
+{{- if .Values.global.tls -}}{{- if .Values.global.tls.serverAdditionalIPSANs -}}{{- range $ipsan := .Values.global.tls.serverAdditionalIPSANs }},{{ $ipsan }} {{- end -}}{{- end -}}{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1174,54 +1174,6 @@ load _helpers
   [ "${actual}" = "key" ]
 }
 
-@test "server/StatefulSet: can set additional alt_names on server cert when tls is enabled" {
-  cd `chart_dir`
-  local object=$(helm template \
-    -s templates/server-statefulset.yaml  \
-    --set 'global.tls.enabled=true' \
-    --set 'global.tls.enableAutoEncrypt=true' \
-    --set 'global.datacenter=dc2' \
-    --set 'server.serverCert.secretName=pki_int/issue/test' \
-    --set 'server.tls.serverAdditionalDNSSANs[0]=*.foo.com' \
-    --set 'server.tls.serverAdditionalDNSSANs[1]=*.bar.com' \
-    . | tee /dev/stderr |
-      yq -r '.spec.template' | tee /dev/stderr)
-
-  local actual=$(echo $object |
-      yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.crt"]' | tee /dev/stderr)
-  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul,*.foo.com,*.bar.com\" \"ip_sans=127.0.0.1\" -}}\n{{- .Data.certificate -}}\n{{- end -}}'
-  [ "${actual}" = "${expected}" ]
-
-  local actual="$(echo $object |
-      yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.key"]' | tee /dev/stderr)"
-  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul,*.foo.com,*.bar.com\" \"ip_sans=127.0.0.1\" -}}\n{{- .Data.private_key -}}\n{{- end -}}'
-  [ "${actual}" = "${expected}" ]
-}
-
-@test "server/StatefulSet: can set additional ip_sans on server cert when tls is enabled" {
-  cd `chart_dir`
-  local object=$(helm template \
-    -s templates/server-statefulset.yaml  \
-    --set 'global.tls.enabled=true' \
-    --set 'global.tls.enableAutoEncrypt=true' \
-    --set 'global.datacenter=dc2' \
-    --set 'server.serverCert.secretName=pki_int/issue/test' \
-    --set 'server.tls.serverAdditionalIPSANs[0]=1.1.1.1' \
-    --set 'server.tls.serverAdditionalIPSANs[1]=2.2.2.2' \
-    . | tee /dev/stderr |
-      yq -r '.spec.template' | tee /dev/stderr)
-
-  local actual=$(echo $object |
-      yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.crt"]' | tee /dev/stderr)
-  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul\" \"ip_sans=127.0.0.1,1.1.1.1,2.2.2.2\" -}}\n{{- .Data.certificate -}}\n{{- end -}}'
-  [ "${actual}" = "${expected}" ]
-
-  local actual="$(echo $object |
-      yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.key"]' | tee /dev/stderr)"
-  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul\" \"ip_sans=127.0.0.1,1.1.1.1,2.2.2.2\" -}}\n{{- .Data.private_key -}}\n{{- end -}}'
-  [ "${actual}" = "${expected}" ]
-}
-
 #--------------------------------------------------------------------
 # global.federation.enabled
 
@@ -1832,6 +1784,66 @@ load _helpers
   local actual=$(echo $object |
     yq -r '.containers[0].volumeMounts[] | select(.name == "consul-ca-key")' | tee /dev/stderr)
   [ "${actual}" = "" ]
+}
+
+@test "server/StatefulSet: vault - can set additional alt_names on server cert when tls is enabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+    -s templates/server-statefulset.yaml  \
+    --set 'global.tls.enabled=true' \
+    --set 'global.tls.enableAutoEncrypt=true' \
+    --set 'global.datacenter=dc2' \
+    --set 'global.secretsBackend.vault.enabled=true' \
+    --set 'global.secretsBackend.vault.consulClientRole=test' \
+    --set 'global.secretsBackend.vault.consulServerRole=foo' \
+    --set 'global.secretsBackend.vault.consulCARole=test' \
+    --set 'global.tls.caCert.secretName=pki_int/cert/ca' \
+    --set 'server.serverCert.secretName=pki_int/issue/test' \
+    --set 'server.tls.serverAdditionalDNSSANs[0]=*.foo.com' \
+    --set 'server.tls.serverAdditionalDNSSANs[1]=*.bar.com' \
+    . | tee /dev/stderr |
+      yq -r '.spec.template' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.crt"]' | tee /dev/stderr)
+  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul,*.foo.com,*.bar.com\" \"ip_sans=127.0.0.1\" -}}\n{{- .Data.certificate -}}\n{{- end -}}'
+  echo "Expected: ${expected}"
+  echo "Actual: ${actual}"
+  [ "${actual}" = "${expected}" ]
+
+  local actual="$(echo $object |
+      yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.key"]' | tee /dev/stderr)"
+  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul,*.foo.com,*.bar.com\" \"ip_sans=127.0.0.1\" -}}\n{{- .Data.private_key -}}\n{{- end -}}'
+  [ "${actual}" = "${expected}" ]
+}
+
+@test "server/StatefulSet: vault - can set additional ip_sans on server cert when tls is enabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+    -s templates/server-statefulset.yaml  \
+    --set 'global.tls.enabled=true' \
+    --set 'global.tls.enableAutoEncrypt=true' \
+    --set 'global.datacenter=dc2' \
+    --set 'global.secretsBackend.vault.enabled=true' \
+    --set 'global.secretsBackend.vault.consulClientRole=test' \
+    --set 'global.secretsBackend.vault.consulServerRole=foo' \
+    --set 'global.secretsBackend.vault.consulCARole=test' \
+    --set 'global.tls.caCert.secretName=pki_int/cert/ca' \
+    --set 'server.serverCert.secretName=pki_int/issue/test' \
+    --set 'server.tls.serverAdditionalIPSANs[0]=1.1.1.1' \
+    --set 'server.tls.serverAdditionalIPSANs[1]=2.2.2.2' \
+    . | tee /dev/stderr |
+      yq -r '.spec.template' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.crt"]' | tee /dev/stderr)
+  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul\" \"ip_sans=127.0.0.1,1.1.1.1,2.2.2.2\" -}}\n{{- .Data.certificate -}}\n{{- end -}}'
+  [ "${actual}" = "${expected}" ]
+
+  local actual="$(echo $object |
+      yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.key"]' | tee /dev/stderr)"
+  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul\" \"ip_sans=127.0.0.1,1.1.1.1,2.2.2.2\" -}}\n{{- .Data.private_key -}}\n{{- end -}}'
+  [ "${actual}" = "${expected}" ]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1174,6 +1174,54 @@ load _helpers
   [ "${actual}" = "key" ]
 }
 
+@test "server/StatefulSet: can set additional alt_names on server cert when tls is enabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+    -s templates/server-statefulset.yaml  \
+    --set 'global.tls.enabled=true' \
+    --set 'global.tls.enableAutoEncrypt=true' \
+    --set 'global.datacenter=dc2' \
+    --set 'server.serverCert.secretName=pki_int/issue/test' \
+    --set 'server.tls.serverAdditionalDNSSANs[0]=*.foo.com' \
+    --set 'server.tls.serverAdditionalDNSSANs[1]=*.bar.com' \
+    . | tee /dev/stderr |
+      yq -r '.spec.template' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.crt"]' | tee /dev/stderr)
+  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul,*.foo.com,*.bar.com\" \"ip_sans=127.0.0.1\" -}}\n{{- .Data.certificate -}}\n{{- end -}}'
+  [ "${actual}" = "${expected}" ]
+
+  local actual="$(echo $object |
+      yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.key"]' | tee /dev/stderr)"
+  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul,*.foo.com,*.bar.com\" \"ip_sans=127.0.0.1\" -}}\n{{- .Data.private_key -}}\n{{- end -}}'
+  [ "${actual}" = "${expected}" ]
+}
+
+@test "server/StatefulSet: can set additional ip_sans on server cert when tls is enabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+    -s templates/server-statefulset.yaml  \
+    --set 'global.tls.enabled=true' \
+    --set 'global.tls.enableAutoEncrypt=true' \
+    --set 'global.datacenter=dc2' \
+    --set 'server.serverCert.secretName=pki_int/issue/test' \
+    --set 'server.tls.serverAdditionalIPSANs[0]=1.1.1.1' \
+    --set 'server.tls.serverAdditionalIPSANs[1]=2.2.2.2' \
+    . | tee /dev/stderr |
+      yq -r '.spec.template' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.crt"]' | tee /dev/stderr)
+  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul\" \"ip_sans=127.0.0.1,1.1.1.1,2.2.2.2\" -}}\n{{- .Data.certificate -}}\n{{- end -}}'
+  [ "${actual}" = "${expected}" ]
+
+  local actual="$(echo $object |
+      yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.key"]' | tee /dev/stderr)"
+  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul\" \"ip_sans=127.0.0.1,1.1.1.1,2.2.2.2\" -}}\n{{- .Data.private_key -}}\n{{- end -}}'
+  [ "${actual}" = "${expected}" ]
+}
+
 #--------------------------------------------------------------------
 # global.federation.enabled
 

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1799,8 +1799,8 @@ load _helpers
     --set 'global.secretsBackend.vault.consulCARole=test' \
     --set 'global.tls.caCert.secretName=pki_int/cert/ca' \
     --set 'server.serverCert.secretName=pki_int/issue/test' \
-    --set 'server.tls.serverAdditionalDNSSANs[0]=*.foo.com' \
-    --set 'server.tls.serverAdditionalDNSSANs[1]=*.bar.com' \
+    --set 'global.tls.serverAdditionalDNSSANs[0]=*.foo.com' \
+    --set 'global.tls.serverAdditionalDNSSANs[1]=*.bar.com' \
     . | tee /dev/stderr |
       yq -r '.spec.template' | tee /dev/stderr)
 
@@ -1828,8 +1828,8 @@ load _helpers
     --set 'global.secretsBackend.vault.consulCARole=test' \
     --set 'global.tls.caCert.secretName=pki_int/cert/ca' \
     --set 'server.serverCert.secretName=pki_int/issue/test' \
-    --set 'server.tls.serverAdditionalIPSANs[0]=1.1.1.1' \
-    --set 'server.tls.serverAdditionalIPSANs[1]=2.2.2.2' \
+    --set 'global.tls.serverAdditionalIPSANs[0]=1.1.1.1' \
+    --set 'global.tls.serverAdditionalIPSANs[1]=2.2.2.2' \
     . | tee /dev/stderr |
       yq -r '.spec.template' | tee /dev/stderr)
 

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1807,8 +1807,6 @@ load _helpers
   local actual=$(echo $object |
       yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.crt"]' | tee /dev/stderr)
   local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul,*.foo.com,*.bar.com\" \"ip_sans=127.0.0.1\" -}}\n{{- .Data.certificate -}}\n{{- end -}}'
-  echo "Expected: ${expected}"
-  echo "Actual: ${actual}"
   [ "${actual}" = "${expected}" ]
 
   local actual="$(echo $object |


### PR DESCRIPTION
Changes proposed in this PR:
- Add support customized IPSans and DNSSans for server-tls server cert for vault

How I've tested this PR:
- [x] unit tests
- [ ] manual verification in a consul/vault/k8s environment

How I expect reviewers to test this PR:
manual verification in a consul/vault/k8s environment

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 

