### PR TITLE
Adding acceptance test for Vault Namespaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -900,9 +900,11 @@ workflows:
             - build-distros-amd64
       # Run acceptance tests using the docker image built for the control plane
       - acceptance:
+          context: consul-ci
           requires:
             - dev-upload-docker
       - acceptance-tproxy:
+          context: consul-ci
           requires:
             - dev-upload-docker
   nightly-acceptance-tests:

--- a/acceptance/framework/vault/helpers.go
+++ b/acceptance/framework/vault/helpers.go
@@ -255,31 +255,3 @@ func CreateConnectCAPolicy(t *testing.T, vaultClient *vapi.Client, datacenter st
 		fmt.Sprintf(connectCAPolicyTemplate, datacenter, datacenter))
 	require.NoError(t, err)
 }
-
-// CreateConnectCAPolicy creates the Vault Policy for the connect-ca in a given datacenter.
-func CreateConnectCAPolicyWithoutDataCenters(t *testing.T, vaultClient *vapi.Client) {
-	connectCAPolicyTemplate := `
-path "/sys/mounts" {
-  capabilities = [ "read" ]
-}
-
-path "/sys/mounts/connect_root" {
-  capabilities = [ "create", "read", "update", "delete", "list" ]
-}
-
-path "/sys/mounts/connect_inter" {
-  capabilities = [ "create", "read", "update", "delete", "list" ]
-}
-
-path "/connect_root/*" {
-  capabilities = [ "create", "read", "update", "delete", "list" ]
-}
-
-path "/connect_inter/*" {
-  capabilities = [ "create", "read", "update", "delete", "list" ]
-}
-`
-	err := vaultClient.Sys().PutPolicy(
-		fmt.Sprintf("connect-ca"), connectCAPolicyTemplate)
-	require.NoError(t, err)
-}

--- a/acceptance/framework/vault/helpers.go
+++ b/acceptance/framework/vault/helpers.go
@@ -83,7 +83,6 @@ func GenerateGossipSecret() (string, error) {
 // ConfigureGossipVaultSecret generates a gossip encryption key,
 // stores it in Vault as a secret and configures a policy to access it.
 func ConfigureGossipVaultSecret(t *testing.T, vaultClient *vapi.Client) string {
-	vaultClient.SetNamespace("admin")
 	// Create the Vault Policy for the gossip key.
 	logger.Log(t, "Creating gossip policy")
 	err := vaultClient.Sys().PutPolicy("gossip", gossipPolicy)

--- a/acceptance/tests/snapshot-agent/snapshot_agent_vault_test.go
+++ b/acceptance/tests/snapshot-agent/snapshot_agent_vault_test.go
@@ -34,7 +34,7 @@ func TestSnapshotAgent_Vault(t *testing.T) {
 	vaultReleaseName := helpers.RandomName()
 
 	vaultCluster := vault.NewVaultCluster(t, ctx, cfg, vaultReleaseName, nil)
-	vaultCluster.Create(t, ctx)
+	vaultCluster.Create(t, ctx, "")
 	// Vault is now installed in the cluster.
 
 	// Now fetch the Vault client so we can create the policies and secrets.

--- a/acceptance/tests/vault/vault_namespaces_test.go
+++ b/acceptance/tests/vault/vault_namespaces_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestVault installs Vault, configures a Vault namespace, and then bootstraps it
+// TestVault_VaultNamespace installs Vault, configures a Vault namespace, and then bootstraps it
 // with secrets, policies, and Kube Auth Method.
 // It then configures Consul to use vault as the backend and checks that it works
-//with the vault namespace.
+// with the vault namespace.
 func TestVault_VaultNamespace(t *testing.T) {
 	cfg := suite.Config()
 	ctx := suite.Environment().DefaultContext(t)
@@ -36,7 +36,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 	logger.Log(t, "Creating secret for Vault license")
 	consul.CreateK8sSecret(t, k8sClient, cfg, ns, vaultLicenseSecretName, vaultLicenseSecretKey, vaultEnterpriseLicense)
 	vaultHelmvalues := map[string]string{
-		"server.image.repository":             "hashicorp/vault-enterprise",
+		"server.image.repository":             "docker.mirror.hashicorp.services/hashicorp/vault-enterprise",
 		"server.image.tag":                    "1.9.4-ent",
 		"server.enterpriseLicense.secretName": vaultLicenseSecretName,
 		"server.enterpriseLicense.secretKey":  vaultLicenseSecretKey,

--- a/acceptance/tests/vault/vault_namespaces_test.go
+++ b/acceptance/tests/vault/vault_namespaces_test.go
@@ -31,7 +31,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 	vaultLicenseSecretName := fmt.Sprintf("%s-enterprise-license", vaultReleaseName)
 	vaultLicenseSecretKey := "license"
 
-	vaultEnterpriseLicense := os.Getenv("VAULT_ENT_LICENSE")
+	vaultEnterpriseLicense := os.Getenv("VAULT_LICENSE")
 
 	logger.Log(t, "Creating secret for Vault license")
 	consul.CreateK8sSecret(t, k8sClient, cfg, ns, vaultLicenseSecretName, vaultLicenseSecretKey, vaultEnterpriseLicense)

--- a/acceptance/tests/vault/vault_namespaces_test.go
+++ b/acceptance/tests/vault/vault_namespaces_test.go
@@ -2,10 +2,12 @@ package vault
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	terratestLogger "github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
@@ -13,20 +15,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const staticClientName = "static-client"
-
-// TestVault installs Vault, bootstraps it with secrets, policies, and Kube Auth Method.
-// It then configures Consul to use vault as the backend and checks that it works.
-func TestVault(t *testing.T) {
+// TestVault installs Vault, configures a Vault namespace, and then bootstraps it
+// with secrets, policies, and Kube Auth Method.
+// It then configures Consul to use vault as the backend and checks that it works
+//with the vault namespace.
+func TestVault_VaultNamespace(t *testing.T) {
 	cfg := suite.Config()
 	ctx := suite.Environment().DefaultContext(t)
 	ns := ctx.KubectlOptions(t).Namespace
-
+	vaultNamespacePath := "admin"
 	consulReleaseName := helpers.RandomName()
 	vaultReleaseName := helpers.RandomName()
 
-	vaultCluster := vault.NewVaultCluster(t, ctx, cfg, vaultReleaseName, nil)
-	vaultCluster.Create(t, ctx, "")
+	k8sClient := environment.KubernetesClientFromOptions(t, ctx.KubectlOptions(t))
+	vaultLicenseSecretName := fmt.Sprintf("%s-enterprise-license", vaultReleaseName)
+	vaultLicenseSecretKey := "license"
+
+	vaultEnterpriseLicense := os.Getenv("VAULT_ENT_LICENSE")
+
+	logger.Log(t, "Creating secret for Vault license")
+	consul.CreateK8sSecret(t, k8sClient, cfg, ns, vaultLicenseSecretName, vaultLicenseSecretKey, vaultEnterpriseLicense)
+	vaultHelmvalues := map[string]string{
+		"server.image.repository":             "hashicorp/vault-enterprise",
+		"server.image.tag":                    "1.9.4-ent",
+		"server.enterpriseLicense.secretName": vaultLicenseSecretName,
+		"server.enterpriseLicense.secretKey":  vaultLicenseSecretKey,
+	}
+	vaultCluster := vault.NewVaultCluster(t, ctx, cfg, vaultReleaseName, vaultHelmvalues)
+	vaultCluster.Create(t, ctx, vaultNamespacePath)
 	// Vault is now installed in the cluster.
 
 	// Now fetch the Vault client so we can create the policies and secrets.
@@ -51,7 +67,7 @@ func TestVault(t *testing.T) {
 	vault.ConfigureConsulCAKubernetesAuthRole(t, vaultClient, ns, "kubernetes")
 
 	vault.ConfigurePKICA(t, vaultClient)
-	certPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1", "1h")
+	certPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1")
 
 	vaultCASecret := vault.CASecretName(vaultReleaseName)
 
@@ -76,6 +92,9 @@ func TestVault(t *testing.T) {
 		"global.secretsBackend.vault.connectCA.address":             vaultCluster.Address(),
 		"global.secretsBackend.vault.connectCA.rootPKIPath":         "connect_root",
 		"global.secretsBackend.vault.connectCA.intermediatePKIPath": "dc1/connect_inter",
+		"global.secretsBackend.vault.connectCA.additionalConfig":    fmt.Sprintf(`"{\"connect\": [{ \"ca_config\": [{ \"namespace\": \"%s\"}]}]}"`, vaultNamespacePath),
+
+		"global.secretsBackend.vault.agentAnnotations": fmt.Sprintf("\"vault.hashicorp.com/namespace\": \"%s\"", vaultNamespacePath),
 
 		"global.acls.manageSystemACLs":          "true",
 		"global.acls.bootstrapToken.secretName": "consul/data/secret/bootstrap",
@@ -114,7 +133,7 @@ func TestVault(t *testing.T) {
 	// Validate that the gossip encryption key is set correctly.
 	logger.Log(t, "Validating the gossip key has been set correctly.")
 	consulCluster.ACLToken = bootstrapToken
-	consulClient, _ := consulCluster.SetupConsulClient(t, true)
+	consulClient := consulCluster.SetupConsulClient(t, true)
 	keys, err := consulClient.Operator().KeyringList(nil)
 	require.NoError(t, err)
 	// There are two identical keys for LAN and WAN since there is only 1 dc.

--- a/acceptance/tests/vault/vault_namespaces_test.go
+++ b/acceptance/tests/vault/vault_namespaces_test.go
@@ -67,7 +67,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 	vault.ConfigureConsulCAKubernetesAuthRole(t, vaultClient, ns, "kubernetes")
 
 	vault.ConfigurePKICA(t, vaultClient)
-	certPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1")
+	certPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1", "1h")
 
 	vaultCASecret := vault.CASecretName(vaultReleaseName)
 
@@ -133,7 +133,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 	// Validate that the gossip encryption key is set correctly.
 	logger.Log(t, "Validating the gossip key has been set correctly.")
 	consulCluster.ACLToken = bootstrapToken
-	consulClient := consulCluster.SetupConsulClient(t, true)
+	consulClient, _ := consulCluster.SetupConsulClient(t, true)
 	keys, err := consulClient.Operator().KeyringList(nil)
 	require.NoError(t, err)
 	// There are two identical keys for LAN and WAN since there is only 1 dc.

--- a/acceptance/tests/vault/vault_namespaces_test.go
+++ b/acceptance/tests/vault/vault_namespaces_test.go
@@ -23,7 +23,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 	cfg := suite.Config()
 	ctx := suite.Environment().DefaultContext(t)
 	ns := ctx.KubectlOptions(t).Namespace
-	vaultNamespacePath := "admin"
+	vaultNamespacePath := "test-namespace"
 	consulReleaseName := helpers.RandomName()
 	vaultReleaseName := helpers.RandomName()
 

--- a/acceptance/tests/vault/vault_partitions_test.go
+++ b/acceptance/tests/vault/vault_partitions_test.go
@@ -45,7 +45,7 @@ func TestVault_Partitions(t *testing.T) {
 		serverClusterVaultHelmValues["server.service.nodePort"] = "31000"
 	}
 	serverClusterVault := vault.NewVaultCluster(t, serverClusterCtx, cfg, vaultReleaseName, serverClusterVaultHelmValues)
-	serverClusterVault.Create(t, serverClusterCtx)
+	serverClusterVault.Create(t, serverClusterCtx, "")
 
 	externalVaultAddress := vaultAddress(t, cfg, serverClusterCtx, vaultReleaseName)
 
@@ -59,7 +59,7 @@ func TestVault_Partitions(t *testing.T) {
 	}
 
 	secondaryVaultCluster := vault.NewVaultCluster(t, clientClusterCtx, cfg, vaultReleaseName, clientClusterVaultHelmValues)
-	secondaryVaultCluster.Create(t, clientClusterCtx)
+	secondaryVaultCluster.Create(t, clientClusterCtx, "")
 
 	vaultClient := serverClusterVault.VaultClient(t)
 

--- a/acceptance/tests/vault/vault_tls_auto_reload_test.go
+++ b/acceptance/tests/vault/vault_tls_auto_reload_test.go
@@ -28,7 +28,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 	vaultReleaseName := helpers.RandomName()
 
 	vaultCluster := vault.NewVaultCluster(t, ctx, cfg, vaultReleaseName, nil)
-	vaultCluster.Create(t, ctx)
+	vaultCluster.Create(t, ctx, "")
 	// Vault is now installed in the cluster.
 
 	// Now fetch the Vault client so we can create the policies and secrets.

--- a/acceptance/tests/vault/vault_wan_fed_test.go
+++ b/acceptance/tests/vault/vault_wan_fed_test.go
@@ -48,7 +48,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	}
 
 	primaryVaultCluster := vault.NewVaultCluster(t, primaryCtx, cfg, vaultReleaseName, primaryVaultHelmValues)
-	primaryVaultCluster.Create(t, primaryCtx)
+	primaryVaultCluster.Create(t, primaryCtx, "")
 
 	externalVaultAddress := vaultAddress(t, cfg, primaryCtx, vaultReleaseName)
 
@@ -62,7 +62,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	}
 
 	secondaryVaultCluster := vault.NewVaultCluster(t, secondaryCtx, cfg, vaultReleaseName, secondaryVaultHelmValues)
-	secondaryVaultCluster.Create(t, secondaryCtx)
+	secondaryVaultCluster.Create(t, secondaryCtx, "")
 
 	vaultClient := primaryVaultCluster.VaultClient(t)
 


### PR DESCRIPTION
Changes proposed in this PR:
- an acceptance test that sets up vault using namespaces and confirms that the pods come up and an app deployed on the cluster works
- a signature change to `vaultCluster.Create()` to allow passing in a namespace

How I've tested this PR:
- running the test

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

