### PR TITLE
Added the namespace flag to the "learn more about the release" of helm install output if a namespace has been provided.

### DIFF
--- a/charts/consul/templates/NOTES.txt
+++ b/charts/consul/templates/NOTES.txt
@@ -5,8 +5,8 @@ Your release is named {{ .Release.Name }}.
 
 To learn more about the release, run:
 
-  $ helm status {{ .Release.Name }}
-  $ helm get all {{ .Release.Name }}
+  $ helm status {{ .Release.Name }} {{- if .Release.Namespace }} -n {{ .Release.Namespace }}{{ end }}
+  $ helm get all {{ .Release.Name }} {{- if .Release.Namespace }} -n {{ .Release.Namespace }}{{ end }}
 
 Consul on Kubernetes Documentation:
 https://www.consul.io/docs/platform/k8s


### PR DESCRIPTION

Changes proposed in this PR:
- Added the namespace flag to the "learn more about the release" of helm install output if a namespace has been provided.
- addresses https://github.com/hashicorp/consul-k8s/issues/1224

How I've tested this PR:
- verified locally
- the output looks like this:
<img width="988" alt="Screen Shot 2022-05-17 at 10 39 25 AM" src="https://user-images.githubusercontent.com/2481360/168864880-b1b16135-26bf-4e63-ad5a-878965cc58a4.png">

How I expect reviewers to test this PR:
👀 

Checklist:
- ~~[ ] Tests added~~
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

