### PR TITLE
Improve Nightly Test Debugging and Reliability with Docker Uploads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -891,6 +891,23 @@ workflows:
       - acceptance-tproxy:
           requires:
             - dev-upload-docker
+      - cleanup-gcp-resources
+      - cleanup-azure-resources
+      - cleanup-eks-resources
+      # Disable until we can use UBI images.
+      #      - acceptance-openshift:
+      #          requires:
+      #          - cleanup-azure-resources
+      - acceptance-gke-1-20:
+          requires:
+            - cleanup-gcp-resources
+      - acceptance-eks-1-19:
+          requires:
+            - cleanup-eks-resources
+      - acceptance-aks-1-21:
+          requires:
+            - cleanup-azure-resources
+      - acceptance-kind-1-23
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,7 +303,7 @@ jobs:
       - run:
           name: make ci.nightly-dev-docker
           working_directory: *control-plane-path
-          command: make ci.dev-docker
+          command: make ci.nightly-dev-docker
 
   unit-cli:
     executor: go
@@ -931,6 +931,7 @@ workflows:
               only:
                 - main
     jobs:
+      - nightly-dev-upload-docker
       - cleanup-gcp-resources
       - cleanup-azure-resources
       - cleanup-eks-resources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -905,23 +905,6 @@ workflows:
       - acceptance-tproxy:
           requires:
             - dev-upload-docker
-      - cleanup-gcp-resources
-      - cleanup-azure-resources
-      - cleanup-eks-resources
-      # Disable until we can use UBI images.
-      #      - acceptance-openshift:
-      #          requires:
-      #          - cleanup-azure-resources
-      - acceptance-gke-1-20:
-          requires:
-            - cleanup-gcp-resources
-      - acceptance-eks-1-19:
-          requires:
-            - cleanup-eks-resources
-      - acceptance-aks-1-21:
-          requires:
-            - cleanup-azure-resources
-      - acceptance-kind-1-23
   nightly-acceptance-tests:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,6 +291,20 @@ jobs:
           working_directory: *control-plane-path
           command: make ci.dev-docker
 
+  # upload nightly dev docker image
+  nightly-dev-upload-docker:
+    executor: go
+    steps:
+      - checkout
+      # get consul-k8s binary
+      - attach_workspace:
+          at: .
+      - setup_remote_docker
+      - run:
+          name: make ci.nightly-dev-docker
+          working_directory: *control-plane-path
+          command: make ci.dev-docker
+
   unit-cli:
     executor: go
     steps:

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -205,37 +205,67 @@ func (h *HelmCluster) Destroy(t *testing.T) {
 	// Verify all Consul Pods are deleted.
 	pods, err = h.kubernetesClient.CoreV1().Pods(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "release=" + h.releaseName})
 	require.NoError(t, err)
-	require.Len(t, pods.Items, 0)
+	for _, pod := range pods.Items {
+		if strings.Contains(pod.Name, h.releaseName) {
+			t.Logf("Found pod which should have been deleted: %s", pod.Name)
+			t.Fail()
+		}
+	}
 
 	// Verify all Consul PVCs are deleted.
 	pvcs, err := h.kubernetesClient.CoreV1().PersistentVolumeClaims(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "release=" + h.releaseName})
 	require.NoError(t, err)
 	require.Len(t, pvcs.Items, 0)
 
-	// Verify all Consul service accounts are deleted.
+	// Verify all Consul Service Accounts are deleted.
 	sas, err = h.kubernetesClient.CoreV1().ServiceAccounts(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "release=" + h.releaseName})
 	require.NoError(t, err)
-	require.Len(t, sas.Items, 0)
+	for _, sa := range sas.Items {
+		if strings.Contains(sa.Name, h.releaseName) {
+			t.Logf("Found service account which should have been deleted: %s", sa.Name)
+			t.Fail()
+		}
+	}
 
 	// Verify all Consul Roles are deleted.
 	roles, err = h.kubernetesClient.RbacV1().Roles(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "release=" + h.releaseName})
 	require.NoError(t, err)
-	require.Len(t, roles.Items, 0)
+	for _, role := range roles.Items {
+		if strings.Contains(role.Name, h.releaseName) {
+			t.Logf("Found role which should have been deleted: %s", role.Name)
+			t.Fail()
+		}
+	}
 
 	// Verify all Consul Role Bindings are deleted.
 	roleBindings, err = h.kubernetesClient.RbacV1().RoleBindings(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "release=" + h.releaseName})
 	require.NoError(t, err)
-	require.Len(t, roleBindings.Items, 0)
+	for _, roleBinding := range roleBindings.Items {
+		if strings.Contains(roleBinding.Name, h.releaseName) {
+			t.Logf("Found role binding which should have been deleted: %s", roleBinding.Name)
+			t.Fail()
+		}
+	}
 
 	// Verify all Consul Secrets are deleted.
 	secrets, err = h.kubernetesClient.CoreV1().Secrets(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
-	require.Len(t, secrets.Items, 0)
+	for _, secret := range secrets.Items {
+		if strings.Contains(secret.Name, h.releaseName) {
+			t.Logf("Found secret which should have been deleted: %s", secret.Name)
+			t.Fail()
+		}
+	}
 
 	// Verify all Consul Jobs are deleted.
 	jobs, err = h.kubernetesClient.BatchV1().Jobs(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "release=" + h.releaseName})
 	require.NoError(t, err)
-	require.Len(t, jobs.Items, 0)
+	for _, job := range jobs.Items {
+		if strings.Contains(job.Name, h.releaseName) {
+			t.Logf("Found job which should have been deleted: %s", job.Name)
+			t.Fail()
+		}
+	}
 }
 
 func (h *HelmCluster) Upgrade(t *testing.T, helmValues map[string]string) {

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -201,6 +201,41 @@ func (h *HelmCluster) Destroy(t *testing.T) {
 			}
 		}
 	}
+
+	// Verify all Consul Pods are deleted.
+	pods, err = h.kubernetesClient.CoreV1().Pods(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "release=" + h.releaseName})
+	require.NoError(t, err)
+	require.Len(t, pods.Items, 0)
+
+	// Verify all Consul PVCs are deleted.
+	pvcs, err := h.kubernetesClient.CoreV1().PersistentVolumeClaims(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "release=" + h.releaseName})
+	require.NoError(t, err)
+	require.Len(t, pvcs.Items, 0)
+
+	// Verify all Consul service accounts are deleted.
+	sas, err = h.kubernetesClient.CoreV1().ServiceAccounts(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "release=" + h.releaseName})
+	require.NoError(t, err)
+	require.Len(t, sas.Items, 0)
+
+	// Verify all Consul Roles are deleted.
+	roles, err = h.kubernetesClient.RbacV1().Roles(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "release=" + h.releaseName})
+	require.NoError(t, err)
+	require.Len(t, roles.Items, 0)
+
+	// Verify all Consul Role Bindings are deleted.
+	roleBindings, err = h.kubernetesClient.RbacV1().RoleBindings(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "release=" + h.releaseName})
+	require.NoError(t, err)
+	require.Len(t, roleBindings.Items, 0)
+
+	// Verify all Consul Secrets are deleted.
+	secrets, err = h.kubernetesClient.CoreV1().Secrets(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, secrets.Items, 0)
+
+	// Verify all Consul Jobs are deleted.
+	jobs, err = h.kubernetesClient.BatchV1().Jobs(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "release=" + h.releaseName})
+	require.NoError(t, err)
+	require.Len(t, jobs.Items, 0)
 }
 
 func (h *HelmCluster) Upgrade(t *testing.T, helmValues map[string]string) {

--- a/control-plane/Makefile
+++ b/control-plane/Makefile
@@ -48,7 +48,7 @@ endif
 
 # TODO: Remove this ci.nightly-dev-docker target once we move the acceptance tests to Github Actions.
 # In CircleCI, the linux binary will be attached from a previous step at pkg/bin/linux_amd64/. This make target
-# should only run in CI and not locally.
+# should only run in CI and not locally. This is a guardrail for a case where the latest commit on main does not succeed to upload a docker image, so with this step the nightly test will upload its own docker image off of main before starting.
 ci.nightly-dev-docker:
 	@echo "Building consul-k8s Nightly Development container - $(CI_DEV_DOCKER_IMAGE_NAME)"
 	@docker build -t '$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):nightly-$(GIT_COMMIT)' \

--- a/control-plane/Makefile
+++ b/control-plane/Makefile
@@ -46,6 +46,25 @@ ifeq ($(CIRCLE_BRANCH), main)
 	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
 endif
 
+# TODO: Remove this ci.nightly-dev-docker target once we move the acceptance tests to Github Actions.
+# In CircleCI, the linux binary will be attached from a previous step at pkg/bin/linux_amd64/. This make target
+# should only run in CI and not locally.
+ci.nightly-dev-docker:
+	@echo "Building consul-k8s Nightly Development container - $(CI_DEV_DOCKER_IMAGE_NAME)"
+	@docker build -t '$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):nightly-$(GIT_COMMIT)' \
+	--target=dev \
+	--label COMMIT_SHA=$(CIRCLE_SHA1) \
+	--label PULL_REQUEST=$(CIRCLE_PULL_REQUEST) \
+	--label CIRCLE_BUILD_URL=$(CIRCLE_BUILD_URL) \
+	$(CI_DEV_DOCKER_WORKDIR) -f $(CURDIR)/Dockerfile
+	@echo $(DOCKER_PASS) | docker login -u="$(DOCKER_USER)" --password-stdin
+	@echo "Pushing dev image to: https://cloud.docker.com/u/$(CI_DEV_DOCKER_NAMESPACE)/repository/docker/$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME)"
+	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT)
+ifeq ($(CIRCLE_BRANCH), main)
+	@docker tag $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT) $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
+	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
+endif
+
 # In Github Actions, the linux binary will be attached from a previous step at pkg/bin/linux_amd64/. This make target
 # should only run in CI and not locally.
 ci.dev-docker-github:


### PR DESCRIPTION

Changes proposed in this PR:
- Add checks to verify deletion of resources in Destroy method on Helm Cluster

How I've tested this PR:
I set up this PR run nightly-acceptance-tests.

How I expect reviewers to test this PR:
Watch the nightly-acceptance-tests and see if they succeed.

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

