### PR TITLE
Refactor logic in common.Login

### DIFF
--- a/control-plane/subcommand/acl-init/command.go
+++ b/control-plane/subcommand/acl-init/command.go
@@ -187,20 +187,26 @@ func (c *Command) Run(args []string) int {
 			return 1
 		}
 
-		meta := map[string]string{
-			"component": c.flagComponentName,
+		loginParams := common.LoginParams{
+			AuthMethod:      c.flagACLAuthMethod,
+			Datacenter:      c.flagPrimaryDatacenter,
+			BearerTokenFile: c.bearerTokenFile,
+			TokenSinkFile:   c.flagTokenSinkFile,
+			Meta: map[string]string{
+				"component": c.flagComponentName,
+			},
 		}
-		secret, err = common.ConsulLogin(c.consulClient, cfg, c.flagACLAuthMethod, c.flagPrimaryDatacenter, "", c.bearerTokenFile, "", c.flagTokenSinkFile, meta, c.logger)
+		secret, err = common.ConsulLogin(c.consulClient, loginParams, c.logger)
 		if err != nil {
 			c.logger.Error("Consul login failed", "error", err)
 			return 1
 		}
 		c.logger.Info("Successfully read ACL token from the server")
 	} else {
-		// Use k8s secret to obtain token
+		// Use k8s secret to obtain token.
 
 		// Check if the client secret exists yet
-		// If not, wait until it does
+		// If not, wait until it does.
 		for {
 			var err error
 			secret, err = c.getSecret(c.flagSecretName)

--- a/control-plane/subcommand/common/common_test.go
+++ b/control-plane/subcommand/common/common_test.go
@@ -54,23 +54,112 @@ func TestValidateUnprivilegedPort(t *testing.T) {
 // TestConsulLogin ensures that our implementation of consul login hits `/v1/acl/login`.
 func TestConsulLogin(t *testing.T) {
 	t.Parallel()
-	require := require.New(t)
 
-	counter := 0
 	bearerTokenFile := WriteTempFile(t, "foo")
 	tokenFile := WriteTempFile(t, "")
 
 	// This is a common.Logger.
 	log, err := Logger("INFO", false)
-	require.NoError(err)
-	client, cfg := startMockServer(t, &counter)
-	_, err = ConsulLogin(client, cfg, testAuthMethod, "dc1", "", bearerTokenFile, "", tokenFile, testPodMeta, log)
-	require.NoError(err)
-	require.Equal(counter, 1)
+	require.NoError(t, err)
+	client := startMockServer(t)
+	params := LoginParams{
+		AuthMethod:      testAuthMethod,
+		Datacenter:      "dc1",
+		BearerTokenFile: bearerTokenFile,
+		TokenSinkFile:   tokenFile,
+	}
+	_, err = ConsulLogin(client, params, log)
+	require.NoError(t, err)
 	// Validate that the token file was written to disk.
 	data, err := ioutil.ReadFile(tokenFile)
-	require.NoError(err)
-	require.Equal(string(data), "b78d37c7-0ca7-5f4d-99ee-6d9975ce4586")
+	require.NoError(t, err)
+	require.Equal(t, string(data), "b78d37c7-0ca7-5f4d-99ee-6d9975ce4586")
+}
+
+// TestConsulLogin_Retries tests we retry /v1/acl/login call if it fails.
+func TestConsulLogin_Retries(t *testing.T) {
+	t.Parallel()
+
+	numLoginCalls := 0
+	bearerTokenFile := WriteTempFile(t, "foo")
+	tokenFile := WriteTempFile(t, "")
+
+	// This is a common.Logger.
+	log, err := Logger("INFO", false)
+	require.NoError(t, err)
+	// Start the Consul server.
+	consulServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Record all the API calls made.
+		if r != nil && r.URL.Path == "/v1/acl/login" && r.Method == "POST" {
+			if numLoginCalls == 0 {
+				w.WriteHeader(500)
+			} else {
+				w.Write([]byte(testLoginResponse))
+			}
+			numLoginCalls++
+		}
+		if r != nil && r.URL.Path == "/v1/acl/token/self" && r.Method == "GET" {
+			w.Write([]byte(testLoginResponse))
+		}
+	}))
+	t.Cleanup(consulServer.Close)
+
+	serverURL, err := url.Parse(consulServer.URL)
+	require.NoError(t, err)
+	clientConfig := &api.Config{Address: serverURL.String()}
+	client, err := api.NewClient(clientConfig)
+	require.NoError(t, err)
+	params := LoginParams{
+		AuthMethod:      testAuthMethod,
+		Datacenter:      "dc1",
+		BearerTokenFile: bearerTokenFile,
+		TokenSinkFile:   tokenFile,
+	}
+	_, err = ConsulLogin(client, params, log)
+	require.NoError(t, err)
+	require.Equal(t, 2, numLoginCalls)
+	// Validate that the token file was written to disk.
+	data, err := ioutil.ReadFile(tokenFile)
+	require.NoError(t, err)
+	require.Equal(t, string(data), "b78d37c7-0ca7-5f4d-99ee-6d9975ce4586")
+}
+
+// TestConsulLogin_TokenNotReplicated tests that if we can't read the token in stale consistency mode
+// we return an error.
+func TestConsulLogin_TokenNotReplicated(t *testing.T) {
+	t.Parallel()
+
+	bearerTokenFile := WriteTempFile(t, "foo")
+	tokenFile := WriteTempFile(t, "")
+
+	// This is a common.Logger.
+	log, err := Logger("INFO", false)
+	require.NoError(t, err)
+	// Start the Consul server.
+	consulServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Record all the API calls made.
+		if r != nil && r.URL.Path == "/v1/acl/login" && r.Method == "POST" {
+			w.Write([]byte(testLoginResponse))
+		}
+		if r != nil && r.URL.Path == "/v1/acl/token/self" && r.Method == "GET" {
+			w.WriteHeader(500)
+		}
+	}))
+	t.Cleanup(consulServer.Close)
+
+	serverURL, err := url.Parse(consulServer.URL)
+	require.NoError(t, err)
+	clientConfig := &api.Config{Address: serverURL.String()}
+	client, err := api.NewClient(clientConfig)
+	require.NoError(t, err)
+	params := LoginParams{
+		AuthMethod:      testAuthMethod,
+		Datacenter:      "dc1",
+		BearerTokenFile: bearerTokenFile,
+		TokenSinkFile:   tokenFile,
+	}
+	_, err = ConsulLogin(client, params, log)
+	require.EqualError(t, err, "Unexpected response code: 500 ()")
 }
 
 func TestConsulLogin_EmptyBearerTokenFile(t *testing.T) {
@@ -78,30 +167,41 @@ func TestConsulLogin_EmptyBearerTokenFile(t *testing.T) {
 	require := require.New(t)
 
 	bearerTokenFile := WriteTempFile(t, "")
-	_, err := ConsulLogin(nil, nil, testAuthMethod, "", "", bearerTokenFile, "", "", testPodMeta, hclog.NewNullLogger())
-	require.EqualError(err, fmt.Sprintf("no bearer token found in %s", bearerTokenFile))
+	params := LoginParams{
+		BearerTokenFile: bearerTokenFile,
+	}
+	_, err := ConsulLogin(nil, params, hclog.NewNullLogger())
+	require.EqualError(err, fmt.Sprintf("no bearer token found in %q", bearerTokenFile))
 }
 
 func TestConsulLogin_BearerTokenFileDoesNotExist(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	randFileName := fmt.Sprintf("/foo/%d/%d", rand.Int(), rand.Int())
-	_, err := ConsulLogin(nil, nil, testAuthMethod, "", "", randFileName, "", "", testPodMeta, hclog.NewNullLogger())
+	params := LoginParams{
+		BearerTokenFile: randFileName,
+	}
+	_, err := ConsulLogin(nil, params, hclog.NewNullLogger())
 	require.Error(err)
-	require.Contains(err.Error(), "unable to read bearerTokenFile")
+	require.Contains(err.Error(), "unable to read bearer token file")
 }
 
 func TestConsulLogin_TokenFileUnwritable(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	counter := 0
 	bearerTokenFile := WriteTempFile(t, "foo")
-	client, cfg := startMockServer(t, &counter)
+	client := startMockServer(t)
 	// This is a common.Logger.
 	log, err := Logger("INFO", false)
 	require.NoError(err)
 	randFileName := fmt.Sprintf("/foo/%d/%d", rand.Int(), rand.Int())
-	_, err = ConsulLogin(client, cfg, testAuthMethod, "", "", bearerTokenFile, "", randFileName, testPodMeta, log)
+	params := LoginParams{
+		AuthMethod:      testAuthMethod,
+		BearerTokenFile: bearerTokenFile,
+		TokenSinkFile:   randFileName,
+		numRetries:      2,
+	}
+	_, err = ConsulLogin(client, params, log)
 	require.Error(err)
 	require.Contains(err.Error(), "error writing token to file sink")
 }
@@ -199,15 +299,16 @@ func TestGetResolvedServerAddresses(t *testing.T) {
 // startMockServer starts an httptest server used to mock a Consul server's
 // /v1/acl/login endpoint. apiCallCounter will be incremented on each call to /v1/acl/login.
 // It returns a consul client pointing at the server.
-func startMockServer(t *testing.T, apiCallCounter *int) (*api.Client, *api.Config) {
-
+func startMockServer(t *testing.T) *api.Client {
 	// Start the Consul server.
 	consulServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Record all the API calls made.
 		if r != nil && r.URL.Path == "/v1/acl/login" && r.Method == "POST" {
-			*apiCallCounter++
+			w.Write([]byte(testLoginResponse))
 		}
-		w.Write([]byte(testLoginResponse))
+		if r != nil && r.URL.Path == "/v1/acl/token/self" && r.Method == "GET" {
+			w.Write([]byte(testLoginResponse))
+		}
 	}))
 	t.Cleanup(consulServer.Close)
 
@@ -217,7 +318,7 @@ func startMockServer(t *testing.T, apiCallCounter *int) (*api.Client, *api.Confi
 	client, err := api.NewClient(clientConfig)
 	require.NoError(t, err)
 
-	return client, clientConfig
+	return client
 }
 
 const testAuthMethod = "consul-k8s-auth-method"
@@ -243,5 +344,3 @@ const testLoginResponse = `{
   "CreateIndex": 36,
   "ModifyIndex": 36
 }`
-
-var testPodMeta = map[string]string{"pod": "default/podName"}


### PR DESCRIPTION
Changes proposed in this PR:
- convert function args to a struct
- add some missing tests
- move logic that is only relevant for connect out

How I've tested this PR:
unit tests

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

