### PR TITLE
Adding timeout to EKS terraform for VPC due to it timing out at 20 minutes in nightly run

### DIFF
--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -48,6 +48,11 @@ module "vpc" {
   }
 
   tags = var.tags
+
+  timeouts {
+    create = "20m"
+    delete = "20m"
+  }
 }
 
 module "eks" {


### PR DESCRIPTION
Changes proposed in this PR:
- Add 20m timeout for VPC on EKS in Nightly acceptance job terraform

How I've tested this PR:
👀 
How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

