### PR TITLE
Add annotation for explicitly specifying which service you want registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ IMPROVEMENTS:
 * Helm
   * API Gateway: Allow controller to read Kubernetes namespaces in order to determine if route is allowed for gateway. [[GH-1092](https://github.com/hashicorp/consul-k8s/pull/1092)]
   * Support a pre-configured bootstrap ACL token. [[GH-1125](https://github.com/hashicorp/consul-k8s/pull/1125)]
+  * Add a `"consul.hashicorp.com/kubernetes-service"` annotation for pods to specify which Kubernetes service they want to use for registration when multiple services target the same pod. [[GH-1150](https://github.com/hashicorp/consul-k8s/pull/1150)]
 * Vault
   * Enable snapshot agent configuration to be retrieved from vault. [[GH-1113](https://github.com/hashicorp/consul-k8s/pull/1113)]
 * CLI

--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -20,6 +20,11 @@ const (
 	// This defaults to the name of the Kubernetes service associated with the pod.
 	annotationService = "consul.hashicorp.com/connect-service"
 
+	// annotationKubernetesService is the name of the Kubernetes service to register.
+	// This allows a pod to specify what Kubernetes service should trigger a Consul
+	// service registration in the case of multiple services referencing a deployment.
+	annotationKubernetesService = "consul.hashicorp.com/kubernetes-service"
+
 	// annotationPort is the name or value of the port to proxy incoming
 	// connections to.
 	annotationPort = "consul.hashicorp.com/connect-service-port"

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -178,7 +178,7 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 				serviceName, ok := pod.Annotations[annotationKubernetesService]
 				if ok && serviceEndpoints.Name != serviceName {
 					r.Log.Info("ignoring endpoint because it doesn't match explicit service annotation", "name", serviceEndpoints.Name, "ns", serviceEndpoints.Namespace)
-					// deregistration happens later because we don't add this pod to the endpointAddressMap
+					// deregistration for service instances that don't match the annotation happens later because we don't add this pod to the endpointAddressMap.
 					continue
 				}
 

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -175,6 +175,12 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 					continue
 				}
 
+				serviceName, ok := pod.Annotations[annotationKubernetesService]
+				if ok && serviceEndpoints.Name != serviceName {
+					r.Log.Info("ignoring endpoint because it doesn't match explicit service annotation", "name", serviceEndpoints.Name, "ns", serviceEndpoints.Namespace)
+					continue
+				}
+
 				if hasBeenInjected(pod) {
 					endpointPods.Add(address.TargetRef.Name)
 					if err := r.registerServicesAndHealthCheck(pod, serviceEndpoints, healthStatus, endpointAddressMap); err != nil {

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -178,6 +178,7 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 				serviceName, ok := pod.Annotations[annotationKubernetesService]
 				if ok && serviceEndpoints.Name != serviceName {
 					r.Log.Info("ignoring endpoint because it doesn't match explicit service annotation", "name", serviceEndpoints.Name, "ns", serviceEndpoints.Namespace)
+					// deregistration happens later because we don't add this pod to the endpointAddressMap
 					continue
 				}
 

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -3491,7 +3491,7 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 
 	// Run the reconcile again with the service we want to register.
 	serviceName = endpoint.Name
-	namespacedName = types.NamespacedName{Namespace: badEndpoint.Namespace, Name: serviceName}
+	namespacedName = types.NamespacedName{Namespace: endpoint.Namespace, Name: serviceName}
 	resp, err = ep.Reconcile(context.Background(), ctrl.Request{NamespacedName: namespacedName})
 	require.NoError(t, err)
 	require.False(t, resp.Requeue)


### PR DESCRIPTION
So, I was helping someone go through the process of setting up an Elasticsearch instance on the service mesh so it could be routed to via the API Gateway. All of the pods and services are created via a CRD specified by [this project](https://github.com/elastic/cloud-on-k8s).

One of the pain points of this is that the CRD + controller create a single deployment that has multiple services targeting it. You can override parts of the pod spec template in the CRD and some of the service templates, but not all of them. This makes things difficult because our only way of properly specifying which service we want to use in Consul registration when a pod is using `connect-inject` and has multiple services targeting it is through the service label [consul.hashicorp.com/service-ignore](https://www.consul.io/docs/k8s/annotations-and-labels#consul-hashicorp-com-service-ignore). Since these services are managed by a third-party controller it means you have to patch that label onto each service (and who knows if the controller just resets it in a reconciliation run).

In the case of a vanilla setup without all of these additional CRDs and controllers, you would have to go through the cumbersome process of ensuring _every_ service that targets the deployment is labeled with `service-ignore` other than the one you want registered.

As an alternative to doing that, my thought is that we should just allow for an annotation on the pod that says, "here's the Kubernetes service that I want to use for registration" and, when specified, ignore any endpoints that don't have that explicit name. I think apart from increasing the likelihood of compatibility with third-party systems, this is an overall better user experience than having to label a bunch of services.

Changes proposed in this PR:
- Add a `"consul.hashicorp.com/kubernetes-service"` annotation for pods

How I've tested this PR:
- Unit tested - can probably end-to-end test this later today with a custom Docker build.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 