### PR TITLE
Allow building arm64 dev docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,10 @@ control-plane-dev: ## Build consul-k8s-control-plane binary.
 	@$(SHELL) $(CURDIR)/control-plane/build-support/scripts/build-local.sh -o $(GOOS) -a $(GOARCH)
 
 control-plane-dev-docker: ## Build consul-k8s-control-plane dev Docker image.
-	@$(SHELL) $(CURDIR)/control-plane/build-support/scripts/build-local.sh -o linux -a amd64
-	@DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build -t '$(DEV_IMAGE)' \
+	@$(SHELL) $(CURDIR)/control-plane/build-support/scripts/build-local.sh -o linux -a $(GOARCH)
+	docker build -t '$(DEV_IMAGE)' \
        --target=dev \
+       --build-arg 'ARCH=$(GOARCH)' \
        --build-arg 'GIT_COMMIT=$(GIT_COMMIT)' \
        --build-arg 'GIT_DIRTY=$(GIT_DIRTY)' \
        --build-arg 'GIT_DESCRIBE=$(GIT_DESCRIBE)' \

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -21,6 +21,7 @@ FROM alpine:3.15 AS dev
 # and the version to download. Example: NAME=consul VERSION=1.2.3.
 ARG BIN_NAME=consul-k8s-control-plane
 ARG VERSION
+ARG ARCH
 
 LABEL name=${BIN_NAME} \
       maintainer="Team Consul Kubernetes <team-consul-kubernetes@hashicorp.com>" \
@@ -40,7 +41,7 @@ RUN apk add --no-cache ca-certificates curl gnupg libcap openssl su-exec iputils
 RUN addgroup ${BIN_NAME} && \
     adduser -S -G ${BIN_NAME} 100
 
-COPY pkg/bin/linux_amd64/${BIN_NAME} /bin
+COPY pkg/bin/linux_${ARCH}/${BIN_NAME} /bin
 
 USER 100
 CMD /bin/${BIN_NAME}

--- a/control-plane/Makefile
+++ b/control-plane/Makefile
@@ -34,6 +34,7 @@ ci.dev-docker:
 	@echo "Building consul-k8s Development container - $(CI_DEV_DOCKER_IMAGE_NAME)"
 	@docker build -t '$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT)' \
 	--target=dev \
+	--build-arg ARCH=amd64 \
 	--label COMMIT_SHA=$(CIRCLE_SHA1) \
 	--label PULL_REQUEST=$(CIRCLE_PULL_REQUEST) \
 	--label CIRCLE_BUILD_URL=$(CIRCLE_BUILD_URL) \


### PR DESCRIPTION
Changes proposed in this PR:

When using kind on an arm64 architecture locally
and installing consul-k8s with tproxy,
the service-mesh init container will fail to apply iptables rules.
This is because kind is running on an arm64 architecture but uses
amd64 docker image for consul-k8s. If we switch to arm64 images instead,
the error goes away.

How I've tested this PR:
built a dev image and deployed to kind running arm64. Then tried to deploy a service with tproxy enabled and saw that iptables are applied correctly

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

