### PR TITLE
Fixing make ci.nightly-dev-docker to push the correct tag

### DIFF
--- a/control-plane/Makefile
+++ b/control-plane/Makefile
@@ -59,9 +59,9 @@ ci.nightly-dev-docker:
 	$(CI_DEV_DOCKER_WORKDIR) -f $(CURDIR)/Dockerfile
 	@echo $(DOCKER_PASS) | docker login -u="$(DOCKER_USER)" --password-stdin
 	@echo "Pushing dev image to: https://cloud.docker.com/u/$(CI_DEV_DOCKER_NAMESPACE)/repository/docker/$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME)"
-	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT)
+	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):nightly-$(GIT_COMMIT)
 ifeq ($(CIRCLE_BRANCH), main)
-	@docker tag $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT) $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
+	@docker tag $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):nightly-$(GIT_COMMIT) $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
 	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
 endif
 


### PR DESCRIPTION
Changes proposed in this PR:
- adding the `nightly-`prefix to the tag that gets pushed.  CI currently fails with the below. It should try to push image `hashicorpdev/consul-k8s-control-plane:nightly-875319b2`

```
The push refers to a repository [docker.io/hashicorpdev/consul-k8s-control-plane]
tag does not exist: hashicorpdev/consul-k8s-control-plane:875319b2
make: *** [Makefile:57: ci.nightly-dev-docker] Error 1
```

How I've tested this PR:
👀 
How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

