### PR TITLE
CNI Helm Charts

### DIFF
--- a/charts/consul/templates/cni-clusterrole.yaml
+++ b/charts/consul/templates/cni-clusterrole.yaml
@@ -1,14 +1,24 @@
+{{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.transparentProxy.defaultEnabled)) }}{{ fail "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" }}{{ end -}}
+{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.transparentProxy.defaultEnabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: consul-cni
+  name: {{ template "consul.fullname" . }}-cni
+  namespace: {{ .Release.Namespace }}
   labels:
-    app: consul-cni
-    release: cni-poc
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: consul-cni 
 rules:
 - apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "list", "watch", "patch", "update"]
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["get", "list", "watch", "patch", "update"]
+  resources: 
+  - pods
+  verbs: 
+  - get
+  - list
+  - watch
+  - patch
+  - update
+{{- end }}

--- a/charts/consul/templates/cni-clusterrole.yaml
+++ b/charts/consul/templates/cni-clusterrole.yaml
@@ -10,7 +10,7 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-    component: consul-cni 
+    component: cni 
 rules:
 - apiGroups: [""]
   resources: 

--- a/charts/consul/templates/cni-clusterrole.yaml
+++ b/charts/consul/templates/cni-clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: consul-cni
+  labels:
+    app: consul-cni
+    release: cni-poc
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch", "patch", "update"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "patch", "update"]

--- a/charts/consul/templates/cni-clusterrole.yaml
+++ b/charts/consul/templates/cni-clusterrole.yaml
@@ -1,5 +1,4 @@
-{{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.transparentProxy.defaultEnabled)) }}{{ fail "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" }}{{ end -}}
-{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.transparentProxy.defaultEnabled) }}
+{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/consul/templates/cni-clusterrole.yaml
+++ b/charts/consul/templates/cni-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.enabled) }}
+{{- if .Values.connectInject.cni.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/consul/templates/cni-clusterrolebinding.yaml
+++ b/charts/consul/templates/cni-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: consul-cni
+  labels:
+    app: consul-cni
+    release: cni-poc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: consul-cni
+subjects:
+- kind: ServiceAccount
+  name: consul-cni
+  namespace: consul

--- a/charts/consul/templates/cni-clusterrolebinding.yaml
+++ b/charts/consul/templates/cni-clusterrolebinding.yaml
@@ -1,5 +1,4 @@
-{{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.transparentProxy.defaultEnabled)) }}{{ fail "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" }}{{ end -}}
-{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.transparentProxy.defaultEnabled) }}
+{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/consul/templates/cni-clusterrolebinding.yaml
+++ b/charts/consul/templates/cni-clusterrolebinding.yaml
@@ -17,5 +17,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-cni
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.connectInject.cni.namespace }}
 {{- end }}

--- a/charts/consul/templates/cni-clusterrolebinding.yaml
+++ b/charts/consul/templates/cni-clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-    component: auth-method
+    component: consul-cni
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/consul/templates/cni-clusterrolebinding.yaml
+++ b/charts/consul/templates/cni-clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-    component: consul-cni
+    component: cni
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/consul/templates/cni-clusterrolebinding.yaml
+++ b/charts/consul/templates/cni-clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-cni
-  namespace: {{ .Values.connectInject.cni.namespace }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/consul/templates/cni-clusterrolebinding.yaml
+++ b/charts/consul/templates/cni-clusterrolebinding.yaml
@@ -1,15 +1,21 @@
+{{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.transparentProxy.defaultEnabled)) }}{{ fail "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" }}{{ end -}}
+{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.transparentProxy.defaultEnabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: consul-cni
+  name: {{ template "consul.fullname" . }}-cni
   labels:
-    app: consul-cni
-    release: cni-poc
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: auth-method
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: consul-cni
+  name: {{ template "consul.fullname" . }}-cni
 subjects:
 - kind: ServiceAccount
-  name: consul-cni
-  namespace: consul
+  name: {{ template "consul.fullname" . }}-cni
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/consul/templates/cni-clusterrolebinding.yaml
+++ b/charts/consul/templates/cni-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.enabled) }}
+{{- if .Values.connectInject.cni.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -72,9 +72,9 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - mountPath: /host{{ .Values.connectInject.cni.cniBinDir }}
+            - mountPath: {{ .Values.connectInject.cni.cniBinDir }}
               name: cni-bin-dir
-            - mountPath: /host{{ .Values.connectInject.cni.cniNetDir }}
+            - mountPath: {{ .Values.connectInject.cni.cniNetDir }}
               name: cni-net-dir
       volumes:
         # Used to install CNI.

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -1,5 +1,5 @@
-{{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.transparentProxy.defaultEnabled)) }}{{ fail "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" }}{{ end -}}
-{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.transparentProxy.defaultEnabled) }}
+{{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.enabled)) }}{{ fail "connectInject.enabled must be true if connectInject.cni.enabled is true" }}{{ end -}}
+{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.enabled) }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.global.imageK8s }}{{ fail "global.imageK8s is not a valid key, use global.imageK8S (note the capital 'S')" }}{{ end -}}
+{{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.transparentProxy.defaultEnabled)) }}{{ fail "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled=true" }}{{ end -}}
+{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.transparentProxy.defaultEnabled) }}
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: consul-cni-node
+  namespace: consul
+  labels:
+    k8s-app: consul-cni-node
+    release: cni-poc
+spec:
+  selector:
+    matchLabels:
+      k8s-app: consul-cni-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: consul-cni-node
+        sidecar.consul.io/inject: "false"
+      annotations:
+        sidecar.consul.io/inject: "false"
+        # Add Prometheus Scrape annotations
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: "15014"
+        prometheus.io/path: '/metrics'
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        # Make sure consul-cni-node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      priorityClassName: system-node-critical
+      serviceAccountName: consul-cni
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 5
+      containers:
+        # This container installs the consul CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: "curtbushko/cni-poc:0.2"
+          # readinessProbe:
+          #   httpGet:
+          #     path: /readyz
+          #     port: 8000
+          securityContext:
+            runAsGroup: 0
+            runAsUser: 0
+            runAsNonRoot: false
+            privileged: true 
+          command: ["/bin/sh", "-ec", "/bin/consul-k8s install-cni", "-cni-net-dir=/etc/cni/net.d/multus.d", "-multus=true"]
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: "/opt/cni/bin"
+        - name: cni-net-dir
+          hostPath:
+            path: "/etc/cni/net.d"
+{{- end }}

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "consul.fullname" . }}-cni
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.connectInject.cni.namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -11,7 +11,7 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-    component: consul-cni 
+    component: cni 
 spec:
   {{- if .Values.connectInject.cni.updateStrategy }}
   updateStrategy:
@@ -22,17 +22,18 @@ spec:
       app: {{ template "consul.name" . }}
       chart: {{ template "consul.chart" . }}
       release: {{ .Release.Name }}
-      component: consul-cni
+      component: cni
   template:
     metadata:
       labels:
         app: {{ template "consul.name" . }}
         chart: {{ template "consul.chart" . }}
         release: {{ .Release.Name }}
-        component: consul-cni
+        component: cni
       annotations:
         consul.hashicorp.com/connect-inject: "false"
     spec:
+      # consul-cni only runs on linux operating systems
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.imageK8s }}{{ fail "global.imageK8s is not a valid key, use global.imageK8S (note the capital 'S')" }}{{ end -}}
 {{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.transparentProxy.defaultEnabled)) }}{{ fail "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" }}{{ end -}}
 {{- if (and .Values.connectInject.cni.enabled .Values.connectInject.transparentProxy.defaultEnabled) }}
 apiVersion: apps/v1
@@ -37,9 +36,6 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        # Make sure consul-cni-node gets scheduled on all nodes.
-        - effect: NoSchedule
-          operator: Exists
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "consul.fullname" . }}-cni
-  namespace: {{ .Values.connectInject.cni.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -56,7 +56,7 @@ spec:
         - name: install-cni
           image: {{ .Values.global.imageK8S }}
           securityContext:
-            privileged: {{ .Values.connectInject.cni.privileged }}
+            privileged: true
           command:
           - "/bin/sh"
           - "-ec"

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -1,33 +1,37 @@
 {{- if .Values.global.imageK8s }}{{ fail "global.imageK8s is not a valid key, use global.imageK8S (note the capital 'S')" }}{{ end -}}
-{{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.transparentProxy.defaultEnabled)) }}{{ fail "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled=true" }}{{ end -}}
+{{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.transparentProxy.defaultEnabled)) }}{{ fail "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" }}{{ end -}}
 {{- if (and .Values.connectInject.cni.enabled .Values.connectInject.transparentProxy.defaultEnabled) }}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: consul-cni-node
-  namespace: consul
+  name: {{ template "consul.fullname" . }}-cni
+  namespace: {{ .Release.Namespace }}
   labels:
-    k8s-app: consul-cni-node
-    release: cni-poc
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: consul-cni 
 spec:
+  {{- if .Values.connectInject.cni.updateStrategy }}
+  updateStrategy:
+    {{ tpl .Values.connectInject.cni.updateStrategy . | nindent 4 | trim }}
+  {{- end }}
   selector:
     matchLabels:
-      k8s-app: consul-cni-node
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
+      app: {{ template "consul.name" . }}
+      chart: {{ template "consul.chart" . }}
+      release: {{ .Release.Name }}
+      component: consul-cni
   template:
     metadata:
       labels:
-        k8s-app: consul-cni-node
-        sidecar.consul.io/inject: "false"
+        app: {{ template "consul.name" . }}
+        chart: {{ template "consul.chart" . }}
+        release: {{ .Release.Name }}
+        component: consul-cni
       annotations:
-        sidecar.consul.io/inject: "false"
-        # Add Prometheus Scrape annotations
-        prometheus.io/scrape: 'true'
-        prometheus.io/port: "15014"
-        prometheus.io/path: '/metrics'
+        consul.hashicorp.com/connect-inject: false
     spec:
       nodeSelector:
         kubernetes.io/os: linux
@@ -40,37 +44,46 @@ spec:
           operator: Exists
         - effect: NoExecute
           operator: Exists
+      # Tell kubernetes that this daemonset is critical so that it will be scheduled on a new node before other pods
       priorityClassName: system-node-critical
-      serviceAccountName: consul-cni
+      serviceAccountName: {{ template "consul.fullname" . }}-cni
+      {{- if not .Values.global.openshift.enabled }}
+      securityContext:
+        {{- toYaml .Values.connectInject.cni.securityContext | nindent 8 -}}
+      {{- end }}
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 5
       containers:
-        # This container installs the consul CNI binaries
-        # and CNI network config file on each node.
+        # This container installs the consul CNI binaries and CNI network config file on each node
         - name: install-cni
-          image: "curtbushko/cni-poc:0.2"
-          # readinessProbe:
-          #   httpGet:
-          #     path: /readyz
-          #     port: 8000
+          image: {{ .Values.global.imageK8S }}
           securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-            runAsNonRoot: false
-            privileged: true 
-          command: ["/bin/sh", "-ec", "/bin/consul-k8s install-cni", "-cni-net-dir=/etc/cni/net.d/multus.d", "-multus=true"]
+            privileged: {{ .Values.connectInject.cni.privileged }}
+          command:
+          - "/bin/sh"
+          - "-ec"
+          - |
+            consul-k8s-control-plane install-cni \
+              -multus={{ .Values.connectInject.cni.multus }} \
+              -log-level={{ default .Values.global.logLevel .Values.connectInject.cni.logLevel }} \
+              -cni-bin-dir={{ .Values.connectInject.cni.cniBinDir }} \
+              -cni-net-dir={{ .Values.connectInject.cni.cniNetDir }}
+          {{- with .Values.connectInject.cni.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
-            - mountPath: /host/opt/cni/bin
+            - mountPath: /host{{ .Values.connectInject.cni.cniBinDir }}
               name: cni-bin-dir
-            - mountPath: /host/etc/cni/net.d
+            - mountPath: /host{{ .Values.connectInject.cni.cniNetDir }}
               name: cni-net-dir
       volumes:
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
-            path: "/opt/cni/bin"
+            path: {{ .Values.connectInject.cni.cniBinDir }} 
         - name: cni-net-dir
           hostPath:
-            path: "/etc/cni/net.d"
+            path: {{ .Values.connectInject.cni.cniNetDir }} 
 {{- end }}

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -69,7 +69,8 @@ spec:
               -multus={{ .Values.connectInject.cni.multus }} \
               -log-level={{ default .Values.global.logLevel .Values.connectInject.cni.logLevel }} \
               -cni-bin-dir={{ .Values.connectInject.cni.cniBinDir }} \
-              -cni-net-dir={{ .Values.connectInject.cni.cniNetDir }}
+              -cni-net-dir={{ .Values.connectInject.cni.cniNetDir }} \
+              -dns-prefix={{ template "consul.fullname" . }}
           {{- with .Values.connectInject.cni.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.global.imageK8s }}{{ fail "global.imageK8s is not a valid key, use global.imageK8S (note the capital 'S')" }}{{ end -}}
 {{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.transparentProxy.defaultEnabled)) }}{{ fail "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" }}{{ end -}}
 {{- if (and .Values.connectInject.cni.enabled .Values.connectInject.transparentProxy.defaultEnabled) }}
-kind: DaemonSet
 apiVersion: apps/v1
+kind: DaemonSet
 metadata:
   name: {{ template "consul.fullname" . }}-cni
   namespace: {{ .Release.Namespace }}
@@ -31,7 +31,7 @@ spec:
         release: {{ .Release.Name }}
         component: consul-cni
       annotations:
-        consul.hashicorp.com/connect-inject: false
+        consul.hashicorp.com/connect-inject: "false"
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.enabled)) }}{{ fail "connectInject.enabled must be true if connectInject.cni.enabled is true" }}{{ end -}}
-{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.enabled) }}
+{{- if .Values.connectInject.cni.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -50,7 +50,7 @@ spec:
       {{- end }}
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       containers:
         # This container installs the consul CNI binaries and CNI network config file on each node
         - name: install-cni

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -58,15 +58,13 @@ spec:
           securityContext:
             privileged: true
           command:
-          - "/bin/sh"
-          - "-ec"
-          - |
-            consul-k8s-control-plane install-cni \
-              -multus={{ .Values.connectInject.cni.multus }} \
-              -log-level={{ default .Values.global.logLevel .Values.connectInject.cni.logLevel }} \
-              -cni-bin-dir={{ .Values.connectInject.cni.cniBinDir }} \
-              -cni-net-dir={{ .Values.connectInject.cni.cniNetDir }} \
-              -dns-prefix={{ template "consul.fullname" . }}
+            - consul-k8s-control-plane
+            - install-cni
+            - -multus={{ .Values.connectInject.cni.multus }}
+            - -log-level={{ default .Values.global.logLevel .Values.connectInject.cni.logLevel }}
+            - -cni-bin-dir={{ .Values.connectInject.cni.cniBinDir }}
+            - -cni-net-dir={{ .Values.connectInject.cni.cniNetDir }}
+            - -dns-prefix={{ template "consul.fullname" . }}
           {{- with .Values.connectInject.cni.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/consul/templates/cni-podsecuritypolicy.yaml
+++ b/charts/consul/templates/cni-podsecuritypolicy.yaml
@@ -18,7 +18,7 @@ spec:
   - hostPath
   - secret
   - emptyDir
-  hostNetwork: true
+  hostNetwork: false
   readOnlyRootFilesystem: false
   runAsUser:
     rule: 'RunAsAny'

--- a/charts/consul/templates/cni-podsecuritypolicy.yaml
+++ b/charts/consul/templates/cni-podsecuritypolicy.yaml
@@ -1,0 +1,31 @@
+{{- if (and .Values.connectInject.cni.enabled .Values.global.enablePodSecurityPolicies) }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "consul.fullname" . }}-cni
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: cni 
+spec:
+  privileged: true
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  volumes:
+  - hostPath
+  - secret
+  - emptyDir
+  hostNetwork: true
+  readOnlyRootFilesystem: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+{{- end }}

--- a/charts/consul/templates/cni-resourcequota.yaml
+++ b/charts/consul/templates/cni-resourcequota.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: {{ template "consul.fullname" . }}-cni
-  namespace: {{ .Values.connectInject.cni.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/cni-resourcequota.yaml
+++ b/charts/consul/templates/cni-resourcequota.yaml
@@ -11,7 +11,7 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-    component: consul-cni 
+    component: cni 
 spec:
   hard:
     pods: {{ .Values.connectInject.cni.resourceQuota.pods | quote }}

--- a/charts/consul/templates/cni-resourcequota.yaml
+++ b/charts/consul/templates/cni-resourcequota.yaml
@@ -1,5 +1,4 @@
-{{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.transparentProxy.defaultEnabled)) }}{{ fail "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" }}{{ end -}}
-{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.transparentProxy.defaultEnabled) }}
+{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.enabled) }}
 apiVersion: v1
 kind: ResourceQuota
 metadata:

--- a/charts/consul/templates/cni-resourcequota.yaml
+++ b/charts/consul/templates/cni-resourcequota.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.imageK8s }}{{ fail "global.imageK8s is not a valid key, use global.imageK8S (note the capital 'S')" }}{{ end -}}
 {{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.transparentProxy.defaultEnabled)) }}{{ fail "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" }}{{ end -}}
 {{- if (and .Values.connectInject.cni.enabled .Values.connectInject.transparentProxy.defaultEnabled) }}
 apiVersion: v1

--- a/charts/consul/templates/cni-resourcequota.yaml
+++ b/charts/consul/templates/cni-resourcequota.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: consul-cni-resource-quota
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.connectInject.cni.namespace }}
 spec:
   hard:
     pods: {{ .Values.connectInject.cni.resourceQuota.pods | quote }}

--- a/charts/consul/templates/cni-resourcequota.yaml
+++ b/charts/consul/templates/cni-resourcequota.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.global.imageK8s }}{{ fail "global.imageK8s is not a valid key, use global.imageK8S (note the capital 'S')" }}{{ end -}}
+{{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.transparentProxy.defaultEnabled)) }}{{ fail "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" }}{{ end -}}
+{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.transparentProxy.defaultEnabled) }}
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: consul-cni-resource-quota
+  namespace: {{ .Release.Namespace }}
+spec:
+  hard:
+    pods: {{ .Values.connectInject.cni.resourceQuota.pods | quote }}
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+      - system-node-critical
+{{- end }}

--- a/charts/consul/templates/cni-resourcequota.yaml
+++ b/charts/consul/templates/cni-resourcequota.yaml
@@ -4,8 +4,14 @@
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  name: consul-cni-resource-quota
+  name: {{ template "consul.fullname" . }}-cni
   namespace: {{ .Values.connectInject.cni.namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: consul-cni 
 spec:
   hard:
     pods: {{ .Values.connectInject.cni.resourceQuota.pods | quote }}

--- a/charts/consul/templates/cni-resourcequota.yaml
+++ b/charts/consul/templates/cni-resourcequota.yaml
@@ -1,4 +1,4 @@
-{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.enabled) }}
+{{- if .Values.connectInject.cni.enabled }}
 apiVersion: v1
 kind: ResourceQuota
 metadata:

--- a/charts/consul/templates/cni-serviceaccount.yaml
+++ b/charts/consul/templates/cni-serviceaccount.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-cni
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.connectInject.cni.namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/cni-serviceaccount.yaml
+++ b/charts/consul/templates/cni-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-cni
-  namespace: {{ .Values.connectInject.cni.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/cni-serviceaccount.yaml
+++ b/charts/consul/templates/cni-serviceaccount.yaml
@@ -1,5 +1,4 @@
-{{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.transparentProxy.defaultEnabled)) }}{{ fail "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" }}{{ end -}}
-{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.transparentProxy.defaultEnabled) }}
+{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.enabled) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/consul/templates/cni-serviceaccount.yaml
+++ b/charts/consul/templates/cni-serviceaccount.yaml
@@ -1,8 +1,14 @@
+{{- if (and (.Values.connectInject.cni.enabled) (not .Values.connectInject.transparentProxy.defaultEnabled)) }}{{ fail "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" }}{{ end -}}
+{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.transparentProxy.defaultEnabled) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: consul-cni
-  namespace: consul
+  name: {{ template "consul.fullname" . }}-cni
+  namespace: {{ .Release.Namespace }}
   labels:
-    app: consul-cni
-    release: cni-poc 
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: consul-cni 
+{{- end}}

--- a/charts/consul/templates/cni-serviceaccount.yaml
+++ b/charts/consul/templates/cni-serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: consul-cni
+  namespace: consul
+  labels:
+    app: consul-cni
+    release: cni-poc 

--- a/charts/consul/templates/cni-serviceaccount.yaml
+++ b/charts/consul/templates/cni-serviceaccount.yaml
@@ -11,4 +11,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: cni 
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range . }}
+- name: {{ .name }}
+{{- end }}
+{{- end }}
 {{- end}}

--- a/charts/consul/templates/cni-serviceaccount.yaml
+++ b/charts/consul/templates/cni-serviceaccount.yaml
@@ -10,5 +10,5 @@ metadata:
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-    component: consul-cni 
+    component: cni 
 {{- end}}

--- a/charts/consul/templates/cni-serviceaccount.yaml
+++ b/charts/consul/templates/cni-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if (and .Values.connectInject.cni.enabled .Values.connectInject.enabled) }}
+{{- if .Values.connectInject.cni.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/consul/templates/connect-inject-clusterrole.yaml
+++ b/charts/consul/templates/connect-inject-clusterrole.yaml
@@ -19,11 +19,19 @@ rules:
   - get
 {{- end }}
 - apiGroups: [ "" ]
-  resources: [ "pods", "endpoints", "services", "namespaces" ]
+  resources: [ "endpoints", "services", "namespaces" ]
   verbs:
   - "get"
   - "list"
   - "watch"
+- apiGroups: [ "" ]
+  resources:
+  - pods
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+  - "update"
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -138,7 +138,7 @@ spec:
                 {{- if .Values.connectInject.cni.enabled }}
                 -enable-cni=true \
                 {{- else }}
-                --enable-cni=false \
+                -enable-cni=false \
                 {{- end }}
                 {{- if .Values.global.peering.enabled }}
                 -enable-peering=true \

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -135,6 +135,11 @@ spec:
                 {{- else }}
                 -default-enable-transparent-proxy=false \
                 {{- end }}
+                {{- if .Values.connectInject.cni.enabled }}
+                -enable-cni=true \
+                {{- else }}
+                --enable-cni=false \
+                {{- end }}
                 {{- if .Values.global.peering.enabled }}
                 -enable-peering=true \
                 {{- end }}

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -135,11 +135,7 @@ spec:
                 {{- else }}
                 -default-enable-transparent-proxy=false \
                 {{- end }}
-                {{- if .Values.connectInject.cni.enabled }}
-                -enable-cni=true \
-                {{- else }}
-                -enable-cni=false \
-                {{- end }}
+                -enable-cni={{ .Values.connectInject.cni.enabled }} \
                 {{- if .Values.global.peering.enabled }}
                 -enable-peering=true \
                 {{- end }}

--- a/charts/consul/test/unit/cni-clusterrole.bats
+++ b/charts/consul/test/unit/cni-clusterrole.bats
@@ -20,14 +20,15 @@ load _helpers
   [[ "${actual}" == *"true"* ]]
 }
 
-@test "cni/clusterrole: disabled with connectInject.enabled=false and connectInject.transparentProxy.defaultEnabled=true" {
+@test "cni/clusterrole: disabled with connectInject.cni.enabled=false and connectInject.transparentProxy.defaultEnabled=true" {
   cd `chart_dir`
   assert_empty helm template \
       -s templates/cni-clusterrole.yaml  \
+      --set connectInject.cni.enabled=false \
       .
 }
 
-@test "cni/clusterrole: throws error when connectInject.enabled=true and connectInject.transparentProxy.defaultEnabled=false" {
+@test "cni/clusterrole: throws error when connectInject.cni.enabled=true and connectInject.transparentProxy.defaultEnabled=false" {
   cd `chart_dir`
   run helm template \
       -s templates/cni-clusterrole.yaml  \

--- a/charts/consul/test/unit/cni-clusterrole.bats
+++ b/charts/consul/test/unit/cni-clusterrole.bats
@@ -2,43 +2,31 @@
 
 load _helpers
 
-@test "cni/clusterrole: disabled by default" {
+@test "cni/daemonset: disabled by default" {
   cd `chart_dir`
   assert_empty helm template \
-      -s templates/cni-clusterrole.yaml  \
+      -s templates/cni-daemonset.yaml  \
       .
 }
 
-@test "cni/clusterrole: enabled with connectInject.cni.enabled=true and connectInject.transparentProxy.defaultEnabled=true" {
+@test "cni/daemonset: enabled with connectInject.cni.enabled=true and connectInject.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/cni-clusterrole.yaml  \
+      -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [[ "${actual}" == *"true"* ]]
 }
 
-@test "cni/clusterrole: disabled with connectInject.cni.enabled=false and connectInject.transparentProxy.defaultEnabled=true" {
+@test "cni/daemonset: disabled with connectInject.cni.enabled=false and connectInject.enabled=true" {
   cd `chart_dir`
   assert_empty helm template \
-      -s templates/cni-clusterrole.yaml  \
-      --set connectInject.cni.enabled=false \
+      --set 'connectInject.cni.enabled=false' \
+      --set 'connectInject.enabled=true' \
+      -s templates/cni-daemonset.yaml  \
       .
-}
-
-@test "cni/clusterrole: throws error when connectInject.cni.enabled=true and connectInject.transparentProxy.defaultEnabled=false" {
-  cd `chart_dir`
-  run helm template \
-      -s templates/cni-clusterrole.yaml  \
-      --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.transparentProxy.defaultEnabled=false' \
-      -s templates/cni-clusterrole.yaml  \
-      .
-
-  [ "$status" -eq 1 ]
-  [[ "$output" =~ "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" ]]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/test/unit/cni-clusterrole.bats
+++ b/charts/consul/test/unit/cni-clusterrole.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "cni/clusterrole: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-clusterrole.yaml  \
+      .
+}
+
+@test "cni/clusterrole: enabled with connectInject.cni.enabled=true and connectInject.transparentProxy.defaultEnabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-clusterrole.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [[ "${actual}" == *"true"* ]]
+}
+
+@test "cni/clusterrole: disabled with connectInject.enabled=false and connectInject.transparentProxy.defaultEnabled=true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-clusterrole.yaml  \
+      .
+}
+
+@test "cni/clusterrole: throws error when connectInject.enabled=true and connectInject.transparentProxy.defaultEnabled=false" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/cni-clusterrole.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.transparentProxy.defaultEnabled=false' \
+      -s templates/cni-clusterrole.yaml  \
+      .
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" ]]
+}
+
+#--------------------------------------------------------------------
+# rules
+
+@test "cni/clusterrole: sets get, list, watch, patch, update to pods in all api groups" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/cni-clusterrole.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+     . | tee /dev/stderr |
+      yq -r '.rules[0]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.resources[| index("pods")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  # .apiGroups[0] = pods
+  local actual=$(echo $object | yq -r '.apiGroups[0]' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+
+  local actual=$(echo $object | yq -r '.verbs | index("get")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  local actual=$(echo $object | yq -r '.verbs | index("list")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  local actual=$(echo $object | yq -r '.verbs | index("watch")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  local actual=$(echo $object | yq -r '.verbs | index("patch")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  local actual=$(echo $object | yq -r '.verbs | index("update")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+}

--- a/charts/consul/test/unit/cni-clusterrole.bats
+++ b/charts/consul/test/unit/cni-clusterrole.bats
@@ -2,64 +2,30 @@
 
 load _helpers
 
-@test "cni/daemonset: disabled by default" {
+@test "cni/ClusterRole: disabled by default" {
   cd `chart_dir`
   assert_empty helm template \
-      -s templates/cni-daemonset.yaml  \
+      -s templates/cni-clusterrole.yaml  \
       .
 }
 
-@test "cni/daemonset: enabled with connectInject.cni.enabled=true and connectInject.enabled=true" {
+@test "cni/ClusterRole: enabled with connectInject.cni.enabled=true and connectInject.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/cni-daemonset.yaml  \
+      -s templates/cni-clusterrole.yaml  \
       --set 'connectInject.cni.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [[ "${actual}" == *"true"* ]]
+  [[ "${actual}" == "true" ]]
 }
 
-@test "cni/daemonset: disabled with connectInject.cni.enabled=false and connectInject.enabled=true" {
+@test "cni/ClusterRole: disabled with connectInject.cni.enabled=false and connectInject.enabled=true" {
   cd `chart_dir`
   assert_empty helm template \
       --set 'connectInject.cni.enabled=false' \
       --set 'connectInject.enabled=true' \
-      -s templates/cni-daemonset.yaml  \
+      -s templates/cni-clusterrole.yaml  \
       .
 }
 
-#--------------------------------------------------------------------
-# rules
-
-@test "cni/clusterrole: sets get, list, watch, patch, update to pods in all api groups" {
-  cd `chart_dir`
-  local object=$(helm template \
-      -s templates/cni-clusterrole.yaml  \
-      --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.transparentProxy.defaultEnabled=true' \
-     . | tee /dev/stderr |
-      yq -r '.rules[0]' | tee /dev/stderr)
-
-  local actual=$(echo $object | yq -r '.resources[| index("pods")' | tee /dev/stderr)
-  [ "${actual}" != null ]
-
-  # .apiGroups[0] = pods
-  local actual=$(echo $object | yq -r '.apiGroups[0]' | tee /dev/stderr)
-  [ "${actual}" = "" ]
-
-  local actual=$(echo $object | yq -r '.verbs | index("get")' | tee /dev/stderr)
-  [ "${actual}" != null ]
-
-  local actual=$(echo $object | yq -r '.verbs | index("list")' | tee /dev/stderr)
-  [ "${actual}" != null ]
-
-  local actual=$(echo $object | yq -r '.verbs | index("watch")' | tee /dev/stderr)
-  [ "${actual}" != null ]
-
-  local actual=$(echo $object | yq -r '.verbs | index("patch")' | tee /dev/stderr)
-  [ "${actual}" != null ]
-
-  local actual=$(echo $object | yq -r '.verbs | index("update")' | tee /dev/stderr)
-  [ "${actual}" != null ]
-}

--- a/charts/consul/test/unit/cni-clusterrolebinding.bats
+++ b/charts/consul/test/unit/cni-clusterrolebinding.bats
@@ -75,8 +75,9 @@ load _helpers
       -s templates/cni-clusterrolebinding.yaml  \
       --set 'connectInject.cni.enabled=true' \
       --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      --namespace foo \
       . | tee /dev/stderr |
       yq -r '.subjects[0].namespace' | tee /dev/stderr)
-  [ "${actual}" = "default" ]
+  [ "${actual}" = "foo" ]
 }
 

--- a/charts/consul/test/unit/cni-clusterrolebinding.bats
+++ b/charts/consul/test/unit/cni-clusterrolebinding.bats
@@ -63,7 +63,7 @@ load _helpers
       -s templates/cni-clusterrolebinding.yaml  \
       --set 'connectInject.cni.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'connectInject.cni.namespace=foo' \
+      --namespace foo \
       . | tee /dev/stderr |
       yq -r '.subjects[0].namespace' | tee /dev/stderr)
   [ "${actual}" = "foo" ]

--- a/charts/consul/test/unit/cni-clusterrolebinding.bats
+++ b/charts/consul/test/unit/cni-clusterrolebinding.bats
@@ -75,7 +75,7 @@ load _helpers
       -s templates/cni-clusterrolebinding.yaml  \
       --set 'connectInject.cni.enabled=true' \
       --set 'connectInject.transparentProxy.defaultEnabled=true' \
-      --namespace foo \
+      --set 'connectInject.cni.namespace=foo' \
       . | tee /dev/stderr |
       yq -r '.subjects[0].namespace' | tee /dev/stderr)
   [ "${actual}" = "foo" ]

--- a/charts/consul/test/unit/cni-clusterrolebinding.bats
+++ b/charts/consul/test/unit/cni-clusterrolebinding.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "cni/clusterrolebinding: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-clusterrolebinding.yaml  \
+      .
+}
+
+@test "cni/clusterrolebinding: enabled with connectInject.cni.enabled=true and connectInject.transparentProxy.defaultEnabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-clusterrolebinding.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [[ "${actual}" == *"true"* ]]
+}
+
+@test "cni/clusterrolebinding: disabled with connectInject.cni.enabled=false and connectInject.transparentProxy.defaultEnabled=true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-clusterrolebinding.yaml  \
+      --set 'connectInject.cni.enabled=false' \
+      .
+}
+
+@test "cni/clusterrolebinding: throws error when connectInject.cni.enabled=true and connectInject.transparentProxy.defaultEnabled=false" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/cni-clusterrolebinding.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.transparentProxy.defaultEnabled=false' \
+      -s templates/cni-clusterrolebinding.yaml  \
+      .
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" ]]
+}
+
+#--------------------------------------------------------------------
+# roleRef
+
+@test "cni/clusterrolebinding: roleref name is correct" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-clusterrolebinding.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.roleRef.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-cni" ]
+}
+
+#--------------------------------------------------------------------
+# subjects
+
+@test "cni/clusterrolebinding: subject name is correct" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-clusterrolebinding.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.subjects[0].name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-consul-cni" ]
+}
+
+@test "cni/clusterrolebinding: subject namespace is correct" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-clusterrolebinding.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.subjects[0].namespace' | tee /dev/stderr)
+  [ "${actual}" = "default" ]
+}
+

--- a/charts/consul/test/unit/cni-clusterrolebinding.bats
+++ b/charts/consul/test/unit/cni-clusterrolebinding.bats
@@ -2,43 +2,31 @@
 
 load _helpers
 
-@test "cni/clusterrolebinding: disabled by default" {
+@test "cni/daemonset: disabled by default" {
   cd `chart_dir`
   assert_empty helm template \
-      -s templates/cni-clusterrolebinding.yaml  \
+      -s templates/cni-daemonset.yaml  \
       .
 }
 
-@test "cni/clusterrolebinding: enabled with connectInject.cni.enabled=true and connectInject.transparentProxy.defaultEnabled=true" {
+@test "cni/daemonset: enabled with connectInject.cni.enabled=true and connectInject.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/cni-clusterrolebinding.yaml  \
+      -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [[ "${actual}" == *"true"* ]]
 }
 
-@test "cni/clusterrolebinding: disabled with connectInject.cni.enabled=false and connectInject.transparentProxy.defaultEnabled=true" {
+@test "cni/daemonset: disabled with connectInject.cni.enabled=false and connectInject.enabled=true" {
   cd `chart_dir`
   assert_empty helm template \
-      -s templates/cni-clusterrolebinding.yaml  \
       --set 'connectInject.cni.enabled=false' \
+      --set 'connectInject.enabled=true' \
+      -s templates/cni-daemonset.yaml  \
       .
-}
-
-@test "cni/clusterrolebinding: throws error when connectInject.cni.enabled=true and connectInject.transparentProxy.defaultEnabled=false" {
-  cd `chart_dir`
-  run helm template \
-      -s templates/cni-clusterrolebinding.yaml  \
-      --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.transparentProxy.defaultEnabled=false' \
-      -s templates/cni-clusterrolebinding.yaml  \
-      .
-
-  [ "$status" -eq 1 ]
-  [[ "$output" =~ "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" ]]
 }
 
 #--------------------------------------------------------------------
@@ -49,7 +37,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-clusterrolebinding.yaml  \
       --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.roleRef.name' | tee /dev/stderr)
   [ "${actual}" = "release-name-consul-cni" ]
@@ -63,7 +51,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-clusterrolebinding.yaml  \
       --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.subjects[0].name' | tee /dev/stderr)
   [ "${actual}" = "release-name-consul-cni" ]
@@ -74,7 +62,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-clusterrolebinding.yaml  \
       --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      --set 'connectInject.enabled=true' \
       --set 'connectInject.cni.namespace=foo' \
       . | tee /dev/stderr |
       yq -r '.subjects[0].namespace' | tee /dev/stderr)

--- a/charts/consul/test/unit/cni-clusterrolebinding.bats
+++ b/charts/consul/test/unit/cni-clusterrolebinding.bats
@@ -2,51 +2,37 @@
 
 load _helpers
 
-@test "cni/daemonset: disabled by default" {
+@test "cni/ClusterRoleBinding: disabled by default" {
   cd `chart_dir`
   assert_empty helm template \
-      -s templates/cni-daemonset.yaml  \
+      -s templates/cni-clusterrolebinding.yaml  \
       .
 }
 
-@test "cni/daemonset: enabled with connectInject.cni.enabled=true and connectInject.enabled=true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/cni-daemonset.yaml  \
-      --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [[ "${actual}" == *"true"* ]]
-}
-
-@test "cni/daemonset: disabled with connectInject.cni.enabled=false and connectInject.enabled=true" {
-  cd `chart_dir`
-  assert_empty helm template \
-      --set 'connectInject.cni.enabled=false' \
-      --set 'connectInject.enabled=true' \
-      -s templates/cni-daemonset.yaml  \
-      .
-}
-
-#--------------------------------------------------------------------
-# roleRef
-
-@test "cni/clusterrolebinding: roleref name is correct" {
+@test "cni/ClusterRoleBinding: enabled with connectInject.cni.enabled=true and connectInject.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/cni-clusterrolebinding.yaml  \
       --set 'connectInject.cni.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
-      yq -r '.roleRef.name' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-cni" ]
+      yq 'length > 0' | tee /dev/stderr)
+  [[ "${actual}" == "true" ]]
+}
+
+@test "cni/ClusterRoleBinding: disabled with connectInject.cni.enabled=false and connectInject.enabled=true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      --set 'connectInject.cni.enabled=false' \
+      --set 'connectInject.enabled=true' \
+      -s templates/cni-clusterrolebinding.yaml  \
+      .
 }
 
 #--------------------------------------------------------------------
 # subjects
 
-@test "cni/clusterrolebinding: subject name is correct" {
+@test "cni/ClusterRoleBinding: subject name is correct" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/cni-clusterrolebinding.yaml  \
@@ -57,7 +43,7 @@ load _helpers
   [ "${actual}" = "release-name-consul-cni" ]
 }
 
-@test "cni/clusterrolebinding: subject namespace is correct" {
+@test "cni/ClusterRoleBinding: subject namespace is correct" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/cni-clusterrolebinding.yaml  \

--- a/charts/consul/test/unit/cni-daemonset.bats
+++ b/charts/consul/test/unit/cni-daemonset.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "cni/daemonset: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-daemonset.yaml  \
+      .
+}
+
+@test "cni/daemonset: enabled with connectInject.cni.enabled=true and connectInject.transparentProxy.defaultEnabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [[ "${actual}" == *"true"* ]]
+}
+
+@test "cni/daemonset: disabled with connectInject.enabled=false and connectInject.transparentProxy.defaultEnabled=true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-daemonset.yaml  \
+      .
+}
+
+@test "cni/daemonset: throws error when connectInject.enabled=true and connectInject.transparentProxy.defaultEnabled=false" {
+  cd `chart_dir`
+  assert_empty helm template \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.transparentProxy.defaultEnabled=false' \
+      -s templates/cni-daemonset.yaml  \
+      .
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled=true" ]]
+}
+

--- a/charts/consul/test/unit/cni-daemonset.bats
+++ b/charts/consul/test/unit/cni-daemonset.bats
@@ -29,13 +29,215 @@ load _helpers
 
 @test "cni/daemonset: throws error when connectInject.enabled=true and connectInject.transparentProxy.defaultEnabled=false" {
   cd `chart_dir`
-  assert_empty helm template \
+  run helm template \
+      -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
       --set 'connectInject.transparentProxy.defaultEnabled=false' \
       -s templates/cni-daemonset.yaml  \
       .
 
   [ "$status" -eq 1 ]
-  [[ "$output" =~ "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled=true" ]]
+  [[ "$output" =~ "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" ]]
+}
+
+@test "cni/DaemonSet: image defaults to global.imageK8S" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'global.imageK8S=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+}
+
+@test "cni/DaemonSet: no updateStrategy when not updating" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.updateStrategy' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+#--------------------------------------------------------------------
+# resources
+
+@test "cni/DaemonSet: resources defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      . | tee /dev/stderr |
+      yq -rc '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
+  [ "${actual}" = '{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"50m","memory":"50Mi"}}' ]
+}
+
+@test "cni/DaemonSet: resources can be overridden" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.resources.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].resources.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+#--------------------------------------------------------------------
+# securityContext
+
+@test "cni/DaemonSet: securityContext is not set when global.openshift.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'global.openshift.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "cni/DaemonSet: sets default security context settings" {
+  cd `chart_dir`
+  local security_context=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext' | tee /dev/stderr)
+
+  local actual=$(echo $security_context | jq -r .runAsNonRoot)
+  [ "${actual}" = "false" ]
+
+  local actual=$(echo $security_context | jq -r .runAsUser)
+  [ "${actual}" = "0" ]
+
+  local actual=$(echo $security_context | jq -r .runAsGroup)
+  [ "${actual}" = "0" ]
+}
+
+@test "cni/DaemonSet: can overwrite security context settings" {
+  cd `chart_dir`
+  local security_context=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.securityContext.runAsNonRoot=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext' | tee /dev/stderr)
+
+  local actual=$(echo $security_context | jq -r .runAsNonRoot)
+  [ "${actual}" = "true" ]
+}
+
+@test "cni/DaemonSet: sets default privileged security context settings" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].securityContext.privileged' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "cni/DaemonSet: can overwrite privileged security context settings" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.privileged=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].securityContext.privileged' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+#--------------------------------------------------------------------
+# volumes
+
+@test "cni/DaemonSet: sets default cni-bin-dir volume hostPath" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.volumes[] | select(.name == "cni-bin-dir")' | tee /dev/stderr)
+      [ "${actual}" = '{"name":"cni-bin-dir","hostPath":{"path":"/opt/cni/bin"}}' ]
+}
+
+@test "cni/DaemonSet: sets default cni-net-dir volume hostPath" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.volumes[] | select(.name == "cni-net-dir")' | tee /dev/stderr)
+      [ "${actual}" = '{"name":"cni-net-dir","hostPath":{"path":"/etc/cni/net.d"}}' ]
+}
+
+@test "cni/DaemonSet: can overwrite default cni-bin-dir volume hostPath" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.cniBinDir=foo' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.volumes[] | select(.name == "cni-bin-dir")' | tee /dev/stderr)
+      [ "${actual}" = '{"name":"cni-bin-dir","hostPath":{"path":"foo"}}' ]
+}
+
+@test "cni/DaemonSet: can overwrite cni-net-dir volume hostPath" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.cniNetDir=bar' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.volumes[] | select(.name == "cni-net-dir")' | tee /dev/stderr)
+      [ "${actual}" = '{"name":"cni-net-dir","hostPath":{"path":"bar"}}' ]
+}
+
+#--------------------------------------------------------------------
+# volumeMounts
+
+@test "cni/DaemonSet: sets default host cni-bin-dir volumeMount" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "cni-bin-dir")' | tee /dev/stderr)
+      [ "${actual}" = '{"mountPath":"/host/opt/cni/bin","name":"cni-bin-dir"}' ]
+}
+
+@test "cni/DaemonSet: sets default host cni-net-dir volumeMount" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "cni-net-dir")' | tee /dev/stderr)
+      [ "${actual}" = '{"mountPath":"/host/etc/cni/net.d","name":"cni-net-dir"}' ]
+}
+
+@test "cni/DaemonSet: cano overwrite host cni-bin-dir volumeMount" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.cniBinDir=foo' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "cni-bin-dir")' | tee /dev/stderr)
+      [ "${actual}" = '{"mountPath":"/hostfoo","name":"cni-bin-dir"}' ]
+}
+
+@test "cni/DaemonSet: can overwrite host cni-net-dir volumeMount" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.cniNetDir=bar' \
+      . | tee /dev/stderr |
+      yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "cni-net-dir")' | tee /dev/stderr)
+      [ "${actual}" = '{"mountPath":"/hostbar","name":"cni-net-dir"}' ]
 }
 

--- a/charts/consul/test/unit/cni-daemonset.bats
+++ b/charts/consul/test/unit/cni-daemonset.bats
@@ -51,6 +51,17 @@ load _helpers
   [ "${actual}" = "foo" ]
 }
 
+@test "cni/DaemonSet: can set cni.namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.namespace=foo' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+}
+
 @test "cni/DaemonSet: no updateStrategy when not updating" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/cni-daemonset.bats
+++ b/charts/consul/test/unit/cni-daemonset.bats
@@ -9,35 +9,37 @@ load _helpers
       .
 }
 
-@test "cni/daemonset: enabled with connectInject.cni.enabled=true and connectInject.transparentProxy.defaultEnabled=true" {
+@test "cni/daemonset: enabled with connectInject.cni.enabled=true and connectInject.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [[ "${actual}" == *"true"* ]]
 }
 
-@test "cni/daemonset: disabled with connectInject.enabled=false and connectInject.transparentProxy.defaultEnabled=true" {
+@test "cni/daemonset: disabled with connectInject.cni.enabled=false and connectInject.enabled=true" {
   cd `chart_dir`
   assert_empty helm template \
+      --set 'connectInject.cni.enabled=false' \
+      --set 'connectInject.enabled=true' \
       -s templates/cni-daemonset.yaml  \
       .
 }
 
-@test "cni/daemonset: throws error when connectInject.enabled=true and connectInject.transparentProxy.defaultEnabled=false" {
+@test "cni/daemonset: throws error when connectInject.enabled=true and connectInject.enabled=false" {
   cd `chart_dir`
   run helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.transparentProxy.defaultEnabled=false' \
+      --set 'connectInject.enabled=false' \
       -s templates/cni-daemonset.yaml  \
       .
 
   [ "$status" -eq 1 ]
-  [[ "$output" =~ "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" ]]
+  [[ "$output" =~ "connectInject.enabled must be true if connectInject.cni.enabled is true" ]]
 }
 
 @test "cni/DaemonSet: image defaults to global.imageK8S" {
@@ -45,6 +47,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       --set 'global.imageK8S=foo' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
@@ -56,6 +59,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       --set 'connectInject.cni.namespace=foo' \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)
@@ -67,6 +71,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.updateStrategy' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -80,6 +85,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -rc '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
   [ "${actual}" = '{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"50m","memory":"50Mi"}}' ]
@@ -90,6 +96,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       --set 'connectInject.cni.resources.foo=bar' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].resources.foo' | tee /dev/stderr)
@@ -104,6 +111,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       --set 'global.openshift.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.securityContext' | tee /dev/stderr)
@@ -115,6 +123,7 @@ load _helpers
   local security_context=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.securityContext' | tee /dev/stderr)
 
@@ -133,6 +142,7 @@ load _helpers
   local security_context=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       --set 'connectInject.cni.securityContext.runAsNonRoot=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.securityContext' | tee /dev/stderr)
@@ -146,6 +156,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].securityContext.privileged' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -156,6 +167,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       --set 'connectInject.cni.privileged=false' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].securityContext.privileged' | tee /dev/stderr)
@@ -170,6 +182,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.volumes[] | select(.name == "cni-bin-dir")' | tee /dev/stderr)
       [ "${actual}" = '{"name":"cni-bin-dir","hostPath":{"path":"/opt/cni/bin"}}' ]
@@ -180,6 +193,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.volumes[] | select(.name == "cni-net-dir")' | tee /dev/stderr)
       [ "${actual}" = '{"name":"cni-net-dir","hostPath":{"path":"/etc/cni/net.d"}}' ]
@@ -190,6 +204,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       --set 'connectInject.cni.cniBinDir=foo' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.volumes[] | select(.name == "cni-bin-dir")' | tee /dev/stderr)
@@ -201,6 +216,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       --set 'connectInject.cni.cniNetDir=bar' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.volumes[] | select(.name == "cni-net-dir")' | tee /dev/stderr)
@@ -215,6 +231,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "cni-bin-dir")' | tee /dev/stderr)
       [ "${actual}" = '{"mountPath":"/host/opt/cni/bin","name":"cni-bin-dir"}' ]
@@ -225,16 +242,18 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "cni-net-dir")' | tee /dev/stderr)
       [ "${actual}" = '{"mountPath":"/host/etc/cni/net.d","name":"cni-net-dir"}' ]
 }
 
-@test "cni/DaemonSet: cano overwrite host cni-bin-dir volumeMount" {
+@test "cni/DaemonSet: can overwrite host cni-bin-dir volumeMount" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       --set 'connectInject.cni.cniBinDir=foo' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "cni-bin-dir")' | tee /dev/stderr)
@@ -246,6 +265,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       --set 'connectInject.cni.cniNetDir=bar' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "cni-net-dir")' | tee /dev/stderr)

--- a/charts/consul/test/unit/cni-daemonset.bats
+++ b/charts/consul/test/unit/cni-daemonset.bats
@@ -54,18 +54,6 @@ load _helpers
   [ "${actual}" = "foo" ]
 }
 
-@test "cni/DaemonSet: can set cni.namespace" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/cni-daemonset.yaml  \
-      --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'connectInject.cni.namespace=foo' \
-      . | tee /dev/stderr |
-      yq -r '.metadata.namespace' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
-}
-
 @test "cni/DaemonSet: no updateStrategy when not updating" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -160,18 +148,6 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].securityContext.privileged' | tee /dev/stderr)
   [ "${actual}" = "true" ]
-}
-
-@test "cni/DaemonSet: can overwrite privileged security context settings" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/cni-daemonset.yaml  \
-      --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'connectInject.cni.privileged=false' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].securityContext.privileged' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/test/unit/cni-daemonset.bats
+++ b/charts/consul/test/unit/cni-daemonset.bats
@@ -210,7 +210,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "cni-bin-dir")' | tee /dev/stderr)
-      [ "${actual}" = '{"mountPath":"/host/opt/cni/bin","name":"cni-bin-dir"}' ]
+      [ "${actual}" = '{"mountPath":"/opt/cni/bin","name":"cni-bin-dir"}' ]
 }
 
 @test "cni/DaemonSet: sets default host cni-net-dir volumeMount" {
@@ -221,7 +221,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "cni-net-dir")' | tee /dev/stderr)
-      [ "${actual}" = '{"mountPath":"/host/etc/cni/net.d","name":"cni-net-dir"}' ]
+      [ "${actual}" = '{"mountPath":"/etc/cni/net.d","name":"cni-net-dir"}' ]
 }
 
 @test "cni/DaemonSet: can overwrite host cni-bin-dir volumeMount" {
@@ -233,7 +233,7 @@ load _helpers
       --set 'connectInject.cni.cniBinDir=foo' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "cni-bin-dir")' | tee /dev/stderr)
-      [ "${actual}" = '{"mountPath":"/hostfoo","name":"cni-bin-dir"}' ]
+      [ "${actual}" = '{"mountPath":"foo","name":"cni-bin-dir"}' ]
 }
 
 @test "cni/DaemonSet: can overwrite host cni-net-dir volumeMount" {
@@ -245,6 +245,6 @@ load _helpers
       --set 'connectInject.cni.cniNetDir=bar' \
       . | tee /dev/stderr |
       yq -r -c '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "cni-net-dir")' | tee /dev/stderr)
-      [ "${actual}" = '{"mountPath":"/hostbar","name":"cni-net-dir"}' ]
+      [ "${actual}" = '{"mountPath":"bar","name":"cni-net-dir"}' ]
 }
 

--- a/charts/consul/test/unit/cni-podsecuritypolicy.bats
+++ b/charts/consul/test/unit/cni-podsecuritypolicy.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "cni/PodSecurityPolicy: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-podsecuritypolicies.yaml  \
+      .
+}
+
+@test "cni/PodSecurityPolicy: disabled with cni disabled and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-podsecuritypolicy.yaml  \
+      --set 'connectInject.cni.enabled=false' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      .
+}
+
+@test "cni/PodSecurityPolicy: enabled with connectInject.cni.enabled=true and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-podsecuritypolicy.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [[ "${actual}" == "true" ]]
+}
+

--- a/charts/consul/test/unit/cni-resourcequota.bats
+++ b/charts/consul/test/unit/cni-resourcequota.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "cni/resourcequota: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-resourcequota.yaml  \
+      .
+}
+
+@test "cni/resourcequota: enabled with connectInject.cni.enabled=true and connectInject.transparentProxy.defaultEnabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-resourcequota.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [[ "${actual}" == *"true"* ]]
+}
+
+@test "cni/resourcequota: disabled with connectInject.cni.enabled=false and connectInject.transparentProxy.defaultEnabled=true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-resourcequota.yaml  \
+      --set 'connectInject.cni.enabled=false' \
+      .
+}
+
+@test "cni/resourcequota: throws error when connectInject.enabled=true and connectInject.transparentProxy.defaultEnabled=false" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/cni-resourcequota.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.transparentProxy.defaultEnabled=false' \
+      -s templates/cni-resourcequota.yaml  \
+      .
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" ]]
+}
+
+#--------------------------------------------------------------------
+# pods 
+
+@test "cni/resourcequota: resources defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-resourcequota.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      . | tee /dev/stderr |
+      yq -rc '.spec.hard.pods' | tee /dev/stderr)
+  [ "${actual}" = "5000" ]
+}
+
+@test "cni/resourcequota: resources can be overridden" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-resourcequota.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.resourceQuota.pods=bar' \
+      . | tee /dev/stderr |
+      yq -rc '.spec.hard.pods' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+

--- a/charts/consul/test/unit/cni-resourcequota.bats
+++ b/charts/consul/test/unit/cni-resourcequota.bats
@@ -2,43 +2,31 @@
 
 load _helpers
 
-@test "cni/resourcequota: disabled by default" {
+@test "cni/daemonset: disabled by default" {
   cd `chart_dir`
   assert_empty helm template \
-      -s templates/cni-resourcequota.yaml  \
+      -s templates/cni-daemonset.yaml  \
       .
 }
 
-@test "cni/resourcequota: enabled with connectInject.cni.enabled=true and connectInject.transparentProxy.defaultEnabled=true" {
+@test "cni/daemonset: enabled with connectInject.cni.enabled=true and connectInject.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/cni-resourcequota.yaml  \
+      -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [[ "${actual}" == *"true"* ]]
 }
 
-@test "cni/resourcequota: disabled with connectInject.cni.enabled=false and connectInject.transparentProxy.defaultEnabled=true" {
+@test "cni/daemonset: disabled with connectInject.cni.enabled=false and connectInject.enabled=true" {
   cd `chart_dir`
   assert_empty helm template \
-      -s templates/cni-resourcequota.yaml  \
       --set 'connectInject.cni.enabled=false' \
+      --set 'connectInject.enabled=true' \
+      -s templates/cni-daemonset.yaml  \
       .
-}
-
-@test "cni/resourcequota: throws error when connectInject.enabled=true and connectInject.transparentProxy.defaultEnabled=false" {
-  cd `chart_dir`
-  run helm template \
-      -s templates/cni-resourcequota.yaml  \
-      --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.transparentProxy.defaultEnabled=false' \
-      -s templates/cni-resourcequota.yaml  \
-      .
-
-  [ "$status" -eq 1 ]
-  [[ "$output" =~ "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" ]]
 }
 
 #--------------------------------------------------------------------
@@ -49,6 +37,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-resourcequota.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -rc '.spec.hard.pods' | tee /dev/stderr)
   [ "${actual}" = "5000" ]
@@ -59,6 +48,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/cni-resourcequota.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       --set 'connectInject.cni.resourceQuota.pods=bar' \
       . | tee /dev/stderr |
       yq -rc '.spec.hard.pods' | tee /dev/stderr)

--- a/charts/consul/test/unit/cni-resourcequota.bats
+++ b/charts/consul/test/unit/cni-resourcequota.bats
@@ -2,37 +2,37 @@
 
 load _helpers
 
-@test "cni/daemonset: disabled by default" {
+@test "cni/ResourceQuota: disabled by default" {
   cd `chart_dir`
   assert_empty helm template \
-      -s templates/cni-daemonset.yaml  \
+      -s templates/cni-resourcequota.yaml  \
       .
 }
 
-@test "cni/daemonset: enabled with connectInject.cni.enabled=true and connectInject.enabled=true" {
+@test "cni/ResourceQuota: enabled with connectInject.cni.enabled=true and connectInject.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/cni-daemonset.yaml  \
+      -s templates/cni-resourcequota.yaml  \
       --set 'connectInject.cni.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [[ "${actual}" == *"true"* ]]
+  [[ "${actual}" == "true" ]]
 }
 
-@test "cni/daemonset: disabled with connectInject.cni.enabled=false and connectInject.enabled=true" {
+@test "cni/ResourceQuota: disabled with connectInject.cni.enabled=false and connectInject.enabled=true" {
   cd `chart_dir`
   assert_empty helm template \
       --set 'connectInject.cni.enabled=false' \
       --set 'connectInject.enabled=true' \
-      -s templates/cni-daemonset.yaml  \
+      -s templates/cni-resourcequota.yaml  \
       .
 }
 
 #--------------------------------------------------------------------
 # pods 
 
-@test "cni/resourcequota: resources defined by default" {
+@test "cni/ResourceQuota: resources defined by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/cni-resourcequota.yaml  \
@@ -43,7 +43,7 @@ load _helpers
   [ "${actual}" = "5000" ]
 }
 
-@test "cni/resourcequota: resources can be overridden" {
+@test "cni/ResourceQuota: resources can be overridden" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/cni-resourcequota.yaml  \

--- a/charts/consul/test/unit/cni-serviceaccount.bats
+++ b/charts/consul/test/unit/cni-serviceaccount.bats
@@ -41,3 +41,24 @@ load _helpers
   [[ "$output" =~ "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" ]]
 }
 
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "cni/serviceaccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/cni-serviceaccount.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}
+

--- a/charts/consul/test/unit/cni-serviceaccount.bats
+++ b/charts/consul/test/unit/cni-serviceaccount.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "cni/serviceaccount: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-serviceaccount.yaml  \
+      .
+}
+
+@test "cni/serviceaccount: enabled with connectInject.cni.enabled=true and connectInject.transparentProxy.defaultEnabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-serviceaccount.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [[ "${actual}" == *"true"* ]]
+}
+
+@test "cni/serviceaccount: disabled with connectInject.cni.enabled=false and connectInject.transparentProxy.defaultEnabled=true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-serviceaccount.yaml  \
+      --set 'connectInject.cni.enabled=false' \
+      .
+}
+
+@test "cni/serviceaccount: throws error when connectInject.enabled=true and connectInject.transparentProxy.defaultEnabled=false" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/cni-serviceaccount.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.transparentProxy.defaultEnabled=false' \
+      -s templates/cni-serviceaccount.yaml  \
+      .
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" ]]
+}
+

--- a/charts/consul/test/unit/cni-serviceaccount.bats
+++ b/charts/consul/test/unit/cni-serviceaccount.bats
@@ -2,43 +2,31 @@
 
 load _helpers
 
-@test "cni/serviceaccount: disabled by default" {
+@test "cni/daemonset: disabled by default" {
   cd `chart_dir`
   assert_empty helm template \
-      -s templates/cni-serviceaccount.yaml  \
+      -s templates/cni-daemonset.yaml  \
       .
 }
 
-@test "cni/serviceaccount: enabled with connectInject.cni.enabled=true and connectInject.transparentProxy.defaultEnabled=true" {
+@test "cni/daemonset: enabled with connectInject.cni.enabled=true and connectInject.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/cni-serviceaccount.yaml  \
+      -s templates/cni-daemonset.yaml  \
       --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.transparentProxy.defaultEnabled=true' \
+      --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [[ "${actual}" == *"true"* ]]
 }
 
-@test "cni/serviceaccount: disabled with connectInject.cni.enabled=false and connectInject.transparentProxy.defaultEnabled=true" {
+@test "cni/daemonset: disabled with connectInject.cni.enabled=false and connectInject.enabled=true" {
   cd `chart_dir`
   assert_empty helm template \
-      -s templates/cni-serviceaccount.yaml  \
       --set 'connectInject.cni.enabled=false' \
+      --set 'connectInject.enabled=true' \
+      -s templates/cni-daemonset.yaml  \
       .
-}
-
-@test "cni/serviceaccount: throws error when connectInject.enabled=true and connectInject.transparentProxy.defaultEnabled=false" {
-  cd `chart_dir`
-  run helm template \
-      -s templates/cni-serviceaccount.yaml  \
-      --set 'connectInject.cni.enabled=true' \
-      --set 'connectInject.transparentProxy.defaultEnabled=false' \
-      -s templates/cni-serviceaccount.yaml  \
-      .
-
-  [ "$status" -eq 1 ]
-  [[ "$output" =~ "connectInject.transparentProxy.defaultEnabled must be true if connectInject.cni.enabled is true" ]]
 }
 
 #--------------------------------------------------------------------
@@ -49,6 +37,7 @@ load _helpers
   local object=$(helm template \
       -s templates/cni-serviceaccount.yaml  \
       --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
       --set 'global.imagePullSecrets[0].name=my-secret' \
       --set 'global.imagePullSecrets[1].name=my-secret2' \
       . | tee /dev/stderr)

--- a/charts/consul/test/unit/cni-serviceaccount.bats
+++ b/charts/consul/test/unit/cni-serviceaccount.bats
@@ -2,37 +2,37 @@
 
 load _helpers
 
-@test "cni/daemonset: disabled by default" {
+@test "cni/ServiceAccount: disabled by default" {
   cd `chart_dir`
   assert_empty helm template \
-      -s templates/cni-daemonset.yaml  \
+      -s templates/cni-serviceaccount.yaml  \
       .
 }
 
-@test "cni/daemonset: enabled with connectInject.cni.enabled=true and connectInject.enabled=true" {
+@test "cni/ServiceAccount: enabled with connectInject.cni.enabled=true and connectInject.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/cni-daemonset.yaml  \
+      -s templates/cni-serviceaccount.yaml  \
       --set 'connectInject.cni.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [[ "${actual}" == *"true"* ]]
+  [[ "${actual}" == "true" ]]
 }
 
-@test "cni/daemonset: disabled with connectInject.cni.enabled=false and connectInject.enabled=true" {
+@test "cni/ServiceAccount: disabled with connectInject.cni.enabled=false and connectInject.enabled=true" {
   cd `chart_dir`
   assert_empty helm template \
       --set 'connectInject.cni.enabled=false' \
       --set 'connectInject.enabled=true' \
-      -s templates/cni-daemonset.yaml  \
+      -s templates/cni-serviceaccount.yaml  \
       .
 }
 
 #--------------------------------------------------------------------
 # global.imagePullSecrets
 
-@test "cni/serviceaccount: can set image pull secrets" {
+@test "cni/ServiceAccount: can set image pull secrets" {
   cd `chart_dir`
   local object=$(helm template \
       -s templates/cni-serviceaccount.yaml  \

--- a/charts/consul/test/unit/connect-inject-clusterrole.bats
+++ b/charts/consul/test/unit/connect-inject-clusterrole.bats
@@ -32,7 +32,7 @@ load _helpers
 #--------------------------------------------------------------------
 # rules
 
-@test "connectInject/ClusterRole: sets get, list, and watch access to pods, endpoints, services, and namespaces in all api groups" {
+@test "connectInject/ClusterRole: sets get, list, and watch access to endpoints, services, and namespaces in all api groups" {
   cd `chart_dir`
   local object=$(helm template \
       -s templates/connect-inject-clusterrole.yaml  \
@@ -41,9 +41,6 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.rules[0]' | tee /dev/stderr)
-
-  local actual=$(echo $object | yq -r '.resources[| index("pods")' | tee /dev/stderr)
-  [ "${actual}" != null ]
 
   local actual=$(echo $object | yq -r '.resources[| index("endpoints")' | tee /dev/stderr)
   [ "${actual}" != null ]
@@ -67,7 +64,7 @@ load _helpers
   [ "${actual}" != null ]
 }
 
-@test "connectInject/ClusterRole: sets create, get, list, and update access to leases in the coordination.k8s.io api group" {
+@test "connectInject/ClusterRole: sets get, list, watch and update access to pods in all api groups" {
   cd `chart_dir`
   local object=$(helm template \
       -s templates/connect-inject-clusterrole.yaml  \
@@ -76,6 +73,35 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.rules[1]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.resources[| index("pods")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  local actual=$(echo $object | yq -r '.apiGroups[0]' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+
+  local actual=$(echo $object | yq -r '.verbs | index("get")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  local actual=$(echo $object | yq -r '.verbs | index("list")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  local actual=$(echo $object | yq -r '.verbs | index("watch")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  local actual=$(echo $object | yq -r '.verbs | index("update")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+}
+
+@test "connectInject/ClusterRole: sets create, get, list, and update access to leases in the coordination.k8s.io api group" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/connect-inject-clusterrole.yaml  \
+      --set 'global.enabled=false' \
+      --set 'client.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules[2]' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.resources[| index("leases")' | tee /dev/stderr)
   [ "${actual}" != null ]
@@ -166,7 +192,7 @@ load _helpers
       --set 'global.secretsBackend.vault.consulServerRole=bar' \
       --set 'global.secretsBackend.vault.consulCARole=test2' \
       . | tee /dev/stderr |
-      yq -r '.rules[2]' | tee /dev/stderr)
+      yq -r '.rules[3]' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.resources[0]' | tee /dev/stderr)
   [ "${actual}" = "mutatingwebhookconfigurations" ]

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -1796,6 +1796,32 @@ EOF
 }
 
 #--------------------------------------------------------------------
+# cni 
+
+@test "connectInject/Deployment: cni is disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-cni=false"))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: cni can be enabled by setting connectInject.cni.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.cni.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-cni=true"))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # peering
 
 @test "connectInject/Deployment: peering is not set by default" {

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -1800,24 +1800,28 @@ EOF
 
 @test "connectInject/Deployment: cni is disabled by default" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local cmd=$(helm template \
       -s templates/connect-inject-deployment.yaml  \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-enable-cni=false"))' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-enable-cni=false"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
 @test "connectInject/Deployment: cni can be enabled by setting connectInject.cni.enabled=true" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local cmd=$(helm template \
       -s templates/connect-inject-deployment.yaml  \
       --set 'connectInject.enabled=true' \
       --set 'connectInject.cni.enabled=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-enable-cni=true"))' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-enable-cni=true"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1865,6 +1865,10 @@ connectInject:
     # If true, then all traffic redirection setup with use the consul-cni plugin
     # @type: boolean
     enabled: false
+
+    # Namespace to install cni plugin.
+    # @type: string
+    namespace: kube-system
  
     # If multus plugin is enabled or not. If true, the cni installer will generate a consul cni configuration
     # in a location for the multus program to use. Also, the helm chart will create a custom resource for

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1864,10 +1864,6 @@ connectInject:
     # If true, then all traffic redirection setup with use the consul-cni plugin
     # @type: boolean
     enabled: false
-
-    # Namespace to install cni plugin.
-    # @type: string
-    namespace: kube-system
  
     # If multus plugin is enabled or not. If true, the CNI installer will generate a consul CNI configuration
     # in a location for the multus program to use. Also, the helm chart will create a custom resource for
@@ -1888,12 +1884,7 @@ connectInject:
     # Location on the kubernetes node of all CNI configuration. Should be the absolute path and start with a '/'
     # @type: string
     cniNetDir: "/etc/cni/net.d"
-
-    # The daemonset should in privileged mode on all kubernetes platforms as it needs to interact with the
-    # kubernetes host file system
-    # @type: boolean
-    privileged: true
-  
+ 
     # The resource settings for CNI installer daemonset.
     # @recurse: false
     # @type: map

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1877,15 +1877,17 @@ connectInject:
     # @type: string
     logLevel: null 
     
-    # Location on the kubernetes node where the CNI plugin is installed
+    # Location on the kubernetes node where the CNI plugin is installed. Shoud be the absolute path and start with a '/'
     # @type: string
     cniBinDir: "/opt/cni/bin"
 
-    # Location on the kubernetes node of all CNI configuration
+    # Location on the kubernetes node of all CNI configuration. Should be the absolute path and start with a '/'
     # @type: string
     cniNetDir: "/etc/cni/net.d"
 
-    # Allow the cni daemonset to run in privileged mode
+    # The daemonset should in privileged mode on all kubernetes platforms as it needs to interact with the
+    # kubernetes host file system
+    # @type: boolean
     privileged: true
   
     # The resource settings for cni daemonset.

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1900,7 +1900,11 @@ connectInject:
       limits:
         memory: "50Mi"
         cpu: "50m"
- 
+
+    # Resource quotas for running the daemonset as system critical pods
+    resourceQuota:
+      pods: 5000
+
     # The security context for the cni installer daemonset. This should be a YAML map corresponding to a
     # Kubernetes [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) object.
     # By default, servers will run as non-root, with user ID `100` and group ID `1000`,

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1,4 +1,4 @@
-# Available parameters and tienteir default values for the Consul chart.
+# Available parameters and their default values for the Consul chart.
 
 # Holds values that affect multiple components of the chart.
 global:
@@ -1859,7 +1859,7 @@ connectInject:
     # Note: This value has no effect if transparent proxy is disabled on the pod.
     defaultOverwriteProbes: true
 
-  # Configures consul-cni pluging for Consul Service mesh services
+  # Configures consul-cni plugin for Consul Service mesh services
   # Using this feature requires Consul 1.13.0-beta+
   cni:
     # If true, then all traffic redirection setup with use the consul-cni plugin
@@ -1911,8 +1911,7 @@ connectInject:
 
     # The security context for the cni installer daemonset. This should be a YAML map corresponding to a
     # Kubernetes [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) object.
-    # By default, servers will run as non-root, with user ID `100` and group ID `1000`,
-    # which correspond to the consul user and group created by the Consul docker image.
+    # By default, servers will run as root, with user ID `0` and group ID `0`.
     # Note: if running on OpenShift, this setting is ignored because the user and group are set automatically
     # by the OpenShift platform.
     # @type: map

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1,4 +1,4 @@
-# Available parameters and their default values for the Consul chart.
+# Available parameters and tienteir default values for the Consul chart.
 
 # Holds values that affect multiple components of the chart.
 global:
@@ -1863,7 +1863,71 @@ connectInject:
   # Using this feature requires Consul 1.13.0-beta+
   cni:
     # If true, then all traffic redirection setup with use the consul-cni plugin
+    # @type: boolean
     enabled: false
+ 
+    # If multus plugin is enabled or not. If true, the cni installer will generate a consul cni configuration
+    # in a location for the multus program to use. Also, the helm chart will create a custom resource for
+    # NetworkAttachmentDefintion that multis. cniBinDir and cniNetDir must be changed to work with multus.
+    # Please refer to your cloud platform for more informaton on using multus.
+    # @type: boolean
+    multus: false
+
+    # Log level for the installer and plugin. Overrides global.logLevel
+    # @type: string
+    logLevel: null 
+    
+    # Location on the kubernetes node where the CNI plugin is installed
+    # @type: string
+    cniBinDir: "/opt/cni/bin"
+
+    # Location on the kubernetes node of all CNI configuration
+    # @type: string
+    cniNetDir: "/etc/cni/net.d"
+
+    # Allow the cni daemonset to run in privileged mode
+    privileged: true
+  
+    # The resource settings for cni daemonset.
+    # @recurse: false
+    # @type: map
+    resources:
+      requests:
+        memory: "50Mi"
+        cpu: "50m"
+      limits:
+        memory: "50Mi"
+        cpu: "50m"
+ 
+    # The security context for the cni installer daemonset. This should be a YAML map corresponding to a
+    # Kubernetes [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) object.
+    # By default, servers will run as non-root, with user ID `100` and group ID `1000`,
+    # which correspond to the consul user and group created by the Consul docker image.
+    # Note: if running on OpenShift, this setting is ignored because the user and group are set automatically
+    # by the OpenShift platform.
+    # @type: map
+    # @recurse: false
+    securityContext:
+      runAsNonRoot: false
+      runAsGroup: 0
+      runAsUser: 0
+
+    # updateStrategy for the cni DaemonSet.
+    # See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy.
+    # This should be a multi-line string mapping directly to the updateStrategy
+    #
+    # Example:
+    #
+    # ```yaml
+    # updateStrategy: |
+    #   rollingUpdate:
+    #     maxUnavailable: 5
+    #   type: RollingUpdate
+    # ```
+    #
+    # @type: string
+    updateStrategy: null
+
 
   # Configures metrics for Consul Connect services. All values are overridable
   # via annotations on a per-pod basis.

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1860,7 +1860,6 @@ connectInject:
     defaultOverwriteProbes: true
 
   # Configures consul-cni plugin for Consul Service mesh services
-  # Using this feature requires Consul 1.13.0-beta+
   cni:
     # If true, then all traffic redirection setup with use the consul-cni plugin
     # @type: boolean
@@ -1870,9 +1869,10 @@ connectInject:
     # @type: string
     namespace: kube-system
  
-    # If multus plugin is enabled or not. If true, the cni installer will generate a consul cni configuration
+    # If multus plugin is enabled or not. If true, the CNI installer will generate a consul CNI configuration
     # in a location for the multus program to use. Also, the helm chart will create a custom resource for
-    # NetworkAttachmentDefintion that multis. cniBinDir and cniNetDir must be changed to work with multus.
+    # NetworkAttachmentDefintion that multis will consume. The values for cniBinDir and cniNetDir must also be 
+    # changed for multus to work.
     # Please refer to your cloud platform for more informaton on using multus.
     # @type: boolean
     multus: false
@@ -1894,7 +1894,7 @@ connectInject:
     # @type: boolean
     privileged: true
   
-    # The resource settings for cni daemonset.
+    # The resource settings for CNI installer daemonset.
     # @recurse: false
     # @type: map
     resources:
@@ -1909,7 +1909,7 @@ connectInject:
     resourceQuota:
       pods: 5000
 
-    # The security context for the cni installer daemonset. This should be a YAML map corresponding to a
+    # The security context for the CNI installer daemonset. This should be a YAML map corresponding to a
     # Kubernetes [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) object.
     # By default, servers will run as root, with user ID `0` and group ID `0`.
     # Note: if running on OpenShift, this setting is ignored because the user and group are set automatically
@@ -1921,7 +1921,7 @@ connectInject:
       runAsGroup: 0
       runAsUser: 0
 
-    # updateStrategy for the cni DaemonSet.
+    # updateStrategy for the CNI installer DaemonSet.
     # See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy.
     # This should be a multi-line string mapping directly to the updateStrategy
     #

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1885,7 +1885,7 @@ connectInject:
     # If multus plugin is enabled or not. If true, the CNI installer will generate a consul CNI configuration
     # in a location for the multus program to use. Also, the helm chart will create a custom resource for
     # NetworkAttachmentDefintion that multus will consume. The values for cniBinDir and cniNetDir must also be 
-    # changed for multus to work. There is a GKE example for cniBinDir below. 
+    # changed for multus to work. 
     # Please refer to your cloud platform for more informaton on using multus.
     # @type: boolean
     multus: false
@@ -1900,7 +1900,6 @@ connectInject:
     # ```yaml
     # cniBinDir: "/home/kubernetes/bin"
     # ```
-
     # @type: string
     cniBinDir: "/opt/cni/bin"
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -534,8 +534,7 @@ global:
     # `<helm-release-name>-consul-federation`.
     createFederationSecret: false
 
-    # The name of the primary datacenter.  This should only be set for datacenters
-    # that are not the primary datacenter.
+    # The name of the primary datacenter.
     # @type: string
     primaryDatacenter: null
 
@@ -1860,21 +1859,11 @@ connectInject:
     # Note: This value has no effect if transparent proxy is disabled on the pod.
     defaultOverwriteProbes: true
 
-  # This configures the PodDisruptionBudget (https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
-  # for the service mesh sidecar injector.
-  disruptionBudget: 
-    # This will enable/disable registering a PodDisruptionBudget for the 
-    # service mesh sidecar injector. If this is enabled, it will only register the budget so long as
-    # the service mesh is enabled.
-    enabled: true
-
-    # The maximum number of unavailable pods. By default, this will be
-    # automatically computed based on the `connectInject.replicas` value to be `(n/2)-1`.
-    # If you need to set this to `0`, you will need to add a
-    # --set 'connectInject.disruptionBudget.maxUnavailable=0'` flag to the helm chart installation
-    # command because of a limitation in the Helm templating language.
-    # @type: integer
-    maxUnavailable: null
+  # Configures consul-cni pluging for Consul Service mesh services
+  # Using this feature requires Consul 1.13.0-beta+
+  cni:
+    # If true, then all traffic redirection setup with use the consul-cni plugin
+    enabled: false
 
   # Configures metrics for Consul Connect services. All values are overridable
   # via annotations on a per-pod basis.

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1859,6 +1859,22 @@ connectInject:
     # Note: This value has no effect if transparent proxy is disabled on the pod.
     defaultOverwriteProbes: true
 
+  # This configures the PodDisruptionBudget (https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
+  # for the service mesh sidecar injector.
+  disruptionBudget: 
+    # This will enable/disable registering a PodDisruptionBudget for the 
+    # service mesh sidecar injector. If this is enabled, it will only register the budget so long as
+    # the service mesh is enabled.
+    enabled: true
+
+    # The maximum number of unavailable pods. By default, this will be
+    # automatically computed based on the `connectInject.replicas` value to be `(n/2)-1`.
+    # If you need to set this to `0`, you will need to add a
+    # --set 'connectInject.disruptionBudget.maxUnavailable=0'` flag to the helm chart installation
+    # command because of a limitation in the Helm templating language.
+    # @type: integer
+    maxUnavailable: null
+
   # Configures consul-cni plugin for Consul Service mesh services
   cni:
     # If true, then all traffic redirection setup will use the consul-cni plugin. 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1861,14 +1861,15 @@ connectInject:
 
   # Configures consul-cni plugin for Consul Service mesh services
   cni:
-    # If true, then all traffic redirection setup with use the consul-cni plugin
+    # If true, then all traffic redirection setup will use the consul-cni plugin. 
+    # Requires connectInject.enabled to also be true.
     # @type: boolean
     enabled: false
  
     # If multus plugin is enabled or not. If true, the CNI installer will generate a consul CNI configuration
     # in a location for the multus program to use. Also, the helm chart will create a custom resource for
-    # NetworkAttachmentDefintion that multis will consume. The values for cniBinDir and cniNetDir must also be 
-    # changed for multus to work.
+    # NetworkAttachmentDefintion that multus will consume. The values for cniBinDir and cniNetDir must also be 
+    # changed for multus to work. There is a GKE example for cniBinDir below. 
     # Please refer to your cloud platform for more informaton on using multus.
     # @type: boolean
     multus: false
@@ -1878,6 +1879,12 @@ connectInject:
     logLevel: null 
     
     # Location on the kubernetes node where the CNI plugin is installed. Shoud be the absolute path and start with a '/'
+    # Example on GKE:
+    #
+    # ```yaml
+    # cniBinDir: "/home/kubernetes/bin"
+    # ```
+
     # @type: string
     cniBinDir: "/opt/cni/bin"
 

--- a/control-plane/subcommand/install-cni/testdata/ZZZ-consul-cni-kubeconfig.golden
+++ b/control-plane/subcommand/install-cni/testdata/ZZZ-consul-cni-kubeconfig.golden
@@ -1,7 +1,7 @@
 apiVersion: v1
 clusters:
 - cluster:
-    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0
+    certificate-authority: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0
     server: https://[172.30.0.1]:443
   name: local
 contexts:

--- a/control-plane/subcommand/install-cni/testdata/ZZZ-consul-cni-kubeconfig.golden
+++ b/control-plane/subcommand/install-cni/testdata/ZZZ-consul-cni-kubeconfig.golden
@@ -1,7 +1,7 @@
 apiVersion: v1
 clusters:
 - cluster:
-    certificate-authority: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0
     server: https://[172.30.0.1]:443
   name: local
 contexts:
@@ -15,4 +15,5 @@ preferences: {}
 users:
 - name: consul-cni
   user:
+    as-user-extra: null
     token: eyJhbGciOiJSUzI1NiIsImtp

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -21,6 +21,8 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/mapstructure"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -755,7 +757,7 @@ func (c *Command) configureGateway(gatewayParams ConfigureGatewayParams, consulC
 	for _, name := range gatewayParams.GatewayNames {
 		if name == "" {
 			errMessage := fmt.Sprintf("%s gateway name cannot be empty",
-				strings.Title(strings.ToLower(gatewayParams.GatewayType)))
+				cases.Title(language.English).String(gatewayParams.GatewayType))
 			c.log.Error(errMessage)
 			return errors.New(errMessage)
 		}


### PR DESCRIPTION
This PR contains the base helm charts for installing CNI.

Changes proposed in this PR:

 - A daemonset for the cni installer
 - Service account for the cni plugin
 - Clusterrole and clusterrolebinding for the service account
 - Bats tests for all of the above.

Note: Helm changes coming in follow on PRs

- Openshift support (SCC)
- Disabling redirect-traffic in connect-inject

How I've tested this PR:

- bats tests
- manual installing in my kind cluster

How I expect reviewers to test this PR:

👀

Checklist:

[x] Tests added
[ ] CHANGELOG entry added
    HashiCorp engineers only, community PRs should not add a changelog entry.
    Entries should use present tense (e.g. Add support for...)

