### PR TITLE
Add annotations to support specifying userVolumes and userVolumeMounts for the envoy sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ FEATURES:
 IMPROVEMENTS:
 * Control Plane
   * Added annotations `consul.hashicorp.com/prometheus-ca-file`, `consul.hashicorp.com/prometheus-ca-path`, `consul.hashicorp.com/prometheus-cert-file`, and `consul.hashicorp.com/prometheus-key-file` for configuring TLS scraping on Prometheus metrics endpoints for Envoy sidecars. To enable, set the cert and key file annotations along with one of the ca file/path annotations. [[GH-1303](https://github.com/hashicorp/consul-k8s/pull/1303)]
+ * Added annotations `consul.hashicorp.com/consul-sidecar-user-volume` and `consul.hashicorp.com/consul-sidecar-user-volume-mount` for attaching Volumes and VolumeMounts to the Envoy sidecar. Both should be JSON objects. [[GH-1315](https://github.com/hashicorp/consul-k8s/pull/1315)]
 * Helm
   * Added `connectInject.annotations` and `syncCatalog.annotations` values for setting annotations on connect inject and sync catalog deployments. [[GH-775](https://github.com/hashicorp/consul-k8s/pull/775)]
 

--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -86,6 +86,10 @@ const (
 	annotationConsulSidecarMemoryLimit   = "consul.hashicorp.com/consul-sidecar-memory-limit"
 	annotationConsulSidecarMemoryRequest = "consul.hashicorp.com/consul-sidecar-memory-request"
 
+	// annotations for sidecar volumes.
+	annotationConsulSidecarUserVolume      = "consul.hashicorp.com/consul-sidecar-user-volume"
+	annotationConsulSidecarUserVolumeMount = "consul.hashicorp.com/consul-sidecar-user-volume-mount"
+
 	// annotations for sidecar concurrency.
 	annotationEnvoyProxyConcurrency = "consul.hashicorp.com/consul-envoy-proxy-concurrency"
 

--- a/control-plane/connect-inject/envoy_sidecar.go
+++ b/control-plane/connect-inject/envoy_sidecar.go
@@ -1,6 +1,7 @@
 package connectinject
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -46,6 +47,16 @@ func (w *MeshWebhook) envoySidecar(namespace corev1.Namespace, pod corev1.Pod, m
 			},
 		},
 		Command: cmd,
+	}
+
+	// Add any extra Envoy VolumeMounts.
+	if _, ok := pod.Annotations[annotationConsulSidecarUserVolumeMount]; ok {
+		var volumeMount []corev1.VolumeMount
+		err := json.Unmarshal([]byte(pod.Annotations[annotationConsulSidecarUserVolumeMount]), &volumeMount)
+		if err != nil {
+			return corev1.Container{}, err
+		}
+		container.VolumeMounts = append(container.VolumeMounts, volumeMount...)
 	}
 
 	tproxyEnabled, err := transparentProxyEnabled(namespace, pod, w.EnableTransparentProxy)

--- a/control-plane/connect-inject/envoy_sidecar_test.go
+++ b/control-plane/connect-inject/envoy_sidecar_test.go
@@ -412,15 +412,15 @@ func TestHandlerEnvoySidecar_UserVolumeMounts(t *testing.T) {
 				},
 			},
 			expectedContainerVolumeMounts: []corev1.VolumeMount{
-				corev1.VolumeMount{
+				{
 					Name:      "consul-connect-inject-data",
 					MountPath: "/consul/connect-inject",
 				},
-				corev1.VolumeMount{
+				{
 					Name:      "tls-cert",
 					MountPath: "/custom/path",
 				},
-				corev1.VolumeMount{
+				{
 					Name:      "tls-ca",
 					MountPath: "/custom/path2",
 				},

--- a/control-plane/connect-inject/mesh_webhook.go
+++ b/control-plane/connect-inject/mesh_webhook.go
@@ -220,6 +220,16 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 	// Optionally mount data volume to other containers
 	w.injectVolumeMount(pod)
 
+	// Optionally add any volumes that are to be used by the envoy sidecar.
+	if _, ok := pod.Annotations[annotationConsulSidecarUserVolume]; ok {
+		var userVolumes []corev1.Volume
+		err := json.Unmarshal([]byte(pod.Annotations[annotationConsulSidecarUserVolume]), &userVolumes)
+		if err != nil {
+			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error unmarshalling sidecar user volumes: %s", err))
+		}
+		pod.Spec.Volumes = append(pod.Spec.Volumes, userVolumes...)
+	}
+
 	// Add the upstream services as environment variables for easy
 	// service discovery.
 	containerEnvVars := w.containerEnvVars(pod)
@@ -326,16 +336,6 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 			}
 			pod.Spec.Containers = append(pod.Spec.Containers, envoySidecar)
 		}
-	}
-
-	// Optionally add any volumes that are to be used by the envoy sidecar.
-	if _, ok := pod.Annotations[annotationConsulSidecarUserVolume]; ok {
-		var userVolumes []corev1.Volume
-		err := json.Unmarshal([]byte(pod.Annotations[annotationConsulSidecarUserVolume]), &userVolumes)
-		if err != nil {
-			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error unmarshalling sidecar user volumes: %s", err))
-		}
-		pod.Spec.Volumes = append(pod.Spec.Volumes, userVolumes...)
 	}
 
 	// Now that the consul-sidecar no longer needs to re-register services periodically

--- a/control-plane/connect-inject/mesh_webhook_ent_test.go
+++ b/control-plane/connect-inject/mesh_webhook_ent_test.go
@@ -30,7 +30,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 
 	basicSpec := corev1.PodSpec{
 		Containers: []corev1.Container{
-			corev1.Container{
+			{
 				Name: "web",
 			},
 		},
@@ -285,7 +285,7 @@ func TestHandler_MutateWithNamespaces(t *testing.T) {
 func TestHandler_MutateWithNamespaces_ACLs(t *testing.T) {
 	basicSpec := corev1.PodSpec{
 		Containers: []corev1.Container{
-			corev1.Container{
+			{
 				Name: "web",
 			},
 		},


### PR DESCRIPTION
Changes proposed in this PR:
- Adds 2 new annotations `consul.hashicorp.com/consul-sidecar-user-volume` `consul.hashicorp.com/consul-sidecar-user-volume-mount` that accept JSON objects that define Volumes and VolumeMounts which will be attached to the envoy sidecar.
- This will allow the user to pass in an arbitrary mount that can be used to for example mount the TLS certs/keys via a Kube secret, CSI volume, etc, for prometheus scraping.
- This should work in the same manner that istio's `sidecar.istio.io/userVolumeMount` and `sidecar.istio.io/userVolume`
annotations work.

How I've tested this PR:
* unit tests
* built a test image under `kyleschochenmaier/consul-k8s-prom-tls` and deployed consul-k8s with a demo application that used the annotation `consul.hashicorp.com/consul-sidecar-user-volume-mount: "[{\"name\": \"secrets-store-inline\", \"mountPath\": \"/mnt/secrets-store\"}]"` and confirmed the mount and secrets contents are attached to the envoy-sidecar.

How I expect reviewers to test this PR:
unit tests

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

