### PR TITLE
Support storing bootstrap token in Vault

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,7 @@ commands:
         type: string
       consul-k8s-image:
         type: string
-        #default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s-control-plane:latest"
-        default: "kyleschochenmaier/consul-k8s-acls"
+        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s-control-plane:$(git rev-parse --short HEAD)"
       go-path:
         type: string
         default: "/home/circleci/.go_workspace"

--- a/acceptance/framework/vault/vault_cluster.go
+++ b/acceptance/framework/vault/vault_cluster.go
@@ -172,8 +172,8 @@ func (v *VaultCluster) ConfigureAuthMethod(t *testing.T, vaultClient *vapi.Clien
 	var sa *corev1.ServiceAccount
 	retry.Run(t, func(r *retry.R) {
 		sa, err = v.kubernetesClient.CoreV1().ServiceAccounts(saNS).Get(context.Background(), saName, metav1.GetOptions{})
-		require.NoError(t, err)
-		require.Len(t, sa.Secrets, 1)
+		require.NoError(r, err)
+		require.Len(r, sa.Secrets, 1)
 	})
 
 	v.logger.Logf(t, "updating vault kubernetes auth config for %s auth path", authPath)

--- a/acceptance/tests/vault/helpers.go
+++ b/acceptance/tests/vault/helpers.go
@@ -24,10 +24,9 @@ path "consul/data/secret/bootstrap" {
   capabilities = ["read"]
 }`
 
-	// todo: should this policy be only "read"?
 	replicationTokenPolicy = `
 path "consul/data/secret/replication" {
-  capabilities = ["read", "update"]
+  capabilities = ["read"]
 }`
 
 	enterpriseLicensePolicy = `

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -59,7 +59,7 @@ func TestVault(t *testing.T) {
 		"global.secretsBackend.vault.consulServerRole":     "consul-server",
 		"global.secretsBackend.vault.consulClientRole":     "consul-client",
 		"global.secretsBackend.vault.consulCARole":         "consul-ca",
-		"global.secretsBackend.vault.manageSystemACLsRole": "server-acl-init", // todo: we need to fail in helm templates if this role is not provided
+		"global.secretsBackend.vault.manageSystemACLsRole": "server-acl-init",
 
 		"global.secretsBackend.vault.ca.secretName": vaultCASecret,
 		"global.secretsBackend.vault.ca.secretKey":  "tls.crt",

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -37,6 +37,8 @@ func TestVault(t *testing.T) {
 		configureEnterpriseLicenseVaultSecret(t, vaultClient, cfg)
 	}
 
+	bootstrapToken := configureBootstrapTokenVaultSecret(t, vaultClient)
+
 	configureKubernetesAuthRoles(t, vaultClient, consulReleaseName, ns, "kubernetes", "dc1", cfg)
 
 	configurePKICA(t, vaultClient)
@@ -53,10 +55,11 @@ func TestVault(t *testing.T) {
 		"connectInject.replicas": "1",
 		"controller.enabled":     "true",
 
-		"global.secretsBackend.vault.enabled":          "true",
-		"global.secretsBackend.vault.consulServerRole": "consul-server",
-		"global.secretsBackend.vault.consulClientRole": "consul-client",
-		"global.secretsBackend.vault.consulCARole":     "consul-ca",
+		"global.secretsBackend.vault.enabled":              "true",
+		"global.secretsBackend.vault.consulServerRole":     "consul-server",
+		"global.secretsBackend.vault.consulClientRole":     "consul-client",
+		"global.secretsBackend.vault.consulCARole":         "consul-ca",
+		"global.secretsBackend.vault.manageSystemACLsRole": "server-acl-init", // todo: we need to fail in helm templates if this role is not provided
 
 		"global.secretsBackend.vault.ca.secretName": vaultCASecret,
 		"global.secretsBackend.vault.ca.secretKey":  "tls.crt",
@@ -65,10 +68,12 @@ func TestVault(t *testing.T) {
 		"global.secretsBackend.vault.connectCA.rootPKIPath":         "connect_root",
 		"global.secretsBackend.vault.connectCA.intermediatePKIPath": "dc1/connect_inter",
 
-		"global.acls.manageSystemACLs":       "true",
-		"global.tls.enabled":                 "true",
-		"global.gossipEncryption.secretName": "consul/data/secret/gossip",
-		"global.gossipEncryption.secretKey":  "gossip",
+		"global.acls.manageSystemACLs":          "true",
+		"global.acls.bootstrapToken.secretName": "consul/data/secret/bootstrap",
+		"global.acls.bootstrapToken.secretKey":  "token",
+		"global.tls.enabled":                    "true",
+		"global.gossipEncryption.secretName":    "consul/data/secret/gossip",
+		"global.gossipEncryption.secretKey":     "gossip",
 
 		"ingressGateways.enabled":               "true",
 		"ingressGateways.defaults.replicas":     "1",
@@ -99,6 +104,7 @@ func TestVault(t *testing.T) {
 
 	// Validate that the gossip encryption key is set correctly.
 	logger.Log(t, "Validating the gossip key has been set correctly.")
+	consulCluster.ACLToken = bootstrapToken
 	consulClient := consulCluster.SetupConsulClient(t, true)
 	keys, err := consulClient.Operator().KeyringList(nil)
 	require.NoError(t, err)

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -39,7 +39,7 @@ func TestVault(t *testing.T) {
 
 	bootstrapToken := configureBootstrapTokenVaultSecret(t, vaultClient)
 
-	configureKubernetesAuthRoles(t, vaultClient, consulReleaseName, ns, "kubernetes", "dc1", cfg)
+	configureKubernetesAuthRoles(t, vaultClient, consulReleaseName, ns, "kubernetes", "dc1", cfg, true)
 
 	configurePKICA(t, vaultClient)
 	certPath := configurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1")

--- a/acceptance/tests/vault/vault_wan_fed_test.go
+++ b/acceptance/tests/vault/vault_wan_fed_test.go
@@ -69,6 +69,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	configureGossipVaultSecret(t, vaultClient)
 
 	if cfg.EnableEnterprise {
+		logger.Log(t, "configuring enterprise license secret")
 		configureEnterpriseLicenseVaultSecret(t, vaultClient, cfg)
 	}
 
@@ -222,7 +223,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 		// ACL config.
 		"global.acls.manageSystemACLs":            "true",
 		"global.acls.replicationToken.secretName": "consul/data/secret/replication",
-		"global.acls.replicationToken.secretKey":  "replication",
+		"global.acls.replicationToken.secretKey":  "token",
 
 		// Mesh config.
 		"connectInject.enabled": "true",

--- a/acceptance/tests/vault/vault_wan_fed_test.go
+++ b/acceptance/tests/vault/vault_wan_fed_test.go
@@ -69,7 +69,6 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	configureGossipVaultSecret(t, vaultClient)
 
 	if cfg.EnableEnterprise {
-		logger.Log(t, "configuring enterprise license secret")
 		configureEnterpriseLicenseVaultSecret(t, vaultClient, cfg)
 	}
 

--- a/acceptance/tests/vault/vault_wan_fed_test.go
+++ b/acceptance/tests/vault/vault_wan_fed_test.go
@@ -72,7 +72,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 		configureEnterpriseLicenseVaultSecret(t, vaultClient, cfg)
 	}
 
-	configureKubernetesAuthRoles(t, vaultClient, consulReleaseName, ns, "kubernetes", "dc1", cfg)
+	configureKubernetesAuthRoles(t, vaultClient, consulReleaseName, ns, "kubernetes", "dc1", cfg, true)
 
 	// Configure Vault Kubernetes auth method for the secondary datacenter.
 	{
@@ -113,7 +113,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 		secondaryVaultCluster.ConfigureAuthMethod(t, vaultClient, "kubernetes-dc2", k8sAuthMethodHost, authMethodRBACName, ns)
 	}
 
-	configureKubernetesAuthRoles(t, vaultClient, consulReleaseName, ns, "kubernetes-dc2", "dc2", cfg)
+	configureKubernetesAuthRoles(t, vaultClient, consulReleaseName, ns, "kubernetes-dc2", "dc2", cfg, false)
 
 	// Generate a CA and create PKI roles for the primary and secondary Consul servers.
 	configurePKICA(t, vaultClient)

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -73,6 +73,13 @@ as well as the global.name setting.
           {{ "{{" }}- end -{{ "}}" }}
 {{- end -}}
 
+{{- define "consul.vaultBootstrapTokenConfigTemplate" -}}
+|
+          {{ "{{" }}- with secret "{{ .Values.global.acls.bootstrapToken.secretName }}" -{{ "}}" }}
+          acl { tokens { initial_management = "{{ "{{" }}- {{ printf ".Data.data.%s" .Values.global.acls.bootstrapToken.secretKey }} -{{ "}}" }}" }}
+          {{ "{{" }}- end -{{ "}}" }}
+{{- end -}}
+
 {{/*
 Sets up the extra-from-values config file passed to consul and then uses sed to do any necessary
 substitution for HOST_IP/POD_IP/HOSTNAME. Useful for dogstats telemetry. The output file

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -4,9 +4,10 @@
 {{- if and .Values.global.acls.createReplicationToken (not .Values.global.acls.manageSystemACLs) }}{{ fail "if global.acls.createReplicationToken is true, global.acls.manageSystemACLs must be true" }}{{ end -}}
 {{- if .Values.global.bootstrapACLs }}{{ fail "global.bootstrapACLs was removed, use global.acls.manageSystemACLs instead" }}{{ end -}}
 {{- if .Values.global.acls.manageSystemACLs }}
+{{- if or (and .Values.global.acls.bootstrapToken.secretName (not .Values.global.acls.bootstrapToken.secretKey))  (and .Values.global.acls.bootstrapToken.secretKey (not .Values.global.acls.bootstrapToken.secretName))}}{{ fail "both global.acls.bootstrapToken.secretKey and global.acls.bootstrapToken.secretName must be set if one of them is provided" }}{{ end -}}
 {{- if or (and .Values.global.acls.replicationToken.secretName (not .Values.global.acls.replicationToken.secretKey))  (and .Values.global.acls.replicationToken.secretKey (not .Values.global.acls.replicationToken.secretName))}}{{ fail "both global.acls.replicationToken.secretKey and global.acls.replicationToken.secretName must be set if one of them is provided" }}{{ end -}}
-{{- if (and .Values.global.secretsBackend.vault.enabled (and (not (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey)) (not .Values.global.acls.replicationToken.secretName ))) }}{{fail "global.acls.bootstrapToken or global.acls.replicationToken must be provided when global.secretsBackend.vault.enabled and global.acls.manageSystemACLs are true" }}{{ end -}}
-{{- if (and .Values.global.secretsBackend.vault.enabled (not .Values.global.secretsBackend.vault.manageSystemACLsRole)) }}{{fail "both global.secretsBackend.vault.manageSystemACLsRole is required when global.secretsBackend.vault.enabled and global.acls.manageSystemACLs are true" }}{{ end -}}
+{{- if (and .Values.global.secretsBackend.vault.enabled (and (not .Values.global.acls.bootstrapToken.secretName) (not .Values.global.acls.replicationToken.secretName ))) }}{{fail "global.acls.bootstrapToken or global.acls.replicationToken must be provided when global.secretsBackend.vault.enabled and global.acls.manageSystemACLs are true" }}{{ end -}}
+{{- if (and .Values.global.secretsBackend.vault.enabled (not .Values.global.secretsBackend.vault.manageSystemACLsRole)) }}{{fail "global.secretsBackend.vault.manageSystemACLsRole is required when global.secretsBackend.vault.enabled and global.acls.manageSystemACLs are true" }}{{ end -}}
   {{- /* We don't render this job when server.updatePartition > 0 because that
     means a server rollout is in progress and this job won't complete unless
     the rollout is finished (which won't happen until the partition is 0).
@@ -70,7 +71,7 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-server-acl-init
-      {{- if (or .Values.global.tls.enabled .Values.global.acls.replicationToken.secretName (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey)) }}
+      {{- if (or .Values.global.tls.enabled .Values.global.acls.replicationToken.secretName .Values.global.acls.bootstrapToken.secretName) }}
       volumes:
         {{- if and .Values.global.tls.enabled (not .Values.global.secretsBackend.vault.enabled) }}
         - name: consul-ca-cert
@@ -84,7 +85,7 @@ spec:
               - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
                 path: tls.crt
         {{- end }}
-        {{- if (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey (not .Values.global.secretsBackend.vault.enabled)) }}
+        {{- if (and .Values.global.acls.bootstrapToken.secretName (not .Values.global.secretsBackend.vault.enabled)) }}
         - name: bootstrap-token
           secret:
             secretName: {{ .Values.global.acls.bootstrapToken.secretName }}
@@ -108,14 +109,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          {{- if (or .Values.global.tls.enabled .Values.global.acls.replicationToken.secretName (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey)) }}
+          {{- if (or .Values.global.tls.enabled .Values.global.acls.replicationToken.secretName .Values.global.acls.bootstrapToken.secretName) }}
           volumeMounts:
             {{- if and .Values.global.tls.enabled (not .Values.global.secretsBackend.vault.enabled) }}
             - name: consul-ca-cert
               mountPath: /consul/tls/ca
               readOnly: true
             {{- end }}
-            {{- if (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey (not .Values.global.secretsBackend.vault.enabled)) }}
+            {{- if (and .Values.global.acls.bootstrapToken.secretName (not .Values.global.secretsBackend.vault.enabled)) }}
             - name: bootstrap-token
               mountPath: /consul/acl/tokens
               readOnly: true
@@ -250,7 +251,7 @@ spec:
                 -federation=true \
                 {{- end }}
 
-                {{- if (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey) }}
+                {{- if .Values.global.acls.bootstrapToken.secretName }}
                 {{- if .Values.global.secretsBackend.vault.enabled }}
                 -bootstrap-token-file=/vault/secrets/bootstrap-token \
                 {{- else }}

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -6,6 +6,7 @@
 {{- if .Values.global.acls.manageSystemACLs }}
 {{- if and .Values.global.secretsBackend.vault.enabled .Values.global.acls.replicationToken.secretName (not .Values.global.secretsBackend.vault.manageSystemACLsRole) }}{{ fail "global.secretsBackend.vault.manageSystemACLsRole must be set if global.secretsBackend.vault.enabled is true and global.acls.replicationToken is provided" }}{{ end -}}
 {{- if or (and .Values.global.acls.replicationToken.secretName (not .Values.global.acls.replicationToken.secretKey))  (and .Values.global.acls.replicationToken.secretKey (not .Values.global.acls.replicationToken.secretName))}}{{ fail "both global.acls.replicationToken.secretKey and global.acls.replicationToken.secretName must be set if one of them is provided" }}{{ end -}}
+{{- if (and .Values.global.secretsBackend.vault.enabled .Values.global.acls.manageSystemACLs (not (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey))) }}{{fail "both global.acls.bootstrapToken.secretName and global.acls.bootstrapToken.secretKey must be provided when global.secretsBackend.vault.enabled and global.acls.manageSystemACLs are true" }}{{ end -}}
   {{- /* We don't render this job when server.updatePartition > 0 because that
     means a server rollout is in progress and this job won't complete unless
     the rollout is finished (which won't happen until the partition is 0).
@@ -36,11 +37,17 @@ spec:
         component: server-acl-init
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
-        {{- if (and .Values.global.secretsBackend.vault.enabled .Values.global.tls.enabled) }}
+        {{- if .Values.global.secretsBackend.vault.enabled }}
         "vault.hashicorp.com/agent-pre-populate-only": "true"
         "vault.hashicorp.com/agent-inject": "true"
+        {{- with .Values.global.acls.bootstrapToken }}
+        "vault.hashicorp.com/agent-inject-secret-bootstrap-token": "{{ .secretName }}"
+        "vault.hashicorp.com/agent-inject-template-bootstrap-token": {{ template "consul.vaultSecretTemplate" . }}
+        {{- end }}
+        {{- if .Values.global.tls.enabled }}
         "vault.hashicorp.com/agent-inject-secret-serverca.crt": {{ .Values.global.tls.caCert.secretName }}
         "vault.hashicorp.com/agent-inject-template-serverca.crt": {{ template "consul.serverTLSCATemplate" . }}
+        {{- end }}
         {{- if .Values.global.secretsBackend.vault.manageSystemACLsRole }}
         "vault.hashicorp.com/role": {{ .Values.global.secretsBackend.vault.manageSystemACLsRole }}
         {{- else if .Values.global.tls.enabled }}
@@ -75,7 +82,7 @@ spec:
               - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
                 path: tls.crt
         {{- end }}
-        {{- if (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey) }}
+        {{- if (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey (not .Values.global.secretsBackend.vault.enabled)) }}
         - name: bootstrap-token
           secret:
             secretName: {{ .Values.global.acls.bootstrapToken.secretName }}
@@ -106,7 +113,7 @@ spec:
               mountPath: /consul/tls/ca
               readOnly: true
             {{- end }}
-            {{- if (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey) }}
+            {{- if (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey (not .Values.global.secretsBackend.vault.enabled)) }}
             - name: bootstrap-token
               mountPath: /consul/acl/tokens
               readOnly: true
@@ -127,6 +134,7 @@ spec:
                 -log-json={{ .Values.global.logJSON }} \
                 -resource-prefix=${CONSUL_FULLNAME} \
                 -k8s-namespace={{ .Release.Namespace }} \
+                -set-server-token={{ $serverEnabled }} \
 
                 {{- if .Values.externalServers.enabled }}
                 {{- if and .Values.externalServers.enabled (not .Values.externalServers.hosts) }}{{ fail "externalServers.hosts must be set if externalServers.enabled is true" }}{{ end -}}
@@ -241,7 +249,11 @@ spec:
                 {{- end }}
 
                 {{- if (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey) }}
+                {{- if .Values.global.secretsBackend.vault.enabled }}
+                -bootstrap-token-file=/vault/secrets/bootstrap-token \
+                {{- else }}
                 -bootstrap-token-file=/consul/acl/tokens/bootstrap-token \
+                {{- end }}
                 {{- else if .Values.global.acls.replicationToken.secretName }}
                 {{- if .Values.global.secretsBackend.vault.enabled }}
                 -acl-replication-token-file=/vault/secrets/replication-token \

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -4,9 +4,9 @@
 {{- if and .Values.global.acls.createReplicationToken (not .Values.global.acls.manageSystemACLs) }}{{ fail "if global.acls.createReplicationToken is true, global.acls.manageSystemACLs must be true" }}{{ end -}}
 {{- if .Values.global.bootstrapACLs }}{{ fail "global.bootstrapACLs was removed, use global.acls.manageSystemACLs instead" }}{{ end -}}
 {{- if .Values.global.acls.manageSystemACLs }}
-{{- if and .Values.global.secretsBackend.vault.enabled .Values.global.acls.replicationToken.secretName (not .Values.global.secretsBackend.vault.manageSystemACLsRole) }}{{ fail "global.secretsBackend.vault.manageSystemACLsRole must be set if global.secretsBackend.vault.enabled is true and global.acls.replicationToken is provided" }}{{ end -}}
 {{- if or (and .Values.global.acls.replicationToken.secretName (not .Values.global.acls.replicationToken.secretKey))  (and .Values.global.acls.replicationToken.secretKey (not .Values.global.acls.replicationToken.secretName))}}{{ fail "both global.acls.replicationToken.secretKey and global.acls.replicationToken.secretName must be set if one of them is provided" }}{{ end -}}
-{{- if (and .Values.global.secretsBackend.vault.enabled .Values.global.acls.manageSystemACLs (not (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey))) }}{{fail "both global.acls.bootstrapToken.secretName and global.acls.bootstrapToken.secretKey must be provided when global.secretsBackend.vault.enabled and global.acls.manageSystemACLs are true" }}{{ end -}}
+{{- if (and .Values.global.secretsBackend.vault.enabled (and (not (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey)) (not .Values.global.acls.replicationToken.secretName ))) }}{{fail "global.acls.bootstrapToken or global.acls.replicationToken must be provided when global.secretsBackend.vault.enabled and global.acls.manageSystemACLs are true" }}{{ end -}}
+{{- if (and .Values.global.secretsBackend.vault.enabled (not .Values.global.secretsBackend.vault.manageSystemACLsRole)) }}{{fail "both global.secretsBackend.vault.manageSystemACLsRole is required when global.secretsBackend.vault.enabled and global.acls.manageSystemACLs are true" }}{{ end -}}
   {{- /* We don't render this job when server.updatePartition > 0 because that
     means a server rollout is in progress and this job won't complete unless
     the rollout is finished (which won't happen until the partition is 0).
@@ -134,7 +134,7 @@ spec:
                 -log-json={{ .Values.global.logJSON }} \
                 -resource-prefix=${CONSUL_FULLNAME} \
                 -k8s-namespace={{ .Release.Namespace }} \
-                -set-server-token={{ $serverEnabled }} \
+                -set-server-tokens={{ $serverEnabled }} \
 
                 {{- if .Values.externalServers.enabled }}
                 {{- if and .Values.externalServers.enabled (not .Values.externalServers.hosts) }}{{ fail "externalServers.hosts must be set if externalServers.enabled is true" }}{{ end -}}

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -40,9 +40,11 @@ spec:
         {{- if .Values.global.secretsBackend.vault.enabled }}
         "vault.hashicorp.com/agent-pre-populate-only": "true"
         "vault.hashicorp.com/agent-inject": "true"
+        {{- if .Values.global.acls.bootstrapToken.secretName }}
         {{- with .Values.global.acls.bootstrapToken }}
         "vault.hashicorp.com/agent-inject-secret-bootstrap-token": "{{ .secretName }}"
         "vault.hashicorp.com/agent-inject-template-bootstrap-token": {{ template "consul.vaultSecretTemplate" . }}
+        {{- end }}
         {{- end }}
         {{- if .Values.global.tls.enabled }}
         "vault.hashicorp.com/agent-inject-secret-serverca.crt": {{ .Values.global.tls.caCert.secretName }}

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -256,7 +256,8 @@ spec:
                 {{- else }}
                 -bootstrap-token-file=/consul/acl/tokens/bootstrap-token \
                 {{- end }}
-                {{- else if .Values.global.acls.replicationToken.secretName }}
+                {{- end }}
+                {{- if .Values.global.acls.replicationToken.secretName }}
                 {{- if .Values.global.secretsBackend.vault.enabled }}
                 -acl-replication-token-file=/vault/secrets/replication-token \
                 {{- else }}

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -81,6 +81,10 @@ spec:
         "vault.hashicorp.com/agent-inject-secret-replication-token-config.hcl": "{{ .Values.global.acls.replicationToken.secretName }}"
         "vault.hashicorp.com/agent-inject-template-replication-token-config.hcl":  {{ template "consul.vaultReplicationTokenConfigTemplate" . }}
         {{- end }}
+        {{- if .Values.global.acls.manageSystemACLs }}
+        "vault.hashicorp.com/agent-inject-secret-bootstrap-token-config.hcl": "{{ .Values.global.acls.bootstrapToken.secretName }}"
+        "vault.hashicorp.com/agent-inject-template-bootstrap-token-config.hcl":  {{ template "consul.vaultBootstrapTokenConfigTemplate" . }}
+        {{- end }}
         {{- if .Values.global.secretsBackend.vault.agentAnnotations }}
         {{ tpl .Values.global.secretsBackend.vault.agentAnnotations . | nindent 8 | trim }}
         {{- end }}
@@ -286,14 +290,6 @@ spec:
                 {{- end }}
                 -client=0.0.0.0 \
                 -config-dir=/consul/config \
-                {{- /* Always include the extraVolumes at the end so that users can
-                    override other Consul settings. The last -config-dir takes
-                    precedence. */}}
-                {{- range .Values.server.extraVolumes }}
-                {{- if .load }}
-                -config-dir=/consul/userconfig/{{ .name }} \
-                {{- end }}
-                {{- end }}
                 -datacenter={{ .Values.global.datacenter }} \
                 -data-dir=/consul/data \
                 -domain={{ .Values.global.domain }} \
@@ -332,6 +328,17 @@ spec:
                 {{- end }}
                 {{- if (and .Values.dns.enabled .Values.dns.enableRedirection) }}
                 $recursor_flags \
+                {{- end }}
+                {{- if and .Values.global.secretsBackend.vault.enabled .Values.global.acls.manageSystemACLs }}
+                -config-file=/vault/secrets/bootstrap-token-config.hcl \
+                {{- end }}
+                {{- /* Always include the extraVolumes at the end so that users can
+                      override other Consul settings. The last -config-dir takes
+                      precedence. */}}
+                {{- range .Values.server.extraVolumes }}
+                {{- if .load }}
+                -config-dir=/consul/userconfig/{{ .name }} \
+                {{- end }}
                 {{- end }}
                 -config-file=/consul/extra-config/extra-from-values.json \
                 -server

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
         "vault.hashicorp.com/agent-inject-secret-replication-token-config.hcl": "{{ .Values.global.acls.replicationToken.secretName }}"
         "vault.hashicorp.com/agent-inject-template-replication-token-config.hcl":  {{ template "consul.vaultReplicationTokenConfigTemplate" . }}
         {{- end }}
-        {{- if .Values.global.acls.manageSystemACLs }}
+        {{- if (and .Values.global.acls.manageSystemACLs .Values.global.acls.bootstrapToken.secretName) }}
         "vault.hashicorp.com/agent-inject-secret-bootstrap-token-config.hcl": "{{ .Values.global.acls.bootstrapToken.secretName }}"
         "vault.hashicorp.com/agent-inject-template-bootstrap-token-config.hcl":  {{ template "consul.vaultBootstrapTokenConfigTemplate" . }}
         {{- end }}
@@ -329,7 +329,7 @@ spec:
                 {{- if (and .Values.dns.enabled .Values.dns.enableRedirection) }}
                 $recursor_flags \
                 {{- end }}
-                {{- if and .Values.global.secretsBackend.vault.enabled .Values.global.acls.manageSystemACLs }}
+                {{- if and .Values.global.secretsBackend.vault.enabled .Values.global.acls.bootstrapToken.secretName }}
                 -config-file=/vault/secrets/bootstrap-token-config.hcl \
                 {{- end }}
                 {{- /* Always include the extraVolumes at the end so that users can

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -576,6 +576,8 @@ load _helpers
   local object=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.bootstrapToken.secretName=foo' \
+      --set 'global.acls.bootstrapToken.secretKey=bar' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       --set 'global.server.serverCert.secretName=foo' \
@@ -584,6 +586,7 @@ load _helpers
       --set 'global.secretsBackend.vault.consulClientRole=test' \
       --set 'global.secretsBackend.vault.consulServerRole=foo' \
       --set 'global.secretsBackend.vault.consulCARole=carole' \
+      --set 'global.secretsBackend.vault.manageSystemACLsRole=aclrole' \
       . | tee /dev/stderr |
       yq -r '.spec.template' | tee /dev/stderr)
 
@@ -596,7 +599,7 @@ load _helpers
   [ "${actual}" = "true" ]
   local actual
   actual=$(echo $object | jq -r '.metadata.annotations["vault.hashicorp.com/role"]' | tee /dev/stderr)
-  [ "${actual}" = "carole" ]
+  [ "${actual}" = "aclrole" ]
   local actual
   actual=$(echo $object | jq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-secret-serverca.crt"]' | tee /dev/stderr)
   [ "${actual}" = "foo" ]
@@ -617,6 +620,8 @@ load _helpers
   local object=$(helm template \
     -s templates/server-acl-init-job.yaml  \
     --set 'global.acls.manageSystemACLs=true' \
+    --set 'global.acls.bootstrapToken.secretName=foo' \
+    --set 'global.acls.bootstrapToken.secretKey=bar' \
     --set 'global.tls.enabled=true' \
     --set 'global.tls.enableAutoEncrypt=true' \
     --set 'global.tls.caCert.secretName=foo' \
@@ -625,6 +630,7 @@ load _helpers
     --set 'global.secretsBackend.vault.consulClientRole=foo' \
     --set 'global.secretsBackend.vault.consulServerRole=test' \
     --set 'global.secretsBackend.vault.consulCARole=carole' \
+    --set 'global.secretsBackend.vault.manageSystemACLsRole=aclrole' \
     . | tee /dev/stderr |
       yq -r '.spec.template' | tee /dev/stderr)
 
@@ -639,6 +645,8 @@ load _helpers
   local object=$(helm template \
     -s templates/server-acl-init-job.yaml  \
     --set 'global.acls.manageSystemACLs=true' \
+    --set 'global.acls.bootstrapToken.secretName=foo' \
+    --set 'global.acls.bootstrapToken.secretKey=bar' \
     --set 'global.tls.enabled=true' \
     --set 'global.tls.enableAutoEncrypt=true' \
     --set 'global.server.serverCert.secretName=foo' \
@@ -648,6 +656,7 @@ load _helpers
     --set 'global.secretsBackend.vault.consulServerRole=test' \
     --set 'global.secretsBackend.vault.consulCARole=carole' \
     --set 'global.secretsBackend.vault.ca.secretName=ca' \
+    --set 'global.secretsBackend.vault.manageSystemACLsRole=aclrole' \
     . | tee /dev/stderr |
       yq -r '.spec.template' | tee /dev/stderr)
 
@@ -662,6 +671,8 @@ load _helpers
   local object=$(helm template \
     -s templates/server-acl-init-job.yaml  \
     --set 'global.acls.manageSystemACLs=true' \
+    --set 'global.acls.bootstrapToken.secretName=foo' \
+    --set 'global.acls.bootstrapToken.secretKey=bar' \
     --set 'global.tls.enabled=true' \
     --set 'global.tls.enableAutoEncrypt=true' \
     --set 'global.tls.caCert.secretName=foo' \
@@ -671,6 +682,7 @@ load _helpers
     --set 'global.secretsBackend.vault.consulServerRole=test' \
     --set 'global.secretsBackend.vault.consulCARole=carole' \
     --set 'global.secretsBackend.vault.ca.secretKey=tls.crt' \
+    --set 'global.secretsBackend.vault.manageSystemACLsRole=aclrole' \
     . | tee /dev/stderr |
       yq -r '.spec.template' | tee /dev/stderr)
 
@@ -685,6 +697,8 @@ load _helpers
   local object=$(helm template \
     -s templates/server-acl-init-job.yaml  \
     --set 'global.acls.manageSystemACLs=true' \
+    --set 'global.acls.bootstrapToken.secretName=foo' \
+    --set 'global.acls.bootstrapToken.secretKey=bar' \
     --set 'global.tls.enabled=true' \
     --set 'global.tls.enableAutoEncrypt=true' \
     --set 'global.tls.caCert.secretName=foo' \
@@ -695,6 +709,7 @@ load _helpers
     --set 'global.secretsBackend.vault.consulCARole=carole' \
     --set 'global.secretsBackend.vault.ca.secretName=ca' \
     --set 'global.secretsBackend.vault.ca.secretKey=tls.crt' \
+    --set 'global.secretsBackend.vault.manageSystemACLsRole=aclrole' \
     . | tee /dev/stderr |
       yq -r '.spec.template' | tee /dev/stderr)
 
@@ -752,24 +767,6 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "serverACLInit/Job: manageSystemACLsRole is required when Vault is enabled and replication token is set" {
-  cd `chart_dir`
-  run helm template \
-      -s templates/server-acl-init-job.yaml  \
-      --set 'global.acls.manageSystemACLs=true' \
-      --set 'global.acls.replicationToken.secretName=/vault/secret' \
-      --set 'global.acls.replicationToken.secretKey=foo' \
-      --set 'global.tls.enabled=true' \
-      --set 'global.tls.enableAutoEncrypt=true' \
-      --set 'global.tls.caCert.secretName=foo' \
-      --set 'global.secretsBackend.vault.enabled=true' \
-      --set 'global.secretsBackend.vault.consulClientRole=foo' \
-      --set 'global.secretsBackend.vault.consulServerRole=test' \
-      --set 'global.secretsBackend.vault.consulCARole=carole' .
-  [ "$status" -eq 1 ]
-  [[ "$output" =~ "global.secretsBackend.vault.manageSystemACLsRole must be set if global.secretsBackend.vault.enabled is true and global.acls.replicationToken is provided" ]]
-}
-
 #--------------------------------------------------------------------
 # Vault agent annotations
 
@@ -778,13 +775,16 @@ load _helpers
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.bootstrapToken.secretName=foo' \
+      --set 'global.acls.bootstrapToken.secretKey=bar' \
       --set 'global.secretsBackend.vault.enabled=true' \
       --set 'global.secretsBackend.vault.consulClientRole=test' \
       --set 'global.secretsBackend.vault.consulServerRole=foo' \
       --set 'global.tls.caCert.secretName=foo' \
       --set 'global.secretsBackend.vault.consulCARole=carole' \
+      --set 'global.secretsBackend.vault.manageSystemACLsRole=aclrole' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."vault.hashicorp.com/agent-inject") | del(."vault.hashicorp.com/role")' | tee /dev/stderr)
+      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."vault.hashicorp.com/agent-inject") | del(."vault.hashicorp.com/agent-pre-populate-only") | del(."vault.hashicorp.com/role") | del(."vault.hashicorp.com/agent-inject-secret-bootstrap-token") | del(."vault.hashicorp.com/agent-inject-template-bootstrap-token")' | tee /dev/stderr)
   [ "${actual}" = "{}" ]
 }
 
@@ -793,6 +793,8 @@ load _helpers
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.bootstrapToken.secretName=foo' \
+      --set 'global.acls.bootstrapToken.secretKey=bar' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       --set 'global.secretsBackend.vault.enabled=true' \
@@ -800,6 +802,7 @@ load _helpers
       --set 'global.secretsBackend.vault.consulServerRole=foo' \
       --set 'global.tls.caCert.secretName=foo' \
       --set 'global.secretsBackend.vault.consulCARole=carole' \
+      --set 'global.secretsBackend.vault.manageSystemACLsRole=aclrole' \
       --set 'global.secretsBackend.vault.agentAnnotations=foo: bar' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -574,7 +574,7 @@ load _helpers
 #--------------------------------------------------------------------
 # Vault
 
-@test "serverACLInit/Job: fails when vault is enabled but neither bootstrap nor replication token are provided" {
+@test "serverACLInit/Job: fails when vault is enabled but neither bootstrap nor replication token is provided" {
   cd `chart_dir`
   run helm template \
       -s templates/server-acl-init-job.yaml  \

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -571,7 +571,80 @@ load _helpers
   [ "${actual}" = "key" ]
 }
 
-@test "serverACLInit/Job: configures server CA to come from vault when vault is enabled" {
+#--------------------------------------------------------------------
+# Vault
+
+@test "serverACLInit/Job: fails when vault is enabled but neither bootstrap nor replication token are provided" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulClientRole=test' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "global.acls.bootstrapToken or global.acls.replicationToken must be provided when global.secretsBackend.vault.enabled and global.acls.manageSystemACLs are true" ]]
+}
+
+@test "serverACLInit/Job: fails when vault is enabled but manageSystemACLsRole is not provided" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.bootstrapToken.secretName=name' \
+      --set 'global.acls.bootstrapToken.secretKey=key' \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulClientRole=test' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "global.secretsBackend.vault.manageSystemACLsRole is required when global.secretsBackend.vault.enabled and global.acls.manageSystemACLs are true" ]]
+}
+
+@test "serverACLInit/Job: configures vault annotations and bootstrap token secret by default" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.bootstrapToken.secretName=foo' \
+      --set 'global.acls.bootstrapToken.secretKey=bar' \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulClientRole=test' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      --set 'global.secretsBackend.vault.manageSystemACLsRole=aclrole' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template' | tee /dev/stderr)
+
+  # Check annotations
+  local actual
+  actual=$(echo $object | jq -r '.metadata.annotations["vault.hashicorp.com/agent-pre-populate-only"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  local actual
+  actual=$(echo $object | jq -r '.metadata.annotations["vault.hashicorp.com/agent-inject"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  local actual
+  actual=$(echo $object | jq -r '.metadata.annotations["vault.hashicorp.com/role"]' | tee /dev/stderr)
+  [ "${actual}" = "aclrole" ]
+
+  local actual=$(echo $object | yq -r '.metadata.annotations."vault.hashicorp.com/agent-inject-secret-bootstrap-token"')
+  [ "${actual}" = "foo" ]
+
+  local actual=$(echo $object | yq -r '.metadata.annotations."vault.hashicorp.com/agent-inject-template-bootstrap-token"')
+  local expected=$'{{- with secret \"foo\" -}}\n{{- .Data.data.bar -}}\n{{- end -}}'
+  [ "${actual}" = "${expected}" ]
+
+  # Check that the bootstrap token flag is set to the path of the Vault secret.
+  local actual=$(echo $object | jq -r '.spec.containers[] | select(.name="post-install-job").command | any(contains("-bootstrap-token-file=/vault/secrets/bootstrap-token"))')
+  [ "${actual}" = "true" ]
+
+  # Check that no (secret) volumes are not attached
+  local actual=$(echo $object | jq -r '.spec.volumes')
+  [ "${actual}" = "null" ]
+
+  local actual=$(echo $object | jq -r '.spec.containers[] | select(.name="post-install-job").volumeMounts')
+  [ "${actual}" = "null" ]
+}
+
+@test "serverACLInit/Job: configures server CA to come from vault when vault and TLS are enabled" {
   cd `chart_dir`
   local object=$(helm template \
       -s templates/server-acl-init-job.yaml  \
@@ -753,9 +826,6 @@ load _helpers
   [ "${actual}" = "${expected}" ]
 
   # Check that replication token Kubernetes secret volumes and volumeMounts are not attached.
-  local actual=$(echo $object | yq -r '.metadata.annotations."vault.hashicorp.com/agent-inject-secret-replication-token"')
-  [ "${actual}" = "/vault/secret" ]
-
   local actual=$(echo $object | jq -r '.spec.volumes')
   [ "${actual}" = "null" ]
 
@@ -764,6 +834,60 @@ load _helpers
 
   # Check that the replication token flag is set to the path of the Vault secret.
   local actual=$(echo $object | jq -r '.spec.containers[] | select(.name="post-install-job").command | any(contains("-acl-replication-token-file=/vault/secrets/replication-token"))')
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: both replication and bootstrap tokens can be provided together" {
+  cd `chart_dir`
+  local object=$(helm template \
+    -s templates/server-acl-init-job.yaml  \
+    --set 'global.acls.manageSystemACLs=true' \
+    --set 'global.tls.enabled=true' \
+    --set 'global.tls.enableAutoEncrypt=true' \
+    --set 'global.tls.caCert.secretName=foo' \
+    --set 'global.secretsBackend.vault.enabled=true' \
+    --set 'global.secretsBackend.vault.consulClientRole=foo' \
+    --set 'global.secretsBackend.vault.consulServerRole=test' \
+    --set 'global.secretsBackend.vault.consulCARole=carole' \
+    --set 'global.secretsBackend.vault.manageSystemACLsRole=acl-role' \
+    --set 'global.acls.replicationToken.secretName=/vault/replication' \
+    --set 'global.acls.replicationToken.secretKey=token' \
+    --set 'global.acls.bootstrapToken.secretName=/vault/bootstrap' \
+    --set 'global.acls.bootstrapToken.secretKey=token' \
+    . | tee /dev/stderr |
+      yq -r '.spec.template' | tee /dev/stderr)
+
+  # Check that the role is set.
+  local actual=$(echo $object | yq -r '.metadata.annotations."vault.hashicorp.com/role"')
+  [ "${actual}" = "acl-role" ]
+
+  # Check Vault secret annotations.
+  local actual=$(echo $object | yq -r '.metadata.annotations."vault.hashicorp.com/agent-inject-secret-replication-token"')
+  [ "${actual}" = "/vault/replication" ]
+
+  local actual=$(echo $object | yq -r '.metadata.annotations."vault.hashicorp.com/agent-inject-template-replication-token"')
+  local expected=$'{{- with secret \"/vault/replication\" -}}\n{{- .Data.data.token -}}\n{{- end -}}'
+  [ "${actual}" = "${expected}" ]
+
+  local actual=$(echo $object | yq -r '.metadata.annotations."vault.hashicorp.com/agent-inject-secret-bootstrap-token"')
+  [ "${actual}" = "/vault/bootstrap" ]
+
+  local actual=$(echo $object | yq -r '.metadata.annotations."vault.hashicorp.com/agent-inject-template-bootstrap-token"')
+  local expected=$'{{- with secret \"/vault/bootstrap\" -}}\n{{- .Data.data.token -}}\n{{- end -}}'
+  [ "${actual}" = "${expected}" ]
+
+  # Check that replication token Kubernetes secret volumes and volumeMounts are not attached.
+  local actual=$(echo $object | jq -r '.spec.volumes')
+  [ "${actual}" = "null" ]
+
+  local actual=$(echo $object | jq -r '.spec.containers[] | select(.name="post-install-job").volumeMounts')
+  [ "${actual}" = "null" ]
+
+  # Check that the replication and bootstrap token flags are set to the path of the Vault secret.
+  local actual=$(echo $object | jq -r '.spec.containers[] | select(.name="post-install-job").command | any(contains("-acl-replication-token-file=/vault/secrets/replication-token"))')
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object | jq -r '.spec.containers[] | select(.name="post-install-job").command | any(contains("-bootstrap-token-file=/vault/secrets/bootstrap-token"))')
   [ "${actual}" = "true" ]
 }
 
@@ -1486,6 +1610,26 @@ load _helpers
 #--------------------------------------------------------------------
 # global.acls.bootstrapToken
 
+@test "serverACLInit/Job: bootstrapToken.secretKey is required when bootstrapToken.secretName is set" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.bootstrapToken.secretName=name' \ .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "both global.acls.bootstrapToken.secretKey and global.acls.bootstrapToken.secretName must be set if one of them is provided" ]]
+}
+
+@test "serverACLInit/Job: bootstrapToken.secretName is required when bootstrapToken.secretKey is set" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.bootstrapToken.secretKey=key' \ .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "both global.acls.bootstrapToken.secretKey and global.acls.bootstrapToken.secretName must be set if one of them is provided" ]]
+}
+
 @test "serverACLInit/Job: -bootstrap-token-file is not set by default" {
   cd `chart_dir`
   local object=$(helm template \
@@ -1496,54 +1640,6 @@ load _helpers
   # Test the flag is not set.
   local actual=$(echo "$object" |
   yq '.spec.template.spec.containers[0].command | any(contains("-bootstrap-token-file"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-
-  # Test the volume doesn't exist
-  local actual=$(echo "$object" |
-  yq '.spec.template.spec.volumes | length == 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-
-  # Test the volume mount doesn't exist
-  local actual=$(echo "$object" |
-  yq '.spec.template.spec.containers[0].volumeMounts | length == 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-@test "serverACLInit/Job: -bootstrap-token-file is not set when acls.bootstrapToken.secretName is set but secretKey is not" {
-  cd `chart_dir`
-  local object=$(helm template \
-      -s templates/server-acl-init-job.yaml  \
-      --set 'global.acls.manageSystemACLs=true' \
-      --set 'global.acls.bootstrapToken.secretName=name' \
-      . | tee /dev/stderr)
-
-  # Test the flag is not set.
-  local actual=$(echo "$object" |
-  yq '.spec.template.spec.containers[0].command | any(contains("-bootstrap-token-file"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-
-  # Test the volume doesn't exist
-  local actual=$(echo "$object" |
-  yq '.spec.template.spec.volumes | length == 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-
-  # Test the volume mount doesn't exist
-  local actual=$(echo "$object" |
-  yq '.spec.template.spec.containers[0].volumeMounts | length == 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-@test "serverACLInit/Job: -bootstrap-token-file is not set when acls.bootstrapToken.secretKey is set but secretName is not" {
-  cd `chart_dir`
-  local object=$(helm template \
-      -s templates/server-acl-init-job.yaml  \
-      --set 'global.acls.manageSystemACLs=true' \
-      --set 'global.acls.bootstrapToken.secretKey=key' \
-      . | tee /dev/stderr)
-
-  # Test the flag is not set.
-  local actual=$(echo "$object" |
-    yq '.spec.template.spec.containers[0].command | any(contains("-bootstrap-token-file"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 
   # Test the volume doesn't exist

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -119,7 +119,7 @@ func (c *Command) init() {
 	c.flags.StringVar(&c.flagK8sNamespace, "k8s-namespace", "",
 		"Name of Kubernetes namespace where Consul and consul-k8s components are deployed.")
 
-	c.flags.BoolVar(&c.flagSetServerToken, "set-server-token", false, "Toggle for setting server's agent token.")
+	c.flags.BoolVar(&c.flagSetServerToken, "set-server-tokens", true, "Toggle for setting server's agent token.")
 
 	c.flags.BoolVar(&c.flagAllowDNS, "allow-dns", false,
 		"Toggle for updating the anonymous token to allow DNS queries to work")

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -38,6 +38,8 @@ type Command struct {
 
 	flagAllowDNS bool
 
+	flagSetServerToken bool
+
 	flagCreateClientToken bool
 
 	flagCreateSyncToken    bool
@@ -116,6 +118,8 @@ func (c *Command) init() {
 		"Prefix to use for Kubernetes resources.")
 	c.flags.StringVar(&c.flagK8sNamespace, "k8s-namespace", "",
 		"Name of Kubernetes namespace where Consul and consul-k8s components are deployed.")
+
+	c.flags.BoolVar(&c.flagSetServerToken, "set-server-token", false, "Toggle for setting server's agent token.")
 
 	c.flags.BoolVar(&c.flagAllowDNS, "allow-dns", false,
 		"Toggle for updating the anonymous token to allow DNS queries to work")

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -119,7 +119,7 @@ func (c *Command) init() {
 	c.flags.StringVar(&c.flagK8sNamespace, "k8s-namespace", "",
 		"Name of Kubernetes namespace where Consul and consul-k8s components are deployed.")
 
-	c.flags.BoolVar(&c.flagSetServerTokens, "set-server-tokens", true, "Toggle for setting server's agent token.")
+	c.flags.BoolVar(&c.flagSetServerTokens, "set-server-tokens", true, "Toggle for setting agent tokens for the servers.")
 
 	c.flags.BoolVar(&c.flagAllowDNS, "allow-dns", false,
 		"Toggle for updating the anonymous token to allow DNS queries to work")

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -38,7 +38,7 @@ type Command struct {
 
 	flagAllowDNS bool
 
-	flagSetServerToken bool
+	flagSetServerTokens bool
 
 	flagCreateClientToken bool
 
@@ -119,7 +119,7 @@ func (c *Command) init() {
 	c.flags.StringVar(&c.flagK8sNamespace, "k8s-namespace", "",
 		"Name of Kubernetes namespace where Consul and consul-k8s components are deployed.")
 
-	c.flags.BoolVar(&c.flagSetServerToken, "set-server-tokens", true, "Toggle for setting server's agent token.")
+	c.flags.BoolVar(&c.flagSetServerTokens, "set-server-tokens", true, "Toggle for setting server's agent token.")
 
 	c.flags.BoolVar(&c.flagAllowDNS, "allow-dns", false,
 		"Toggle for updating the anonymous token to allow DNS queries to work")

--- a/control-plane/subcommand/server-acl-init/command_test.go
+++ b/control-plane/subcommand/server-acl-init/command_test.go
@@ -1696,6 +1696,7 @@ func TestRun_AlreadyBootstrapped(t *testing.T) {
 
 			serverURL, err := url.Parse(consulServer.URL)
 			require.NoError(err)
+			setUpK8sServiceAccount(t, k8s, ns)
 
 			cmdArgs := []string{
 				"-timeout=500ms",
@@ -1906,6 +1907,8 @@ func TestRun_SkipBootstrapping_WhenServersAreDisabled(t *testing.T) {
 		Path   string
 	}
 	var consulAPICalls []APICall
+
+	setUpK8sServiceAccount(t, k8s, ns)
 
 	// Start the Consul server.
 	consulServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/control-plane/subcommand/server-acl-init/servers.go
+++ b/control-plane/subcommand/server-acl-init/servers.go
@@ -32,7 +32,7 @@ func (c *Command) bootstrapServers(serverAddresses []string, bootstrapToken, boo
 	}
 
 	// We should only create and set server tokens when servers are running within this cluster.
-	if c.flagSetServerToken {
+	if c.flagSetServerTokens {
 		c.log.Info("Setting Consul server tokens")
 
 		// Override our original client with a new one that has the bootstrap token


### PR DESCRIPTION
Changes proposed in this PR:
Support providing a bootstrap token secret that is stored in Vault. Previously in our code, we assumed that the bootstrap token secret would only need to be provided when running with external servers (i.e. consul servers running outside of *this* Kubernetes cluster). This is no longer the case. 

To accomodate for the case when servers are running externally, there's now a new flag `-set-server-tokens` for the server-acl-init command. When servers are running in this cluster, we will set this flag to true so that we set server tokens. When servers are running externally, we don't want to set server tokens because we don't manage those servers.

To configure the bootstrap token for the server, we provide it via config (`initial_manangement` token: https://www.consul.io/docs/agent/options#acl_tokens_initial_management)

How I've tested this PR:
acceptance tests

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

