### PR TITLE
Fix nightly dev docker upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,20 +289,6 @@ jobs:
           working_directory: *control-plane-path
           command: make ci.dev-docker
 
-  # upload nightly dev docker image
-  nightly-dev-upload-docker:
-    executor: go
-    steps:
-      - checkout
-      # get consul-k8s binary
-      - attach_workspace:
-          at: .
-      - setup_remote_docker
-      - run:
-          name: make ci.nightly-dev-docker
-          working_directory: *control-plane-path
-          command: make ci.nightly-dev-docker
-
   unit-cli:
     executor: go
     steps:
@@ -918,7 +904,7 @@ workflows:
           OS: "linux"
           ARCH: "amd64"
           name: build-distros-amd64
-      - nightly-dev-upload-docker:
+      - dev-upload-docker:
           requires:
             - build-distros-amd64
       - cleanup-gcp-resources
@@ -931,10 +917,15 @@ workflows:
       - acceptance-gke-1-20:
           requires:
             - cleanup-gcp-resources
+            - dev-upload-docker
       - acceptance-eks-1-19:
           requires:
             - cleanup-eks-resources
+            - dev-upload-docker
       - acceptance-aks-1-21:
           requires:
             - cleanup-azure-resources
-      - acceptance-kind-1-23
+            - dev-upload-docker
+      - acceptance-kind-1-23:
+          requires:
+            - dev-upload-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -892,13 +892,13 @@ workflows:
           requires:
             - dev-upload-docker
   nightly-acceptance-tests:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
+#    triggers:
+#      - schedule:
+#          cron: "0 0 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - main
     jobs:
       - build-distro:
           OS: "linux"
@@ -907,24 +907,24 @@ workflows:
       - dev-upload-docker:
           requires:
             - build-distros-amd64
-      - cleanup-gcp-resources
-      - cleanup-azure-resources
-      - cleanup-eks-resources
+#      - cleanup-gcp-resources
+#      - cleanup-azure-resources
+#      - cleanup-eks-resources
       # Disable until we can use UBI images.
       #      - acceptance-openshift:
       #          requires:
       #          - cleanup-azure-resources
       - acceptance-gke-1-20:
           requires:
-            - cleanup-gcp-resources
+#            - cleanup-gcp-resources
             - dev-upload-docker
       - acceptance-eks-1-19:
           requires:
-            - cleanup-eks-resources
+#            - cleanup-eks-resources
             - dev-upload-docker
       - acceptance-aks-1-21:
           requires:
-            - cleanup-azure-resources
+#            - cleanup-azure-resources
             - dev-upload-docker
       - acceptance-kind-1-23:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -892,13 +892,13 @@ workflows:
           requires:
             - dev-upload-docker
   nightly-acceptance-tests:
-#    triggers:
-#      - schedule:
-#          cron: "0 0 * * *"
-#          filters:
-#            branches:
-#              only:
-#                - main
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
     jobs:
       - build-distro:
           OS: "linux"
@@ -907,24 +907,24 @@ workflows:
       - dev-upload-docker:
           requires:
             - build-distros-amd64
-#      - cleanup-gcp-resources
-#      - cleanup-azure-resources
-#      - cleanup-eks-resources
+      - cleanup-gcp-resources
+      - cleanup-azure-resources
+      - cleanup-eks-resources
       # Disable until we can use UBI images.
       #      - acceptance-openshift:
       #          requires:
       #          - cleanup-azure-resources
       - acceptance-gke-1-20:
           requires:
-#            - cleanup-gcp-resources
+            - cleanup-gcp-resources
             - dev-upload-docker
       - acceptance-eks-1-19:
           requires:
-#            - cleanup-eks-resources
+            - cleanup-eks-resources
             - dev-upload-docker
       - acceptance-aks-1-21:
           requires:
-#            - cleanup-azure-resources
+            - cleanup-azure-resources
             - dev-upload-docker
       - acceptance-kind-1-23:
           requires:

--- a/control-plane/Makefile
+++ b/control-plane/Makefile
@@ -46,25 +46,6 @@ ifeq ($(CIRCLE_BRANCH), main)
 	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
 endif
 
-# TODO: Remove this ci.nightly-dev-docker target once we move the acceptance tests to Github Actions.
-# In CircleCI, the linux binary will be attached from a previous step at pkg/bin/linux_amd64/. This make target
-# should only run in CI and not locally. This is a guardrail for a case where the latest commit on main does not succeed to upload a docker image, so with this step the nightly test will upload its own docker image off of main before starting.
-ci.nightly-dev-docker:
-	@echo "Building consul-k8s Nightly Development container - $(CI_DEV_DOCKER_IMAGE_NAME)"
-	@docker build -t '$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):nightly-$(GIT_COMMIT)' \
-	--target=dev \
-	--label COMMIT_SHA=$(CIRCLE_SHA1) \
-	--label PULL_REQUEST=$(CIRCLE_PULL_REQUEST) \
-	--label CIRCLE_BUILD_URL=$(CIRCLE_BUILD_URL) \
-	$(CI_DEV_DOCKER_WORKDIR) -f $(CURDIR)/Dockerfile
-	@echo $(DOCKER_PASS) | docker login -u="$(DOCKER_USER)" --password-stdin
-	@echo "Pushing dev image to: https://cloud.docker.com/u/$(CI_DEV_DOCKER_NAMESPACE)/repository/docker/$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME)"
-	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):nightly-$(GIT_COMMIT)
-ifeq ($(CIRCLE_BRANCH), main)
-	@docker tag $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):nightly-$(GIT_COMMIT) $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
-	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
-endif
-
 # In Github Actions, the linux binary will be attached from a previous step at pkg/bin/linux_amd64/. This make target
 # should only run in CI and not locally.
 ci.dev-docker-github:

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -10,7 +10,6 @@ import (
 	logrtest "github.com/go-logr/logr/testing"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	cpconsul "github.com/hashicorp/consul-k8s/control-plane/consul"
 	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -3575,115 +3574,6 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 	require.Len(t, proxyServiceInstances, 1)
 }
 
-// TestReconcileUnreachableClient tests the scenario where a consul client is unreachable.  We want to verify that
-// the Timeout on the HttpClient has timed out quickly so as not to infinitely wait and cause queuing of subsequent
-// endpoint objects.
-func TestReconcileUnreachableClient(t *testing.T) {
-	t.Parallel()
-	nodeName := "test-node"
-	cases := []struct {
-		name          string
-		consulSvcName string
-		k8sObjects    func() []runtime.Object
-	}{
-		{
-			name:          "Basic endpoints",
-			consulSvcName: "service-created",
-			k8sObjects: func() []runtime.Object {
-				pod1 := createPod("pod1", "1.2.3.4", true, true)
-				endpoint := &corev1.Endpoints{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "service-created",
-						Namespace: "default",
-					},
-					Subsets: []corev1.EndpointSubset{
-						{
-							Addresses: []corev1.EndpointAddress{
-								{
-									IP:       "1.2.3.4",
-									NodeName: &nodeName,
-									TargetRef: &corev1.ObjectReference{
-										Kind:      "Pod",
-										Name:      "pod1",
-										Namespace: "default",
-									},
-								},
-							},
-						},
-					},
-				}
-				return []runtime.Object{pod1, endpoint}
-			},
-		},
-	}
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			// The agent ip address will be set to 126.0.0.1 which is an unreachable address.
-			// The test will assert that a Client Timeout kicked in rather than just an infinite
-			// wait- in which case the test time of 30s out would expire first.
-			fakeClientPod := createPod("fake-consul-client", "126.0.0.1", false, true)
-			fakeClientPod.Labels = map[string]string{"component": "client", "app": "consul", "release": "consul"}
-
-			// Add the default namespace.
-			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
-			// Create fake k8s client
-			k8sObjects := append(tt.k8sObjects(), fakeClientPod, &ns)
-
-			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
-
-			// Create test consul server
-			consul, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
-				c.NodeName = nodeName
-			})
-			require.NoError(t, err)
-			defer consul.Stop()
-			consul.WaitForServiceIntentions(t)
-
-			cfg := &api.Config{
-				Address: consul.HTTPAddr,
-			}
-			consulClient, err := cpconsul.NewClient(cfg, 0)
-			require.NoError(t, err)
-			addr := strings.Split(consul.HTTPAddr, ":")
-			consulPort := addr[1]
-
-			// Create the endpoints controller
-			ep := &EndpointsController{
-				Client:                fakeClient,
-				Log:                   logrtest.TestLogger{T: t},
-				ConsulClient:          consulClient,
-				ConsulPort:            consulPort,
-				ConsulScheme:          "http",
-				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
-				DenyK8sNamespacesSet:  mapset.NewSetWith(),
-				ReleaseName:           "consul",
-				ReleaseNamespace:      "default",
-				ConsulClientCfg:       cfg,
-			}
-			namespacedName := types.NamespacedName{
-				Namespace: "default",
-				Name:      "service-created",
-			}
-
-			resp, err := ep.Reconcile(context.Background(), ctrl.Request{
-				NamespacedName: namespacedName,
-			})
-
-			// using concat (+) instead of fmt.Sprintf because string has lots of %s in it that cause issues
-			expectedErrorFragment := "Get \"http://126.0.0.1:" + consulPort + "/v1/agent/services?filter=Meta%5B%22k8s-service-name%22%5D+%3D%3D+%22service-created%22+and+Meta%5B%22k8s-namespace%22%5D+%3D%3D+%22default%22+and+Meta%5B%22managed-by%22%5D+%3D%3D+%22consul-k8s-endpoints-controller%22\""
-			expectedErrorFragmentTwo := "(Client.Timeout exceeded while awaiting headers)"
-
-			// Splitting this into two asserts on fragments of the error because the error thrown
-			// can be either of the two below and matching on the whole string causes the test tobe flakey
-			// "1 error occurred:\n\t* Get \"http://126.0.0.1:31200/v1/agent/services?filter=Meta%5B%22k8s-service-name%22%5D+%3D%3D+%22service-created%22+and+Meta%5B%22k8s-namespace%22%5D+%3D%3D+%22default%22+and+Meta%5B%22managed-by%22%5D+%3D%3D+%22consul-k8s-endpoints-controller%22\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)\n\n"
-			// "1 error occurred:\n\t* Get \"http://126.0.0.1:31200/v1/agent/services?filter=Meta%5B%22k8s-service-name%22%5D+%3D%3D+%22service-created%22+and+Meta%5B%22k8s-namespace%22%5D+%3D%3D+%22default%22+and+Meta%5B%22managed-by%22%5D+%3D%3D+%22consul-k8s-endpoints-controller%22\": dial tcp 126.0.0.1:31200: i/o timeout (Client.Timeout exceeded while awaiting headers)\n\n"
-			require.Contains(t, err.Error(), expectedErrorFragment)
-			require.Contains(t, err.Error(), expectedErrorFragmentTwo)
-			require.False(t, resp.Requeue)
-
-		})
-	}
-}
 func TestFilterAgentPods(t *testing.T) {
 	t.Parallel()
 	cases := map[string]struct {


### PR DESCRIPTION
Changes proposed in this PR:
Recently we've seen cases when a nightly dev image is not uploaded due to a CI failure.
To fix this, we're going to run the `dev-upload-docker` job again before the nightly acceptance tests run

This commit also removes the `nightly-dev-upload-docker` job and its corresponding makefile target as we don't need a separate tag for these images and can re-use the same ones.

How I've tested this PR:

Enabled nightly pipeline (w/o the cleanup jobs) on this commit: https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/5857/workflows/c8e6a9d0-1ba5-47d4-9238-eab66b890368

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

