### PR TITLE
Refactor Vault tests to allow more flexibility in mounting PKI and also be more representative of the integration experience of the user

### DIFF
--- a/acceptance/framework/vault/helpers.go
+++ b/acceptance/framework/vault/helpers.go
@@ -254,3 +254,181 @@ func CreateConnectCAPolicy(t *testing.T, vaultClient *vapi.Client, datacenter st
 		fmt.Sprintf(connectCAPolicyTemplate, datacenter, datacenter))
 	require.NoError(t, err)
 }
+
+// ConfigurePKICerts configures roles in Vault so
+// that controller webhook TLS certificates can be issued by Vault.
+func ConfigurePKICerts(t *testing.T,
+	vaultClient *vapi.Client, baseUrl, allowedSubdomain, roleName, ns, datacenter,
+	maxTTL string) string {
+	allowedDomains := fmt.Sprintf("%s.consul,%s,%s.%s,%s.%s.svc", datacenter,
+		allowedSubdomain, allowedSubdomain, ns, allowedSubdomain, ns)
+	params := map[string]interface{}{
+		"allowed_domains":    allowedDomains,
+		"allow_bare_domains": "true",
+		"allow_localhost":    "true",
+		"allow_subdomains":   "true",
+		"generate_lease":     "true",
+		"max_ttl":            maxTTL,
+	}
+
+	_, err := vaultClient.Logical().Write(
+		fmt.Sprintf("%s/roles/%s", baseUrl, roleName), params)
+	require.NoError(t, err)
+
+	certificateIssuePath := fmt.Sprintf("%s/issue/%s", baseUrl, roleName)
+	policy := fmt.Sprintf(`
+		path %q {
+		capabilities = ["create", "update"]
+		}`, certificateIssuePath)
+
+	// Create the server policy.
+	err = vaultClient.Sys().PutPolicy(roleName, policy)
+	require.NoError(t, err)
+
+	return certificateIssuePath
+}
+
+// ConfigurePKI generates a CA in Vault at a given path with a given policyName.
+func ConfigurePKI(t *testing.T, vaultClient *vapi.Client, baseUrl, policyName, commonName string) {
+	// Mount the PKI Secrets engine at the baseUrl.
+	err := vaultClient.Sys().Mount(baseUrl, &vapi.MountInput{
+		Type:   "pki",
+		Config: vapi.MountConfigInput{},
+	})
+	require.NoError(t, err)
+	// Create root CA to issue Consul server certificates and the `consul-server` PKI role.
+	// See https://learn.hashicorp.com/tutorials/consul/vault-pki-consul-secure-tls.
+	// Generate the root CA.
+	params := map[string]interface{}{
+		"common_name": commonName,
+		"ttl":         "24h",
+	}
+	_, err = vaultClient.Logical().Write(fmt.Sprintf("%s/root/generate/internal", baseUrl), params)
+	require.NoError(t, err)
+
+	policy := fmt.Sprintf(`path "%s/cert/ca" {
+		capabilities = ["read"]
+	  }`, baseUrl)
+	err = vaultClient.Sys().PutPolicy(policyName, policy)
+	require.NoError(t, err)
+}
+
+type KubernetesAuthRoleConfiguration struct {
+	ServiceAccountName  string
+	KubernetesNamespace string
+	PolicyNames         string
+	AuthMethodPath      string
+	RoleName            string
+}
+
+// ConfigureKubernetesAuthRole configures a role in Vault for the component for the Kubernetes auth method
+// that will be used by the test Helm chart installation.
+func ConfigureK8SAuthRole(t *testing.T, vaultClient *vapi.Client, config *KubernetesAuthRoleConfiguration) {
+	// Create the Auth Roles for the component.
+	// Auth roles bind policies to Kubernetes service accounts, which
+	// then enables the Vault agent init container to call 'vault login'
+	// with the Kubernetes auth method to obtain a Vault token.
+	// Please see https://www.vaultproject.io/docs/auth/kubernetes#configuration
+	// for more details.
+	logger.Logf(t, "Creating the %q", config.ServiceAccountName)
+	params := map[string]interface{}{
+		"bound_service_account_names":      config.ServiceAccountName,
+		"bound_service_account_namespaces": config.KubernetesNamespace,
+		"policies":                         config.PolicyNames,
+		"ttl":                              "24h",
+	}
+	_, err := vaultClient.Logical().Write(fmt.Sprintf("auth/%s/role/%s", config.AuthMethodPath, config.RoleName), params)
+	require.NoError(t, err)
+}
+
+type PKIAndAuthRoleConfiguration struct {
+	ServiceAccountName  string
+	BaseURL             string
+	PolicyName          string
+	RoleName            string
+	CommonName          string
+	CAPath              string
+	CertPath            string
+	KubernetesNamespace string
+	DataCenter          string
+	MaxTTL              string
+	AuthMethodPath      string
+	AllowedSubdomain    string
+}
+
+func ConfigurePKIAndAuthRole(t *testing.T, vaultClient *vapi.Client, config *PKIAndAuthRoleConfiguration) {
+	config.CAPath = fmt.Sprintf("%s/cert/ca", config.BaseURL)
+	// Configure role with read access to <baseURL>/cert/ca
+	ConfigurePKI(t, vaultClient, config.BaseURL, config.PolicyName,
+		config.CommonName)
+	// Configure role with create and update access to issue certs at
+	// <baseURL>/issue/<roleName>
+	config.CertPath = ConfigurePKICerts(t, vaultClient, config.BaseURL,
+		config.AllowedSubdomain, config.PolicyName, config.KubernetesNamespace,
+		config.DataCenter, config.MaxTTL)
+	// Configure AuthMethodRole that will map the service account name
+	// to the Vault role
+	authMethodRoleConfig := &KubernetesAuthRoleConfiguration{
+		ServiceAccountName:  config.ServiceAccountName,
+		KubernetesNamespace: config.KubernetesNamespace,
+		AuthMethodPath:      config.AuthMethodPath,
+		RoleName:            config.RoleName,
+		PolicyNames:         config.PolicyName,
+	}
+	ConfigureK8SAuthRole(t, vaultClient, authMethodRoleConfig)
+}
+
+type SaveVaultSecretConfiguration struct {
+	Path       string
+	Key        string
+	PolicyName string
+	Value      string
+}
+
+func SaveSecret(t *testing.T, vaultClient *vapi.Client, config *SaveVaultSecretConfiguration) {
+	policy := fmt.Sprintf(`
+	path "%s" {
+	  capabilities = ["read"]
+	}`, config.Path)
+	// Create the Vault Policy for the gossip key.
+	logger.Log(t, "Creating policy")
+	err := vaultClient.Sys().PutPolicy(config.PolicyName, policy)
+	require.NoError(t, err)
+
+	// Create the gossip secret.
+	logger.Log(t, "Creating the gossip secret")
+	params := map[string]interface{}{
+		"data": map[string]interface{}{
+			config.Key: config.Value,
+		},
+	}
+	_, err = vaultClient.Logical().Write(config.Path, params)
+	require.NoError(t, err)
+}
+
+// CreateConnectCAPolicyForDatacenter creates the Vault Policy for the connect-ca in a given datacenter.
+func CreateConnectCARootAndIntermediatePIKPolicy(t *testing.T, vaultClient *vapi.Client, policyName, rootPath, intermediatePath string) {
+	// connectCAPolicy allows Consul to bootstrap all certificates for the service mesh in Vault.
+	// Adapted from https://www.consul.io/docs/connect/ca/vault#consul-managed-pki-paths.
+	connectCAPolicyTemplate := `
+path "/sys/mounts" {
+  capabilities = [ "read" ]
+}
+path "/sys/mounts/%s" {
+  capabilities = [ "create", "read", "update", "delete", "list" ]
+}
+path "/sys/mounts/%s" {
+  capabilities = [ "create", "read", "update", "delete", "list" ]
+}
+path "/%s/*" {
+  capabilities = [ "create", "read", "update", "delete", "list" ]
+}
+path "/%s/*" {
+  capabilities = [ "create", "read", "update", "delete", "list" ]
+}
+`
+	err := vaultClient.Sys().PutPolicy(
+		policyName,
+		fmt.Sprintf(connectCAPolicyTemplate, rootPath, intermediatePath, rootPath, intermediatePath))
+	require.NoError(t, err)
+}

--- a/acceptance/framework/vault/helpers.go
+++ b/acceptance/framework/vault/helpers.go
@@ -407,7 +407,7 @@ func SaveSecret(t *testing.T, vaultClient *vapi.Client, config *SaveVaultSecretC
 }
 
 // CreateConnectCAPolicyForDatacenter creates the Vault Policy for the connect-ca in a given datacenter.
-func CreateConnectCARootAndIntermediatePIKPolicy(t *testing.T, vaultClient *vapi.Client, policyName, rootPath, intermediatePath string) {
+func CreateConnectCARootAndIntermediatePKIPolicy(t *testing.T, vaultClient *vapi.Client, policyName, rootPath, intermediatePath string) {
 	// connectCAPolicy allows Consul to bootstrap all certificates for the service mesh in Vault.
 	// Adapted from https://www.consul.io/docs/connect/ca/vault#consul-managed-pki-paths.
 	connectCAPolicyTemplate := `

--- a/acceptance/framework/vault/helpers.go
+++ b/acceptance/framework/vault/helpers.go
@@ -154,14 +154,14 @@ func (config *PKIAndAuthRoleConfiguration) ConfigurePKIAndAuthRole(t *testing.T,
 	authMethodRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 }
 
-type SaveVaultSecretConfiguration struct {
+type KV2Secret struct {
 	Path       string
 	Key        string
 	PolicyName string
 	Value      string
 }
 
-func (config *SaveVaultSecretConfiguration) Save(t *testing.T, vaultClient *vapi.Client) {
+func (config *KV2Secret) Save(t *testing.T, vaultClient *vapi.Client) {
 	policy := fmt.Sprintf(`
 	path "%s" {
 	  capabilities = ["read"]

--- a/acceptance/framework/vault/helpers.go
+++ b/acceptance/framework/vault/helpers.go
@@ -98,7 +98,7 @@ type KubernetesAuthRoleConfiguration struct {
 
 // ConfigureKubernetesAuthRole configures a role in Vault for the component for the Kubernetes auth method
 // that will be used by the test Helm chart installation.
-func ConfigureK8SAuthRole(t *testing.T, vaultClient *vapi.Client, config *KubernetesAuthRoleConfiguration) {
+func (config *KubernetesAuthRoleConfiguration) ConfigureK8SAuthRole(t *testing.T, vaultClient *vapi.Client) {
 	// Create the Auth Roles for the component.
 	// Auth roles bind policies to Kubernetes service accounts, which
 	// then enables the Vault agent init container to call 'vault login'
@@ -132,7 +132,7 @@ type PKIAndAuthRoleConfiguration struct {
 	SkipPKIMount        bool
 }
 
-func ConfigurePKIAndAuthRole(t *testing.T, vaultClient *vapi.Client, config *PKIAndAuthRoleConfiguration) {
+func (config *PKIAndAuthRoleConfiguration) ConfigurePKIAndAuthRole(t *testing.T, vaultClient *vapi.Client) {
 	config.CAPath = fmt.Sprintf("%s/cert/ca", config.BaseURL)
 	// Configure role with read access to <baseURL>/cert/ca
 	ConfigurePKI(t, vaultClient, config.BaseURL, config.PolicyName,
@@ -151,7 +151,7 @@ func ConfigurePKIAndAuthRole(t *testing.T, vaultClient *vapi.Client, config *PKI
 		RoleName:            config.RoleName,
 		PolicyNames:         config.PolicyName,
 	}
-	ConfigureK8SAuthRole(t, vaultClient, authMethodRoleConfig)
+	authMethodRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 }
 
 type SaveVaultSecretConfiguration struct {
@@ -161,7 +161,7 @@ type SaveVaultSecretConfiguration struct {
 	Value      string
 }
 
-func SaveSecret(t *testing.T, vaultClient *vapi.Client, config *SaveVaultSecretConfiguration) {
+func (config *SaveVaultSecretConfiguration) Save(t *testing.T, vaultClient *vapi.Client) {
 	policy := fmt.Sprintf(`
 	path "%s" {
 	  capabilities = ["read"]

--- a/acceptance/framework/vault/vault_cluster.go
+++ b/acceptance/framework/vault/vault_cluster.go
@@ -147,13 +147,6 @@ func (v *VaultCluster) bootstrap(t *testing.T, vaultNamespace string) {
 	})
 	require.NoError(t, err)
 
-	// Enable the PKI Secrets engine.
-	err = v.vaultClient.Sys().Mount("pki", &vapi.MountInput{
-		Type:   "pki",
-		Config: vapi.MountConfigInput{},
-	})
-	require.NoError(t, err)
-
 	namespace := v.helmOptions.KubectlOptions.Namespace
 	vaultServerServiceAccountName := fmt.Sprintf("%s-vault", v.releaseName)
 	v.ConfigureAuthMethod(t, v.vaultClient, "kubernetes", "https://kubernetes.default.svc", vaultServerServiceAccountName, namespace)

--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/consul-k8s/control-plane v0.0.0-20211207212234-aea9efea5638
 	github.com/hashicorp/consul/api v1.12.0
 	github.com/hashicorp/consul/sdk v0.9.0
-	github.com/hashicorp/go-uuid v1.0.2
+	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/vault/api v1.2.0
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -442,6 +442,8 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
+github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=

--- a/acceptance/tests/connect/connect_helper.go
+++ b/acceptance/tests/connect/connect_helper.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	staticClientName = "static-client"
+	StaticClientName = "static-client"
 	staticServerName = "static-server"
 )
 
@@ -98,7 +98,7 @@ func (c *ConnectHelper) DeployClientAndServer(t *testing.T) {
 				require.NoError(r, err)
 				for _, token := range tokens {
 					require.NotContains(r, token.Description, staticServerName)
-					require.NotContains(r, token.Description, staticClientName)
+					require.NotContains(r, token.Description, StaticClientName)
 				}
 			})
 		})
@@ -130,9 +130,9 @@ func (c *ConnectHelper) DeployClientAndServer(t *testing.T) {
 func (c *ConnectHelper) TestConnectionFailureWithoutIntention(t *testing.T) {
 	logger.Log(t, "checking that the connection is not successful because there's no intention")
 	if c.Cfg.EnableTransparentProxy {
-		k8s.CheckStaticServerConnectionFailing(t, c.Ctx.KubectlOptions(t), staticClientName, "http://static-server")
+		k8s.CheckStaticServerConnectionFailing(t, c.Ctx.KubectlOptions(t), StaticClientName, "http://static-server")
 	} else {
-		k8s.CheckStaticServerConnectionFailing(t, c.Ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
+		k8s.CheckStaticServerConnectionFailing(t, c.Ctx.KubectlOptions(t), StaticClientName, "http://localhost:1234")
 	}
 }
 
@@ -145,7 +145,7 @@ func (c *ConnectHelper) CreateIntention(t *testing.T) {
 		Name: staticServerName,
 		Sources: []*api.SourceIntention{
 			{
-				Name:   staticClientName,
+				Name:   StaticClientName,
 				Action: api.IntentionActionAllow,
 			},
 		},
@@ -159,9 +159,9 @@ func (c *ConnectHelper) TestConnectionSuccess(t *testing.T) {
 	logger.Log(t, "checking that connection is successful")
 	if c.Cfg.EnableTransparentProxy {
 		// todo: add an assertion that the traffic is going through the proxy
-		k8s.CheckStaticServerConnectionSuccessful(t, c.Ctx.KubectlOptions(t), staticClientName, "http://static-server")
+		k8s.CheckStaticServerConnectionSuccessful(t, c.Ctx.KubectlOptions(t), StaticClientName, "http://static-server")
 	} else {
-		k8s.CheckStaticServerConnectionSuccessful(t, c.Ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
+		k8s.CheckStaticServerConnectionSuccessful(t, c.Ctx.KubectlOptions(t), StaticClientName, "http://localhost:1234")
 	}
 }
 
@@ -185,13 +185,13 @@ func (c *ConnectHelper) TestConnectionFailureWhenUnhealthy(t *testing.T) {
 	// other tests.
 	logger.Log(t, "checking that connection is unsuccessful")
 	if c.Cfg.EnableTransparentProxy {
-		k8s.CheckStaticServerConnectionMultipleFailureMessages(t, c.Ctx.KubectlOptions(t), staticClientName, false, []string{
+		k8s.CheckStaticServerConnectionMultipleFailureMessages(t, c.Ctx.KubectlOptions(t), StaticClientName, false, []string{
 			"curl: (56) Recv failure: Connection reset by peer",
 			"curl: (52) Empty reply from server",
 			"curl: (7) Failed to connect to static-server port 80: Connection refused",
 		}, "", "http://static-server")
 	} else {
-		k8s.CheckStaticServerConnectionMultipleFailureMessages(t, c.Ctx.KubectlOptions(t), staticClientName, false, []string{
+		k8s.CheckStaticServerConnectionMultipleFailureMessages(t, c.Ctx.KubectlOptions(t), StaticClientName, false, []string{
 			"curl: (56) Recv failure: Connection reset by peer",
 			"curl: (52) Empty reply from server",
 		}, "", "http://localhost:1234")

--- a/acceptance/tests/connect/connect_inject_test.go
+++ b/acceptance/tests/connect/connect_inject_test.go
@@ -244,9 +244,9 @@ func TestConnectInject_RestartConsulClients(t *testing.T) {
 
 	logger.Log(t, "checking that connection is successful")
 	if cfg.EnableTransparentProxy {
-		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "http://static-server")
+		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), StaticClientName, "http://static-server")
 	} else {
-		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
+		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), StaticClientName, "http://localhost:1234")
 	}
 
 	logger.Log(t, "restarting Consul client daemonset")
@@ -255,9 +255,9 @@ func TestConnectInject_RestartConsulClients(t *testing.T) {
 
 	logger.Log(t, "checking that connection is still successful")
 	if cfg.EnableTransparentProxy {
-		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "http://static-server")
+		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), StaticClientName, "http://static-server")
 	} else {
-		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
+		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), StaticClientName, "http://localhost:1234")
 	}
 }
 
@@ -316,7 +316,7 @@ func TestConnectInject_MultiportServices(t *testing.T) {
 						for _, token := range tokens {
 							require.NotContains(r, token.Description, multiport)
 							require.NotContains(r, token.Description, multiportAdmin)
-							require.NotContains(r, token.Description, staticClientName)
+							require.NotContains(r, token.Description, StaticClientName)
 							require.NotContains(r, token.Description, staticServerName)
 						}
 					})
@@ -345,8 +345,8 @@ func TestConnectInject_MultiportServices(t *testing.T) {
 
 			if c.secure {
 				logger.Log(t, "checking that the connection is not successful because there's no intention")
-				k8s.CheckStaticServerConnectionFailing(t, ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
-				k8s.CheckStaticServerConnectionFailing(t, ctx.KubectlOptions(t), staticClientName, "http://localhost:2234")
+				k8s.CheckStaticServerConnectionFailing(t, ctx.KubectlOptions(t), StaticClientName, "http://localhost:1234")
+				k8s.CheckStaticServerConnectionFailing(t, ctx.KubectlOptions(t), StaticClientName, "http://localhost:2234")
 
 				logger.Log(t, fmt.Sprintf("creating intention for %s", multiport))
 				_, _, err := consulClient.ConfigEntries().Set(&api.ServiceIntentionsConfigEntry{
@@ -354,7 +354,7 @@ func TestConnectInject_MultiportServices(t *testing.T) {
 					Name: multiport,
 					Sources: []*api.SourceIntention{
 						{
-							Name:   staticClientName,
+							Name:   StaticClientName,
 							Action: api.IntentionActionAllow,
 						},
 					},
@@ -366,7 +366,7 @@ func TestConnectInject_MultiportServices(t *testing.T) {
 					Name: multiportAdmin,
 					Sources: []*api.SourceIntention{
 						{
-							Name:   staticClientName,
+							Name:   StaticClientName,
 							Action: api.IntentionActionAllow,
 						},
 					},
@@ -375,10 +375,10 @@ func TestConnectInject_MultiportServices(t *testing.T) {
 			}
 
 			// Check connection from static-client to multiport.
-			k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
+			k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), StaticClientName, "http://localhost:1234")
 
 			// Check connection from static-client to multiport-admin.
-			k8s.CheckStaticServerConnectionSuccessfulWithMessage(t, ctx.KubectlOptions(t), staticClientName, "hello world from 9090 admin", "http://localhost:2234")
+			k8s.CheckStaticServerConnectionSuccessfulWithMessage(t, ctx.KubectlOptions(t), StaticClientName, "hello world from 9090 admin", "http://localhost:2234")
 
 			// Now that we've checked inbound connections to a multi port pod, check outbound connection from multi port
 			// pod to static-server.
@@ -423,8 +423,8 @@ func TestConnectInject_MultiportServices(t *testing.T) {
 			// We are expecting a "connection reset by peer" error because in a case of health checks,
 			// there will be no healthy proxy host to connect to. That's why we can't assert that we receive an empty reply
 			// from server, which is the case when a connection is unsuccessful due to intentions in other tests.
-			k8s.CheckStaticServerConnectionMultipleFailureMessages(t, ctx.KubectlOptions(t), staticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"}, "", "http://localhost:1234")
-			k8s.CheckStaticServerConnectionMultipleFailureMessages(t, ctx.KubectlOptions(t), staticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"}, "", "http://localhost:2234")
+			k8s.CheckStaticServerConnectionMultipleFailureMessages(t, ctx.KubectlOptions(t), StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"}, "", "http://localhost:1234")
+			k8s.CheckStaticServerConnectionMultipleFailureMessages(t, ctx.KubectlOptions(t), StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"}, "", "http://localhost:2234")
 		})
 	}
 }

--- a/acceptance/tests/ingress-gateway/ingress_gateway_namespaces_test.go
+++ b/acceptance/tests/ingress-gateway/ingress_gateway_namespaces_test.go
@@ -129,7 +129,7 @@ func TestIngressGatewaySingleNamespace(t *testing.T) {
 				// via the bounce pod. It should fail to connect with the
 				// static-server pod because of intentions.
 				logger.Log(t, "testing intentions prevent ingress")
-				k8s.CheckStaticServerConnectionFailing(t, nsK8SOptions, staticClientName, "-H", "Host: static-server.ingress.consul", ingressGatewayService)
+				k8s.CheckStaticServerConnectionFailing(t, nsK8SOptions, StaticClientName, "-H", "Host: static-server.ingress.consul", ingressGatewayService)
 
 				// Now we create the allow intention.
 				logger.Log(t, "creating ingress-gateway => static-server intention")
@@ -151,7 +151,7 @@ func TestIngressGatewaySingleNamespace(t *testing.T) {
 			// Test that we can make a call to the ingress gateway
 			// via the static-client pod. It should route to the static-server pod.
 			logger.Log(t, "trying calls to ingress gateway")
-			k8s.CheckStaticServerConnectionSuccessful(t, nsK8SOptions, staticClientName, "-H", "Host: static-server.ingress.consul", ingressGatewayService)
+			k8s.CheckStaticServerConnectionSuccessful(t, nsK8SOptions, StaticClientName, "-H", "Host: static-server.ingress.consul", ingressGatewayService)
 		})
 	}
 }
@@ -255,7 +255,7 @@ func TestIngressGatewayNamespaceMirroring(t *testing.T) {
 				// via the bounce pod. It should fail to connect with the
 				// static-server pod because of intentions.
 				logger.Log(t, "testing intentions prevent ingress")
-				k8s.CheckStaticServerConnectionFailing(t, nsK8SOptions, staticClientName, "-H", "Host: static-server.ingress.consul", ingressGatewayService)
+				k8s.CheckStaticServerConnectionFailing(t, nsK8SOptions, StaticClientName, "-H", "Host: static-server.ingress.consul", ingressGatewayService)
 
 				// Now we create the allow intention.
 				logger.Log(t, "creating ingress-gateway => static-server intention")
@@ -277,7 +277,7 @@ func TestIngressGatewayNamespaceMirroring(t *testing.T) {
 			// Test that we can make a call to the ingress gateway
 			// via the static-client pod. It should route to the static-server pod.
 			logger.Log(t, "trying calls to ingress gateway")
-			k8s.CheckStaticServerConnectionSuccessful(t, nsK8SOptions, staticClientName, "-H", "Host: static-server.ingress.consul", ingressGatewayService)
+			k8s.CheckStaticServerConnectionSuccessful(t, nsK8SOptions, StaticClientName, "-H", "Host: static-server.ingress.consul", ingressGatewayService)
 		})
 	}
 }

--- a/acceptance/tests/ingress-gateway/ingress_gateway_test.go
+++ b/acceptance/tests/ingress-gateway/ingress_gateway_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const staticClientName = "static-client"
+const StaticClientName = "static-client"
 
 // Test that ingress gateways work in a default installation and a secure installation.
 func TestIngressGateway(t *testing.T) {
@@ -96,7 +96,7 @@ func TestIngressGateway(t *testing.T) {
 				// static-server pod because of intentions.
 				logger.Log(t, "testing intentions prevent ingress")
 				k8s.CheckStaticServerConnectionFailing(t, k8sOptions,
-					staticClientName, "-H", "Host: static-server.ingress.consul",
+					StaticClientName, "-H", "Host: static-server.ingress.consul",
 					fmt.Sprintf("http://%s-consul-%s:8080/", releaseName, igName))
 
 				// Now we create the allow intention.
@@ -118,7 +118,7 @@ func TestIngressGateway(t *testing.T) {
 			// via the static-client pod. It should route to the static-server pod.
 			logger.Log(t, "trying calls to ingress gateway")
 			k8s.CheckStaticServerConnectionSuccessful(t, k8sOptions,
-				staticClientName, "-H", "Host: static-server.ingress.consul",
+				StaticClientName, "-H", "Host: static-server.ingress.consul",
 				fmt.Sprintf("http://%s-consul-%s:8080/", releaseName, igName))
 		})
 	}

--- a/acceptance/tests/mesh-gateway/mesh_gateway_test.go
+++ b/acceptance/tests/mesh-gateway/mesh_gateway_test.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const staticClientName = "static-client"
+const StaticClientName = "static-client"
 
 // Test that Connect and wan federation over mesh gateways work in a default installation
 // i.e. without ACLs because TLS is required for WAN federation over mesh gateways.
@@ -128,7 +128,7 @@ func TestMeshGatewayDefault(t *testing.T) {
 	k8s.DeployKustomize(t, primaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-multi-dc")
 
 	logger.Log(t, "checking that connection is successful")
-	k8s.CheckStaticServerConnectionSuccessful(t, primaryContext.KubectlOptions(t), staticClientName, "http://localhost:1234")
+	k8s.CheckStaticServerConnectionSuccessful(t, primaryContext.KubectlOptions(t), StaticClientName, "http://localhost:1234")
 }
 
 // Test that Connect and wan federation over mesh gateways work in a secure installation,
@@ -287,7 +287,7 @@ func TestMeshGatewaySecure(t *testing.T) {
 				Name: "static-server",
 				Sources: []*api.SourceIntention{
 					{
-						Name:   staticClientName,
+						Name:   StaticClientName,
 						Action: api.IntentionActionAllow,
 					},
 				},
@@ -295,7 +295,7 @@ func TestMeshGatewaySecure(t *testing.T) {
 			require.NoError(t, err)
 
 			logger.Log(t, "checking that connection is successful")
-			k8s.CheckStaticServerConnectionSuccessful(t, primaryContext.KubectlOptions(t), staticClientName, "http://localhost:1234")
+			k8s.CheckStaticServerConnectionSuccessful(t, primaryContext.KubectlOptions(t), StaticClientName, "http://localhost:1234")
 		})
 	}
 }

--- a/acceptance/tests/metrics/metrics_test.go
+++ b/acceptance/tests/metrics/metrics_test.go
@@ -3,9 +3,10 @@ package metrics
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
@@ -16,7 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const staticClientName = "static-client"
+const StaticClientName = "static-client"
 
 // Test that prometheus metrics, when enabled, are accessible from the
 // endpoints that have been exposed on the server, client and gateways.
@@ -67,12 +68,12 @@ func TestComponentMetrics(t *testing.T) {
 	k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/bases/static-client")
 
 	// Server Metrics
-	metricsOutput, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+staticClientName, "--", "curl", "--silent", "--show-error", fmt.Sprintf("http://%s:8500/v1/agent/metrics?format=prometheus", fmt.Sprintf("%s-consul-server.%s.svc", releaseName, ns)))
+	metricsOutput, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+StaticClientName, "--", "curl", "--silent", "--show-error", fmt.Sprintf("http://%s:8500/v1/agent/metrics?format=prometheus", fmt.Sprintf("%s-consul-server.%s.svc", releaseName, ns)))
 	require.NoError(t, err)
 	require.Contains(t, metricsOutput, `consul_acl_ResolveToken{quantile="0.5"}`)
 
 	// Client Metrics
-	metricsOutput, err = k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+staticClientName, "--", "sh", "-c", "curl --silent --show-error http://$HOST_IP:8500/v1/agent/metrics?format=prometheus")
+	metricsOutput, err = k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+StaticClientName, "--", "sh", "-c", "curl --silent --show-error http://$HOST_IP:8500/v1/agent/metrics?format=prometheus")
 	require.NoError(t, err)
 	require.Contains(t, metricsOutput, `consul_acl_ResolveToken{quantile="0.5"}`)
 
@@ -127,7 +128,7 @@ func TestAppMetrics(t *testing.T) {
 	// Retry because sometimes the merged metrics server takes a couple hundred milliseconds
 	// to start.
 	retry.RunWith(&retry.Counter{Count: 3, Wait: 1 * time.Second}, t, func(r *retry.R) {
-		metricsOutput, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+staticClientName, "--", "curl", "--silent", "--show-error", fmt.Sprintf("http://%s:20200/metrics", podIP))
+		metricsOutput, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+StaticClientName, "--", "curl", "--silent", "--show-error", fmt.Sprintf("http://%s:20200/metrics", podIP))
 		require.NoError(r, err)
 		// This assertion represents the metrics from the envoy sidecar.
 		require.Contains(r, metricsOutput, `envoy_cluster_assignment_stale{local_cluster="server",consul_source_service="server"`)
@@ -141,7 +142,7 @@ func assertGatewayMetricsEnabled(t *testing.T, ctx environment.TestContext, ns, 
 	require.NoError(t, err)
 	for _, pod := range pods.Items {
 		podIP := pod.Status.PodIP
-		metricsOutput, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+staticClientName, "--", "curl", "--silent", "--show-error", fmt.Sprintf("http://%s:20200/metrics", podIP))
+		metricsOutput, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+StaticClientName, "--", "curl", "--silent", "--show-error", fmt.Sprintf("http://%s:20200/metrics", podIP))
 		require.NoError(t, err)
 		require.Contains(t, metricsOutput, metricsAssertion)
 	}

--- a/acceptance/tests/partitions/partitions_connect_test.go
+++ b/acceptance/tests/partitions/partitions_connect_test.go
@@ -18,10 +18,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const staticClientName = "static-client"
+const StaticClientName = "static-client"
 const staticServerName = "static-server"
 const staticServerNamespace = "ns1"
-const staticClientNamespace = "ns2"
+const StaticClientNamespace = "ns2"
 
 // Test that Connect works in a default and ACLsAndAutoEncryptEnabled installations for X-Partition and in-partition networking.
 func TestPartitions_Connect(t *testing.T) {
@@ -216,7 +216,7 @@ func TestPartitions_Connect(t *testing.T) {
 			serverClusterStaticClientOpts := &terratestk8s.KubectlOptions{
 				ContextName: serverClusterContext.KubectlOptions(t).ContextName,
 				ConfigPath:  serverClusterContext.KubectlOptions(t).ConfigPath,
-				Namespace:   staticClientNamespace,
+				Namespace:   StaticClientNamespace,
 			}
 			clientClusterStaticServerOpts := &terratestk8s.KubectlOptions{
 				ContextName: clientClusterContext.KubectlOptions(t).ContextName,
@@ -226,30 +226,30 @@ func TestPartitions_Connect(t *testing.T) {
 			clientClusterStaticClientOpts := &terratestk8s.KubectlOptions{
 				ContextName: clientClusterContext.KubectlOptions(t).ContextName,
 				ConfigPath:  clientClusterContext.KubectlOptions(t).ConfigPath,
-				Namespace:   staticClientNamespace,
+				Namespace:   StaticClientNamespace,
 			}
 
-			logger.Logf(t, "creating namespaces %s and %s in servers cluster", staticServerNamespace, staticClientNamespace)
+			logger.Logf(t, "creating namespaces %s and %s in servers cluster", staticServerNamespace, StaticClientNamespace)
 			k8s.RunKubectl(t, serverClusterContext.KubectlOptions(t), "create", "ns", staticServerNamespace)
-			k8s.RunKubectl(t, serverClusterContext.KubectlOptions(t), "create", "ns", staticClientNamespace)
+			k8s.RunKubectl(t, serverClusterContext.KubectlOptions(t), "create", "ns", StaticClientNamespace)
 			helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
-				k8s.RunKubectl(t, serverClusterContext.KubectlOptions(t), "delete", "ns", staticServerNamespace, staticClientNamespace)
+				k8s.RunKubectl(t, serverClusterContext.KubectlOptions(t), "delete", "ns", staticServerNamespace, StaticClientNamespace)
 			})
 
-			logger.Logf(t, "creating namespaces %s and %s in clients cluster", staticServerNamespace, staticClientNamespace)
+			logger.Logf(t, "creating namespaces %s and %s in clients cluster", staticServerNamespace, StaticClientNamespace)
 			k8s.RunKubectl(t, clientClusterContext.KubectlOptions(t), "create", "ns", staticServerNamespace)
-			k8s.RunKubectl(t, clientClusterContext.KubectlOptions(t), "create", "ns", staticClientNamespace)
+			k8s.RunKubectl(t, clientClusterContext.KubectlOptions(t), "create", "ns", StaticClientNamespace)
 			helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
-				k8s.RunKubectl(t, clientClusterContext.KubectlOptions(t), "delete", "ns", staticServerNamespace, staticClientNamespace)
+				k8s.RunKubectl(t, clientClusterContext.KubectlOptions(t), "delete", "ns", staticServerNamespace, StaticClientNamespace)
 			})
 
 			consulClient, _ := serverConsulCluster.SetupConsulClient(t, c.ACLsAndAutoEncryptEnabled)
 
 			serverQueryServerOpts := &api.QueryOptions{Namespace: staticServerNamespace, Partition: defaultPartition}
-			clientQueryServerOpts := &api.QueryOptions{Namespace: staticClientNamespace, Partition: defaultPartition}
+			clientQueryServerOpts := &api.QueryOptions{Namespace: StaticClientNamespace, Partition: defaultPartition}
 
 			serverQueryClientOpts := &api.QueryOptions{Namespace: staticServerNamespace, Partition: secondaryPartition}
-			clientQueryClientOpts := &api.QueryOptions{Namespace: staticClientNamespace, Partition: secondaryPartition}
+			clientQueryClientOpts := &api.QueryOptions{Namespace: StaticClientNamespace, Partition: secondaryPartition}
 
 			if !c.mirrorK8S {
 				serverQueryServerOpts = &api.QueryOptions{Namespace: c.destinationNamespace, Partition: defaultPartition}
@@ -275,7 +275,7 @@ func TestPartitions_Connect(t *testing.T) {
 							tokens, _, err = consulClient.ACL().TokenList(clientQueryServerOpts)
 							require.NoError(r, err)
 							for _, token := range tokens {
-								require.NotContains(r, token.Description, staticClientName)
+								require.NotContains(r, token.Description, StaticClientName)
 							}
 							tokens, _, err = consulClient.ACL().TokenList(serverQueryClientOpts)
 							require.NoError(r, err)
@@ -286,7 +286,7 @@ func TestPartitions_Connect(t *testing.T) {
 							tokens, _, err = consulClient.ACL().TokenList(clientQueryClientOpts)
 							require.NoError(r, err)
 							for _, token := range tokens {
-								require.NotContains(r, token.Description, staticClientName)
+								require.NotContains(r, token.Description, StaticClientName)
 							}
 						})
 					}
@@ -363,7 +363,7 @@ func TestPartitions_Connect(t *testing.T) {
 				require.NoError(t, err)
 				require.Len(t, services, 1)
 
-				services, _, err = consulClient.Catalog().Service(staticClientName, "", clientQueryServerOpts)
+				services, _, err = consulClient.Catalog().Service(StaticClientName, "", clientQueryServerOpts)
 				require.NoError(t, err)
 				require.Len(t, services, 1)
 
@@ -372,18 +372,18 @@ func TestPartitions_Connect(t *testing.T) {
 				require.NoError(t, err)
 				require.Len(t, services, 1)
 
-				services, _, err = consulClient.Catalog().Service(staticClientName, "", clientQueryClientOpts)
+				services, _, err = consulClient.Catalog().Service(StaticClientName, "", clientQueryClientOpts)
 				require.NoError(t, err)
 				require.Len(t, services, 1)
 
 				if c.ACLsAndAutoEncryptEnabled {
 					logger.Log(t, "checking that the connection is not successful because there's no intention")
 					if cfg.EnableTransparentProxy {
-						k8s.CheckStaticServerConnectionFailing(t, serverClusterStaticClientOpts, staticClientName, fmt.Sprintf("http://static-server.%s", staticServerNamespace))
-						k8s.CheckStaticServerConnectionFailing(t, clientClusterStaticClientOpts, staticClientName, fmt.Sprintf("http://static-server.%s", staticServerNamespace))
+						k8s.CheckStaticServerConnectionFailing(t, serverClusterStaticClientOpts, StaticClientName, fmt.Sprintf("http://static-server.%s", staticServerNamespace))
+						k8s.CheckStaticServerConnectionFailing(t, clientClusterStaticClientOpts, StaticClientName, fmt.Sprintf("http://static-server.%s", staticServerNamespace))
 					} else {
-						k8s.CheckStaticServerConnectionFailing(t, serverClusterStaticClientOpts, staticClientName, "http://localhost:1234")
-						k8s.CheckStaticServerConnectionFailing(t, clientClusterStaticClientOpts, staticClientName, "http://localhost:1234")
+						k8s.CheckStaticServerConnectionFailing(t, serverClusterStaticClientOpts, StaticClientName, "http://localhost:1234")
+						k8s.CheckStaticServerConnectionFailing(t, clientClusterStaticClientOpts, StaticClientName, "http://localhost:1234")
 					}
 
 					intention := &api.ServiceIntentionsConfigEntry{
@@ -392,8 +392,8 @@ func TestPartitions_Connect(t *testing.T) {
 						Namespace: staticServerNamespace,
 						Sources: []*api.SourceIntention{
 							{
-								Name:      staticClientName,
-								Namespace: staticClientNamespace,
+								Name:      StaticClientName,
+								Namespace: StaticClientNamespace,
 								Action:    api.IntentionActionAllow,
 							},
 						},
@@ -421,11 +421,11 @@ func TestPartitions_Connect(t *testing.T) {
 
 				logger.Log(t, "checking that connection is successful")
 				if cfg.EnableTransparentProxy {
-					k8s.CheckStaticServerConnectionSuccessful(t, serverClusterStaticClientOpts, staticClientName, fmt.Sprintf("http://static-server.%s", staticServerNamespace))
-					k8s.CheckStaticServerConnectionSuccessful(t, clientClusterStaticClientOpts, staticClientName, fmt.Sprintf("http://static-server.%s", staticServerNamespace))
+					k8s.CheckStaticServerConnectionSuccessful(t, serverClusterStaticClientOpts, StaticClientName, fmt.Sprintf("http://static-server.%s", staticServerNamespace))
+					k8s.CheckStaticServerConnectionSuccessful(t, clientClusterStaticClientOpts, StaticClientName, fmt.Sprintf("http://static-server.%s", staticServerNamespace))
 				} else {
-					k8s.CheckStaticServerConnectionSuccessful(t, serverClusterStaticClientOpts, staticClientName, "http://localhost:1234")
-					k8s.CheckStaticServerConnectionSuccessful(t, clientClusterStaticClientOpts, staticClientName, "http://localhost:1234")
+					k8s.CheckStaticServerConnectionSuccessful(t, serverClusterStaticClientOpts, StaticClientName, "http://localhost:1234")
+					k8s.CheckStaticServerConnectionSuccessful(t, clientClusterStaticClientOpts, StaticClientName, "http://localhost:1234")
 				}
 
 				// Test that kubernetes readiness status is synced to Consul.
@@ -441,11 +441,11 @@ func TestPartitions_Connect(t *testing.T) {
 				// from server, which is the case when a connection is unsuccessful due to intentions in other tests.
 				logger.Log(t, "checking that connection is unsuccessful")
 				if cfg.EnableTransparentProxy {
-					k8s.CheckStaticServerConnectionMultipleFailureMessages(t, serverClusterStaticClientOpts, staticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server", "curl: (7) Failed to connect to static-server.ns1 port 80: Connection refused"}, "", fmt.Sprintf("http://static-server.%s", staticServerNamespace))
-					k8s.CheckStaticServerConnectionMultipleFailureMessages(t, clientClusterStaticClientOpts, staticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server", "curl: (7) Failed to connect to static-server.ns1 port 80: Connection refused"}, "", fmt.Sprintf("http://static-server.%s", staticServerNamespace))
+					k8s.CheckStaticServerConnectionMultipleFailureMessages(t, serverClusterStaticClientOpts, StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server", "curl: (7) Failed to connect to static-server.ns1 port 80: Connection refused"}, "", fmt.Sprintf("http://static-server.%s", staticServerNamespace))
+					k8s.CheckStaticServerConnectionMultipleFailureMessages(t, clientClusterStaticClientOpts, StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server", "curl: (7) Failed to connect to static-server.ns1 port 80: Connection refused"}, "", fmt.Sprintf("http://static-server.%s", staticServerNamespace))
 				} else {
-					k8s.CheckStaticServerConnectionMultipleFailureMessages(t, serverClusterStaticClientOpts, staticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"}, "", "http://localhost:1234")
-					k8s.CheckStaticServerConnectionMultipleFailureMessages(t, clientClusterStaticClientOpts, staticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"}, "", "http://localhost:1234")
+					k8s.CheckStaticServerConnectionMultipleFailureMessages(t, serverClusterStaticClientOpts, StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"}, "", "http://localhost:1234")
+					k8s.CheckStaticServerConnectionMultipleFailureMessages(t, clientClusterStaticClientOpts, StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"}, "", "http://localhost:1234")
 				}
 			})
 			// This section of the tests runs the cross-partition networking tests.
@@ -507,7 +507,7 @@ func TestPartitions_Connect(t *testing.T) {
 				require.NoError(t, err)
 				require.Len(t, services, 1)
 
-				services, _, err = consulClient.Catalog().Service(staticClientName, "", clientQueryServerOpts)
+				services, _, err = consulClient.Catalog().Service(StaticClientName, "", clientQueryServerOpts)
 				require.NoError(t, err)
 				require.Len(t, services, 1)
 
@@ -516,7 +516,7 @@ func TestPartitions_Connect(t *testing.T) {
 				require.NoError(t, err)
 				require.Len(t, services, 1)
 
-				services, _, err = consulClient.Catalog().Service(staticClientName, "", clientQueryClientOpts)
+				services, _, err = consulClient.Catalog().Service(StaticClientName, "", clientQueryClientOpts)
 				require.NoError(t, err)
 				require.Len(t, services, 1)
 
@@ -541,15 +541,15 @@ func TestPartitions_Connect(t *testing.T) {
 					logger.Log(t, "checking that the connection is not successful because there's no intention")
 					if cfg.EnableTransparentProxy {
 						if !c.mirrorK8S {
-							k8s.CheckStaticServerConnectionFailing(t, serverClusterStaticClientOpts, staticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", c.destinationNamespace, secondaryPartition))
-							k8s.CheckStaticServerConnectionFailing(t, clientClusterStaticClientOpts, staticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", c.destinationNamespace, defaultPartition))
+							k8s.CheckStaticServerConnectionFailing(t, serverClusterStaticClientOpts, StaticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", c.destinationNamespace, secondaryPartition))
+							k8s.CheckStaticServerConnectionFailing(t, clientClusterStaticClientOpts, StaticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", c.destinationNamespace, defaultPartition))
 						} else {
-							k8s.CheckStaticServerConnectionFailing(t, serverClusterStaticClientOpts, staticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", staticServerNamespace, secondaryPartition))
-							k8s.CheckStaticServerConnectionFailing(t, clientClusterStaticClientOpts, staticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", staticServerNamespace, defaultPartition))
+							k8s.CheckStaticServerConnectionFailing(t, serverClusterStaticClientOpts, StaticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", staticServerNamespace, secondaryPartition))
+							k8s.CheckStaticServerConnectionFailing(t, clientClusterStaticClientOpts, StaticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", staticServerNamespace, defaultPartition))
 						}
 					} else {
-						k8s.CheckStaticServerConnectionFailing(t, serverClusterStaticClientOpts, staticClientName, "http://localhost:1234")
-						k8s.CheckStaticServerConnectionFailing(t, clientClusterStaticClientOpts, staticClientName, "http://localhost:1234")
+						k8s.CheckStaticServerConnectionFailing(t, serverClusterStaticClientOpts, StaticClientName, "http://localhost:1234")
+						k8s.CheckStaticServerConnectionFailing(t, clientClusterStaticClientOpts, StaticClientName, "http://localhost:1234")
 					}
 
 					intention := &api.ServiceIntentionsConfigEntry{
@@ -558,8 +558,8 @@ func TestPartitions_Connect(t *testing.T) {
 						Namespace: staticServerNamespace,
 						Sources: []*api.SourceIntention{
 							{
-								Name:      staticClientName,
-								Namespace: staticClientNamespace,
+								Name:      StaticClientName,
+								Namespace: StaticClientNamespace,
 								Action:    api.IntentionActionAllow,
 							},
 						},
@@ -590,15 +590,15 @@ func TestPartitions_Connect(t *testing.T) {
 				logger.Log(t, "checking that connection is successful")
 				if cfg.EnableTransparentProxy {
 					if !c.mirrorK8S {
-						k8s.CheckStaticServerConnectionSuccessful(t, serverClusterStaticClientOpts, staticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", c.destinationNamespace, secondaryPartition))
-						k8s.CheckStaticServerConnectionSuccessful(t, clientClusterStaticClientOpts, staticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", c.destinationNamespace, defaultPartition))
+						k8s.CheckStaticServerConnectionSuccessful(t, serverClusterStaticClientOpts, StaticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", c.destinationNamespace, secondaryPartition))
+						k8s.CheckStaticServerConnectionSuccessful(t, clientClusterStaticClientOpts, StaticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", c.destinationNamespace, defaultPartition))
 					} else {
-						k8s.CheckStaticServerConnectionSuccessful(t, serverClusterStaticClientOpts, staticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", staticServerNamespace, secondaryPartition))
-						k8s.CheckStaticServerConnectionSuccessful(t, clientClusterStaticClientOpts, staticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", staticServerNamespace, defaultPartition))
+						k8s.CheckStaticServerConnectionSuccessful(t, serverClusterStaticClientOpts, StaticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", staticServerNamespace, secondaryPartition))
+						k8s.CheckStaticServerConnectionSuccessful(t, clientClusterStaticClientOpts, StaticClientName, fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", staticServerNamespace, defaultPartition))
 					}
 				} else {
-					k8s.CheckStaticServerConnectionSuccessful(t, serverClusterStaticClientOpts, staticClientName, "http://localhost:1234")
-					k8s.CheckStaticServerConnectionSuccessful(t, clientClusterStaticClientOpts, staticClientName, "http://localhost:1234")
+					k8s.CheckStaticServerConnectionSuccessful(t, serverClusterStaticClientOpts, StaticClientName, "http://localhost:1234")
+					k8s.CheckStaticServerConnectionSuccessful(t, clientClusterStaticClientOpts, StaticClientName, "http://localhost:1234")
 				}
 
 				// Test that kubernetes readiness status is synced to Consul.
@@ -615,15 +615,15 @@ func TestPartitions_Connect(t *testing.T) {
 				logger.Log(t, "checking that connection is unsuccessful")
 				if cfg.EnableTransparentProxy {
 					if !c.mirrorK8S {
-						k8s.CheckStaticServerConnectionMultipleFailureMessages(t, serverClusterStaticClientOpts, staticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server", "curl: (7) Failed to connect to static-server.ns1 port 80: Connection refused"}, "", fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", c.destinationNamespace, secondaryPartition))
-						k8s.CheckStaticServerConnectionMultipleFailureMessages(t, clientClusterStaticClientOpts, staticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server", "curl: (7) Failed to connect to static-server.ns1 port 80: Connection refused"}, "", fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", c.destinationNamespace, defaultPartition))
+						k8s.CheckStaticServerConnectionMultipleFailureMessages(t, serverClusterStaticClientOpts, StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server", "curl: (7) Failed to connect to static-server.ns1 port 80: Connection refused"}, "", fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", c.destinationNamespace, secondaryPartition))
+						k8s.CheckStaticServerConnectionMultipleFailureMessages(t, clientClusterStaticClientOpts, StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server", "curl: (7) Failed to connect to static-server.ns1 port 80: Connection refused"}, "", fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", c.destinationNamespace, defaultPartition))
 					} else {
-						k8s.CheckStaticServerConnectionMultipleFailureMessages(t, serverClusterStaticClientOpts, staticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server", "curl: (7) Failed to connect to static-server.ns1 port 80: Connection refused"}, "", fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", staticServerNamespace, secondaryPartition))
-						k8s.CheckStaticServerConnectionMultipleFailureMessages(t, clientClusterStaticClientOpts, staticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server", "curl: (7) Failed to connect to static-server.ns1 port 80: Connection refused"}, "", fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", staticServerNamespace, defaultPartition))
+						k8s.CheckStaticServerConnectionMultipleFailureMessages(t, serverClusterStaticClientOpts, StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server", "curl: (7) Failed to connect to static-server.ns1 port 80: Connection refused"}, "", fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", staticServerNamespace, secondaryPartition))
+						k8s.CheckStaticServerConnectionMultipleFailureMessages(t, clientClusterStaticClientOpts, StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server", "curl: (7) Failed to connect to static-server.ns1 port 80: Connection refused"}, "", fmt.Sprintf("http://static-server.virtual.%s.ns.%s.ap.dc1.dc.consul", staticServerNamespace, defaultPartition))
 					}
 				} else {
-					k8s.CheckStaticServerConnectionMultipleFailureMessages(t, serverClusterStaticClientOpts, staticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"}, "", "http://localhost:1234")
-					k8s.CheckStaticServerConnectionMultipleFailureMessages(t, clientClusterStaticClientOpts, staticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"}, "", "http://localhost:1234")
+					k8s.CheckStaticServerConnectionMultipleFailureMessages(t, serverClusterStaticClientOpts, StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"}, "", "http://localhost:1234")
+					k8s.CheckStaticServerConnectionMultipleFailureMessages(t, clientClusterStaticClientOpts, StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"}, "", "http://localhost:1234")
 				}
 			})
 		})

--- a/acceptance/tests/snapshot-agent/snapshot_agent_vault_test.go
+++ b/acceptance/tests/snapshot-agent/snapshot_agent_vault_test.go
@@ -77,7 +77,7 @@ func TestSnapshotAgent_Vault(t *testing.T) {
 		Value:      gossipKey,
 		PolicyName: "gossip",
 	}
-	gossipSecret.Save(t, vaultClient)
+	gossipSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 
 	// License
 	licenseSecret := &vault.KV2Secret{
@@ -87,7 +87,7 @@ func TestSnapshotAgent_Vault(t *testing.T) {
 		PolicyName: "license",
 	}
 	if cfg.EnableEnterprise {
-		licenseSecret.Save(t, vaultClient)
+		licenseSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 	}
 
 	// Bootstrap Token
@@ -99,7 +99,7 @@ func TestSnapshotAgent_Vault(t *testing.T) {
 		Value:      bootstrapToken,
 		PolicyName: "bootstrap",
 	}
-	bootstrapTokenSecret.Save(t, vaultClient)
+	bootstrapTokenSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 
 	// Snapshot Agent config
 	snapshotAgentConfig := generateSnapshotAgentConfig(t, bootstrapToken)
@@ -110,7 +110,7 @@ func TestSnapshotAgent_Vault(t *testing.T) {
 		Value:      snapshotAgentConfig,
 		PolicyName: "snapshot-agent-config",
 	}
-	snapshotAgentConfigSecret.Save(t, vaultClient)
+	snapshotAgentConfigSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 
 	// -------------------------
 	// Additional Auth Roles

--- a/acceptance/tests/snapshot-agent/snapshot_agent_vault_test.go
+++ b/acceptance/tests/snapshot-agent/snapshot_agent_vault_test.go
@@ -71,7 +71,7 @@ func TestSnapshotAgent_Vault(t *testing.T) {
 	// Gossip key
 	gossipKey, err := vault.GenerateGossipSecret()
 	require.NoError(t, err)
-	gossipSecret := &vault.SaveVaultSecretConfiguration{
+	gossipSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/gossip",
 		Key:        "gossip",
 		Value:      gossipKey,
@@ -80,7 +80,7 @@ func TestSnapshotAgent_Vault(t *testing.T) {
 	gossipSecret.Save(t, vaultClient)
 
 	// License
-	licenseSecret := &vault.SaveVaultSecretConfiguration{
+	licenseSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/license",
 		Key:        "license",
 		Value:      cfg.EnterpriseLicense,
@@ -93,7 +93,7 @@ func TestSnapshotAgent_Vault(t *testing.T) {
 	// Bootstrap Token
 	bootstrapToken, err := uuid.GenerateUUID()
 	require.NoError(t, err)
-	bootstrapTokenSecret := &vault.SaveVaultSecretConfiguration{
+	bootstrapTokenSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/bootstrap",
 		Key:        "token",
 		Value:      bootstrapToken,
@@ -104,7 +104,7 @@ func TestSnapshotAgent_Vault(t *testing.T) {
 	// Snapshot Agent config
 	snapshotAgentConfig := generateSnapshotAgentConfig(t, bootstrapToken)
 	require.NoError(t, err)
-	snapshotAgentConfigSecret := &vault.SaveVaultSecretConfiguration{
+	snapshotAgentConfigSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/snapshot-agent-config",
 		Key:        "config",
 		Value:      snapshotAgentConfig,

--- a/acceptance/tests/terminating-gateway/terminating_gateway_namespaces_test.go
+++ b/acceptance/tests/terminating-gateway/terminating_gateway_namespaces_test.go
@@ -121,7 +121,7 @@ func TestTerminatingGatewaySingleNamespace(t *testing.T) {
 
 			// Test that we can make a call to the terminating gateway.
 			logger.Log(t, "trying calls to terminating gateway")
-			k8s.CheckStaticServerConnectionSuccessful(t, nsK8SOptions, staticClientName, "http://localhost:1234")
+			k8s.CheckStaticServerConnectionSuccessful(t, nsK8SOptions, StaticClientName, "http://localhost:1234")
 		})
 	}
 }
@@ -180,11 +180,11 @@ func TestTerminatingGatewayNamespaceMirroring(t *testing.T) {
 				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "ns", testNamespace)
 			})
 
-			staticClientNamespace := "ns2"
-			logger.Logf(t, "creating Kubernetes namespace %s", staticClientNamespace)
-			k8s.RunKubectl(t, ctx.KubectlOptions(t), "create", "ns", staticClientNamespace)
+			StaticClientNamespace := "ns2"
+			logger.Logf(t, "creating Kubernetes namespace %s", StaticClientNamespace)
+			k8s.RunKubectl(t, ctx.KubectlOptions(t), "create", "ns", StaticClientNamespace)
 			helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
-				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "ns", staticClientNamespace)
+				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "ns", StaticClientNamespace)
 			})
 
 			ns1K8SOptions := &terratestk8s.KubectlOptions{
@@ -195,7 +195,7 @@ func TestTerminatingGatewayNamespaceMirroring(t *testing.T) {
 			ns2K8SOptions := &terratestk8s.KubectlOptions{
 				ContextName: ctx.KubectlOptions(t).ContextName,
 				ConfigPath:  ctx.KubectlOptions(t).ConfigPath,
-				Namespace:   staticClientNamespace,
+				Namespace:   StaticClientNamespace,
 			}
 
 			// Deploy a static-server that will play the role of an external service.
@@ -224,12 +224,12 @@ func TestTerminatingGatewayNamespaceMirroring(t *testing.T) {
 				// With the terminating gateway up, we test that we can make a call to it
 				// via the static-server. It should fail to connect with the
 				// static-server pod because of intentions.
-				assertNoConnectionAndAddIntention(t, consulClient, ns2K8SOptions, staticClientNamespace, testNamespace)
+				assertNoConnectionAndAddIntention(t, consulClient, ns2K8SOptions, StaticClientNamespace, testNamespace)
 			}
 
 			// Test that we can make a call to the terminating gateway
 			logger.Log(t, "trying calls to terminating gateway")
-			k8s.CheckStaticServerConnectionSuccessful(t, ns2K8SOptions, staticClientName, "http://localhost:1234")
+			k8s.CheckStaticServerConnectionSuccessful(t, ns2K8SOptions, StaticClientName, "http://localhost:1234")
 		})
 	}
 }

--- a/acceptance/tests/terminating-gateway/terminating_gateway_test.go
+++ b/acceptance/tests/terminating-gateway/terminating_gateway_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const staticClientName = "static-client"
+const StaticClientName = "static-client"
 const staticServerName = "static-server"
 
 // Test that terminating gateways work in a default and secure installations.
@@ -93,7 +93,7 @@ func TestTerminatingGateway(t *testing.T) {
 
 			// Test that we can make a call to the terminating gateway.
 			logger.Log(t, "trying calls to terminating gateway")
-			k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
+			k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), StaticClientName, "http://localhost:1234")
 		})
 	}
 }
@@ -191,7 +191,7 @@ func assertNoConnectionAndAddIntention(t *testing.T, consulClient *api.Client, k
 	t.Helper()
 
 	logger.Log(t, "testing intentions prevent connections through the terminating gateway")
-	k8s.CheckStaticServerConnectionFailing(t, k8sOptions, staticClientName, "http://localhost:1234")
+	k8s.CheckStaticServerConnectionFailing(t, k8sOptions, StaticClientName, "http://localhost:1234")
 
 	logger.Log(t, "creating static-client => static-server intention")
 	_, _, err := consulClient.ConfigEntries().Set(&api.ServiceIntentionsConfigEntry{
@@ -200,7 +200,7 @@ func assertNoConnectionAndAddIntention(t *testing.T, consulClient *api.Client, k
 		Namespace: destinationNS,
 		Sources: []*api.SourceIntention{
 			{
-				Name:      staticClientName,
+				Name:      StaticClientName,
 				Namespace: sourceNS,
 				Action:    api.IntentionActionAllow,
 			},

--- a/acceptance/tests/vault/vault_namespaces_test.go
+++ b/acceptance/tests/vault/vault_namespaces_test.go
@@ -59,7 +59,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 	// Configure Policy for Connect CA
 	vault.CreateConnectCARootAndIntermediatePKIPolicy(t, vaultClient, connectCAPolicy, connectCARootPath, connectCAIntermediatePath)
 
-	//Configure Server PKI
+	// Configure Server PKI
 	serverPKIConfig := &vault.PKIAndAuthRoleConfiguration{
 		BaseURL:             "pki",
 		PolicyName:          "consul-ca-policy",
@@ -76,7 +76,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 	// -------------------------
 	// KV2 secrets
 	// -------------------------
-	//Gossip key
+	// Gossip key
 	gossipKey, err := vault.GenerateGossipSecret()
 	require.NoError(t, err)
 	gossipSecret := &vault.SaveVaultSecretConfiguration{
@@ -87,7 +87,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 	}
 	vault.SaveSecret(t, vaultClient, gossipSecret)
 
-	//License
+	// License
 	licenseSecret := &vault.SaveVaultSecretConfiguration{
 		Path:       "consul/data/secret/license",
 		Key:        "license",
@@ -117,7 +117,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 		serverPolicies += fmt.Sprintf(",%s", licenseSecret.PolicyName)
 	}
 
-	//server
+	// server
 	consulServerRole := "server"
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  serverPKIConfig.ServiceAccountName,
@@ -127,7 +127,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 		PolicyNames:         serverPolicies,
 	})
 
-	//client
+	// client
 	consulClientRole := "client"
 	consulClientServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "client")
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
@@ -138,7 +138,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 		PolicyNames:         gossipSecret.PolicyName,
 	})
 
-	//manageSystemACLs
+	// manageSystemACLs
 	manageSystemACLsRole := "server-acl-init"
 	manageSystemACLsServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "server-acl-init")
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{

--- a/acceptance/tests/vault/vault_namespaces_test.go
+++ b/acceptance/tests/vault/vault_namespaces_test.go
@@ -79,7 +79,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 	// Gossip key
 	gossipKey, err := vault.GenerateGossipSecret()
 	require.NoError(t, err)
-	gossipSecret := &vault.SaveVaultSecretConfiguration{
+	gossipSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/gossip",
 		Key:        "gossip",
 		Value:      gossipKey,
@@ -88,7 +88,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 	gossipSecret.Save(t, vaultClient)
 
 	// License
-	licenseSecret := &vault.SaveVaultSecretConfiguration{
+	licenseSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/license",
 		Key:        "license",
 		Value:      cfg.EnterpriseLicense,
@@ -101,7 +101,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 	//Bootstrap Token
 	bootstrapToken, err := uuid.GenerateUUID()
 	require.NoError(t, err)
-	bootstrapTokenSecret := &vault.SaveVaultSecretConfiguration{
+	bootstrapTokenSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/bootstrap",
 		Key:        "token",
 		Value:      bootstrapToken,

--- a/acceptance/tests/vault/vault_namespaces_test.go
+++ b/acceptance/tests/vault/vault_namespaces_test.go
@@ -85,7 +85,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 		Value:      gossipKey,
 		PolicyName: "gossip",
 	}
-	gossipSecret.Save(t, vaultClient)
+	gossipSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 
 	// License
 	licenseSecret := &vault.KV2Secret{
@@ -95,7 +95,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 		PolicyName: "license",
 	}
 	if cfg.EnableEnterprise {
-		licenseSecret.Save(t, vaultClient)
+		licenseSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 	}
 
 	//Bootstrap Token
@@ -107,7 +107,7 @@ func TestVault_VaultNamespace(t *testing.T) {
 		Value:      bootstrapToken,
 		PolicyName: "bootstrap",
 	}
-	bootstrapTokenSecret.Save(t, vaultClient)
+	bootstrapTokenSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 
 	// -------------------------
 	// Additional Auth Roles

--- a/acceptance/tests/vault/vault_namespaces_test.go
+++ b/acceptance/tests/vault/vault_namespaces_test.go
@@ -129,8 +129,8 @@ func TestVault_VaultNamespace(t *testing.T) {
 	srvAuthRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 
 	// client
-	consulClientRole := "client"
-	consulClientServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "client")
+	consulClientRole := ClientRole
+	consulClientServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, ClientRole)
 	clientAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  consulClientServiceAccountName,
 		KubernetesNamespace: ns,
@@ -141,8 +141,8 @@ func TestVault_VaultNamespace(t *testing.T) {
 	clientAuthRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 
 	// manageSystemACLs
-	manageSystemACLsRole := "server-acl-init"
-	manageSystemACLsServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "server-acl-init")
+	manageSystemACLsRole := ManageSystemACLsRole
+	manageSystemACLsServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, ManageSystemACLsRole)
 	aclAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  manageSystemACLsServiceAccountName,
 		KubernetesNamespace: ns,
@@ -268,8 +268,8 @@ func TestVault_VaultNamespace(t *testing.T) {
 
 	logger.Log(t, "checking that connection is successful")
 	if cfg.EnableTransparentProxy {
-		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "http://static-server")
+		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), StaticClientName, "http://static-server")
 	} else {
-		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
+		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), StaticClientName, "http://localhost:1234")
 	}
 }

--- a/acceptance/tests/vault/vault_partitions_test.go
+++ b/acceptance/tests/vault/vault_partitions_test.go
@@ -113,7 +113,7 @@ func TestVault_Partitions(t *testing.T) {
 	// Configure Policy for Connect CA
 	vault.CreateConnectCARootAndIntermediatePKIPolicy(t, vaultClient, connectCAPolicy, connectCARootPath, connectCAIntermediatePath)
 
-	//Configure Server PKI
+	// Configure Server PKI
 	serverPKIConfig := &vault.PKIAndAuthRoleConfiguration{
 		BaseURL:             "pki",
 		PolicyName:          "consul-ca-policy",
@@ -130,7 +130,7 @@ func TestVault_Partitions(t *testing.T) {
 	// -------------------------
 	// KV2 secrets
 	// -------------------------
-	//Gossip key
+	// Gossip key
 	gossipKey, err := vault.GenerateGossipSecret()
 	require.NoError(t, err)
 	gossipSecret := &vault.SaveVaultSecretConfiguration{
@@ -141,7 +141,7 @@ func TestVault_Partitions(t *testing.T) {
 	}
 	vault.SaveSecret(t, vaultClient, gossipSecret)
 
-	//License
+	// License
 	licenseSecret := &vault.SaveVaultSecretConfiguration{
 		Path:       "consul/data/secret/license",
 		Key:        "license",
@@ -152,7 +152,7 @@ func TestVault_Partitions(t *testing.T) {
 		vault.SaveSecret(t, vaultClient, licenseSecret)
 	}
 
-	//Bootstrap Token
+	// Bootstrap Token
 	bootstrapToken, err := uuid.GenerateUUID()
 	require.NoError(t, err)
 	bootstrapTokenSecret := &vault.SaveVaultSecretConfiguration{
@@ -163,7 +163,7 @@ func TestVault_Partitions(t *testing.T) {
 	}
 	vault.SaveSecret(t, vaultClient, bootstrapTokenSecret)
 
-	//Partition Token
+	// Partition Token
 	partitionToken, err := uuid.GenerateUUID()
 	require.NoError(t, err)
 	partitionTokenSecret := &vault.SaveVaultSecretConfiguration{
@@ -182,7 +182,7 @@ func TestVault_Partitions(t *testing.T) {
 		serverPolicies += fmt.Sprintf(",%s", licenseSecret.PolicyName)
 	}
 
-	//server
+	// server
 	consulServerRole := "server"
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  serverPKIConfig.ServiceAccountName,
@@ -192,7 +192,7 @@ func TestVault_Partitions(t *testing.T) {
 		PolicyNames:         serverPolicies,
 	})
 
-	//client
+	// client
 	consulClientRole := "client"
 	consulClientServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "client")
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
@@ -203,7 +203,7 @@ func TestVault_Partitions(t *testing.T) {
 		PolicyNames:         gossipSecret.PolicyName,
 	})
 
-	//manageSystemACLs
+	// manageSystemACLs
 	manageSystemACLsRole := "server-acl-init"
 	manageSystemACLsServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "server-acl-init")
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
@@ -227,7 +227,7 @@ func TestVault_Partitions(t *testing.T) {
 	// Additional Auth Roles in Secondary Datacenter
 	// ---------------------------------------------
 
-	//client
+	// client
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  consulClientServiceAccountName,
 		KubernetesNamespace: ns,
@@ -236,7 +236,7 @@ func TestVault_Partitions(t *testing.T) {
 		PolicyNames:         gossipSecret.PolicyName,
 	})
 
-	//manageSystemACLs
+	// manageSystemACLs
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  manageSystemACLsServiceAccountName,
 		KubernetesNamespace: ns,

--- a/acceptance/tests/vault/vault_partitions_test.go
+++ b/acceptance/tests/vault/vault_partitions_test.go
@@ -139,7 +139,7 @@ func TestVault_Partitions(t *testing.T) {
 		Value:      gossipKey,
 		PolicyName: "gossip",
 	}
-	gossipSecret.Save(t, vaultClient)
+	gossipSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 
 	// License
 	licenseSecret := &vault.KV2Secret{
@@ -149,7 +149,7 @@ func TestVault_Partitions(t *testing.T) {
 		PolicyName: "license",
 	}
 	if cfg.EnableEnterprise {
-		licenseSecret.Save(t, vaultClient)
+		licenseSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 	}
 
 	// Bootstrap Token
@@ -161,7 +161,7 @@ func TestVault_Partitions(t *testing.T) {
 		Value:      bootstrapToken,
 		PolicyName: "bootstrap",
 	}
-	bootstrapTokenSecret.Save(t, vaultClient)
+	bootstrapTokenSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 
 	// Partition Token
 	partitionToken, err := uuid.GenerateUUID()
@@ -172,7 +172,7 @@ func TestVault_Partitions(t *testing.T) {
 		Value:      partitionToken,
 		PolicyName: "partition",
 	}
-	partitionTokenSecret.Save(t, vaultClient)
+	partitionTokenSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 
 	// -------------------------------------------
 	// Additional Auth Roles in Primary Datacenter

--- a/acceptance/tests/vault/vault_partitions_test.go
+++ b/acceptance/tests/vault/vault_partitions_test.go
@@ -133,7 +133,7 @@ func TestVault_Partitions(t *testing.T) {
 	// Gossip key
 	gossipKey, err := vault.GenerateGossipSecret()
 	require.NoError(t, err)
-	gossipSecret := &vault.SaveVaultSecretConfiguration{
+	gossipSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/gossip",
 		Key:        "gossip",
 		Value:      gossipKey,
@@ -142,7 +142,7 @@ func TestVault_Partitions(t *testing.T) {
 	gossipSecret.Save(t, vaultClient)
 
 	// License
-	licenseSecret := &vault.SaveVaultSecretConfiguration{
+	licenseSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/license",
 		Key:        "license",
 		Value:      cfg.EnterpriseLicense,
@@ -155,7 +155,7 @@ func TestVault_Partitions(t *testing.T) {
 	// Bootstrap Token
 	bootstrapToken, err := uuid.GenerateUUID()
 	require.NoError(t, err)
-	bootstrapTokenSecret := &vault.SaveVaultSecretConfiguration{
+	bootstrapTokenSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/bootstrap",
 		Key:        "token",
 		Value:      bootstrapToken,
@@ -166,7 +166,7 @@ func TestVault_Partitions(t *testing.T) {
 	// Partition Token
 	partitionToken, err := uuid.GenerateUUID()
 	require.NoError(t, err)
-	partitionTokenSecret := &vault.SaveVaultSecretConfiguration{
+	partitionTokenSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/partition",
 		Key:        "token",
 		Value:      partitionToken,

--- a/acceptance/tests/vault/vault_partitions_test.go
+++ b/acceptance/tests/vault/vault_partitions_test.go
@@ -123,7 +123,7 @@ func TestVault_Partitions(t *testing.T) {
 		ServiceAccountName:  fmt.Sprintf("%s-consul-%s", consulReleaseName, "server"),
 		AllowedSubdomain:    fmt.Sprintf("%s-consul-%s", consulReleaseName, "server"),
 		MaxTTL:              "1h",
-		AuthMethodPath:      "kubernetes",
+		AuthMethodPath:      KubernetesAuthMethodPath,
 	}
 	serverPKIConfig.ConfigurePKIAndAuthRole(t, vaultClient)
 
@@ -187,31 +187,31 @@ func TestVault_Partitions(t *testing.T) {
 	srvAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  serverPKIConfig.ServiceAccountName,
 		KubernetesNamespace: ns,
-		AuthMethodPath:      "kubernetes",
+		AuthMethodPath:      KubernetesAuthMethodPath,
 		RoleName:            consulServerRole,
 		PolicyNames:         serverPolicies,
 	}
 	srvAuthRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 
 	// client
-	consulClientRole := "client"
-	consulClientServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "client")
+	consulClientRole := ClientRole
+	consulClientServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, ClientRole)
 	clientAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  consulClientServiceAccountName,
 		KubernetesNamespace: ns,
-		AuthMethodPath:      "kubernetes",
+		AuthMethodPath:      KubernetesAuthMethodPath,
 		RoleName:            consulClientRole,
 		PolicyNames:         gossipSecret.PolicyName,
 	}
 	clientAuthRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 
 	// manageSystemACLs
-	manageSystemACLsRole := "server-acl-init"
-	manageSystemACLsServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "server-acl-init")
+	manageSystemACLsRole := ManageSystemACLsRole
+	manageSystemACLsServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, ManageSystemACLsRole)
 	aclAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  manageSystemACLsServiceAccountName,
 		KubernetesNamespace: ns,
-		AuthMethodPath:      "kubernetes",
+		AuthMethodPath:      KubernetesAuthMethodPath,
 		RoleName:            manageSystemACLsRole,
 		PolicyNames:         fmt.Sprintf("%s,%s", bootstrapTokenSecret.PolicyName, partitionTokenSecret.PolicyName),
 	}
@@ -221,7 +221,7 @@ func TestVault_Partitions(t *testing.T) {
 	srvCAAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  "*",
 		KubernetesNamespace: ns,
-		AuthMethodPath:      "kubernetes",
+		AuthMethodPath:      KubernetesAuthMethodPath,
 		RoleName:            serverPKIConfig.RoleName,
 		PolicyNames:         serverPKIConfig.PolicyName,
 	}

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -41,7 +41,7 @@ func TestVault(t *testing.T) {
 	connectCARootPath := "connect_root"
 	connectCAIntermediatePath := "dc1/connect_inter"
 	// Configure Policy for Connect CA
-	vault.CreateConnectCARootAndIntermediatePIKPolicy(t, vaultClient, connectCAPolicy, connectCARootPath, connectCAIntermediatePath)
+	vault.CreateConnectCARootAndIntermediatePKIPolicy(t, vaultClient, connectCAPolicy, connectCARootPath, connectCAIntermediatePath)
 
 	//Configure Server PKI
 	serverPKIConfig := &vault.PKIAndAuthRoleConfiguration{

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -43,7 +43,7 @@ func TestVault(t *testing.T) {
 	// Configure Policy for Connect CA
 	vault.CreateConnectCARootAndIntermediatePKIPolicy(t, vaultClient, connectCAPolicy, connectCARootPath, connectCAIntermediatePath)
 
-	//Configure Server PKI
+	// Configure Server PKI
 	serverPKIConfig := &vault.PKIAndAuthRoleConfiguration{
 		BaseURL:             "pki",
 		PolicyName:          "consul-ca-policy",
@@ -60,7 +60,7 @@ func TestVault(t *testing.T) {
 	// -------------------------
 	// KV2 secrets
 	// -------------------------
-	//Gossip key
+	// Gossip key
 	gossipKey, err := vault.GenerateGossipSecret()
 	require.NoError(t, err)
 	gossipSecret := &vault.SaveVaultSecretConfiguration{
@@ -71,7 +71,7 @@ func TestVault(t *testing.T) {
 	}
 	vault.SaveSecret(t, vaultClient, gossipSecret)
 
-	//License
+	// License
 	licenseSecret := &vault.SaveVaultSecretConfiguration{
 		Path:       "consul/data/secret/license",
 		Key:        "license",
@@ -82,7 +82,7 @@ func TestVault(t *testing.T) {
 		vault.SaveSecret(t, vaultClient, licenseSecret)
 	}
 
-	//Bootstrap Token
+	// Bootstrap Token
 	bootstrapToken, err := uuid.GenerateUUID()
 	require.NoError(t, err)
 	bootstrapTokenSecret := &vault.SaveVaultSecretConfiguration{
@@ -101,7 +101,7 @@ func TestVault(t *testing.T) {
 		serverPolicies += fmt.Sprintf(",%s", licenseSecret.PolicyName)
 	}
 
-	//server
+	// server
 	consulServerRole := "server"
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  serverPKIConfig.ServiceAccountName,
@@ -111,7 +111,7 @@ func TestVault(t *testing.T) {
 		PolicyNames:         serverPolicies,
 	})
 
-	//client
+	// client
 	consulClientRole := "client"
 	consulClientServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "client")
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
@@ -122,7 +122,7 @@ func TestVault(t *testing.T) {
 		PolicyNames:         gossipSecret.PolicyName,
 	})
 
-	//manageSystemACLs
+	// manageSystemACLs
 	manageSystemACLsRole := "server-acl-init"
 	manageSystemACLsServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "server-acl-init")
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/vault"
+	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,26 +33,114 @@ func TestVault(t *testing.T) {
 	// Now fetch the Vault client so we can create the policies and secrets.
 	vaultClient := vaultCluster.VaultClient(t)
 
-	gossipKey := vault.ConfigureGossipVaultSecret(t, vaultClient)
+	// -------------------------
+	// PKI
+	// -------------------------
+	// Configure Service Mesh CA
+	connectCAPolicy := "connect-ca-dc1"
+	connectCARootPath := "connect_root"
+	connectCAIntermediatePath := "dc1/connect_inter"
+	// Configure Policy for Connect CA
+	vault.CreateConnectCARootAndIntermediatePIKPolicy(t, vaultClient, connectCAPolicy, connectCARootPath, connectCAIntermediatePath)
 
-	vault.CreateConnectCAPolicy(t, vaultClient, "dc1")
+	//Configure Server PKI
+	serverPKIConfig := &vault.PKIAndAuthRoleConfiguration{
+		BaseURL:             "pki",
+		PolicyName:          "consul-ca-policy",
+		RoleName:            "consul-ca-role",
+		KubernetesNamespace: ns,
+		DataCenter:          "dc1",
+		ServiceAccountName:  fmt.Sprintf("%s-consul-%s", consulReleaseName, "server"),
+		AllowedSubdomain:    fmt.Sprintf("%s-consul-%s", consulReleaseName, "server"),
+		MaxTTL:              "1h",
+		AuthMethodPath:      "kubernetes",
+	}
+	vault.ConfigurePKIAndAuthRole(t, vaultClient, serverPKIConfig)
+
+	// -------------------------
+	// KV2 secrets
+	// -------------------------
+	//Gossip key
+	gossipKey, err := vault.GenerateGossipSecret()
+	require.NoError(t, err)
+	gossipSecret := &vault.SaveVaultSecretConfiguration{
+		Path:       "consul/data/secret/gossip",
+		Key:        "gossip",
+		Value:      gossipKey,
+		PolicyName: "gossip",
+	}
+	vault.SaveSecret(t, vaultClient, gossipSecret)
+
+	//License
+	licenseSecret := &vault.SaveVaultSecretConfiguration{
+		Path:       "consul/data/secret/license",
+		Key:        "license",
+		Value:      cfg.EnterpriseLicense,
+		PolicyName: "license",
+	}
 	if cfg.EnableEnterprise {
-		vault.ConfigureEnterpriseLicenseVaultSecret(t, vaultClient, cfg)
+		vault.SaveSecret(t, vaultClient, licenseSecret)
 	}
 
-	bootstrapToken := vault.ConfigureACLTokenVaultSecret(t, vaultClient, "bootstrap")
-
-	serverPolicies := "gossip,connect-ca-dc1,server-cert-dc1,bootstrap-token"
-	if cfg.EnableEnterprise {
-		serverPolicies += ",license"
+	//Bootstrap Token
+	bootstrapToken, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+	bootstrapTokenSecret := &vault.SaveVaultSecretConfiguration{
+		Path:       "consul/data/secret/bootstrap",
+		Key:        "token",
+		Value:      bootstrapToken,
+		PolicyName: "bootstrap",
 	}
-	vault.ConfigureKubernetesAuthRole(t, vaultClient, consulReleaseName, ns, "kubernetes", "server", serverPolicies)
-	vault.ConfigureKubernetesAuthRole(t, vaultClient, consulReleaseName, ns, "kubernetes", "client", "gossip")
-	vault.ConfigureKubernetesAuthRole(t, vaultClient, consulReleaseName, ns, "kubernetes", "server-acl-init", "bootstrap-token")
-	vault.ConfigureConsulCAKubernetesAuthRole(t, vaultClient, ns, "kubernetes")
+	vault.SaveSecret(t, vaultClient, bootstrapTokenSecret)
 
-	vault.ConfigurePKICA(t, vaultClient)
-	certPath := vault.ConfigurePKICertificates(t, vaultClient, consulReleaseName, ns, "dc1", "1h")
+	// -------------------------
+	// Additional Auth Roles
+	// -------------------------
+	serverPolicies := fmt.Sprintf("%s,%s,%s,%s", gossipSecret.PolicyName, connectCAPolicy, serverPKIConfig.PolicyName, bootstrapTokenSecret.PolicyName)
+	if cfg.EnableEnterprise {
+		serverPolicies += fmt.Sprintf(",%s", licenseSecret.PolicyName)
+	}
+
+	//server
+	consulServerRole := "server"
+	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
+		ServiceAccountName:  serverPKIConfig.ServiceAccountName,
+		KubernetesNamespace: ns,
+		AuthMethodPath:      "kubernetes",
+		RoleName:            consulServerRole,
+		PolicyNames:         serverPolicies,
+	})
+
+	//client
+	consulClientRole := "client"
+	consulClientServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "client")
+	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
+		ServiceAccountName:  consulClientServiceAccountName,
+		KubernetesNamespace: ns,
+		AuthMethodPath:      "kubernetes",
+		RoleName:            consulClientRole,
+		PolicyNames:         gossipSecret.PolicyName,
+	})
+
+	//manageSystemACLs
+	manageSystemACLsRole := "server-acl-init"
+	manageSystemACLsServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "server-acl-init")
+	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
+		ServiceAccountName:  manageSystemACLsServiceAccountName,
+		KubernetesNamespace: ns,
+		AuthMethodPath:      "kubernetes",
+		RoleName:            manageSystemACLsRole,
+		PolicyNames:         bootstrapTokenSecret.PolicyName,
+	})
+
+	// allow all components to access server ca
+	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
+		ServiceAccountName:  "*",
+		KubernetesNamespace: ns,
+		AuthMethodPath:      "kubernetes",
+		RoleName:            serverPKIConfig.RoleName,
+		PolicyNames:         serverPKIConfig.PolicyName,
+	})
 
 	vaultCASecret := vault.CASecretName(vaultReleaseName)
 
@@ -65,32 +154,32 @@ func TestVault(t *testing.T) {
 		"controller.enabled":     "true",
 
 		"global.secretsBackend.vault.enabled":              "true",
-		"global.secretsBackend.vault.consulServerRole":     "server",
-		"global.secretsBackend.vault.consulClientRole":     "client",
-		"global.secretsBackend.vault.consulCARole":         "consul-ca",
-		"global.secretsBackend.vault.manageSystemACLsRole": "server-acl-init",
+		"global.secretsBackend.vault.consulServerRole":     consulServerRole,
+		"global.secretsBackend.vault.consulClientRole":     consulClientRole,
+		"global.secretsBackend.vault.consulCARole":         serverPKIConfig.RoleName,
+		"global.secretsBackend.vault.manageSystemACLsRole": manageSystemACLsRole,
 
 		"global.secretsBackend.vault.ca.secretName": vaultCASecret,
 		"global.secretsBackend.vault.ca.secretKey":  "tls.crt",
 
 		"global.secretsBackend.vault.connectCA.address":             vaultCluster.Address(),
-		"global.secretsBackend.vault.connectCA.rootPKIPath":         "connect_root",
-		"global.secretsBackend.vault.connectCA.intermediatePKIPath": "dc1/connect_inter",
+		"global.secretsBackend.vault.connectCA.rootPKIPath":         connectCARootPath,
+		"global.secretsBackend.vault.connectCA.intermediatePKIPath": connectCAIntermediatePath,
 
 		"global.acls.manageSystemACLs":          "true",
-		"global.acls.bootstrapToken.secretName": "consul/data/secret/bootstrap",
-		"global.acls.bootstrapToken.secretKey":  "token",
+		"global.acls.bootstrapToken.secretName": bootstrapTokenSecret.Path,
+		"global.acls.bootstrapToken.secretKey":  bootstrapTokenSecret.Key,
 		"global.tls.enabled":                    "true",
-		"global.gossipEncryption.secretName":    "consul/data/secret/gossip",
-		"global.gossipEncryption.secretKey":     "gossip",
+		"global.gossipEncryption.secretName":    gossipSecret.Path,
+		"global.gossipEncryption.secretKey":     gossipSecret.Key,
 
 		"ingressGateways.enabled":               "true",
 		"ingressGateways.defaults.replicas":     "1",
 		"terminatingGateways.enabled":           "true",
 		"terminatingGateways.defaults.replicas": "1",
 
-		"server.serverCert.secretName": certPath,
-		"global.tls.caCert.secretName": "pki/cert/ca",
+		"server.serverCert.secretName": serverPKIConfig.CertPath,
+		"global.tls.caCert.secretName": serverPKIConfig.CAPath,
 		"global.tls.enableAutoEncrypt": "true",
 
 		// For sync catalog, it is sufficient to check that the deployment is running and ready
@@ -103,8 +192,8 @@ func TestVault(t *testing.T) {
 	}
 
 	if cfg.EnableEnterprise {
-		consulHelmValues["global.enterpriseLicense.secretName"] = "consul/data/secret/license"
-		consulHelmValues["global.enterpriseLicense.secretKey"] = "license"
+		consulHelmValues["global.enterpriseLicense.secretName"] = licenseSecret.Path
+		consulHelmValues["global.enterpriseLicense.secretKey"] = licenseSecret.Key
 	}
 
 	logger.Log(t, "Installing Consul")

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -69,7 +69,7 @@ func TestVault(t *testing.T) {
 		Value:      gossipKey,
 		PolicyName: "gossip",
 	}
-	gossipSecret.Save(t, vaultClient)
+	gossipSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 
 	// License
 	licenseSecret := &vault.KV2Secret{
@@ -79,7 +79,7 @@ func TestVault(t *testing.T) {
 		PolicyName: "license",
 	}
 	if cfg.EnableEnterprise {
-		licenseSecret.Save(t, vaultClient)
+		licenseSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 	}
 
 	// Bootstrap Token
@@ -91,7 +91,7 @@ func TestVault(t *testing.T) {
 		Value:      bootstrapToken,
 		PolicyName: "bootstrap",
 	}
-	bootstrapTokenSecret.Save(t, vaultClient)
+	bootstrapTokenSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 
 	// -------------------------
 	// Additional Auth Roles

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -55,7 +55,7 @@ func TestVault(t *testing.T) {
 		MaxTTL:              "1h",
 		AuthMethodPath:      "kubernetes",
 	}
-	vault.ConfigurePKIAndAuthRole(t, vaultClient, serverPKIConfig)
+	serverPKIConfig.ConfigurePKIAndAuthRole(t, vaultClient)
 
 	// -------------------------
 	// KV2 secrets
@@ -69,7 +69,7 @@ func TestVault(t *testing.T) {
 		Value:      gossipKey,
 		PolicyName: "gossip",
 	}
-	vault.SaveSecret(t, vaultClient, gossipSecret)
+	gossipSecret.Save(t, vaultClient)
 
 	// License
 	licenseSecret := &vault.SaveVaultSecretConfiguration{
@@ -79,7 +79,7 @@ func TestVault(t *testing.T) {
 		PolicyName: "license",
 	}
 	if cfg.EnableEnterprise {
-		vault.SaveSecret(t, vaultClient, licenseSecret)
+		licenseSecret.Save(t, vaultClient)
 	}
 
 	// Bootstrap Token
@@ -91,7 +91,7 @@ func TestVault(t *testing.T) {
 		Value:      bootstrapToken,
 		PolicyName: "bootstrap",
 	}
-	vault.SaveSecret(t, vaultClient, bootstrapTokenSecret)
+	bootstrapTokenSecret.Save(t, vaultClient)
 
 	// -------------------------
 	// Additional Auth Roles
@@ -103,44 +103,48 @@ func TestVault(t *testing.T) {
 
 	// server
 	consulServerRole := "server"
-	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
+	srvAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  serverPKIConfig.ServiceAccountName,
 		KubernetesNamespace: ns,
 		AuthMethodPath:      "kubernetes",
 		RoleName:            consulServerRole,
 		PolicyNames:         serverPolicies,
-	})
+	}
+	srvAuthRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 
 	// client
 	consulClientRole := "client"
 	consulClientServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "client")
-	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
+	clientAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  consulClientServiceAccountName,
 		KubernetesNamespace: ns,
 		AuthMethodPath:      "kubernetes",
 		RoleName:            consulClientRole,
 		PolicyNames:         gossipSecret.PolicyName,
-	})
+	}
+	clientAuthRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 
 	// manageSystemACLs
 	manageSystemACLsRole := "server-acl-init"
 	manageSystemACLsServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "server-acl-init")
-	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
+	aclAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  manageSystemACLsServiceAccountName,
 		KubernetesNamespace: ns,
 		AuthMethodPath:      "kubernetes",
 		RoleName:            manageSystemACLsRole,
 		PolicyNames:         bootstrapTokenSecret.PolicyName,
-	})
+	}
+	aclAuthRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 
 	// allow all components to access server ca
-	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
+	srvCAAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  "*",
 		KubernetesNamespace: ns,
 		AuthMethodPath:      "kubernetes",
 		RoleName:            serverPKIConfig.RoleName,
 		PolicyNames:         serverPKIConfig.PolicyName,
-	})
+	}
+	srvCAAuthRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 
 	vaultCASecret := vault.CASecretName(vaultReleaseName)
 

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -63,7 +63,7 @@ func TestVault(t *testing.T) {
 	// Gossip key
 	gossipKey, err := vault.GenerateGossipSecret()
 	require.NoError(t, err)
-	gossipSecret := &vault.SaveVaultSecretConfiguration{
+	gossipSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/gossip",
 		Key:        "gossip",
 		Value:      gossipKey,
@@ -72,7 +72,7 @@ func TestVault(t *testing.T) {
 	gossipSecret.Save(t, vaultClient)
 
 	// License
-	licenseSecret := &vault.SaveVaultSecretConfiguration{
+	licenseSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/license",
 		Key:        "license",
 		Value:      cfg.EnterpriseLicense,
@@ -85,7 +85,7 @@ func TestVault(t *testing.T) {
 	// Bootstrap Token
 	bootstrapToken, err := uuid.GenerateUUID()
 	require.NoError(t, err)
-	bootstrapTokenSecret := &vault.SaveVaultSecretConfiguration{
+	bootstrapTokenSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/bootstrap",
 		Key:        "token",
 		Value:      bootstrapToken,

--- a/acceptance/tests/vault/vault_tls_auto_reload_test.go
+++ b/acceptance/tests/vault/vault_tls_auto_reload_test.go
@@ -69,7 +69,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 	// -------------------------
 	// KV2 secrets
 	// -------------------------
-	//Gossip key
+	// Gossip key
 	gossipKey, err := vault.GenerateGossipSecret()
 	require.NoError(t, err)
 	gossipSecret := &vault.SaveVaultSecretConfiguration{
@@ -80,7 +80,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 	}
 	vault.SaveSecret(t, vaultClient, gossipSecret)
 
-	//License
+	// License
 	licenseSecret := &vault.SaveVaultSecretConfiguration{
 		Path:       "consul/data/secret/license",
 		Key:        "license",
@@ -91,7 +91,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 		vault.SaveSecret(t, vaultClient, licenseSecret)
 	}
 
-	//Bootstrap Token
+	// Bootstrap Token
 	bootstrapToken, err := uuid.GenerateUUID()
 	require.NoError(t, err)
 	bootstrapTokenSecret := &vault.SaveVaultSecretConfiguration{
@@ -110,7 +110,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 		serverPolicies += fmt.Sprintf(",%s", licenseSecret.PolicyName)
 	}
 
-	//server
+	// server
 	consulServerRole := "server"
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  serverPKIConfig.ServiceAccountName,
@@ -120,7 +120,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 		PolicyNames:         serverPolicies,
 	})
 
-	//client
+	// client
 	consulClientRole := "client"
 	consulClientServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "client")
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
@@ -131,7 +131,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 		PolicyNames:         gossipSecret.PolicyName,
 	})
 
-	//manageSystemACLs
+	// manageSystemACLs
 	manageSystemACLsRole := "server-acl-init"
 	manageSystemACLsServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "server-acl-init")
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{

--- a/acceptance/tests/vault/vault_tls_auto_reload_test.go
+++ b/acceptance/tests/vault/vault_tls_auto_reload_test.go
@@ -72,7 +72,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 	// Gossip key
 	gossipKey, err := vault.GenerateGossipSecret()
 	require.NoError(t, err)
-	gossipSecret := &vault.SaveVaultSecretConfiguration{
+	gossipSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/gossip",
 		Key:        "gossip",
 		Value:      gossipKey,
@@ -81,7 +81,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 	gossipSecret.Save(t, vaultClient)
 
 	// License
-	licenseSecret := &vault.SaveVaultSecretConfiguration{
+	licenseSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/license",
 		Key:        "license",
 		Value:      cfg.EnterpriseLicense,
@@ -94,7 +94,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 	// Bootstrap Token
 	bootstrapToken, err := uuid.GenerateUUID()
 	require.NoError(t, err)
-	bootstrapTokenSecret := &vault.SaveVaultSecretConfiguration{
+	bootstrapTokenSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/bootstrap",
 		Key:        "token",
 		Value:      bootstrapToken,

--- a/acceptance/tests/vault/vault_tls_auto_reload_test.go
+++ b/acceptance/tests/vault/vault_tls_auto_reload_test.go
@@ -64,7 +64,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 		MaxTTL:              fmt.Sprintf("%ds", expirationInSeconds),
 		AuthMethodPath:      "kubernetes",
 	}
-	vault.ConfigurePKIAndAuthRole(t, vaultClient, serverPKIConfig)
+	serverPKIConfig.ConfigurePKIAndAuthRole(t, vaultClient)
 
 	// -------------------------
 	// KV2 secrets
@@ -78,7 +78,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 		Value:      gossipKey,
 		PolicyName: "gossip",
 	}
-	vault.SaveSecret(t, vaultClient, gossipSecret)
+	gossipSecret.Save(t, vaultClient)
 
 	// License
 	licenseSecret := &vault.SaveVaultSecretConfiguration{
@@ -88,7 +88,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 		PolicyName: "license",
 	}
 	if cfg.EnableEnterprise {
-		vault.SaveSecret(t, vaultClient, licenseSecret)
+		licenseSecret.Save(t, vaultClient)
 	}
 
 	// Bootstrap Token
@@ -100,7 +100,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 		Value:      bootstrapToken,
 		PolicyName: "bootstrap",
 	}
-	vault.SaveSecret(t, vaultClient, bootstrapTokenSecret)
+	bootstrapTokenSecret.Save(t, vaultClient)
 
 	// -------------------------
 	// Additional Auth Roles
@@ -112,44 +112,48 @@ func TestVault_TlsAutoReload(t *testing.T) {
 
 	// server
 	consulServerRole := "server"
-	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
+	srvAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  serverPKIConfig.ServiceAccountName,
 		KubernetesNamespace: ns,
 		AuthMethodPath:      "kubernetes",
 		RoleName:            consulServerRole,
 		PolicyNames:         serverPolicies,
-	})
+	}
+	srvAuthRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 
 	// client
 	consulClientRole := "client"
 	consulClientServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "client")
-	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
+	clientAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  consulClientServiceAccountName,
 		KubernetesNamespace: ns,
 		AuthMethodPath:      "kubernetes",
 		RoleName:            consulClientRole,
 		PolicyNames:         gossipSecret.PolicyName,
-	})
+	}
+	clientAuthRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 
 	// manageSystemACLs
 	manageSystemACLsRole := "server-acl-init"
 	manageSystemACLsServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "server-acl-init")
-	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
+	aclAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  manageSystemACLsServiceAccountName,
 		KubernetesNamespace: ns,
 		AuthMethodPath:      "kubernetes",
 		RoleName:            manageSystemACLsRole,
 		PolicyNames:         bootstrapTokenSecret.PolicyName,
-	})
+	}
+	aclAuthRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 
 	// allow all components to access server ca
-	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
+	srvCAAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  "*",
 		KubernetesNamespace: ns,
 		AuthMethodPath:      "kubernetes",
 		RoleName:            serverPKIConfig.RoleName,
 		PolicyNames:         serverPKIConfig.PolicyName,
-	})
+	}
+	srvCAAuthRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 
 	vaultCASecret := vault.CASecretName(vaultReleaseName)
 

--- a/acceptance/tests/vault/vault_tls_auto_reload_test.go
+++ b/acceptance/tests/vault/vault_tls_auto_reload_test.go
@@ -78,7 +78,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 		Value:      gossipKey,
 		PolicyName: "gossip",
 	}
-	gossipSecret.Save(t, vaultClient)
+	gossipSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 
 	// License
 	licenseSecret := &vault.KV2Secret{
@@ -88,7 +88,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 		PolicyName: "license",
 	}
 	if cfg.EnableEnterprise {
-		licenseSecret.Save(t, vaultClient)
+		licenseSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 	}
 
 	// Bootstrap Token
@@ -100,7 +100,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 		Value:      bootstrapToken,
 		PolicyName: "bootstrap",
 	}
-	bootstrapTokenSecret.Save(t, vaultClient)
+	bootstrapTokenSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 
 	// -------------------------
 	// Additional Auth Roles

--- a/acceptance/tests/vault/vault_tls_auto_reload_test.go
+++ b/acceptance/tests/vault/vault_tls_auto_reload_test.go
@@ -62,7 +62,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 		ServiceAccountName:  fmt.Sprintf("%s-consul-%s", consulReleaseName, "server"),
 		AllowedSubdomain:    fmt.Sprintf("%s-consul-%s", consulReleaseName, "server"),
 		MaxTTL:              fmt.Sprintf("%ds", expirationInSeconds),
-		AuthMethodPath:      "kubernetes",
+		AuthMethodPath:      KubernetesAuthMethodPath,
 	}
 	serverPKIConfig.ConfigurePKIAndAuthRole(t, vaultClient)
 
@@ -115,31 +115,31 @@ func TestVault_TlsAutoReload(t *testing.T) {
 	srvAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  serverPKIConfig.ServiceAccountName,
 		KubernetesNamespace: ns,
-		AuthMethodPath:      "kubernetes",
+		AuthMethodPath:      KubernetesAuthMethodPath,
 		RoleName:            consulServerRole,
 		PolicyNames:         serverPolicies,
 	}
 	srvAuthRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 
 	// client
-	consulClientRole := "client"
-	consulClientServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "client")
+	consulClientRole := ClientRole
+	consulClientServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, ClientRole)
 	clientAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  consulClientServiceAccountName,
 		KubernetesNamespace: ns,
-		AuthMethodPath:      "kubernetes",
+		AuthMethodPath:      KubernetesAuthMethodPath,
 		RoleName:            consulClientRole,
 		PolicyNames:         gossipSecret.PolicyName,
 	}
 	clientAuthRoleConfig.ConfigureK8SAuthRole(t, vaultClient)
 
 	// manageSystemACLs
-	manageSystemACLsRole := "server-acl-init"
-	manageSystemACLsServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "server-acl-init")
+	manageSystemACLsRole := ManageSystemACLsRole
+	manageSystemACLsServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, ManageSystemACLsRole)
 	aclAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  manageSystemACLsServiceAccountName,
 		KubernetesNamespace: ns,
-		AuthMethodPath:      "kubernetes",
+		AuthMethodPath:      KubernetesAuthMethodPath,
 		RoleName:            manageSystemACLsRole,
 		PolicyNames:         bootstrapTokenSecret.PolicyName,
 	}
@@ -149,7 +149,7 @@ func TestVault_TlsAutoReload(t *testing.T) {
 	srvCAAuthRoleConfig := &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  "*",
 		KubernetesNamespace: ns,
-		AuthMethodPath:      "kubernetes",
+		AuthMethodPath:      KubernetesAuthMethodPath,
 		RoleName:            serverPKIConfig.RoleName,
 		PolicyNames:         serverPKIConfig.PolicyName,
 	}
@@ -250,9 +250,9 @@ func TestVault_TlsAutoReload(t *testing.T) {
 
 	logger.Log(t, "checking that connection is successful")
 	if cfg.EnableTransparentProxy {
-		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "http://static-server")
+		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), StaticClientName, "http://static-server")
 	} else {
-		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "http://localhost:1234")
+		k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), StaticClientName, "http://localhost:1234")
 	}
 
 	logger.Logf(t, "Wait %d seconds for certificates to rotate....", expirationInSeconds)

--- a/acceptance/tests/vault/vault_wan_fed_test.go
+++ b/acceptance/tests/vault/vault_wan_fed_test.go
@@ -118,7 +118,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	// Configure Policy for Connect CA
 	vault.CreateConnectCARootAndIntermediatePKIPolicy(t, vaultClient, connectCAPolicy, connectCARootPath, connectCAIntermediatePath)
 
-	//Configure Server PKI
+	// Configure Server PKI
 	serverPKIConfig := &vault.PKIAndAuthRoleConfiguration{
 		BaseURL:             "pki",
 		PolicyName:          "consul-ca-policy",
@@ -140,7 +140,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	// Configure Policy for Connect CA
 	vault.CreateConnectCARootAndIntermediatePKIPolicy(t, vaultClient, connectCAPolicySecondary, connectCARootPathSecondary, connectCAIntermediatePathSecondary)
 
-	//Configure Server PKI
+	// Configure Server PKI
 	serverPKIConfigSecondary := &vault.PKIAndAuthRoleConfiguration{
 		BaseURL:             "pki",
 		PolicyName:          "consul-ca-policy-dc2",
@@ -158,7 +158,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	// -------------------------
 	// KV2 secrets
 	// -------------------------
-	//Gossip key
+	// Gossip key
 	gossipKey, err := vault.GenerateGossipSecret()
 	require.NoError(t, err)
 	gossipSecret := &vault.SaveVaultSecretConfiguration{
@@ -169,7 +169,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	}
 	vault.SaveSecret(t, vaultClient, gossipSecret)
 
-	//License
+	// License
 	licenseSecret := &vault.SaveVaultSecretConfiguration{
 		Path:       "consul/data/secret/license",
 		Key:        "license",
@@ -180,7 +180,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 		vault.SaveSecret(t, vaultClient, licenseSecret)
 	}
 
-	//Bootstrap Token
+	// Bootstrap Token
 	bootstrapToken, err := uuid.GenerateUUID()
 	require.NoError(t, err)
 	bootstrapTokenSecret := &vault.SaveVaultSecretConfiguration{
@@ -191,7 +191,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	}
 	vault.SaveSecret(t, vaultClient, bootstrapTokenSecret)
 
-	//Replication Token
+	// Replication Token
 	replicationToken, err := uuid.GenerateUUID()
 	require.NoError(t, err)
 	replicationTokenSecret := &vault.SaveVaultSecretConfiguration{
@@ -210,7 +210,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	// --------------------------------------------
 	// Additional Auth Roles for Primary Datacenter
 	// --------------------------------------------
-	//server
+	// server
 	serverPolicies := fmt.Sprintf("%s,%s,%s,%s", commonServerPolicies, connectCAPolicy, serverPKIConfig.PolicyName, bootstrapTokenSecret.PolicyName)
 	if cfg.EnableEnterprise {
 		serverPolicies += fmt.Sprintf(",%s", licenseSecret.PolicyName)
@@ -224,7 +224,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 		PolicyNames:         serverPolicies,
 	})
 
-	//client
+	// client
 	consulClientRole := "client"
 	consulClientServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "client")
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
@@ -235,7 +235,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 		PolicyNames:         gossipSecret.PolicyName,
 	})
 
-	//manageSystemACLs
+	// manageSystemACLs
 	manageSystemACLsRole := "server-acl-init"
 	manageSystemACLsServiceAccountName := fmt.Sprintf("%s-consul-%s", consulReleaseName, "server-acl-init")
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
@@ -258,7 +258,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	// --------------------------------------------
 	// Additional Auth Roles for Secondary Datacenter
 	// --------------------------------------------
-	//server
+	// server
 	secondaryServerPolicies := fmt.Sprintf("%s,%s,%s,%s", commonServerPolicies, connectCAPolicySecondary, serverPKIConfigSecondary.PolicyName, replicationTokenSecret.PolicyName)
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  serverPKIConfig.ServiceAccountName,
@@ -268,7 +268,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 		PolicyNames:         secondaryServerPolicies,
 	})
 
-	//client
+	// client
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  consulClientServiceAccountName,
 		KubernetesNamespace: ns,
@@ -277,7 +277,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 		PolicyNames:         gossipSecret.PolicyName,
 	})
 
-	//manageSystemACLs
+	// manageSystemACLs
 	vault.ConfigureK8SAuthRole(t, vaultClient, &vault.KubernetesAuthRoleConfiguration{
 		ServiceAccountName:  manageSystemACLsServiceAccountName,
 		KubernetesNamespace: ns,

--- a/acceptance/tests/vault/vault_wan_fed_test.go
+++ b/acceptance/tests/vault/vault_wan_fed_test.go
@@ -161,7 +161,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	// Gossip key
 	gossipKey, err := vault.GenerateGossipSecret()
 	require.NoError(t, err)
-	gossipSecret := &vault.SaveVaultSecretConfiguration{
+	gossipSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/gossip",
 		Key:        "gossip",
 		Value:      gossipKey,
@@ -170,7 +170,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	gossipSecret.Save(t, vaultClient)
 
 	// License
-	licenseSecret := &vault.SaveVaultSecretConfiguration{
+	licenseSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/license",
 		Key:        "license",
 		Value:      cfg.EnterpriseLicense,
@@ -183,7 +183,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	// Bootstrap Token
 	bootstrapToken, err := uuid.GenerateUUID()
 	require.NoError(t, err)
-	bootstrapTokenSecret := &vault.SaveVaultSecretConfiguration{
+	bootstrapTokenSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/bootstrap",
 		Key:        "token",
 		Value:      bootstrapToken,
@@ -194,7 +194,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	// Replication Token
 	replicationToken, err := uuid.GenerateUUID()
 	require.NoError(t, err)
-	replicationTokenSecret := &vault.SaveVaultSecretConfiguration{
+	replicationTokenSecret := &vault.KV2Secret{
 		Path:       "consul/data/secret/replication",
 		Key:        "token",
 		Value:      replicationToken,

--- a/acceptance/tests/vault/vault_wan_fed_test.go
+++ b/acceptance/tests/vault/vault_wan_fed_test.go
@@ -167,7 +167,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 		Value:      gossipKey,
 		PolicyName: "gossip",
 	}
-	gossipSecret.Save(t, vaultClient)
+	gossipSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 
 	// License
 	licenseSecret := &vault.KV2Secret{
@@ -177,7 +177,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 		PolicyName: "license",
 	}
 	if cfg.EnableEnterprise {
-		licenseSecret.Save(t, vaultClient)
+		licenseSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 	}
 
 	// Bootstrap Token
@@ -189,7 +189,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 		Value:      bootstrapToken,
 		PolicyName: "bootstrap",
 	}
-	bootstrapTokenSecret.Save(t, vaultClient)
+	bootstrapTokenSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 
 	// Replication Token
 	replicationToken, err := uuid.GenerateUUID()
@@ -200,7 +200,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 		Value:      replicationToken,
 		PolicyName: "replication",
 	}
-	replicationTokenSecret.Save(t, vaultClient)
+	replicationTokenSecret.SaveSecretAndAddReadPolicy(t, vaultClient)
 
 	commonServerPolicies := "gossip"
 	if cfg.EnableEnterprise {


### PR DESCRIPTION
## Background
### Easy to follow configuration paths

Over time, the Vault acceptance test have organically grown where multiple helper functions would encapsulate what should be shared knowledge.  For example, all of the tests have helm chart configurations that look like this:

```
"global.secretsBackend.vault.connectCA.rootPKIPath":         "connect_root",
"global.secretsBackend.vault.connectCA.intermediatePKIPath": "dc1/connect_inter",
"global.acls.bootstrapToken.secretName": "consul/data/secret/bootstrap",
"global.acls.bootstrapToken.secretKey":  "token",
"global.gossipEncryption.secretName":    "consul/data/secret/gossip",
"global.gossipEncryption.secretKey":     "gossip",
"global.tls.caCert.secretName": "pki/cert/ca",
```
For each of these, it can be confusing to know where and how this get set previously to arriving here.  It is also easy to misconfigure and can lead to taking longer to troubleshoot.  For the above, you would would have to know:
- rootPKIPath and intermediatePKIPath were set up and encapsulated inside the `vault.CreateConnectCAPolicy(t, vaultClient, "dc1")` call
- bootrapToken secret name and key were setup and encapsulated inside the `vault.ConfigureACLTokenVaultSecret(t, vaultClient, "bootstrap")` call
- gossipEncryption secret name and key were setup and encapsulated inside the `vault.ConfigureGossipVaultSecret(t, vaultClient)` call
- `pki/cert/ca` was configured when `vault.NewVaultCluster(t, ctx, cfg, vaultReleaseName, nil)` and the pki engine was mounted three function calls deep and set at the `pki` path

There are more examples when you look at policies and roles. 

The main thing here is that the existing test code is hard to follow where something was originally configured and where it needed to be mapped downstream.

This PR means to make that more explicit.  While more verbose than the previous tests, one can follow when something is set up and when it is later mapped. This is representative of the UX of the user that is configuring this integration.
 
### Setting up the ability to mount multiple PKI engines at different paths
This work came about while working on https://github.com/hashicorp/consul-k8s/pull/1191.  In that PR, we need the ability to configure: 
- a CA for controller webhook certs
- a CA for connect injector webhook certs
and have these CAs be different from the server tls CA.  

In the current helper code this is difficult to achieve.  This work originally started in that PR, but has been moved here as a pre-requisite for that PR since that PR is already 1k+ lines of changes and so is this one.  This was the easiest way to split it up.

## How to read this PR:
- view `acceptance/tests/snapshot-agent/snapshot_agent_vault_test.go` and see the comments I have made there.
- view all of the other tests.  it should be rinse and repeat concepts.
- view `acceptance/framework/vault/helpers.go` last.  The diff is hard to read because so much changed.  Having viewed everything else beforehand, you will get a good sense of the new functions and how they work.

## How I've tested this PR:
- integration tests locally and in CI

## How I expect reviewers to test this PR:
👀 


## Checklist:
- [x] Tests added
- ~~[ ] CHANGELOG entry added~~
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

