### PR TITLE
helm docs: Escape <ip>:<port> due to JSX issues on Helm reference docs

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -433,7 +433,7 @@ global:
     # The name of the primary datacenter.
     primaryDatacenter: ""
 
-    # A list of addresses of the primary mesh gateways in the form <ip>:<port>.
+    # A list of addresses of the primary mesh gateways in the form `<ip>:<port>`.
     # (e.g. ["1.1.1.1:443", "2.3.4.5:443"] 
     # @type: array<string>
     primaryGateways: []


### PR DESCRIPTION
Changes proposed in this PR:
- Escape `<ip>:<port>` in global.federation.primaryGateways comment due to JSX issues on Helm reference docs. Without this our Helm reference docs break on due to React thinking it is a valid JSX tag.

How I've tested this PR:

- Tested on Vercel with Github PR: https://github.com/hashicorp/consul/pull/12465

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

