### PR TITLE
charts: add ReferenceGrant permissions to Consul API Gateway ClusterRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ FEATURES:
 IMPROVEMENTS:
 * Helm
   * Bump default Envoy version to 1.23.0. [[GH-1377](https://github.com/hashicorp/consul-k8s/pull/1377)]
+  * Added support for Consul API Gateway to read ReferenceGrant custom resources. This will require either installing Consul API Gateway CRDs from the upcoming v0.4.0 release with `kubectl apply --kustomize "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.4.0"` or manually installing the ReferenceGrant CRD from the Gateway API v0.5 [Experimental Channel](https://gateway-api.sigs.k8s.io/concepts/versioning/#release-channels-eg-experimental-standard) when setting `apiGateway.enabled=true` [[GH-1299](https://github.com/hashicorp/consul-k8s/pull/1299)]
 
 ## 0.46.1 (July 26, 2022)
 

--- a/charts/consul/templates/api-gateway-controller-clusterrole.yaml
+++ b/charts/consul/templates/api-gateway-controller-clusterrole.yaml
@@ -117,6 +117,14 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - referencegrants
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
   - referencepolicies
   verbs:
   - get


### PR DESCRIPTION
### Changes proposed in this PR:
- Add ReferenceGrant permissions to Consul API Gateway ClusterRole, refs https://github.com/kubernetes-sigs/gateway-api/pull/1188
- Doesn't remove ReferencePolicy yet, as we want to allow backwards compatibility until the Gateway API v0.6.0 release, refs https://github.com/kubernetes-sigs/gateway-api/pull/1205
- Refs #1148 

### How I've tested this PR:
- Deployed Consul API Gateway from Helm chart from this branch and ran Gateway API conformance tests.
```
[INFO]  k8s/logger.go:30: consul-api-gateway-server.controller-runtime: Starting EventSource: controller=tcproute controllerGroup=gateway.networking.k8s.io controllerKind=TCPRoute info="Starting EventSource" source="kind source: *v1alpha2.ReferenceGrant"
```

### How I expect reviewers to test this PR:
- Consul API Gateway is able to deploy successfully from this branch using the Helm chart, with the changes in https://github.com/hashicorp/consul-api-gateway/pull/224 to watch ReferenceGrant objects. Without this change, the Gateway controller falls into a crash loop with the following error:
```
[ERROR] k8s/logger.go:35: consul-api-gateway-server.kubernetes-client: pkg/mod/k8s.io/client-go@v0.24.1/tools/cache/reflector.go:167: Failed to watch *v1alpha2.ReferenceGrant: failed to list *v1alpha2.ReferenceGrant: referencegrants.gateway.networking.k8s.io is forbidden: User "system:serviceaccount:consul:consul-consul-api-gateway-controller" cannot list resource "referencegrants" in API group "gateway.networking.k8s.io" at the cluster scope
```

Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

