### PR TITLE
bats: bump envoy to 1.20.2 on gateways

### DIFF
--- a/charts/consul/test/unit/ingress-gateways-deployment.bats
+++ b/charts/consul/test/unit/ingress-gateways-deployment.bats
@@ -83,7 +83,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "envoyproxy/envoy-alpine:v1.20.1" ]
+  [ "${actual}" = "envoyproxy/envoy-alpine:v1.20.2" ]
 }
 
 @test "ingressGateways/Deployment: envoy image can be set using the global value" {

--- a/charts/consul/test/unit/mesh-gateway-deployment.bats
+++ b/charts/consul/test/unit/mesh-gateway-deployment.bats
@@ -335,7 +335,7 @@ key2: value2' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "envoyproxy/envoy-alpine:v1.20.1" ]
+  [ "${actual}" = "envoyproxy/envoy-alpine:v1.20.2" ]
 }
 
 @test "meshGateway/Deployment: setting meshGateway.imageEnvoy fails" {

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -83,7 +83,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "envoyproxy/envoy-alpine:v1.20.1" ]
+  [ "${actual}" = "envoyproxy/envoy-alpine:v1.20.2" ]
 }
 
 @test "terminatingGateways/Deployment: envoy image can be set using the global value" {


### PR DESCRIPTION
Changes proposed in this PR:
- Bump envoy on ingress, mesh, and terminating gateways to make helm unit tests to pass 

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

