### PR TITLE
Scheduled jobs in CircleCI cannot have context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -919,7 +919,6 @@ workflows:
           ARCH: "amd64"
           name: build-distros-amd64
       - nightly-dev-upload-docker:
-          context: consul-ci
           requires:
             - build-distros-amd64
       - cleanup-gcp-resources


### PR DESCRIPTION
Changes proposed in this PR:
- The scheduled jobs in circle ci cannot have context
- This removes this so that a new container will be built for nightly acceptance jobs

How I've tested this PR:

- Need to wait for the scheduled job to run

How I expect reviewers to test this PR:

👁️ 👁️ 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

