### PR TITLE
Create an Issue Context Bot

### DIFF
--- a/.github/workflows/issue-context-bot.yml
+++ b/.github/workflows/issue-context-bot.yml
@@ -1,0 +1,28 @@
+name: Issue Context Bot
+
+on:
+  issues:
+    types: transferred
+
+jobs:
+  add-context:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+    - uses: wow-actions/auto-comment@v1.0.7
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        issuesTransferred: |
+          "Hi @{{ author }},
+          
+          It looks like your issue has been transferred to the Consul on Kubernetes repository.
+          If your issue is a question or bug report, there is some additional context that will
+          help us solve your issue. Please reply with the following information if it is not
+          included in your original issue:
+          
+          - the [Helm values](https://www.consul.io/docs/k8s/helm) you used to install Consul
+          on Kubernetes
+          - the version of Consul on Kubernetes used
+          - the version of Kubernetes you are using
+          - if you installed Consul on Kubernetes using Helm or the Consul-K8s CLI"


### PR DESCRIPTION
Changes proposed in this PR:
- This PR adds an Issue Context Bot which will comment on issues which are transferred to this repository with a prompt to add additional K8s-specific context.

How I've tested this PR:

Unfortunately, I can't really test this unless it is in the main branch. However, it relies on standard GitHub Action triggers.

How I expect reviewers to test this PR:

The main feedback I would like is _if_ this is a good addition and any changes to the comment copy that would make it clearer to the user what they are being asked to do.


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

