### PR TITLE
Add secret watchers on Peering Acceptor/Dialer Controllers

### DIFF
--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -146,6 +146,10 @@ const (
 	// registered with Consul.
 	labelServiceIgnore = "consul.hashicorp.com/service-ignore"
 
+	// labelPeeringToken is a label that can be added to a secret to allow it to be watched
+	// by the peering controllers.
+	labelPeeringToken = "consul.hashicorp.com/peering-token"
+
 	// injected is used as the annotation value for annotationInjected.
 	injected = "injected"
 

--- a/control-plane/connect-inject/peering_dialer_controller.go
+++ b/control-plane/connect-inject/peering_dialer_controller.go
@@ -14,8 +14,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // PeeringDialerController reconciles a PeeringDialer object.
@@ -231,7 +236,11 @@ func (r *PeeringDialerController) getSecret(ctx context.Context, name string, na
 func (r *PeeringDialerController) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&consulv1alpha1.PeeringDialer{}).
-		Complete(r)
+		Watches(
+			&source.Kind{Type: &corev1.Secret{}},
+			handler.EnqueueRequestsFromMapFunc(r.requestsForPeeringTokens),
+			builder.WithPredicates(predicate.NewPredicateFuncs(r.filterPeeringDialers)),
+		).Complete(r)
 }
 
 // establishPeering is a helper function that calls the Consul api to generate a token for the peer.
@@ -256,4 +265,41 @@ func (r *PeeringDialerController) deletePeering(ctx context.Context, peerName st
 		return err
 	}
 	return nil
+}
+
+// requestsForPeeringTokens creates a slice of requests for the peering dialer controller.
+// It enqueues a request for each dialer that needs to be reconciled. It iterates through
+// the list of dialers and creates a request for the dialer that has the same secret as it's
+// secret and that of the updated secret that is being watched.
+// We compare it to the secret in the spec as the resource is dependent on the secret.
+func (r *PeeringDialerController) requestsForPeeringTokens(object client.Object) []reconcile.Request {
+	r.Log.Info("received update for Peering Token Secret", "name", object.GetName(), "namespace", object.GetNamespace())
+
+	// Get the list of all dialers.
+	var dialerList consulv1alpha1.PeeringDialerList
+	if err := r.Client.List(r.Context, &dialerList); err != nil {
+		r.Log.Error(err, "failed to list PeeringDialers")
+		return []ctrl.Request{}
+	}
+	for _, dialer := range dialerList.Items {
+		if dialer.Secret().Backend == "kubernetes" {
+			if dialer.Secret().Name == object.GetName() && dialer.Namespace == object.GetNamespace() {
+				return []ctrl.Request{{NamespacedName: types.NamespacedName{Namespace: dialer.Namespace, Name: dialer.Name}}}
+			}
+		}
+	}
+	return []ctrl.Request{}
+}
+
+// filterPeeringAcceptors receives meta and object information for Kubernetes resources that are being watched,
+// which in this case are Secrets. It only returns true if the Secret is a Peering Token Secret. It reads the labels
+// from the meta of the resource and uses the values of the "consul.hashicorp.com/peering-token" label to validate that
+// the Secret is a Peering Token Secret.
+func (r *PeeringDialerController) filterPeeringDialers(object client.Object) bool {
+	secretLabels := object.GetLabels()
+	isPeeringToken, ok := secretLabels[labelPeeringToken]
+	if !ok {
+		return false
+	}
+	return isPeeringToken == "true"
 }


### PR DESCRIPTION
Changes proposed in this PR:
- Add watches to both the Peering Acceptor and Dialer controller. These watch secrets with a specific label and reconcile the associated acceptor/dialer when the secret that matches their status/spec secret is updated. Additionally, when the acceptor creates the token secret, it now adds that label to the created secret.

How I've tested this PR:
- Unit tests.
- Created a peering acceptor and dialer in different clusters. After the secret was created and copied over, deleted the contents of the secret in the secret on the acceptor side. This generated a new token. Copied this secret over again and observed the reconcile happen on the dialer end as well.

How I expect reviewers to test this PR:
- 👀 
- attempt to perform the above as well.

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

