### PR TITLE
Correcting connect-init documentation that said it creates the service rather than listening for so it can extract the proxy id for bootstrapping envoy.

### DIFF
--- a/control-plane/connect-inject/container_init.go
+++ b/control-plane/connect-inject/container_init.go
@@ -104,8 +104,8 @@ func (h *Handler) initCopyContainer() corev1.Container {
 	return container
 }
 
-// containerInit returns the init container spec for registering the Consul
-// service, setting up the Envoy bootstrap, etc.
+// containerInit returns the init container spec for that polls for the service and the connect proxy service to be registered
+// so that it can save theproxy service id to the shared volume and boostrap Envoy with the proxy-id
 func (h *Handler) containerInit(namespace corev1.Namespace, pod corev1.Pod) (corev1.Container, error) {
 	// Check if tproxy is enabled on this pod.
 	tproxyEnabled, err := transparentProxyEnabled(namespace, pod, h.EnableTransparentProxy)

--- a/control-plane/connect-inject/handler.go
+++ b/control-plane/connect-inject/handler.go
@@ -225,7 +225,7 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error getting namespace metadata for container: %s", err))
 	}
 
-	// Add the init container that registers the service and sets up the Envoy configuration.
+	// Add the init container that listens for the service and proxy service and sets up the Envoy configuration.
 	initContainer, err := h.containerInit(*ns, pod)
 	if err != nil {
 		h.Log.Error(err, "error configuring injection init container", "request name", req.Name)


### PR DESCRIPTION
Changes proposed in this PR:
- modified comments to reflect that connect init does not register the service but rather polls for it soit can use the proxy-id for Envoy bootstrapping

How I've tested this PR:
N/A

How I expect reviewers to test this PR:
N/A

