### PR TITLE
Expose optional metrics for API Gateway controller

### DIFF
--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -36,6 +36,11 @@ spec:
         "vault.hashicorp.com/ca-cert": "/vault/custom/{{ .Values.global.secretsBackend.vault.ca.secretKey }}"
         {{- end }}
         {{- end }}
+        {{- if (and .Values.global.metrics.enabled .Values.global.metrics.enableGatewayMetrics) }}
+        "prometheus.io/scrape": "true"
+        "prometheus.io/path": "/metrics"
+        "prometheus.io/port": "20200"
+        {{- end }}
       labels:
         app: {{ template "consul.name" . }}
         chart: {{ template "consul.chart" . }}
@@ -80,6 +85,9 @@ spec:
               -sds-server-host {{ template "consul.fullname" . }}-api-gateway-controller.{{ .Release.Namespace }}.svc \
               -k8s-namespace {{ .Release.Namespace }} \
               -log-level {{ default .Values.global.logLevel .Values.apiGateway.logLevel }} \
+              {{- if (and .Values.global.metrics.enabled .Values.global.metrics.enableGatewayMetrics) }}
+              -metrics-port 20200 \
+              {{ end }}
         volumeMounts:
           {{- if .Values.global.tls.enabled }}
           {{- if .Values.global.tls.enableAutoEncrypt }}


### PR DESCRIPTION
Changes proposed in this PR:
- Expose optional metrics port for Consul API Gateway controller

How I've tested this PR:
- Installed this chart to a local kind cluster with and without the following values set:
  - `global.metrics.enabled=true`
  - `global.metrics.gateway.enableGatewayMetrics=true`
- Verified that the annotations and command on the deployment are update appropriately
- Verified that the controller logs include the following when enabled:

     ```
     2022-02-22T20:21:58.439Z [INFO]  manager/internal.go:383: consul-api-gateway-server.controller-runtime: starting metrics server: path=/metrics
     ```

How I expect reviewers to test this PR:
See above

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

