### PR TITLE
change helm trigger branch from master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ executors:
       CONSUL_VERSION: 1.11.2 # Consul's OSS version to use in tests
       CONSUL_ENT_VERSION: 1.11.2+ent # Consul's enterprise version to use in tests
 
-control-plane-path : &control-plane-path control-plane
-cli-path : &cli-path cli
+control-plane-path: &control-plane-path control-plane
+cli-path: &cli-path cli
 acceptance-mod-path: &acceptance-mod-path acceptance
 acceptance-test-path: &acceptance-test-path acceptance/tests
 acceptance-framework-path: &acceptance-framework-path acceptance/framework
@@ -891,7 +891,7 @@ jobs:
                 -X POST \
                 -H 'Content-Type: application/json' \
                 -H 'Accept: application/json' \
-                -d "{\"branch\": \"master\",\"parameters\":{\"SOURCE_REPO\": \"${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}\",\"SOURCE_TAG\": \"${CIRCLE_TAG}\"}}" \
+                -d "{\"branch\": \"main\",\"parameters\":{\"SOURCE_REPO\": \"${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}\",\"SOURCE_TAG\": \"${CIRCLE_TAG}\"}}" \
                 "${CIRCLE_ENDPOINT}/${CIRCLE_PROJECT}/pipeline"
       - slack/status:
           fail_only: true
@@ -981,10 +981,10 @@ workflows:
       - cleanup-gcp-resources
       - cleanup-azure-resources
       - cleanup-eks-resources
-# Disable until we can use UBI images.
-#      - acceptance-openshift:
-#          requires:
-#          - cleanup-azure-resources
+      # Disable until we can use UBI images.
+      #      - acceptance-openshift:
+      #          requires:
+      #          - cleanup-azure-resources
       - acceptance-gke-1-20:
           requires:
             - cleanup-gcp-resources


### PR DESCRIPTION
Changes proposed in this PR:

The default branch on `hashicorp/helm-charts` was renamed to `main` and this reflects that change. 
