### PR TITLE
Use kube auth method to provision ACL client token

### DIFF
--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -48,7 +48,7 @@ as well as the global.name setting.
 {{- define "consul.serverTLSAltNames" -}}
 {{- $name := include "consul.fullname" . -}}
 {{- $ns := .Release.Namespace -}}
-{{ printf "localhost,%s-server,*.%s-server,*.%s-server.%s,*.%s-server.%s.svc,*.server.%s.%s" $name $name $name $ns $name $ns (.Values.global.datacenter ) (.Values.global.domain) }}{{ include "consul.serverAdditionalDNSSANs" . }}
+{{ printf "localhost,%s-server,*.%s-server,*.%s-server.%s,*.%s-server.%s.svc,%s-server.%s.svc,*.server.%s.%s" $name $name $name $ns $name $ns $name $ns (.Values.global.datacenter ) (.Values.global.domain) }}{{ include "consul.serverAdditionalDNSSANs" . }}
 {{- end -}}
 
 {{- define "consul.serverAdditionalDNSSANs" -}}

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -9,6 +9,8 @@
 {{- if and .Values.global.federation.enabled .Values.global.adminPartitions.enabled }}{{ fail "If global.federation.enabled is true, global.adminPartitions.enabled must be false because they are mutually exclusive" }}{{ end }}
 {{- if (and .Values.global.enterpriseLicense.secretName (not .Values.global.enterpriseLicense.secretKey)) }}{{fail "enterpriseLicense.secretKey and secretName must both be specified." }}{{ end -}}
 {{- if (and (not .Values.global.enterpriseLicense.secretName) .Values.global.enterpriseLicense.secretKey) }}{{fail "enterpriseLicense.secretKey and secretName must both be specified." }}{{ end -}}
+{{- if and .Values.externalServers.enabled (not .Values.externalServers.hosts) }}{{ fail "externalServers.hosts must be set if externalServers.enabled is true" }}{{ end -}}
+              
 # DaemonSet to run the Consul clients on every node.
 apiVersion: apps/v1
 kind: DaemonSet
@@ -47,6 +49,7 @@ spec:
       annotations:
         {{- if .Values.global.secretsBackend.vault.enabled }}
         "vault.hashicorp.com/agent-inject": "true"
+        "vault.hashicorp.com/agent-init-first": "true"
         "vault.hashicorp.com/role": "{{ .Values.global.secretsBackend.vault.consulClientRole }}"
         {{- if and .Values.global.secretsBackend.vault.ca.secretName .Values.global.secretsBackend.vault.ca.secretKey }}
         "vault.hashicorp.com/agent-extra-secret": "{{ .Values.global.secretsBackend.vault.ca.secretName }}"
@@ -123,9 +126,12 @@ spec:
         - name: config
           configMap:
             name: {{ template "consul.fullname" . }}-client-config
+        - name: consul-data
+          emptyDir:
+            medium: "Memory"
         {{- if .Values.global.tls.enabled }}
-        {{- if not .Values.global.secretsBackend.vault.enabled }}
         - name: consul-ca-cert
+          {{- if not .Values.global.secretsBackend.vault.enabled }}
           secret:
             {{- if .Values.global.tls.caCert.secretName }}
             secretName: {{ .Values.global.tls.caCert.secretName }}
@@ -135,6 +141,13 @@ spec:
             items:
             - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
               path: tls.crt
+          {{- else }}
+          emptyDir:
+            # We're using tmpfs here so that
+            # client certs are not written to disk
+            medium: "Memory"          
+          {{- end }}
+        {{- if not .Values.global.secretsBackend.vault.enabled }}
         {{ if not .Values.global.tls.enableAutoEncrypt }}
         - name: consul-ca-key
           secret:
@@ -176,7 +189,21 @@ spec:
       containers:
         - name: consul
           image: "{{ default .Values.global.image .Values.client.image }}"
+          {{- if .Values.global.acls.manageSystemACLs }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "/bin/sh"
+                  - "-ec"
+                  - |
+                    consul logout
+          {{- end }}
           env:
+            {{- if .Values.global.acls.manageSystemACLs }}
+            - name: CONSUL_HTTP_TOKEN_FILE
+              value: "/consul/login/acl-token"
+            {{- end }}
             - name: ADVERTISE_IP
               valueFrom:
                 fieldRef:
@@ -339,6 +366,9 @@ spec:
               mountPath: /consul/data
             - name: config
               mountPath: /consul/config
+            - mountPath: /consul/login
+              name: consul-data
+              readOnly: true
             {{- if .Values.global.tls.enabled }}
             {{- if not .Values.global.secretsBackend.vault.enabled }}
             - name: consul-ca-cert
@@ -434,17 +464,58 @@ spec:
       {{- if .Values.global.acls.manageSystemACLs }}
       - name: client-acl-init
         image: {{ .Values.global.imageK8S }}
+        env:
+        - name: CONSUL_HTTP_ADDR
+          {{- if .Values.global.tls.enabled }}
+          value: https://{{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc:8501
+          {{- else }}
+          value: http://{{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc:8500
+          {{- end }}
+        {{- if (and .Values.global.tls.enabled (not .Values.externalServers.useSystemRoots)) }}
+        - name: CONSUL_CACERT
+          {{- if .Values.global.secretsBackend.vault.enabled }}
+          value: "/vault/secrets/serverca.crt" 
+          {{- else }}
+          value: "/consul/tls/ca/tls.crt"
+          {{- end }}
+        {{- end }}
         command:
           - "/bin/sh"
           - "-ec"
           - |
             consul-k8s-control-plane acl-init \
-              -secret-name="{{ template "consul.fullname" . }}-client-acl-token" \
-              -k8s-namespace={{ .Release.Namespace }} \
-              -init-type="client"
+              -component-name=client \
+              -acl-auth-method="{{ template "consul.fullname" . }}-k8s-component-auth-method" \
+              {{- if .Values.global.adminPartitions.enabled }}
+              -partition={{ .Values.global.adminPartitions.name }} \
+              {{- end }}
+              -log-level={{ default .Values.global.logLevel .Values.controller.logLevel }} \
+              -log-json={{ .Values.global.logJSON }} \
+              -init-type="client" \
+              {{- if .Values.externalServers.enabled }}
+              {{- range .Values.externalServers.hosts }}
+              -server-address={{ quote . }} \
+              {{- end }}
+              -server-port={{ .Values.externalServers.httpsPort }} \
+              {{- if .Values.externalServers.tlsServerName }}
+                -tls-server-name={{ .Values.externalServers.tlsServerName }} \
+              {{- end }}
+              {{- else }}
+              {{- range $index := until (.Values.server.replicas | int) }}
+              -server-address="${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc" \
+              {{- end }}
+              {{- end }}
         volumeMounts:
           - name: aclconfig
             mountPath: /consul/aclconfig
+          - mountPath: /consul/login
+            name: consul-data
+            readOnly: false
+          {{- if (and (not .Values.global.secretsBackend.vault.enabled) (not .Values.externalServers.useSystemRoots)) }}
+          - name: consul-ca-cert
+            mountPath: /consul/tls/ca
+            readOnly: false
+          {{- end }}
         resources:
           requests:
             memory: "25Mi"

--- a/charts/consul/templates/partition-init-job.yaml
+++ b/charts/consul/templates/partition-init-job.yaml
@@ -86,10 +86,10 @@ spec:
                 {{- if .Values.global.tls.enabled }}
                 -use-https \
                 {{- if not .Values.externalServers.useSystemRoots }}
-                -consul-ca-cert=/consul/tls/ca/tls.crt \
+                -ca-file=/consul/tls/ca/tls.crt \
                 {{- end }}
                 {{- if .Values.externalServers.tlsServerName }}
-                -consul-tls-server-name={{ .Values.externalServers.tlsServerName }} \
+                -tls-server-name={{ .Values.externalServers.tlsServerName }} \
                 {{- end }}
                 {{- end }}
                 -partition-name={{ .Values.global.adminPartitions.name }}

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -244,7 +244,7 @@ spec:
                 {{- end }}
 
                 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
-                -create-client-token=false \
+                -client=false \
                 {{- end }}
 
                 {{- if .Values.global.acls.createReplicationToken }}

--- a/charts/consul/templates/tls-init-job.yaml
+++ b/charts/consul/templates/tls-init-job.yaml
@@ -78,6 +78,7 @@ spec:
                 -additional-dnsname="*.{{ template "consul.fullname" . }}-server" \
                 -additional-dnsname="*.{{ template "consul.fullname" . }}-server.${NAMESPACE}" \
                 -additional-dnsname="*.{{ template "consul.fullname" . }}-server.${NAMESPACE}.svc" \
+                -additional-dnsname="{{ template "consul.fullname" . }}-server.${NAMESPACE}.svc" \
                 -additional-dnsname="*.server.{{ .Values.global.datacenter }}.{{ .Values.global.domain }}" \
                 {{- range .Values.global.tls.serverAdditionalIPSANs }}
                 -additional-ipaddress={{ . }} \

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -114,6 +114,7 @@ load _helpers
       -s templates/client-daemonset.yaml  \
       --set 'server.enabled=false' \
       --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=foo' \
       --set 'client.join[0]=1.1.1.1' \
       --set 'client.join[1]=2.2.2.2' \
       . | tee /dev/stderr |
@@ -132,6 +133,7 @@ load _helpers
       -s templates/client-daemonset.yaml  \
       --set 'server.enabled=false' \
       --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=foo' \
       --set 'client.join[0]=provider=my-cloud config=val' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].command')
@@ -804,6 +806,58 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "client/DaemonSet: Adds consul envvars CONSUL_HTTP_ADDR on acl-init init container when ACLs are enabled and tls is enabled" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].env[]' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = "https://RELEASE-NAME-consul-server.default.svc:8501" ]
+}
+
+@test "client/DaemonSet: Adds consul envvars CONSUL_HTTP_ADDR on acl-init init container when ACLs are enabled and tls is not enabled" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].env[]' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = "http://RELEASE-NAME-consul-server.default.svc:8500" ]
+}
+
+@test "client/DaemonSet: Does not add consul envvars CONSUL_CACERT on acl-init init container when ACLs are enabled and tls is not enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers[0].env[] | select(.name == "CONSUL_CACERT")' | tee /dev/stderr)
+
+  [ "${actual}" = "" ]
+}
+
+@test "client/DaemonSet: Adds consul envvars CONSUL_CACERT on acl-init init container when ACLs are enabled and tls is enabled" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+    [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+
+
 @test "client/DaemonSet: both ACL and TLS init containers are created when global.tls.enabled=true and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local has_acl_init_container=$(helm template \
@@ -1023,7 +1077,7 @@ load _helpers
       -s templates/client-daemonset.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.volumes[2].name == "aclconfig"' | tee /dev/stderr)
+      yq '.spec.template.spec.volumes[3].name == "aclconfig"' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
@@ -1033,7 +1087,7 @@ load _helpers
       -s templates/client-daemonset.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].volumeMounts[2]' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].volumeMounts[3]' | tee /dev/stderr)
 
   local actual=$(echo $object |
       yq -r '.name' | tee /dev/stderr)
@@ -1054,7 +1108,7 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "client/DaemonSet: init container is created when global.acls.manageSystemACLs=true" {
+@test "client/DaemonSet: init container is created when global.acls.manageSystemACLs=true and command args are properly set" {
   cd `chart_dir`
   local object=$(helm template \
       -s templates/client-daemonset.yaml  \
@@ -1065,6 +1119,267 @@ load _helpers
   local actual=$(echo $object |
       yq -r '.command | any(contains("consul-k8s-control-plane acl-init"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+
+local actual=$(echo $object |
+      yq -r '.command | any(contains("secret-name"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]  
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("k8s-namespace"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]  
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("component-name=client"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]  
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("init-type=\"client\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]  
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("acl-auth-method=\"RELEASE-NAME-consul-k8s-component-auth-method\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]  
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]  
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("log-json=false"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]  
+}
+
+@test "client/DaemonSet: init container is created when global.acls.manageSystemACLs=true and has correct command with Partitions enabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.adminPartitions.name=default' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers[] | select(.name == "client-acl-init")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("consul-k8s-control-plane acl-init"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("secret-name"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]  
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("k8s-namespace"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]  
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("component-name=client"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]  
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("init-type=\"client\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]  
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("acl-auth-method=\"RELEASE-NAME-consul-k8s-component-auth-method\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]  
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]  
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("log-json=false"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]  
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("partition=default"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: CONSUL_HTTP_TOKEN_FILE is not set when acls are disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=false' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[0].name] | any(contains("CONSUL_HTTP_TOKEN_FILE"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "client/DaemonSet: CONSUL_HTTP_TOKEN_FILE is set when acls are enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[0].name] | any(contains("CONSUL_HTTP_TOKEN_FILE"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: consul-logout preStop hook is added when ACLs are enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]] | any(contains("consul logout"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: Adds consul login volume when ACLs are enabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | yq '.spec.template.spec.volumes[2]' | tee /dev/stderr)
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "consul-data" ]
+
+  local actual=$(echo $object |
+      yq -r '.emptyDir.medium' | tee /dev/stderr)
+  [ "${actual}" = "Memory" ]
+}
+
+@test "client/DaemonSet: Adds consul login volumeMount to client container when ACLs are enabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | yq '.spec.template.spec.containers[0].volumeMounts[2]' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "consul-data" ]
+
+  local actual=$(echo $object |
+      yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/consul/login" ]
+
+  local actual=$(echo $object |
+      yq -r '.readOnly' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: Adds consul login volumeMount to acl-init init container when ACLs are enabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | yq '.spec.template.spec.initContainers[0].volumeMounts[1]' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "consul-data" ]
+
+  local actual=$(echo $object |
+      yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/consul/login" ]
+
+  local actual=$(echo $object |
+      yq -r '.readOnly' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "client/DaemonSet: Adds consul ca cert volumeMount to acl-init init container when ACLs are enabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | yq '.spec.template.spec.initContainers[0].volumeMounts[2]' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "consul-ca-cert" ]
+
+  local actual=$(echo $object |
+      yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/consul/tls/ca" ]
+
+  local actual=$(echo $object |
+      yq -r '.readOnly' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "client/DaemonSet: fail when externalServers is enabled but the externalServers.hosts is not provided" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'externalServers.enabled=true'  \
+      --set 'server.enabled=false' \
+      .
+  echo "status:$status"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "externalServers.hosts must be set if externalServers.enabled is true" ]]
+}
+@test "client/DaemonSet: server-address flag is set to the replica addresses when externalServers.hosts are not provided" {
+  cd `chart_dir`
+  local command=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo $command | jq -r ' . | any(contains("-server-address=\"${CONSUL_FULLNAME}-server-0.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  
+  local actual=$(echo $command | jq -r ' . | any(contains("-server-address=\"${CONSUL_FULLNAME}-server-1.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  
+  local actual=$(echo $command | jq -r ' . | any(contains("-server-address=\"${CONSUL_FULLNAME}-server-2.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: server-address flag is set with hosts when externalServers.hosts are provided" {
+  cd `chart_dir`
+  local command=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'externalServers.enabled=true'  \
+      --set 'server.enabled=false' \
+      --set 'externalServers.hosts[0]=foo'  \
+      --set 'externalServers.hosts[1]=bar'  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo $command | jq -r ' . | any(contains("-server-address=\"foo\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $command | jq -r ' . | any(contains("-server-address=\"bar\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: tls-server-name flag is set when externalServers.tlsServerName is provided" {
+  cd `chart_dir`
+  local command=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'externalServers.enabled=true'  \
+      --set 'server.enabled=false' \
+      --set 'externalServers.hosts[0]=computer'  \
+      --set 'externalServers.tlsServerName=foo'  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo $command | jq -r ' . | any(contains("-tls-server-name=foo"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "client/DaemonSet: tls-server-name flag is not set when externalServers.tlsServerName is not provided" {
+  cd `chart_dir`
+  local command=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'externalServers.enabled=true'  \
+      --set 'server.enabled=false' \
+      --set 'externalServers.hosts[0]=computer'  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo $command | jq -r ' . | any(contains("-tls-server-name"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
 }
 
 #--------------------------------------------------------------------
@@ -1838,7 +2153,7 @@ rollingUpdate:
 
   local actual=$(echo $object |
     yq -r '.volumes[] | select(.name == "consul-ca-cert") | length > 0' | tee /dev/stderr)
-  [ "${actual}" = "" ]
+  [ "${actual}" = "true" ]
 
   local actual=$(echo $object |
     yq -r '.volumes[] | select(.name == "consul-ca-key") | length > 0' | tee /dev/stderr)
@@ -1926,6 +2241,69 @@ rollingUpdate:
       [ "${actual}" = "" ]
 }
 
+@test "client/DaemonSet: vault adds consul envvars CONSUL_CACERT on acl-init init container when ACLs are enabled and tls is enabled" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.secretsBackend.vault.manageSystemACLsRole=true' \
+      --set 'global.acls.replicationToken.secretName=replication' \
+      --set 'global.acls.replicationToken.secretKey=key' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.consulServerRole=test' \
+      --set 'global.secretsBackend.vault.consulCARole=test' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'server.serverCert.secretName=pki_int/issue/test' \
+      --set 'global.tls.caCert.secretName=pki_int/cert/ca' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+    [ "${actual}" = "/vault/secrets/serverca.crt" ]
+}
+
+@test "client/DaemonSet: vault ca cert volume is mounted as tmpfs" {
+  cd `chart_dir`
+  local spec=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.consulServerRole=test' \
+      --set 'global.secretsBackend.vault.consulCARole=test' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'server.serverCert.secretName=pki_int/issue/test' \
+      --set 'global.tls.caCert.secretName=pki_int/cert/ca' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $spec | jq -r '.volumes[] | select(.name=="consul-ca-cert") | .emptyDir.medium' | tee /dev/stderr)
+  [ "${actual}" = "Memory" ]
+
+}
+
+@test "client/DaemonSet: Vault does not add consul ca cert volumeMount to acl-init init container when ACLs are enabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulClientRole=foo' \
+      --set 'global.secretsBackend.vault.consulServerRole=test' \
+      --set 'global.secretsBackend.vault.consulCARole=test' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'server.serverCert.secretName=pki_int/issue/test' \
+      --set 'global.tls.caCert.secretName=pki_int/cert/ca' \
+      . | yq '.spec.template.spec.initContainers[0].volumeMounts[] | select(.name=="consul-ca-cert")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+}
 #--------------------------------------------------------------------
 # Vault agent annotations
 
@@ -1937,7 +2315,7 @@ rollingUpdate:
       --set 'global.secretsBackend.vault.consulClientRole=test' \
       --set 'global.secretsBackend.vault.consulServerRole=foo' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."consul.hashicorp.com/config-checksum") | del(."vault.hashicorp.com/agent-inject") | del(."vault.hashicorp.com/role")' | tee /dev/stderr)
+      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."consul.hashicorp.com/config-checksum") | del(."vault.hashicorp.com/agent-inject") | del(."vault.hashicorp.com/role") | del(."vault.hashicorp.com/agent-init-first")' | tee /dev/stderr)
   [ "${actual}" = "{}" ]
 }
 

--- a/charts/consul/test/unit/partition-init-job.bats
+++ b/charts/consul/test/unit/partition-init-job.bats
@@ -91,7 +91,7 @@ load _helpers
   actual=$(echo $command | jq -r '. | any(contains("-use-https"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
-  actual=$(echo $command | jq -r '. | any(contains("-consul-ca-cert=/consul/tls/ca/tls.crt"))' | tee /dev/stderr)
+  actual=$(echo $command | jq -r '. | any(contains("-ca-file=/consul/tls/ca/tls.crt"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
   actual=$(echo $command | jq -r '. | any(contains("-server-port=8501"))' | tee /dev/stderr)

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -99,25 +99,25 @@ load _helpers
   [[ "$output" =~ "global.bootstrapACLs was removed, use global.acls.manageSystemACLs instead" ]]
 }
 
-@test "serverACLInit/Job: does not set -create-client-token=false when client is enabled (the default)" {
+@test "serverACLInit/Job: does not set -client=false when client is enabled (the default)" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command[2] | contains("-create-client-token=false")' |
+      yq '.spec.template.spec.containers[0].command[2] | contains("-client=false")' |
       tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/Job: sets -create-client-token=false when client is disabled" {
+@test "serverACLInit/Job: sets -client=false when client is disabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command[2] | contains("-create-client-token=false")' |
+      yq '.spec.template.spec.containers[0].command[2] | contains("-client=false")' |
       tee /dev/stderr)
   [ "${actual}" = "true" ]
 }

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1767,7 +1767,7 @@ load _helpers
 
   local actual=$(echo $object |
       yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.crt"]' | tee /dev/stderr)
-  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul\" \"ip_sans=127.0.0.1\" -}}\n{{- .Data.certificate -}}\n{{- end -}}'
+  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul\" \"ip_sans=127.0.0.1\" -}}\n{{- .Data.certificate -}}\n{{- end -}}'
   [ "${actual}" = "${expected}" ]
 
   local actual="$(echo $object |
@@ -1776,7 +1776,7 @@ load _helpers
 
   local actual="$(echo $object |
       yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.key"]' | tee /dev/stderr)"
-  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul\" \"ip_sans=127.0.0.1\" -}}\n{{- .Data.private_key -}}\n{{- end -}}'
+  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul\" \"ip_sans=127.0.0.1\" -}}\n{{- .Data.private_key -}}\n{{- end -}}'
   [ "${actual}" = "${expected}" ]
 
   local actual=$(echo $object |
@@ -1827,12 +1827,12 @@ load _helpers
 
   local actual=$(echo $object |
       yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.crt"]' | tee /dev/stderr)
-  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul,*.foo.com,*.bar.com\" \"ip_sans=127.0.0.1\" -}}\n{{- .Data.certificate -}}\n{{- end -}}'
+  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul,*.foo.com,*.bar.com\" \"ip_sans=127.0.0.1\" -}}\n{{- .Data.certificate -}}\n{{- end -}}'
   [ "${actual}" = "${expected}" ]
 
   local actual="$(echo $object |
       yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.key"]' | tee /dev/stderr)"
-  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul,*.foo.com,*.bar.com\" \"ip_sans=127.0.0.1\" -}}\n{{- .Data.private_key -}}\n{{- end -}}'
+  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul,*.foo.com,*.bar.com\" \"ip_sans=127.0.0.1\" -}}\n{{- .Data.private_key -}}\n{{- end -}}'
   [ "${actual}" = "${expected}" ]
 }
 
@@ -1856,12 +1856,12 @@ load _helpers
 
   local actual=$(echo $object |
       yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.crt"]' | tee /dev/stderr)
-  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul\" \"ip_sans=127.0.0.1,1.1.1.1,2.2.2.2\" -}}\n{{- .Data.certificate -}}\n{{- end -}}'
+  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul\" \"ip_sans=127.0.0.1,1.1.1.1,2.2.2.2\" -}}\n{{- .Data.certificate -}}\n{{- end -}}'
   [ "${actual}" = "${expected}" ]
 
   local actual="$(echo $object |
       yq -r '.metadata.annotations["vault.hashicorp.com/agent-inject-template-servercert.key"]' | tee /dev/stderr)"
-  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul\" \"ip_sans=127.0.0.1,1.1.1.1,2.2.2.2\" -}}\n{{- .Data.private_key -}}\n{{- end -}}'
+  local expected=$'{{- with secret \"pki_int/issue/test\" \"common_name=server.dc2.consul\"\n\"ttl=1h\" \"alt_names=localhost,RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server,*.RELEASE-NAME-consul-server.default,*.RELEASE-NAME-consul-server.default.svc,RELEASE-NAME-consul-server.default.svc,*.server.dc2.consul\" \"ip_sans=127.0.0.1,1.1.1.1,2.2.2.2\" -}}\n{{- .Data.private_key -}}\n{{- end -}}'
   [ "${actual}" = "${expected}" ]
 }
 

--- a/charts/consul/test/unit/tls-init-job.bats
+++ b/charts/consul/test/unit/tls-init-job.bats
@@ -70,6 +70,34 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "tlsInit/Job: sets additional DNS SANs by default when global.tls.enabled=true" {
+  cd `chart_dir`
+  local command=$(helm template \
+      -s templates/tls-init-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$command" |
+    yq 'any(contains("additional-dnsname=\"RELEASE-NAME-consul-server\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  local actual=$(echo "$command" |
+    yq 'any(contains("additional-dnsname=\"*.RELEASE-NAME-consul-server\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  local actual=$(echo "$command" |
+    yq 'any(contains("additional-dnsname=\"*.RELEASE-NAME-consul-server.${NAMESPACE}\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  local actual=$(echo "$command" |
+    yq 'any(contains("additional-dnsname=\"*.RELEASE-NAME-consul-server.${NAMESPACE}.svc\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  local actual=$(echo "$command" |
+    yq 'any(contains("additional-dnsname=\"RELEASE-NAME-consul-server.${NAMESPACE}.svc\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  local actual=$(echo "$command" |
+    yq 'any(contains("additional-dnsname=\"*.server.dc1.consul\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 @test "tlsInit/Job: sets additional DNS SANs when provided and global.tls.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/control-plane/subcommand/acl-init/command.go
+++ b/control-plane/subcommand/acl-init/command.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/flags"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-discover"
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
 	corev1 "k8s.io/api/core/v1"
@@ -50,11 +51,18 @@ type Command struct {
 	bearerTokenFile   string // Location of the bearer token. Default is defaultBearerTokenFile.
 	flagComponentName string // Name of the component to be used as metadata to ACL Login.
 
+	// Flags to configure Consul connection
+	flagServerAddresses []string
+	flagServerPort      uint
+	flagConsulCACert    string
+	flagUseHTTPS        bool
+
 	k8sClient kubernetes.Interface
 
-	once   sync.Once
-	help   string
-	logger hclog.Logger
+	once      sync.Once
+	help      string
+	logger    hclog.Logger
+	providers map[string]discover.Provider
 
 	ctx          context.Context
 	consulClient *api.Client
@@ -78,6 +86,14 @@ func (c *Command) init() {
 	c.flags.StringVar(&c.flagACLAuthMethod, "acl-auth-method", "", "Name of the auth method to login with.")
 	c.flags.StringVar(&c.flagComponentName, "component-name", "",
 		"Name of the component to pass to ACL Login as metadata.")
+	c.flags.Var((*flags.AppendSliceValue)(&c.flagServerAddresses), "server-address",
+		"The IP, DNS name or the cloud auto-join string of the Consul server(s). If providing IPs or DNS names, may be specified multiple times. "+
+			"At least one value is required.")
+	c.flags.UintVar(&c.flagServerPort, "server-port", 8500, "The HTTP or HTTPS port of the Consul server. Defaults to 8500.")
+	c.flags.StringVar(&c.flagConsulCACert, "consul-ca-cert", "",
+		"Path to the PEM-encoded CA certificate of the Consul cluster.")
+	c.flags.BoolVar(&c.flagUseHTTPS, "use-https", false,
+		"Toggle for using HTTPS for all API calls to Consul.")
 	c.flags.StringVar(&c.flagLogLevel, "log-level", "info",
 		"Log verbosity level. Supported values (in order of detail) are \"trace\", "+
 			"\"debug\", \"info\", \"warn\", and \"error\".")
@@ -143,9 +159,31 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
+	var secret string
 	if c.flagACLAuthMethod != "" {
+		// Use consul auth method to write file to sink file and then read token from sink file
 		cfg := api.DefaultConfig()
 		c.http.MergeOntoConfig(cfg)
+
+		if len(c.flagServerAddresses) > 0 {
+			serverAddresses, err := common.GetResolvedServerAddresses(c.flagServerAddresses, c.providers, c.logger)
+			if err != nil {
+				c.UI.Error(fmt.Sprintf("Unable to discover any Consul addresses from %q: %s", c.flagServerAddresses[0], err))
+				return 1
+			}
+
+			scheme := "http"
+			if c.flagUseHTTPS {
+				scheme = "https"
+			}
+			// For all of the next operations we'll need a Consul client.
+			serverAddr := fmt.Sprintf("%s:%d", serverAddresses[0], c.flagServerPort)
+			c.http.MergeOntoConfig(&api.Config{
+				Address: serverAddr,
+				Scheme:  scheme,
+			})
+		}
+
 		c.consulClient, err = consul.NewClient(cfg)
 		if err != nil {
 			c.logger.Error("Unable to get client connection", "error", err)
@@ -155,28 +193,31 @@ func (c *Command) Run(args []string) int {
 		meta := map[string]string{
 			"component": c.flagComponentName,
 		}
-		err := common.ConsulLogin(c.consulClient, cfg, c.flagACLAuthMethod, c.flagPrimaryDatacenter, "", c.bearerTokenFile, "", c.flagTokenSinkFile, meta, c.logger)
+		token, err := common.ConsulLogin(c.consulClient, cfg, c.flagACLAuthMethod, c.flagPrimaryDatacenter, "", c.bearerTokenFile, "", c.flagTokenSinkFile, meta, c.logger)
 		if err != nil {
 			c.logger.Error("Consul login failed", "error", err)
 			return 1
 		}
-		c.logger.Info("Consul login succeeded")
-		return 0
-	}
-	// Check if the client secret exists yet
-	// If not, wait until it does
-	var secret string
-	for {
-		var err error
-		secret, err = c.getSecret(c.flagSecretName)
-		if err != nil {
-			c.logger.Error("Error getting Kubernetes secret", "error", err)
+		secret = token.SecretID
+		c.logger.Info("Successfully read ACL token from the server")
+	} else {
+		// Use k8s secret to obtain token
+
+		// Check if the client secret exists yet
+		// If not, wait until it does
+		for {
+			var err error
+			secret, err = c.getSecret(c.flagSecretName)
+			if err != nil {
+				c.logger.Error("Error getting Kubernetes secret: ", "error", err)
+				//			c.UI.Error(fmt.Sprintf("Error getting Kubernetes secret: %s", err))
+			}
+			if err == nil {
+				c.logger.Info("Successfully read Kubernetes secret")
+				break
+			}
+			time.Sleep(1 * time.Second)
 		}
-		if err == nil {
-			c.logger.Info("Successfully read Kubernetes secret")
-			break
-		}
-		time.Sleep(1 * time.Second)
 	}
 
 	if c.flagInitType == "client" {

--- a/control-plane/subcommand/common/common_test.go
+++ b/control-plane/subcommand/common/common_test.go
@@ -64,7 +64,7 @@ func TestConsulLogin(t *testing.T) {
 	log, err := Logger("INFO", false)
 	require.NoError(err)
 	client, cfg := startMockServer(t, &counter)
-	err = ConsulLogin(client, cfg, testAuthMethod, "dc1", "", bearerTokenFile, "", tokenFile, testPodMeta, log)
+	_, err = ConsulLogin(client, cfg, testAuthMethod, "dc1", "", bearerTokenFile, "", tokenFile, testPodMeta, log)
 	require.NoError(err)
 	require.Equal(counter, 1)
 	// Validate that the token file was written to disk.
@@ -78,7 +78,7 @@ func TestConsulLogin_EmptyBearerTokenFile(t *testing.T) {
 	require := require.New(t)
 
 	bearerTokenFile := WriteTempFile(t, "")
-	err := ConsulLogin(nil, nil, testAuthMethod, "", "", bearerTokenFile, "", "", testPodMeta, hclog.NewNullLogger())
+	_, err := ConsulLogin(nil, nil, testAuthMethod, "", "", bearerTokenFile, "", "", testPodMeta, hclog.NewNullLogger())
 	require.EqualError(err, fmt.Sprintf("no bearer token found in %s", bearerTokenFile))
 }
 
@@ -86,7 +86,7 @@ func TestConsulLogin_BearerTokenFileDoesNotExist(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	randFileName := fmt.Sprintf("/foo/%d/%d", rand.Int(), rand.Int())
-	err := ConsulLogin(nil, nil, testAuthMethod, "", "", randFileName, "", "", testPodMeta, hclog.NewNullLogger())
+	_, err := ConsulLogin(nil, nil, testAuthMethod, "", "", randFileName, "", "", testPodMeta, hclog.NewNullLogger())
 	require.Error(err)
 	require.Contains(err.Error(), "unable to read bearerTokenFile")
 }
@@ -101,7 +101,7 @@ func TestConsulLogin_TokenFileUnwritable(t *testing.T) {
 	log, err := Logger("INFO", false)
 	require.NoError(err)
 	randFileName := fmt.Sprintf("/foo/%d/%d", rand.Int(), rand.Int())
-	err = ConsulLogin(client, cfg, testAuthMethod, "", "", bearerTokenFile, "", randFileName, testPodMeta, log)
+	_, err = ConsulLogin(client, cfg, testAuthMethod, "", "", bearerTokenFile, "", randFileName, testPodMeta, log)
 	require.Error(err)
 	require.Contains(err.Error(), "error writing token to file sink")
 }

--- a/control-plane/subcommand/connect-init/command.go
+++ b/control-plane/subcommand/connect-init/command.go
@@ -123,7 +123,7 @@ func (c *Command) Run(args []string) int {
 	if c.flagACLAuthMethod != "" {
 		// loginMeta is the default metadata that we pass to the consul login API.
 		loginMeta := map[string]string{"pod": fmt.Sprintf("%s/%s", c.flagPodNamespace, c.flagPodName)}
-		err = common.ConsulLogin(consulClient, cfg, c.flagACLAuthMethod, "", c.flagAuthMethodNamespace, c.flagBearerTokenFile, c.flagServiceAccountName, c.flagACLTokenSink, loginMeta, c.logger)
+		_, err = common.ConsulLogin(consulClient, cfg, c.flagACLAuthMethod, "", c.flagAuthMethodNamespace, c.flagBearerTokenFile, c.flagServiceAccountName, c.flagACLTokenSink, loginMeta, c.logger)
 		if err != nil {
 			c.logger.Error("unable to complete login", "error", err)
 			return 1

--- a/control-plane/subcommand/partition-init/command.go
+++ b/control-plane/subcommand/partition-init/command.go
@@ -28,11 +28,10 @@ type Command struct {
 	flagPartitionName string
 
 	// Flags to configure Consul connection
-	flagServerAddresses     []string
-	flagServerPort          uint
-	flagConsulCACert        string
-	flagConsulTLSServerName string
-	flagUseHTTPS            bool
+	flagServerAddresses []string
+	flagServerPort      uint
+	flagConsulCACert    string
+	flagUseHTTPS        bool
 
 	flagLogLevel string
 	flagLogJSON  bool
@@ -62,8 +61,6 @@ func (c *Command) init() {
 	c.flags.UintVar(&c.flagServerPort, "server-port", 8500, "The HTTP or HTTPS port of the Consul server. Defaults to 8500.")
 	c.flags.StringVar(&c.flagConsulCACert, "consul-ca-cert", "",
 		"Path to the PEM-encoded CA certificate of the Consul cluster.")
-	c.flags.StringVar(&c.flagConsulTLSServerName, "consul-tls-server-name", "",
-		"The server name to set as the SNI header when sending HTTPS requests to Consul.")
 	c.flags.BoolVar(&c.flagUseHTTPS, "use-https", false,
 		"Toggle for using HTTPS for all API calls to Consul.")
 	c.flags.DurationVar(&c.flagTimeout, "timeout", 10*time.Minute,
@@ -137,10 +134,6 @@ func (c *Command) Run(args []string) int {
 	consulClient, err := consul.NewClient(&api.Config{
 		Address: serverAddr,
 		Scheme:  scheme,
-		TLSConfig: api.TLSConfig{
-			Address: c.flagConsulTLSServerName,
-			CAFile:  c.flagConsulCACert,
-		},
 	})
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error creating Consul client for addr %q: %s", serverAddr, err))

--- a/control-plane/subcommand/partition-init/command.go
+++ b/control-plane/subcommand/partition-init/command.go
@@ -131,10 +131,11 @@ func (c *Command) Run(args []string) int {
 	}
 	// For all of the next operations we'll need a Consul client.
 	serverAddr := fmt.Sprintf("%s:%d", serverAddresses[0], c.flagServerPort)
-	consulClient, err := consul.NewClient(&api.Config{
-		Address: serverAddr,
-		Scheme:  scheme,
-	})
+	cfg := api.DefaultConfig()
+	cfg.Address = serverAddr
+	cfg.Scheme = scheme
+	c.http.MergeOntoConfig(cfg)
+	consulClient, err := consul.NewClient(cfg)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error creating Consul client for addr %q: %s", serverAddr, err))
 		return 1

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -40,7 +40,7 @@ type Command struct {
 
 	flagSetServerTokens bool
 
-	flagCreateClientToken bool
+	flagClient bool
 
 	flagSyncCatalog        bool
 	flagSyncConsulNodeName string
@@ -123,7 +123,7 @@ func (c *Command) init() {
 
 	c.flags.BoolVar(&c.flagAllowDNS, "allow-dns", false,
 		"Toggle for updating the anonymous token to allow DNS queries to work")
-	c.flags.BoolVar(&c.flagCreateClientToken, "create-client-token", true,
+	c.flags.BoolVar(&c.flagClient, "client", true,
 		"Toggle for creating a client agent token. Default is true.")
 
 	c.flags.BoolVar(&c.flagSyncCatalog, "sync-catalog", false,
@@ -445,14 +445,15 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
-	if c.flagCreateClientToken {
+	if c.flagClient {
 		agentRules, err := c.agentRules()
 		if err != nil {
 			c.log.Error("Error templating client agent rules", "err", err)
 			return 1
 		}
 
-		err = c.createLocalACL("client", agentRules, consulDC, primary, consulClient)
+		serviceAccountName := c.withPrefix("client")
+		err = c.createACLPolicyRoleAndBindingRule("client", agentRules, consulDC, primaryDC, false, primary, localComponentAuthMethodName, serviceAccountName, consulClient)
 		if err != nil {
 			c.log.Error(err.Error())
 			return 1

--- a/control-plane/subcommand/server-acl-init/command_test.go
+++ b/control-plane/subcommand/server-acl-init/command_test.go
@@ -2597,7 +2597,7 @@ func TestRun_ValidateLoginToken_SecondaryDatacenter(t *testing.T) {
 			}
 			cmdArgs := append([]string{
 				"-federation",
-				"-timeout=1m",
+				"-timeout=2m",
 				"-resource-prefix=" + resourcePrefix,
 				"-k8s-namespace=" + ns,
 				"-acl-replication-token-file", tokenFile,

--- a/control-plane/subcommand/server-acl-init/command_test.go
+++ b/control-plane/subcommand/server-acl-init/command_test.go
@@ -2597,7 +2597,7 @@ func TestRun_ValidateLoginToken_SecondaryDatacenter(t *testing.T) {
 			}
 			cmdArgs := append([]string{
 				"-federation",
-				"-timeout=2m",
+				"-timeout=1m",
 				"-resource-prefix=" + resourcePrefix,
 				"-k8s-namespace=" + ns,
 				"-acl-replication-token-file", tokenFile,


### PR DESCRIPTION
*Prior Art: https://github.com/hashicorp/consul-k8s/pull/1059*

Changes proposed in this PR:
- `control-plane/subcommand/acl-init/command.go` - when using ACLs, retrieve the token secret from consul login rather than k8s secrets
-  `control-plane/subcommand/common/common.go` 
    - modify `ConsulLogin()` to also return the token (consul core code does this as well), in addition to storing it in the `tokenSinkFile`, so that it can be used in ACL init to write out the 
    - modify `ConsulLogin()`to write the `tokenSinkFile` with 0644 permissions that was original used before ACLs refactor, in part to support [this bug fix] (https://github.com/hashicorp/consul-k8s/pull/248/files#diff-29d4f970a3786e8c721fe5472dc71f9f94482513a3e6042f03c7481e6cec2195L108).
`acl-config.json` file that is also used in the k8s secrets workflow
- `control-plane/subcommand/connect-init/command.go` - minor changes to support return type change to`ConsulLogin`
- `control-plane/subcommand/server-acl-init/create_or_update.go` - make change to create BindingRule if it does not exist rather than error when there are other existing BindingRules associated with the auth method

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added

