### PR TITLE
Updating CHANGELOG to include breaking change in 0.43 with the reliance on consul 1.12 due to -auto-reload-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ BUG FIXES:
 
 BREAKING CHANGES:
 * Helm
-  * Release 0.43.0 requires Consul 1.12.0+ because of a reliance on the Consul `-auto-reload-config` flag which monitors changes to specific Consul configuration properties and reloads itself when changes are detected. [[GH-1135](https://github.com/hashicorp/consul-k8s/pull/1135)]
+  * Requires Consul 1.12.0+ as the Server statefulsets are now provisioned with Consul `-auto-reload-config` flag which monitors changes to specific Consul configuration properties and reloads itself when changes are detected. [[GH-1135](https://github.com/hashicorp/consul-k8s/pull/1135)]
   * API Gateway: Re-use connectInject.consulNamespaces instead of requiring that apiGateway.consulNamespaces have the same value when ACLs are enabled. [[GH-1169](https://github.com/hashicorp/consul-k8s/pull/1169)]
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ BUG FIXES:
 
 BREAKING CHANGES:
 * Helm
+  * Release 0.43.0 requires Consul 1.12.0+ because of a reliance on the Consul `-auto-reload-config` flag which monitors changes to specific Consul configuration properties and reloads itself when changes are detected. [[GH-1135](https://github.com/hashicorp/consul-k8s/pull/1135)]
   * API Gateway: Re-use connectInject.consulNamespaces instead of requiring that apiGateway.consulNamespaces have the same value when ACLs are enabled. [[GH-1169](https://github.com/hashicorp/consul-k8s/pull/1169)]
 
 FEATURES:


### PR DESCRIPTION
Changes proposed in this PR:
- CHANGELOG entry for breaking change
-

How I've tested this PR:
👀 

How I expect reviewers to test this PR:
👀 & ✍️ 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

