### PR TITLE
ISSUE_TEMPLATE: update labels per new GH labeling recommendations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: You're experiencing an issue with the Consul Helm chart or consul-k8s-control-plane binary that is different than the documented behavior.
+about: You're experiencing an issue with the Consul Helm chart, consul-k8s CLI, or consul-k8s-control-plane binary that is different than the documented behavior.
 labels: type/bug
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: You're experiencing an issue with the Consul Helm chart or consul-k8s-control-plane binary that is different than the documented behavior.
-labels: bug
+labels: type/bug
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: If you have something you think Consul on Kubernetes could improve or add support for.
-labels: enhancement
+labels: type/enhancement
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: You'd like to clarify your understanding about a particular area within Consul K8s. We'd like to help and engage the community through Github!
+about: You'd like to clarify your understanding about a particular area within Consul on Kubernetes. We'd like to help and engage the community through Github!
 labels: type/question
 
 ---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,7 @@
 ---
 name: Question
 about: You'd like to clarify your understanding about a particular area within Consul K8s. We'd like to help and engage the community through Github!
-labels: question
+labels: type/question
 
 ---
 


### PR DESCRIPTION
Changes proposed in this PR:
- Aligning labels with Consul Core labels on Issue Template 

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

