### PR TITLE
Enable connect-injector to talk to external servers.

### DIFF
--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -34,6 +34,10 @@ type HelmCluster struct {
 	// a bootstrap token from a Kubernetes secret stored in the cluster.
 	ACLToken string
 
+	// SkipCheckForPreviousInstallations is a toggle for skipping the check
+	// if there are any previous installations of this Helm chart in the cluster.
+	SkipCheckForPreviousInstallations bool
+
 	ctx                environment.TestContext
 	helmOptions        *helm.Options
 	releaseName        string
@@ -107,7 +111,9 @@ func (h *HelmCluster) Create(t *testing.T) {
 	})
 
 	// Fail if there are any existing installations of the Helm chart.
-	helpers.CheckForPriorInstallations(t, h.kubernetesClient, h.helmOptions, "consul-helm", "chart=consul-helm")
+	if !h.SkipCheckForPreviousInstallations {
+		helpers.CheckForPriorInstallations(t, h.kubernetesClient, h.helmOptions, "consul-helm", "chart=consul-helm")
+	}
 
 	helm.Install(t, h.helmOptions, config.HelmChartPath, h.releaseName)
 

--- a/acceptance/tests/connect/connect_external_servers_test.go
+++ b/acceptance/tests/connect/connect_external_servers_test.go
@@ -1,0 +1,135 @@
+package connect
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestConnectInject_ExternalServers tests that connect works when using external servers.
+// It sets up an external Consul server in the same cluster but a different Helm installation
+// and then treats this server as external.
+func TestConnectInject_ExternalServers(t *testing.T) {
+	cases := []bool{false, true}
+
+	for _, secure := range cases {
+		caseName := fmt.Sprintf("secure: %t", secure)
+		t.Run(caseName, func(t *testing.T) {
+			cfg := suite.Config()
+			ctx := suite.Environment().DefaultContext(t)
+
+			serverHelmValues := map[string]string{
+				"global.acls.manageSystemACLs": strconv.FormatBool(secure),
+				"global.tls.enabled":           strconv.FormatBool(secure),
+			}
+			serverReleaseName := helpers.RandomName()
+			consulServerCluster := consul.NewHelmCluster(t, serverHelmValues, ctx, cfg, serverReleaseName)
+
+			consulServerCluster.Create(t)
+
+			helmValues := map[string]string{
+				"server.enabled":               "false",
+				"global.acls.manageSystemACLs": strconv.FormatBool(secure),
+
+				"global.tls.enabled": strconv.FormatBool(secure),
+
+				"connectInject.enabled": "true",
+
+				"externalServers.enabled":   "true",
+				"externalServers.hosts[0]":  fmt.Sprintf("%s-consul-server", serverReleaseName),
+				"externalServers.httpsPort": "8500",
+			}
+
+			if secure {
+				helmValues["global.tls.caCert.secretName"] = fmt.Sprintf("%s-consul-ca-cert", serverReleaseName)
+				helmValues["global.tls.caCert.secretKey"] = "tls.crt"
+				helmValues["global.acls.bootstrapToken.secretName"] = fmt.Sprintf("%s-consul-bootstrap-acl-token", serverReleaseName)
+				helmValues["global.acls.bootstrapToken.secretKey"] = "token"
+				helmValues["externalServers.httpsPort"] = "8501"
+			}
+
+			releaseName := helpers.RandomName()
+			consulCluster := consul.NewHelmCluster(t, helmValues, ctx, cfg, releaseName)
+			consulCluster.SkipCheckForPreviousInstallations = true
+
+			consulCluster.Create(t)
+
+			logger.Log(t, "creating static-server and static-client deployments")
+			k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
+			if cfg.EnableTransparentProxy {
+				k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-tproxy")
+			} else {
+				k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-inject")
+			}
+
+			// Check that both static-server and static-client have been injected and now have 2 containers.
+			for _, labelSelector := range []string{"app=static-server", "app=static-client"} {
+				podList, err := ctx.KubernetesClient(t).CoreV1().Pods(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{
+					LabelSelector: labelSelector,
+				})
+				require.NoError(t, err)
+				require.Len(t, podList.Items, 1)
+				require.Len(t, podList.Items[0].Spec.Containers, 2)
+			}
+
+			if secure {
+				consulClient, _ := consulServerCluster.SetupConsulClient(t, true)
+
+				logger.Log(t, "checking that the connection is not successful because there's no intention")
+				if cfg.EnableTransparentProxy {
+					k8s.CheckStaticServerConnectionFailing(t, ctx.KubectlOptions(t), StaticClientName, "http://static-server")
+				} else {
+					k8s.CheckStaticServerConnectionFailing(t, ctx.KubectlOptions(t), StaticClientName, "http://localhost:1234")
+				}
+
+				intention := &api.ServiceIntentionsConfigEntry{
+					Kind: api.ServiceIntentions,
+					Name: staticServerName,
+					Sources: []*api.SourceIntention{
+						{
+							Name:   StaticClientName,
+							Action: api.IntentionActionAllow,
+						},
+					},
+				}
+
+				logger.Log(t, "creating intention")
+				_, _, err := consulClient.ConfigEntries().Set(intention, nil)
+				require.NoError(t, err)
+			}
+
+			logger.Log(t, "checking that connection is successful")
+			if cfg.EnableTransparentProxy {
+				k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), StaticClientName, "http://static-server")
+			} else {
+				k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), StaticClientName, "http://localhost:1234")
+			}
+
+			// Test that kubernetes readiness status is synced to Consul.
+			// Create the file so that the readiness probe of the static-server pod fails.
+			logger.Log(t, "testing k8s -> consul health checks sync by making the static-server unhealthy")
+			k8s.RunKubectl(t, ctx.KubectlOptions(t), "exec", "deploy/"+staticServerName, "--", "touch", "/tmp/unhealthy")
+
+			// The readiness probe should take a moment to be reflected in Consul, CheckStaticServerConnection will retry
+			// until Consul marks the service instance unavailable for mesh traffic, causing the connection to fail.
+			// We are expecting a "connection reset by peer" error because in a case of health checks,
+			// there will be no healthy proxy host to connect to. That's why we can't assert that we receive an empty reply
+			// from server, which is the case when a connection is unsuccessful due to intentions in other tests.
+			logger.Log(t, "checking that connection is unsuccessful")
+			if cfg.EnableTransparentProxy {
+				k8s.CheckStaticServerConnectionMultipleFailureMessages(t, ctx.KubectlOptions(t), StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server", "curl: (7) Failed to connect to static-server port 80: Connection refused"}, "", "http://static-server.%s")
+			} else {
+				k8s.CheckStaticServerConnectionMultipleFailureMessages(t, ctx.KubectlOptions(t), StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"}, "", "http://localhost:1234")
+			}
+		})
+	}
+}

--- a/acceptance/tests/connect/connect_inject_test.go
+++ b/acceptance/tests/connect/connect_inject_test.go
@@ -24,7 +24,6 @@ func TestConnectInject(t *testing.T) {
 		clusterKind consul.ClusterKind
 		releaseName string
 		secure      bool
-		autoEncrypt bool
 	}{
 		"Helm install without secure": {
 			clusterKind: consul.Helm,
@@ -54,7 +53,6 @@ func TestConnectInject(t *testing.T) {
 			connHelper := ConnectHelper{
 				ClusterKind: c.clusterKind,
 				Secure:      c.secure,
-				AutoEncrypt: c.autoEncrypt,
 				ReleaseName: c.releaseName,
 				Ctx:         ctx,
 				Cfg:         cfg,

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -96,13 +96,15 @@ spec:
                   name: {{ .Values.connectInject.aclInjectToken.secretName }}
                   key: {{ .Values.connectInject.aclInjectToken.secretKey }}
             {{- end }}
+            {{- if not .Values.externalServers.enabled }}
             - name: CONSUL_HTTP_ADDR
               {{- if .Values.global.tls.enabled }}
               value: https://{{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc:8501
               {{- else }}
               value: http://{{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc:8500
             {{- end }}
-            {{- if (and .Values.global.tls.enabled (not .Values.externalServers.useSystemRoots)) }}
+            {{- end }}
+            {{- if (and .Values.global.tls.enabled (not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots))) }}
             - name: CONSUL_CACERT
               {{- if .Values.global.secretsBackend.vault.enabled }}
               value: "/vault/secrets/serverca.crt"
@@ -125,6 +127,19 @@ spec:
                 -release-name="{{ .Release.Name }}" \
                 -release-namespace="{{ .Release.Namespace }}" \
                 -listen=:8080 \
+                {{- if and .Values.externalServers.enabled (not .Values.externalServers.hosts) }}{{ fail "externalServers.hosts must be set if externalServers.enabled is true" }}{{ end -}}
+                {{- if .Values.externalServers.enabled }}
+                {{- if .Values.global.tls.enabled }}
+                -use-https \
+                {{- end }}
+                {{- range .Values.externalServers.hosts }}
+                -server-address={{ quote . }} \
+                {{- end }}
+                -server-port={{ .Values.externalServers.httpsPort }} \
+                {{- if .Values.externalServers.tlsServerName }}
+                -tls-server-name={{ .Values.externalServers.tlsServerName }} \
+                {{- end }}
+                {{- end }}
                 {{- if .Values.connectInject.transparentProxy.defaultEnabled }}
                 -default-enable-transparent-proxy=true \
                 {{- else }}
@@ -288,7 +303,7 @@ spec:
           - mountPath: /consul/login
             name: consul-data
             readOnly: true
-          {{- if .Values.global.tls.enabled }}
+          {{- if and .Values.global.tls.enabled (not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots))}}
           - name: consul-ca-cert
             mountPath: /consul/tls/ca
             readOnly: true
@@ -325,13 +340,15 @@ spec:
       initContainers:
       - name: connect-injector-acl-init
         env:
+        {{- if not .Values.externalServers.enabled }}
         - name: CONSUL_HTTP_ADDR
           {{- if .Values.global.tls.enabled }}
           value: https://{{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc:8501
           {{- else }}
           value: http://{{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc:8500
           {{- end }}
-        {{- if (and .Values.global.tls.enabled (not .Values.externalServers.useSystemRoots)) }}
+        {{- end }}
+        {{- if (and .Values.global.tls.enabled (not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots))) }}
         - name: CONSUL_CACERT
           {{- if .Values.global.secretsBackend.vault.enabled }}
           value: "/vault/secrets/serverca.crt"
@@ -344,7 +361,7 @@ spec:
         - mountPath: /consul/login
           name: consul-data
           readOnly: false
-        {{- if .Values.global.tls.enabled }}
+        {{- if and .Values.global.tls.enabled (not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots))}}
         - name: consul-ca-cert
           mountPath: /consul/tls/ca
           readOnly: true
@@ -363,6 +380,18 @@ spec:
               {{- end }}
               {{- if .Values.global.adminPartitions.enabled }}
               -partition={{ .Values.global.adminPartitions.name }} \
+              {{- end }}
+              {{- if .Values.externalServers.enabled }}
+              {{- if .Values.global.tls.enabled }}
+              -use-https \
+              {{- end }}
+              {{- range .Values.externalServers.hosts }}
+              -server-address={{ quote . }} \
+              {{- end }}
+              -server-port={{ .Values.externalServers.httpsPort }} \
+              {{- if .Values.externalServers.tlsServerName }}
+              -tls-server-name={{ .Values.externalServers.tlsServerName }} \
+              {{- end }}
               {{- end }}
               -consul-api-timeout={{ .Values.global.consulAPITimeout }} \
               -log-level={{ default .Values.global.logLevel .Values.connectInject.logLevel }} \

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -2193,3 +2193,136 @@ reservedNameTest() {
 		[ "$status" -eq 1 ]
 		[[ "$output" =~ "The name $name set for key connectInject.consulNamespaces.consulDestinationNamespace is reserved by Consul for future use" ]]
 }
+
+#--------------------------------------------------------------------
+# externalServers
+
+@test "connectInject/Deployment: fails if externalServers.hosts is not provided when externalServers.enabled is true" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'server.enabled=false' \
+      --set 'externalServers.enabled=true' \
+       .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "externalServers.hosts must be set if externalServers.enabled is true" ]]
+}
+
+@test "connectInject/Deployment: configures the sidecar-injector and acl-init containers to use external servers" {
+  cd `chart_dir`
+  local spec=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'server.enabled=false' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=consul' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec' | tee /dev/stderr)
+
+  local actual=$(echo "$spec" | yq '.containers[0].command | any(contains("-server-address=\"consul\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$spec" | yq '.containers[0].command | any(contains("-server-port=8501"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$spec" | yq '.containers[0].env[] | select(.name == "CONSUL_HTTP_ADDR")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+
+  local actual=$(echo "$spec" | yq '.initContainers[0].command | any(contains("-server-address=\"consul\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$spec" | yq '.initContainers[0].command | any(contains("-server-port=8501"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$spec" | yq '.initContainers[0].env[] | select(.name == "CONSUL_HTTP_ADDR")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+}
+
+@test "connectInject/Deployment: can provide a different port for the sidecar-injector and acl-init containers when external servers are enabled" {
+  cd `chart_dir`
+  local spec=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'server.enabled=false' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=consul' \
+      --set 'externalServers.httpsPort=443' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec' | tee /dev/stderr)
+
+  local actual=$(echo "$spec" | yq '.containers[0].command | any(contains("-server-port=443"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$spec" | yq '.initContainers[0].command | any(contains("-server-port=443"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: can provide a TLS server name for the sidecar-injector and acl-init containers when external servers are enabled" {
+  cd `chart_dir`
+  local spec=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'server.enabled=false' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=consul' \
+      --set 'externalServers.tlsServerName=foo' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec' | tee /dev/stderr)
+
+  local actual=$(echo "$spec" | yq '.containers[0].command | any(contains("-tls-server-name=foo"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$spec" | yq '.initContainers[0].command | any(contains("-tls-server-name=foo"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: sets -use-https flag for the sidecar-injector and acl-init containers when external servers with TLS are enabled" {
+  cd `chart_dir`
+  local spec=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'server.enabled=false' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=consul' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec' | tee /dev/stderr)
+
+  local actual=$(echo "$spec" | yq '.containers[0].command | any(contains("-use-https"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$spec" | yq '.initContainers[0].command | any(contains("-use-https"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "connectInject/Deployment: does not configure CA cert for the sidecar-injector and acl-init containers when external servers with useSystemRoots are enabled" {
+  cd `chart_dir`
+  local spec=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'server.enabled=false' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=consul' \
+      --set 'externalServers.useSystemRoots=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec' | tee /dev/stderr)
+
+  local actual=$(echo "$spec" | yq '.containers[0].env[] | select(.name == "CONSUL_CACERT")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+
+  local actual=$(echo "$spec" | yq '.containers[0].volumeMounts[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+
+  local actual=$(echo "$spec" | yq '.initContainers[0].volumeMounts[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+
+  local actual=$(echo "$spec" | yq '.volumes[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+}

--- a/control-plane/connect-inject/mesh_webhook.go
+++ b/control-plane/connect-inject/mesh_webhook.go
@@ -31,7 +31,7 @@ var (
 	kubeSystemNamespaces = mapset.NewSetWith(metav1.NamespaceSystem, metav1.NamespacePublic)
 )
 
-// Webhook is the HTTP meshWebhook for admission webhooks.
+// MeshWebhook is the HTTP meshWebhook for admission webhooks.
 type MeshWebhook struct {
 	ConsulClient *api.Client
 	Clientset    kubernetes.Interface
@@ -64,6 +64,8 @@ type MeshWebhook struct {
 	// If not set, will use HTTP.
 	ConsulCACert string
 
+	// ConsulAddress is the address of the Consul server. This should be only the
+	// host (i.e. not including port or protocol).
 	ConsulAddress string
 
 	// ConsulPartition is the name of the Admin Partition that the controller

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/flags"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-discover"
 	"github.com/mitchellh/cli"
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
@@ -51,6 +52,10 @@ type Command struct {
 	flagEnableWebhookCAUpdate bool
 	flagLogLevel              string
 	flagLogJSON               bool
+
+	flagServerAddresses []string
+	flagServerPort      uint
+	flagUseHTTPS        bool
 
 	flagAllowK8sNamespacesList []string // K8s namespaces to explicitly inject
 	flagDenyK8sNamespacesList  []string // K8s namespaces to deny injection (has precedence)
@@ -115,6 +120,8 @@ type Command struct {
 
 	once sync.Once
 	help string
+
+	providers map[string]discover.Provider
 }
 
 var (
@@ -152,6 +159,12 @@ func (c *Command) init() {
 		"The default protocol to use in central config registrations.")
 	c.flagSet.StringVar(&c.flagConsulCACert, "consul-ca-cert", "",
 		"[Deprecated] Please use '-ca-file' flag instead. Path to CA certificate to use if communicating with Consul clients over HTTPS.")
+	c.flagSet.Var((*flags.AppendSliceValue)(&c.flagServerAddresses), "server-address",
+		"The IP, DNS name or the cloud auto-join string of the Consul server(s). If providing IPs or DNS names, may be specified multiple times. "+
+			"At least one value is required.")
+	c.flagSet.UintVar(&c.flagServerPort, "server-port", 8500, "The HTTP or HTTPS port of the Consul server. Defaults to 8500.")
+	c.flagSet.BoolVar(&c.flagUseHTTPS, "use-https", false,
+		"Toggle for using HTTPS for all API calls to Consul.")
 	c.flagSet.Var((*flags.AppendSliceValue)(&c.flagAllowK8sNamespacesList), "allow-k8s-namespace",
 		"K8s namespaces to explicitly allow. May be specified multiple times.")
 	c.flagSet.Var((*flags.AppendSliceValue)(&c.flagDenyK8sNamespacesList), "deny-k8s-namespace",
@@ -318,19 +331,13 @@ func (c *Command) Run(args []string) int {
 
 	// Create Consul API config object.
 	cfg := api.DefaultConfig()
+	cfg.Scheme = "http"
+	if c.flagUseHTTPS {
+		cfg.Scheme = "https"
+	}
 	c.http.MergeOntoConfig(cfg)
 	if cfg.TLSConfig.CAFile == "" && c.flagConsulCACert != "" {
 		cfg.TLSConfig.CAFile = c.flagConsulCACert
-	}
-	consulURLRaw := cfg.Address
-	// cfg.Address may or may not be prefixed with scheme.
-	if !strings.Contains(cfg.Address, "://") {
-		consulURLRaw = fmt.Sprintf("%s://%s", cfg.Scheme, cfg.Address)
-	}
-	consulURL, err := url.Parse(consulURLRaw)
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("error parsing consul address %q: %s", consulURLRaw, err))
-		return 1
 	}
 
 	// Load CA file contents.
@@ -342,6 +349,35 @@ func (c *Command) Run(args []string) int {
 			c.UI.Error(fmt.Sprintf("error reading Consul's CA cert file %q: %s", cfg.TLSConfig.CAFile, err))
 			return 1
 		}
+	}
+
+	if len(c.flagServerAddresses) > 0 {
+		// TODO (ishustava): eventually we will use go-netaddr library which doesn't use hclog,
+		// and so this additional logger will go away and we'll be able to use zap logger.
+		hclogger, err := common.Logger(c.flagLogLevel, c.flagLogJSON)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Unable to create logger: %s", err))
+			return 1
+		}
+		serverAddresses, err := common.GetResolvedServerAddresses(c.flagServerAddresses, c.providers, hclogger)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Unable to discover any Consul addresses from %q: %s", c.flagServerAddresses[0], err))
+			return 1
+		}
+
+		serverAddr := fmt.Sprintf("%s:%d", serverAddresses[0], c.flagServerPort)
+		cfg.Address = serverAddr
+	}
+
+	consulURLRaw := cfg.Address
+	// cfg.Address may or may not be prefixed with scheme.
+	if !strings.Contains(cfg.Address, "://") {
+		consulURLRaw = fmt.Sprintf("%s://%s", cfg.Scheme, cfg.Address)
+	}
+	consulURL, err := url.Parse(consulURLRaw)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("error parsing consul address %q: %s", consulURLRaw, err))
+		return 1
 	}
 
 	// Set up Consul client.


### PR DESCRIPTION
With agentless, connect-injector now needs to be able to talk to servers directly even when they live outside the cluster. Previously, connect-injector always needed to talk to clients and so this deployment did not need to worry about external servers. 

Changes proposed in this PR:
- Enable connect-injector talk to external servers. This involves providing both acl-init and inject-connect commands with external server configuration
- The `inject-connect` command has been changed to accept external server configuration similar to other commands (e.g. `server-acl-init`) that already support external servers

How I've tested this PR:
acceptance tests

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

