### PR TITLE
Adding ability to mount extra volumes to the server-acl-init job

### DIFF
--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -61,8 +61,17 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-server-acl-init
-      {{- if (or .Values.global.tls.enabled .Values.global.acls.replicationToken.secretName (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey)) }}
+      {{- if (or .Values.global.tls.enabled .Values.global.acls.replicationToken.secretName (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey) .Values.externalServers.aclInit.extraVolumes) }}
       volumes:
+        {{- range .Values.externalServers.aclInit.extraVolumes }}
+        - name: userconfig-{{ .name }}
+          {{ .type }}:
+            {{- if (eq .type "configMap") }}
+            name: {{ .name }}
+            {{- else if (eq .type "secret") }}
+            secretName: {{ .name }}
+            {{- end }}
+        {{- end }}
         {{- if and .Values.global.tls.enabled (not .Values.global.secretsBackend.vault.enabled) }}
         - name: consul-ca-cert
           secret:
@@ -99,8 +108,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          {{- if (or .Values.global.tls.enabled .Values.global.acls.replicationToken.secretName (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey)) }}
+          {{- if (or .Values.global.tls.enabled .Values.global.acls.replicationToken.secretName (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey) .Values.externalServers.aclInit.extraVolumes) }}
           volumeMounts:
+            {{- range .Values.externalServers.aclInit.extraVolumes }}
+            - name: userconfig-{{ .name }}
+              readOnly: true
+              mountPath: /consul/userconfig/{{ .name }}
+            {{- end }}
             {{- if and .Values.global.tls.enabled (not .Values.global.secretsBackend.vault.enabled) }}
             - name: consul-ca-cert
               mountPath: /consul/tls/ca

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -434,7 +434,7 @@ global:
     primaryDatacenter: ""
 
     # A list of addresses of the primary mesh gateways in the form `<ip>:<port>`.
-    # (e.g. ["1.1.1.1:443", "2.3.4.5:443"] 
+    # (e.g. ["1.1.1.1:443", "2.3.4.5:443"]
     # @type: array<string>
     primaryGateways: []
 
@@ -558,7 +558,7 @@ server:
   #
   # Vault Secrets backend:
   # If you are using Vault as a secrets backend, a Vault Policy must be created which allows `["create", "update"]`
-  # capabilities on the PKI issuing endpoint, which is usually of the form `pki/issue/consul-server`. 
+  # capabilities on the PKI issuing endpoint, which is usually of the form `pki/issue/consul-server`.
   # Please see the following guide for steps to generate a compatible certificate:
   # https://learn.hashicorp.com/tutorials/consul/vault-pki-consul-secure-tls
   # Note: when using TLS, both the `server.serverCert` and `global.tls.caCert` which points to the CA endpoint of this PKI engine
@@ -933,6 +933,36 @@ externalServers:
   #
   # @type: string
   k8sAuthMethodHost: null
+
+  # Values that configure the server-acl-init-job
+  aclInit:
+    # A list of extra volumes to mount to the server-acl-init-job. This
+    # is useful for bringing in extra data that can be referenced by other configurations
+    # at a well known path, such as kubeconfig. The
+    # value of this should be a list of objects.
+    #
+    # Example:
+    #
+    # ```yaml
+    # extraVolumes:
+    #   - type: secret
+    #     name: consul-certs
+    #     load: false
+    # ```
+    #
+    # Each object supports the following keys:
+    #
+    # - `type` - Type of the volume, must be one of "configMap" or "secret". Case sensitive.
+    #
+    # - `name` - Name of the configMap or secret to be mounted. This also controls
+    #   the path that it is mounted to. The volume will be mounted to `/consul/userconfig/<name>`.
+    #
+    # - `load` - If true, then the agent will be
+    #   configured to automatically load HCL/JSON configuration files from this volume
+    #   with `-config-dir`. This defaults to false.
+    #
+    # @type: array<map>
+    extraVolumes: []
 
 # Values that configure running a Consul client on Kubernetes nodes.
 client:
@@ -1796,7 +1826,7 @@ connectInject:
   # This setting can be safely disabled by setting to "Ignore".
   failurePolicy: "Fail"
 
-  # Selector for restricting the webhook to only specific namespaces. 
+  # Selector for restricting the webhook to only specific namespaces.
   # Use with `connectInject.default: true` to automatically inject all pods in namespaces that match the selector. This should be set to a multiline string.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
   # for more details.


### PR DESCRIPTION
Changes proposed in this PR:
Adding ability to mount extra volumes to the server-acl-init job of the helm chart


Checklist:
- [ x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

