### PR TITLE
[RelAPI Onboarding] Add release API metadata file

### DIFF
--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,0 +1,4 @@
+url_docker_registry_dockerhub = "https://hub.docker.com/r/hashicorp/consul-k8s"
+url_license = "https://github.com/hashicorp/consul-k8s/blob/main/LICENSE.md"
+url_project_website = "https://www.consul.io/docs/k8s"
+url_source_repository = "https://github.com/hashicorp/consul-k8s"


### PR DESCRIPTION
👋  This PR adds a `.release/release-metadata.hcl` file to the repo. This contains static metadata that will be processed and sent as part of the payload in RelAPI POST requests, which will be sent when staging and production releases are triggered.  

This can be merged now, but will not have any effect until after the RelAPI launch. Similar additions are being added across all projects that publish to releases.hashicorp.com.