### PR TITLE
Change value: global.imageK8S => global.imageK8s

### DIFF
--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -152,7 +152,7 @@ This template is for an init container.
 */}}
 {{- define "consul.getAutoEncryptClientCA" -}}
 - name: get-auto-encrypt-client-ca
-  image: {{ .Values.global.imageK8S }}
+  image: {{ template "consul.controlPlaneImage" . }}
   command:
     - "/bin/sh"
     - "-ec"
@@ -212,4 +212,17 @@ Usage: {{ template "consul.reservedNamesFailer" (list .Values.key "key") }}
 {{- if or (eq "system" $name) (eq "universal" $name) (eq "consul" $name) (eq "operator" $name) (eq "root" $name) }}
 {{- fail (cat "The name" $name "set for key" $key "is reserved by Consul for future use." ) }}
 {{- end }}
+{{- end -}}
+
+
+{{- define "consul.controlPlaneImage" -}}
+{{ .Values.global.imageK8S | default .Values.global.imageK8s }}
+{{- end -}}
+
+{{- define "consul.controlPlaneImageConnect" -}}
+{{ .Values.connectInject.image | default .Values.global.imageK8S | default .Values.global.imageK8s }}
+{{- end -}}
+
+{{- define "consul.controlPlaneImageSync" -}}
+{{ .Values.syncCatalog.image | default .Values.global.imageK8S | default .Values.global.imageK8s }}
 {{- end -}}

--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -125,7 +125,7 @@ spec:
       initContainers:
       {{- if .Values.global.acls.manageSystemACLs }}
       - name: api-gateway-controller-acl-init
-        image: {{ .Values.global.imageK8S }}
+        image: {{ template "consul.controlPlaneImage" . }}
         command:
           - "/bin/sh"
           - "-ec"

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -433,7 +433,7 @@ spec:
       initContainers:
       {{- if .Values.global.acls.manageSystemACLs }}
       - name: client-acl-init
-        image: {{ .Values.global.imageK8S }}
+        image: {{ template "consul.controlPlaneImage" . }}
         command:
           - "/bin/sh"
           - "-ec"

--- a/charts/consul/templates/client-snapshot-agent-deployment.yaml
+++ b/charts/consul/templates/client-snapshot-agent-deployment.yaml
@@ -184,7 +184,7 @@ spec:
       initContainers:
       {{- if .Values.global.acls.manageSystemACLs }}
       - name: client-snapshot-agent-acl-init
-        image: {{ .Values.global.imageK8S }}
+        image: {{ template "consul.controlPlaneImage" . }}
         command:
           - "/bin/sh"
           - "-ec"

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: {{ template "consul.fullname" . }}-connect-injector
       containers:
         - name: sidecar-injector
-          image: "{{ default .Values.global.imageK8S .Values.connectInject.image }}"
+          image: {{ template "consul.controlPlaneImageConnect" . }}
           ports:
           - containerPort: 8080
             name: webhook-server
@@ -103,7 +103,7 @@ spec:
                 -default-inject={{ .Values.connectInject.default }} \
                 -consul-image="{{ default .Values.global.image .Values.connectInject.imageConsul }}" \
                 -envoy-image="{{ .Values.global.imageEnvoy }}" \
-                -consul-k8s-image="{{ default .Values.global.imageK8S .Values.connectInject.image }}" \
+                -consul-k8s-image="{{ template "consul.controlPlaneImageConnect" . }}" \
                 -release-name="{{ .Release.Name }}" \
                 -release-namespace="{{ .Release.Namespace }}" \
                 -listen=:8080 \
@@ -287,7 +287,7 @@ spec:
       initContainers:
       {{- if .Values.global.acls.manageSystemACLs }}
       - name: injector-acl-init
-        image: {{ .Values.global.imageK8S }}
+        image: {{ template "consul.controlPlaneImage" . }}
         command:
           - "/bin/sh"
           - "-ec"

--- a/charts/consul/templates/controller-deployment.yaml
+++ b/charts/consul/templates/controller-deployment.yaml
@@ -49,7 +49,7 @@ spec:
       initContainers:
       {{- if .Values.global.acls.manageSystemACLs }}
       - name: controller-acl-init
-        image: {{ .Values.global.imageK8S }}
+        image: {{ template "consul.controlPlaneImage" . }}
         command:
           - "/bin/sh"
           - "-ec"
@@ -127,7 +127,7 @@ spec:
           {{- else }}
           value: http://$(HOST_IP):8500
           {{- end }}
-        image: {{ .Values.global.imageK8S }}
+        image: {{ template "consul.controlPlaneImage" . }}
         name: controller
         ports:
         - containerPort: 9443

--- a/charts/consul/templates/create-federation-secret-job.yaml
+++ b/charts/consul/templates/create-federation-secret-job.yaml
@@ -84,7 +84,7 @@ spec:
 
       containers:
         - name: create-federation-secret
-          image: "{{ .Values.global.imageK8S }}"
+          image: {{ template "consul.controlPlaneImage" . }}
           env:
             - name: NAMESPACE
               valueFrom:

--- a/charts/consul/templates/enterprise-license-job.yaml
+++ b/charts/consul/templates/enterprise-license-job.yaml
@@ -117,7 +117,7 @@ spec:
       {{- if .Values.global.acls.manageSystemACLs }}
       initContainers:
       - name: ent-license-acl-init
-        image: {{ .Values.global.imageK8S }}
+        image: {{ template "consul.controlPlaneImage" . }}
         command:
           - "/bin/sh"
           - "-ec"

--- a/charts/consul/templates/gossip-encryption-autogenerate-job.yaml
+++ b/charts/consul/templates/gossip-encryption-autogenerate-job.yaml
@@ -39,7 +39,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: gossip-encryption-autogen
-          image: "{{ .Values.global.imageK8S }}"
+          image: {{ template "consul.controlPlaneImage" . }}
           command:
             - "/bin/sh"
             - "-ec"

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -142,7 +142,7 @@ spec:
         {{- end }}
         # service-init registers the ingress gateway service.
         - name: service-init
-          image: {{ $root.Values.global.imageK8S }}
+          image: {{ template "consul.controlPlaneImage" $root }}
           env:
             - name: HOST_IP
               valueFrom:
@@ -403,7 +403,7 @@ spec:
         # consul-sidecar ensures the ingress gateway is always registered with
         # the local Consul agent, even if it loses the initial registration.
         - name: consul-sidecar
-          image: {{ $root.Values.global.imageK8S }}
+          image: {{ template "consul.controlPlaneImage" $root }}
           volumeMounts:
             - name: consul-service
               mountPath: /consul/service

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -123,7 +123,7 @@ spec:
         {{- end }}
         # service-init registers the mesh gateway service.
         - name: service-init
-          image: {{ .Values.global.imageK8S }}
+          image: {{ template "consul.controlPlaneImage" . }}
           env:
             - name: HOST_IP
               valueFrom:
@@ -342,7 +342,7 @@ spec:
         # consul-sidecar ensures the mesh gateway is always registered with
         # the local Consul agent, even if it loses the initial registration.
         - name: consul-sidecar
-          image: {{ .Values.global.imageK8S }}
+          image: {{ template "consul.controlPlaneImage" . }}
           volumeMounts:
             - name: consul-service
               mountPath: /consul/service

--- a/charts/consul/templates/partition-init-job.yaml
+++ b/charts/consul/templates/partition-init-job.yaml
@@ -48,7 +48,7 @@ spec:
       {{- end }}
       containers:
         - name: partition-init-job
-          image: {{ .Values.global.imageK8S }}
+          image: {{ template "consul.controlPlaneImage" . }}
           env:
             - name: NAMESPACE
               valueFrom:

--- a/charts/consul/templates/server-acl-init-cleanup-job.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-job.yaml
@@ -46,7 +46,7 @@ spec:
       serviceAccountName: {{ template "consul.fullname" . }}-server-acl-init-cleanup
       containers:
         - name: server-acl-init-cleanup
-          image: {{ .Values.global.imageK8S }}
+          image: {{ template "consul.controlPlaneImage" . }}
           command:
             - consul-k8s-control-plane
           args:

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -93,7 +93,7 @@ spec:
       {{- end }}
       containers:
         - name: post-install-job
-          image: {{ .Values.global.imageK8S }}
+          image: {{ template "consul.controlPlaneImage" . }}
           env:
             - name: NAMESPACE
               valueFrom:

--- a/charts/consul/templates/sync-catalog-deployment.yaml
+++ b/charts/consul/templates/sync-catalog-deployment.yaml
@@ -71,7 +71,7 @@ spec:
       {{- end }}
       containers:
         - name: consul-sync-catalog
-          image: "{{ default .Values.global.imageK8S .Values.syncCatalog.image }}"
+          image: {{ template "consul.controlPlaneImageSync" . }}
           env:
             - name: HOST_IP
               valueFrom:
@@ -216,7 +216,7 @@ spec:
       initContainers:
       {{- if .Values.global.acls.manageSystemACLs }}
       - name: sync-acl-init
-        image: {{ .Values.global.imageK8S }}
+        image: {{ template "consul.controlPlaneImage" . }}
         command:
           - "/bin/sh"
           - "-ec"

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -156,7 +156,7 @@ spec:
         {{- end }}
         # service-init registers the terminating gateway service.
         - name: service-init
-          image: {{ $root.Values.global.imageK8S }}
+          image: {{ template "consul.controlPlaneImage" $root }}
           env:
             - name: HOST_IP
               valueFrom:
@@ -349,7 +349,7 @@ spec:
         # consul-sidecar ensures the terminating gateway is always registered with
         # the local Consul agent, even if it loses the initial registration.
         - name: consul-sidecar
-          image: {{ $root.Values.global.imageK8S }}
+          image: {{ template "consul.controlPlaneImage" $root }}
           volumeMounts:
             - name: consul-service
               mountPath: /consul/service

--- a/charts/consul/templates/tests/test-runner.yaml
+++ b/charts/consul/templates/tests/test-runner.yaml
@@ -11,6 +11,9 @@ metadata:
     release: {{ .Release.Name }}
   annotations:
     "helm.sh/hook": test-success
+    "consul-k8s-image": {{ template "consul.controlPlaneImage" . }}
+    "consul-k8s-image-connect": {{ template "consul.controlPlaneImageConnect" . }}
+    "consul-k8s-image-sync": {{ template "consul.controlPlaneImageSync" . }}
 spec:
   {{- if .Values.global.tls.enabled }}
   volumes:

--- a/charts/consul/templates/tls-init-job.yaml
+++ b/charts/consul/templates/tls-init-job.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
       containers:
         - name: tls-init
-          image: "{{ .Values.global.imageK8S }}"
+          image: {{ template "consul.controlPlaneImage" . }}
           env:
             - name: NAMESPACE
               valueFrom:

--- a/charts/consul/templates/webhook-cert-manager-deployment.yaml
+++ b/charts/consul/templates/webhook-cert-manager-deployment.yaml
@@ -42,7 +42,7 @@ spec:
             -config-file=/bootstrap/config/webhook-config.json \
             -deployment-name={{ template "consul.fullname" . }}-webhook-cert-manager \
             -deployment-namespace={{ .Release.Namespace }}
-        image: {{ .Values.global.imageK8S }}
+        image: {{ template "consul.controlPlaneImage" . }}
         name: webhook-cert-manager
         resources:
           limits:

--- a/charts/consul/test/unit/helpers.bats
+++ b/charts/consul/test/unit/helpers.bats
@@ -307,3 +307,106 @@ load _helpers
   actual=$(echo $object | jq '.volumeMounts[] | select(.name == "consul-ca-cert")')
   [ "${actual}" = "" ]
 }
+
+@test "helper/consul.controlPlaneImage: allows override by imageK8S" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tests/test-runner.yaml  \
+      --set 'global.imageK8S=override' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["consul-k8s-image"]' | tee /dev/stderr)
+
+  [ "${actual}" = "override" ]
+}
+
+@test "helper/consul.controlPlaneImage: allows override by imageK8s" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tests/test-runner.yaml  \
+      --set 'global.imageK8s=override' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["consul-k8s-image"]' | tee /dev/stderr)
+
+  [ "${actual}" = "override" ]
+}
+
+@test "helper/consul.controlPlaneImageConnect: allows override by imageK8S" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tests/test-runner.yaml  \
+      --set 'global.imageK8S=override' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["consul-k8s-image-connect"]' | tee /dev/stderr)
+
+  [ "${actual}" = "override" ]
+}
+
+@test "helper/consul.controlPlaneImageConnect: allows override by imageK8s" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tests/test-runner.yaml  \
+      --set 'global.imageK8s=override' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["consul-k8s-image-connect"]' | tee /dev/stderr)
+
+  [ "${actual}" = "override" ]
+}
+
+@test "helper/consul.controlPlaneImageConnect: allows override by connectInject.image" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tests/test-runner.yaml  \
+      --set 'connectInject.image=override' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["consul-k8s-image-connect"]' | tee /dev/stderr)
+
+  [ "${actual}" = "override" ]
+}
+
+@test "helper/consul.controlPlaneImageSync: allows override by imageK8S" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tests/test-runner.yaml  \
+      --set 'global.imageK8S=override' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["consul-k8s-image-sync"]' | tee /dev/stderr)
+
+  [ "${actual}" = "override" ]
+}
+
+@test "helper/consul.controlPlaneImageSync: allows override by imageK8s" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tests/test-runner.yaml  \
+      --set 'global.imageK8s=override' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["consul-k8s-image-sync"]' | tee /dev/stderr)
+
+  [ "${actual}" = "override" ]
+}
+
+@test "helper/consul.controlPlaneImageSync: allows override by catalogSync.image" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tests/test-runner.yaml  \
+      --set 'syncCatalog.image=override' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["consul-k8s-image-sync"]' | tee /dev/stderr)
+
+  [ "${actual}" = "override" ]
+}
+
+# These tests ensure that we use {{ template "consul.controlPlaneImage" . }} everywhere instead of
+# {{ .Values.imageK8S }} or {{ .Values.imageK8s }}.
+# You must use this helper because we want to support imageK8S for backwards compatibility.
+@test ".Values.imageK8S not used anywhere" {
+  cd `chart_dir`
+  local actual=$(grep -r 'imageK8S' templates/*.yaml | tee /dev/stderr )
+  [ "${actual}" = '' ]
+}
+
+@test ".Values.imageK8s not used anywhere" {
+  cd `chart_dir`
+  local actual=$(grep -r 'imageK8s' templates/*.yaml | tee /dev/stderr )
+  [ "${actual}" = '' ]
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -105,7 +105,7 @@ global:
   # image that is used for functionality such as catalog sync.
   # This can be overridden per component.
   # @default: hashicorp/consul-k8s-control-plane:<latest version>
-  imageK8S: "hashicorp/consul-k8s-control-plane:0.41.1"
+  imageK8s: "hashicorp/consul-k8s-control-plane:0.41.1"
 
   # The name of the datacenter that the agents should
   # register as. This can't be changed once the Consul cluster is up and running


### PR DESCRIPTION
The old value global.imageK8S will still be supported.
Adds helper templates to ensure backwards compatibility and adds tests
to ensure the values aren't referenced directly anywhere.

Added three template helpers. Two additional helpers were needed because of `connectInject.image` and `syncCatalog.image`.

How I've tested this PR:
- unit

How I expect reviewers to test this PR:
- with a fine toothed comb

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

