### PR TITLE
Updating retry from 10 to 60 seconds for cloud clean up because of AKS failure.

### DIFF
--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -201,9 +201,9 @@ func (h *HelmCluster) Destroy(t *testing.T) {
 			}
 		}
 	}
-	// Retry a few times because sometimes certain resources (like PVC) take time to delete
+	// Retry because sometimes certain resources (like PVC) take time to delete
 	// in cloud providers.
-	retry.RunWith(&retry.Counter{Wait: 1 * time.Second, Count: 10}, t, func(r *retry.R) {
+	retry.RunWith(&retry.Counter{Wait: 1 * time.Second, Count: 60}, t, func(r *retry.R) {
 		// Verify all Consul Pods are deleted.
 		pods, err = h.kubernetesClient.CoreV1().Pods(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "release=" + h.releaseName})
 		require.NoError(r, err)

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -203,7 +203,7 @@ func (h *HelmCluster) Destroy(t *testing.T) {
 	}
 	// Retry because sometimes certain resources (like PVC) take time to delete
 	// in cloud providers.
-	retry.RunWith(&retry.Counter{Wait: 1 * time.Second, Count: 60}, t, func(r *retry.R) {
+	retry.RunWith(&retry.Counter{Wait: 1 * time.Second, Count: 600}, t, func(r *retry.R) {
 		// Verify all Consul Pods are deleted.
 		pods, err = h.kubernetesClient.CoreV1().Pods(h.helmOptions.KubectlOptions.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "release=" + h.releaseName})
 		require.NoError(r, err)


### PR DESCRIPTION
Changes proposed in this PR:
- Updating retry from 10 to 60 seconds for cloud clean up because of AKS failure.

If this does not solve things, we might even consider just doing like 5, 10, or 15 minutes since we are just trying to clean up and if its not ready, having a low number is not helpful when your signal gets corrupted with noise.

How I've tested this PR:
👀 
How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

