### PR TITLE
Updating values docs to only set  global.federation.primaryDatacenter outside of the primary datacenter.

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -534,7 +534,8 @@ global:
     # `<helm-release-name>-consul-federation`.
     createFederationSecret: false
 
-    # The name of the primary datacenter.
+    # The name of the primary datacenter.  This should only be set for datacenters
+    # that are not the primary datacenter.
     # @type: string
     primaryDatacenter: null
 


### PR DESCRIPTION
Related to issues found in https://github.com/hashicorp/consul-k8s/issues/1309 when setting this in the primary datacenter.

Changes proposed in this PR:
- Updating values docs to only set  global.federation.primaryDatacenter outside of the primary datacenter.

How I've tested this PR:
N/A

How I expect reviewers to test this PR:
👀 

