### PR TITLE
Add peerName to ExportedServices.

### DIFF
--- a/charts/consul/templates/crd-exportedservices.yaml
+++ b/charts/consul/templates/crd-exportedservices.yaml
@@ -75,6 +75,10 @@ spec:
                             description: Partition is the admin partition to export
                               the service to.
                             type: string
+                          peerName:
+                            description: PeerName is the name of the peer to export
+                              the service to.
+                            type: string
                         type: object
                       type: array
                     name:

--- a/control-plane/config/crd/bases/consul.hashicorp.com_exportedservices.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_exportedservices.yaml
@@ -68,6 +68,10 @@ spec:
                             description: Partition is the admin partition to export
                               the service to.
                             type: string
+                          peerName:
+                            description: PeerName is the name of the peer to export
+                              the service to.
+                            type: string
                         type: object
                       type: array
                     name:

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.7
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
-	github.com/hashicorp/consul/api v1.10.1-0.20220425143126-6d0162a58a94
+	github.com/hashicorp/consul/api v1.10.1-0.20220519230759-6167400b28c9
 	github.com/hashicorp/consul/sdk v0.9.0
 	github.com/hashicorp/go-discover v0.0.0-20200812215701-c4b85f6ed31f
 	github.com/hashicorp/go-hclog v0.16.1

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -297,8 +297,8 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
-github.com/hashicorp/consul/api v1.10.1-0.20220425143126-6d0162a58a94 h1:mPhpaeGO4BmD0Fi9gmevT7kYDyDml1kNjf0HKCFF5xM=
-github.com/hashicorp/consul/api v1.10.1-0.20220425143126-6d0162a58a94/go.mod h1:ZlVrynguJKcYr54zGaDbaL3fOvKC9m72FhPvA8T35KQ=
+github.com/hashicorp/consul/api v1.10.1-0.20220519230759-6167400b28c9 h1:HWXZXOMz3EXKtpE+ETagwEtppdCywlcQ799oEpdxfxc=
+github.com/hashicorp/consul/api v1.10.1-0.20220519230759-6167400b28c9/go.mod h1:ZlVrynguJKcYr54zGaDbaL3fOvKC9m72FhPvA8T35KQ=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.4.1-0.20220214194852-80dfcb1bcd68 h1:yw3OXf1OUgfnitE8rwnr+zaT9VluSgvrCHQGwSvA7V4=
 github.com/hashicorp/consul/sdk v0.4.1-0.20220214194852-80dfcb1bcd68/go.mod h1:K9S7H8bLBwkBb2I4hq0Ddm4LCVGuhtenfzSTx2Y36RM=


### PR DESCRIPTION
Changes proposed in this PR:
- add peerName to ExportedServices CRD
- add validations to ensure both peername and partition cannot be specified but at least one of them needs to be specified.

How I've tested this PR:
- unit tests
- deploying locally on kubernetes
How I expect reviewers to test this PR:
- 👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

