### PR TITLE
Use SHA instead of latest for acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
         type: string
       consul-k8s-image:
         type: string
-        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s-control-plane:latest"
+        default: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s-control-plane:$(git rev-parse --short HEAD)"
       go-path:
         type: string
         default: "/home/circleci/.go_workspace"


### PR DESCRIPTION
Changes proposed in this PR:
- I broke this change when I changed the build-and-test pipelines
- Change the acceptance tests to use SHA instead of :latest

How I've tested this PR:

- I ran the acceptance tests. The change has been tests in another PR also..

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

