### PR TITLE
Fix cli to work on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ BUG FIXES:
 * Helm
   * Don't set TTL for server certificates when using Vault as the secrets backend. [[GH-1104](https://github.com/hashicorp/consul-k8s/pull/1104)]
   * Fix PodSecurityPolicies for clients/mesh gateways when hostNetwork is used. [[GH-1090](https://github.com/hashicorp/consul-k8s/pull/1090)]
+* CLI
+  * Fix `install` and `upgrade` commands for Windows. [[GH-1139](https://github.com/hashicorp/consul-k8s/pull/1139)]
 
 ## 0.41.1 (February 24, 2022)
 


### PR DESCRIPTION
Previously would error about missing file `consul\Chart.yaml`. This
is because the go embedded filesystem must be accessed using `/`
delimiters but we were using `filepath` functions which on windows
use `\`.

How I've tested this PR:
- tested on windows

How I expect reviewers to test this PR:
- code

Checklist:
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

