### PR TITLE
Support hostNetwork with pod security policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ IMPROVEMENTS:
 * Control Plane
   * Upgrade Docker image Alpine version from 3.14 to 3.15. [[GH-1058](https://github.com/hashicorp/consul-k8s/pull/1058)]
 
+BUG FIXES:
+* Helm
+  * Fix PodSecurityPolicies for clients/mesh gateways when hostNetwork is used. [[GH-1090](https://github.com/hashicorp/consul-k8s/pull/1090)]
+
 ## 0.41.1 (February 24, 2022)
 
 BUG FIXES:

--- a/charts/consul/templates/client-podsecuritypolicy.yaml
+++ b/charts/consul/templates/client-podsecuritypolicy.yaml
@@ -49,9 +49,13 @@ spec:
   - min: 8502
     max: 8502
   {{- end }}
-  {{- if .Values.client.exposeGossipPorts }}
+  {{- if (or .Values.client.exposeGossipPorts .Values.client.hostNetwork) }}
   - min: 8301
     max: 8301
+  {{- end }}
+  {{- if .Values.client.hostNetwork }}
+  - min: 8600
+    max: 8600
   {{- end }}
   hostIPC: false
   hostPID: false

--- a/charts/consul/templates/mesh-gateway-podsecuritypolicy.yaml
+++ b/charts/consul/templates/mesh-gateway-podsecuritypolicy.yaml
@@ -30,6 +30,14 @@ spec:
   {{- else }}
   hostNetwork: false
   {{- end }}
+  hostPorts:
+  {{- if .Values.meshGateway.hostPort }}
+  - min: {{ .Values.meshGateway.hostPort }}
+    max: {{ .Values.meshGateway.hostPort }}
+  {{- else if .Values.meshGateway.hostNetwork }}
+  - min: {{ .Values.meshGateway.containerPort }}
+    max: {{ .Values.meshGateway.containerPort }}
+  {{- end }}
   hostIPC: false
   hostPID: false
   runAsUser:

--- a/charts/consul/test/unit/client-podsecuritypolicy.bats
+++ b/charts/consul/test/unit/client-podsecuritypolicy.bats
@@ -140,7 +140,21 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "client/PodSecurityPolicy: hostPorts when hostNetwork=true" {
+  # hostPorts must be allowed because when Kube sets all container ports as host ports when hostNetwork is true.
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-podsecuritypolicy.yaml  \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'client.hostNetwork=true' \
+      . | tee /dev/stderr |
+      yq -c '.spec.hostPorts' | tee /dev/stderr)
+  [ "${actual}" = '[{"min":8500,"max":8500},{"min":8502,"max":8502},{"min":8301,"max":8301},{"min":8600,"max":8600}]' ]
+}
+
+#--------------------------------------------------------------------
 # client.hostNetwork = false
+
 @test "client/PodSecurityPolicy: enabled with global.enablePodSecurityPolicies=true and default hostNetwork=false" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/mesh-gateway-podsecuritypolicy.bats
+++ b/charts/consul/test/unit/mesh-gateway-podsecuritypolicy.bats
@@ -45,3 +45,29 @@ load _helpers
       yq '.spec.hostNetwork' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "meshGateway/PodSecurityPolicy: hostPorts are allowed when setting hostPort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/mesh-gateway-podsecuritypolicy.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'meshGateway.hostPort=9999' \
+      . | tee /dev/stderr |
+      yq -c '.spec.hostPorts' | tee /dev/stderr)
+  [ "${actual}" = '[{"min":9999,"max":9999}]' ]
+}
+
+@test "meshGateway/PodSecurityPolicy: hostPorts are allowed when hostNetwork=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/mesh-gateway-podsecuritypolicy.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'meshGateway.hostNetwork=true' \
+      . | tee /dev/stderr |
+      yq -c '.spec.hostPorts' | tee /dev/stderr)
+  [ "${actual}" = '[{"min":8443,"max":8443}]' ]
+}


### PR DESCRIPTION
Changes proposed in this PR:
- fixes https://github.com/hashicorp/consul-k8s/issues/1037
- when `hostNetwork` is true, kube sets all containerPorts as hostPorts. We then need to allow those ports in our PSP.

How I've tested this PR:
- bats only

How I expect reviewers to test this PR:
- bats

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

