### PR TITLE
CHANGELOG: bump to k8s 1.19+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UNRELEASED
 
+BREAKING CHANGES:
+* Minimum Kubernetes versions supported is 1.19+ and now matches what is stated in the `README.md` file.  [[GH-1049](https://github.com/hashicorp/consul-k8s/pull/1049)] 
+
 ## 0.41.1 (February 24, 2022)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## UNRELEASED
 
 BREAKING CHANGES:
-* Minimum Kubernetes versions supported is 1.19+ and now matches what is stated in the `README.md` file.  [[GH-1049](https://github.com/hashicorp/consul-k8s/pull/1049)] 
+* Minimum Kubernetes version supported is 1.19 and now matches what is stated in the `README.md` file.  [[GH-1049](https://github.com/hashicorp/consul-k8s/pull/1049)] 
 
 ## 0.41.1 (February 24, 2022)
 


### PR DESCRIPTION
Changes proposed in this PR:
- Follow up changelog PR to https://github.com/hashicorp/consul-k8s/pull/1049 

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

