### PR TITLE
fix permissions for /consul/extra-config

### DIFF
--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -142,7 +142,6 @@ substitution for HOST_IP/POD_IP/HOSTNAME. Useful for dogstats telemetry. The out
 is passed to consul as a -config-file param on command line.
 */}}
 {{- define "consul.extraconfig" -}}
-              mkdir -p /consul/extra-config
               cp /consul/config/extra-from-values.json /consul/extra-config/extra-from-values.json
               [ -n "${HOST_IP}" ] && sed -Ei "s|HOST_IP|${HOST_IP?}|g" /consul/extra-config/extra-from-values.json
               [ -n "${POD_IP}" ] && sed -Ei "s|POD_IP|${POD_IP?}|g" /consul/extra-config/extra-from-values.json

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -126,6 +126,8 @@ spec:
         - name: config
           configMap:
             name: {{ template "consul.fullname" . }}-client-config
+        - name: extra-config
+          emptyDir: {}
         - name: consul-data
           emptyDir:
             medium: "Memory"
@@ -359,6 +361,8 @@ spec:
               mountPath: /consul/data
             - name: config
               mountPath: /consul/config
+            - name: extra-config
+              mountPath: /consul/extra-config
             - mountPath: /consul/login
               name: consul-data
               readOnly: true

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -130,6 +130,8 @@ spec:
         - name: config
           configMap:
             name: {{ template "consul.fullname" . }}-server-config
+        - name: extra-config
+          emptyDir: {}
         {{- if (and .Values.global.tls.enabled (not .Values.global.secretsBackend.vault.enabled)) }}
         - name: consul-ca-cert
           secret:
@@ -303,6 +305,8 @@ spec:
               mountPath: /consul/data
             - name: config
               mountPath: /consul/config
+            - name: extra-config
+              mountPath: /consul/extra-config
             {{- if (and .Values.global.tls.enabled (not .Values.global.secretsBackend.vault.enabled)) }}
             - name: consul-ca-cert
               mountPath: /consul/tls/ca/

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -239,6 +239,27 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# extra-config
+
+@test "client/DaemonSet: has extra-config volume" {
+  cd `chart_dir`
+
+  # check that the extra-config volume is defined
+  local volume_name=$(helm template \
+      -s templates/client-daemonset.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.volumes[] | select(.name == "extra-config") | .name' | tee /dev/stderr)
+  [ "${volume_name}" = "extra-config" ]
+
+  # check that the consul container mounts the volume at /consul/extra-config
+  local mount_path=$(helm template \
+      -s templates/client-daemonset.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[] | select(.name == "consul") | .volumeMounts[] | select(.name == "extra-config") | .mountPath' | tee /dev/stderr)
+  [ "${mount_path}" = "/consul/extra-config" ]
+}
+
+#--------------------------------------------------------------------
 # extraVolumes
 
 @test "client/DaemonSet: adds extra volume" {

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -1093,29 +1093,22 @@ load _helpers
 
 @test "client/DaemonSet: aclconfig volume is created when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local volume_name=$(helm template \
       -s templates/client-daemonset.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.volumes[3].name == "aclconfig"' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
+      yq -r '.spec.template.spec.volumes[] | select(.name == "aclconfig") | .name' | tee /dev/stderr)
+  [ "${volume_name}" = "aclconfig" ]
 }
 
 @test "client/DaemonSet: aclconfig volumeMount is created when global.acls.manageSystemACLs=true" {
   cd `chart_dir`
-  local object=$(helm template \
+  local mount_path=$(helm template \
       -s templates/client-daemonset.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].volumeMounts[3]' | tee /dev/stderr)
-
-  local actual=$(echo $object |
-      yq -r '.name' | tee /dev/stderr)
-  [ "${actual}" = "aclconfig" ]
-
-  local actual=$(echo $object |
-      yq -r '.mountPath' | tee /dev/stderr)
-  [ "${actual}" = "/consul/aclconfig" ]
+      yq -r '.spec.template.spec.containers[] | select(.name == "consul") | .volumeMounts[] | select(.name == "aclconfig") | .mountPath' | tee /dev/stderr)
+  [ "${mount_path}" = "/consul/aclconfig" ]
 }
 
 @test "client/DaemonSet: command includes aclconfig dir when global.acls.manageSystemACLs=true" {
@@ -1253,37 +1246,34 @@ local actual=$(echo $object |
 
 @test "client/DaemonSet: Adds consul login volume when ACLs are enabled" {
   cd `chart_dir`
-  local object=$(helm template \
+  local volume=$(helm template \
       -s templates/client-daemonset.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
-      . | yq '.spec.template.spec.volumes[2]' | tee /dev/stderr)
-  local actual=$(echo $object |
-      yq -r '.name' | tee /dev/stderr)
-  [ "${actual}" = "consul-data" ]
+      . | yq '.spec.template.spec.volumes[] | select(.name == "consul-data")' | tee /dev/stderr)
 
-  local actual=$(echo $object |
+  local volume_name=$(echo $volume |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${volume_name}" = "consul-data" ]
+
+  local volume_emptydir_medium=$(echo $volume |
       yq -r '.emptyDir.medium' | tee /dev/stderr)
-  [ "${actual}" = "Memory" ]
+  [ "${volume_emptydir_medium}" = "Memory" ]
 }
 
 @test "client/DaemonSet: Adds consul login volumeMount to client container when ACLs are enabled" {
   cd `chart_dir`
-  local object=$(helm template \
+  local volume_mount=$(helm template \
       -s templates/client-daemonset.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
-      . | yq '.spec.template.spec.containers[0].volumeMounts[2]' | tee /dev/stderr)
+      . | yq '.spec.template.spec.containers[] | select(.name == "consul") | .volumeMounts[] | select(.name == "consul-data")' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-      yq -r '.name' | tee /dev/stderr)
-  [ "${actual}" = "consul-data" ]
-
-  local actual=$(echo $object |
+  local volume_mount_path=$(echo $volume_mount |
       yq -r '.mountPath' | tee /dev/stderr)
-  [ "${actual}" = "/consul/login" ]
+  [ "${volume_mount_path}" = "/consul/login" ]
 
-  local actual=$(echo $object |
+  local volume_mount_ro=$(echo $volume_mount |
       yq -r '.readOnly' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
+  [ "${volume_mount_ro}" = "true" ]
 }
 
 @test "client/DaemonSet: Adds consul login volumeMount to acl-init init container when ACLs are enabled" {

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -207,7 +207,7 @@ load _helpers
         . | tee /dev/stderr )
 
     local actual=$(echo "$object" |
-        yq -r '.spec.template.spec.volumes[2].secret.secretName' | tee /dev/stderr)
+        yq -r '.spec.template.spec.volumes[] | select(.name == "consul-server-cert") | .secret.secretName' | tee /dev/stderr)
     [ "${actual}" = "release-name-consul-server-cert" ]
 }
 
@@ -221,7 +221,7 @@ load _helpers
         . | tee /dev/stderr )
 
     local actual=$(echo "$object" |
-        yq -r '.spec.template.spec.volumes[2].secret.secretName' | tee /dev/stderr)
+        yq -r '.spec.template.spec.volumes[] | select(.name == "consul-server-cert") | .secret.secretName' | tee /dev/stderr)
     [ "${actual}" = "server-cert" ]
 }
 

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -349,6 +349,27 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# extra-config
+
+@test "server/StatefulSet: has extra-config volume" {
+  cd `chart_dir`
+
+  # check that the extra-config volume is defined
+  local volume_name=$(helm template \
+      -s templates/server-statefulset.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.volumes[] | select(.name == "extra-config") | .name' | tee /dev/stderr)
+  [ "${volume_name}" = "extra-config" ]
+
+  # check that the consul container mounts the volume at /consul/extra-config
+  local mount_path=$(helm template \
+      -s templates/server-statefulset.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[] | select(.name == "consul") | .volumeMounts[] | select(.name == "extra-config") | .mountPath' | tee /dev/stderr)
+  [ "${mount_path}" = "/consul/extra-config" ]
+}
+
+#--------------------------------------------------------------------
 # extraVolumes
 
 @test "server/StatefulSet: adds extra volume" {


### PR DESCRIPTION
On openshift/okd you might not have permissions to create directories
everywhere. But you can introduce mounts.

Here we're just creating insignificant mount-points for the extra-config
to do it's thing, thus eliminating the need for creating the directory,
which the user running the container might not have permissions to do.

Fixes #1306
