### PR TITLE
[WIP] Modified IGW to allow duplicate names across consul namespaces.  

### DIFF
--- a/acceptance/tests/ingress-gateway/ingress_gateway_namespaces_test.go
+++ b/acceptance/tests/ingress-gateway/ingress_gateway_namespaces_test.go
@@ -103,7 +103,7 @@ func TestIngressGatewaySingleNamespace(t *testing.T) {
 			logger.Log(t, "creating config entry")
 			created, _, err := consulClient.ConfigEntries().Set(&api.IngressGatewayConfigEntry{
 				Kind:      api.IngressGateway,
-				Name:      igName,
+				Name:      fmt.Sprintf("%s-%s", igName, testNamespace),
 				Namespace: testNamespace,
 				Listeners: []api.IngressListener{
 					{
@@ -121,7 +121,7 @@ func TestIngressGatewaySingleNamespace(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, true, created, "config entry failed")
 
-			ingressGatewayService := fmt.Sprintf("http://%s-consul-%s.%s:8080/", releaseName, igName, ctx.KubectlOptions(t).Namespace)
+			ingressGatewayService := fmt.Sprintf("http://%s-consul-%s.%s:8080/", releaseName, fmt.Sprintf("%s-%s", igName, testNamespace), ctx.KubectlOptions(t).Namespace)
 
 			// If ACLs are enabled, test that intentions prevent connections.
 			if c.secure {
@@ -139,7 +139,7 @@ func TestIngressGatewaySingleNamespace(t *testing.T) {
 					Namespace: testNamespace,
 					Sources: []*api.SourceIntention{
 						{
-							Name:      igName,
+							Name:      fmt.Sprintf("%s-%s", igName, testNamespace),
 							Namespace: testNamespace,
 							Action:    api.IntentionActionAllow,
 						},

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -299,3 +299,9 @@ Usage: {{ template "consul.validateVaultWebhookCertConfiguration" . }}
 {{ end }}
 {{ end }}
 {{- end -}}
+
+
+
+{{- define "consul.maybeAppendGatewayNamespace" -}}
+{{- if .consulNamespace -}}{{- printf "-%s" .consulNamespace -}}{{- end -}}
+{{- end -}}

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -7,14 +7,13 @@
 
 {{- $root := . }}
 {{- $defaults := .Values.ingressGateways.defaults }}
-{{- $names := dict }}
 
 {{- /* Check if gateway names are unique. */ -}}
 {{- $gateways := .Values.ingressGateways.gateways }}
 {{- range $outerIngressIndex, $outerIngressVal := $gateways }}
 
 {{- range $innerIngressIndex, $innerIngressVal := $gateways }}
-{{- if (and (ne $outerIngressIndex $innerIngressIndex) (eq $outerIngressVal.name $innerIngressVal.name)) }}
+{{- if (and (ne $outerIngressIndex $innerIngressIndex) (eq $outerIngressVal.name $innerIngressVal.name) (eq $outerIngressVal.consulNamespace $innerIngressVal.consulNamespace)) }}
 {{ fail (cat "ingress gateways must have unique names but found duplicate name" $innerIngressVal.name) }}
 {{ end -}}
 {{ end -}}
@@ -28,16 +27,10 @@
 # Check that the gateway name is provided
 {{ fail "Ingress gateway names cannot be empty"}}
 {{ end -}}
-{{- if hasKey $names .name }}
-#  Check that the gateway name is unique
-{{ fail "Ingress gateway names must be unique"}}
-{{ end -}}
-{{- /* Add the gateway name to the $names dict to ensure uniqueness */ -}}
-{{- $_ := set $names .name .name }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "consul.fullname" $root }}-{{ .name }}
+  name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
@@ -45,7 +38,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: ingress-gateway
-    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
 spec:
   replicas: {{ default $defaults.replicas .replicas }}
   selector:
@@ -55,7 +48,7 @@ spec:
       heritage: {{ $root.Release.Service }}
       release: {{ $root.Release.Name }}
       component: ingress-gateway
-      ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+      ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
   template:
     metadata:
       labels:
@@ -64,7 +57,7 @@ spec:
         heritage: {{ $root.Release.Service }}
         release: {{ $root.Release.Name }}
         component: ingress-gateway
-        ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+        ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
       annotations:
         {{- if (and $root.Values.global.secretsBackend.vault.enabled $root.Values.global.tls.enabled) }}
         "vault.hashicorp.com/agent-init-first": "true"
@@ -107,7 +100,7 @@ spec:
         {{ tpl (default $defaults.topologySpreadConstraints .topologySpreadConstraints) $root | nindent 8 | trim }}
       {{- end }}
       terminationGracePeriodSeconds: {{ default $defaults.terminationGracePeriodSeconds .terminationGracePeriodSeconds }}
-      serviceAccountName: {{ template "consul.fullname" $root }}-{{ .name }}
+      serviceAccountName: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
       volumes:
         - name: consul-bin
           emptyDir: {}
@@ -186,7 +179,7 @@ spec:
             - |
                 {{- if $root.Values.global.acls.manageSystemACLs }}
                 consul-k8s-control-plane acl-init \
-                  -component-name=ingress-gateway/{{ template "consul.fullname" $root }}-{{ .name }} \
+                  -component-name=ingress-gateway/{{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }} \
                   -acl-auth-method={{ template "consul.fullname" $root }}-k8s-component-auth-method \
                   {{- if $root.Values.global.adminPartitions.enabled }}
                   -partition={{ $root.Values.global.adminPartitions.name }} \
@@ -205,7 +198,7 @@ spec:
                   -log-level={{ $root.Values.global.logLevel }} \
                   -log-json={{ $root.Values.global.logJSON }} \
                   -k8s-namespace={{ $root.Release.Namespace }} \
-                  -name={{ template "consul.fullname" $root }}-{{ .name }} \
+                  -name={{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }} \
                   -output-file=/tmp/address.txt
                 WAN_ADDR="$(cat /tmp/address.txt)"
                 {{- else }}
@@ -248,7 +241,7 @@ spec:
                 cat > /consul/service/service.hcl << EOF
                 service {
                   kind = "ingress-gateway"
-                  name = "{{ .name }}"
+                  name = "{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}"
                   id = "${POD_NAME}"
                   {{- if $root.Values.global.enableConsulNamespaces }}
                   namespace = "{{ (default $defaults.consulNamespace .consulNamespace) }}"

--- a/charts/consul/templates/ingress-gateways-podsecuritypolicy.yaml
+++ b/charts/consul/templates/ingress-gateways-podsecuritypolicy.yaml
@@ -4,7 +4,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "consul.fullname" $root }}-{{ .name }}
+  name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
@@ -12,7 +12,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: ingress-gateway
-    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
 spec:
   privileged: false
   # Required to prevent escalations to root.

--- a/charts/consul/templates/ingress-gateways-role.yaml
+++ b/charts/consul/templates/ingress-gateways-role.yaml
@@ -7,7 +7,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "consul.fullname" $root }}-{{ .name }}
+  name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
@@ -15,20 +15,20 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: ingress-gateway
-    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
 rules:
   - apiGroups: [""]
     resources:
       - services
     resourceNames:
-      - {{ template "consul.fullname" $root }}-{{ .name }}
+      - {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
     verbs:
       - get
 {{- if $root.Values.global.enablePodSecurityPolicies }}
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
     resourceNames:
-      - {{ template "consul.fullname" $root }}-{{ .name }}
+      - {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
     verbs:
       - use
 {{- end }}
@@ -37,7 +37,7 @@ rules:
     resources:
       - secrets
     resourceNames:
-      - {{ template "consul.fullname" $root }}-{{ .name }}-acl-token
+      - {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}-acl-token
     verbs:
       - get
 {{- end }}

--- a/charts/consul/templates/ingress-gateways-rolebinding.yaml
+++ b/charts/consul/templates/ingress-gateways-rolebinding.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "consul.fullname" $root }}-{{ .name }}
+  name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
@@ -12,14 +12,14 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: ingress-gateway
-    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "consul.fullname" $root }}-{{ .name }}
+  name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "consul.fullname" $root }}-{{ .name }}
+    name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/ingress-gateways-service.yaml
+++ b/charts/consul/templates/ingress-gateways-service.yaml
@@ -9,7 +9,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "consul.fullname" $root }}-{{ .name }}
+  name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
@@ -17,7 +17,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: ingress-gateway
-    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
   {{- if (or $defaults.service.annotations $service.annotations) }}
   # We allow both default annotations and gateway-specific annotations
   annotations:
@@ -33,7 +33,7 @@ spec:
     app: {{ template "consul.name" $root }}
     release: "{{ $root.Release.Name }}"
     component: ingress-gateway
-    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
   ports:
     {{- range $index, $ports := (default $defaults.service.ports $service.ports) }}
     - name: gateway-{{ $index }}

--- a/charts/consul/templates/ingress-gateways-serviceaccount.yaml
+++ b/charts/consul/templates/ingress-gateways-serviceaccount.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "consul.fullname" $root }}-{{ .name }}
+  name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
   namespace: {{ $root.Release.Namespace }}
   labels:
     app: {{ template "consul.name" $root }}
@@ -14,7 +14,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
     release: {{ $root.Release.Name }}
     component: ingress-gateway
-    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+    ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}
   {{- if (or $defaults.serviceAccount.annotations $serviceAccount.annotations) }}
   annotations:
     {{- if $defaults.serviceAccount.annotations }}

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -209,14 +209,14 @@ spec:
                 {{- $root := . }}
                 {{- range .Values.ingressGateways.gateways }}
                 {{- if (or $root.Values.ingressGateways.defaults.consulNamespace .consulNamespace) }}
-                -ingress-gateway-name="{{ .name }}.{{ (default $root.Values.ingressGateways.defaults.consulNamespace .consulNamespace) }}" \
+                -ingress-gateway-name="{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}.{{ (default $root.Values.ingressGateways.defaults.consulNamespace .consulNamespace) }}" \
                 {{- else }}
-                -ingress-gateway-name="{{ .name }}" \
+                -ingress-gateway-name="{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}" \
                 {{- end }}
                 {{- end }}
                 {{- else }}
                 {{- range .Values.ingressGateways.gateways }}
-                -ingress-gateway-name="{{ .name }}" \
+                -ingress-gateway-name="{{ .name }}{{ template "consul.maybeAppendGatewayNamespace" . }}" \
                 {{- end }}
                 {{- end }}
                 {{- end }}


### PR DESCRIPTION
*NOTE: Still need to modify consul.maybeAppendGatewayNamespace helper template to work when defaultNamespace is defined.*

Changes proposed in this PR:
- Modified IGW to allow duplicate names across consul namespaces.  

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

