### PR TITLE
use ent images for nightlies and add consul-1.13 nightlies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -869,7 +869,7 @@ jobs:
   acceptance-kind-1-23-consul-nightly-1-11:
     environment:
       - TEST_RESULTS: /tmp/test-results
-      - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul:1.11-dev"
+      - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul:1.11-dev-ent"
       - ENVOY_IMAGE: "envoyproxy/envoy:1.20.2"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.44.0"
     machine:
@@ -905,7 +905,7 @@ jobs:
   acceptance-kind-1-23-consul-nightly-1-12:
     environment:
       - TEST_RESULTS: /tmp/test-results
-      - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul:1.12-dev"
+      - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul:1.12-dev-ent"
       - ENVOY_IMAGE: "envoyproxy/envoy:1.22.2"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.44.0"
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -869,7 +869,7 @@ jobs:
   acceptance-kind-1-23-consul-nightly-1-11:
     environment:
       - TEST_RESULTS: /tmp/test-results
-      - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.11.3-ent-dev"
+      - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.11-dev"
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.20.2"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.45.0"
     machine:
@@ -1047,6 +1047,6 @@ workflows:
               only:
                 - main
     jobs:
-      - acceptance-kind-1-23-consul-nightly-1-11
-      - acceptance-kind-1-23-consul-nightly-1-12
-      - acceptance-kind-1-23-consul-nightly-1-13
+#      - acceptance-kind-1-23-consul-nightly-1-11
+#      - acceptance-kind-1-23-consul-nightly-1-12
+#      - acceptance-kind-1-23-consul-nightly-1-13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1038,15 +1038,15 @@ workflows:
           requires:
             - dev-upload-docker
 
-  nightly-acceptance-tests-consul:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
+#  nightly-acceptance-tests-consul:
+#    triggers:
+#      - schedule:
+#          cron: "0 0 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - main
+#    jobs:
 #      - acceptance-kind-1-23-consul-nightly-1-11
 #      - acceptance-kind-1-23-consul-nightly-1-12
 #      - acceptance-kind-1-23-consul-nightly-1-13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -869,9 +869,9 @@ jobs:
   acceptance-kind-1-23-consul-nightly-1-11:
     environment:
       - TEST_RESULTS: /tmp/test-results
-      - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul:1.11-dev-ent"
+      - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.11-dev-ent"
       - ENVOY_IMAGE: "envoyproxy/envoy:1.20.2"
-      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.44.0"
+      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.45.0"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
@@ -905,9 +905,9 @@ jobs:
   acceptance-kind-1-23-consul-nightly-1-12:
     environment:
       - TEST_RESULTS: /tmp/test-results
-      - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul:1.12-dev-ent"
+      - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul:1.12-enterprise-dev-ent"
       - ENVOY_IMAGE: "envoyproxy/envoy:1.22.2"
-      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.44.0"
+      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.45.0"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -869,7 +869,7 @@ jobs:
   acceptance-kind-1-23-consul-nightly-1-11:
     environment:
       - TEST_RESULTS: /tmp/test-results
-      - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.11-dev-ent"
+      - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.11.3-ent-dev"
       - ENVOY_IMAGE: "envoyproxy/envoy:1.20.2"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.45.0"
     machine:
@@ -893,7 +893,7 @@ jobs:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -consul-k8s-image=$CONSUL_K8S_IMAGE -consul-image=$CONSUL_IMAGE -consul-version="1.11-dev" -envoy-image=$ENVOY_IMAGE
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -consul-k8s-image=$CONSUL_K8S_IMAGE -consul-image=$CONSUL_IMAGE -consul-version="1.11" -envoy-image=$ENVOY_IMAGE
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -905,7 +905,7 @@ jobs:
   acceptance-kind-1-23-consul-nightly-1-12:
     environment:
       - TEST_RESULTS: /tmp/test-results
-      - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul:1.12-enterprise-dev-ent"
+      - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.12-dev"
       - ENVOY_IMAGE: "envoyproxy/envoy:1.22.2"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.45.0"
     machine:
@@ -929,7 +929,7 @@ jobs:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -consul-k8s-image=$CONSUL_K8S_IMAGE -consul-image=$CONSUL_IMAGE -consul-version="1.12-dev" -envoy-image=$ENVOY_IMAGE
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -consul-k8s-image=$CONSUL_K8S_IMAGE -consul-image=$CONSUL_IMAGE -consul-version="1.12" -envoy-image=$ENVOY_IMAGE
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -937,6 +937,42 @@ jobs:
       - slack/status:
           fail_only: true
           failure_message: "Acceptance tests against Kind with Kubernetes v1.23 with Consul 1.12 nightly failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+
+  acceptance-kind-1-23-consul-nightly-1-13:
+    environment:
+      - TEST_RESULTS: /tmp/test-results
+      - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.13-dev"
+      - ENVOY_IMAGE: "envoyproxy/envoy:1.22.2"
+      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.45.0"
+    machine:
+      image: ubuntu-2004:202010-01
+    resource_class: xlarge
+    steps:
+      - checkout
+      - install-prereqs
+      - create-kind-clusters:
+          version: "v1.23.0"
+      - restore_cache:
+          keys:
+            - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
+      - run:
+          name: go mod download
+          working_directory: *acceptance-mod-path
+          command: go mod download
+      - save_cache:
+          key: consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
+          paths:
+            - ~/.go_workspace/pkg/mod
+      - run: mkdir -p $TEST_RESULTS
+      - run-acceptance-tests:
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -consul-k8s-image=$CONSUL_K8S_IMAGE -consul-image=$CONSUL_IMAGE -consul-version="1.13" -envoy-image=$ENVOY_IMAGE
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+      - slack/status:
+          fail_only: true
+          failure_message: "Acceptance tests against Kind with Kubernetes v1.23 with Consul 1.13 nightly failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
 workflows:
   version: 2
@@ -1013,3 +1049,4 @@ workflows:
     jobs:
       - acceptance-kind-1-23-consul-nightly-1-11
       - acceptance-kind-1-23-consul-nightly-1-12
+      - acceptance-kind-1-23-consul-nightly-1-13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -870,7 +870,7 @@ jobs:
     environment:
       - TEST_RESULTS: /tmp/test-results
       - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.11.3-ent-dev"
-      - ENVOY_IMAGE: "envoyproxy/envoy:1.20.2"
+      - ENVOY_IMAGE: "envoyproxy/envoy:v1.20.2"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.45.0"
     machine:
       image: ubuntu-2004:202010-01
@@ -906,7 +906,7 @@ jobs:
     environment:
       - TEST_RESULTS: /tmp/test-results
       - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.12-dev"
-      - ENVOY_IMAGE: "envoyproxy/envoy:1.22.2"
+      - ENVOY_IMAGE: "envoyproxy/envoy:v1.22.2"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.45.0"
     machine:
       image: ubuntu-2004:202010-01
@@ -942,7 +942,7 @@ jobs:
     environment:
       - TEST_RESULTS: /tmp/test-results
       - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.13-dev"
-      - ENVOY_IMAGE: "envoyproxy/envoy:1.22.2"
+      - ENVOY_IMAGE: "envoyproxy/envoy:v1.22.2"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.45.0"
     machine:
       image: ubuntu-2004:202010-01

--- a/acceptance/tests/peering/peering_connect_namespaces_test.go
+++ b/acceptance/tests/peering/peering_connect_namespaces_test.go
@@ -2,6 +2,7 @@ package peering
 
 import (
 	"context"
+	"github.com/hashicorp/go-version"
 	"strconv"
 	"testing"
 
@@ -32,6 +33,12 @@ func TestPeering_ConnectNamespaces(t *testing.T) {
 
 	if cfg.EnableTransparentProxy {
 		t.Skipf("skipping this test because Transparent Proxy is enabled")
+	}
+
+	ver, err := version.NewVersion("1.13.0")
+	require.NoError(t, err)
+	if cfg.ConsulVersion != nil && cfg.ConsulVersion.LessThan(ver) {
+		t.Skipf("skipping this test because peering is not supported in version %v", cfg.ConsulVersion.String())
 	}
 
 	const staticServerPeer = "server"

--- a/acceptance/tests/peering/peering_connect_test.go
+++ b/acceptance/tests/peering/peering_connect_test.go
@@ -2,6 +2,7 @@ package peering
 
 import (
 	"context"
+	"github.com/hashicorp/go-version"
 	"strconv"
 	"testing"
 
@@ -23,6 +24,12 @@ func TestPeering_Connect(t *testing.T) {
 
 	if cfg.EnableTransparentProxy {
 		t.Skipf("skipping this test because Transparent Proxy is enabled")
+	}
+
+	ver, err := version.NewVersion("1.13.0")
+	require.NoError(t, err)
+	if cfg.ConsulVersion != nil && cfg.ConsulVersion.LessThan(ver) {
+		t.Skipf("skipping this test because peering is not supported in version %v", cfg.ConsulVersion.String())
 	}
 
 	const staticServerPeer = "server"


### PR DESCRIPTION
Changes proposed in this PR:
- Nightly tests run the enterprise tests and so need a consul-ent image.
- adds support for consul-1.13 nightlies
- disables peering tests for < consul-1.13
- disable nightlies until the images are available

How I've tested this PR:
manually using the included images.

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

