### PR TITLE
Adding Acceptance test for Auto Reload Config

### DIFF
--- a/acceptance/framework/consul/cli_cluster.go
+++ b/acceptance/framework/consul/cli_cluster.go
@@ -194,7 +194,7 @@ func (c *CLICluster) Destroy(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func (c *CLICluster) SetupConsulClient(t *testing.T, secure bool) *api.Client {
+func (c *CLICluster) SetupConsulClient(t *testing.T, secure bool) (*api.Client, string) {
 	t.Helper()
 
 	namespace := c.kubectlOptions.Namespace
@@ -264,7 +264,7 @@ func (c *CLICluster) SetupConsulClient(t *testing.T, secure bool) *api.Client {
 	consulClient, err := api.NewClient(config)
 	require.NoError(t, err)
 
-	return consulClient
+	return consulClient, config.Address
 }
 
 func createOrUpdateNamespace(t *testing.T, client kubernetes.Interface, namespace string) {

--- a/acceptance/framework/consul/cluster.go
+++ b/acceptance/framework/consul/cluster.go
@@ -9,7 +9,7 @@ import (
 // Cluster represents a consul cluster object.
 type Cluster interface {
 	// SetupConsulClient returns a new Consul client.
-	SetupConsulClient(t *testing.T, secure bool) *api.Client
+	SetupConsulClient(t *testing.T, secure bool) (*api.Client, string)
 
 	// Create creates a new Consul Cluster.
 	Create(t *testing.T)

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -211,12 +211,38 @@ func (h *HelmCluster) Upgrade(t *testing.T, helmValues map[string]string) {
 	k8s.WaitForAllPodsToBeReady(t, h.kubernetesClient, h.helmOptions.KubectlOptions.Namespace, fmt.Sprintf("release=%s", h.releaseName))
 }
 
+func (h *HelmCluster) CreatePortForwardTunnel(t *testing.T, remotePort int) string {
+	localPort := terratestk8s.GetAvailablePort(t)
+	serverPod := fmt.Sprintf("%s-consul-server-0", h.releaseName)
+	tunnel := terratestk8s.NewTunnelWithLogger(
+		h.helmOptions.KubectlOptions,
+		terratestk8s.ResourceTypePod,
+		serverPod,
+		localPort,
+		remotePort,
+		h.logger)
+
+	// Retry creating the port forward since it can fail occasionally.
+	retry.RunWith(&retry.Counter{Wait: 1 * time.Second, Count: 3}, t, func(r *retry.R) {
+		// NOTE: It's okay to pass in `t` to ForwardPortE despite being in a retry
+		// because we're using ForwardPortE (not ForwardPort) so the `t` won't
+		// get used to fail the test, just for logging.
+		require.NoError(r, tunnel.ForwardPortE(t))
+	})
+
+	t.Cleanup(func() {
+		tunnel.Close()
+	})
+
+	return fmt.Sprintf("127.0.0.1:%d", localPort)
+
+}
+
 func (h *HelmCluster) SetupConsulClient(t *testing.T, secure bool) (*api.Client, string) {
 	t.Helper()
 
 	namespace := h.helmOptions.KubectlOptions.Namespace
 	config := api.DefaultConfig()
-	localPort := terratestk8s.GetAvailablePort(t)
 	remotePort := 8500 // use non-secure by default
 
 	if secure {
@@ -250,28 +276,7 @@ func (h *HelmCluster) SetupConsulClient(t *testing.T, secure bool) (*api.Client,
 		}
 	}
 
-	serverPod := fmt.Sprintf("%s-consul-server-0", h.releaseName)
-	tunnel := terratestk8s.NewTunnelWithLogger(
-		h.helmOptions.KubectlOptions,
-		terratestk8s.ResourceTypePod,
-		serverPod,
-		localPort,
-		remotePort,
-		h.logger)
-
-	// Retry creating the port forward since it can fail occasionally.
-	retry.RunWith(&retry.Counter{Wait: 1 * time.Second, Count: 3}, t, func(r *retry.R) {
-		// NOTE: It's okay to pass in `t` to ForwardPortE despite being in a retry
-		// because we're using ForwardPortE (not ForwardPort) so the `t` won't
-		// get used to fail the test, just for logging.
-		require.NoError(r, tunnel.ForwardPortE(t))
-	})
-
-	t.Cleanup(func() {
-		tunnel.Close()
-	})
-
-	config.Address = fmt.Sprintf("127.0.0.1:%d", localPort)
+	config.Address = h.CreatePortForwardTunnel(t, remotePort)
 	consulClient, err := api.NewClient(config)
 	require.NoError(t, err)
 

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -211,7 +211,7 @@ func (h *HelmCluster) Upgrade(t *testing.T, helmValues map[string]string) {
 	k8s.WaitForAllPodsToBeReady(t, h.kubernetesClient, h.helmOptions.KubectlOptions.Namespace, fmt.Sprintf("release=%s", h.releaseName))
 }
 
-func (h *HelmCluster) SetupConsulClient(t *testing.T, secure bool) *api.Client {
+func (h *HelmCluster) SetupConsulClient(t *testing.T, secure bool) (*api.Client, string) {
 	t.Helper()
 
 	namespace := h.helmOptions.KubectlOptions.Namespace
@@ -275,7 +275,7 @@ func (h *HelmCluster) SetupConsulClient(t *testing.T, secure bool) *api.Client {
 	consulClient, err := api.NewClient(config)
 	require.NoError(t, err)
 
-	return consulClient
+	return consulClient, config.Address
 }
 
 // configurePodSecurityPolicies creates a simple pod security policy, a cluster role to allow access to the PSP,

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -238,7 +238,7 @@ func (h *HelmCluster) CreatePortForwardTunnel(t *testing.T, remotePort int) stri
 
 }
 
-func (h *HelmCluster) SetupConsulClient(t *testing.T, secure bool) (*api.Client, string) {
+func (h *HelmCluster) SetupConsulClient(t *testing.T, secure bool) (client *api.Client, configAddress string) {
 	t.Helper()
 
 	namespace := h.helmOptions.KubectlOptions.Namespace

--- a/acceptance/framework/vault/helpers.go
+++ b/acceptance/framework/vault/helpers.go
@@ -190,8 +190,11 @@ func ConfigurePKICA(t *testing.T, vaultClient *vapi.Client) {
 
 // ConfigurePKICertificates configures roles in Vault so that Consul server TLS certificates
 // can be issued by Vault.
-func ConfigurePKICertificates(t *testing.T, vaultClient *vapi.Client, consulReleaseName, ns, datacenter string) string {
+func ConfigurePKICertificates(t *testing.T, vaultClient *vapi.Client, consulReleaseName, ns, datacenter string, maxTtl string) string {
 	// Create the Vault PKI Role.
+	if maxTtl == "" {
+		maxTtl = "1h"
+	}
 	consulServerDNSName := consulReleaseName + "-consul-server"
 	allowedDomains := fmt.Sprintf("%s.consul,%s,%s.%s,%s.%s.svc", datacenter, consulServerDNSName, consulServerDNSName, ns, consulServerDNSName, ns)
 	params := map[string]interface{}{
@@ -200,7 +203,7 @@ func ConfigurePKICertificates(t *testing.T, vaultClient *vapi.Client, consulRele
 		"allow_localhost":    "true",
 		"allow_subdomains":   "true",
 		"generate_lease":     "true",
-		"max_ttl":            "1h",
+		"max_ttl":            maxTtl,
 	}
 
 	pkiRoleName := fmt.Sprintf("server-cert-%s", datacenter)

--- a/acceptance/framework/vault/helpers.go
+++ b/acceptance/framework/vault/helpers.go
@@ -190,11 +190,7 @@ func ConfigurePKICA(t *testing.T, vaultClient *vapi.Client) {
 
 // ConfigurePKICertificates configures roles in Vault so that Consul server TLS certificates
 // can be issued by Vault.
-func ConfigurePKICertificates(t *testing.T, vaultClient *vapi.Client, consulReleaseName, ns, datacenter string, maxTtl string) string {
-	// Create the Vault PKI Role.
-	if maxTtl == "" {
-		maxTtl = "1h"
-	}
+func ConfigurePKICertificates(t *testing.T, vaultClient *vapi.Client, consulReleaseName, ns, datacenter string, maxTTL string) string {
 	consulServerDNSName := consulReleaseName + "-consul-server"
 	allowedDomains := fmt.Sprintf("%s.consul,%s,%s.%s,%s.%s.svc", datacenter, consulServerDNSName, consulServerDNSName, ns, consulServerDNSName, ns)
 	params := map[string]interface{}{
@@ -203,7 +199,7 @@ func ConfigurePKICertificates(t *testing.T, vaultClient *vapi.Client, consulRele
 		"allow_localhost":    "true",
 		"allow_subdomains":   "true",
 		"generate_lease":     "true",
-		"max_ttl":            maxTtl,
+		"max_ttl":            maxTTL,
 	}
 
 	pkiRoleName := fmt.Sprintf("server-cert-%s", datacenter)

--- a/acceptance/tests/basic/basic_test.go
+++ b/acceptance/tests/basic/basic_test.go
@@ -51,7 +51,7 @@ func TestBasicInstallation(t *testing.T) {
 
 			consulCluster.Create(t)
 
-			client := consulCluster.SetupConsulClient(t, c.secure)
+			client, _ := consulCluster.SetupConsulClient(t, c.secure)
 
 			// Create a KV entry
 			randomKey := helpers.RandomName()

--- a/acceptance/tests/connect/connect_helper.go
+++ b/acceptance/tests/connect/connect_helper.go
@@ -68,7 +68,7 @@ func (c *ConnectHelper) Setup(t *testing.T) {
 func (c *ConnectHelper) Install(t *testing.T) {
 	logger.Log(t, "Installing Consul cluster")
 	c.consulCluster.Create(t)
-	c.consulClient = c.consulCluster.SetupConsulClient(t, c.Secure)
+	c.consulClient, _ = c.consulCluster.SetupConsulClient(t, c.Secure)
 }
 
 // Upgrade uses the existing Consul cluster and upgrades it using Helm values

--- a/acceptance/tests/connect/connect_inject_namespaces_test.go
+++ b/acceptance/tests/connect/connect_inject_namespaces_test.go
@@ -108,7 +108,7 @@ func TestConnectInjectNamespaces(t *testing.T) {
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "ns", staticClientNamespace)
 			})
 
-			consulClient := consulCluster.SetupConsulClient(t, c.secure)
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
 
 			serverQueryOpts := &api.QueryOptions{Namespace: staticServerNamespace}
 			clientQueryOpts := &api.QueryOptions{Namespace: staticClientNamespace}
@@ -313,7 +313,7 @@ func TestConnectInjectNamespaces_CleanupController(t *testing.T) {
 			k8s.DeployKustomize(t, staticClientOpts, cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-namespaces")
 
 			logger.Log(t, "waiting for static-client to be registered with Consul")
-			consulClient := consulCluster.SetupConsulClient(t, c.secure)
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
 			expectedConsulNS := staticClientNamespace
 			if !c.mirrorK8S {
 				expectedConsulNS = c.destinationNamespace

--- a/acceptance/tests/connect/connect_inject_test.go
+++ b/acceptance/tests/connect/connect_inject_test.go
@@ -179,7 +179,7 @@ func TestConnectInject_CleanupKilledPods(t *testing.T) {
 			k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-inject")
 
 			logger.Log(t, "waiting for static-client to be registered with Consul")
-			consulClient := consulCluster.SetupConsulClient(t, c.secure)
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
 			retry.Run(t, func(r *retry.R) {
 				for _, name := range []string{"static-client", "static-client-sidecar-proxy"} {
 					instances, _, err := consulClient.Catalog().Service(name, "", nil)
@@ -301,7 +301,7 @@ func TestConnectInject_MultiportServices(t *testing.T) {
 
 			consulCluster.Create(t)
 
-			consulClient := consulCluster.SetupConsulClient(t, c.secure)
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
 
 			// Check that the ACL token is deleted.
 			if c.secure {

--- a/acceptance/tests/controller/controller_namespaces_test.go
+++ b/acceptance/tests/controller/controller_namespaces_test.go
@@ -114,7 +114,7 @@ func TestControllerNamespaces(t *testing.T) {
 			defaultOpts := &api.QueryOptions{
 				Namespace: DefaultConsulNamespace,
 			}
-			consulClient := consulCluster.SetupConsulClient(t, c.secure)
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
 
 			// Test creation.
 			{

--- a/acceptance/tests/controller/controller_test.go
+++ b/acceptance/tests/controller/controller_test.go
@@ -49,7 +49,7 @@ func TestController(t *testing.T) {
 			consulCluster := consul.NewHelmCluster(t, helmValues, ctx, cfg, releaseName)
 
 			consulCluster.Create(t)
-			consulClient := consulCluster.SetupConsulClient(t, c.secure)
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
 
 			// Test creation.
 			{

--- a/acceptance/tests/example/example_test.go
+++ b/acceptance/tests/example/example_test.go
@@ -54,7 +54,7 @@ func TestExample(t *testing.T) {
 
 	// To make Consul API calls, you can get the Consul client from the consulCluster object,
 	// indicating whether the client needs to be secure or not (i.e. whether TLS and ACLs are enabled on the Consul cluster):
-	consulClient := consulCluster.SetupConsulClient(t, true)
+	consulClient, _ := consulCluster.SetupConsulClient(t, true)
 	consulServices, _, err := consulClient.Catalog().Services(nil)
 	require.NoError(t, err)
 	require.NotNil(t, consulServices)

--- a/acceptance/tests/ingress-gateway/ingress_gateway_namespaces_test.go
+++ b/acceptance/tests/ingress-gateway/ingress_gateway_namespaces_test.go
@@ -58,7 +58,7 @@ func TestIngressGatewaySingleNamespace(t *testing.T) {
 
 			consulCluster.Create(t)
 
-			consulClient := consulCluster.SetupConsulClient(t, c.secure)
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
 
 			// Create the destination namespace in the non-secure case.
 			// In the secure installation, this namespace is created by the server-acl-init job.
@@ -223,7 +223,7 @@ func TestIngressGatewayNamespaceMirroring(t *testing.T) {
 			logger.Logf(t, "creating static-client in %s namespace", testNamespace)
 			k8s.DeployKustomize(t, nsK8SOptions, cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/bases/static-client")
 
-			consulClient := consulCluster.SetupConsulClient(t, c.secure)
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
 
 			// With the cluster up, we can create our ingress-gateway config entry.
 			logger.Log(t, "creating config entry")

--- a/acceptance/tests/ingress-gateway/ingress_gateway_test.go
+++ b/acceptance/tests/ingress-gateway/ingress_gateway_test.go
@@ -66,7 +66,7 @@ func TestIngressGateway(t *testing.T) {
 
 			// With the cluster up, we can create our ingress-gateway config entry.
 			logger.Log(t, "creating config entry")
-			consulClient := consulCluster.SetupConsulClient(t, c.secure)
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
 
 			// Create config entry
 			created, _, err := consulClient.ConfigEntries().Set(&api.IngressGatewayConfigEntry{

--- a/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -104,8 +104,8 @@ func TestMeshGatewayDefault(t *testing.T) {
 		k8s.RunKubectl(t, primaryContext.KubectlOptions(t), "rollout", "status", fmt.Sprintf("sts/%s-consul-server", releaseName))
 	}
 
-	primaryClient := primaryConsulCluster.SetupConsulClient(t, false)
-	secondaryClient := secondaryConsulCluster.SetupConsulClient(t, false)
+	primaryClient, _ := primaryConsulCluster.SetupConsulClient(t, false)
+	secondaryClient, _ := secondaryConsulCluster.SetupConsulClient(t, false)
 
 	// Verify federation between servers
 	logger.Log(t, "verifying federation was successful")
@@ -258,8 +258,8 @@ func TestMeshGatewaySecure(t *testing.T) {
 				k8s.RunKubectl(t, primaryContext.KubectlOptions(t), "rollout", "status", fmt.Sprintf("sts/%s-consul-server", releaseName))
 			}
 
-			primaryClient := primaryConsulCluster.SetupConsulClient(t, true)
-			secondaryClient := secondaryConsulCluster.SetupConsulClient(t, true)
+			primaryClient, _ := primaryConsulCluster.SetupConsulClient(t, true)
+			secondaryClient, _ := secondaryConsulCluster.SetupConsulClient(t, true)
 
 			// Verify federation between servers
 			logger.Log(t, "verifying federation was successful")

--- a/acceptance/tests/partitions/partitions_test.go
+++ b/acceptance/tests/partitions/partitions_test.go
@@ -243,7 +243,7 @@ func TestPartitions(t *testing.T) {
 				k8s.RunKubectl(t, clientClusterContext.KubectlOptions(t), "delete", "ns", staticServerNamespace, staticClientNamespace)
 			})
 
-			consulClient := serverConsulCluster.SetupConsulClient(t, c.ACLsAndAutoEncryptEnabled)
+			consulClient, _ := serverConsulCluster.SetupConsulClient(t, c.ACLsAndAutoEncryptEnabled)
 
 			serverQueryServerOpts := &api.QueryOptions{Namespace: staticServerNamespace, Partition: defaultPartition}
 			clientQueryServerOpts := &api.QueryOptions{Namespace: staticClientNamespace, Partition: defaultPartition}

--- a/acceptance/tests/snapshot-agent/snapshot_agent_vault_test.go
+++ b/acceptance/tests/snapshot-agent/snapshot_agent_vault_test.go
@@ -61,7 +61,7 @@ func TestSnapshotAgent_Vault(t *testing.T) {
 	vault.ConfigureConsulCAKubernetesAuthRole(t, vaultClient, ns, "kubernetes")
 
 	vault.ConfigurePKICA(t, vaultClient)
-	certPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1")
+	certPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1", "")
 
 	vaultCASecret := vault.CASecretName(vaultReleaseName)
 

--- a/acceptance/tests/snapshot-agent/snapshot_agent_vault_test.go
+++ b/acceptance/tests/snapshot-agent/snapshot_agent_vault_test.go
@@ -61,7 +61,7 @@ func TestSnapshotAgent_Vault(t *testing.T) {
 	vault.ConfigureConsulCAKubernetesAuthRole(t, vaultClient, ns, "kubernetes")
 
 	vault.ConfigurePKICA(t, vaultClient)
-	certPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1", "")
+	certPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1", "1h")
 
 	vaultCASecret := vault.CASecretName(vaultReleaseName)
 

--- a/acceptance/tests/sync/sync_catalog_namespaces_test.go
+++ b/acceptance/tests/sync/sync_catalog_namespaces_test.go
@@ -98,7 +98,7 @@ func TestSyncCatalogNamespaces(t *testing.T) {
 			logger.Log(t, "creating a static-server with a service")
 			k8s.DeployKustomize(t, staticServerOpts, cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/bases/static-server")
 
-			consulClient := consulCluster.SetupConsulClient(t, c.secure)
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
 
 			logger.Log(t, "checking that the service has been synced to Consul")
 			var services map[string][]string

--- a/acceptance/tests/sync/sync_catalog_test.go
+++ b/acceptance/tests/sync/sync_catalog_test.go
@@ -63,7 +63,7 @@ func TestSyncCatalog(t *testing.T) {
 			logger.Log(t, "creating a static-server with a service")
 			k8s.DeployKustomize(t, ctx.KubectlOptions(t), suite.Config().NoCleanupOnFailure, suite.Config().DebugDirectory, "../fixtures/bases/static-server")
 
-			consulClient := consulCluster.SetupConsulClient(t, c.secure)
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
 
 			logger.Log(t, "checking that the service has been synced to Consul")
 			var services map[string][]string

--- a/acceptance/tests/terminating-gateway/terminating_gateway_namespaces_test.go
+++ b/acceptance/tests/terminating-gateway/terminating_gateway_namespaces_test.go
@@ -58,7 +58,7 @@ func TestTerminatingGatewaySingleNamespace(t *testing.T) {
 
 			consulCluster.Create(t)
 
-			consulClient := consulCluster.SetupConsulClient(t, c.secure)
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
 
 			// Create the destination namespace in the non-secure case.
 			// In the secure installation, this namespace is created by the server-acl-init job.
@@ -172,7 +172,7 @@ func TestTerminatingGatewayNamespaceMirroring(t *testing.T) {
 
 			consulCluster.Create(t)
 
-			consulClient := consulCluster.SetupConsulClient(t, c.secure)
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
 
 			logger.Logf(t, "creating Kubernetes namespace %s", testNamespace)
 			k8s.RunKubectl(t, ctx.KubectlOptions(t), "create", "ns", testNamespace)

--- a/acceptance/tests/terminating-gateway/terminating_gateway_test.go
+++ b/acceptance/tests/terminating-gateway/terminating_gateway_test.go
@@ -64,7 +64,7 @@ func TestTerminatingGateway(t *testing.T) {
 			k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/bases/static-server")
 
 			// Once the cluster is up, register the external service, then create the config entry.
-			consulClient := consulCluster.SetupConsulClient(t, c.secure)
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
 
 			// Register the external service
 			registerExternalService(t, consulClient, "")

--- a/acceptance/tests/vault/vault_partitions_test.go
+++ b/acceptance/tests/vault/vault_partitions_test.go
@@ -119,7 +119,7 @@ func TestVault_Partitions(t *testing.T) {
 	vault.ConfigureKubernetesAuthRole(t, vaultClient, consulReleaseName, ns, "kubernetes-"+secondaryPartition, "partition-init", "partition-token")
 	vault.ConfigureConsulCAKubernetesAuthRole(t, vaultClient, ns, "kubernetes-"+secondaryPartition)
 	vault.ConfigurePKICA(t, vaultClient)
-	certPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1")
+	certPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1", "")
 
 	vaultCASecretName := vault.CASecretName(vaultReleaseName)
 

--- a/acceptance/tests/vault/vault_partitions_test.go
+++ b/acceptance/tests/vault/vault_partitions_test.go
@@ -119,7 +119,7 @@ func TestVault_Partitions(t *testing.T) {
 	vault.ConfigureKubernetesAuthRole(t, vaultClient, consulReleaseName, ns, "kubernetes-"+secondaryPartition, "partition-init", "partition-token")
 	vault.ConfigureConsulCAKubernetesAuthRole(t, vaultClient, ns, "kubernetes-"+secondaryPartition)
 	vault.ConfigurePKICA(t, vaultClient)
-	certPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1", "")
+	certPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1", "1h")
 
 	vaultCASecretName := vault.CASecretName(vaultReleaseName)
 

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -51,7 +51,7 @@ func TestVault(t *testing.T) {
 	vault.ConfigureConsulCAKubernetesAuthRole(t, vaultClient, ns, "kubernetes")
 
 	vault.ConfigurePKICA(t, vaultClient)
-	certPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1", "")
+	certPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1", "1h")
 
 	vaultCASecret := vault.CASecretName(vaultReleaseName)
 

--- a/acceptance/tests/vault/vault_tls_auto_reload_test.go
+++ b/acceptance/tests/vault/vault_tls_auto_reload_test.go
@@ -57,8 +57,6 @@ func TestVault_TlsAutoReload(t *testing.T) {
 	vaultCASecret := vault.CASecretName(vaultReleaseName)
 
 	consulHelmValues := map[string]string{
-		"server.extraConfig": `"{\"auto_reload_config\": true}"`,
-
 		"server.extraVolumes[0].type": "secret",
 		"server.extraVolumes[0].name": vaultCASecret,
 		"server.extraVolumes[0].load": "false",

--- a/acceptance/tests/vault/vault_wan_fed_test.go
+++ b/acceptance/tests/vault/vault_wan_fed_test.go
@@ -23,7 +23,7 @@ import (
 // as the secrets backend, testing all possible credentials that can be used for WAN federation.
 // This test deploys a Vault cluster with a server in the primary k8s cluster and exposes it to the
 // secondary cluster via a Kubernetes service. We then only need to deploy Vault agent injector
-// in the secondary that will treat the Vault server in the primary as an external server.
+// // in the secondary that will treat the Vault server in the primary as an external server.
 func TestVault_WANFederationViaGateways(t *testing.T) {
 	cfg := suite.Config()
 	if !cfg.EnableMultiCluster {
@@ -129,8 +129,8 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 
 	// Generate a CA and create PKI roles for the primary and secondary Consul servers.
 	vault.ConfigurePKICA(t, vaultClient)
-	primaryCertPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1")
-	secondaryCertPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc2")
+	primaryCertPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1", "")
+	secondaryCertPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc2", "")
 
 	bootstrapToken := vault.ConfigureACLTokenVaultSecret(t, vaultClient, "bootstrap")
 	replicationToken := vault.ConfigureACLTokenVaultSecret(t, vaultClient, "replication")
@@ -293,9 +293,9 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	// Verify federation between servers.
 	logger.Log(t, "verifying federation was successful")
 	primaryConsulCluster.ACLToken = bootstrapToken
-	primaryClient := primaryConsulCluster.SetupConsulClient(t, true)
+	primaryClient, _ := primaryConsulCluster.SetupConsulClient(t, true)
 	secondaryConsulCluster.ACLToken = replicationToken
-	secondaryClient := secondaryConsulCluster.SetupConsulClient(t, true)
+	secondaryClient, _ := secondaryConsulCluster.SetupConsulClient(t, true)
 	helpers.VerifyFederation(t, primaryClient, secondaryClient, consulReleaseName, true)
 
 	// Create a ProxyDefaults resource to configure services to use the mesh

--- a/acceptance/tests/vault/vault_wan_fed_test.go
+++ b/acceptance/tests/vault/vault_wan_fed_test.go
@@ -23,7 +23,7 @@ import (
 // as the secrets backend, testing all possible credentials that can be used for WAN federation.
 // This test deploys a Vault cluster with a server in the primary k8s cluster and exposes it to the
 // secondary cluster via a Kubernetes service. We then only need to deploy Vault agent injector
-// // in the secondary that will treat the Vault server in the primary as an external server.
+// in the secondary that will treat the Vault server in the primary as an external server.
 func TestVault_WANFederationViaGateways(t *testing.T) {
 	cfg := suite.Config()
 	if !cfg.EnableMultiCluster {

--- a/acceptance/tests/vault/vault_wan_fed_test.go
+++ b/acceptance/tests/vault/vault_wan_fed_test.go
@@ -129,8 +129,8 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 
 	// Generate a CA and create PKI roles for the primary and secondary Consul servers.
 	vault.ConfigurePKICA(t, vaultClient)
-	primaryCertPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1", "")
-	secondaryCertPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc2", "")
+	primaryCertPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1", "1h")
+	secondaryCertPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc2", "1h")
 
 	bootstrapToken := vault.ConfigureACLTokenVaultSecret(t, vaultClient, "bootstrap")
 	replicationToken := vault.ConfigureACLTokenVaultSecret(t, vaultClient, "replication")

--- a/charts/consul/templates/client-config-configmap.yaml
+++ b/charts/consul/templates/client-config-configmap.yaml
@@ -13,6 +13,10 @@ metadata:
     release: {{ .Release.Name }}
     component: client
 data:
+  client.json: |-
+    {
+      "auto_reload_config": true
+    }
   extra-from-values.json: |-
 {{ tpl .Values.client.extraConfig . | trimAll "\"" | indent 4 }}
   central-config.json: |-

--- a/charts/consul/templates/server-config-configmap.yaml
+++ b/charts/consul/templates/server-config-configmap.yaml
@@ -14,6 +14,7 @@ metadata:
 data:
   server.json: |
     {
+      "auto_reload_config": true,
       "bind_addr": "0.0.0.0",
       "bootstrap_expect": {{ if .Values.server.bootstrapExpect }}{{ .Values.server.bootstrapExpect }}{{ else }}{{ .Values.server.replicas }}{{ end }},
       "client_addr": "0.0.0.0",

--- a/charts/consul/test/unit/client-config-configmap.bats
+++ b/charts/consul/test/unit/client-config-configmap.bats
@@ -70,3 +70,16 @@ load _helpers
       yq '.data["config.json"] | contains("check_update_interval")' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# retry-join
+
+@test "client/ConfigMap: auto reload config is set to true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-config-configmap.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.data["client.json"]' | jq -r .auto_reload_config | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/client-config-configmap.bats
+++ b/charts/consul/test/unit/client-config-configmap.bats
@@ -72,7 +72,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# retry-join
+# auto_reload_config
 
 @test "client/ConfigMap: auto reload config is set to true" {
   cd `chart_dir`

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -551,7 +551,7 @@ load _helpers
       -s templates/client-daemonset.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 004aa147bf69db24da4d7f61ee4e3fc725dcb04effcec707a66dab1ae91543cc ]
+  [ "${actual}" = aa432a6e22a4c6c7c07f39896f893df1d638575222eea0245d33a5094914ab61 ]
 }
 
 @test "client/DaemonSet: config-checksum annotation changes when extraConfig is provided" {
@@ -561,7 +561,7 @@ load _helpers
       --set 'client.extraConfig="{\"hello\": \"world\"}"' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 6ab8217573bf5486889ff6d3fe8d2f70a0a1d0bfbb48c20f568a4fc566cb3909 ]
+  [ "${actual}" = 50357c9dd53f1cb8e5b4c953f832269df82f4fea12cb63f1581890ac55d9ce58 ]
 }
 
 @test "client/DaemonSet: config-checksum annotation changes when connectInject.enabled=true" {
@@ -571,7 +571,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = b0be8c9b3ae8692a4e393b93976c55988e95cb9d9dae96fbd8626f3f5b6c404b ]
+  [ "${actual}" = 60a99c69e2b0fc842723ef1c5e34b60fbdf15460b70deb1831b692f14f74e972 ]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/test/unit/server-config-configmap.bats
+++ b/charts/consul/test/unit/server-config-configmap.bats
@@ -797,7 +797,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# retry-join
+# auto_reload_config
 
 @test "server/ConfigMap: auto reload config is set to true" {
   cd `chart_dir`

--- a/charts/consul/test/unit/server-config-configmap.bats
+++ b/charts/consul/test/unit/server-config-configmap.bats
@@ -795,3 +795,16 @@ load _helpers
 
   [ "${actual}" = "5m" ]
 }
+
+#--------------------------------------------------------------------
+# retry-join
+
+@test "server/ConfigMap: auto reload config is set to true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.data["server.json"]' | jq -r .auto_reload_config | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -671,7 +671,7 @@ load _helpers
       -s templates/server-statefulset.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 0413362d01133dcd9c1da159e01c20143fb1fe4e2e2ade27bd3b85645653d7cf ]
+  [ "${actual}" = 5302306ae80c4a74dc23c90c24b23064c8d6c00ad1a7b981763e23cfcc8c71f1 ]
 }
 
 @test "server/StatefulSet: adds config-checksum annotation when extraConfig is provided" {
@@ -681,7 +681,7 @@ load _helpers
       --set 'server.extraConfig="{\"hello\": \"world\"}"' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 7394f1cb933e3501be41dd0225d8d2248f2d592e0241876035127e5b9540ec31 ]
+  [ "${actual}" = 6c2ac4d32ceda09ae07cbe6a4e118908f9167bad765a1db6b37a5c6a93c279a4 ]
 }
 
 @test "server/StatefulSet: adds config-checksum annotation when config is updated" {
@@ -691,7 +691,7 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 62db9fd78a8dd95db274586c7d372af85c899b8c9db942a2a0bb691b25c87f55 ]
+  [ "${actual}" = c6712ea13c42769198eecfbdaaf18d5922e9495a1dc14523522f28dec50d33f8 ]
 }
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
*NOTE:  This looks like more files at first glance but there are many files that changed because of a signature change to `SetupConsulClient`*

Changes proposed in this PR:
- Added TestVault_TlsAutoReload to verify that certificates get rotated
- had to change signature of `SetupConsulClient` to also return the portward address

How I've tested this PR:
- Acceptance test added

How I expect reviewers to test this PR:
- 👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

