### PR TITLE
Updating GitHub Actions config to use Consul v1.11.4

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,8 +4,8 @@ on:
 
 env:
   TEST_RESULTS: /tmp/test-results # path to where test results are saved
-  CONSUL_VERSION: 1.11.2 # Consul's OSS version to use in tests
-  CONSUL_ENT_VERSION: 1.11.2+ent # Consul's enterprise version to use in tests
+  CONSUL_VERSION: 1.11.4 # Consul's OSS version to use in tests
+  CONSUL_ENT_VERSION: 1.11.4+ent # Consul's enterprise version to use in tests
   GOTESTSUM_VERSION: 1.6.4 # You cannot use environment variables with workflows. The gotestsum version is hardcoded in the reusable workflows too.
 
 jobs:


### PR DESCRIPTION
Changes proposed in this PR:
- Updating GitHub Actions config to use Consul v1.11.4


How I've tested this PR: 
- Currently getting GH Action failures in unit tests for vault work that is related to a bug that is fixed in Consul 1.11.4.  The bug shows this error
```
agent.http: Request error: method=PUT url=/v1/acl/auth-method?dc=dc1 from=127.0.0.1:41136 error="Invalid Auth Method: TokenLocality 'global' can only be used in the primary datacenter"
```

- Also, we currently updated this version in CircleCI in the last week or so (after the GH migration work started).

How I expect reviewers to test this PR:
👀 

