### PR TITLE
Allow configuring primary DC and gateways via designated Helm values

### DIFF
--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -63,11 +63,11 @@ func (t *TestConfig) HelmValuesFromConfig() (map[string]string, error) {
 			return nil, err
 		}
 		setIfNotEmpty(helmValues, "global.image", entImage)
-	}
 
-	if t.EnterpriseLicense != "" {
-		setIfNotEmpty(helmValues, "global.enterpriseLicense.secretName", LicenseSecretName)
-		setIfNotEmpty(helmValues, "global.enterpriseLicense.secretKey", LicenseSecretKey)
+		if t.EnterpriseLicense != "" {
+			setIfNotEmpty(helmValues, "global.enterpriseLicense.secretName", LicenseSecretName)
+			setIfNotEmpty(helmValues, "global.enterpriseLicense.secretKey", LicenseSecretKey)
+		}
 	}
 
 	if t.EnableOpenshift {

--- a/acceptance/framework/config/config_test.go
+++ b/acceptance/framework/config/config_test.go
@@ -58,12 +58,15 @@ func TestConfig_HelmValuesFromConfig(t *testing.T) {
 		{
 			"sets ent license secret",
 			TestConfig{
+				EnableEnterprise:  true,
 				EnterpriseLicense: "ent-license",
+				ConsulImage:       "consul:test-version",
 			},
 			map[string]string{
 				"global.enterpriseLicense.secretName":           "license",
 				"global.enterpriseLicense.secretKey":            "key",
 				"connectInject.transparentProxy.defaultEnabled": "false",
+				"global.image": "consul:test-version",
 			},
 		},
 		{
@@ -109,7 +112,7 @@ func TestConfig_HelmValuesFromConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			values, err := tt.testConfig.HelmValuesFromConfig()
 			require.NoError(t, err)
-			require.Equal(t, values, tt.want)
+			require.Equal(t, tt.want, values)
 		})
 	}
 }

--- a/acceptance/tests/vault/vault_wan_fed_test.go
+++ b/acceptance/tests/vault/vault_wan_fed_test.go
@@ -199,11 +199,12 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 
 	// Get the address of the mesh gateway.
 	primaryMeshGWAddress := meshGatewayAddress(t, cfg, primaryCtx, consulReleaseName)
-	serverExtraConfig := fmt.Sprintf(`"{\"primary_gateways\":[\"%s\"]\,\"primary_datacenter\":\"dc1\"}"`, primaryMeshGWAddress)
 	secondaryConsulHelmValues := map[string]string{
 		"global.datacenter": "dc2",
 
-		"global.federation.enabled": "true",
+		"global.federation.enabled":            "true",
+		"global.federation.primaryDatacenter":  "dc1",
+		"global.federation.primaryGateways[0]": primaryMeshGWAddress,
 
 		// TLS config.
 		"global.tls.enabled":           "true",
@@ -229,7 +230,6 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 		"server.extraVolumes[0].type": "secret",
 		"server.extraVolumes[0].name": vaultCASecretName,
 		"server.extraVolumes[0].load": "false",
-		"server.extraConfig":          serverExtraConfig,
 
 		// Vault config.
 		"global.secretsBackend.vault.enabled":                       "true",

--- a/charts/consul/templates/server-config-configmap.yaml
+++ b/charts/consul/templates/server-config-configmap.yaml
@@ -78,4 +78,11 @@ data:
     {
       "enable_central_service_config": true
     }
+  {{- if .Values.global.federation.enabled }}
+  federation-config.json: |-
+    {
+      "primary_datacenter": "{{ .Values.global.federation.primaryDatacenter }}",
+      "primary_gateways": {{ .Values.global.federation.primaryGateways | toJson }}
+    }
+  {{- end }}
 {{- end }}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -430,6 +430,13 @@ global:
     # `<helm-release-name>-consul-federation`.
     createFederationSecret: false
 
+    # The name of the primary datacenter.
+    primaryDatacenter: ""
+
+    # A list of addresses of the primary mesh gateways in the form <ip>:<port>.
+    # @type: array<string>
+    primaryGateways: []
+
   # Configures metrics for Consul service mesh
   metrics:
     # Configures the Helm chart’s components

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -434,6 +434,7 @@ global:
     primaryDatacenter: ""
 
     # A list of addresses of the primary mesh gateways in the form <ip>:<port>.
+    # (e.g. ["1.1.1.1:443", "2.3.4.5:443"] 
     # @type: array<string>
     primaryGateways: []
 


### PR DESCRIPTION
Changes proposed in this PR:
- Add `global.federation.primaryDatacenter` and `global.federation.primaryGateway` to allow users to specify these values directly rather than via `server.extraConfig` or `server.extraVolumes`

Note that we will keep the existing behavior of `create-federation-secret` that generates the serverExtraConfig with those values for the time being and will re-assess it when the ACL work to switch out tokens for auth methods will be complete as it will likely affect it. So at the moment we will allow using both methods, and if the user provides these values via any of the `server.extra*` values, they will take precedence.

How I've tested this PR:
vault acceptance tests

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

