### PR TITLE
Removing agent:read ACL permissions from mesh gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ IMPROVEMENTS:
   * Update minimum go version for project to 1.19 [[GH-1633](https://github.com/hashicorp/consul-k8s/pull/1633)]
 * Control Plane
   * Update minimum go version for project to 1.19 [[GH-1633](https://github.com/hashicorp/consul-k8s/pull/1633)]
+  * Remove unneeded `agent:read` ACL permissions from mesh gateway policy. [[GH-1255](https://github.com/hashicorp/consul-k8s/pull/1255)]
 * Helm:
   * Remove deprecated annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"` in the `server-service` template. [[GH-1619](https://github.com/hashicorp/consul-k8s/pull/1619)]
   * Support `minAvailable` on connect injector `PodDisruptionBudget`. [[GH-1557](https://github.com/hashicorp/consul-k8s/pull/1557)]

--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -179,9 +179,6 @@ func (c *Command) meshGatewayRules() (string, error) {
 	// that its ACL token has access to. So, in the case of
 	// Consul namespaces, it needs access to all namespaces.
 	meshGatewayRulesTpl := `mesh = "write"
-agent_prefix "" {
-  policy = "read"
-}
 {{- if .EnableNamespaces }}
 namespace "default" {
 {{- end }}

--- a/control-plane/subcommand/server-acl-init/rules_test.go
+++ b/control-plane/subcommand/server-acl-init/rules_test.go
@@ -200,9 +200,6 @@ func TestMeshGatewayRules(t *testing.T) {
 		{
 			Name: "Namespaces are disabled",
 			Expected: `mesh = "write"
-agent_prefix "" {
-  policy = "read"
-}
   service "mesh-gateway" {
      policy = "write"
   }
@@ -217,9 +214,6 @@ agent_prefix "" {
 			Name:             "Namespaces are enabled",
 			EnableNamespaces: true,
 			Expected: `mesh = "write"
-agent_prefix "" {
-  policy = "read"
-}
 namespace "default" {
   service "mesh-gateway" {
      policy = "write"


### PR DESCRIPTION
Changes proposed in this PR:
- Remove unnecessary `agent_prefix` ACL policy for mesh gateways.
  - This is only necessary to look up the gRPC port but since we're setting CONSUL_GRPC_ADDR we don't need this permission

How I've tested this PR:
* acceptance tests

How I expect reviewers to test this PR:
* code

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

