### PR TITLE
Resolving flakey behavior in TestPartitions_Sync with Controller by removing Controller because it is not needed for the test.

### DIFF
--- a/acceptance/tests/partitions/partitions_sync_test.go
+++ b/acceptance/tests/partitions/partitions_sync_test.go
@@ -99,8 +99,6 @@ func TestPartitions_Sync(t *testing.T) {
 				"syncCatalog.consulNamespaces.mirroringK8S":               strconv.FormatBool(c.mirrorK8S),
 				"syncCatalog.addK8SNamespaceSuffix":                       "false",
 
-				"controller.enabled": "true",
-
 				"dns.enabled":           "true",
 				"dns.enableRedirection": strconv.FormatBool(cfg.EnableTransparentProxy),
 			}


### PR DESCRIPTION
Changes proposed in this PR:
- Remove use of controller from TestPartitions_Sync

How I've tested this PR:
- running acceptance test locally
- 
How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

