### PR TITLE
build the distro so that nightly-dev-docker runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -889,7 +889,7 @@ workflows:
      # the summer of 2022 for larger puplic Github Action VMs be available before the acceptance tests can
      # be moved
       - build-distro:
-          OS: "linux"
+          OS: "darwin freebsd linux solaris windows"
           ARCH: "amd64"
           name: build-distros-amd64
       - dev-upload-docker:
@@ -915,10 +915,13 @@ workflows:
                 - main
     jobs:
       - build-distro:
-          OS: "darwin freebsd linux solaris windows"
+          OS: "linux"
           ARCH: "amd64"
           name: build-distros-amd64
-      - nightly-dev-upload-docker
+      - nightly-dev-upload-docker:
+          context: consul-ci
+          requires:
+            - build-distros-amd64
       - cleanup-gcp-resources
       - cleanup-azure-resources
       - cleanup-eks-resources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -914,6 +914,10 @@ workflows:
               only:
                 - main
     jobs:
+      - build-distro:
+          OS: "darwin freebsd linux solaris windows"
+          ARCH: "amd64"
+          name: build-distros-amd64
       - nightly-dev-upload-docker
       - cleanup-gcp-resources
       - cleanup-azure-resources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -889,7 +889,7 @@ workflows:
      # the summer of 2022 for larger puplic Github Action VMs be available before the acceptance tests can
      # be moved
       - build-distro:
-          OS: "darwin freebsd linux solaris windows"
+          OS: "linux"
           ARCH: "amd64"
           name: build-distros-amd64
       - dev-upload-docker:


### PR DESCRIPTION
Changes proposed in this PR:
- I believe that nightly acceptance tests are failing because we need to build the binary first
- I am taking a shot at this as it is difficult to test

How I've tested this PR:

:eyes:

How I expect reviewers to test this PR:

👀  & 🙏 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

