### PR TITLE
Revert "Add changelog for cluster peering (#1279)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,5 @@
 ## UNRELEASED
 
-FEATURES:
-* [Experimental] Cluster Peering: Support Consul cluster peering, which allows service connectivity between two independent clusters.
-  [[GH-1273](https://github.com/hashicorp/consul-k8s/pull/1273)]
-
-  Enabling peering will deploy the peering controllers and PeeringAcceptor and PeeringDialer CRDs. The new CRDs are used
-  to establish a peering connection between two clusters.
-
-  See the [Cluster Peering on Kubernetes](https://www.consul.io/docs/connect/cluster-peering/k8s)
-  for full instructions.
-
-  Requirements:
-  * Consul 1.13+
-  * `global.peering.enabled=true` and `connectInject.enabled=true` must be set to enable peering.
-  * Mesh gateways are required for service to service communication across peers, i.e `meshGateway.enabled=true`.
-
 IMPROVEMENTS:
 * Helm
   * Enable the configuring of snapshot intervals in the client snapshot agent via `client.snapshotAgent.interval`. [[GH-1235](https://github.com/hashicorp/consul-k8s/pull/1235)]


### PR DESCRIPTION
This reverts commit 136d3126e01658a032efe6c7d7accd037920cc21.

Changes proposed in this PR:
-
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

