### PR TITLE
Enable terminating gateways to use ACL Auth Method

### DIFF
--- a/acceptance/tests/terminating-gateway/terminating_gateway_namespaces_test.go
+++ b/acceptance/tests/terminating-gateway/terminating_gateway_namespaces_test.go
@@ -97,11 +97,11 @@ func TestTerminatingGatewaySingleNamespace(t *testing.T) {
 			// Register the external service.
 			registerExternalService(t, consulClient, testNamespace)
 
-			// If ACLs are enabled we need to update the token of the terminating gateway
+			// If ACLs are enabled we need to update the role of the terminating gateway
 			// with service:write permissions to the static-server service
 			// so that it can can request Connect certificates for it.
 			if c.secure {
-				updateTerminatingGatewayToken(t, consulClient, fmt.Sprintf(staticServerPolicyRulesNamespace, testNamespace))
+				updateTerminatingGatewayRole(t, consulClient, fmt.Sprintf(staticServerPolicyRulesNamespace, testNamespace))
 			}
 
 			// Create the config entry for the terminating gateway.
@@ -205,11 +205,11 @@ func TestTerminatingGatewayNamespaceMirroring(t *testing.T) {
 			// Register the external service
 			registerExternalService(t, consulClient, testNamespace)
 
-			// If ACLs are enabled we need to update the token of the terminating gateway
+			// If ACLs are enabled we need to update the role of the terminating gateway
 			// with service:write permissions to the static-server service
 			// so that it can can request Connect certificates for it.
 			if c.secure {
-				updateTerminatingGatewayToken(t, consulClient, fmt.Sprintf(staticServerPolicyRulesNamespace, testNamespace))
+				updateTerminatingGatewayRole(t, consulClient, fmt.Sprintf(staticServerPolicyRulesNamespace, testNamespace))
 			}
 
 			// Create the config entry for the terminating gateway

--- a/acceptance/tests/terminating-gateway/terminating_gateway_test.go
+++ b/acceptance/tests/terminating-gateway/terminating_gateway_test.go
@@ -69,11 +69,11 @@ func TestTerminatingGateway(t *testing.T) {
 			// Register the external service
 			registerExternalService(t, consulClient, "")
 
-			// If ACLs are enabled we need to update the token of the terminating gateway
+			// If ACLs are enabled we need to update the role of the terminating gateway
 			// with service:write permissions to the static-server service
 			// so that it can can request Connect certificates for it.
 			if c.secure {
-				updateTerminatingGatewayToken(t, consulClient, staticServerPolicyRules)
+				updateTerminatingGatewayRole(t, consulClient, staticServerPolicyRules)
 			}
 
 			// Create the config entry for the terminating gateway.
@@ -133,32 +133,32 @@ func registerExternalService(t *testing.T, consulClient *api.Client, namespace s
 	require.NoError(t, err)
 }
 
-func updateTerminatingGatewayToken(t *testing.T, consulClient *api.Client, rules string) {
+func updateTerminatingGatewayRole(t *testing.T, consulClient *api.Client, rules string) {
 	t.Helper()
 
-	// Create a write policy for the static-server.
+	logger.Log(t, "creating a write policy for the static-server")
 	_, _, err := consulClient.ACL().PolicyCreate(&api.ACLPolicy{
 		Name:  "static-server-write-policy",
 		Rules: rules,
 	}, nil)
 	require.NoError(t, err)
 
-	// Get the terminating gateway token.
-	tokens, _, err := consulClient.ACL().TokenList(nil)
+	logger.Log(t, "getting the terminating gateway role")
+	roles, _, err := consulClient.ACL().RoleList(nil)
 	require.NoError(t, err)
-	var termGwTokenID string
-	for _, token := range tokens {
-		if strings.Contains(token.Description, "token created via login: {\"component\":\"terminating-gateway\"}") {
-			termGwTokenID = token.AccessorID
+	terminatingGatewayRoleID := ""
+	for _, role := range roles {
+		if strings.Contains(role.Name, "terminating-gateway") {
+			terminatingGatewayRoleID = role.ID
 			break
 		}
 	}
-	termGwToken, _, err := consulClient.ACL().TokenRead(termGwTokenID, nil)
-	require.NoError(t, err)
 
-	// Add policy to the token and update it
-	termGwToken.Policies = append(termGwToken.Policies, &api.ACLTokenPolicyLink{Name: "static-server-write-policy"})
-	_, _, err = consulClient.ACL().TokenUpdate(termGwToken, nil)
+	logger.Log(t, "update role with policy")
+	termGwRole, _, err := consulClient.ACL().RoleRead(terminatingGatewayRoleID, nil)
+	require.NoError(t, err)
+	termGwRole.Policies = append(termGwRole.Policies, &api.ACLTokenPolicyLink{Name: "static-server-write-policy"})
+	_, _, err = consulClient.ACL().RoleUpdate(termGwRole, nil)
 	require.NoError(t, err)
 }
 

--- a/acceptance/tests/terminating-gateway/terminating_gateway_test.go
+++ b/acceptance/tests/terminating-gateway/terminating_gateway_test.go
@@ -148,7 +148,7 @@ func updateTerminatingGatewayToken(t *testing.T, consulClient *api.Client, rules
 	require.NoError(t, err)
 	var termGwTokenID string
 	for _, token := range tokens {
-		if strings.Contains(token.Description, "terminating-gateway-terminating-gateway-token") {
+		if strings.Contains(token.Description, "token created via login: {\"component\":\"terminating-gateway\"}") {
 			termGwTokenID = token.AccessorID
 			break
 		}

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -351,7 +351,9 @@ spec:
                 - "/bin/sh"
                 - "-ec"
                 - "/consul-bin/consul services deregister -id=\"{{ .Values.meshGateway.consulServiceName }}\""
+                {{- if .Values.global.acls.manageSystemACLs }}
                 - "/consul-bin/consul logout"
+                {{- end}}
 
         # consul-sidecar ensures the mesh gateway is always registered with
         # the local Consul agent, even if it loses the initial registration.

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -347,7 +347,11 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-ec", "/consul-bin/consul services deregister -id=\"{{ .Values.meshGateway.consulServiceName }}\"", "&&", "/bin/sh", "-ec", "/consul-bin/consul logout"]
+                command: 
+                - "/bin/sh"
+                - "-ec"
+                - "/consul-bin/consul services deregister -id=\"{{ .Values.meshGateway.consulServiceName }}\""
+                - "/consul-bin/consul logout"
 
         # consul-sidecar ensures the mesh gateway is always registered with
         # the local Consul agent, even if it loses the initial registration.

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -24,7 +24,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "consul.fullname" $root }}-{{ .name }}
+  name: {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
@@ -32,7 +32,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: terminating-gateway
-    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
 spec:
   replicas: {{ default $defaults.replicas .replicas }}
   selector:
@@ -42,7 +42,7 @@ spec:
       heritage: {{ $root.Release.Service }}
       release: {{ $root.Release.Name }}
       component: terminating-gateway
-      terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+      terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
   template:
     metadata:
       labels:
@@ -51,7 +51,7 @@ spec:
         heritage: {{ $root.Release.Service }}
         release: {{ $root.Release.Name }}
         component: terminating-gateway
-        terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+        terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
       annotations:
         {{- if (and $root.Values.global.secretsBackend.vault.enabled $root.Values.global.tls.enabled) }}
         "vault.hashicorp.com/agent-init-first": "true"

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -179,13 +179,13 @@ spec:
             - name: CONSUL_HTTP_ADDR
               value: http://$(HOST_IP):8500
             {{- end }}
-          command:
+          command:  
             - "/bin/sh"
             - "-ec"
             - |
                 {{- if $root.Values.global.acls.manageSystemACLs }}
                 consul-k8s-control-plane acl-init \
-                  -component-name=terminating-gateway \
+                  -component-name=terminating-gateway/{{ template "consul.fullname" $root }}-{{ .name }} \
                   -acl-auth-method={{ template "consul.fullname" $root }}-k8s-component-auth-method \
                   {{- if $root.Values.global.adminPartitions.enabled }}
                   -partition={{ $root.Values.global.adminPartitions.name }} \

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -154,8 +154,8 @@ spec:
         {{- if (and $root.Values.global.tls.enabled $root.Values.global.tls.enableAutoEncrypt) }}
         {{- include "consul.getAutoEncryptClientCA" $root | nindent 8 }}
         {{- end }}
-        # service-init registers the terminating gateway service.
-        - name: service-init
+        # terminating-gateway-init registers the terminating gateway service with Consul.
+        - name: terminating-gateway-init
           image: {{ $root.Values.global.imageK8S }}
           env:
             - name: HOST_IP
@@ -185,9 +185,14 @@ spec:
             - |
                 {{- if $root.Values.global.acls.manageSystemACLs }}
                 consul-k8s-control-plane acl-init \
-                  -secret-name="{{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway-acl-token" \
-                  -k8s-namespace={{ $root.Release.Namespace }} \
-                  -token-sink-file=/consul/service/acl-token
+                  -component-name=terminating-gateway \
+                  -acl-auth-method={{ template "consul.fullname" $root }}-k8s-component-auth-method \
+                  {{- if $root.Values.global.adminPartitions.enabled }}
+                  -partition={{ $root.Values.global.adminPartitions.name }} \
+                  {{- end }}
+                  -token-sink-file=/consul/service/acl-token \
+                  -log-level={{ default $root.Values.global.logLevel }} \
+                  -log-json={{ $root.Values.global.logJSON }}
                 {{- end }}
 
                 cat > /consul/service/service.hcl << EOF
@@ -252,6 +257,9 @@ spec:
           volumeMounts:
           - name: consul-bin
             mountPath: /consul-bin
+          - mountPath: /consul/service
+            name: consul-service
+            readOnly: true
           {{- if $root.Values.global.tls.enabled }}
           {{- if $root.Values.global.tls.enableAutoEncrypt }}
           - name: consul-auto-encrypt-ca-cert
@@ -280,12 +288,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             {{- if $root.Values.global.acls.manageSystemACLs }}
-            - name: CONSUL_HTTP_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway-acl-token"
-                  key: "token"
-            {{- end}}
+            - name: CONSUL_HTTP_TOKEN_FILE
+              value: "/consul/service/acl-token"
+            {{- end }}
             {{- if $root.Values.global.tls.enabled }}
             - name: CONSUL_HTTP_ADDR
               value: https://$(HOST_IP):8501
@@ -345,6 +350,10 @@ spec:
                       -partition={{ $root.Values.global.adminPartitions.name }} \
                       {{- end }}
                       -id="${POD_NAME}"
+                  {{- if $root.Values.global.acls.manageSystemACLs }}
+                  - |
+                    "/consul-bin/consul logout"
+                  {{- end}}
 
         # consul-sidecar ensures the terminating gateway is always registered with
         # the local Consul agent, even if it loses the initial registration.

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -90,7 +90,7 @@ spec:
         {{ tpl (default $defaults.tolerations .tolerations) $root | nindent 8 | trim }}
       {{- end }}
       terminationGracePeriodSeconds: 10
-      serviceAccountName: {{ template "consul.fullname" $root }}-{{ .name }}
+      serviceAccountName: {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
       volumes:
         - name: consul-bin
           emptyDir: {}

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -351,8 +351,7 @@ spec:
                       {{- end }}
                       -id="${POD_NAME}"
                   {{- if $root.Values.global.acls.manageSystemACLs }}
-                  - |
-                    "/consul-bin/consul logout"
+                  - "/consul-bin/consul logout"
                   {{- end}}
 
         # consul-sidecar ensures the terminating gateway is always registered with

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -179,7 +179,7 @@ spec:
             - name: CONSUL_HTTP_ADDR
               value: http://$(HOST_IP):8500
             {{- end }}
-          command:  
+          command:
             - "/bin/sh"
             - "-ec"
             - |

--- a/charts/consul/templates/terminating-gateways-podsecuritypolicy.yaml
+++ b/charts/consul/templates/terminating-gateways-podsecuritypolicy.yaml
@@ -4,7 +4,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name:  {{ template "consul.fullname" $root }}-{{ .name }}
+  name:  {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
@@ -12,7 +12,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: terminating-gateway
-    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
 spec:
   privileged: false
   # Required to prevent escalations to root.

--- a/charts/consul/templates/terminating-gateways-role.yaml
+++ b/charts/consul/templates/terminating-gateways-role.yaml
@@ -7,7 +7,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name:  {{ template "consul.fullname" $root }}-{{ .name }}
+  name:  {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
@@ -15,14 +15,14 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: terminating-gateway
-    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
 {{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.enablePodSecurityPolicies) }}
 rules:
 {{- if $root.Values.global.enablePodSecurityPolicies }}
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
     resourceNames:
-      -  {{ template "consul.fullname" $root }}-{{ .name }}
+      -  {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
     verbs:
       - use
 {{- end }}

--- a/charts/consul/templates/terminating-gateways-rolebinding.yaml
+++ b/charts/consul/templates/terminating-gateways-rolebinding.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name:  {{ template "consul.fullname" $root }}-{{ .name }}
+  name:  {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
@@ -12,14 +12,14 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: terminating-gateway
-    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name:  {{ template "consul.fullname" $root }}-{{ .name }}
+  name:  {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
 subjects:
   - kind: ServiceAccount
-    name:  {{ template "consul.fullname" $root }}-{{ .name }}
+    name:  {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
     namespace: {{ $root.Release.Namespace }}
 ---
 {{- end }}

--- a/charts/consul/templates/terminating-gateways-serviceaccount.yaml
+++ b/charts/consul/templates/terminating-gateways-serviceaccount.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name:  {{ template "consul.fullname" $root }}-{{ .name }}
+  name:  {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
@@ -14,7 +14,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: terminating-gateway
-    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
   {{- if (or $defaults.serviceAccount.annotations $serviceAccount.annotations) }}
   annotations:
     {{- if $defaults.serviceAccount.annotations }}

--- a/charts/consul/templates/terminating-gateways-serviceaccount.yaml
+++ b/charts/consul/templates/terminating-gateways-serviceaccount.yaml
@@ -14,7 +14,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: terminating-gateway
-    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
+    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
   {{- if (or $defaults.serviceAccount.annotations $serviceAccount.annotations) }}
   annotations:
     {{- if $defaults.serviceAccount.annotations }}

--- a/charts/consul/templates/terminating-gateways-serviceaccount.yaml
+++ b/charts/consul/templates/terminating-gateways-serviceaccount.yaml
@@ -14,7 +14,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: terminating-gateway
-    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+    terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}-terminating-gateway
   {{- if (or $defaults.serviceAccount.annotations $serviceAccount.annotations) }}
   annotations:
     {{- if $defaults.serviceAccount.annotations }}

--- a/charts/consul/test/unit/mesh-gateway-deployment.bats
+++ b/charts/consul/test/unit/mesh-gateway-deployment.bats
@@ -587,7 +587,7 @@ key2: value2' \
 #--------------------------------------------------------------------
 # manageSystemACLs
 
-@test "meshGateway/Deployment: consul logout preStop hook is added when ACLs are enabled" {
+@test "meshGateway/Deployment: consul-logout preStop hook is added when ACLs are enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/mesh-gateway-deployment.yaml  \
@@ -595,7 +595,7 @@ key2: value2' \
       --set 'connectInject.enabled=true' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq '[.spec.template.spec.containers[0].lifecycle.preStop.exec.command[6]] | any(contains("logout"))' | tee /dev/stderr)
+      yq '[.spec.template.spec.containers[0].lifecycle.preStop.exec.command[3]] | any(contains("/consul-bin/consul logout"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -25,6 +25,29 @@ load _helpers
   [ "${actual}" = "RELEASE-NAME-consul-terminating-gateway" ]
 }
 
+@test "terminatingGateways/Deployment: Adds consul service volumeMount to gateway container" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | yq '.spec.template.spec.containers[0].volumeMounts[1]' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "consul-service" ]
+
+  local actual=$(echo $object |
+      yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/consul/service" ]
+
+  local actual=$(echo $object |
+      yq -r '.readOnly' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 #--------------------------------------------------------------------
 # prerequisites
 
@@ -234,18 +257,6 @@ load _helpers
 #--------------------------------------------------------------------
 # global.acls.manageSystemACLs
 
-@test "terminatingGateways/Deployment: CONSUL_HTTP_TOKEN env variable created when global.acls.manageSystemACLs=true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/terminating-gateways-deployment.yaml \
-      --set 'terminatingGateways.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'global.acls.manageSystemACLs=true' \
-      . | tee /dev/stderr |
-      yq -s '[.[0].spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
 @test "terminatingGateways/Deployment: consul-sidecar uses -token-file flag when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -255,6 +266,103 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -s '.[0].spec.template.spec.containers[1].command | any(contains("-token-file=/consul/service/acl-token"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "terminatingGateways/Deployment: Adds consul envvars CONSUL_HTTP_ADDR on terminating-gateway-init init container when ACLs are enabled and tls is enabled" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[1].env[]' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = "https://\$(HOST_IP):8501" ]
+}
+
+@test "terminatingGateways/Deployment: Adds consul envvars CONSUL_HTTP_ADDR on terminating-gateway-init init container when ACLs are enabled and tls is not enabled" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[1].env[]' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo $env | jq -r '. | select(.name == "CONSUL_HTTP_ADDR") | .value' | tee /dev/stderr)
+  [ "${actual}" = "http://\$(HOST_IP):8500" ]
+}
+
+@test "terminatingGateways/Deployment: Does not add consul envvars CONSUL_CACERT on terminating-gateway-init init container when ACLs are enabled and tls is not enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers[1].env[] | select(.name == "CONSUL_CACERT")' | tee /dev/stderr)
+
+  [ "${actual}" = "" ]
+}
+
+@test "terminatingGateways/Deployment: Adds consul envvars CONSUL_CACERT on terminating-gateway-init init container when ACLs are enabled and tls is enabled" {
+  cd `chart_dir`
+  local env=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[1].env[]' | tee /dev/stderr)
+
+  local actual=$(echo $env | jq -r '. | select(.name == "CONSUL_CACERT") | .value' | tee /dev/stderr)
+    [ "${actual}" = "/consul/tls/ca/tls.crt" ]
+}
+
+@test "terminatingGateways/Deployment: CONSUL_HTTP_TOKEN_FILE is not set when acls are disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'global.acls.manageSystemACLs=false' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].env[0].name] | any(contains("CONSUL_HTTP_TOKEN_FILE"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "terminatingGateways/Deployment: CONSUL_HTTP_TOKEN_FILE is set when acls are enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -s '[.[0].spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN_FILE"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "terminatingGateways/Deployment: consul-logout preStop hook is added when ACLs are enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[0].lifecycle.preStop.exec.command[3]] | any(contains("consul-k8s-control-plane consul-logout"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
@@ -1005,16 +1113,16 @@ key2: value2' \
 }
 
 #--------------------------------------------------------------------
-# service-init init container command
+# terminating-gateway-init init container command
 
-@test "terminatingGateways/Deployment: service-init init container defaults" {
+@test "terminatingGateways/Deployment: terminating-gateway-init init container defaults" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/terminating-gateways-deployment.yaml \
       --set 'terminatingGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
-      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "terminating-gateway-init"))[0] | .command[2]' | tee /dev/stderr)
 
   exp='
 cat > /consul/service/service.hcl << EOF
@@ -1041,7 +1149,7 @@ EOF
   [ "${actual}" = "${exp}" ]
 }
 
-@test "terminatingGateways/Deployment: service-init init container with acls.manageSystemACLs=true" {
+@test "terminatingGateways/Deployment: terminating-gateway-init init container with acls.manageSystemACLs=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/terminating-gateways-deployment.yaml \
@@ -1049,12 +1157,14 @@ EOF
       --set 'connectInject.enabled=true' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "terminating-gateway-init"))[0] | .command[2]' | tee /dev/stderr)
 
   exp='consul-k8s-control-plane acl-init \
-  -secret-name="RELEASE-NAME-consul-terminating-gateway-terminating-gateway-acl-token" \
-  -k8s-namespace=default \
-  -token-sink-file=/consul/service/acl-token
+  -component-name=terminating-gateway \
+  -acl-auth-method=RELEASE-NAME-consul-k8s-component-auth-method \
+  -token-sink-file=/consul/service/acl-token \
+  -log-level=info \
+  -log-json=false
 
 cat > /consul/service/service.hcl << EOF
 service {
@@ -1081,7 +1191,7 @@ EOF
   [ "${actual}" = "${exp}" ]
 }
 
-@test "terminatingGateways/Deployment: service-init init container gateway namespace can be specified through defaults" {
+@test "terminatingGateways/Deployment: terminating-gateway-init init container gateway namespace can be specified through defaults" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/terminating-gateways-deployment.yaml \
@@ -1090,7 +1200,7 @@ EOF
       --set 'global.enableConsulNamespaces=true' \
       --set 'terminatingGateways.defaults.consulNamespace=namespace' \
       . | tee /dev/stderr |
-      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "terminating-gateway-init"))[0] | .command[2]' | tee /dev/stderr)
 
   exp='
 cat > /consul/service/service.hcl << EOF
@@ -1118,7 +1228,7 @@ EOF
   [ "${actual}" = "${exp}" ]
 }
 
-@test "terminatingGateways/Deployment: service-init init container gateway namespace can be specified through specific gateway overriding defaults" {
+@test "terminatingGateways/Deployment: terminating-gateway-init init container gateway namespace can be specified through specific gateway overriding defaults" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/terminating-gateways-deployment.yaml \
@@ -1129,7 +1239,7 @@ EOF
       --set 'terminatingGateways.gateways[0].name=terminating-gateway' \
       --set 'terminatingGateways.gateways[0].consulNamespace=new-namespace' \
       . | tee /dev/stderr |
-      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "service-init"))[0] | .command[2]' | tee /dev/stderr)
+      yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "terminating-gateway-init"))[0] | .command[2]' | tee /dev/stderr)
 
   exp='
 cat > /consul/service/service.hcl << EOF

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -22,7 +22,7 @@ load _helpers
   [ "${actual}" = "true" ]
 
   local actual=$(echo $object | yq -r '.metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "RELEASE-NAME-consul-terminating-gateway" ]
+  [ "${actual}" = "RELEASE-NAME-consul-terminating-gateway-terminating-gateway" ]
 }
 
 @test "terminatingGateways/Deployment: Adds consul service volumeMount to gateway container" {
@@ -1406,10 +1406,10 @@ EOF
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1-terminating-gateway" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2-terminating-gateway" ]
 
   local actual=$(echo $object | yq '.[0] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -1156,11 +1156,12 @@ EOF
       --set 'terminatingGateways.enabled=true' \
       --set 'connectInject.enabled=true' \
       --set 'global.acls.manageSystemACLs=true' \
+      --set 'terminatingGateways.gateways[0].name=terminating' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.spec.initContainers | map(select(.name == "terminating-gateway-init"))[0] | .command[2]' | tee /dev/stderr)
 
   exp='consul-k8s-control-plane acl-init \
-  -component-name=terminating-gateway \
+  -component-name=terminating-gateway/RELEASE-NAME-consul-terminating \
   -acl-auth-method=RELEASE-NAME-consul-k8s-component-auth-method \
   -token-sink-file=/consul/service/acl-token \
   -log-level=info \
@@ -1169,7 +1170,7 @@ EOF
 cat > /consul/service/service.hcl << EOF
 service {
   kind = "terminating-gateway"
-  name = "terminating-gateway"
+  name = "terminating"
   id = "${POD_NAME}"
   address = "${POD_IP}"
   port = 8443

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -254,6 +254,20 @@ load _helpers
   [ "${actual}" = "" ]
 }
 
+@test "terminatingGateways/Deployment: serviceAccountName is set properly" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'terminatingGateways.defaults.consulNamespace=namespace' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.serviceAccountName' | tee /dev/stderr)
+
+  [ "${actual}" = "RELEASE-NAME-consul-terminating-gateway-terminating-gateway" ]
+}
+
 #--------------------------------------------------------------------
 # global.acls.manageSystemACLs
 

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -362,7 +362,7 @@ load _helpers
       --set 'terminatingGateways.enabled=true' \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq '[.spec.template.spec.containers[0].lifecycle.preStop.exec.command[3]] | any(contains("consul-k8s-control-plane consul-logout"))' | tee /dev/stderr)
+      yq '[.spec.template.spec.containers[0].lifecycle.preStop.exec.command[3]] | any(contains("/consul-bin/consul logout"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/charts/consul/test/unit/terminating-gateways-podsecuritypolicy.bats
+++ b/charts/consul/test/unit/terminating-gateways-podsecuritypolicy.bats
@@ -43,8 +43,8 @@ load _helpers
   [ "${actual}" = "false" ]
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1-terminating-gateway" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2-terminating-gateway" ]
 }

--- a/charts/consul/test/unit/terminating-gateways-role.bats
+++ b/charts/consul/test/unit/terminating-gateways-role.bats
@@ -87,10 +87,10 @@ load _helpers
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1-terminating-gateway" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2-terminating-gateway" ]
 
   local actual=$(echo $object | yq '.[0].rules | length' | tee /dev/stderr)
   [ "${actual}" = "2" ]

--- a/charts/consul/test/unit/terminating-gateways-rolebinding.bats
+++ b/charts/consul/test/unit/terminating-gateways-rolebinding.bats
@@ -32,10 +32,10 @@ load _helpers
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1-terminating-gateway" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2-terminating-gateway" ]
 
   local actual=$(echo $object | yq '.[2] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]

--- a/charts/consul/test/unit/terminating-gateways-serviceaccount.bats
+++ b/charts/consul/test/unit/terminating-gateways-serviceaccount.bats
@@ -57,10 +57,10 @@ load _helpers
       yq -s -r '.' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.[0].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "RELEASE-NAME-consul-gateway1" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway1-terminating-gateway" ]
 
   local actual=$(echo $object | yq -r '.[1].metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "RELEASE-NAME-consul-gateway2" ]
+  [ "${actual}" = "RELEASE-NAME-consul-gateway2-terminating-gateway" ]
 
   local actual=$(echo "$object" |
       yq -r '.[2] | length > 0' | tee /dev/stderr)

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -252,7 +252,6 @@ func (c *Command) Run(args []string) int {
 		c.UI.Error(err.Error())
 		return 1
 	}
-
 	var aclReplicationToken string
 	if c.flagACLReplicationTokenFile != "" {
 		var err error
@@ -666,58 +665,19 @@ func (c *Command) Run(args []string) int {
 	}
 
 	if len(c.flagTerminatingGatewayNames) > 0 {
-		// Create a token for each terminating gateway name. Each gateway needs a
-		// separate token because users may need to attach different policies
-		// to each gateway token depending on what the services it represents
-		for _, name := range c.flagTerminatingGatewayNames {
-			if name == "" {
-				c.log.Error("Terminating gateway names cannot be empty")
-				return 1
-			}
-
-			// Parse optional namespace. This does not protect against a user
-			// that provides a namespace with namespaces not enabled.
-			var namespace string
-			if c.flagEnableNamespaces {
-				parts := strings.SplitN(strings.TrimSpace(name), ".", 2)
-				if len(parts) > 1 {
-					// Name and namespace were provided
-					name = parts[0]
-
-					// Use default namespace if provided flag is of the
-					// form "name."
-					if parts[1] != "" {
-						namespace = parts[1]
-					} else {
-						namespace = consulDefaultNamespace
-					}
-				} else {
-					// Use the default Consul namespace
-					namespace = consulDefaultNamespace
-				}
-			} else if strings.ContainsAny(name, ".") {
-				c.log.Error("Gateway names shouldn't include a namespace if Consul namespaces aren't enabled",
-					"gateway-name", name)
-				return 1
-			}
-
-			// Define the gateway rules
-			terminatingGatewayRules, err := c.terminatingGatewayRules(name, namespace)
-			if err != nil {
-				c.log.Error("Error templating terminating gateway rules", "gateway-name", name,
-					"namespace", namespace, "err", err)
-				return 1
-			}
-
-			// The names in the Helm chart are specified by users and so may not contain
-			// the words "ingress-gateway". We need to create unique names for tokens
-			// across all gateway types and so must suffix with `-terminating-gateway`.
-			tokenName := fmt.Sprintf("%s-terminating-gateway", name)
-			err = c.createLocalACL(tokenName, terminatingGatewayRules, consulDC, primary, consulClient)
-			if err != nil {
-				c.log.Error(err.Error())
-				return 1
-			}
+		params := ConfigureGatewayParams{
+			GatewayType:    "terminating",
+			GatewayNames:   c.flagTerminatingGatewayNames,
+			AuthMethodName: localComponentAuthMethodName,
+			RulesGenerator: c.terminatingGatewayRules,
+			ConsulDC:       consulDC,
+			PrimaryDC:      primaryDC,
+			Primary:        primary,
+		}
+		err := c.configureGateway(params, consulClient)
+		if err != nil {
+			c.log.Error(err.Error())
+			return 1
 		}
 	}
 
@@ -802,6 +762,91 @@ func (c *Command) createAuthMethod(consulClient *api.Client, authMethod *api.ACL
 			_, _, err = consulClient.ACL().AuthMethodCreate(authMethod, writeOptions)
 			return err
 		})
+}
+
+type gatewayRulesGenerator func(name, namespace string) (string, error)
+
+// ConfigureGatewayParams are parameters used to configure Ingress and Terminating Gateways.
+type ConfigureGatewayParams struct {
+	//GatewayType specifies whether it is an ingress or terminating gateway
+	GatewayType string
+	//GatewayNames is the collection of gateways that have been specified.
+	GatewayNames []string
+	//AuthMethodName is the authmethod for which to register the binding rules and policies for the gateways
+	AuthMethodName string
+	//RuleGenerator is the function that supplies the rules that will be added to the policy.
+	RulesGenerator gatewayRulesGenerator
+	//ConsulDC is the name of the DC where the gateways will be registered
+	ConsulDC string
+	//PrimaryDC is the name of the Primary Data Center
+	PrimaryDC string
+	//Primary specifies whether the ConsulDC is the Primary Data Center
+	Primary bool
+}
+
+func (c *Command) configureGateway(gatewayParams ConfigureGatewayParams, consulClient *api.Client) error {
+	// Create a token for each gateway name. Each gateway needs a
+	// separate token because users may need to attach different policies
+	// to each gateway token depending on what the services it represents
+	for _, name := range gatewayParams.GatewayNames {
+		if name == "" {
+			errMessage := fmt.Sprintf("%s gateway names cannot be empty",
+				strings.Title(strings.ToLower(gatewayParams.GatewayType)))
+			c.log.Error(errMessage)
+			return errors.New(errMessage)
+		}
+
+		// Parse optional namespace, erroring if a user
+		// provides a namespace when not enabling namespaces.
+		var namespace string
+		if c.flagEnableNamespaces {
+			parts := strings.SplitN(strings.TrimSpace(name), ".", 2)
+			if len(parts) > 1 {
+				// Name and namespace were provided
+				name = parts[0]
+
+				// Use default namespace if provided flag is of the
+				// form "name."
+				if parts[1] != "" {
+					namespace = parts[1]
+				} else {
+					namespace = consulDefaultNamespace
+				}
+			} else {
+				// Use the default Consul namespace
+				namespace = consulDefaultNamespace
+			}
+		} else if strings.ContainsAny(name, ".") {
+			errMessage := "Gateway names shouldn't include a namespace if Consul namespaces aren't enabled"
+			c.log.Error(errMessage, "gateway-name", name)
+			return errors.New(errMessage)
+		}
+
+		// Define the gateway rules
+		rules, err := gatewayParams.RulesGenerator(name, namespace)
+		if err != nil {
+
+			errMessage := fmt.Sprintf("Error templating %s gateway rules",
+				gatewayParams.GatewayType)
+			c.log.Error(errMessage, "gateway-name", name,
+				"namespace", namespace, "err", err)
+			return errors.New(errMessage)
+		}
+
+		// The names in the Helm chart are specified by users and so may not contain
+		// the words "ingress-gateway" or "terminating-gateway". We need to create unique names for tokens
+		// across all gateway types and so must suffix with either `-ingress-gateway` of `-terminating-gateway`.
+		componentName := fmt.Sprintf("%s-%s-gateway", name, gatewayParams.GatewayType)
+		serviceAccountName := c.withPrefix(name)
+		err = c.createACLPolicyRoleAndBindingRule(componentName, rules,
+			gatewayParams.ConsulDC, gatewayParams.PrimaryDC, localPolicy,
+			gatewayParams.Primary, gatewayParams.AuthMethodName, serviceAccountName, consulClient)
+		if err != nil {
+			c.log.Error(err.Error())
+			return err
+		}
+	}
+	return nil
 }
 
 // getBootstrapToken returns the existing bootstrap token if there is one by

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -817,7 +817,7 @@ func (c *Command) configureGateway(gatewayParams ConfigureGatewayParams, consulC
 				namespace = consulDefaultNamespace
 			}
 		} else if strings.ContainsAny(name, ".") {
-			errMessage := "Gateway names shouldn't include a namespace if Consul namespaces aren't enabled"
+			errMessage := "gateway names shouldn't include a namespace if Consul namespaces aren't enabled"
 			c.log.Error(errMessage, "gateway-name", name)
 			return errors.New(errMessage)
 		}

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -785,9 +785,9 @@ type ConfigureGatewayParams struct {
 }
 
 func (c *Command) configureGateway(gatewayParams ConfigureGatewayParams, consulClient *api.Client) error {
-	// Create a token for each gateway name. Each gateway needs a
-	// separate token because users may need to attach different policies
-	// to each gateway token depending on what the services it represents
+	// Each gateway needs to be configured
+	// separately because users may need to attach different policies
+	// to each gateway role depending on what services it represents.
 	for _, name := range gatewayParams.GatewayNames {
 		if name == "" {
 			errMessage := fmt.Sprintf("%s gateway names cannot be empty",

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -836,9 +836,8 @@ func (c *Command) configureGateway(gatewayParams ConfigureGatewayParams, consulC
 		// The names in the Helm chart are specified by users and so may not contain
 		// the words "ingress-gateway" or "terminating-gateway". We need to create unique names for tokens
 		// across all gateway types and so must suffix with either `-ingress-gateway` of `-terminating-gateway`.
-		componentName := fmt.Sprintf("%s-%s-gateway", name, gatewayParams.GatewayType)
-		serviceAccountName := c.withPrefix(name)
-		err = c.createACLPolicyRoleAndBindingRule(componentName, rules,
+		serviceAccountName := c.withPrefix(fmt.Sprintf("%s-%s", name, fmt.Sprintf("%s-gateway", gatewayParams.GatewayType)))
+		err = c.createACLPolicyRoleAndBindingRule(serviceAccountName, rules,
 			gatewayParams.ConsulDC, gatewayParams.PrimaryDC, localPolicy,
 			gatewayParams.Primary, gatewayParams.AuthMethodName, serviceAccountName, consulClient)
 		if err != nil {

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -768,7 +768,7 @@ type gatewayRulesGenerator func(name, namespace string) (string, error)
 
 // ConfigureGatewayParams are parameters used to configure Ingress and Terminating Gateways.
 type ConfigureGatewayParams struct {
-	//GatewayType specifies whether it is an ingress or terminating gateway
+	// GatewayType specifies whether it is an ingress or terminating gateway.
 	GatewayType string
 	//GatewayNames is the collection of gateways that have been specified.
 	GatewayNames []string

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -790,7 +790,7 @@ func (c *Command) configureGateway(gatewayParams ConfigureGatewayParams, consulC
 	// to each gateway role depending on what services it represents.
 	for _, name := range gatewayParams.GatewayNames {
 		if name == "" {
-			errMessage := fmt.Sprintf("%s gateway names cannot be empty",
+			errMessage := fmt.Sprintf("%s gateway name cannot be empty",
 				strings.Title(strings.ToLower(gatewayParams.GatewayType)))
 			c.log.Error(errMessage)
 			return errors.New(errMessage)

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -826,7 +826,7 @@ func (c *Command) configureGateway(gatewayParams ConfigureGatewayParams, consulC
 		rules, err := gatewayParams.RulesGenerator(name, namespace)
 		if err != nil {
 
-			errMessage := fmt.Sprintf("Error templating %s gateway rules",
+			errMessage := fmt.Sprintf("error templating %s gateway rules",
 				gatewayParams.GatewayType)
 			c.log.Error(errMessage, "gateway-name", name,
 				"namespace", namespace, "err", err)

--- a/control-plane/subcommand/server-acl-init/command_ent_test.go
+++ b/control-plane/subcommand/server-acl-init/command_ent_test.go
@@ -335,8 +335,8 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 				"enterprise-license-token",
 				"gw-ingress-gateway-token",
 				"anothergw-ingress-gateway-token",
-				"gw-terminating-gateway-token",
-				"anothergw-terminating-gateway-token",
+				"gw-terminating-gateway-policy",
+				"anothergw-terminating-gateway-policy",
 				"connect-inject-policy",
 				"controller-policy",
 			}
@@ -388,8 +388,8 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 				"cross-namespace-policy",
 				"gw-ingress-gateway-token",
 				"anothergw-ingress-gateway-token",
-				"gw-terminating-gateway-token",
-				"anothergw-terminating-gateway-token",
+				"gw-terminating-gateway-policy",
+				"anothergw-terminating-gateway-policy",
 				"controller-policy",
 				"partitions-token",
 			}
@@ -692,19 +692,6 @@ func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
 				resourcePrefix + "-another-gateway-ingress-gateway-acl-token"},
 			LocalToken: true,
 		},
-		"terminating gateway tokens": {
-			TokenFlags: []string{"-terminating-gateway-name=terminating",
-				"-terminating-gateway-name=gateway",
-				"-terminating-gateway-name=another-gateway"},
-			PolicyNames: []string{"terminating-terminating-gateway-token",
-				"gateway-terminating-gateway-token",
-				"another-gateway-terminating-gateway-token"},
-			PolicyDCs: []string{"dc1"},
-			SecretNames: []string{resourcePrefix + "-terminating-terminating-gateway-acl-token",
-				resourcePrefix + "-gateway-terminating-gateway-acl-token",
-				resourcePrefix + "-another-gateway-terminating-gateway-acl-token"},
-			LocalToken: true,
-		},
 		"acl-replication token": {
 			TokenFlags:  []string{"-create-acl-replication-token"},
 			PolicyNames: []string{"acl-replication-token"},
@@ -900,9 +887,9 @@ partition "default" {
 			TokenFlags: []string{"-terminating-gateway-name=terminating",
 				"-terminating-gateway-name=gateway",
 				"-terminating-gateway-name=another-gateway"},
-			PolicyNames: []string{"terminating-terminating-gateway-token",
-				"gateway-terminating-gateway-token",
-				"another-gateway-terminating-gateway-token"},
+			PolicyNames: []string{"terminating-terminating-gateway-policy",
+				"gateway-terminating-gateway-policy",
+				"another-gateway-terminating-gateway-policy"},
 			ExpectedPolicies: []string{`
 partition "default" {
   namespace "default" {
@@ -940,9 +927,9 @@ partition "default" {
 			TokenFlags: []string{"-terminating-gateway-name=terminating.",
 				"-terminating-gateway-name=gateway.namespace1",
 				"-terminating-gateway-name=another-gateway.namespace2"},
-			PolicyNames: []string{"terminating-terminating-gateway-token",
-				"gateway-terminating-gateway-token",
-				"another-gateway-terminating-gateway-token"},
+			PolicyNames: []string{"terminating-terminating-gateway-policy",
+				"gateway-terminating-gateway-policy",
+				"another-gateway-terminating-gateway-policy"},
 			ExpectedPolicies: []string{`
 partition "default" {
   namespace "default" {

--- a/control-plane/subcommand/server-acl-init/command_ent_test.go
+++ b/control-plane/subcommand/server-acl-init/command_ent_test.go
@@ -335,8 +335,8 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 				"enterprise-license-token",
 				"gw-ingress-gateway-token",
 				"anothergw-ingress-gateway-token",
-				"gw-terminating-gateway-policy",
-				"anothergw-terminating-gateway-policy",
+				resourcePrefix + "-gw-terminating-gateway-policy",
+				resourcePrefix + "-anothergw-terminating-gateway-policy",
 				"connect-inject-policy",
 				"controller-policy",
 			}
@@ -388,8 +388,8 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 				"cross-namespace-policy",
 				"gw-ingress-gateway-token",
 				"anothergw-ingress-gateway-token",
-				"gw-terminating-gateway-policy",
-				"anothergw-terminating-gateway-policy",
+				resourcePrefix + "-gw-terminating-gateway-policy",
+				resourcePrefix + "-anothergw-terminating-gateway-policy",
 				"controller-policy",
 				"partitions-token",
 			}
@@ -887,9 +887,9 @@ partition "default" {
 			TokenFlags: []string{"-terminating-gateway-name=terminating",
 				"-terminating-gateway-name=gateway",
 				"-terminating-gateway-name=another-gateway"},
-			PolicyNames: []string{"terminating-terminating-gateway-policy",
-				"gateway-terminating-gateway-policy",
-				"another-gateway-terminating-gateway-policy"},
+			PolicyNames: []string{resourcePrefix + "-terminating-terminating-gateway-policy",
+				resourcePrefix + "-gateway-terminating-gateway-policy",
+				resourcePrefix + "-another-gateway-terminating-gateway-policy"},
 			ExpectedPolicies: []string{`
 partition "default" {
   namespace "default" {
@@ -927,9 +927,9 @@ partition "default" {
 			TokenFlags: []string{"-terminating-gateway-name=terminating.",
 				"-terminating-gateway-name=gateway.namespace1",
 				"-terminating-gateway-name=another-gateway.namespace2"},
-			PolicyNames: []string{"terminating-terminating-gateway-policy",
-				"gateway-terminating-gateway-policy",
-				"another-gateway-terminating-gateway-policy"},
+			PolicyNames: []string{resourcePrefix + "-terminating-terminating-gateway-policy",
+				resourcePrefix + "-gateway-terminating-gateway-policy",
+				resourcePrefix + "-another-gateway-terminating-gateway-policy"},
 			ExpectedPolicies: []string{`
 partition "default" {
   namespace "default" {

--- a/control-plane/subcommand/server-acl-init/command_test.go
+++ b/control-plane/subcommand/server-acl-init/command_test.go
@@ -2450,7 +2450,7 @@ func TestRun_ValidateLoginToken_PrimaryDatacenter(t *testing.T) {
 			GlobalToken:   false,
 		},
 		{
-			ComponentName: "terminating gateway",
+			ComponentName: "terminating-gateway",
 			TokenFlags: []string{"-terminating-gateway-name=terminating",
 				"-terminating-gateway-name=gateway",
 				"-terminating-gateway-name=another-gateway"},
@@ -2504,18 +2504,20 @@ func TestRun_ValidateLoginToken_PrimaryDatacenter(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			tok, _, err := client.ACL().Login(&api.ACLLoginParams{
-				AuthMethod:  authMethodName,
-				BearerToken: jwtToken,
-				Meta:        map[string]string{},
-			}, &api.WriteOptions{})
-			require.NoError(t, err)
+			if len(c.Roles) == 1 {
+				tok, _, err := client.ACL().Login(&api.ACLLoginParams{
+					AuthMethod:  authMethodName,
+					BearerToken: jwtToken,
+					Meta:        map[string]string{},
+				}, &api.WriteOptions{})
+				require.NoError(t, err)
 
-			require.Equal(t, len(tok.Roles), len(c.Roles))
-			for _, role := range tok.Roles {
-				require.Contains(t, c.Roles, role.Name)
+				require.Equal(t, len(tok.Roles), len(c.Roles))
+				for _, role := range tok.Roles {
+					require.Contains(t, c.Roles, role.Name)
+				}
+				require.Equal(t, !c.GlobalToken, tok.Local)
 			}
-			require.Equal(t, !c.GlobalToken, tok.Local)
 
 		})
 	}


### PR DESCRIPTION
Changes proposed in this PR:
- change terminating gateway deployment to pass `acl-auth-method` so it can properly call Consul login.
- add prestop for logout to terminating gateway container.
- refactor logic from `server-acl-init` command for terminating gateway so that it can also be used for upcoming ingress gateway work.

How I've tested this PR:
- unit tests
- acceptance tests

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 

