### PR TITLE
Only lookup secrets in the namespace where the install is targeting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BUG FIXES:
 * CLI
   * Fix issue where clusters not in the same namespace as their deployment name could not be upgraded. [[GH-1115](https://github.com/hashicorp/consul-k8s/pull/1115)]
+  * Fix issue where the CLI was looking for secrets in namespaces other than the namespace targeted by the release. [[GH-1156](https://github.com/hashicorp/consul-k8s/pull/1156)]
 
 IMPROVEMENTS:
 * Helm

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -411,7 +411,7 @@ func (c *Command) checkForPreviousPVCs() error {
 // and returns a message if the secret configuration is ok or an error if
 // the secret configuration could cause a conflict.
 func (c *Command) checkForPreviousSecrets(release release.Release) (string, error) {
-	secrets, err := validation.ListConsulSecrets(c.Ctx, c.kubernetes)
+	secrets, err := validation.ListConsulSecrets(c.Ctx, c.kubernetes, release.Namespace)
 	if err != nil {
 		return "", fmt.Errorf("Error listing Consul secrets: %s", err)
 	}

--- a/cli/validation/kubernetes.go
+++ b/cli/validation/kubernetes.go
@@ -11,8 +11,8 @@ import (
 )
 
 // ListConsulSecrets attempts to find secrets with the Consul label.
-func ListConsulSecrets(ctx context.Context, client kubernetes.Interface) (*v1.SecretList, error) {
-	secrets, err := client.CoreV1().Secrets("").List(ctx, metav1.ListOptions{
+func ListConsulSecrets(ctx context.Context, client kubernetes.Interface, namespace string) (*v1.SecretList, error) {
+	secrets, err := client.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", common.CLILabelKey, common.CLILabelValue),
 	})
 

--- a/cli/validation/kubernetes_test.go
+++ b/cli/validation/kubernetes_test.go
@@ -16,6 +16,7 @@ func TestListConsulSecrets(t *testing.T) {
 
 	cases := map[string]struct {
 		secrets         *v1.SecretList
+		namespace       string
 		expectedSecrets int
 	}{
 		"No secrets": {
@@ -33,6 +34,7 @@ func TestListConsulSecrets(t *testing.T) {
 					},
 				},
 			},
+			namespace:       v1.NamespaceDefault,
 			expectedSecrets: 1,
 		},
 		"A Consul and a non-Consul Secret": {
@@ -51,7 +53,22 @@ func TestListConsulSecrets(t *testing.T) {
 					},
 				},
 			},
+			namespace:       v1.NamespaceDefault,
 			expectedSecrets: 1,
+		},
+		"A Consul Secret in default namespace with lookup in consul namespace": {
+			secrets: &v1.SecretList{
+				Items: []v1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   "test-consul-bootstrap-acl-token",
+							Labels: map[string]string{common.CLILabelKey: common.CLILabelValue},
+						},
+					},
+				},
+			},
+			namespace:       "consul",
+			expectedSecrets: 0,
 		},
 	}
 
@@ -64,7 +81,7 @@ func TestListConsulSecrets(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			actual, err := ListConsulSecrets(context.Background(), client)
+			actual, err := ListConsulSecrets(context.Background(), client, tc.namespace)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedSecrets, len(actual.Items))
 		})


### PR DESCRIPTION
Changes proposed in this PR:
- The install command will only look for secrets in the namespace the install is targeting.
  This fixes the issue raised by @lkysow.
  > another one, it's complaining I have a secret in my default ns but I'm installing consul into the consul ns:
  > ``` bash
  > consul-k8s install
  > ==> Checking if Consul can be installed
  > ✓ No existing Consul installations found.
  > ✓ No existing Consul persistent volume claims found
  > ! Found Consul secrets, possibly from a previous installation.
  > Delete existing Consul secrets from Kubernetes:
  > 
  > kubectl delete secret consul-federation --namespace default
  > ``` 

How I've tested this PR:

Extended existing unit tests to cover this case.

How I expect reviewers to test this PR:

:eyes: and running unit tests.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

