### PR TITLE
Adding ability to mount extra volumes to get-auto-encrypt-client-ca i…

### DIFF
--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -191,6 +191,11 @@ This template is for an init container.
       mountPath: /consul/tls/ca
     {{- end }}
     {{- end }}
+    {{- range .Values.connectInject.extraVolumes }}
+    - name: userconfig-{{ .name }}
+      readOnly: true
+      mountPath: /consul/userconfig/{{ .name }}
+    {{- end }}
     - name: consul-auto-encrypt-ca-cert
       mountPath: /consul/tls/client/ca
   resources:

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -297,6 +297,15 @@ spec:
           medium: "Memory"
       {{- end }}
       {{- end }}
+      {{- range .Values.connectInject.extraVolumes }}
+      - name: userconfig-{{ .name }}
+        {{ .type }}:
+          {{- if (eq .type "configMap") }}
+          name: {{ .name }}
+          {{- else if (eq .type "secret") }}
+          secretName: {{ .name }}
+          {{- end }}
+      {{- end }}
       {{- if or (and .Values.global.acls.manageSystemACLs) (and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt) }}
       initContainers:
       {{- if and .Values.global.tls.enabled .Values.global.tls.enableAutoEncrypt }}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -611,7 +611,7 @@ server:
   #
   # Vault Secrets backend:
   # If you are using Vault as a secrets backend, a Vault Policy must be created which allows `["create", "update"]`
-  # capabilities on the PKI issuing endpoint, which is usually of the form `pki/issue/consul-server`. 
+  # capabilities on the PKI issuing endpoint, which is usually of the form `pki/issue/consul-server`.
   # Please see the following guide for steps to generate a compatible certificate:
   # https://learn.hashicorp.com/tutorials/consul/vault-pki-consul-secure-tls
   # Note: when using TLS, both the `server.serverCert` and `global.tls.caCert` which points to the CA endpoint of this PKI engine
@@ -1799,6 +1799,21 @@ connectInject:
     # `consul.hashicorp.com/service-metrics-path` annotation.
     defaultPrometheusScrapePath: "/metrics"
 
+  # A list of extra volumes to mount. These will be exposed to Consul in the path `/consul/userconfig/<name>/`.
+  #
+  # Example:
+  #
+  # ```yaml
+  # extraVolumes:
+  #   - type: secret
+  #     name: my-secret
+  #     items: # optional items array
+  #       - key: key
+  #         path: path # secret will now mount to /consul/userconfig/my-secret/path
+  # ```
+  # @type: array<map>
+  extraVolumes: []
+
   # Used to pass arguments to the injected envoy sidecar.
   # Valid arguments to pass to envoy can be found here: https://www.envoyproxy.io/docs/envoy/latest/operations/cli
   # e.g "--log-level debug --disable-hot-restart"
@@ -1849,7 +1864,7 @@ connectInject:
   # This setting can be safely disabled by setting to "Ignore".
   failurePolicy: "Fail"
 
-  # Selector for restricting the webhook to only specific namespaces. 
+  # Selector for restricting the webhook to only specific namespaces.
   # Use with `connectInject.default: true` to automatically inject all pods in namespaces that match the selector. This should be set to a multiline string.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
   # for more details.


### PR DESCRIPTION
Changes proposed in this PR:
Adding the ability to mount extra volumes to the connect-inject get-auto-encrypt-client-ca init container

https://github.com/hashicorp/consul-k8s/issues/1107

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

