### PR TITLE
Increase machine size for acceptance tests on kind

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -480,7 +480,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     machine:
       image: ubuntu-2004:202010-01
-    resource_class: xlarge
+    resource_class: 2xlarge
     parallelism: 6
     steps:
       - checkout
@@ -512,7 +512,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     machine:
       image: ubuntu-2004:202010-01
-    resource_class: xlarge
+    resource_class: 2xlarge
     parallelism: 6
     steps:
       - checkout
@@ -838,7 +838,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     machine:
       image: ubuntu-2004:202010-01
-    resource_class: xlarge
+    resource_class: 2xlarge
     steps:
       - checkout
       - install-prereqs


### PR DESCRIPTION
Changes proposed in this PR:
- One of the last failures for mesh gateway tests had a consul server that was OOMKilled. Other flakiness potentially could be explained by not having enough resources on kind.

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

