### PR TITLE
Enable auto_reload_config only when Vault is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+BREAKING CHANGES:
+* Helm
+  * Using the Vault integration requires Consul 1.12.0+.
+
 IMPROVEMENTS:
 * Helm
   * Enable the ability to `configure global.consulAPITimeout` to configure how long requests to the Consul API will wait to resolve before canceling.  The default value is 5 seconds. [[GH-1178](https://github.com/hashicorp/consul-k8s/pull/1178)]
@@ -12,6 +16,7 @@ BUG FIXES:
   * Update create-federation-secret-job to look up the automatically generated gossip encryption key by the right name when global.name is unset or set to something other than consul. [[GH-1196](https://github.com/hashicorp/consul-k8s/pull/1196)]
   * Add Admin Partitions support to Sync Catalog **(Consul Enterprise only)**. [[GH-1180](https://github.com/hashicorp/consul-k8s/pull/1190)]
   * Correct webhook-cert-manager-clusterrole to utilize the web-cert-manager podsecuritypolicy rather than connect-injectors when `global.enablePodSecurityPolicies` is true. [[GH-1202](https://github.com/hashicorp/consul-k8s/pull/1202)]
+  * Enable Consul auto-reload-config only when Vault is enabled. [[GH-1213](https://github.com/hashicorp/consul-k8s/pull/1213)]
 
 ## 0.43.0 (April 21, 2022)
 

--- a/charts/consul/templates/client-config-configmap.yaml
+++ b/charts/consul/templates/client-config-configmap.yaml
@@ -15,7 +15,9 @@ metadata:
 data:
   client.json: |-
     {
+      {{- if and .Values.global.secretsBackend.vault.enabled }}
       "auto_reload_config": true
+      {{- end }}
     }
   extra-from-values.json: |-
 {{ tpl .Values.client.extraConfig . | trimAll "\"" | indent 4 }}

--- a/charts/consul/templates/server-config-configmap.yaml
+++ b/charts/consul/templates/server-config-configmap.yaml
@@ -14,7 +14,9 @@ metadata:
 data:
   server.json: |
     {
+      {{- if and .Values.global.secretsBackend.vault.enabled }}
       "auto_reload_config": true,
+      {{- end }}
       "bind_addr": "0.0.0.0",
       "bootstrap_expect": {{ if .Values.server.bootstrapExpect }}{{ .Values.server.bootstrapExpect }}{{ else }}{{ .Values.server.replicas }}{{ end }},
       "client_addr": "0.0.0.0",

--- a/charts/consul/test/unit/client-config-configmap.bats
+++ b/charts/consul/test/unit/client-config-configmap.bats
@@ -74,12 +74,26 @@ load _helpers
 #--------------------------------------------------------------------
 # auto_reload_config
 
-@test "client/ConfigMap: auto reload config is set to true" {
+@test "client/ConfigMap: auto reload config is set to true when Vault is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true'  \
+      --set 'global.secretsBackend.vault.consulServerRole=test' \
+      --set 'global.secretsBackend.vault.consulClientRole=test' \
+      --set 'global.secretsBackend.vault.consulCARole=test' \
+      . | tee /dev/stderr |
+      yq -r '.data["client.json"]' | jq -r .auto_reload_config | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+@test "client/ConfigMap: auto reload config is config is not set by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/client-config-configmap.yaml  \
       . | tee /dev/stderr |
       yq -r '.data["client.json"]' | jq -r .auto_reload_config | tee /dev/stderr)
 
-  [ "${actual}" = "true" ]
+  [ "${actual}" = null ]
 }

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -551,7 +551,7 @@ load _helpers
       -s templates/client-daemonset.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 3bd6198418457f5acc746c0d21fbb4afdf2b38e5bbcfef23fb3f97e2600fe964 ]
+  [ "${actual}" = 55f93d04c3f0b85c7ef2869e4b8623296025a8388c881eab63be9f2dc70bafd6 ]
 }
 
 @test "client/DaemonSet: config-checksum annotation changes when extraConfig is provided" {
@@ -561,7 +561,7 @@ load _helpers
       --set 'client.extraConfig="{\"hello\": \"world\"}"' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 41535aa4cb7cffc4c70641efc882f5d6e3e87fce6e76d409409ff287cb4b23e8 ]
+  [ "${actual}" = 891c0e207e1e0259ffb150d7364b667b7b12786ce37af3dd89f366bc6d2f21aa ]
 }
 
 @test "client/DaemonSet: config-checksum annotation changes when connectInject.enabled=true" {
@@ -571,7 +571,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = bad77069ea6e4915272cf520faecb96333f6adef97c992e0aecc324381754eb2 ]
+  [ "${actual}" = f9be2829fed80a127e3752e10be32f29c2f9ca0ea548abcf3d4fc2c985cb7201 ]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/test/unit/server-config-configmap.bats
+++ b/charts/consul/test/unit/server-config-configmap.bats
@@ -799,12 +799,26 @@ load _helpers
 #--------------------------------------------------------------------
 # auto_reload_config
 
-@test "server/ConfigMap: auto reload config is set to true" {
+@test "server/ConfigMap: auto reload config is set to true when Vault is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.secretsBackend.vault.enabled=true'  \
+      --set 'global.secretsBackend.vault.consulServerRole=test' \
+      --set 'global.secretsBackend.vault.consulClientRole=test' \
+      --set 'global.secretsBackend.vault.consulCARole=test' \
+      . | tee /dev/stderr |
+      yq -r '.data["server.json"]' | jq -r .auto_reload_config | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+@test "server/ConfigMap: auto reload config is not set by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-config-configmap.yaml  \
       . | tee /dev/stderr |
       yq -r '.data["server.json"]' | jq -r .auto_reload_config | tee /dev/stderr)
 
-  [ "${actual}" = "true" ]
+  [ "${actual}" = null ]
 }

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -671,7 +671,7 @@ load _helpers
       -s templates/server-statefulset.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 4c8adc33d5123dd1decbbe11d4999a3a8dd209003df703fe5035b0591e904624 ]
+  [ "${actual}" = 8c29e583455a2e8d0372cbb884f00214d8b4ccf31f1647aab119778707ab56f8 ]
 }
 
 @test "server/StatefulSet: adds config-checksum annotation when extraConfig is provided" {
@@ -681,7 +681,7 @@ load _helpers
       --set 'server.extraConfig="{\"hello\": \"world\"}"' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = 472da13553591e000f0354a013c661955fd4ee1b7dade29570785d8eb303182a ]
+  [ "${actual}" = 66fb7e1b861234b5291a0f2e464610febb721b358e6a6985f9b17d7a459edc50 ]
 }
 
 @test "server/StatefulSet: adds config-checksum annotation when config is updated" {
@@ -691,7 +691,7 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = a42be230e4c41dc0d3c239d099bd90b9e43b2a17b904d2a32fe9c8622d8f2194 ]
+  [ "${actual}" = 51c076418d5d7654ac239e16773cf4dbd3bc4af413db48e88340ca25536b57ad ]
 }
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
Changes proposed in this PR:
- Enable auto_reload_config only when Vault is enabled.

How I've tested this PR:
- Bats tests
How I expect reviewers to test this PR:
- 👀 

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

