### PR TITLE
Allow the consul namespace to be a destination.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ BUG FIXES:
 IMPROVEMENTS:
 * Helm
   * API Gateway: Allow controller to read ReferencePolicy in order to determine if route is allowed for backend in different namespace. [[GH-1148](https://github.com/hashicorp/consul-k8s/pull/1148)]
+  * Allow `consul` to be a destination namespace. [[GH-1163](https://github.com/hashicorp/consul-k8s/pull/1163)]
 
 ## 0.42.0 (April 04, 2022)
 

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -215,7 +215,7 @@ Usage: {{ template "consul.reservedNamesFailer" (list .Values.key "key") }}
 {{- define "consul.reservedNamesFailer" -}}
 {{- $name := index . 0 -}}
 {{- $key := index . 1 -}}
-{{- if or (eq "system" $name) (eq "universal" $name) (eq "consul" $name) (eq "operator" $name) (eq "root" $name) }}
+{{- if or (eq "system" $name) (eq "universal" $name) (eq "operator" $name) (eq "root" $name) }}
 {{- fail (cat "The name" $name "set for key" $key "is reserved by Consul for future use." ) }}
 {{- end }}
 {{- end -}}

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -1926,10 +1926,6 @@ EOF
   reservedNameTest "universal"
 }
 
-@test "connectInject/Deployment: fails when consulDestinationNamespace=consul" {
-  reservedNameTest "consul"
-}
-
 @test "connectInject/Deployment: fails when consulDestinationNamespace=operator" {
   reservedNameTest "operator"
 }

--- a/charts/consul/test/unit/partition-init-job.bats
+++ b/charts/consul/test/unit/partition-init-job.bats
@@ -174,10 +174,6 @@ load _helpers
   reservedNameTest "universal"
 }
 
-@test "partitionInit/Job: fails when adminPartitions.name=consul" {
-  reservedNameTest "consul"
-}
-
 @test "partitionInit/Job: fails when adminPartitions.name=operator" {
   reservedNameTest "operator"
 }

--- a/charts/consul/test/unit/sync-catalog-deployment.bats
+++ b/charts/consul/test/unit/sync-catalog-deployment.bats
@@ -1358,10 +1358,6 @@ load _helpers
   reservedNameTest "universal"
 }
 
-@test "syncCatalog/Deployment: fails when consulDestinationNamespace=consul" {
-  reservedNameTest "consul"
-}
-
 @test "syncCatalog/Deployment: fails when consulDestinationNamespace=operator" {
   reservedNameTest "operator"
 }


### PR DESCRIPTION
With upcoming consul-enterprise this ns will be valid.

How I've tested this PR:
- unit tests

How I expect reviewers to test this PR:
- code

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

