### PR TITLE
Set DOCKER_DEFAULT_PLATFORM for make control-plane-dev-docker so that images built on M1/arm64machines do not have failures in k8s.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ control-plane-dev: ## Build consul-k8s-control-plane binary.
 
 control-plane-dev-docker: ## Build consul-k8s-control-plane dev Docker image.
 	@$(SHELL) $(CURDIR)/control-plane/build-support/scripts/build-local.sh -o linux -a amd64
-	@docker build -t '$(DEV_IMAGE)' \
+	@DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build -t '$(DEV_IMAGE)' \
        --build-arg 'GIT_COMMIT=$(GIT_COMMIT)' \
        --build-arg 'GIT_DIRTY=$(GIT_DIRTY)' \
        --build-arg 'GIT_DESCRIBE=$(GIT_DESCRIBE)' \


### PR DESCRIPTION
Changes proposed in this PR:
-  Update Makefile for `control-plane-dev-docker` so that it sets DOCKER_DEFAULT_PLATFORM=linux/amd64.  This sets the proper architecture in the docker manifest. Without this if you build adocker image on an arm64 machine, it will set the docker manifest to arm64.  This then causes errors in kubernetes running the image.

How I've tested this PR:
- completely blocked from publishing images that i could use in acceptance tests running locally
- implemented this
- unblocked

How I expect reviewers to test this PR:
👀 

