### PR TITLE
updating make control-plane-dev to work ondarwin/arm64.  Update helm version for bats tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -582,7 +582,7 @@ The acceptance tests require a Kubernetes cluster with a configured `kubectl`.
   ```bash
   brew install python-yq
   ```
-* [Helm 3](https://helm.sh) (Helm 2 is not supported)
+* [Helm 3](https://helm.sh) (Currently, must use v3.6.3. Also, Helm 2 is not supported) 
   ```bash
   brew install kubernetes-helm
   ```
@@ -611,7 +611,11 @@ To run a specific test by name use the `--filter` flag:
     bats ./charts/consul/test/unit/<filename>.bats --filter "my test name"
 
 #### Acceptance Tests
-
+##### Pre-requisites 
+* [gox](https://github.com/mitchellh/gox) (v1.14+)
+  ```bash
+  brew install gox
+  ```
 To run the acceptance tests:
 
     cd acceptance/tests

--- a/control-plane/build-support/functions/20-build.sh
+++ b/control-plane/build-support/functions/20-build.sh
@@ -242,7 +242,6 @@ function build_consul_local {
       CGO_ENABLED=0 gox \
          -os="${build_os}" \
          -arch="${build_arch}" \
-         -osarch="!darwin/arm !darwin/arm64" \
          -ldflags="${GOLDFLAGS}" \
          -parallel="${GOXPARALLEL:-"-1"}" \
          -output "pkg.bin.new/${extra_dir}{{.OS}}_{{.Arch}}/${bin_name}" \


### PR DESCRIPTION
Changes proposed in this PR:
- Update docs to require `gox` as a pre-requisite install so you can run `make control-plane-dev` and `make-control-plane-dev-docker`
- Update local build scripts to not exclude darwin/arm64, which was set 4 years ago, when it was probably not supported by gox at that time, but works now.
- update `helm` pre-requisited to denote pinned version of 3.6.3, otherwise helm changes its output in bats test to be non-cpaitalized and they fail.

How I've tested this PR:
- `make control-plane-dev` and `make-control-plane-docker` failed for me on my darwin/arm64 laptop.
- implemented changes and they worked
- 
How I expect reviewers to test this PR:
👀 

