### PR TITLE
[CRT] Disable security scans (for now)

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -8,11 +8,7 @@ project "consul-k8s" {
   github {
     organization = "hashicorp"
     repository = "consul-k8s"
-    release_branches = [
-      # The CRT tool does not support * as a branch name
-      "main",
-      "crt-testing"
-    ]
+    release_branches = ["main"]
   }
 }
 

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -11,7 +11,7 @@ project "consul-k8s" {
     release_branches = [
       # The CRT tool does not support * as a branch name
       "main",
-      "cb/crt-testing"
+      "crt-testing"
     ]
   }
 }

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,14 +1,14 @@
 container {
-	dependencies = true
-	alpine_secdb = true
-	secrets      = true
+	dependencies = false
+	alpine_secdb = false
+	secrets      = false
 }
 
 binary {
-	secrets      = true
-	go_modules   = true
-	osv          = true
-	oss_index    = true
-	nvd          = true
+	secrets      = false
+	go_modules   = false
+	osv          = false
+	oss_index    = false
+	nvd          = false
 }
 


### PR DESCRIPTION
Changes proposed in this PR:
- Disable security scans for now so that I can test CRT
- CRT only runs on merges so testing with a branch is not possible

How I've tested this PR:

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

