### PR TITLE
Allow Consul API Gateway controller to read ReferencePolicy

### DIFF
--- a/charts/consul/templates/api-gateway-controller-clusterrole.yaml
+++ b/charts/consul/templates/api-gateway-controller-clusterrole.yaml
@@ -117,6 +117,14 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - referencepolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
   - gatewayclasses
   verbs:
   - create


### PR DESCRIPTION
This is a prerequisite for https://github.com/hashicorp/consul-api-gateway/pull/142 being included in a release.

**Changes proposed in this PR:**
Allow the Consul API Gateway controller to `get`, `list` and `watch` `ReferencePolicy` from the k8s Gateway API. This will allow the controller to verify that a route is allowed to send traffic to a service in a different namespace.

In this example, the `ReferencePolicy` allows any `HTTPRoute` in the gateway-conformance-infra namespace to attach to the web-backend service in the gateway-conformance-web-backend namespace. Without this policy, cross-namespace routing will be blocked at some point in the future.
```yaml
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: ReferencePolicy
metadata:
  name: reference-policy
  namespace: gateway-conformance-web-backend
spec:
  from:
    - group: gateway.networking.k8s.io
      kind: HTTPRoute
      namespace: gateway-conformance-infra
  to:
    - group: ""
      kind: Service
      name: web-backend
```

**How I've tested this PR:**
Consumed in our conformance testing Actions workflow [here](https://github.com/hashicorp/consul-api-gateway/pull/142/commits/9053231fa27842c51e5aaa7b00184494ad01385d)

**How I expect reviewers to test this PR:**


**Checklist:**
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

