### PR TITLE
Exempt ACL Bootstrap logic from`global.consulAPITimeout` by giving it a 5 timeout

### DIFF
--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"regexp"
 	"strings"
 	"sync"
@@ -361,9 +360,6 @@ func (c *Command) Run(args []string) int {
 
 	if c.flagEnablePartitions {
 		clientConfig.Partition = c.flagPartitionName
-	}
-	clientConfig.HttpClient = &http.Client{
-		Timeout: 5 * time.Minute,
 	}
 	consulClient, err := consul.NewClient(clientConfig, c.flagConsulAPITimeout)
 	if err != nil {

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"regexp"
 	"strings"
 	"sync"
@@ -360,6 +361,9 @@ func (c *Command) Run(args []string) int {
 
 	if c.flagEnablePartitions {
 		clientConfig.Partition = c.flagPartitionName
+	}
+	clientConfig.HttpClient = &http.Client{
+		Timeout: 5 * time.Minute,
 	}
 	consulClient, err := consul.NewClient(clientConfig, c.flagConsulAPITimeout)
 	if err != nil {

--- a/control-plane/subcommand/server-acl-init/servers.go
+++ b/control-plane/subcommand/server-acl-init/servers.go
@@ -72,6 +72,14 @@ func (c *Command) bootstrapACLs(firstServerAddr string, scheme string, bootToken
 		Address: c.flagConsulTLSServerName,
 		CAFile:  c.flagConsulCACert,
 	}
+	// Exempting this particular use of the http client from using global.consulAPITimeout
+	// which defaults to 5 seconds.  In acceptance tests, we saw that the call
+	// to /v1/acl/bootstrap taking 5-7 seconds and when it does, the request times
+	// out without returning the bootstrap token, but the bootstrapping does complete.
+	// This would leave cases where server-acl-init job would get a 403 that it had
+	// already bootstrapped and would not be able to complete.
+	// Since this is an area where we have to wait and can't retry, we are setting it
+	// to a large number like 5 minutes since previously this had no timeout.
 	clientConfig.HttpClient = &http.Client{
 		Timeout: 5 * time.Minute,
 	}

--- a/control-plane/subcommand/server-acl-init/servers.go
+++ b/control-plane/subcommand/server-acl-init/servers.go
@@ -3,7 +3,9 @@ package serveraclinit
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/consul/api"
 	apiv1 "k8s.io/api/core/v1"
@@ -69,6 +71,9 @@ func (c *Command) bootstrapACLs(firstServerAddr string, scheme string, bootToken
 	clientConfig.TLSConfig = api.TLSConfig{
 		Address: c.flagConsulTLSServerName,
 		CAFile:  c.flagConsulCACert,
+	}
+	clientConfig.HttpClient = &http.Client{
+		Timeout: 5 * time.Minute,
 	}
 	consulClient, err := consul.NewClient(clientConfig,
 		c.flagConsulAPITimeout)


### PR DESCRIPTION
Changes proposed in this PR:
- give httpclient that calls bootstrap ACLs a 5 minute timeout since this is one area where we have to wait and we can't retry.
- our nightly acceptance tests have gone from basically green to close to a dozen failures per cloud provider.

How I've tested this PR:
- CI runs of acceptance tests

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

