### PR TITLE
Adding ability to populate -init-auth-method from a secret

### DIFF
--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -99,6 +99,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- if .Values.externalServers.k8sAuthMethodHostSecretName }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.externalServers.k8sAuthMethodHostSecretName }}
+          {{- end }}
           {{- if (or .Values.global.tls.enabled .Values.global.acls.replicationToken.secretName (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey)) }}
           volumeMounts:
             {{- if and .Values.global.tls.enabled (not .Values.global.secretsBackend.vault.enabled) }}
@@ -175,6 +180,8 @@ spec:
                 -create-inject-token=true \
                 {{- if and .Values.externalServers.enabled .Values.externalServers.k8sAuthMethodHost }}
                 -inject-auth-method-host={{ .Values.externalServers.k8sAuthMethodHost }} \
+                {{- else if and .Values.externalServers.enabled .Values.externalServers.k8sAuthMethodHostSecretName }}
+                -inject-auth-method-host=${K8S_API_SERVER_ENDPOINT} \
                 {{- end }}
                 {{- end }}
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -434,7 +434,7 @@ global:
     primaryDatacenter: ""
 
     # A list of addresses of the primary mesh gateways in the form `<ip>:<port>`.
-    # (e.g. ["1.1.1.1:443", "2.3.4.5:443"] 
+    # (e.g. ["1.1.1.1:443", "2.3.4.5:443"]
     # @type: array<string>
     primaryGateways: []
 
@@ -558,7 +558,7 @@ server:
   #
   # Vault Secrets backend:
   # If you are using Vault as a secrets backend, a Vault Policy must be created which allows `["create", "update"]`
-  # capabilities on the PKI issuing endpoint, which is usually of the form `pki/issue/consul-server`. 
+  # capabilities on the PKI issuing endpoint, which is usually of the form `pki/issue/consul-server`.
   # Please see the following guide for steps to generate a compatible certificate:
   # https://learn.hashicorp.com/tutorials/consul/vault-pki-consul-secure-tls
   # Note: when using TLS, both the `server.serverCert` and `global.tls.caCert` which points to the CA endpoint of this PKI engine
@@ -933,6 +933,10 @@ externalServers:
   #
   # @type: string
   k8sAuthMethodHost: null
+
+  # Alternatively, specify a secret to pull the K8S_API_SERVER_ENDPOINT environment variable from
+  # and use that to define the address of the Kubernetes API server.
+  k8sAuthMethodSecretName: null
 
 # Values that configure running a Consul client on Kubernetes nodes.
 client:
@@ -1796,7 +1800,7 @@ connectInject:
   # This setting can be safely disabled by setting to "Ignore".
   failurePolicy: "Fail"
 
-  # Selector for restricting the webhook to only specific namespaces. 
+  # Selector for restricting the webhook to only specific namespaces.
   # Use with `connectInject.default: true` to automatically inject all pods in namespaces that match the selector. This should be set to a multiline string.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
   # for more details.


### PR DESCRIPTION
Changes proposed in this PR:
https://github.com/hashicorp/consul-k8s/issues/1129

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

