### PR TITLE
use anchor link alias for TOC

### DIFF
--- a/hack/helm-reference-gen/fixtures/full-values.golden
+++ b/hack/helm-reference-gen/fixtures/full-values.golden
@@ -2,23 +2,23 @@
 
 Use these links to navigate to a particular top-level stanza.
 
-- [`global`](#global)
-- [`server`](#server)
-- [`externalServers`](#externalservers)
-- [`client`](#client)
-- [`dns`](#dns)
-- [`ui`](#ui)
-- [`syncCatalog`](#synccatalog)
-- [`connectInject`](#connectinject)
-- [`controller`](#controller)
-- [`meshGateway`](#meshgateway)
-- [`ingressGateways`](#ingressgateways)
-- [`terminatingGateways`](#terminatinggateways)
-- [`tests`](#tests)
+- [`global`](#h-global)
+- [`server`](#h-server)
+- [`externalServers`](#h-externalservers)
+- [`client`](#h-client)
+- [`dns`](#h-dns)
+- [`ui`](#h-ui)
+- [`syncCatalog`](#h-synccatalog)
+- [`connectInject`](#h-connectinject)
+- [`controller`](#h-controller)
+- [`meshGateway`](#h-meshgateway)
+- [`ingressGateways`](#h-ingressgateways)
+- [`terminatingGateways`](#h-terminatinggateways)
+- [`tests`](#h-tests)
 
 ## All Values
 
-### global
+### global ((#h-global))
 
 - `global` ((#v-global)) - Holds values that affect multiple components of the chart.
 
@@ -245,7 +245,7 @@ Use these links to navigate to a particular top-level stanza.
     - `enabled` ((#v-global-openshift-enabled)) (`boolean: false`) - If true, the Helm chart will create necessary configuration for running
       its components on OpenShift.
 
-### server
+### server ((#h-server))
 
 - `server` ((#v-server)) - Server, when enabled, configures a server cluster to run. This should
   be disabled if you plan on connecting to a Consul cluster external to
@@ -459,7 +459,7 @@ Use these links to navigate to a particular top-level stanza.
     feature, in case kubernetes cluster is behind egress http proxies. Additionally,
     it could be used to configure custom consul parameters.
 
-### externalServers
+### externalServers ((#h-externalservers))
 
 - `externalServers` ((#v-externalservers)) - Configuration for Consul servers when the servers are running outside of Kubernetes.
   When running external servers, configuring these values is recommended
@@ -503,7 +503,7 @@ Use these links to navigate to a particular top-level stanza.
       -o jsonpath="{.clusters[?(@.name=='<your cluster name>')].cluster.server}"
     ```
 
-### client
+### client ((#h-client))
 
 - `client` ((#v-client)) - Values that configure running a Consul client on Kubernetes nodes.
 
@@ -712,7 +712,7 @@ Use these links to navigate to a particular top-level stanza.
         ...
       ```
 
-### dns
+### dns ((#h-dns))
 
 - `dns` ((#v-dns)) - Configuration for DNS configuration within the Kubernetes cluster.
   This creates a service that routes to all agents (client or server)
@@ -739,7 +739,7 @@ Use these links to navigate to a particular top-level stanza.
     This should be a multi-line string mapping directly to a Kubernetes
     ServiceSpec object.
 
-### ui
+### ui ((#h-ui))
 
 - `ui` ((#v-ui)) - Values that configure the Consul UI.
 
@@ -773,7 +773,7 @@ Use these links to navigate to a particular top-level stanza.
       This should be a multi-line string mapping directly to a Kubernetes
       ServiceSpec object.
 
-### syncCatalog
+### syncCatalog ((#h-synccatalog))
 
 - `syncCatalog` ((#v-synccatalog)) - syncCatalog will run the catalog sync process to sync K8S with Consul
   services. This can run bidirectional (default) or unidirectionally (Consul
@@ -938,7 +938,7 @@ Use these links to navigate to a particular top-level stanza.
 
   - `consulWriteInterval` ((#v-synccatalog-consulwriteinterval)) (`string: null`) - Override the default interval to perform syncing operations creating Consul services.
 
-### connectInject
+### connectInject ((#h-connectinject))
 
 - `connectInject` ((#v-connectinject)) - ConnectInject will enable the automatic Connect sidecar injector.
 
@@ -1170,7 +1170,7 @@ Use these links to navigate to a particular top-level stanza.
 
         - `cpu` ((#v-connectinject-initcontainer-resources-limits-cpu)) (`string: 50m`)
 
-### controller
+### controller ((#h-controller))
 
 - `controller` ((#v-controller)) - Controller handles config entry custom resources.
   Requires consul >= 1.8.4.
@@ -1205,7 +1205,7 @@ Use these links to navigate to a particular top-level stanza.
 
   - `priorityClassName` ((#v-controller-priorityclassname)) (`string: ""`) - Optional priorityClassName.
 
-### meshGateway
+### meshGateway ((#h-meshgateway))
 
 - `meshGateway` ((#v-meshgateway)) - Mesh Gateways enable Consul Connect to work across Consul datacenters.
 
@@ -1354,7 +1354,7 @@ Use these links to navigate to a particular top-level stanza.
         "annotation-key": "annotation-value"
     ```
 
-### ingressGateways
+### ingressGateways ((#h-ingressgateways))
 
 - `ingressGateways` ((#v-ingressgateways)) - Configuration options for ingress gateways. Default values for all
   ingress gateways are defined in `ingressGateways.defaults`. Any of
@@ -1460,7 +1460,7 @@ Use these links to navigate to a particular top-level stanza.
 
     - `name` ((#v-ingressgateways-gateways-name)) (`string: ingress-gateway`)
 
-### terminatingGateways
+### terminatingGateways ((#h-terminatinggateways))
 
 - `terminatingGateways` ((#v-terminatinggateways)) - Configuration options for terminating gateways. Default values for all
   terminating gateways are defined in `terminatingGateways.defaults`. Any of
@@ -1555,7 +1555,7 @@ Use these links to navigate to a particular top-level stanza.
 
     - `name` ((#v-terminatinggateways-gateways-name)) (`string: terminating-gateway`)
 
-### tests
+### tests ((#h-tests))
 
 - `tests` ((#v-tests)) - Control whether a test Pod manifest is generated when running helm template.
   When using helm install, the test Pod is not submitted to the cluster so this

--- a/hack/helm-reference-gen/main.go
+++ b/hack/helm-reference-gen/main.go
@@ -407,7 +407,7 @@ func generateTOC(node DocNode) string {
 	toc := tocPrefix
 
 	for _, c := range node.Children {
-		toc += fmt.Sprintf("- [`%s`](#%s)\n", c.Key, strings.ToLower(c.Key))
+		toc += fmt.Sprintf("- [`%s`](#h-%s)\n", c.Key, strings.ToLower(c.Key))
 	}
 
 	return toc + tocSuffix

--- a/hack/helm-reference-gen/main.go
+++ b/hack/helm-reference-gen/main.go
@@ -54,13 +54,17 @@ var (
 	// And will not match the "# yaml comment" incorrectly.
 	commentPrefix = regexp.MustCompile(`(?m)^[^\S\n]*#[^\S\n]?`)
 
+	funcMap = template.FuncMap{
+		"ToLower": strings.ToLower,
+	}
+
 	// docNodeTmpl is the go template used to print a DocNode node.
 	// We use $ instead of ` in the template so we can use the golang raw string
 	// format. We then do the replace from $ => `.
 	docNodeTmpl = template.Must(
-		template.New("").Parse(
+		template.New("").Funcs(funcMap).Parse(
 			strings.Replace(
-				`{{- if eq .Column 1 }}### {{ .Key }}
+				`{{- if eq .Column 1 }}### {{ .Key }} ((#h-{{ .Key | ToLower }}))
 
 {{ end }}{{ .LeadingIndent }}- ${{ .Key }}$ ((#v{{ .HTMLAnchor }})){{ if ne .FormattedKind "" }} (${{ .FormattedKind }}{{ if .FormattedDefault }}: {{ .FormattedDefault }}{{ end }}$){{ end }}{{ if .FormattedDocumentation}} - {{ .FormattedDocumentation }}{{ end }}`,
 				"$", "`", -1)),

--- a/hack/helm-reference-gen/main_test.go
+++ b/hack/helm-reference-gen/main_test.go
@@ -20,11 +20,11 @@ func Test(t *testing.T) {
 # Line 1
 # Line 2
 key: value`,
-			Exp: `- [$key$](#key)
+			Exp: `- [$key$](#h-key)
 
 ## All Values
 
-### key
+### key ((#h-key))
 
 - $key$ ((#v-key)) ($string: value$) - Line 1\n  Line 2
 `,
@@ -34,11 +34,11 @@ key: value`,
 # Line 1
 # Line 2
 replicas: 3`,
-			Exp: `- [$replicas$](#replicas)
+			Exp: `- [$replicas$](#h-replicas)
 
 ## All Values
 
-### replicas
+### replicas ((#h-replicas))
 
 - $replicas$ ((#v-replicas)) ($integer: 3$) - Line 1\n  Line 2
 `,
@@ -48,11 +48,11 @@ replicas: 3`,
 # Line 1
 # Line 2
 enabled: true`,
-			Exp: `- [$enabled$](#enabled)
+			Exp: `- [$enabled$](#h-enabled)
 
 ## All Values
 
-### enabled
+### enabled ((#h-enabled))
 
 - $enabled$ ((#v-enabled)) ($boolean: true$) - Line 1\n  Line 2
 `,
@@ -65,11 +65,11 @@ map:
   # Key line 1
   # Key line 2
   key: value`,
-			Exp: `- [$map$](#map)
+			Exp: `- [$map$](#h-map)
 
 ## All Values
 
-### map
+### map ((#h-map))
 
 - $map$ ((#v-map)) - Map line 1\n  Map line 2
 
@@ -88,11 +88,11 @@ map:
   int: 1
   # Bool docs
   bool: true`,
-			Exp: `- [$map$](#map)
+			Exp: `- [$map$](#h-map)
 
 ## All Values
 
-### map
+### map ((#h-map))
 
 - $map$ ((#v-map)) - Map line 1\n  Map line 2
 
@@ -109,11 +109,11 @@ map:
 # key docs
 # @type: string
 key: null`,
-			Exp: `- [$key$](#key)
+			Exp: `- [$key$](#h-key)
 
 ## All Values
 
-### key
+### key ((#h-key))
 
 - $key$ ((#v-key)) ($string: null$) - key docs
 `,
@@ -124,11 +124,11 @@ key: null`,
 #
 # line 2
 key: value`,
-			Exp: `- [$key$](#key)
+			Exp: `- [$key$](#h-key)
 
 ## All Values
 
-### key
+### key ((#h-key))
 
 - $key$ ((#v-key)) ($string: value$) - line 1\n\n  line 2
 `,
@@ -139,11 +139,11 @@ key: value`,
 # @type: array<string>
 serverAdditionalDNSSANs: []
 `,
-			Exp: `- [$serverAdditionalDNSSANs$](#serveradditionaldnssans)
+			Exp: `- [$serverAdditionalDNSSANs$](#h-serveradditionaldnssans)
 
 ## All Values
 
-### serverAdditionalDNSSANs
+### serverAdditionalDNSSANs ((#h-serveradditionaldnssans))
 
 - $serverAdditionalDNSSANs$ ((#v-serveradditionaldnssans)) ($array<string>: []$) - line 1
 `,
@@ -157,11 +157,11 @@ gossipEncryption:
   # secretKey
   secretKey: ""
 `,
-			Exp: `- [$gossipEncryption$](#gossipencryption)
+			Exp: `- [$gossipEncryption$](#h-gossipencryption)
 
 ## All Values
 
-### gossipEncryption
+### gossipEncryption ((#h-gossipencryption))
 
 - $gossipEncryption$ ((#v-gossipencryption)) - gossipEncryption
 
@@ -178,11 +178,11 @@ bootstrapToken:
   # @type: string
   secretKey: null
 `,
-			Exp: `- [$bootstrapToken$](#bootstraptoken)
+			Exp: `- [$bootstrapToken$](#h-bootstraptoken)
 
 ## All Values
 
-### bootstrapToken
+### bootstrapToken ((#h-bootstraptoken))
 
 - $bootstrapToken$ ((#v-bootstraptoken))
 
@@ -217,11 +217,11 @@ lifecycleSidecarContainer:
       memory: "50Mi"
       cpu: "20m"
 `,
-			Exp: `- [$lifecycleSidecarContainer$](#lifecyclesidecarcontainer)
+			Exp: `- [$lifecycleSidecarContainer$](#h-lifecyclesidecarcontainer)
 
 ## All Values
 
-### lifecycleSidecarContainer
+### lifecycleSidecarContainer ((#h-lifecyclesidecarcontainer))
 
 - $lifecycleSidecarContainer$ ((#v-lifecyclesidecarcontainer)) - lifecycle
 
@@ -263,11 +263,11 @@ server:
   # @type: boolean
   enabled: "-"
 `,
-			Exp: `- [$server$](#server)
+			Exp: `- [$server$](#h-server)
 
 ## All Values
 
-### server
+### server ((#h-server))
 
 - $server$ ((#v-server))
 
@@ -281,11 +281,11 @@ server:
 extraConfig: |
   {}
 `,
-			Exp: `- [$extraConfig$](#extraconfig)
+			Exp: `- [$extraConfig$](#h-extraconfig)
 
 ## All Values
 
-### extraConfig
+### extraConfig ((#h-extraconfig))
 
 - $extraConfig$ ((#v-extraconfig)) ($string: {}$)
 `,
@@ -303,11 +303,11 @@ affinity: |
             component: server
         topologyKey: kubernetes.io/hostname
 `,
-			Exp: `- [$affinity$](#affinity)
+			Exp: `- [$affinity$](#h-affinity)
 
 ## All Values
 
-### affinity
+### affinity ((#h-affinity))
 
 - $affinity$ ((#v-affinity)) ($string$) - Affinity Settings
 `,
@@ -316,11 +316,11 @@ affinity: |
 			Input: `---
 # @type: array<string>
 k8sAllowNamespaces: ["*"]`,
-			Exp: `- [$k8sAllowNamespaces$](#k8sallownamespaces)
+			Exp: `- [$k8sAllowNamespaces$](#h-k8sallownamespaces)
 
 ## All Values
 
-### k8sAllowNamespaces
+### k8sAllowNamespaces ((#h-k8sallownamespaces))
 
 - $k8sAllowNamespaces$ ((#v-k8sallownamespaces)) ($array<string>: ["*"]$)
 `,
@@ -329,11 +329,11 @@ k8sAllowNamespaces: ["*"]`,
 			Input: `---
 # @type: array<string>
 k8sDenyNamespaces: ["kube-system", "kube-public"]`,
-			Exp: `- [$k8sDenyNamespaces$](#k8sdenynamespaces)
+			Exp: `- [$k8sDenyNamespaces$](#h-k8sdenynamespaces)
 
 ## All Values
 
-### k8sDenyNamespaces
+### k8sDenyNamespaces ((#h-k8sdenynamespaces))
 
 - $k8sDenyNamespaces$ ((#v-k8sdenynamespaces)) ($array<string>: ["kube-system", "kube-public"]$)
 `,
@@ -343,11 +343,11 @@ k8sDenyNamespaces: ["kube-system", "kube-public"]`,
 # @type: array<map>
 gateways:
   - name: ingress-gateway`,
-			Exp: `- [$gateways$](#gateways)
+			Exp: `- [$gateways$](#h-gateways)
 
 ## All Values
 
-### gateways
+### gateways ((#h-gateways))
 
 - $gateways$ ((#v-gateways)) ($array<map>$)
 
@@ -360,11 +360,11 @@ gateways:
 # line 2
 key: value
 `,
-			Exp: `- [$key$](#key)
+			Exp: `- [$key$](#h-key)
 
 ## All Values
 
-### key
+### key ((#h-key))
 
 - $key$ ((#v-key)) ($string: value$) - <EnterpriseAlert inline /> line 1\n  line 2
 `,
@@ -381,11 +381,11 @@ key: value
 # $$$
 key: value
 `,
-			Exp: `- [$key$](#key)
+			Exp: `- [$key$](#h-key)
 
 ## All Values
 
-### key
+### key ((#h-key))
 
 - $key$ ((#v-key)) ($string: value$) - Examples:
 
@@ -403,11 +403,11 @@ key: value
 # @type: override-2
 key: value
 `,
-			Exp: `- [$key$](#key)
+			Exp: `- [$key$](#h-key)
 
 ## All Values
 
-### key
+### key ((#h-key))
 
 - $key$ ((#v-key)) ($override-2: value$)
 `,
@@ -424,16 +424,16 @@ ports:
 - port: 8443
   nodePort: null
 `,
-			Exp: `- [$key$](#key)
-- [$ports$](#ports)
+			Exp: `- [$key$](#h-key)
+- [$ports$](#h-ports)
 
 ## All Values
 
-### key
+### key ((#h-key))
 
 - $key$ ((#v-key)) ($string: value$)
 
-### ports
+### ports ((#h-ports))
 
 - $ports$ ((#v-ports)) ($array<map>$) - port docs
 `,
@@ -443,11 +443,11 @@ ports:
 # @type: map
 key: null
 `,
-			Exp: `- [$key$](#key)
+			Exp: `- [$key$](#h-key)
 
 ## All Values
 
-### key
+### key ((#h-key))
 
 - $key$ ((#v-key)) ($map$)
 `,
@@ -457,11 +457,11 @@ key: null
 key:
   foo: bar
 `,
-			Exp: `- [$key$](#key)
+			Exp: `- [$key$](#h-key)
 
 ## All Values
 
-### key
+### key ((#h-key))
 
 - $key$ ((#v-key))
 


### PR DESCRIPTION
Changes proposed in this PR:
- Uses anchor link alias for table of contents.
- Used to generate latest helm docs, see https://github.com/hashicorp/consul/pull/13527 for additional details.

How I've tested this PR:
👀 
How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

