### PR TITLE
fix a broken link in values.yaml

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -756,7 +756,7 @@ server:
 
   # The resource requests (CPU, memory, etc.)
   # for each of the server agents. This should be a YAML map corresponding to a Kubernetes
-  # ResourceRequirements (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#resourcerequirements-v1-core)
+  # ResourceRequirements (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core)
   # object. NOTE: The use of a YAML string is deprecated.
   #
   # Example:


### PR DESCRIPTION
Changes proposed in this PR:
- fixes a broken link to k8s api docs for resource requirements
-

How I've tested this PR:
clicked the link

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

