### PR TITLE
update docs to align with new makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -953,12 +953,12 @@ To generate the docs and update the `helm.mdx` file:
    ```shell-session
    cd /path/to/consul-k8s
    ```
-1. Run `make gen-docs` using the path to your consul (not consul-k8s) repo:
+1. Run `make gen-helm-docs` using the path to your consul (not consul-k8s) repo:
    ```shell-session
-   make gen-docs consul=<path-to-consul-repo>
+   make gen-helm-docs consul=<path-to-consul-repo>
    # Examples:
-   # make gen-docs consul=/Users/my-name/code/hashicorp/consul
-   # make gen-docs consul=../consul
+   # make gen-helm-docs consul=/Users/my-name/code/hashicorp/consul
+   # make gen-helm-docs consul=../consul
    ```
 1. Open up a pull request to `hashicorp/consul` (in addition to your `hashicorp/consul-k8s` pull request)
 

--- a/hack/helm-reference-gen/main.go
+++ b/hack/helm-reference-gen/main.go
@@ -3,7 +3,7 @@ package main
 // This script generates markdown documentation out of the values.yaml file
 // for use on consul.io.
 //
-// Usage: make gen-docs [consul-repo-path] [-validate]
+// Usage: make gen-helm-docs [consul-repo-path] [-validate]
 //        Where [consul-repo-path] is the location of the hashicorp/consul repo. Defaults to ../../../consul.
 //        If -validate is set, the generated docs won't be output anywhere.
 //        This is useful in CI to ensure the generation will succeed.


### PR DESCRIPTION
Changes proposed in this PR:
- `make gen-helm-docs`  instead of `make gen-docs` everywhere

How I've tested this PR:
👀 
How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

