### PR TITLE
chart: bump k8s requirement to 1.19

### DIFF
--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: consul
 version: 0.40.0
 appVersion: 1.11.2
-kubeVersion: ">=1.18.0-0"
+kubeVersion: ">=1.19.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
 icon: https://raw.githubusercontent.com/hashicorp/consul-k8s/main/assets/icon.png

--- a/charts/consul/templates/ui-ingress.yaml
+++ b/charts/consul/templates/ui-ingress.yaml
@@ -25,9 +25,7 @@ metadata:
     {{ tpl .Values.ui.ingress.annotations . | nindent 4 | trim }}
   {{- end }}
 spec:
-  {{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "18" ) }}
   ingressClassName: {{ .Values.ui.ingress.ingressClassName }}
-  {{- end }}
   rules:
   {{ $global := .Values.global }}
   {{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "19" ) }}

--- a/charts/consul/test/unit/ui-ingress.bats
+++ b/charts/consul/test/unit/ui-ingress.bats
@@ -59,7 +59,7 @@ load _helpers
   [ "${actual}" = "foo.com" ]
 }
 
-@test "ui/Ingress: exposes single port 80 when global.tls.enabled=false when Kube version >= 1.19" {
+@test "ui/Ingress: exposes single port 80 when global.tls.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
      -s templates/ui-ingress.yaml  \
@@ -72,20 +72,19 @@ load _helpers
   [ "${actual}" = "80" ]
 }
 
-@test "ui/Ingress: exposes single port 443 when global.tls.enabled=true and global.tls.httpsOnly=true when Kube version >= 1.19" {
+@test "ui/Ingress: exposes single port 443 when global.tls.enabled=true and global.tls.httpsOnly=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
       --set 'ui.ingress.enabled=true' \
       --set 'global.tls.enabled=true' \
       --set 'ui.ingress.hosts[0].host=foo.com' \
-      --kube-version "1.19" \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[0].backend.service.port.number' | tee /dev/stderr)
   [ "${actual}" = "443" ]
 }
 
-@test "ui/Ingress: exposes the port 80 when global.tls.enabled=true and global.tls.httpsOnly=false when Kube version >= 1.19" {
+@test "ui/Ingress: exposes the port 80 when global.tls.enabled=true and global.tls.httpsOnly=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
@@ -93,13 +92,12 @@ load _helpers
       --set 'global.tls.enabled=true' \
       --set 'global.tls.httpsOnly=false' \
       --set 'ui.ingress.hosts[0].host=foo.com' \
-      --kube-version "1.19" \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[0].backend.service.port.number' | tee /dev/stderr)
   [ "${actual}" = "80" ]
 }
 
-@test "ui/Ingress: exposes the port 443 when global.tls.enabled=true and global.tls.httpsOnly=false when Kube version >= 1.19" {
+@test "ui/Ingress: exposes the port 443 when global.tls.enabled=true and global.tls.httpsOnly=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/ui-ingress.yaml  \
@@ -107,7 +105,6 @@ load _helpers
       --set 'global.tls.enabled=true' \
       --set 'global.tls.httpsOnly=false' \
       --set 'ui.ingress.hosts[0].host=foo.com' \
-      --kube-version "1.19" \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[1].backend.service.port.number' | tee /dev/stderr)
   [ "${actual}" = "443" ]

--- a/charts/consul/test/unit/ui-ingress.bats
+++ b/charts/consul/test/unit/ui-ingress.bats
@@ -66,7 +66,6 @@ load _helpers
      --set 'ui.ingress.enabled=true' \
      --set 'global.tls.enabled=false' \
      --set 'ui.ingress.hosts[0].host=foo.com' \
-     --kube-version "1.19" \
      . | tee /dev/stderr |
      yq -r '.spec.rules[0].http.paths[0].backend.service.port.number' | tee /dev/stderr)
   [ "${actual}" = "80" ]

--- a/charts/consul/test/unit/ui-ingress.bats
+++ b/charts/consul/test/unit/ui-ingress.bats
@@ -59,19 +59,6 @@ load _helpers
   [ "${actual}" = "foo.com" ]
 }
 
-@test "ui/Ingress: exposes single port 80 when global.tls.enabled=false when Kube version < 1.19" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/ui-ingress.yaml  \
-      --set 'ui.ingress.enabled=true' \
-      --set 'global.tls.enabled=false' \
-      --set 'ui.ingress.hosts[0].host=foo.com' \
-      --kube-version "1.18" \
-      . | tee /dev/stderr |
-      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
-  [ "${actual}" = "80" ]
-}
-
 @test "ui/Ingress: exposes single port 80 when global.tls.enabled=false when Kube version >= 1.19" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -83,19 +70,6 @@ load _helpers
      . | tee /dev/stderr |
      yq -r '.spec.rules[0].http.paths[0].backend.service.port.number' | tee /dev/stderr)
   [ "${actual}" = "80" ]
-}
-
-@test "ui/Ingress: exposes single port 443 when global.tls.enabled=true and global.tls.httpsOnly=true when Kube version < 1.19" {
-  cd `chart_dir`
-  local actual=$(helm template \
-    -s templates/ui-ingress.yaml  \
-    --set 'ui.ingress.enabled=true' \
-    --set 'global.tls.enabled=true' \
-    --set 'ui.ingress.hosts[0].host=foo.com' \
-    --kube-version "1.18" \
-    . | tee /dev/stderr |
-    yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
-  [ "${actual}" = "443" ]
 }
 
 @test "ui/Ingress: exposes single port 443 when global.tls.enabled=true and global.tls.httpsOnly=true when Kube version >= 1.19" {
@@ -111,20 +85,6 @@ load _helpers
   [ "${actual}" = "443" ]
 }
 
-@test "ui/Ingress: exposes the port 80 when global.tls.enabled=true and global.tls.httpsOnly=false when Kube version < 1.19" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/ui-ingress.yaml  \
-      --set 'ui.ingress.enabled=true' \
-      --set 'global.tls.enabled=true' \
-      --set 'global.tls.httpsOnly=false' \
-      --set 'ui.ingress.hosts[0].host=foo.com' \
-      --kube-version "1.18" \
-      . | tee /dev/stderr |
-      yq -r '.spec.rules[0].http.paths[0].backend.servicePort' | tee /dev/stderr)
-  [ "${actual}" = "80" ]
-}
-
 @test "ui/Ingress: exposes the port 80 when global.tls.enabled=true and global.tls.httpsOnly=false when Kube version >= 1.19" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -137,20 +97,6 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[0].backend.service.port.number' | tee /dev/stderr)
   [ "${actual}" = "80" ]
-}
-
-@test "ui/Ingress: exposes the port 443 when global.tls.enabled=true and global.tls.httpsOnly=false when Kube version < 1.19" {
-  cd `chart_dir`
-  local actual=$(helm template \
-    -s templates/ui-ingress.yaml  \
-    --set 'ui.ingress.enabled=true' \
-    --set 'global.tls.enabled=true' \
-    --set 'global.tls.httpsOnly=false' \
-    --set 'ui.ingress.hosts[0].host=foo.com' \
-    --kube-version "1.18" \
-    . | tee /dev/stderr |
-    yq -r '.spec.rules[0].http.paths[1].backend.servicePort' | tee /dev/stderr)
-  [ "${actual}" = "443" ]
 }
 
 @test "ui/Ingress: exposes the port 443 when global.tls.enabled=true and global.tls.httpsOnly=false when Kube version >= 1.19" {


### PR DESCRIPTION
Changes proposed in this PR:
- bump kubeVersionAPI to 1.19 to reflect what we see in README
- default to using ingressClassName value
- remove bats tests for 1.19 on UI Ingress and remove --kube-version flags since tests run on 1.19+ by default

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

