### PR TITLE
Rename controller flag in server-acl-init to `-controller`

### DIFF
--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -271,7 +271,7 @@ spec:
                 {{- end }}
 
                 {{- if .Values.controller.enabled }}
-                -create-controller-token=true \
+                -controller=true \
                 {{- end }}
 
                 {{- if .Values.apiGateway.enabled }}

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -1763,24 +1763,24 @@ load _helpers
 #--------------------------------------------------------------------
 # controller
 
-@test "serverACLInit/Job: -create-controller-token not set by default" {
+@test "serverACLInit/Job: -controller not set by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("create-controller-token"))' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command | any(contains("controller"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "serverACLInit/Job: -create-controller-token set when controller.enabled=true" {
+@test "serverACLInit/Job: -controller set when controller.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'controller.enabled=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("create-controller-token"))' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command | any(contains("controller"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -49,7 +49,7 @@ type Command struct {
 	flagAuthMethodHost      string
 	flagBindingRuleSelector string
 
-	flagCreateControllerPoliciesAndBindings bool
+	flagController bool
 
 	flagCreateEntLicenseToken bool
 
@@ -140,8 +140,8 @@ func (c *Command) init() {
 	c.flags.StringVar(&c.flagBindingRuleSelector, "acl-binding-rule-selector", "",
 		"Selector string for connectInject ACL Binding Rule.")
 
-	c.flags.BoolVar(&c.flagCreateControllerPoliciesAndBindings, "create-controller-token", false,
-		"Toggle for creating acl policies and rolebindings for the controller.")
+	c.flags.BoolVar(&c.flagController, "controller", false,
+		"Toggle for configuring ACLs for the controller.")
 
 	c.flags.BoolVar(&c.flagCreateEntLicenseToken, "create-enterprise-license-token", false,
 		"Toggle for creating a token for the enterprise license job.")
@@ -727,7 +727,7 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
-	if c.flagCreateControllerPoliciesAndBindings {
+	if c.flagController {
 		rules, err := c.controllerRules()
 		if err != nil {
 			c.log.Error("Error templating controller token rules", "err", err)

--- a/control-plane/subcommand/server-acl-init/command_ent_test.go
+++ b/control-plane/subcommand/server-acl-init/command_ent_test.go
@@ -295,7 +295,7 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 				"-ingress-gateway-name=anothergw",
 				"-terminating-gateway-name=gw",
 				"-terminating-gateway-name=anothergw",
-				"-create-controller-token",
+				"-controller",
 			}
 			// Our second run, we're going to update from partitions and namespaces disabled to
 			// namespaces enabled with a single destination ns and partitions enabled.

--- a/control-plane/subcommand/server-acl-init/command_test.go
+++ b/control-plane/subcommand/server-acl-init/command_test.go
@@ -2147,7 +2147,7 @@ func TestRun_PoliciesAndBindingRulesForACLLogin_PrimaryDatacenter(t *testing.T) 
 	}{
 		{
 			TestName:    "Controller",
-			TokenFlags:  []string{"-create-controller-token"},
+			TokenFlags:  []string{"-controller"},
 			PolicyNames: []string{"controller-policy"},
 			Roles:       []string{resourcePrefix + "-controller-acl-role"},
 		},
@@ -2255,7 +2255,7 @@ func TestRun_PoliciesAndBindingRulesACLLogin_SecondaryDatacenter(t *testing.T) {
 	}{
 		{
 			TestName:         "Controller",
-			TokenFlags:       []string{"-create-controller-token"},
+			TokenFlags:       []string{"-controller"},
 			PolicyNames:      []string{"controller-policy-" + secondaryDatacenter},
 			Roles:            []string{resourcePrefix + "-controller-acl-role-" + secondaryDatacenter},
 			GlobalAuthMethod: true,
@@ -2365,7 +2365,7 @@ func TestRun_ValidateLoginToken_PrimaryDatacenter(t *testing.T) {
 	}{
 		{
 			ComponentName: "controller",
-			TokenFlags:    []string{"-create-controller-token"},
+			TokenFlags:    []string{"-controller"},
 			Roles:         []string{resourcePrefix + "-controller-acl-role"},
 			GlobalToken:   false,
 		},
@@ -2456,7 +2456,7 @@ func TestRun_ValidateLoginToken_SecondaryDatacenter(t *testing.T) {
 	}{
 		{
 			ComponentName:    "controller",
-			TokenFlags:       []string{"-create-controller-token"},
+			TokenFlags:       []string{"-controller"},
 			Roles:            []string{resourcePrefix + "-controller-acl-role-dc2"},
 			GlobalAuthMethod: true,
 			GlobalToken:      true,


### PR DESCRIPTION
Changes proposed in this PR:
- renames -create-controller-token flag to -enable-controller for server-acl-init.
- This PR replaces PR #1072 because the rebase got really disgusting.

How I've tested this PR:
unit tests pass

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

