### PR TITLE
update agent config urls in values.yaml

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -25,7 +25,7 @@ global:
   name: null
 
   # The domain Consul will answer DNS queries for
-  # (see `-domain` (https://consul.io/docs/agent/options#_domain)) and the domain services synced from
+  # (see `-domain` (https://consul.io/docs/agent/options#domain)) and the domain services synced from
   # Consul into Kubernetes will have, e.g. `service-name.service.consul`.
   domain: consul
 
@@ -264,7 +264,7 @@ global:
           {}
 
   # Configures Consul's gossip encryption key.
-  # (see `-encrypt` (https://consul.io/docs/agent/options#_encrypt)).
+  # (see `-encrypt` (https://consul.io/docs/agent/options#encrypt)).
   # By default, gossip encryption is not enabled. The gossip encryption key may be set automatically or manually.
   # The recommended method is to automatically generate the key.
   # To automatically generate and set a gossip encryption key, set autoGenerate to true.
@@ -297,7 +297,7 @@ global:
 
   # A list of addresses of upstream DNS servers that are used to recursively resolve DNS queries.
   # These values are given as `-recursor` flags to Consul servers and clients.
-  # See https://www.consul.io/docs/agent/options#_recursor for more details.
+  # See https://www.consul.io/docs/agent/options#recursors for more details.
   # If this is an empty array (the default), then Consul DNS will only resolve queries for the Consul top level domain (by default `.consul`).
   # @type: array<string>
   recursors: []
@@ -1019,7 +1019,7 @@ client:
   # @type: string
   image: null
 
-  # A list of valid `-retry-join` values (https://consul.io/docs/agent/options#retry-join).
+  # A list of valid `-retry-join` values (https://consul.io/docs/agent/options#retry_join).
   # If this is `null` (default), then the clients will attempt to automatically
   # join the server cluster running within Kubernetes.
   # This means that with `server.enabled` set to true, clients will automatically
@@ -1045,7 +1045,7 @@ client:
   grpc: true
 
   # nodeMeta specifies an arbitrary metadata key/value pair to associate with the node
-  # (see https://www.consul.io/docs/agent/options.html#_node_meta)
+  # (see https://www.consul.io/docs/agent/options.html#node_meta)
   nodeMeta:
     pod-name: ${HOSTNAME}
     host-ip: ${HOST_IP}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -25,7 +25,7 @@ global:
   name: null
 
   # The domain Consul will answer DNS queries for
-  # (see `-domain` (https://consul.io/docs/agent/options#domain)) and the domain services synced from
+  # (see `-domain` (https://www.consul.io/docs/agent/config/cli-flags#_domain)) and the domain services synced from
   # Consul into Kubernetes will have, e.g. `service-name.service.consul`.
   domain: consul
 
@@ -264,7 +264,7 @@ global:
           {}
 
   # Configures Consul's gossip encryption key.
-  # (see `-encrypt` (https://consul.io/docs/agent/options#encrypt)).
+  # (see `-encrypt` (https://www.consul.io/docs/agent/config/cli-flags#_encrypt)).
   # By default, gossip encryption is not enabled. The gossip encryption key may be set automatically or manually.
   # The recommended method is to automatically generate the key.
   # To automatically generate and set a gossip encryption key, set autoGenerate to true.
@@ -297,7 +297,7 @@ global:
 
   # A list of addresses of upstream DNS servers that are used to recursively resolve DNS queries.
   # These values are given as `-recursor` flags to Consul servers and clients.
-  # See https://www.consul.io/docs/agent/options#recursors for more details.
+  # See https://www.consul.io/docs/agent/config/cli-flags#_recursor for more details.
   # If this is an empty array (the default), then Consul DNS will only resolve queries for the Consul top level domain (by default `.consul`).
   # @type: array<string>
   recursors: []
@@ -1019,7 +1019,7 @@ client:
   # @type: string
   image: null
 
-  # A list of valid `-retry-join` values (https://consul.io/docs/agent/options#retry_join).
+  # A list of valid `-retry-join` values (https://www.consul.io/docs/agent/config/cli-flags#_retry_join).
   # If this is `null` (default), then the clients will attempt to automatically
   # join the server cluster running within Kubernetes.
   # This means that with `server.enabled` set to true, clients will automatically
@@ -1045,7 +1045,7 @@ client:
   grpc: true
 
   # nodeMeta specifies an arbitrary metadata key/value pair to associate with the node
-  # (see https://www.consul.io/docs/agent/options.html#node_meta)
+  # (see https://www.consul.io/docs/agent/config/cli-flags#_node_meta)
   nodeMeta:
     pod-name: ${HOSTNAME}
     host-ip: ${HOST_IP}


### PR DESCRIPTION
Changes proposed in this PR:
- there were some invalid URLs in the values.yaml that referenced consul.io pages that were incorrect.
- These links get auto-gen'd to consul.io docs for the k8s helm chart so they need to be correct

How I've tested this PR:
👓 
Manually clicked the links :)

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

