### PR TITLE
Dockerfile: bump to alpine 3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## UNRELEASED
 
 BREAKING CHANGES:
-* Minimum Kubernetes version supported is 1.19 and now matches what is stated in the `README.md` file.  [[GH-1049](https://github.com/hashicorp/consul-k8s/pull/1049)] 
+* Helm
+  * Minimum Kubernetes version supported is 1.19 and now matches what is stated in the `README.md` file.  [[GH-1049](https://github.com/hashicorp/consul-k8s/pull/1049)] 
+
+IMPROVEMENTS:
+* Control Plane
+  * Bump `consul-k8s-control-plane` base image to use `alpine:3.15` [GH-1058](https://github.com/hashicorp/consul-k8s/pull/1058)
 
 ## 0.41.1 (February 24, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ BREAKING CHANGES:
 
 IMPROVEMENTS:
 * Control Plane
-  * Upgrade Docker image Alpine version from 3.14 to 3.15. [GH-1058](https://github.com/hashicorp/consul-k8s/pull/1058)
+  * Upgrade Docker image Alpine version from 3.14 to 3.15. [[GH-1058](https://github.com/hashicorp/consul-k8s/pull/1058)]
 
 ## 0.41.1 (February 24, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ BREAKING CHANGES:
 
 IMPROVEMENTS:
 * Control Plane
-  * Bump `consul-k8s-control-plane` base image to use `alpine:3.15` [GH-1058](https://github.com/hashicorp/consul-k8s/pull/1058)
+  * Upgrade Docker image Alpine version from 3.14 to 3.15. [GH-1058](https://github.com/hashicorp/consul-k8s/pull/1058)
 
 ## 0.41.1 (February 24, 2022)
 

--- a/control-plane/build-support/docker/Release.dockerfile
+++ b/control-plane/build-support/docker/Release.dockerfile
@@ -5,7 +5,7 @@
 # We don't rebuild the software because we want the exact checksums and
 # binary signatures to match the software and our builds aren't fully
 # reproducible currently.
-FROM alpine:3.14
+FROM alpine:3.15
 
 # NAME and VERSION are the name of the software in releases.hashicorp.com
 # and the version to download. Example: NAME=consul VERSION=1.2.3.


### PR DESCRIPTION
Changes proposed in this PR:
- Bump `consul-k8s-control-plane` alpine base image to 3.15

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

