### PR TITLE
Expose new options for API Gateway's High Availability feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ IMPROVEMENTS:
 * Helm
   * Enable the configuring of snapshot intervals in the client snapshot agent via `client.snapshotAgent.interval`. [[GH-1235](https://github.com/hashicorp/consul-k8s/pull/1235)]
   * Enable configuring the pod topologySpreadConstraints for mesh, terminating, and ingress gateways. [[GH-1257](https://github.com/hashicorp/consul-k8s/pull/1257)]
+  * API Gateway: Enable the configuring of new High Availability feature (requires Consul API Gateway v0.3.0+). [[GH-1261](https://github.com/hashicorp/consul-k8s/pull/1261)]
 * Control Plane
   * Bump Dockerfile base image for RedHat UBI `consul-k8s-control-plane` image to `ubi-minimal:8.6`. [[GH-1244](https://github.com/hashicorp/consul-k8s/pull/1244)]
   * Add additional metadata to service instances registered via catalog sync. [[GH-447](https://github.com/hashicorp/consul-k8s/pull/447)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ IMPROVEMENTS:
 * Helm
   * Enable the configuring of snapshot intervals in the client snapshot agent via `client.snapshotAgent.interval`. [[GH-1235](https://github.com/hashicorp/consul-k8s/pull/1235)]
   * Enable configuring the pod topologySpreadConstraints for mesh, terminating, and ingress gateways. [[GH-1257](https://github.com/hashicorp/consul-k8s/pull/1257)]
-  * API Gateway: Enable the configuring of new High Availability feature (requires Consul API Gateway v0.3.0+). [[GH-1261](https://github.com/hashicorp/consul-k8s/pull/1261)]
+  * API Gateway: Enable configuring of the new High Availability feature (requires Consul API Gateway v0.3.0+). [[GH-1261](https://github.com/hashicorp/consul-k8s/pull/1261)]
 * Control Plane
   * Bump Dockerfile base image for RedHat UBI `consul-k8s-control-plane` image to `ubi-minimal:8.6`. [[GH-1244](https://github.com/hashicorp/consul-k8s/pull/1244)]
   * Add additional metadata to service instances registered via catalog sync. [[GH-447](https://github.com/hashicorp/consul-k8s/pull/447)]

--- a/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
+++ b/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
@@ -28,6 +28,12 @@ spec:
     {{- else }}
       http: 8500
     {{- end }}
+  deployment:
+    {{- if .Values.apiGateway.managedGatewayClass.deployment }}
+    defaultInstances: {{ default 1 .Values.apiGateway.managedGatewayClass.deployment.defaultInstances }}
+    maxInstances: {{ default 8 .Values.apiGateway.managedGatewayClass.deployment.maxInstances }}
+    minInstances: {{ default 1 .Values.apiGateway.managedGatewayClass.deployment.minInstances }}
+    {{- end }}
   image:
     consulAPIGateway: {{ .Values.apiGateway.image }}
     envoy: {{ .Values.global.imageEnvoy }}

--- a/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
+++ b/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
@@ -28,9 +28,9 @@ spec:
     {{- else }}
       http: 8500
     {{- end }}
+  {{- if .Values.apiGateway.managedGatewayClass.deployment }}
   deployment:
-    {{- if .Values.apiGateway.managedGatewayClass.deployment }}
-    {{if .Values.apiGateway.managedGatewayClass.deployment.defaultInstances }}
+    {{- if .Values.apiGateway.managedGatewayClass.deployment.defaultInstances }}
     defaultInstances: {{ .Values.apiGateway.managedGatewayClass.deployment.defaultInstances }}
     {{- end }}
     {{- if .Values.apiGateway.managedGatewayClass.deployment.maxInstances }}
@@ -39,7 +39,7 @@ spec:
     {{- if .Values.apiGateway.managedGatewayClass.deployment.minInstances }}
     minInstances: {{ .Values.apiGateway.managedGatewayClass.deployment.minInstances }}
     {{- end }}
-    {{- end }}
+  {{- end }}
   image:
     consulAPIGateway: {{ .Values.apiGateway.image }}
     envoy: {{ .Values.global.imageEnvoy }}

--- a/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
+++ b/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
@@ -28,17 +28,9 @@ spec:
     {{- else }}
       http: 8500
     {{- end }}
-  {{- if .Values.apiGateway.managedGatewayClass.deployment }}
+  {{- with .Values.apiGateway.managedGatewayClass.deployment }}
   deployment:
-    {{- if .Values.apiGateway.managedGatewayClass.deployment.defaultInstances }}
-    defaultInstances: {{ .Values.apiGateway.managedGatewayClass.deployment.defaultInstances }}
-    {{- end }}
-    {{- if .Values.apiGateway.managedGatewayClass.deployment.maxInstances }}
-    maxInstances: {{ .Values.apiGateway.managedGatewayClass.deployment.maxInstances }}
-    {{- end }}
-    {{- if .Values.apiGateway.managedGatewayClass.deployment.minInstances }}
-    minInstances: {{ .Values.apiGateway.managedGatewayClass.deployment.minInstances }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   image:
     consulAPIGateway: {{ .Values.apiGateway.image }}

--- a/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
+++ b/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
@@ -30,9 +30,15 @@ spec:
     {{- end }}
   deployment:
     {{- if .Values.apiGateway.managedGatewayClass.deployment }}
-    defaultInstances: {{ default 1 .Values.apiGateway.managedGatewayClass.deployment.defaultInstances }}
-    maxInstances: {{ default 8 .Values.apiGateway.managedGatewayClass.deployment.maxInstances }}
-    minInstances: {{ default 1 .Values.apiGateway.managedGatewayClass.deployment.minInstances }}
+    {{if .Values.apiGateway.managedGatewayClass.deployment.defaultInstances }}
+    defaultInstances: {{ .Values.apiGateway.managedGatewayClass.deployment.defaultInstances }}
+    {{- end }}
+    {{- if .Values.apiGateway.managedGatewayClass.deployment.maxInstances }}
+    maxInstances: {{ .Values.apiGateway.managedGatewayClass.deployment.maxInstances }}
+    {{- end }}
+    {{- if .Values.apiGateway.managedGatewayClass.deployment.minInstances }}
+    minInstances: {{ .Values.apiGateway.managedGatewayClass.deployment.minInstances }}
+    {{- end }}
     {{- end }}
   image:
     consulAPIGateway: {{ .Values.apiGateway.image }}

--- a/charts/consul/test/unit/api-gateway-gatewayclassconfig.bats
+++ b/charts/consul/test/unit/api-gateway-gatewayclassconfig.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "apiGateway/GatewayClassConfig: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/api-gateway-gatewayclassconfig.yaml \
+      .
+}
+
+@test "apiGateway/GatewayClassConfig: enabled with apiGateway.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-gatewayclassconfig.yaml  \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=foo' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "apiGateway/GatewayClassConfig: deployment config disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-gatewayclassconfig.yaml \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=foo' \
+      . | tee /dev/stderr |
+      yq '.spec | has("deployment") | not' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "apiGateway/GatewayClassConfig: deployment config enabled with defaultInstances=3" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-gatewayclassconfig.yaml \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=foo' \
+      --set 'apiGateway.managedGatewayClass.deployment.defaultInstances=3' \
+      . | tee /dev/stderr |
+      yq '.spec.deployment.defaultInstances == 3' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "apiGateway/GatewayClassConfig: deployment config enabled with maxInstances=3" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-gatewayclassconfig.yaml \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=foo' \
+      --set 'apiGateway.managedGatewayClass.deployment.maxInstances=3' \
+      . | tee /dev/stderr |
+      yq '.spec.deployment.maxInstances == 3' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "apiGateway/GatewayClassConfig: deployment config enabled with minInstances=3" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-gatewayclassconfig.yaml \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=foo' \
+      --set 'apiGateway.managedGatewayClass.deployment.minInstances=3' \
+      . | tee /dev/stderr |
+      yq '.spec.deployment.minInstances == 3' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2708,6 +2708,16 @@ apiGateway:
       # @type: string
       service: null
 
+    # This values defines the number of pods to deploy for each Gateway as well as a min and max number of pods for all Gateways
+    #
+    # Example:
+    # ```yaml
+    # deployment:
+    #   defaultInstances: 3
+    #   minInstances: 1
+    #   maxInstances: 8
+    deployment: null
+
   # Configuration for the ServiceAccount created for the api-gateway component
   serviceAccount:
     # This value defines additional annotations for the client service account. This should be formatted as a multi-line

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2711,11 +2711,15 @@ apiGateway:
     # This values defines the number of pods to deploy for each Gateway as well as a min and max number of pods for all Gateways
     #
     # Example:
+    #
     # ```yaml
     # deployment:
     #   defaultInstances: 3
-    #   minInstances: 1
     #   maxInstances: 8
+    #   minInstances: 1
+    # ```
+    #
+    # @type: map
     deployment: null
 
   # Configuration for the ServiceAccount created for the api-gateway component

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2708,7 +2708,7 @@ apiGateway:
       # @type: string
       service: null
 
-    # This values defines the number of pods to deploy for each Gateway as well as a min and max number of pods for all Gateways
+    # This value defines the number of pods to deploy for each Gateway as well as a min and max number of pods for all Gateways
     #
     # Example:
     #


### PR DESCRIPTION
> **Note**: This will need to be included in a tagged release before consul-api-gateway v0.3.0 becomes available

### Changes proposed in this PR:
- Allow chart consumers to configure Consul API Gateway's new High Availability values on the `GatewayClassConfig`
  - **Please note that this functionality will not be available until the release of Consul API Gateway `0.3.0` in the near future.**

For example:
```yaml
deployment:
  defaultInstances: 3
  maxInstances: 8
  minInstances: 1
```

### How I've tested this PR:
`helm install` with various combinations of deployment config
- Without updating gateway CRDs (`$ kubectl apply --kustomize "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.2.1"`)
  - No `deployment` at all without updating gateway CRDs
    - This matches the situation users will be in after consuming the release with this code change but before consuming Consul API Gateway `0.3.0`
- After updating gateway CRDs (`$ kubectl apply --kustomize "github.com/hashicorp/consul-api-gateway/config/crd?ref=main"`)
  - No `deployment` at all
  - `deployment` with one field at a time
  - `deployment` with all fields set

### How I expect reviewers to test this PR:
See above

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

