### PR TITLE
Remove timeouts from EKS vpc tf module definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -919,6 +919,7 @@ workflows:
           ARCH: "amd64"
           name: build-distros-amd64
       - nightly-dev-upload-docker:
+          context: consul-ci
           requires:
             - build-distros-amd64
       - cleanup-gcp-resources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -919,7 +919,6 @@ workflows:
           ARCH: "amd64"
           name: build-distros-amd64
       - nightly-dev-upload-docker:
-          context: consul-ci
           requires:
             - build-distros-amd64
       - cleanup-gcp-resources

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -48,11 +48,6 @@ module "vpc" {
   }
 
   tags = var.tags
-
-  timeouts {
-    create = "20m"
-    delete = "20m"
-  }
 }
 
 module "eks" {


### PR DESCRIPTION
Background:
- I added this timeouts section last night when we had a nightly EKS job fail when trying to destroy and it timeout on destroying the VPC.
- It turns out that this module does not expose timeouts
- Also the [aws_vpc resource does not either](https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/master/main.tf#L20) compared to [others that do](https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/41da6881e295ff5e94bbf97b41018e7c550c7285/main.tf#L148).

Changes proposed in this PR:
-  Removing timeouts as it is not a valid option

How I've tested this PR:
- re-run tf apply locally

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

