### PR TITLE
CHANGELOG: move changelog entry for GH-1150 to unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+FEATURES:
+* Control Plane
+  * Add `"consul.hashicorp.com/kubernetes-service"` annotation for explicitly specifying which service you want registered, when multiple Kubernetes services are selected for a pod. [[GH-1150](https://github.com/hashicorp/consul-k8s/pull/1150)
+
 BUG FIXES:
 * CLI
   * Fix issue where clusters not in the same namespace as their deployment name could not be upgraded. [[GH-1115](https://github.com/hashicorp/consul-k8s/pull/1115)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 FEATURES:
 * Control Plane
-  * Add `"consul.hashicorp.com/kubernetes-service"` annotation for explicitly specifying which service you want registered, when multiple Kubernetes services are selected for a pod. [[GH-1150](https://github.com/hashicorp/consul-k8s/pull/1150)
+    * Add a `"consul.hashicorp.com/kubernetes-service"` annotation for pods to specify which Kubernetes service they want to use for registration when multiple services target the same pod. [[GH-1150](https://github.com/hashicorp/consul-k8s/pull/1150)]
 
 BUG FIXES:
 * CLI
@@ -46,7 +46,6 @@ IMPROVEMENTS:
 * Helm
   * API Gateway: Allow controller to read Kubernetes namespaces in order to determine if route is allowed for gateway. [[GH-1092](https://github.com/hashicorp/consul-k8s/pull/1092)]
   * Support a pre-configured bootstrap ACL token. [[GH-1125](https://github.com/hashicorp/consul-k8s/pull/1125)]
-  * Add a `"consul.hashicorp.com/kubernetes-service"` annotation for pods to specify which Kubernetes service they want to use for registration when multiple services target the same pod. [[GH-1150](https://github.com/hashicorp/consul-k8s/pull/1150)]
 * Vault
   * Enable snapshot agent configuration to be retrieved from vault. [[GH-1113](https://github.com/hashicorp/consul-k8s/pull/1113)]
 * CLI


### PR DESCRIPTION
Changes proposed in this PR:
- Move changelog for merged PR from 0.42.0 to UNRELEASED: https://github.com/hashicorp/consul-k8s/pull/1150

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

