### PR TITLE
[CRT] Enable Orchestrator

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -1,0 +1,274 @@
+schema = "1"
+
+project "consul-k8s" {
+  team = "consul-k8s"
+  slack {
+    notification_channel = "CBXF3CGAF" # team-consul-kubernetes
+  }
+  github {
+    organization = "hashicorp"
+    repository = "consul-k8s"
+    release_branches = [
+      # The CRT tool does not support * yes as a branch name
+      "main",
+      "release/0.41.x",
+      "release/0.42.x",
+      "cb/crt-production-workflows"
+    ]
+  }
+}
+
+event "merge" {
+  // "entrypoint" to use if build is not run automatically
+  // i.e. send "merge" complete signal to orchestrator to trigger build
+}
+
+event "build" {
+  depends = ["merge"]
+  action "build" {
+    organization = "hashicorp"
+    repository = "consul-k8s"
+    workflow = "build"
+  }
+}
+
+event "upload-dev" {
+  depends = ["build"]
+  action "upload-dev" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "upload-dev"
+    depends = ["build"]
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "promote-dev-docker" {
+  depends = ["verify"]
+  action "promote-dev-docker" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "promote-dev-docker"
+    depends = ["verify"]
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "security-scan-binaries" {
+  depends = ["upload-dev"]
+  action "security-scan-binaries" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "security-scan-binaries"
+    config = "security-scan.hcl"
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "security-scan-containers" {
+  depends = ["security-scan-binaries"]
+  action "security-scan-containers" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "security-scan-containers"
+    config = "security-scan.hcl"
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "notarize-darwin-amd64" {
+  depends = ["security-scan-containers"]
+  action "notarize-darwin-amd64" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "notarize-darwin-amd64"
+
+    parameter {
+      key = "SOME_KEY"
+      value = "SOME_VALUE"
+    }
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "notarize-windows-386" {
+  depends = ["notarize-darwin-amd64"]
+  action "notarize-windows-386" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "notarize-windows-386"
+
+    parameter {
+      key = "SOME_KEY"
+      value = "SOME_VALUE"
+    }
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "notarize-windows-amd64" {
+  depends = ["notarize-windows-386"]
+  action "notarize-windows-amd64" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "notarize-windows-amd64"
+
+    parameter {
+      key = "SOME_KEY"
+      value = "SOME_VALUE"
+    }
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "sign" {
+  depends = ["notarize-windows-amd64"]
+  action "sign" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "sign"
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "sign-linux-rpms" {
+  depends = ["sign"]
+  action "sign-linux-rpms" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "sign-linux-rpms"
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "verify" {
+  depends = ["sign-linux-rpms"]
+  action "verify" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "verify"
+  }
+
+  notification {
+    on = "always"
+  }
+}
+
+## These are promotion and post-publish events
+## they should be added to the end of the file after the verify event stanza.
+
+event "trigger-staging" {
+// This event is dispatched by the bob trigger-promotion command
+// and is required - do not delete.
+}
+
+event "promote-staging" {
+  depends = ["trigger-staging"]
+  action "promote-staging" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "promote-staging"
+  }
+
+  notification {
+    on = "always"
+  }
+}
+
+event "promote-staging-new-hc-releases" {
+  depends = ["promote-staging"]
+  action "promote-staging-new-hc-releases" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "promote-staging-new-hc-releases"
+	config = "release-metadata.hcl"
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "promote-staging-docker" {
+  depends = ["promote-staging-new-hc-releases"]
+  action "promote-staging-docker" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "promote-staging-docker"
+  }
+
+  notification {
+    on = "always"
+  }
+}
+
+event "trigger-production" {
+// This event is dispatched by the bob trigger-promotion command
+// and is required - do not delete.
+}
+
+event "promote-production" {
+  depends = ["trigger-production"]
+  action "promote-production" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "promote-production"
+  }
+
+  notification {
+    on = "always"
+  }
+}
+
+event "promote-production-docker" {
+  depends = ["promote-production"]
+  action "promote-production-docker" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "promote-production-docker"
+  }
+
+  notification {
+    on = "always"
+  }
+}
+
+event "promote-production-packaging" {
+  depends = ["promote-production-docker"]
+  action "promote-production-packaging" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "promote-production-packaging"
+  }
+
+  notification {
+    on = "always"
+  }
+}

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -9,7 +9,7 @@ project "consul-k8s" {
     organization = "hashicorp"
     repository = "consul-k8s"
     release_branches = [
-      # The CRT tool does not support * yes as a branch name
+      # The CRT tool does not support * as a branch name
       "main",
       "cb/crt-testing"
     ]

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -44,20 +44,6 @@ event "upload-dev" {
   }
 }
 
-event "promote-dev-docker" {
-  depends = ["verify"]
-  action "promote-dev-docker" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-dev-docker"
-    depends = ["verify"]
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
 event "security-scan-binaries" {
   depends = ["upload-dev"]
   action "security-scan-binaries" {
@@ -176,6 +162,21 @@ event "verify" {
     on = "always"
   }
 }
+
+event "promote-dev-docker" {
+  depends = ["verify"]
+  action "promote-dev-docker" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "promote-dev-docker"
+    depends = ["verify"]
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
 
 ## These are promotion and post-publish events
 ## they should be added to the end of the file after the verify event stanza.

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -10,8 +10,6 @@ project "consul-k8s" {
     repository = "consul-k8s"
     release_branches = [
       # The CRT tool does not support * yes as a branch name
-      "main",
-      "release/0.41.x",
       "release/0.42.x",
       "cb/crt-production-workflows"
     ]
@@ -94,11 +92,19 @@ event "notarize-darwin-amd64" {
     organization = "hashicorp"
     repository = "crt-workflows-common"
     workflow = "notarize-darwin-amd64"
+  }
 
-    parameter {
-      key = "SOME_KEY"
-      value = "SOME_VALUE"
-    }
+  notification {
+    on = "fail"
+  }
+}
+
+event "notarize-darwin-arm64" {
+  depends = ["notarize-darwin-amd64"]
+  action "notarize-darwin-arm64" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "notarize-darwin-arm64"
   }
 
   notification {
@@ -107,16 +113,11 @@ event "notarize-darwin-amd64" {
 }
 
 event "notarize-windows-386" {
-  depends = ["notarize-darwin-amd64"]
+  depends = ["notarize-darwin-arm64"]
   action "notarize-windows-386" {
     organization = "hashicorp"
     repository = "crt-workflows-common"
     workflow = "notarize-windows-386"
-
-    parameter {
-      key = "SOME_KEY"
-      value = "SOME_VALUE"
-    }
   }
 
   notification {
@@ -130,11 +131,6 @@ event "notarize-windows-amd64" {
     organization = "hashicorp"
     repository = "crt-workflows-common"
     workflow = "notarize-windows-amd64"
-
-    parameter {
-      key = "SOME_KEY"
-      value = "SOME_VALUE"
-    }
   }
 
   notification {

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -10,8 +10,8 @@ project "consul-k8s" {
     repository = "consul-k8s"
     release_branches = [
       # The CRT tool does not support * yes as a branch name
-      "release/0.42.x",
-      "cb/crt-production-workflows"
+      "main",
+      "cb/crt-testing"
     ]
   }
 }

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,0 +1,13 @@
+container {
+	dependencies = true
+	alpine_secdb = true
+	secrets      = true
+}
+
+binary {
+	secrets      = true
+	go_modules   = true
+	osv          = true
+	oss_index    = true
+	nvd          = true
+}

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -11,3 +11,4 @@ binary {
 	oss_index    = true
 	nvd          = true
 }
+


### PR DESCRIPTION
Changes proposed in this PR:

- This PR needs to be merged before I can start testing the orchestrator
- Note: This will not break anything as it is the orchestrator that needs these files
- Turning on builds, slack notifications, signing/notarizing, security scanning of artifacts we create 

How I've tested this PR:

- Will test post merge and probably make changes

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

