### PR TITLE
Use discoveryv1 EndpointSlice instead of corev1 Endpoints in the endpoints controller

### DIFF
--- a/charts/consul/templates/connect-inject-clusterrole.yaml
+++ b/charts/consul/templates/connect-inject-clusterrole.yaml
@@ -19,11 +19,14 @@ rules:
   - get
 {{- end }}
 - apiGroups: [ "" ]
-  resources: [ "pods", "endpoints", "services", "namespaces" ]
+  resources: [ "pods", "services", "namespaces" ]
   verbs:
   - "get"
   - "list"
   - "watch"
+- apiGroups: [ "discovery.k8s.io" ]
+  resources: [ "endpointslices" ]
+  verbs: [ "get", "list", "watch" ]
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	corev1 "k8s.io/api/core/v1"
 	discv1 "k8s.io/api/discovery/v1"
+	discv1beta1 "k8s.io/api/discovery/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -59,10 +60,6 @@ const (
 	// exposedPathsStartupPortsRangeStart is the start of the port range that we will use as
 	// the ListenerPort for the Expose configuration of the proxy registration for a startup probe.
 	exposedPathsStartupPortsRangeStart = 20500
-
-	// annotationKubeService is the Label that the EndpointSlice is assigned by Kubernetes that
-	// references it's Kube Service.
-	annotationKubeService = "kubernetes.io/service-name"
 )
 
 type EndpointsController struct {
@@ -1066,7 +1063,7 @@ func (r *EndpointsController) consulNamespace(namespace string) string {
 }
 
 func getServiceNameFromEndpointSlice(endpointSlice discv1.EndpointSlice) string {
-	return endpointSlice.Labels[annotationKubeService]
+	return endpointSlice.Labels[discv1beta1.LabelServiceName]
 }
 
 // hasBeenInjected checks the value of the status annotation and returns true if the Pod has been injected.

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -177,7 +177,7 @@ func (r *EndpointsController) Reconcile(ctx context.Context, req ctrl.Request) (
 		// indicates an unknown state. In most cases consumers should interpret this
 		// unknown state as ready. For compatibility reasons, ready should never be
 		// "true" for terminating endpoints.
-		if endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready == true {
+		if endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready {
 			healthStatus = api.HealthPassing
 		}
 		if endpoint.TargetRef != nil && endpoint.TargetRef.Kind == "Pod" {

--- a/control-plane/connect-inject/endpoints_controller_ent_test.go
+++ b/control-plane/connect-inject/endpoints_controller_ent_test.go
@@ -447,6 +447,13 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						Port:      80,
 						Address:   "1.2.3.4",
 						Namespace: ts.ExpConsulNS,
+						Meta: map[string]string{
+							MetaKeyPodName:           "pod1",
+							MetaKeyKubeServiceName:   "service-updated",
+							MetaKeyKubeNS:            ts.SourceKubeNS,
+							MetaKeyManagedBy:         managedByValue,
+							MetaKeyEndpointSliceName: "service-updated-123456",
+						},
 					},
 					{
 						Kind:    api.ServiceKindConnectProxy,
@@ -457,6 +464,13 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						Proxy: &api.AgentServiceConnectProxyConfig{
 							DestinationServiceName: "service-updated",
 							DestinationServiceID:   "pod1-service-updated",
+						},
+						Meta: map[string]string{
+							MetaKeyPodName:           "pod1",
+							MetaKeyKubeServiceName:   "service-updated",
+							MetaKeyKubeNS:            ts.SourceKubeNS,
+							MetaKeyManagedBy:         managedByValue,
+							MetaKeyEndpointSliceName: "service-updated-123456",
 						},
 						Namespace: ts.ExpConsulNS,
 					},
@@ -772,11 +786,16 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						Namespace: ts.ExpConsulNS,
 					},
 					{
-						ID:        "pod2-service-updated",
-						Name:      "service-updated",
-						Port:      80,
-						Address:   "2.2.3.4",
-						Meta:      map[string]string{"k8s-service-name": "service-updated", "k8s-namespace": ts.SourceKubeNS, MetaKeyManagedBy: managedByValue},
+						ID:      "pod2-service-updated",
+						Name:    "service-updated",
+						Port:    80,
+						Address: "2.2.3.4",
+						Meta: map[string]string{
+							MetaKeyKubeServiceName:   "service-updated",
+							MetaKeyKubeNS:            ts.SourceKubeNS,
+							MetaKeyManagedBy:         managedByValue,
+							MetaKeyEndpointSliceName: "service-updated-123456",
+						},
 						Namespace: ts.ExpConsulNS,
 					},
 					{
@@ -874,11 +893,16 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						Namespace: ts.ExpConsulNS,
 					},
 					{
-						ID:        "pod2-different-consul-svc-name",
-						Name:      "different-consul-svc-name",
-						Port:      80,
-						Address:   "2.2.3.4",
-						Meta:      map[string]string{"k8s-service-name": "service-updated", "k8s-namespace": ts.SourceKubeNS, MetaKeyManagedBy: managedByValue},
+						ID:      "pod2-different-consul-svc-name",
+						Name:    "different-consul-svc-name",
+						Port:    80,
+						Address: "2.2.3.4",
+						Meta: map[string]string{
+							MetaKeyKubeServiceName:   "service-updated",
+							MetaKeyKubeNS:            ts.SourceKubeNS,
+							MetaKeyManagedBy:         managedByValue,
+							MetaKeyEndpointSliceName: "service-updated-123456",
+						},
 						Namespace: ts.ExpConsulNS,
 					},
 					{

--- a/control-plane/connect-inject/endpoints_controller_ent_test.go
+++ b/control-plane/connect-inject/endpoints_controller_ent_test.go
@@ -26,8 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-// TestReconcileCreateEndpoint tests the logic to create service instances in Consul from the addresses in the Endpoints
-// object. The cases test a basic endpoints object with two addresses. This test verifies that the services and their TTL
+// TestReconcileCreateEndpoint tests the logic to create service instances in Consul from the addresses in the EndpointSlice
+// object. The cases test a basic endpointslice object with two endpoints. This test verifies that the services and their TTL
 // health checks are created in the expected Consul namespace for various combinations of namespace flags.
 // This test covers EndpointsController.createServiceRegistrations.
 func TestReconcileCreateEndpointWithNamespaces(t *testing.T) {
@@ -93,7 +93,7 @@ func TestReconcileCreateEndpointWithNamespaces(t *testing.T) {
 				pod2 := createPodWithNamespace("pod2", test.SourceKubeNS, "2.2.3.4", true, true)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-created",
+						Name:      "service-created-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-created"},
@@ -257,7 +257,7 @@ func TestReconcileCreateEndpointWithNamespaces(t *testing.T) {
 			}
 			namespacedName := types.NamespacedName{
 				Namespace: test.SourceKubeNS,
-				Name:      "service-created",
+				Name:      "service-created-123456",
 			}
 
 			resp, err := ep.Reconcile(context.Background(), ctrl.Request{
@@ -321,7 +321,7 @@ func TestReconcileCreateEndpointWithNamespaces(t *testing.T) {
 	}
 }
 
-// Tests updating an Endpoints object when Consul namespaces are enabled.
+// Tests updating an EndpointSlice object when Consul namespaces are enabled.
 //   - Tests updates via the register codepath:
 //     - When an address in an Endpoint is updated, that the corresponding service instance in Consul is updated in the correct Consul namespace.
 //     - When an address is added to an Endpoint, an additional service instance in Consul is registered in the correct Consul namespace.
@@ -398,7 +398,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					pod1 := createPodWithNamespace("pod1", ts.SourceKubeNS, "1.2.3.4", true, false)
 					endpointslice := &v1.EndpointSlice{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "service-updated",
+							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
 								{Name: "service-updated"},
@@ -475,7 +475,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					pod1 := createPodWithNamespace("pod1", ts.SourceKubeNS, "4.4.4.4", true, true)
 					endpointslice := &v1.EndpointSlice{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "service-updated",
+							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
 								{Name: "service-updated"},
@@ -542,7 +542,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					pod1.Annotations[annotationService] = "different-consul-svc-name"
 					endpointslice := &v1.EndpointSlice{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "service-updated",
+							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
 								{Name: "service-updated"},
@@ -609,7 +609,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					pod2 := createPodWithNamespace("pod2", ts.SourceKubeNS, "2.2.3.4", true, true)
 					endpointslice := &v1.EndpointSlice{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "service-updated",
+							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
 								{Name: "service-updated"},
@@ -696,7 +696,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					pod1 := createPodWithNamespace("pod1", ts.SourceKubeNS, "1.2.3.4", true, true)
 					endpointslice := &v1.EndpointSlice{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "service-updated",
+							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
 								{Name: "service-updated"},
@@ -785,7 +785,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					pod1.Annotations[annotationService] = "different-consul-svc-name"
 					endpointslice := &v1.EndpointSlice{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "service-updated",
+							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
 								{Name: "service-updated"},
@@ -874,7 +874,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 				k8sObjects: func() []runtime.Object {
 					endpointslice := &v1.EndpointSlice{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "service-updated",
+							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
 								{Name: "service-updated"},
@@ -939,7 +939,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 				k8sObjects: func() []runtime.Object {
 					endpointslice := &v1.EndpointSlice{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "service-updated",
+							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
 								{Name: "service-updated"},
@@ -1003,7 +1003,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					pod2 := createPodWithNamespace("pod2", ts.SourceKubeNS, "4.4.4.4", true, true)
 					endpointslice := &v1.EndpointSlice{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "service-updated",
+							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
 								{Name: "service-updated"},
@@ -1081,7 +1081,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					pod1 := createPodWithNamespace("pod1", ts.SourceKubeNS, "1.2.3.4", true, true)
 					endpointslice := &v1.EndpointSlice{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "service-updated",
+							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
 								{Name: "service-updated"},
@@ -1298,7 +1298,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 				}
 				namespacedName := types.NamespacedName{
 					Namespace: ts.SourceKubeNS,
-					Name:      "service-updated",
+					Name:      "service-updated-123456",
 				}
 
 				resp, err := ep.Reconcile(context.Background(), ctrl.Request{
@@ -1370,7 +1370,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 	}
 }
 
-// Tests deleting an Endpoints object, with and without matching Consul and K8s service names when Consul namespaces are enabled.
+// Tests deleting an EndpointSlice object, with and without matching Consul and K8s service names when Consul namespaces are enabled.
 // This test covers EndpointsController.deregisterServiceOnAllAgents when the map is nil (not selectively deregistered).
 func TestReconcileDeleteEndpointWithNamespaces(t *testing.T) {
 	t.Parallel()
@@ -1608,10 +1608,10 @@ func TestReconcileDeleteEndpointWithNamespaces(t *testing.T) {
 					ep.AuthMethod = test.AuthMethod
 				}
 
-				// Set up the Endpoint that will be reconciled, and reconcile.
+				// Set up the EndpointSlice that will be reconciled, and reconcile.
 				namespacedName := types.NamespacedName{
 					Namespace: ts.SourceKubeNS,
-					Name:      "service-deleted",
+					Name:      "service-deleted-123456",
 				}
 				resp, err := ep.Reconcile(context.Background(), ctrl.Request{
 					NamespacedName: namespacedName,

--- a/control-plane/connect-inject/endpoints_controller_ent_test.go
+++ b/control-plane/connect-inject/endpoints_controller_ent_test.go
@@ -5,7 +5,6 @@ package connectinject
 import (
 	"context"
 	"fmt"
-	v1 "k8s.io/api/discovery/v1"
 	"strings"
 	"testing"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -26,11 +26,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-// TestReconcileCreateEndpoint tests the logic to create service instances in Consul from the addresses in the EndpointSlice
+// TestReconcileCreateEndpointSlice tests the logic to create service instances in Consul from the addresses in the EndpointSlice
 // object. The cases test a basic endpointslice object with two endpoints. This test verifies that the services and their TTL
 // health checks are created in the expected Consul namespace for various combinations of namespace flags.
 // This test covers EndpointsController.createServiceRegistrations.
-func TestReconcileCreateEndpointWithNamespaces(t *testing.T) {
+func TestReconcileCreateEndpointSliceWithNamespaces(t *testing.T) {
 	t.Parallel()
 	nodeName := "test-node"
 	cases := map[string]struct {
@@ -94,7 +94,7 @@ func TestReconcileCreateEndpointWithNamespaces(t *testing.T) {
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-created-123456",
-						Namespace: "default",
+						Namespace: test.SourceKubeNS,
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-created"},
 						},
@@ -107,7 +107,7 @@ func TestReconcileCreateEndpointWithNamespaces(t *testing.T) {
 							TargetRef: &corev1.ObjectReference{
 								Kind:      "Pod",
 								Name:      "pod1",
-								Namespace: "default",
+								Namespace: test.SourceKubeNS,
 							},
 							NodeName: &nodeName,
 						},
@@ -118,7 +118,7 @@ func TestReconcileCreateEndpointWithNamespaces(t *testing.T) {
 							TargetRef: &corev1.ObjectReference{
 								Kind:      "Pod",
 								Name:      "pod2",
-								Namespace: "default",
+								Namespace: test.SourceKubeNS,
 							},
 							NodeName: &nodeName,
 						},
@@ -634,7 +634,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 								TargetRef: &corev1.ObjectReference{
 									Kind:      "Pod",
 									Name:      "pod2",
-									Namespace: "default",
+									Namespace: ts.SourceKubeNS,
 								},
 								NodeName: &nodeName,
 							},

--- a/control-plane/connect-inject/endpoints_controller_ent_test.go
+++ b/control-plane/connect-inject/endpoints_controller_ent_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	discv1 "k8s.io/api/discovery/v1"
+	discv1beta1 "k8s.io/api/discovery/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -95,7 +96,7 @@ func TestReconcileCreateEndpointSliceWithNamespaces(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-created-123456",
 						Namespace: test.SourceKubeNS,
-						Labels:    map[string]string{annotationKubeService: "service-created"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-created"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -422,7 +423,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
-							Labels:    map[string]string{annotationKubeService: "service-updated"},
+							Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 						},
 						Endpoints: []discv1.Endpoint{
 							{
@@ -511,7 +512,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
-							Labels:    map[string]string{annotationKubeService: "service-updated"},
+							Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 						},
 						Endpoints: []discv1.Endpoint{
 							{
@@ -579,7 +580,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
-							Labels:    map[string]string{annotationKubeService: "service-updated"},
+							Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 						},
 						Endpoints: []discv1.Endpoint{
 							{
@@ -647,7 +648,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
-							Labels:    map[string]string{annotationKubeService: "service-updated"},
+							Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 						},
 						Endpoints: []discv1.Endpoint{
 							{
@@ -735,7 +736,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
-							Labels:    map[string]string{annotationKubeService: "service-updated"},
+							Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 						},
 						Endpoints: []discv1.Endpoint{
 							{
@@ -842,7 +843,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
-							Labels:    map[string]string{annotationKubeService: "service-updated"},
+							Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 						},
 						Endpoints: []discv1.Endpoint{
 							{
@@ -949,7 +950,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
-							Labels:    map[string]string{annotationKubeService: "service-updated"},
+							Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 						},
 						Endpoints: []discv1.Endpoint{},
 					}
@@ -1032,7 +1033,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
-							Labels:    map[string]string{annotationKubeService: "service-updated"},
+							Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 						},
 						Endpoints: []discv1.Endpoint{},
 					}
@@ -1114,7 +1115,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
-							Labels:    map[string]string{annotationKubeService: "service-updated"},
+							Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 						},
 						Endpoints: []discv1.Endpoint{
 							{
@@ -1192,7 +1193,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "service-updated-123456",
 							Namespace: ts.SourceKubeNS,
-							Labels:    map[string]string{annotationKubeService: "service-updated"},
+							Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 						},
 						Endpoints: []discv1.Endpoint{
 							{

--- a/control-plane/connect-inject/endpoints_controller_ent_test.go
+++ b/control-plane/connect-inject/endpoints_controller_ent_test.go
@@ -96,7 +96,7 @@ func TestReconcileCreateEndpointWithNamespaces(t *testing.T) {
 						Name:      "service-created",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-created"},
+							{Name: "service-created"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -401,7 +401,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 							Name:      "service-updated",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
-								metav1.OwnerReference{Name: "service-updated"},
+								{Name: "service-updated"},
 							},
 						},
 						Endpoints: []v1.Endpoint{
@@ -478,7 +478,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 							Name:      "service-updated",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
-								metav1.OwnerReference{Name: "service-updated"},
+								{Name: "service-updated"},
 							},
 						},
 						Endpoints: []v1.Endpoint{
@@ -545,7 +545,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 							Name:      "service-updated",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
-								metav1.OwnerReference{Name: "service-updated"},
+								{Name: "service-updated"},
 							},
 						},
 						Endpoints: []v1.Endpoint{
@@ -612,7 +612,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 							Name:      "service-updated",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
-								metav1.OwnerReference{Name: "service-updated"},
+								{Name: "service-updated"},
 							},
 						},
 						Endpoints: []v1.Endpoint{
@@ -699,7 +699,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 							Name:      "service-updated",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
-								metav1.OwnerReference{Name: "service-updated"},
+								{Name: "service-updated"},
 							},
 						},
 						Endpoints: []v1.Endpoint{
@@ -788,7 +788,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 							Name:      "service-updated",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
-								metav1.OwnerReference{Name: "service-updated"},
+								{Name: "service-updated"},
 							},
 						},
 						Endpoints: []v1.Endpoint{
@@ -877,7 +877,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 							Name:      "service-updated",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
-								metav1.OwnerReference{Name: "service-updated"},
+								{Name: "service-updated"},
 							},
 						},
 						Endpoints: []v1.Endpoint{},
@@ -942,7 +942,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 							Name:      "service-updated",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
-								metav1.OwnerReference{Name: "service-updated"},
+								{Name: "service-updated"},
 							},
 						},
 						Endpoints: []v1.Endpoint{},
@@ -1006,7 +1006,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 							Name:      "service-updated",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
-								metav1.OwnerReference{Name: "service-updated"},
+								{Name: "service-updated"},
 							},
 						},
 						Endpoints: []v1.Endpoint{
@@ -1084,7 +1084,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 							Name:      "service-updated",
 							Namespace: ts.SourceKubeNS,
 							OwnerReferences: []metav1.OwnerReference{
-								metav1.OwnerReference{Name: "service-updated"},
+								{Name: "service-updated"},
 							},
 						},
 						Endpoints: []v1.Endpoint{

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -3642,7 +3642,6 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 
 	// Check that the correct services are registered with Consul.
 	serviceInstances, _, err = consulClient.Catalog().Service(serviceName, "", nil)
-	svc, _, err := consulClient.Catalog().Services(nil)
 	require.NoError(t, err)
 	require.Len(t, serviceInstances, 1)
 	proxyServiceInstances, _, err = consulClient.Catalog().Service(serviceName+"-sidecar-proxy", "", nil)

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -172,7 +172,7 @@ func TestProcessUpstreamsTLSandACLs(t *testing.T) {
 
 	esl := v1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svcname_name",
+			Name:      "svcname-123456",
 			Namespace: "default",
 			OwnerReferences: []metav1.OwnerReference{
 				{Name: "svcname"},
@@ -539,7 +539,7 @@ func TestProcessUpstreams(t *testing.T) {
 
 			esl := v1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "svcname_name",
+					Name:      "svcname-123456",
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
 						{Name: "svcname"},
@@ -576,7 +576,7 @@ func TestGetServiceName(t *testing.T) {
 			},
 			endpointslice: &v1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "svcname_name",
+					Name:      "not-web-123456",
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
 						{Name: "not-web"},
@@ -595,7 +595,7 @@ func TestGetServiceName(t *testing.T) {
 			},
 			endpointslice: &v1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "svcname_name",
+					Name:      "ep-name-123456",
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
 						{Name: "ep-name"},
@@ -613,10 +613,9 @@ func TestGetServiceName(t *testing.T) {
 				pod1.Annotations[annotationService] = "web,web-admin"
 				return pod1
 			},
-			// TODO: Investigate multiport
 			endpointslice: &v1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "svcname_name",
+					Name:      "ep-name-multiport-123456",
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
 						{Name: "ep-name-multiport"},
@@ -661,7 +660,7 @@ func TestReconcileCreateEndpoint_MultiportService(t *testing.T) {
 				pod1.Annotations[annotationUpstreams] = "upstream1:1234"
 				endpointslice1 := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "web",
+						Name:      "web-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "web"},
@@ -684,7 +683,7 @@ func TestReconcileCreateEndpoint_MultiportService(t *testing.T) {
 				}
 				endpointslice2 := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "web-admin",
+						Name:      "web-admin-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "web-admin"},
@@ -867,11 +866,11 @@ func TestReconcileCreateEndpoint_MultiportService(t *testing.T) {
 			}
 			namespacedName := types.NamespacedName{
 				Namespace: "default",
-				Name:      "web",
+				Name:      "web-123456",
 			}
 			namespacedName2 := types.NamespacedName{
 				Namespace: "default",
-				Name:      "web-admin",
+				Name:      "web-admin-123456",
 			}
 
 			resp, err := ep.Reconcile(context.Background(), ctrl.Request{
@@ -973,7 +972,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 			k8sObjects: func() []runtime.Object {
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "web",
+						Name:      "service-created-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-created"},
@@ -997,7 +996,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 				pod1 := createPod("pod1", "1.2.3.4", true, true)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-created",
+						Name:      "service-created-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-created"},
@@ -1068,7 +1067,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 				pod2 := createPod("pod2", "2.2.3.4", true, true)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-created",
+						Name:      "service-created-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-created"},
@@ -1184,7 +1183,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 				pod2 := createPod("pod2", "2.2.3.4", true, true)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-created",
+						Name:      "service-created-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-created"},
@@ -1320,7 +1319,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 				pod1.Annotations[annotationPrometheusScrapePort] = "12345"
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-created",
+						Name:      "service-created-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-created"},
@@ -1421,7 +1420,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 				// reproduce the bug where we were exiting the loop early if any pod was non-mesh.
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-created",
+						Name:      "service-created-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-created"},
@@ -1548,7 +1547,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 			}
 			namespacedName := types.NamespacedName{
 				Namespace: "default",
-				Name:      "service-created",
+				Name:      "service-created-123456",
 			}
 
 			resp, err := ep.Reconcile(context.Background(), ctrl.Request{
@@ -1658,7 +1657,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				pod1 := createPod("pod1", "1.2.3.4", true, false)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -1730,7 +1729,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				pod1 := createPod("pod1", "1.2.3.4", true, false)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -1805,7 +1804,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				pod1 := createPod("pod1", "1.2.3.4", true, false)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -1887,7 +1886,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				pod1 := createPod("pod1", "1.2.3.4", true, false)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -1967,7 +1966,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				pod1 := createPod("pod1", "1.2.3.4", true, true)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -2049,7 +2048,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				pod1 := createPod("pod1", "1.2.3.4", true, true)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -2133,7 +2132,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				pod1 := createPod("pod1", "4.4.4.4", true, true)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -2207,7 +2206,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				pod1.Annotations[annotationService] = "different-consul-svc-name"
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -2281,7 +2280,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				pod2 := createPod("pod2", "2.2.3.4", true, true)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -2382,7 +2381,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				pod1 := createPod("pod1", "1.2.3.4", true, true)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -2465,7 +2464,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				pod1.Annotations[annotationService] = "different-consul-svc-name"
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -2548,7 +2547,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			k8sObjects: func() []runtime.Object {
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -2609,7 +2608,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			k8sObjects: func() []runtime.Object {
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -2669,7 +2668,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				pod2 := createPod("pod2", "4.4.4.4", true, true)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -2755,7 +2754,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				pod1 := createPod("pod1", "1.2.3.4", true, true)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -2874,7 +2873,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				pod2 := createPod("pod2", "2.3.4.5", false, false)
 				endpointslice := &v1.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-updated",
+						Name:      "service-updated-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "service-updated"},
@@ -3027,7 +3026,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			if tt.enableACLs {
 				ep.AuthMethod = test.AuthMethod
 			}
-			namespacedName := types.NamespacedName{Namespace: "default", Name: "service-updated"}
+			namespacedName := types.NamespacedName{Namespace: "default", Name: "service-updated-123456"}
 
 			resp, err := ep.Reconcile(context.Background(), ctrl.Request{NamespacedName: namespacedName})
 			require.NoError(t, err)
@@ -3054,7 +3053,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					filter := fmt.Sprintf("CheckID == `%s`", tt.expectedAgentHealthChecks[i].CheckID)
 					check, err := consulClient.Agent().ChecksWithFilter(filter)
 					require.NoError(t, err)
-					require.EqualValues(t, len(check), 1)
+					require.EqualValues(t, 1, len(check))
 					// Ignoring Namespace because the response from ENT includes it and OSS does not.
 					var ignoredFields = []string{"Node", "Definition", "Namespace", "Partition"}
 					require.True(t, cmp.Equal(check[tt.expectedAgentHealthChecks[i].CheckID], tt.expectedAgentHealthChecks[i], cmpopts.IgnoreFields(api.AgentCheck{}, ignoredFields...)))
@@ -3343,10 +3342,10 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 				ep.AuthMethod = test.AuthMethod
 			}
 
-			// Set up the Endpoint that will be reconciled, and reconcile
+			// Set up the EndpointSlice that will be reconciled, and reconcile.
 			namespacedName := types.NamespacedName{
 				Namespace: "default",
-				Name:      "service-deleted",
+				Name:      "service-deleted-123456",
 			}
 			resp, err := ep.Reconcile(context.Background(), ctrl.Request{
 				NamespacedName: namespacedName,
@@ -3419,7 +3418,7 @@ func TestReconcileIgnoresServiceIgnoreLabel(t *testing.T) {
 			// Set up the fake Kubernetes client with an endpoint, pod, consul client, and the default namespace.
 			endpointslice := &v1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      serviceName,
+					Name:      serviceName + "-123456",
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
 						{Name: serviceName},
@@ -3502,7 +3501,7 @@ func TestReconcileIgnoresServiceIgnoreLabel(t *testing.T) {
 			}
 
 			// Run the reconcile process to deregister the service if it was registered before.
-			namespacedName := types.NamespacedName{Namespace: namespace, Name: serviceName}
+			namespacedName := types.NamespacedName{Namespace: namespace, Name: serviceName + "-123456"}
 			resp, err := ep.Reconcile(context.Background(), ctrl.Request{NamespacedName: namespacedName})
 			require.NoError(t, err)
 			require.False(t, resp.Requeue)
@@ -3527,8 +3526,8 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 	// Set up the fake Kubernetes client with a few endpoints, pod, consul client, and the default namespace.
 	badendpointslice := &v1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "not-in-mesh",
-			Namespace: "default",
+			Name:      "not-in-mesh-123456",
+			Namespace: namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{Name: "not-in-mesh"},
 			},
@@ -3541,7 +3540,7 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 				TargetRef: &corev1.ObjectReference{
 					Kind:      "Pod",
 					Name:      "pod1",
-					Namespace: "default",
+					Namespace: namespace,
 				},
 				NodeName: &nodeName,
 			},
@@ -3549,8 +3548,8 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 	}
 	endpointslice := &v1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "in-mesh",
-			Namespace: "default",
+			Name:      "in-mesh-123456",
+			Namespace: namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{Name: "in-mesh"},
 			},
@@ -3563,14 +3562,14 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 				TargetRef: &corev1.ObjectReference{
 					Kind:      "Pod",
 					Name:      "pod1",
-					Namespace: "default",
+					Namespace: namespace,
 				},
 				NodeName: &nodeName,
 			},
 		},
 	}
 	pod1 := createPod("pod1", "1.2.3.4", true, true)
-	pod1.Annotations[annotationKubernetesService] = endpointslice.Name
+	pod1.Annotations[annotationKubernetesService] = endpointslice.OwnerReferences[0].Name
 	fakeClientPod := createPod("fake-consul-client", "127.0.0.1", false, true)
 	fakeClientPod.Labels = map[string]string{"component": "client", "app": "consul", "release": "consul"}
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
@@ -3601,9 +3600,7 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 		ReleaseNamespace:      namespace,
 		ConsulClientCfg:       cfg,
 	}
-
-	serviceName := badendpointslice.Name
-
+	serviceName := "not-in-mesh"
 	// Initially register the pod with the bad endpoint
 	err = consulClient.Agent().ServiceRegister(&api.AgentServiceRegistration{
 		ID:      "pod1-" + serviceName,
@@ -3623,7 +3620,7 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 	require.Len(t, serviceInstances, 1)
 
 	// Run the reconcile process to check service deregistration.
-	namespacedName := types.NamespacedName{Namespace: badendpointslice.Namespace, Name: serviceName}
+	namespacedName := types.NamespacedName{Namespace: badendpointslice.Namespace, Name: serviceName + "-123456"}
 	resp, err := ep.Reconcile(context.Background(), ctrl.Request{NamespacedName: namespacedName})
 	require.NoError(t, err)
 	require.False(t, resp.Requeue)
@@ -3637,14 +3634,15 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 	require.Len(t, proxyServiceInstances, 0)
 
 	// Run the reconcile again with the service we want to register.
-	serviceName = endpointslice.Name
-	namespacedName = types.NamespacedName{Namespace: endpointslice.Namespace, Name: serviceName}
+	serviceName = endpointslice.OwnerReferences[0].Name
+	namespacedName = types.NamespacedName{Namespace: endpointslice.Namespace, Name: endpointslice.Name}
 	resp, err = ep.Reconcile(context.Background(), ctrl.Request{NamespacedName: namespacedName})
 	require.NoError(t, err)
 	require.False(t, resp.Requeue)
 
 	// Check that the correct services are registered with Consul.
 	serviceInstances, _, err = consulClient.Catalog().Service(serviceName, "", nil)
+	svc, _, err := consulClient.Catalog().Services(nil)
 	require.NoError(t, err)
 	require.Len(t, serviceInstances, 1)
 	proxyServiceInstances, _, err = consulClient.Catalog().Service(serviceName+"-sidecar-proxy", "", nil)
@@ -3670,7 +3668,7 @@ func TestReconcileUnreachableClient(t *testing.T) {
 				pod1 := createPod("pod1", "1.2.3.4", true, true)
 				endpoint := &corev1.Endpoints{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-created",
+						Name:      "service-created-123456",
 						Namespace: "default",
 					},
 					Subsets: []corev1.EndpointSubset{
@@ -3739,7 +3737,7 @@ func TestReconcileUnreachableClient(t *testing.T) {
 			}
 			namespacedName := types.NamespacedName{
 				Namespace: "default",
-				Name:      "service-created",
+				Name:      "service-created-123456",
 			}
 
 			resp, err := ep.Reconcile(context.Background(), ctrl.Request{
@@ -3906,7 +3904,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			endpointslices: []*v1.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endpoint-1",
+						Name:      "endpoint-1-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "endpoint-1"},
@@ -3943,7 +3941,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			expectedRequests: []ctrl.Request{
 				{
 					NamespacedName: types.NamespacedName{
-						Name:      "endpoint-1",
+						Name:      "endpoint-1-123456",
 						Namespace: "default",
 					},
 				},
@@ -3970,7 +3968,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			endpointslices: []*v1.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endpoint-1",
+						Name:      "endpoint-1-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "endpoint-1"},
@@ -3993,7 +3991,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			expectedRequests: []ctrl.Request{
 				{
 					NamespacedName: types.NamespacedName{
-						Name:      "endpoint-1",
+						Name:      "endpoint-1-123456",
 						Namespace: "default",
 					},
 				},
@@ -4020,7 +4018,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			endpointslices: []*v1.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endpoint-1",
+						Name:      "endpoint-1-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "endpoint-1"},
@@ -4045,7 +4043,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			expectedRequests: []ctrl.Request{
 				{
 					NamespacedName: types.NamespacedName{
-						Name:      "endpoint-1",
+						Name:      "endpoint-1-123456",
 						Namespace: "default",
 					},
 				},
@@ -4072,7 +4070,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			endpointslices: []*v1.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endpoint-1",
+						Name:      "endpoint-1-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "endpoint-1"},
@@ -4103,9 +4101,11 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endpoint-2",
+						Name:      "endpoint-2-123456",
 						Namespace: "default",
-						Labels:    map[string]string{"kubernetes.io/service-name": "endpoint-2"},
+						OwnerReferences: []metav1.OwnerReference{
+							{Name: "endpoint-2"},
+						},
 					},
 					Endpoints: []v1.Endpoint{
 						{
@@ -4132,9 +4132,11 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endpoint-3",
+						Name:      "endpoint-3-123456",
 						Namespace: "default",
-						Labels:    map[string]string{"kubernetes.io/service-name": "endpoint-3"},
+						OwnerReferences: []metav1.OwnerReference{
+							{Name: "endpoint-3"},
+						},
 					},
 					Endpoints: []v1.Endpoint{
 						{
@@ -4163,13 +4165,13 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			expectedRequests: []ctrl.Request{
 				{
 					NamespacedName: types.NamespacedName{
-						Name:      "endpoint-1",
+						Name:      "endpoint-1-123456",
 						Namespace: "default",
 					},
 				},
 				{
 					NamespacedName: types.NamespacedName{
-						Name:      "endpoint-3",
+						Name:      "endpoint-3-123456",
 						Namespace: "default",
 					},
 				},
@@ -4196,7 +4198,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			endpointslices: []*v1.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endpoint-1",
+						Name:      "endpoint-1-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "endpoint-1"},
@@ -4231,7 +4233,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endpoint-2",
+						Name:      "endpoint-2-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "endpoint-2"},
@@ -4266,7 +4268,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endpoint-3",
+						Name:      "endpoint-3-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "endpoint-3"},
@@ -4323,7 +4325,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			endpointslices: []*v1.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endpoint-1",
+						Name:      "endpoint-1-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "endpoint-1"},
@@ -4346,7 +4348,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endpoint-3",
+						Name:      "endpoint-3-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "endpoint-3"},
@@ -4391,7 +4393,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			endpointslices: []*v1.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endpoint-1",
+						Name:      "endpoint-1-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "endpoint-1"},
@@ -4414,7 +4416,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endpoint-3",
+						Name:      "endpoint-3-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "endpoint-3"},
@@ -4443,7 +4445,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			endpointslices: []*v1.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endpoint-1",
+						Name:      "endpoint-1-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "endpoint-1"},
@@ -4466,7 +4468,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endpoint-3",
+						Name:      "endpoint-3-123456",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{Name: "endpoint-3"},
@@ -5901,7 +5903,7 @@ func TestCreateServiceRegistrations_withTransparentProxy(t *testing.T) {
 
 			endpointslice := &v1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      serviceName,
+					Name:      serviceName + "-123456",
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
 						{Name: serviceName},

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -3943,7 +3943,8 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			expectedRequests: []ctrl.Request{
 				{
 					NamespacedName: types.NamespacedName{
-						Name: "endpoint-1",
+						Name:      "endpoint-1",
+						Namespace: "default",
 					},
 				},
 			},
@@ -3992,7 +3993,8 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			expectedRequests: []ctrl.Request{
 				{
 					NamespacedName: types.NamespacedName{
-						Name: "endpoint-1",
+						Name:      "endpoint-1",
+						Namespace: "default",
 					},
 				},
 			},
@@ -4043,7 +4045,8 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			expectedRequests: []ctrl.Request{
 				{
 					NamespacedName: types.NamespacedName{
-						Name: "endpoint-1",
+						Name:      "endpoint-1",
+						Namespace: "default",
 					},
 				},
 			},
@@ -4160,12 +4163,14 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 			expectedRequests: []ctrl.Request{
 				{
 					NamespacedName: types.NamespacedName{
-						Name: "endpoint-1",
+						Name:      "endpoint-1",
+						Namespace: "default",
 					},
 				},
 				{
 					NamespacedName: types.NamespacedName{
-						Name: "endpoint-3",
+						Name:      "endpoint-3",
+						Namespace: "default",
 					},
 				},
 			},
@@ -4491,7 +4496,8 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			logger := logrtest.TestLogger{T: t}
 			s := runtime.NewScheme()
-			s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Pod{}, &v1.EndpointSlice{}, &v1.EndpointSliceList{})
+			s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Pod{})
+			s.AddKnownTypes(v1.SchemeGroupVersion, &v1.EndpointSlice{}, &v1.EndpointSliceList{})
 			var objects []runtime.Object
 			if test.agentPod != nil {
 				objects = append(objects, test.agentPod)

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	discv1 "k8s.io/api/discovery/v1"
+	discv1beta1 "k8s.io/api/discovery/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -174,7 +175,7 @@ func TestProcessUpstreamsTLSandACLs(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "svcname-123456",
 			Namespace: "default",
-			Labels:    map[string]string{annotationKubeService: "svcname"},
+			Labels:    map[string]string{discv1beta1.LabelServiceName: "svcname"},
 		},
 		Endpoints: []discv1.Endpoint{},
 		Ports:     nil,
@@ -539,7 +540,7 @@ func TestProcessUpstreams(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "svcname-123456",
 					Namespace: "default",
-					Labels:    map[string]string{annotationKubeService: "svcname"},
+					Labels:    map[string]string{discv1beta1.LabelServiceName: "svcname"},
 				},
 				Endpoints: []discv1.Endpoint{},
 				Ports:     nil,
@@ -574,7 +575,7 @@ func TestGetServiceName(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "not-web-123456",
 					Namespace: "default",
-					Labels:    map[string]string{annotationKubeService: "not-web"},
+					Labels:    map[string]string{discv1beta1.LabelServiceName: "not-web"},
 				},
 				Endpoints: []discv1.Endpoint{},
 				Ports:     nil,
@@ -591,7 +592,7 @@ func TestGetServiceName(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ep-name-123456",
 					Namespace: "default",
-					Labels:    map[string]string{annotationKubeService: "ep-name"},
+					Labels:    map[string]string{discv1beta1.LabelServiceName: "ep-name"},
 				},
 				Endpoints: []discv1.Endpoint{},
 				Ports:     nil,
@@ -609,7 +610,7 @@ func TestGetServiceName(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ep-name-multiport-123456",
 					Namespace: "default",
-					Labels:    map[string]string{annotationKubeService: "ep-name-multiport"},
+					Labels:    map[string]string{discv1beta1.LabelServiceName: "ep-name-multiport"},
 				},
 				Endpoints: []discv1.Endpoint{},
 				Ports:     nil,
@@ -652,7 +653,7 @@ func TestReconcileCreateEndpoint_MultiportService(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "web-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "web"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "web"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -673,7 +674,7 @@ func TestReconcileCreateEndpoint_MultiportService(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "web-admin-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "web-admin"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "web-admin"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -964,7 +965,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-created-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-created"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-created"},
 					},
 					Endpoints: []discv1.Endpoint{},
 					Ports:     nil,
@@ -986,7 +987,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-created-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-created"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-created"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -1067,7 +1068,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-created-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-created"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-created"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -1205,7 +1206,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-created-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-created"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-created"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -1363,7 +1364,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-created-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-created"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-created"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -1464,7 +1465,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-created-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-created"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-created"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -1711,7 +1712,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -1781,7 +1782,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					AddressType: "",
 					Endpoints: []discv1.Endpoint{
@@ -1854,7 +1855,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -1934,7 +1935,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -2012,7 +2013,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -2092,7 +2093,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -2174,7 +2175,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -2246,7 +2247,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -2318,7 +2319,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -2417,7 +2418,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -2518,7 +2519,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -2619,7 +2620,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					Endpoints: []discv1.Endpoint{},
 				}
@@ -2698,7 +2699,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					Endpoints: []discv1.Endpoint{},
 				}
@@ -2776,7 +2777,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -2864,7 +2865,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -2987,7 +2988,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-updated-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-updated"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-updated"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -3540,30 +3541,30 @@ func TestReconcileIgnoresServiceIgnoreLabel(t *testing.T) {
 		"Registered endpoint with label is deregistered.": {
 			svcInitiallyRegistered: true,
 			serviceLabels: map[string]string{
-				labelServiceIgnore:    "true",
-				annotationKubeService: serviceName,
+				labelServiceIgnore:           "true",
+				discv1beta1.LabelServiceName: serviceName,
 			},
 			expectedNumSvcInstances: 0,
 		},
 		"Not registered endpoint with label is never registered": {
 			svcInitiallyRegistered: false,
 			serviceLabels: map[string]string{
-				labelServiceIgnore:    "true",
-				annotationKubeService: serviceName,
+				labelServiceIgnore:           "true",
+				discv1beta1.LabelServiceName: serviceName,
 			},
 			expectedNumSvcInstances: 0,
 		},
 		"Registered endpoint without label is unaffected": {
 			svcInitiallyRegistered: true,
 			serviceLabels: map[string]string{
-				annotationKubeService: serviceName,
+				discv1beta1.LabelServiceName: serviceName,
 			},
 			expectedNumSvcInstances: 1,
 		},
 		"Not registered endpoint without label is registered": {
 			svcInitiallyRegistered: false,
 			serviceLabels: map[string]string{
-				annotationKubeService: serviceName,
+				discv1beta1.LabelServiceName: serviceName,
 			},
 			expectedNumSvcInstances: 1,
 		},
@@ -3683,7 +3684,7 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "not-in-mesh-123456",
 			Namespace: namespace,
-			Labels:    map[string]string{annotationKubeService: "not-in-mesh"},
+			Labels:    map[string]string{discv1beta1.LabelServiceName: "not-in-mesh"},
 		},
 		Endpoints: []discv1.Endpoint{
 			{
@@ -3703,7 +3704,7 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "in-mesh-123456",
 			Namespace: namespace,
-			Labels:    map[string]string{annotationKubeService: "in-mesh"},
+			Labels:    map[string]string{discv1beta1.LabelServiceName: "in-mesh"},
 		},
 		Endpoints: []discv1.Endpoint{
 			{
@@ -3720,7 +3721,7 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 		},
 	}
 	pod1 := createPod("pod1", "1.2.3.4", true, true)
-	pod1.Annotations[annotationKubernetesService] = endpointslice.Labels[annotationKubeService]
+	pod1.Annotations[annotationKubernetesService] = endpointslice.Labels[discv1beta1.LabelServiceName]
 	fakeClientPod := createPod("fake-consul-client", "127.0.0.1", false, true)
 	fakeClientPod.Labels = map[string]string{"component": "client", "app": "consul", "release": "consul"}
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
@@ -3786,7 +3787,7 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 	require.Len(t, proxyServiceInstances, 0)
 
 	// Run the reconcile again with the service we want to register.
-	serviceName = endpointslice.Labels[annotationKubeService]
+	serviceName = endpointslice.Labels[discv1beta1.LabelServiceName]
 	namespacedName = types.NamespacedName{Namespace: endpointslice.Namespace, Name: endpointslice.Name}
 	resp, err = ep.Reconcile(context.Background(), ctrl.Request{NamespacedName: namespacedName})
 	require.NoError(t, err)
@@ -3821,7 +3822,7 @@ func TestReconcileUnreachableClient(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-created-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "service-created"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "service-created"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -4054,7 +4055,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "endpoint-1-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "endpoint-1"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "endpoint-1"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -4116,7 +4117,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "endpoint-1-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "endpoint-1"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "endpoint-1"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -4164,7 +4165,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "endpoint-1-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "endpoint-1"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "endpoint-1"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -4214,7 +4215,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "endpoint-1-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "endpoint-1"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "endpoint-1"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -4243,7 +4244,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "endpoint-2-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "endpoint-2"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "endpoint-2"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -4272,7 +4273,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "endpoint-3-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "endpoint-3"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "endpoint-3"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -4336,7 +4337,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "endpoint-1-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "endpoint-1"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "endpoint-1"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -4369,7 +4370,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "endpoint-2-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "endpoint-2"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "endpoint-2"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -4402,7 +4403,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "endpoint-3-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "endpoint-3"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "endpoint-3"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -4457,7 +4458,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "endpoint-1-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "endpoint-1"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "endpoint-1"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -4478,7 +4479,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "endpoint-3-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "endpoint-3"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "endpoint-3"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -4521,7 +4522,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "endpoint-1-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "endpoint-1"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "endpoint-1"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -4542,7 +4543,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "endpoint-3-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "endpoint-3"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "endpoint-3"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -4569,7 +4570,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "endpoint-1-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "endpoint-1"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "endpoint-1"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -4590,7 +4591,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "endpoint-3-123456",
 						Namespace: "default",
-						Labels:    map[string]string{annotationKubeService: "endpoint-3"},
+						Labels:    map[string]string{discv1beta1.LabelServiceName: "endpoint-3"},
 					},
 					Endpoints: []discv1.Endpoint{
 						{
@@ -6023,7 +6024,7 @@ func TestCreateServiceRegistrations_withTransparentProxy(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      serviceName + "-123456",
 					Namespace: "default",
-					Labels:    map[string]string{annotationKubeService: serviceName},
+					Labels:    map[string]string{discv1beta1.LabelServiceName: serviceName},
 				},
 				Endpoints: []discv1.Endpoint{
 					{
@@ -6138,7 +6139,7 @@ func TestReconcileMultipleEndpointSlices_AddAndDelete(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "web-1",
 			Namespace: "default",
-			Labels:    map[string]string{annotationKubeService: "web"},
+			Labels:    map[string]string{discv1beta1.LabelServiceName: "web"},
 		},
 		Endpoints: []discv1.Endpoint{
 			{
@@ -6159,7 +6160,7 @@ func TestReconcileMultipleEndpointSlices_AddAndDelete(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "web-2",
 			Namespace: "default",
-			Labels:    map[string]string{annotationKubeService: "web"},
+			Labels:    map[string]string{discv1beta1.LabelServiceName: "web"},
 		},
 		Endpoints: []discv1.Endpoint{
 			{

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -175,7 +175,7 @@ func TestProcessUpstreamsTLSandACLs(t *testing.T) {
 			Name:      "svcname_name",
 			Namespace: "default",
 			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{Name: "svcname"},
+				{Name: "svcname"},
 			},
 		},
 		Endpoints: []v1.Endpoint{},
@@ -542,7 +542,7 @@ func TestProcessUpstreams(t *testing.T) {
 					Name:      "svcname_name",
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
-						metav1.OwnerReference{Name: "svcname"},
+						{Name: "svcname"},
 					},
 				},
 				Endpoints: []v1.Endpoint{},
@@ -579,7 +579,7 @@ func TestGetServiceName(t *testing.T) {
 					Name:      "svcname_name",
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
-						metav1.OwnerReference{Name: "not-web"},
+						{Name: "not-web"},
 					},
 				},
 				Endpoints: []v1.Endpoint{},
@@ -598,7 +598,7 @@ func TestGetServiceName(t *testing.T) {
 					Name:      "svcname_name",
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
-						metav1.OwnerReference{Name: "ep-name"},
+						{Name: "ep-name"},
 					},
 				},
 				Endpoints: []v1.Endpoint{},
@@ -619,7 +619,7 @@ func TestGetServiceName(t *testing.T) {
 					Name:      "svcname_name",
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
-						metav1.OwnerReference{Name: "ep-name-multiport"},
+						{Name: "ep-name-multiport"},
 					},
 				},
 				Endpoints: []v1.Endpoint{},
@@ -664,7 +664,7 @@ func TestReconcileCreateEndpoint_MultiportService(t *testing.T) {
 						Name:      "web",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "web"},
+							{Name: "web"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -687,7 +687,7 @@ func TestReconcileCreateEndpoint_MultiportService(t *testing.T) {
 						Name:      "web-admin",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "web-admin"},
+							{Name: "web-admin"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -976,7 +976,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 						Name:      "web",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-created"},
+							{Name: "service-created"},
 						},
 					},
 					Endpoints: []v1.Endpoint{},
@@ -1000,7 +1000,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 						Name:      "service-created",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-created"},
+							{Name: "service-created"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -1071,7 +1071,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 						Name:      "service-created",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-created"},
+							{Name: "service-created"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -1187,7 +1187,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 						Name:      "service-created",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-created"},
+							{Name: "service-created"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -1323,7 +1323,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 						Name:      "service-created",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-created"},
+							{Name: "service-created"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -1424,7 +1424,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 						Name:      "service-created",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-created"},
+							{Name: "service-created"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -1661,7 +1661,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -1733,7 +1733,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					AddressType: "",
@@ -1808,7 +1808,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -1890,7 +1890,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -1970,7 +1970,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -2052,7 +2052,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -2136,7 +2136,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -2210,7 +2210,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -2284,7 +2284,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -2385,7 +2385,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -2468,7 +2468,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -2551,7 +2551,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					Endpoints: []v1.Endpoint{},
@@ -2612,7 +2612,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					Endpoints: []v1.Endpoint{},
@@ -2672,7 +2672,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -2758,7 +2758,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -2877,7 +2877,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 						Name:      "service-updated",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "service-updated"},
+							{Name: "service-updated"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -3422,7 +3422,7 @@ func TestReconcileIgnoresServiceIgnoreLabel(t *testing.T) {
 					Name:      serviceName,
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
-						metav1.OwnerReference{Name: serviceName},
+						{Name: serviceName},
 					},
 					Labels: tt.serviceLabels,
 				},
@@ -3530,7 +3530,7 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 			Name:      "not-in-mesh",
 			Namespace: "default",
 			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{Name: "not-in-mesh"},
+				{Name: "not-in-mesh"},
 			},
 		},
 		Endpoints: []v1.Endpoint{
@@ -3552,7 +3552,7 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 			Name:      "in-mesh",
 			Namespace: "default",
 			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{Name: "in-mesh"},
+				{Name: "in-mesh"},
 			},
 		},
 		Endpoints: []v1.Endpoint{
@@ -3909,7 +3909,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 						Name:      "endpoint-1",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "endpoint-1"},
+							{Name: "endpoint-1"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -3973,7 +3973,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 						Name:      "endpoint-1",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "endpoint-1"},
+							{Name: "endpoint-1"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -4023,7 +4023,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 						Name:      "endpoint-1",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "endpoint-1"},
+							{Name: "endpoint-1"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -4075,7 +4075,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 						Name:      "endpoint-1",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "endpoint-1"},
+							{Name: "endpoint-1"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -4199,7 +4199,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 						Name:      "endpoint-1",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "endpoint-1"},
+							{Name: "endpoint-1"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -4234,7 +4234,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 						Name:      "endpoint-2",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "endpoint-2"},
+							{Name: "endpoint-2"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -4269,7 +4269,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 						Name:      "endpoint-3",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "endpoint-3"},
+							{Name: "endpoint-3"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -4326,7 +4326,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 						Name:      "endpoint-1",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "endpoint-1"},
+							{Name: "endpoint-1"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -4349,7 +4349,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 						Name:      "endpoint-3",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "endpoint-3"},
+							{Name: "endpoint-3"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -4394,7 +4394,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 						Name:      "endpoint-1",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "endpoint-1"},
+							{Name: "endpoint-1"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -4417,7 +4417,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 						Name:      "endpoint-3",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "endpoint-3"},
+							{Name: "endpoint-3"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -4446,7 +4446,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 						Name:      "endpoint-1",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "endpoint-1"},
+							{Name: "endpoint-1"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -4469,7 +4469,7 @@ func TestRequestsForRunningAgentPods(t *testing.T) {
 						Name:      "endpoint-3",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							metav1.OwnerReference{Name: "endpoint-3"},
+							{Name: "endpoint-3"},
 						},
 					},
 					Endpoints: []v1.Endpoint{
@@ -5904,7 +5904,7 @@ func TestCreateServiceRegistrations_withTransparentProxy(t *testing.T) {
 					Name:      serviceName,
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
-						metav1.OwnerReference{Name: serviceName},
+						{Name: serviceName},
 					},
 				},
 				Endpoints: []v1.Endpoint{

--- a/control-plane/connect-inject/handler_ent_test.go
+++ b/control-plane/connect-inject/handler_ent_test.go
@@ -30,7 +30,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 
 	basicSpec := corev1.PodSpec{
 		Containers: []corev1.Container{
-			corev1.Container{
+			{
 				Name: "web",
 			},
 		},
@@ -285,7 +285,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 	basicSpec := corev1.PodSpec{
 		Containers: []corev1.Container{
-			corev1.Container{
+			{
 				Name: "web",
 			},
 		},


### PR DESCRIPTION
Changes proposed in this PR:
- Convert the endpoints controller to use `discoveryv1.EndpointSlice` instead of `corev1.Endpoints`
- Change the connect-inject clusterrole to use `EndpointSlice` resources instead of `Endpoints` resources.
- Adds a new MetaKey/Value to each service which holds the name of the ServiceEndpoint that it was registered with. This is used to ensure we do not Reconcile/deregister endpoints of the same Kubernetes service that reside in different EndpointSlices. Ex: a k8s service with 2 endpoint slices and one endpointslice is deleted, we should not deregister the service for the still-valid-endpointslice's service instances.
- Update all of the unit tests accordingly. Much of this involves just building up EndpointSlice's instead, but it also requires us to change a lot of the expected object names since `EndpointSlice` objects do not have the exact same name as their `Service`, which was expected for `Endpoints`. 
- This simply means adding something like `-123456` to the end of the `EndpointSlice` objects Name and then parsing it out in the controller.
Here is an example :
```
demo $ k get endpoints
NAME                                  ENDPOINTS                                                        AGE
test-pa49y1-consul-connect-injector   10.244.0.20:8080,10.244.0.21:8080                                3m19s

demo $ k get svc
NAME                                  TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                                                                   AGE
test-pa49y1-consul-connect-injector   ClusterIP   10.96.139.240   <none>        443/TCP                                                                   3m25s

demo $ k get endpointslice
NAME                                        ADDRESSTYPE   PORTS                        ENDPOINTS                 AGE
test-pa49y1-consul-connect-injector-th6fx   IPv4          8080                         10.244.0.21,10.244.0.20   3m31s

```

How I've tested this PR:
Manual testing, acceptance tests and unit tests.

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

