### PR TITLE
Upload docker image in nightly tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ commands:
           command: |
             kind create cluster --name dc1 --image kindest/node:<< parameters.version >>
             kind create cluster --name dc2 --image kindest/node:<< parameters.version >>
+
   run-acceptance-tests:
     parameters:
       failfast:
@@ -907,13 +908,27 @@ workflows:
       #      - acceptance-openshift:
       #          requires:
       #          - cleanup-azure-resources
+      - build-distro:
+          OS: "darwin freebsd linux solaris windows"
+          ARCH: "amd64"
+          name: build-distros-amd64
+      # Upload docker image in case it has not been uploaded
+      - dev-upload-docker:
+          context: consul-ci
+          requires:
+            - build-distros-amd64
       - acceptance-gke-1-20:
           requires:
             - cleanup-gcp-resources
+            - dev-upload-docker
       - acceptance-eks-1-19:
           requires:
             - cleanup-eks-resources
+            - dev-upload-docker
       - acceptance-aks-1-21:
           requires:
             - cleanup-azure-resources
-      - acceptance-kind-1-23
+            - dev-upload-docker
+      - acceptance-kind-1-23:
+          requires:
+            - dev-upload-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -893,10 +893,6 @@ workflows:
           requires:
             - dev-upload-docker
       - cleanup-gcp-resources
-      - dev-upload-docker:
-          context: consul-ci
-          requires:
-            - build-distros-amd64
       - acceptance-gke-1-20:
           requires:
             - cleanup-gcp-resources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -892,6 +892,15 @@ workflows:
       - acceptance-tproxy:
           requires:
             - dev-upload-docker
+      - cleanup-gcp-resources
+      - dev-upload-docker:
+          context: consul-ci
+          requires:
+            - build-distros-amd64
+      - acceptance-gke-1-20:
+          requires:
+            - cleanup-gcp-resources
+            - dev-upload-docker
   nightly-acceptance-tests:
     triggers:
       - schedule:


### PR DESCRIPTION
Changes proposed in this PR:
- Nightly tests will upload their own Docker image instead of relying on the image existing from a previous `test-and-build` run.

How I've tested this PR:

I will see how this performs tonight and see if there are any adjustments I need to make.

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

