### PR TITLE
Add consul-version flag to acceptance test framework

### DIFF
--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/go-version"
 	"gopkg.in/yaml.v2"
 )
 
@@ -41,6 +42,7 @@ type TestConfig struct {
 
 	ConsulImage    string
 	ConsulK8SImage string
+	ConsulVersion  *version.Version
 
 	NoCleanupOnFailure bool
 	DebugDirectory     string

--- a/acceptance/framework/flags/flags.go
+++ b/acceptance/framework/flags/flags.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/consul-k8s/acceptance/framework/config"
+	"github.com/hashicorp/go-version"
 )
 
 type TestFlags struct {
@@ -30,6 +31,7 @@ type TestFlags struct {
 
 	flagConsulImage    string
 	flagConsulK8sImage string
+	flagConsulVersion  string
 
 	flagNoCleanupOnFailure bool
 
@@ -56,6 +58,7 @@ func (t *TestFlags) init() {
 
 	flag.StringVar(&t.flagConsulImage, "consul-image", "", "The Consul image to use for all tests.")
 	flag.StringVar(&t.flagConsulK8sImage, "consul-k8s-image", "", "The consul-k8s image to use for all tests.")
+	flag.StringVar(&t.flagConsulVersion, "consul-version", "", "The consul version used for all tests.")
 
 	flag.BoolVar(&t.flagEnableMultiCluster, "enable-multi-cluster", false,
 		"If true, the tests that require multiple Kubernetes clusters will be run. "+
@@ -113,6 +116,9 @@ func (t *TestFlags) Validate() error {
 func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 	tempDir := t.flagDebugDirectory
 
+	// if the Version is empty consulVersion will be nil
+	consulVersion, _ := version.NewVersion(t.flagConsulVersion)
+
 	return &config.TestConfig{
 		Kubeconfig:    t.flagKubeconfig,
 		KubeContext:   t.flagKubecontext,
@@ -134,6 +140,7 @@ func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 
 		ConsulImage:    t.flagConsulImage,
 		ConsulK8SImage: t.flagConsulK8sImage,
+		ConsulVersion:  consulVersion,
 
 		NoCleanupOnFailure: t.flagNoCleanupOnFailure,
 		DebugDirectory:     tempDir,

--- a/acceptance/tests/vault/vault_namespaces_test.go
+++ b/acceptance/tests/vault/vault_namespaces_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/vault"
 	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,6 +25,13 @@ func TestVault_VaultNamespace(t *testing.T) {
 	cfg := suite.Config()
 	ctx := suite.Environment().DefaultContext(t)
 	ns := ctx.KubectlOptions(t).Namespace
+
+	ver, err := version.NewVersion("1.12.0")
+	require.NoError(t, err)
+	if cfg.ConsulVersion != nil && cfg.ConsulVersion.LessThan(ver) {
+		t.Skipf("skipping this test because vault secrets backend is not supported in version %v", cfg.ConsulVersion.String())
+	}
+
 	vaultNamespacePath := "test-namespace"
 	consulReleaseName := helpers.RandomName()
 	vaultReleaseName := helpers.RandomName()

--- a/acceptance/tests/vault/vault_partitions_test.go
+++ b/acceptance/tests/vault/vault_partitions_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/vault"
 	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -27,6 +28,11 @@ func TestVault_Partitions(t *testing.T) {
 
 	const secondaryPartition = "secondary"
 
+	ver, err := version.NewVersion("1.12.0")
+	require.NoError(t, err)
+	if cfg.ConsulVersion != nil && cfg.ConsulVersion.LessThan(ver) {
+		t.Skipf("skipping this test because vault secrets backend is not supported in version %v", cfg.ConsulVersion.String())
+	}
 	if !cfg.EnableEnterprise {
 		t.Skipf("skipping this test because -enable-enterprise is not set")
 	}

--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/vault"
 	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,6 +29,12 @@ func TestVault(t *testing.T) {
 	cfg := suite.Config()
 	ctx := suite.Environment().DefaultContext(t)
 	ns := ctx.KubectlOptions(t).Namespace
+
+	ver, err := version.NewVersion("1.12.0")
+	require.NoError(t, err)
+	if cfg.ConsulVersion != nil && cfg.ConsulVersion.LessThan(ver) {
+		t.Skipf("skipping this test because vault secrets backend is not supported in version %v", cfg.ConsulVersion.String())
+	}
 
 	consulReleaseName := helpers.RandomName()
 	vaultReleaseName := helpers.RandomName()

--- a/acceptance/tests/vault/vault_tls_auto_reload_test.go
+++ b/acceptance/tests/vault/vault_tls_auto_reload_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"github.com/hashicorp/go-version"
 	"testing"
 	"time"
 
@@ -24,6 +25,12 @@ func TestVault_TlsAutoReload(t *testing.T) {
 	cfg := suite.Config()
 	ctx := suite.Environment().DefaultContext(t)
 	ns := ctx.KubectlOptions(t).Namespace
+
+	ver, err := version.NewVersion("1.12.0")
+	require.NoError(t, err)
+	if cfg.ConsulVersion != nil && cfg.ConsulVersion.LessThan(ver) {
+		t.Skipf("skipping this test because vault secrets backend is not supported in version %v", cfg.ConsulVersion.String())
+	}
 
 	consulReleaseName := helpers.RandomName()
 	vaultReleaseName := helpers.RandomName()

--- a/acceptance/tests/vault/vault_tls_auto_reload_test.go
+++ b/acceptance/tests/vault/vault_tls_auto_reload_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/hashicorp/go-version"
 	"testing"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/vault"
 	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
 )
 

--- a/acceptance/tests/vault/vault_wan_fed_test.go
+++ b/acceptance/tests/vault/vault_wan_fed_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/consul-k8s/acceptance/framework/vault"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -30,6 +31,12 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	if !cfg.EnableMultiCluster {
 		t.Skipf("skipping this test because -enable-multi-cluster is not set")
 	}
+	ver, err := version.NewVersion("1.12.0")
+	require.NoError(t, err)
+	if cfg.ConsulVersion != nil && cfg.ConsulVersion.LessThan(ver) {
+		t.Skipf("skipping this test because vault secrets backend is not supported in version %v", cfg.ConsulVersion.String())
+	}
+
 	primaryCtx := suite.Environment().DefaultContext(t)
 	secondaryCtx := suite.Environment().Context(t, environment.SecondaryContextName)
 


### PR DESCRIPTION
Changes proposed in this PR:
- Adds a new flag "-consul-version" to the acceptance test framework that will be used to prevent tests from running against incompatible consul releases.
- Forces Vault acceptance tests to be skipped if consul-1.12+ is not used.
- In the follow-on PR which uses this feature, the acceptance tests will be enhanced to have 2 new jobs which each target specific consul versions and will pass this flag to indicate that.

How I've tested this PR:
* Manually validated the version comparison code.
* Manually tested that the Vault tests pass (are skipped) when consul-1.11.6 is used and "1.11.6" is passed in as a flag.

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

