### PR TITLE
Add support for Enterprise License to be configured in Vault

### DIFF
--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -15,7 +15,7 @@ as well as the global.name setting.
 {{- end -}}
 {{- end -}}
 
-{{- define "consul.vaultGossipTemplate" -}}
+{{- define "consul.vaultSecretTemplate" -}}
  |
             {{ "{{" }}- with secret "{{ .secretName }}" -{{ "}}" }}
             {{ "{{" }}- {{ printf ".Data.data.%s" .secretKey }} -{{ "}}" }}

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -63,6 +63,12 @@ spec:
         {{- if .Values.global.secretsBackend.vault.agentAnnotations }}
         {{ tpl .Values.global.secretsBackend.vault.agentAnnotations . | nindent 8 | trim }}
         {{- end }}
+        {{- if .Values.global.enterpriseLicense.secretName }}
+        {{- with .Values.global.enterpriseLicense }}
+        "vault.hashicorp.com/agent-inject-secret-enterpriselicense.txt": "{{ .secretName }}"
+        "vault.hashicorp.com/agent-inject-template-enterpriselicense.txt": {{ template "consul.vaultSecretTemplate" . }}
+        {{- end }}
+        {{- end }}
         {{- end }}
         "consul.hashicorp.com/connect-inject": "false"
         "consul.hashicorp.com/config-checksum": {{ include (print $.Template.BasePath "/client-config-configmap.yaml") . | sha256sum }}
@@ -211,7 +217,7 @@ spec:
                 {{- end }}
             {{- end }}
             {{- end }}
-            {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload (not .Values.global.acls.manageSystemACLs)) }}
+            {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload (not .Values.global.acls.manageSystemACLs) (not .Values.global.secretsBackend.vault.enabled)) }}
             - name: CONSUL_LICENSE_PATH
               value: /consul/license/{{ .Values.global.enterpriseLicense.secretKey }}
             {{- end }}
@@ -233,8 +239,13 @@ spec:
             - |
               CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
-              {{- if and .Values.global.secretsBackend.vault.enabled .Values.global.gossipEncryption.secretName }}
+              {{- if .Values.global.secretsBackend.vault.enabled }}
+              {{- if .Values.global.gossipEncryption.secretName }}
               GOSSIP_KEY=`cat /vault/secrets/gossip.txt`
+              {{- end }}
+              {{- if and .Values.global.secretsBackend.vault.enabled .Values.global.enterpriseLicense.secretName }}
+              CONSUL_LICENSE_PATH=`cat /vault/secrets/enterpriselicense.txt`
+              {{- end }}
               {{- end }}
               {{- if (and .Values.dns.enabled .Values.dns.enableRedirection) }}
               {{ template "consul.recursors" }}

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -53,7 +53,7 @@ spec:
         {{- if .Values.global.gossipEncryption.secretName }}
         {{- with .Values.global.gossipEncryption }}
         "vault.hashicorp.com/agent-inject-secret-gossip.txt": {{ .secretName }}
-        "vault.hashicorp.com/agent-inject-template-gossip.txt": {{ template "consul.vaultGossipTemplate" . }}
+        "vault.hashicorp.com/agent-inject-template-gossip.txt": {{ template "consul.vaultSecretTemplate" . }}
         {{- end }}
         {{- end }}
         {{- if .Values.global.tls.enabled }}

--- a/charts/consul/templates/client-snapshot-agent-deployment.yaml
+++ b/charts/consul/templates/client-snapshot-agent-deployment.yaml
@@ -28,7 +28,8 @@ spec:
         component: client-snapshot-agent
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
-        {{- if (and .Values.global.secretsBackend.vault.enabled .Values.global.tls.enabled) }}
+        {{- if .Values.global.secretsBackend.vault.enabled }}
+        {{- if .Values.global.tls.enabled }}
         "vault.hashicorp.com/agent-init-first": "true"
         "vault.hashicorp.com/agent-inject": "true"
         "vault.hashicorp.com/role": {{ .Values.global.secretsBackend.vault.consulCARole }}
@@ -40,7 +41,14 @@ spec:
         {{- end }}
         {{- if .Values.global.secretsBackend.vault.agentAnnotations }}
         {{ tpl .Values.global.secretsBackend.vault.agentAnnotations . | nindent 8 | trim }}
+        {{- end }}        
         {{- end }}
+        {{- if .Values.global.enterpriseLicense.secretName }}
+        {{- with .Values.global.enterpriseLicense }}
+        "vault.hashicorp.com/agent-inject-secret-enterpriselicense.txt": "{{ .secretName }}"
+        "vault.hashicorp.com/agent-inject-template-enterpriselicense.txt": {{ template "consul.vaultSecretTemplate" . }}
+        {{- end }}
+        {{- end }}        
         {{- end }}
     spec:
       {{- if .Values.client.tolerations }}
@@ -116,7 +124,7 @@ spec:
                   name: "{{ template "consul.fullname" . }}-client-snapshot-agent-acl-token"
                   key: "token"
             {{- else }}
-            {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload) }}
+            {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload (not .Values.global.secretsBackend.vault.enabled)) }}
             - name: CONSUL_LICENSE_PATH
               value: /consul/license/{{ .Values.global.enterpriseLicense.secretKey }}
             {{- end }}
@@ -129,6 +137,9 @@ spec:
               cat <<EOF > /etc/ssl/certs/custom-ca.pem
               {{- .Values.client.snapshotAgent.caCert | nindent 14 }}
               EOF
+              {{- end }}
+              {{- if and .Values.global.secretsBackend.vault.enabled .Values.global.enterpriseLicense.secretName }}
+              CONSUL_LICENSE_PATH=`cat /vault/secrets/enterpriselicense.txt`
               {{- end }}
               exec /bin/consul snapshot agent \
                 {{- if (and .Values.client.snapshotAgent.configSecret.secretName .Values.client.snapshotAgent.configSecret.secretKey) }}

--- a/charts/consul/templates/enterprise-license-job.yaml
+++ b/charts/consul/templates/enterprise-license-job.yaml
@@ -53,11 +53,13 @@ spec:
         - name: apply-enterprise-license
           image: "{{ default .Values.global.image .Values.server.image }}"
           env:
+            {{- if not .Values.global.secretsBackend.vault.enabled }}
             - name: ENTERPRISE_LICENSE
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.enterpriseLicense.secretName }}
                   key: {{ .Values.global.enterpriseLicense.secretKey }}
+            {{- end}}
             - name: CONSUL_HTTP_ADDR
               {{- if .Values.global.tls.enabled }}
               value: https://{{ template "consul.fullname" . }}-server:8501
@@ -85,6 +87,9 @@ spec:
                 #!/bin/sh
                 while true; do
                   echo "Applying license..."
+                  {{- if .Values.global.secretsBackend.vault.enabled }}
+                  ENTERPRISE_LICENSE=`cat /vault/secrets/enterpriselicense.txt`
+                  {{- end }}
                   if consul license put "${ENTERPRISE_LICENSE}" 2>&1; then
                     echo "License applied successfully"
                     break

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
         {{- if .Values.global.gossipEncryption.secretName }}
         {{- with .Values.global.gossipEncryption }}
         "vault.hashicorp.com/agent-inject-secret-gossip.txt": "{{ .secretName }}"
-        "vault.hashicorp.com/agent-inject-template-gossip.txt": {{ template "consul.vaultGossipTemplate" . }}
+        "vault.hashicorp.com/agent-inject-template-gossip.txt": {{ template "consul.vaultSecretTemplate" . }}
         {{- end }}
         {{- end }}
         {{- if .Values.server.serverCert.secretName }}
@@ -79,6 +79,12 @@ spec:
         {{- end }}
         {{- if .Values.global.secretsBackend.vault.agentAnnotations }}
         {{ tpl .Values.global.secretsBackend.vault.agentAnnotations . | nindent 8 | trim }}
+        {{- end }}
+        {{- if .Values.global.enterpriseLicense.secretName }}
+        {{- with .Values.global.enterpriseLicense }}
+        "vault.hashicorp.com/agent-inject-secret-enterpriselicense.txt": "{{ .secretName }}"
+        "vault.hashicorp.com/agent-inject-template-enterpriselicense.txt": {{ template "consul.vaultSecretTemplate" . }}
+        {{- end }}
         {{- end }}
         {{- end }}
         "consul.hashicorp.com/connect-inject": "false"
@@ -133,7 +139,7 @@ spec:
             secretName: {{ template "consul.fullname" . }}-server-cert
             {{- end }}
         {{- end }}
-        {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload) }}
+        {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload (not .Values.global.secretsBackend.vault.enabled)) }}
         - name: consul-license
           secret:
             secretName: {{ .Values.global.enterpriseLicense.secretName }}
@@ -215,7 +221,7 @@ spec:
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
             {{- end }}
-            {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload) }}
+            {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey .Values.global.enterpriseLicense.enableLicenseAutoload (not .Values.global.secretsBackend.vault.enabled)) }}
             - name: CONSUL_LICENSE_PATH
               value: /consul/license/{{ .Values.global.enterpriseLicense.secretKey }}
             {{- end }}
@@ -235,6 +241,10 @@ spec:
 
               {{- if and .Values.global.secretsBackend.vault.enabled .Values.global.gossipEncryption.secretName }}
               GOSSIP_KEY=`cat /vault/secrets/gossip.txt`
+              {{- end }}
+
+              {{- if and .Values.global.secretsBackend.vault.enabled .Values.global.enterpriseLicense.secretName }}
+              CONSUL_LICENSE_PATH=`cat /vault/secrets/enterpriselicense.txt`
               {{- end }}
               
               {{- if (and .Values.dns.enabled .Values.dns.enableRedirection) }}

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -13,6 +13,8 @@
 {{- if (and (and .Values.global.secretsBackend.vault.enabled .Values.global.tls.enabled) (not .Values.global.tls.caCert.secretName)) }}{{ fail "global.tls.caCert.secretName must be provided if global.tls.enabled=true and global.secretsBackend.vault.enabled=true." }}{{ end -}}
 {{- if (and (and .Values.global.secretsBackend.vault.enabled .Values.global.tls.enabled) (not .Values.global.tls.enableAutoEncrypt)) }}{{ fail "global.tls.enableAutoEncrypt must be true if global.secretsBackend.vault.enabled=true and global.tls.enabled=true" }}{{ end -}}
 {{- if (and (and .Values.global.secretsBackend.vault.enabled .Values.global.tls.enabled) (not .Values.global.secretsBackend.vault.consulCARole)) }}{{ fail "global.secretsBackend.vault.consulCARole must be provided if global.secretsBackend.vault.enabled=true and global.tls.enabled=true" }}{{ end -}}
+{{- if (and .Values.global.enterpriseLicense.secretName (not .Values.global.enterpriseLicense.secretKey)) }}{{fail "enterpriseLicense.secretKey and secretName must both be specified." }}{{ end -}}
+{{- if (and (not .Values.global.enterpriseLicense.secretName) .Values.global.enterpriseLicense.secretKey) }}{{fail "enterpriseLicense.secretKey and secretName must both be specified." }}{{ end -}}
 # StatefulSet to run the actual Consul server cluster.
 apiVersion: apps/v1
 kind: StatefulSet

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -1836,6 +1836,51 @@ rollingUpdate:
   [ "${actual}" = "true" ]
 }
 
+@test "client/DaemonSet: vault enterprise license annotations are correct when enabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+    -s templates/client-daemonset.yaml  \
+    --set 'global.secretsBackend.vault.enabled=true' \
+    --set 'global.secretsBackend.vault.consulClientRole=foo' \
+    --set 'global.secretsBackend.vault.consulServerRole=test' \
+    --set 'global.enterpriseLicense.secretName=path/to/secret' \
+    --set 'global.enterpriseLicense.secretKey=enterpriselicense' \
+    . | tee /dev/stderr |
+      yq -r '.spec.template.metadata' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.annotations["vault.hashicorp.com/agent-inject-secret-enterpriselicense.txt"]' | tee /dev/stderr)
+  [ "${actual}" = "path/to/secret" ]
+  local actual=$(echo $object |
+      yq -r '.annotations["vault.hashicorp.com/agent-inject-template-enterpriselicense.txt"]' | tee /dev/stderr)
+  local actual="$(echo $object |
+      yq -r '.annotations["vault.hashicorp.com/agent-inject-template-enterpriselicense.txt"]' | tee /dev/stderr)"
+  local expected=$'{{- with secret \"path/to/secret\" -}}\n{{- .Data.data.enterpriselicense -}}\n{{- end -}}'
+  [ "${actual}" = "${expected}" ]
+}
+
+@test "client/DaemonSet: vault no CONSUL_LICENSE_PATH env variable and command defines CONSUL_LICENSE_PATH" {
+  cd `chart_dir`
+  local object=$(helm template \
+    -s templates/client-daemonset.yaml  \
+    --set 'global.secretsBackend.vault.enabled=true' \
+    --set 'global.secretsBackend.vault.consulClientRole=foo' \
+    --set 'global.secretsBackend.vault.consulServerRole=test' \
+    --set 'global.enterpriseLicense.secretName=a/b/c/d' \
+    --set 'global.enterpriseLicense.secretKey=gossip' \
+    . | tee /dev/stderr |
+      yq -r '.spec.template.spec' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+    yq -r '.containers[] | select(.name=="consul") | .env[] | select(.name == "CONSUL_LICENSE_PATH")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+
+  local actual=$(echo $object |
+    yq -r '.containers[] | select(.name=="consul") | .command | any(contains("CONSUL_LICENSE_PATH="))' \
+      | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 #--------------------------------------------------------------------
 # Vault agent annotations
 

--- a/charts/consul/test/unit/client-snapshot-agent-deployment.bats
+++ b/charts/consul/test/unit/client-snapshot-agent-deployment.bats
@@ -583,6 +583,53 @@ exec /bin/consul snapshot agent \'
   [ "${actual}" = "/vault/custom/tls.crt" ]
 }
 
+@test "client/SnapshotAgentDeployment: vault enterprise license annotations are correct when enabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+    -s templates/client-snapshot-agent-deployment.yaml  \
+    --set 'client.snapshotAgent.enabled=true' \
+    --set 'global.secretsBackend.vault.enabled=true' \
+    --set 'global.secretsBackend.vault.consulClientRole=foo' \
+    --set 'global.secretsBackend.vault.consulServerRole=test' \
+    --set 'global.enterpriseLicense.secretName=path/to/secret' \
+    --set 'global.enterpriseLicense.secretKey=enterpriselicense' \
+    . | tee /dev/stderr |
+      yq -r '.spec.template.metadata' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.annotations["vault.hashicorp.com/agent-inject-secret-enterpriselicense.txt"]' | tee /dev/stderr)
+  [ "${actual}" = "path/to/secret" ]
+  local actual=$(echo $object |
+      yq -r '.annotations["vault.hashicorp.com/agent-inject-template-enterpriselicense.txt"]' | tee /dev/stderr)
+  local actual="$(echo $object |
+      yq -r '.annotations["vault.hashicorp.com/agent-inject-template-enterpriselicense.txt"]' | tee /dev/stderr)"
+  local expected=$'{{- with secret \"path/to/secret\" -}}\n{{- .Data.data.enterpriselicense -}}\n{{- end -}}'
+  [ "${actual}" = "${expected}" ]
+}
+
+@test "client/SnapshotAgentDeployment: vault no CONSUL_LICENSE_PATH env variable and command defines CONSUL_LICENSE_PATH" {
+  cd `chart_dir`
+  local object=$(helm template \
+    -s templates/client-snapshot-agent-deployment.yaml  \
+    --set 'client.snapshotAgent.enabled=true' \
+    --set 'global.secretsBackend.vault.enabled=true' \
+    --set 'global.secretsBackend.vault.consulClientRole=foo' \
+    --set 'global.secretsBackend.vault.consulServerRole=test' \
+    --set 'global.enterpriseLicense.secretName=a/b/c/d' \
+    --set 'global.enterpriseLicense.secretKey=gossip' \
+    . | tee /dev/stderr |
+      yq -r '.spec.template.spec' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+    yq -r '.containers[] | select(.name=="consul-snapshot-agent") | .env[] | select(.name == "CONSUL_LICENSE_PATH")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+
+  local actual=$(echo $object |
+    yq -r '.containers[] | select(.name=="consul-snapshot-agent") | .command | any(contains("CONSUL_LICENSE_PATH="))' \
+      | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 #--------------------------------------------------------------------
 # Vault agent annotations
 

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1332,6 +1332,7 @@ load _helpers
 #--------------------------------------------------------------------
 # license-autoload
 
+
 @test "server/StatefulSet: adds volume for license secret when enterprise license secret name and key are provided" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1851,19 +1851,19 @@ load _helpers
     --set 'global.secretsBackend.vault.enabled=true' \
     --set 'global.secretsBackend.vault.consulClientRole=foo' \
     --set 'global.secretsBackend.vault.consulServerRole=test' \
-    --set 'global.enterpriseLicense.secretName=path/to/secret' \
+    --set 'global.enterpriseLicense.secretName=path/to/enterpriselicensesecret' \
     --set 'global.enterpriseLicense.secretKey=enterpriselicense' \
     . | tee /dev/stderr |
       yq -r '.spec.template.metadata' | tee /dev/stderr)
 
   local actual=$(echo $object |
       yq -r '.annotations["vault.hashicorp.com/agent-inject-secret-enterpriselicense.txt"]' | tee /dev/stderr)
-  [ "${actual}" = "path/to/secret" ]
+  [ "${actual}" = "path/to/enterpriselicensesecret" ]
   local actual=$(echo $object |
       yq -r '.annotations["vault.hashicorp.com/agent-inject-template-enterpriselicense.txt"]' | tee /dev/stderr)
   local actual="$(echo $object |
       yq -r '.annotations["vault.hashicorp.com/agent-inject-template-enterpriselicense.txt"]' | tee /dev/stderr)"
-  local expected=$'{{- with secret \"path/to/secret\" -}}\n{{- .Data.data.enterpriselicense -}}\n{{- end -}}'
+  local expected=$'{{- with secret \"path/to/enterpriselicensesecret\" -}}\n{{- .Data.data.enterpriselicense -}}\n{{- end -}}'
   [ "${actual}" = "${expected}" ]
 }
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -388,10 +388,10 @@ global:
   # introduce the license key via another route, then set these fields to null.
   # Note: the job to apply license runs on both Helm installs and upgrades.
   enterpriseLicense:
-    # The name of the Kubernetes secret that holds the enterprise license.
-    # The secret must be in the same namespace that Consul is installed into.
+    # secretName is the name of the Kubernetes secret or Vault secret path that holds the enterprise license.
+    # A Kubernetes secret must be in the same namespace that Consul is installed into.
     secretName: null
-    # The key within the Kubernetes secret that holds the enterprise license.
+    # secretKey is the key within the Kubernetes secret or Vault secret key that holds the enterprise license.
     secretKey: null
     # Manages license autoload. Required in Consul 1.10.0+, 1.9.7+ and 1.8.12+.
     enableLicenseAutoload: true


### PR DESCRIPTION
Changes proposed in this PR:
For server-statefulset, client-agent-snapshot-deployment, and client-daemonset:
- when vault is enabled as secrets backend, allow default behavior of retrieving kubernetes secret for enterprise license
- when vault is enabled as secrets backend
  - use vault injectors to get retrieve the license from vault and write it to disk
  - use the license from disk to write the license value to the environment variable for the license.  (server-statefulset and client-daemonset use CONSUL_LICENSE_PATH and client-agent-snapshot-deployment uses ENTERPRISE_LICENSE).

How I've tested this PR:
- [x] unit tests
- [ ] acceptance tests
- [ ] manual verification

How I expect reviewers to test this PR:
- review code and test changes

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added
- [ ] Acceptance tests added
- [ ] Docs PR todescribe how to enable this behavior

