### PR TITLE
values.yaml: Add docs warning about reserved Consul namespaces when turning on mirroring

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1934,7 +1934,9 @@ connectInject:
     # of the same name as their k8s namespace, optionally prefixed if
     # `mirroringK8SPrefix` is set below. If the Consul namespace does not
     # already exist, it will be created. Turning this on overrides the
-    # `consulDestinationNamespace` setting.
+    # `consulDestinationNamespace` setting. If mirroring is enabled, avoid creating any Consul 
+    # resources in the following Kubernetes namespaces, as Consul currently reserves these namespaces
+    # for system use: "system", "universal", "operator", "root". 
     mirroringK8S: false
 
     # If `mirroringK8S` is set to true, `mirroringK8SPrefix` allows each Consul namespace


### PR DESCRIPTION
Changes proposed in this PR:
- We plan to remove `consul` from our reserved namespaces list in Core, to allow us to cleanly install Consul K8s and Consul API Gateway.  
- In addition, system", "universal",  "operator", "root" are the remaining reserved namespaces within Consul which we should clearly document so as to prevent issues if `mirroringK8s` is turned on. 

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

