### PR TITLE
Add helm value to enable cluster peering

### DIFF
--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.global.peering.enabled (not .Values.connectInject.enabled) }}{{ fail "setting global.peering.enabled to true requires connectInject.enabled to be true" }}{{ end }}
 {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}{{ fail "clients must be enabled for connect injection" }}{{ end }}
 {{- if not .Values.client.grpc }}{{ fail "client.grpc must be true for connect injection" }}{{ end }}

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -111,6 +111,9 @@ spec:
                 {{- else }}
                 -default-enable-transparent-proxy=false \
                 {{- end }}
+                {{- if .Values.global.peering.enabled }}
+                -enable-peering=true \
+                {{- end }}
                 {{- if .Values.global.openshift.enabled }}
                 -enable-openshift \
                 {{- end }}

--- a/charts/consul/templates/crd-exportedservices.yaml
+++ b/charts/consul/templates/crd-exportedservices.yaml
@@ -76,8 +76,8 @@ spec:
                               the service to.
                             type: string
                           peerName:
-                            description: PeerName is the name of the peer to export
-                              the service to.
+                            description: '[Experimental] PeerName is the name of the
+                              peer to export the service to.'
                             type: string
                         type: object
                       type: array

--- a/charts/consul/templates/crd-peeringacceptors.yaml
+++ b/charts/consul/templates/crd-peeringacceptors.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.connectInject.enabled }}
+{{- if and .Values.connectInject.enabled .Values.global.peering.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/consul/templates/crd-peeringdialers.yaml
+++ b/charts/consul/templates/crd-peeringdialers.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.connectInject.enabled }}
+{{- if and .Values.connectInject.enabled .Values.global.peering.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/consul/templates/crd-serviceintentions.yaml
+++ b/charts/consul/templates/crd-serviceintentions.yaml
@@ -102,7 +102,8 @@ spec:
                       description: Partition is the Admin Partition for the Name parameter.
                       type: string
                     peer:
-                      description: Peer is the peer name for the Name parameter.
+                      description: '[Experimental] Peer is the peer name for the Name
+                        parameter.'
                       type: string
                     permissions:
                       description: Permissions is the list of all additional L7 attributes

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -1731,6 +1731,33 @@ EOF
 }
 
 #--------------------------------------------------------------------
+# peering
+
+@test "connectInject/Deployment: peering is not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-peering=true"))' | tee /dev/stderr)
+
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: -enable-peering=true is set when global.peering.enabled is true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.peering.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-peering=true"))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+
+#--------------------------------------------------------------------
 # openshift
 
 @test "connectInject/Deployment: openshift is is not set by default" {

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -1756,6 +1756,16 @@ EOF
   [ "${actual}" = "true" ]
 }
 
+@test "connectInject/Deployment: fails if peering is enabled but connect inject is not" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=false' \
+      --set 'global.peering.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "setting global.peering.enabled to true requires connectInject.enabled to be true" ]]
+}
+
 
 #--------------------------------------------------------------------
 # openshift

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -29,7 +29,7 @@ global:
   # Consul into Kubernetes will have, e.g. `service-name.service.consul`.
   domain: consul
 
-  # Configures the Cluster Peering feature.
+  # [Experimental] Configures the Cluster Peering feature. Requires Consul v1.13+ and Consul-K8s v0.45+.
   peering:
     # If true, the Helm chart will enable Cluster Peering for the cluster. This will enable peering controllers and
     # allow use of the PeeringAcceptor and PeeringDialer CRDs to establish peerings for service mesh.

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -29,6 +29,13 @@ global:
   # Consul into Kubernetes will have, e.g. `service-name.service.consul`.
   domain: consul
 
+  # Configures the Cluster Peering feature.
+  peering:
+    # If true, the Helm chart will enable Cluster Peering for the cluster. This will enable peering controllers and
+    # allow use of the PeeringAcceptor and PeeringDialer CRDs to establish peerings for service mesh.
+    # @type boolean
+    enabled: false
+
   # [Enterprise Only] Enabling `adminPartitions` allows creation of Admin Partitions in Kubernetes clusters.
   # It additionally indicates that you are running Consul Enterprise v1.11+ with a valid Consul Enterprise
   # license. Admin partitions enables deploying services across partitions, while sharing

--- a/control-plane/api/v1alpha1/exportedservices_types.go
+++ b/control-plane/api/v1alpha1/exportedservices_types.go
@@ -68,7 +68,7 @@ type ExportedService struct {
 type ServiceConsumer struct {
 	// Partition is the admin partition to export the service to.
 	Partition string `json:"partition,omitempty"`
-	// PeerName is the name of the peer to export the service to.
+	// [Experimental] PeerName is the name of the peer to export the service to.
 	PeerName string `json:"peerName,omitempty"`
 }
 

--- a/control-plane/api/v1alpha1/serviceintentions_types.go
+++ b/control-plane/api/v1alpha1/serviceintentions_types.go
@@ -78,7 +78,7 @@ type SourceIntention struct {
 	Name string `json:"name,omitempty"`
 	// Namespace is the namespace for the Name parameter.
 	Namespace string `json:"namespace,omitempty"`
-	// Peer is the peer name for the Name parameter.
+	// [Experimental] Peer is the peer name for the Name parameter.
 	Peer string `json:"peer,omitempty"`
 	// Partition is the Admin Partition for the Name parameter.
 	Partition string `json:"partition,omitempty"`

--- a/control-plane/config/crd/bases/consul.hashicorp.com_exportedservices.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_exportedservices.yaml
@@ -69,8 +69,8 @@ spec:
                               the service to.
                             type: string
                           peerName:
-                            description: PeerName is the name of the peer to export
-                              the service to.
+                            description: '[Experimental] PeerName is the name of the
+                              peer to export the service to.'
                             type: string
                         type: object
                       type: array

--- a/control-plane/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
@@ -95,7 +95,8 @@ spec:
                       description: Partition is the Admin Partition for the Name parameter.
                       type: string
                     peer:
-                      description: Peer is the peer name for the Name parameter.
+                      description: '[Experimental] Peer is the peer name for the Name
+                        parameter.'
                       type: string
                     permissions:
                       description: Permissions is the list of all additional L7 attributes


### PR DESCRIPTION
Changes proposed in this PR:
- when global.peering.enabled is true, and connectInject.enabled is true, enable the peering controllers and the peering CRDs. 


How I've tested this PR:
unit tests

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

