### PR TITLE
Get federation secret from any of the places it is set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ BUG FIXES:
 * CLI
   * Fix issue where clusters not in the same namespace as their deployment name could not be upgraded. [[GH-1115](https://github.com/hashicorp/consul-k8s/pull/1115)]
   * Fix issue where the CLI was looking for secrets in namespaces other than the namespace targeted by the release. [[GH-1156](https://github.com/hashicorp/consul-k8s/pull/1156)]
+  * Fix issue where the federation secret was not being found in certain configurations. [[GH-1154](https://github.com/hashicorp/consul-k8s/issue/1154)]
 
 IMPROVEMENTS:
 * Helm

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -418,7 +418,7 @@ func (c *Command) checkForPreviousSecrets(release release.Release) (string, erro
 
 	// If the Consul configuration is a secondary DC, only one secret should
 	// exist, the Consul federation secret.
-	fedSecret := release.Configuration.Global.Acls.ReplicationToken.SecretName
+	fedSecret := release.FedSecret()
 	if release.ShouldExpectFederationSecret() {
 		if len(secrets.Items) == 1 && secrets.Items[0].Name == fedSecret {
 			return fmt.Sprintf("Found secret %s for Consul federation.", fedSecret), nil

--- a/cli/cmd/install/install_test.go
+++ b/cli/cmd/install/install_test.go
@@ -54,19 +54,22 @@ func TestCheckForPreviousSecrets(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]struct {
-		helmValues helm.Values
-		secret     *v1.Secret
-		expectMsg  bool
-		expectErr  bool
+		releaseName string
+		helmValues  helm.Values
+		secret      *v1.Secret
+		expectMsg   bool
+		expectErr   bool
 	}{
 		"No secrets, none expected": {
-			helmValues: helm.Values{},
-			secret:     nil,
-			expectMsg:  true,
-			expectErr:  false,
+			releaseName: "consul",
+			helmValues:  helm.Values{},
+			secret:      nil,
+			expectMsg:   true,
+			expectErr:   false,
 		},
 		"Non-Consul secrets, none expected": {
-			helmValues: helm.Values{},
+			releaseName: "consul",
+			helmValues:  helm.Values{},
 			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "non-consul-secret",
@@ -76,7 +79,8 @@ func TestCheckForPreviousSecrets(t *testing.T) {
 			expectErr: false,
 		},
 		"Consul secrets, none expected": {
-			helmValues: helm.Values{},
+			releaseName: "consul",
+			helmValues:  helm.Values{},
 			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "consul-secret",
@@ -87,6 +91,7 @@ func TestCheckForPreviousSecrets(t *testing.T) {
 			expectErr: true,
 		},
 		"Federation secret, expected": {
+			releaseName: "consul",
 			helmValues: helm.Values{
 				Global: helm.Global{
 					Datacenter: "dc2",
@@ -112,6 +117,7 @@ func TestCheckForPreviousSecrets(t *testing.T) {
 			expectErr: false,
 		},
 		"No federation secret, but expected": {
+			releaseName: "consul",
 			helmValues: helm.Values{
 				Global: helm.Global{
 					Datacenter: "dc2",
@@ -140,7 +146,7 @@ func TestCheckForPreviousSecrets(t *testing.T) {
 
 			c.kubernetes.CoreV1().Secrets("consul").Create(context.Background(), tc.secret, metav1.CreateOptions{})
 
-			release := release.Release{Configuration: tc.helmValues}
+			release := release.Release{Name: tc.releaseName, Configuration: tc.helmValues}
 			msg, err := c.checkForPreviousSecrets(release)
 
 			require.Equal(t, tc.expectMsg, msg != "")

--- a/cli/helm/values.go
+++ b/cli/helm/values.go
@@ -75,13 +75,13 @@ type GossipEncryption struct {
 }
 
 type CaCert struct {
-	SecretName interface{} `yaml:"secretName"`
-	SecretKey  interface{} `yaml:"secretKey"`
+	SecretName string `yaml:"secretName"`
+	SecretKey  string `yaml:"secretKey"`
 }
 
 type CaKey struct {
-	SecretName interface{} `yaml:"secretName"`
-	SecretKey  interface{} `yaml:"secretKey"`
+	SecretName string `yaml:"secretName"`
+	SecretKey  string `yaml:"secretKey"`
 }
 
 type TLS struct {

--- a/cli/release/release.go
+++ b/cli/release/release.go
@@ -23,3 +23,27 @@ func (r *Release) ShouldExpectFederationSecret() bool {
 		r.Configuration.Global.Datacenter != r.Configuration.Global.Federation.PrimaryDatacenter &&
 		!r.Configuration.Global.Federation.CreateFederationSecret
 }
+
+// FedSecret fetches the federation secret for the release or an empty string
+// if the federation secret is not set. The federation secret could be set
+// in several places in the configuration. This method returns the first
+// secret name that is set.
+func (r *Release) FedSecret() string {
+	if s := r.Configuration.Global.TLS.CaCert.SecretName; s != "" {
+		return s
+	}
+
+	if s := r.Configuration.Global.TLS.CaKey.SecretName; s != "" {
+		return s
+	}
+
+	if s := r.Configuration.Global.Acls.ReplicationToken.SecretName; s != "" {
+		return s
+	}
+
+	if s := r.Configuration.Global.GossipEncryption.SecretName; s != "" {
+		return s
+	}
+
+	return ""
+}

--- a/cli/release/release.go
+++ b/cli/release/release.go
@@ -24,26 +24,8 @@ func (r *Release) ShouldExpectFederationSecret() bool {
 		!r.Configuration.Global.Federation.CreateFederationSecret
 }
 
-// FedSecret fetches the federation secret for the release or an empty string
-// if the federation secret is not set. The federation secret could be set
-// in several places in the configuration. This method returns the first
-// secret name that is set.
+// FedSecret returns the name of the federation secret which should be created
+// by the operator.
 func (r *Release) FedSecret() string {
-	if s := r.Configuration.Global.TLS.CaCert.SecretName; s != "" {
-		return s
-	}
-
-	if s := r.Configuration.Global.TLS.CaKey.SecretName; s != "" {
-		return s
-	}
-
-	if s := r.Configuration.Global.Acls.ReplicationToken.SecretName; s != "" {
-		return s
-	}
-
-	if s := r.Configuration.Global.GossipEncryption.SecretName; s != "" {
-		return s
-	}
-
-	return ""
+	return r.Name + "-federation"
 }

--- a/cli/release/release.go
+++ b/cli/release/release.go
@@ -21,7 +21,8 @@ type Release struct {
 func (r *Release) ShouldExpectFederationSecret() bool {
 	return r.Configuration.Global.Federation.Enabled &&
 		r.Configuration.Global.Datacenter != r.Configuration.Global.Federation.PrimaryDatacenter &&
-		!r.Configuration.Global.Federation.CreateFederationSecret
+		!r.Configuration.Global.Federation.CreateFederationSecret &&
+		!r.Configuration.Global.SecretsBackend.Vault.Enabled
 }
 
 // FedSecret returns the name of the federation secret which should be created

--- a/cli/release/release_test.go
+++ b/cli/release/release_test.go
@@ -61,3 +61,75 @@ func TestShouldExpectFederationSecret(t *testing.T) {
 		})
 	}
 }
+
+func TestFedSecret(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		configuration helm.Values
+		expected      string
+	}{
+		"No Fed Secret": {
+			configuration: helm.Values{},
+			expected:      "",
+		},
+		"Secret in Global.TLS.CaCert.SecretName": {
+			configuration: helm.Values{
+				Global: helm.Global{
+					TLS: helm.TLS{
+						CaCert: helm.CaCert{
+							SecretName: "secret-name",
+						},
+					},
+				},
+			},
+			expected: "secret-name",
+		},
+		"Secret in Global.TLS.CaKey.SecretName": {
+			configuration: helm.Values{
+				Global: helm.Global{
+					TLS: helm.TLS{
+						CaKey: helm.CaKey{
+							SecretName: "secret-name",
+						},
+					},
+				},
+			},
+			expected: "secret-name",
+		},
+		"Secret in Global.Acls.ReplicationToken.SecretName": {
+			configuration: helm.Values{
+				Global: helm.Global{
+					Acls: helm.Acls{
+						ReplicationToken: helm.ReplicationToken{
+							SecretName: "secret-name",
+						},
+					},
+				},
+			},
+			expected: "secret-name",
+		},
+		"Secret in Global.GossipEncryption.SecretName": {
+			configuration: helm.Values{
+				Global: helm.Global{
+					GossipEncryption: helm.GossipEncryption{
+						SecretName: "secret-name",
+					},
+				},
+			},
+			expected: "secret-name",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			release := Release{
+				Configuration: tc.configuration,
+			}
+
+			actual := release.FedSecret()
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+
+}

--- a/cli/release/release_test.go
+++ b/cli/release/release_test.go
@@ -48,6 +48,24 @@ func TestShouldExpectFederationSecret(t *testing.T) {
 			},
 			expected: true,
 		},
+		"Non-primary DC, federation enabled, Vault secrets backend": {
+			configuration: helm.Values{
+				Global: helm.Global{
+					Datacenter: "dc2",
+					Federation: helm.Federation{
+						Enabled:                true,
+						PrimaryDatacenter:      "dc1",
+						CreateFederationSecret: false,
+					},
+					SecretsBackend: helm.SecretsBackend{
+						Vault: helm.Vault{
+							Enabled: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
 	}
 
 	for name, tc := range cases {

--- a/cli/release/release_test.go
+++ b/cli/release/release_test.go
@@ -63,73 +63,12 @@ func TestShouldExpectFederationSecret(t *testing.T) {
 }
 
 func TestFedSecret(t *testing.T) {
-	t.Parallel()
-
-	cases := map[string]struct {
-		configuration helm.Values
-		expected      string
-	}{
-		"No Fed Secret": {
-			configuration: helm.Values{},
-			expected:      "",
-		},
-		"Secret in Global.TLS.CaCert.SecretName": {
-			configuration: helm.Values{
-				Global: helm.Global{
-					TLS: helm.TLS{
-						CaCert: helm.CaCert{
-							SecretName: "secret-name",
-						},
-					},
-				},
-			},
-			expected: "secret-name",
-		},
-		"Secret in Global.TLS.CaKey.SecretName": {
-			configuration: helm.Values{
-				Global: helm.Global{
-					TLS: helm.TLS{
-						CaKey: helm.CaKey{
-							SecretName: "secret-name",
-						},
-					},
-				},
-			},
-			expected: "secret-name",
-		},
-		"Secret in Global.Acls.ReplicationToken.SecretName": {
-			configuration: helm.Values{
-				Global: helm.Global{
-					Acls: helm.Acls{
-						ReplicationToken: helm.ReplicationToken{
-							SecretName: "secret-name",
-						},
-					},
-				},
-			},
-			expected: "secret-name",
-		},
-		"Secret in Global.GossipEncryption.SecretName": {
-			configuration: helm.Values{
-				Global: helm.Global{
-					GossipEncryption: helm.GossipEncryption{
-						SecretName: "secret-name",
-					},
-				},
-			},
-			expected: "secret-name",
-		},
+	release := Release{
+		Name: "test",
 	}
+	expected := "test-federation"
 
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			release := Release{
-				Configuration: tc.configuration,
-			}
+	actual := release.FedSecret()
 
-			actual := release.FedSecret()
-			require.Equal(t, tc.expected, actual)
-		})
-	}
-
+	require.Equal(t, expected, actual)
 }


### PR DESCRIPTION
Changes proposed in this PR:
- When installing a federated cluster, the install command will look in all of the places the name of the federation secret could be set and return the first set value it finds.

How I've tested this PR:

Added unit tests, ran the install tests which exercise the presence of the fed secret.

How I expect reviewers to test this PR:

Running the unit tests as well if you like.


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

