### PR TITLE
Correct webhook-cert-manager-clusterrole to utilize the web-cert-manager podsecuritypolicy rather than connect-injectors when global.EnablePodSecurityPolicies is true.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ BUG FIXES:
   * Update client-daemonset to include ca-cert volumeMount only when tls is enabled. [[GH-1194](https://github.com/hashicorp/consul-k8s/pull/1194)]
   * Update create-federation-secret-job to look up the automatically generated gossip encryption key by the right name when global.name is unset or set to something other than consul. [[GH-1196](https://github.com/hashicorp/consul-k8s/pull/1196)]
   * Add Admin Partitions support to Sync Catalog **(Consul Enterprise only)**. [[GH-1180](https://github.com/hashicorp/consul-k8s/pull/1190)]
-  * Correct webhook-cert-manager-clusterrole to utilize the web-cert-manager podsecuritypolicy rather than connect-injectors when global.EnablePodSecurityPolicies is true. [[GH-1202](https://github.com/hashicorp/consul-k8s/pull/1202)]
+  * Correct webhook-cert-manager-clusterrole to utilize the web-cert-manager podsecuritypolicy rather than connect-injectors when `global.enablePodSecurityPolicies` is true. [[GH-1202](https://github.com/hashicorp/consul-k8s/pull/1202)]
 
 ## 0.43.0 (April 21, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ BUG FIXES:
   * Update client-daemonset to include ca-cert volumeMount only when tls is enabled. [[GH-1194](https://github.com/hashicorp/consul-k8s/pull/1194)]
   * Update create-federation-secret-job to look up the automatically generated gossip encryption key by the right name when global.name is unset or set to something other than consul. [[GH-1196](https://github.com/hashicorp/consul-k8s/pull/1196)]
   * Add Admin Partitions support to Sync Catalog **(Consul Enterprise only)**. [[GH-1180](https://github.com/hashicorp/consul-k8s/pull/1190)]
+  * Correct webhook-cert-manager-clusterrole to utilize the web-cert-manager podsecuritypolicy rather than connect-injectors when global.EnablePodSecurityPolicies is true. [[GH-1202](https://github.com/hashicorp/consul-k8s/pull/1202)]
 
 ## 0.43.0 (April 21, 2022)
 

--- a/charts/consul/templates/webhook-cert-manager-clusterrole.yaml
+++ b/charts/consul/templates/webhook-cert-manager-clusterrole.yaml
@@ -45,6 +45,14 @@ rules:
   resources:
   - podsecuritypolicies
   resourceNames:
+  - {{ template "consul.fullname" . }}-webhook-cert-manager
+  verbs:
+  - use
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
   - {{ template "consul.fullname" . }}-connect-injector
   verbs:
   - use

--- a/charts/consul/templates/webhook-cert-manager-clusterrole.yaml
+++ b/charts/consul/templates/webhook-cert-manager-clusterrole.yaml
@@ -48,13 +48,5 @@ rules:
   - {{ template "consul.fullname" . }}-webhook-cert-manager
   verbs:
   - use
-- apiGroups:
-  - policy
-  resources:
-  - podsecuritypolicies
-  resourceNames:
-  - {{ template "consul.fullname" . }}-connect-injector
-  verbs:
-  - use
 {{- end }}
 {{- end }}

--- a/charts/consul/test/unit/webhook-cert-manager-clusterrole.bats
+++ b/charts/consul/test/unit/webhook-cert-manager-clusterrole.bats
@@ -43,13 +43,34 @@ load _helpers
 #--------------------------------------------------------------------
 # global.enablePodSecurityPolicies
 
-@test "webhookCertManager/ClusterRole: allows podsecuritypolicies access with global.enablePodSecurityPolicies=true" {
+@test "webhookCertManager/ClusterRole: allows podsecuritypolicies access for webhook-cert-manager with global.enablePodSecurityPolicies=true" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local object=$(helm template \
       -s templates/webhook-cert-manager-clusterrole.yaml  \
       --set 'controller.enabled=true' \
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
-      yq -r '.rules[3].resources[0]' | tee /dev/stderr)
+      yq -r '.rules[3]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.resources[0]' | tee /dev/stderr)
   [ "${actual}" = "podsecuritypolicies" ]
+
+  local actual=$(echo $object | yq -r '.resourceNames[0]' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-webhook-cert-manager" ]
+}
+
+@test "webhookCertManager/ClusterRole: allows podsecuritypolicies access for connect-injector with global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/webhook-cert-manager-clusterrole.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules[4]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "podsecuritypolicies" ]
+
+  local actual=$(echo $object | yq -r '.resourceNames[0]' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-connect-injector" ]
 }

--- a/charts/consul/test/unit/webhook-cert-manager-clusterrole.bats
+++ b/charts/consul/test/unit/webhook-cert-manager-clusterrole.bats
@@ -58,19 +58,3 @@ load _helpers
   local actual=$(echo $object | yq -r '.resourceNames[0]' | tee /dev/stderr)
   [ "${actual}" = "release-name-consul-webhook-cert-manager" ]
 }
-
-@test "webhookCertManager/ClusterRole: allows podsecuritypolicies access for connect-injector with global.enablePodSecurityPolicies=true" {
-  cd `chart_dir`
-  local object=$(helm template \
-      -s templates/webhook-cert-manager-clusterrole.yaml  \
-      --set 'controller.enabled=true' \
-      --set 'global.enablePodSecurityPolicies=true' \
-      . | tee /dev/stderr |
-      yq -r '.rules[4]' | tee /dev/stderr)
-
-  local actual=$(echo $object | yq -r '.resources[0]' | tee /dev/stderr)
-  [ "${actual}" = "podsecuritypolicies" ]
-
-  local actual=$(echo $object | yq -r '.resourceNames[0]' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-connect-injector" ]
-}


### PR DESCRIPTION
Changes proposed in this PR:
- add podsecuritypolicy use for webhook-cert-manager to the clusterrole.

How I've tested this PR:
- will run acceptance jobs

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

