### PR TITLE
Peering consul server external ip

### DIFF
--- a/charts/consul/templates/server-role.yaml
+++ b/charts/consul/templates/server-role.yaml
@@ -29,6 +29,14 @@ rules:
   - use
 {{- end }}
 {{- else}}
-rules: []
+#todo: add a case for this
+rules:
+- apiGroups: [ "" ]
+  resources: [ "services" ]
+  verbs:
+    - "get"
+    - "list"
+    - "watch"
+
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/server-service.yaml
+++ b/charts/consul/templates/server-service.yaml
@@ -24,7 +24,11 @@ metadata:
     # https://github.com/kubernetes/kubernetes/issues/58662
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
+  {{- if eq (trim .Values.server.service.type) `Headless` }}
   clusterIP: None
+  {{- else }}
+  type: {{ .Values.server.service.type }}
+  {{- end }}
   # We want the servers to become available even if they're not ready
   # since this DNS is also used for join operations.
   publishNotReadyAddresses: true
@@ -43,18 +47,18 @@ spec:
       protocol: "TCP"
       port: 8301
       targetPort: 8301
-    - name: serflan-udp
-      protocol: "UDP"
-      port: 8301
-      targetPort: 8301
+#    - name: serflan-udp
+#      protocol: "UDP"
+#      port: 8301
+#      targetPort: 8301
     - name: serfwan-tcp
       protocol: "TCP"
       port: 8302
       targetPort: 8302
-    - name: serfwan-udp
-      protocol: "UDP"
-      port: 8302
-      targetPort: 8302
+#    - name: serfwan-udp
+#      protocol: "UDP"
+#      port: 8302
+#      targetPort: 8302
     - name: server
       port: 8300
       targetPort: 8300
@@ -62,10 +66,10 @@ spec:
       protocol: "TCP"
       port: 8600
       targetPort: dns-tcp
-    - name: dns-udp
-      protocol: "UDP"
-      port: 8600
-      targetPort: dns-udp
+#    - name: dns-udp
+#      protocol: "UDP"
+#      port: 8600
+#      targetPort: dns-udp
   selector:
     app: {{ template "consul.name" . }}
     release: "{{ .Release.Name }}"

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -181,6 +181,27 @@ spec:
       {{- if .Values.server.priorityClassName }}
       priorityClassName: {{ .Values.server.priorityClassName | quote }}
       {{- end }}
+      initContainers:
+        - name: consul-init
+          image: {{ .Values.global.imageK8S }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              {{- $serviceType := .Values.server.service.type }}
+              {{- if (eq $serviceType "LoadBalancer") }}
+              consul-k8s-control-plane service-address \
+                -log-level={{ .Values.global.logLevel }} \
+                -log-json={{ .Values.global.logJSON }} \
+                -k8s-namespace={{ .Release.Namespace }} \
+                -name={{ template "consul.fullname" . }}-server \
+                -resolve-hostnames=true \
+                -output-file=/consul/data/address.txt
+              {{- end }}
+          volumeMounts:
+            - name: data-{{ .Release.Namespace | trunc 58 | trimSuffix "-" }}
+              mountPath: /consul/data
+
       containers:
         - name: consul
           image: "{{ default .Values.global.image .Values.server.image }}"
@@ -267,9 +288,14 @@ spec:
               {{- end }}
 
               {{ template "consul.extraconfig" }}
+              
+              WAN_ADDR="$(cat /consul/data/address.txt)"
 
               exec /usr/local/bin/docker-entrypoint.sh consul agent \
                 -advertise="${ADVERTISE_IP}" \
+                {{- if (eq $serviceType "LoadBalancer") }}
+                -advertise-wan="${WAN_ADDR}" \
+                {{- end }}
                 -config-dir=/consul/config \
                 {{- if (or .Values.global.gossipEncryption.autoGenerate (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey)) }}
                 -encrypt="${GOSSIP_KEY}" \

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -937,6 +937,9 @@ server:
 
   # Server service properties.
   service:
+    # Type of service, ex. LoadBalancer, ClusterIP. Additionally, the value "Headless" is supported to not have a cluster ip.
+    type: Headless
+
     # Annotations to apply to the server service.
     #
     # ```yaml


### PR DESCRIPTION
Changes proposed in this PR:
- Add service type for consul server service, and if it's a LB service, use that address as the -advertise-wan flag in Consul
  - Issues: 
    - ~The consul server service has UDP and TCP ports, and different protocols are not supported for LB services [k8s issue](https://github.com/kubernetes/kubernetes/pull/64471)~ we can use a different service and not expose the UDP/TCP ports, and just expose grpc
    - ~Needs an additional container for consul server that uses the k8s image instead~ this is ok
    - ~On EKS, the address is a hostname that takes several minutes to resolve to an IP, and currently the -advertise-wan flag doesn't support hostnames.~ using -resolve-addresses works, but takes a little while to resolve dns to the LB in eks 
    - ~After everything comes up (several minutes after installation), the wan address shows up in the consul service registration, but the pod itself is still NotReady and fails healthchecks (maybe because of commenting out ports)?~ this was from the consul-init container not actually being an init container, and finishing its run
    - The current issue is that when deploying multiple servers, you can't just provide 1 IP as the WAN IP, since leader election will fail. We are going to defer this to later, and there will need to be a change in consul to provide a wan address that will not be used as part of wan gossip.

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

