### PR TITLE
don't set securitycontext on openshift/okd

### DIFF
--- a/charts/consul/templates/gossip-encryption-autogenerate-job.yaml
+++ b/charts/consul/templates/gossip-encryption-autogenerate-job.yaml
@@ -32,11 +32,13 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-gossip-encryption-autogenerate
+      {{- if not .Values.global.openshift.enabled }}
       securityContext:
         runAsNonRoot: true
         runAsGroup: 1000 
         runAsUser: 100 
         fsGroup: 1000
+      {{- end }}
       containers:
         - name: gossip-encryption-autogen
           image: "{{ .Values.global.imageK8S }}"

--- a/charts/consul/test/unit/gossip-encryption-autogenerate-job.bats
+++ b/charts/consul/test/unit/gossip-encryption-autogenerate-job.bats
@@ -51,3 +51,13 @@ load _helpers
   [[ "$output" =~ "If global.gossipEncryption.autoGenerate is true, global.gossipEncryption.secretName and global.gossipEncryption.secretKey must not be set." ]]
 }
 
+@test "gossipEncryptionAutogenerate/Job: securityContext is not set when global.openshift.enabled=true" {
+  cd `chart_dir`
+  local has_security_context=$(helm template \
+      -s templates/gossip-encryption-autogenerate-job.yaml \
+      --set 'global.gossipEncryption.autoGenerate=true' \
+      --set 'global.openshift.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec | has("securityContext")' | tee /dev/stderr)
+  [ "${has_security_context}" = "false" ]
+}


### PR DESCRIPTION
If running on OpenShift, these settings cause problems because the
user and group ids are below the range OpenShift expects. If not
specified, they're automatically handled by OpenShift.