### PR TITLE
Cleanup EKS VPC peering connections

### DIFF
--- a/hack/aws-acceptance-test-cleanup/main.go
+++ b/hack/aws-acceptance-test-cleanup/main.go
@@ -197,6 +197,30 @@ func realMain(ctx context.Context) error {
 
 		vpcID := cluster.ResourcesVpcConfig.VpcId
 
+		filternameAccepter := "accepter-vpc-info.vpc-id"
+		filternameRequester := "requester-vpc-info.vpc-id"
+		vpcPeeringConnectionsWithAccepter, err := ec2Client.DescribeVpcPeeringConnections(&ec2.DescribeVpcPeeringConnectionsInput{
+			Filters: []*ec2.Filter{
+				{
+					Name:   &filternameAccepter,
+					Values: []*string{vpcID},
+				},
+			},
+		})
+
+		if err != nil {
+			return err
+		}
+		vpcPeeringConnectionsWithRequester, err := ec2Client.DescribeVpcPeeringConnections(&ec2.DescribeVpcPeeringConnectionsInput{
+			Filters: []*ec2.Filter{
+				{
+					Name:   &filternameRequester,
+					Values: []*string{vpcID},
+				},
+			},
+		})
+		vpcPeeringConnectionsToDelete := append(vpcPeeringConnectionsWithAccepter.VpcPeeringConnections, vpcPeeringConnectionsWithRequester.VpcPeeringConnections...)
+
 		// Delete NAT gateways.
 		natGateways, err := ec2Client.DescribeNatGatewaysWithContext(ctx, &ec2.DescribeNatGatewaysInput{
 			Filter: []*ec2.Filter{
@@ -417,6 +441,14 @@ func realMain(ctx context.Context) error {
 				return err
 			}
 			fmt.Printf("Security group: Destroyed [id=%s]\n", *sg.GroupId)
+		}
+
+		for _, vpcpc := range vpcPeeringConnectionsToDelete {
+			_, err = ec2Client.DeleteVpcPeeringConnection(&ec2.DeleteVpcPeeringConnectionInput{VpcPeeringConnectionId: vpcpc.VpcPeeringConnectionId})
+			if err != nil {
+				return err
+			}
+			fmt.Printf("VPC PeeringConnection: Destroyed [id=%s]\n", *vpcpc.VpcPeeringConnectionId)
 		}
 
 		// Delete VPC. Sometimes there's a race condition where AWS thinks

--- a/hack/aws-acceptance-test-cleanup/main.go
+++ b/hack/aws-acceptance-test-cleanup/main.go
@@ -197,6 +197,7 @@ func realMain(ctx context.Context) error {
 
 		vpcID := cluster.ResourcesVpcConfig.VpcId
 
+		// Once we have the VPC ID, collect VPC peering connections to delete.
 		filternameAccepter := "accepter-vpc-info.vpc-id"
 		filternameRequester := "requester-vpc-info.vpc-id"
 		vpcPeeringConnectionsWithAccepter, err := ec2Client.DescribeVpcPeeringConnections(&ec2.DescribeVpcPeeringConnectionsInput{
@@ -443,6 +444,7 @@ func realMain(ctx context.Context) error {
 			fmt.Printf("Security group: Destroyed [id=%s]\n", *sg.GroupId)
 		}
 
+		// Delete VPC Peering Connections.
 		for _, vpcpc := range vpcPeeringConnectionsToDelete {
 			_, err = ec2Client.DeleteVpcPeeringConnection(&ec2.DeleteVpcPeeringConnectionInput{VpcPeeringConnectionId: vpcpc.VpcPeeringConnectionId})
 			if err != nil {


### PR DESCRIPTION
Changes proposed in this PR:
- Currently if you run terraform apply with cluster count of 2, and then run our cleanup script, it will fail because VPCs can't get deleted since they have a dependency on peering connections
- This allows you to run the cleanup script successfully, by deleting peering conns

How I've tested this PR:
- Ran script after terraforming 2 eks clusters, and saw it succeed.

How I expect reviewers to test this PR:
👀 



