### PR TITLE
update the flags library to prevent overflows

### DIFF
--- a/cli/common/flag/flag_int.go
+++ b/cli/common/flag/flag_int.go
@@ -23,7 +23,7 @@ type IntVar struct {
 func (f *Set) IntVar(i *IntVar) {
 	initial := i.Default
 	if v, exist := os.LookupEnv(i.EnvVar); exist {
-		if i, err := strconv.ParseInt(v, 0, 64); err == nil {
+		if i, err := strconv.ParseInt(v, 0, 32); err == nil {
 			initial = int(i)
 		}
 	}
@@ -60,7 +60,7 @@ func newIntValue(v *IntVar, def int, target *int, hidden bool) *intValue {
 }
 
 func (i *intValue) Set(s string) error {
-	v, err := strconv.ParseInt(s, 0, 64)
+	v, err := strconv.ParseInt(s, 0, 32)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ type UintVar struct {
 func (f *Set) UintVar(i *UintVar) {
 	initial := i.Default
 	if v, exist := os.LookupEnv(i.EnvVar); exist {
-		if i, err := strconv.ParseUint(v, 0, 64); err == nil {
+		if i, err := strconv.ParseUint(v, 0, 32); err == nil {
 			initial = uint(i)
 		}
 	}
@@ -204,7 +204,7 @@ func newUintValue(v *UintVar, def uint, target *uint, hidden bool) *uintValue {
 }
 
 func (i *uintValue) Set(s string) error {
-	v, err := strconv.ParseUint(s, 0, 64)
+	v, err := strconv.ParseUint(s, 0, 32)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is intended to fix alerts flagged by CodeQL: https://github.com/hashicorp/consul-k8s/security/code-scanning
Whereby we are using `strconv.ParseInt` with 64bits length and then casting it to a 32bit value without error checking.

Changes proposed in this PR:
- Updates `flags_int.go`'s use of `parse_Int` and `parse_Uint` to specify 32bit length for `strconv.ParseUint/Int` so that it will return error on overflow instead of actually overflow.
When `ParseInt` overflows it will return :
`value out of range`
Example:
```
func main() {
	a := "100000000000000000000000000000000000000"
	v, err := strconv.ParseInt(a, 0, 32)
	fmt.Println("%v", err)
}
```
Results in : `strconv.ParseInt: parsing "100000000000000000000000000000000000000": value out of range`


How I've tested this PR:
👀
Should I add a unit test?
 
How I expect reviewers to test this PR:
👀

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

