### PR TITLE
Allow API Gateway controller to get Namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ IMPROVEMENTS:
 * Control Plane
   * Upgrade Docker image Alpine version from 3.14 to 3.15. [[GH-1058](https://github.com/hashicorp/consul-k8s/pull/1058)]
 * Helm
-  * API Gateway: Allow controller to read Kubernetes namespaces in order to determine if route is allowed for gateway [[GH-1092](https://github.com/hashicorp/consul-k8s/pull/1092)]
+  * API Gateway: Allow controller to read Kubernetes namespaces in order to determine if route is allowed for gateway. [[GH-1092](https://github.com/hashicorp/consul-k8s/pull/1092)]
 
 ## 0.41.1 (February 24, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ BREAKING CHANGES:
 IMPROVEMENTS:
 * Control Plane
   * Upgrade Docker image Alpine version from 3.14 to 3.15. [[GH-1058](https://github.com/hashicorp/consul-k8s/pull/1058)]
+* Helm
+  * API Gateway: Allow controller to read Kubernetes namespaces in order to determine if route is allowed for gateway [[GH-1092](https://github.com/hashicorp/consul-k8s/pull/1092)]
 
 ## 0.41.1 (February 24, 2022)
 

--- a/charts/consul/templates/api-gateway-controller-clusterrole.yaml
+++ b/charts/consul/templates/api-gateway-controller-clusterrole.yaml
@@ -75,6 +75,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - list


### PR DESCRIPTION
**Changes proposed in this PR:**
Allow the Consul API Gateway controller to `get`, `list` and `watch` namespaces. This enables the controller to validate `HTTPRoutes` before attaching them to a `Gateway` that uses a namespace selector for `allowedRoutes`.

In this example, the `Gateway` only allows routes from a K8s `Namespace` with labels matching `amAllowed: sure`:

```yaml
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: Gateway
metadata:
  name: example-gateway
  namespace: consul
spec:
  gatewayClassName: consul-api-gateway
  listeners:
    - allowedRoutes:
        namespaces:
          from: Selector
          selector:
            matchLabels:
              amAllowed: sure
      name: http
      port: 80
      protocol: HTTP
```

Before the controller attaches a route to this gateway, it needs to retrieve the namespace and see if the label selector matches, thus these new permissions.

**How I've tested this PR:**
Tested as part of analogous PR, https://github.com/hashicorp/consul-api-gateway/pull/121.

**How I expect reviewers to test this PR:**
Follow testing described in https://github.com/hashicorp/consul-api-gateway/pull/121.

Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

