### PR TITLE
Build multi-arch dev-images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,13 +277,18 @@ jobs:
 
   # upload dev docker image
   dev-upload-docker:
-    executor: go
+    machine:
+      image: ubuntu-2004:202010-01
+    environment:
+      DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
       - checkout
       # get consul-k8s binary
       - attach_workspace:
           at: .
-      - setup_remote_docker
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y qemu-user-static
+      - run: docker buildx create --use
       - run:
           name: make ci.dev-docker
           working_directory: *control-plane-path
@@ -983,13 +988,13 @@ workflows:
      # the summer of 2022 for larger puplic Github Action VMs be available before the acceptance tests can
      # be moved
       - build-distro:
-          OS: "darwin freebsd linux solaris windows"
-          ARCH: "amd64"
-          name: build-distros-amd64
+          OS: "linux"
+          ARCH: "amd64 arm64"
+          name: build-distros-linux
       - dev-upload-docker:
           context: consul-ci
           requires:
-            - build-distros-amd64
+            - build-distros-linux
       # Run acceptance tests using the docker image built for the control plane
       - acceptance:
           context: consul-ci
@@ -1010,11 +1015,11 @@ workflows:
     jobs:
       - build-distro:
           OS: "linux"
-          ARCH: "amd64"
-          name: build-distros-amd64
+          ARCH: "amd64 arm64"
+          name: build-distros-linux
       - dev-upload-docker:
           requires:
-            - build-distros-amd64
+            - build-distros-linux
       - cleanup-gcp-resources
       - cleanup-azure-resources
       - cleanup-eks-resources

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ bats-tests: ## Run Helm chart bats tests.
 control-plane-dev: ## Build consul-k8s-control-plane binary.
 	@$(SHELL) $(CURDIR)/control-plane/build-support/scripts/build-local.sh -o $(GOOS) -a $(GOARCH)
 
-control-plane-dev-docker: get-dev-image-env ## Build consul-k8s-control-plane dev Docker image.
+control-plane-dev-docker: ## Build consul-k8s-control-plane dev Docker image.
 	@$(SHELL) $(CURDIR)/control-plane/build-support/scripts/build-local.sh -o linux -a $(GOARCH)
 	@docker build -t '$(DEV_IMAGE)' \
        --target=dev \

--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,30 @@ bats-tests: ## Run Helm chart bats tests.
 control-plane-dev: ## Build consul-k8s-control-plane binary.
 	@$(SHELL) $(CURDIR)/control-plane/build-support/scripts/build-local.sh -o $(GOOS) -a $(GOARCH)
 
-control-plane-dev-docker: ## Build consul-k8s-control-plane dev Docker image.
+control-plane-dev-docker: get-dev-image-env ## Build consul-k8s-control-plane dev Docker image.
 	@$(SHELL) $(CURDIR)/control-plane/build-support/scripts/build-local.sh -o linux -a $(GOARCH)
-	docker build -t '$(DEV_IMAGE)' \
+	@docker build -t '$(DEV_IMAGE)' \
        --target=dev \
-       --build-arg 'ARCH=$(GOARCH)' \
+       --build-arg 'TARGETARCH=$(GOARCH)' \
        --build-arg 'GIT_COMMIT=$(GIT_COMMIT)' \
        --build-arg 'GIT_DIRTY=$(GIT_DIRTY)' \
        --build-arg 'GIT_DESCRIBE=$(GIT_DESCRIBE)' \
+       -f $(CURDIR)/control-plane/Dockerfile $(CURDIR)/control-plane
+
+check-remote-dev-image-env:
+ifndef REMOTE_DEV_IMAGE
+	$(error REMOTE_DEV_IMAGE is undefined: set this image to <your_docker_repo>/<your_docker_image>:<image_tag>, e.g. hashicorp/consul-k8s-dev:latest)
+endif
+
+control-plane-dev-docker-multi-arch: check-remote-dev-image-env ## Build consul-k8s-control-plane dev multi-arch Docker image.
+	@$(SHELL) $(CURDIR)/control-plane/build-support/scripts/build-local.sh -o linux -a "arm64 amd64"
+	@docker buildx create --use && docker buildx build -t '$(REMOTE_DEV_IMAGE)' \
+       --platform linux/amd64,linux/arm64 \
+       --target=dev \
+       --build-arg 'GIT_COMMIT=$(GIT_COMMIT)' \
+       --build-arg 'GIT_DIRTY=$(GIT_DIRTY)' \
+       --build-arg 'GIT_DESCRIBE=$(GIT_DESCRIBE)' \
+       --push \
        -f $(CURDIR)/control-plane/Dockerfile $(CURDIR)/control-plane
 
 control-plane-test: ## Run go test for the control plane.
@@ -67,7 +83,7 @@ acceptance-lint: ## Run linter in the control-plane directory.
 # ===========> Shared Targets
 
 help: ## Show targets and their descriptions.
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-38s\033[0m %s\n", $$1, $$2}'
 
 lint: ## Run linter in the control-plane, cli, and acceptance directories.
 	for p in control-plane cli acceptance; do cd $$p; golangci-lint run --path-prefix $$p -c ../.golangci.yml; cd ..; done

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -22,6 +22,7 @@ FROM alpine:3.15 AS dev
 ARG BIN_NAME=consul-k8s-control-plane
 ARG VERSION
 ARG TARGETARCH
+ARG TARGETOS
 
 LABEL name=${BIN_NAME} \
       maintainer="Team Consul Kubernetes <team-consul-kubernetes@hashicorp.com>" \

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -21,7 +21,7 @@ FROM alpine:3.15 AS dev
 # and the version to download. Example: NAME=consul VERSION=1.2.3.
 ARG BIN_NAME=consul-k8s-control-plane
 ARG VERSION
-ARG ARCH
+ARG TARGETARCH
 
 LABEL name=${BIN_NAME} \
       maintainer="Team Consul Kubernetes <team-consul-kubernetes@hashicorp.com>" \
@@ -41,7 +41,7 @@ RUN apk add --no-cache ca-certificates curl gnupg libcap openssl su-exec iputils
 RUN addgroup ${BIN_NAME} && \
     adduser -S -G ${BIN_NAME} 100
 
-COPY pkg/bin/linux_${ARCH}/${BIN_NAME} /bin
+COPY pkg/bin/linux_${TARGETARCH}/${BIN_NAME} /bin
 
 USER 100
 CMD /bin/${BIN_NAME}

--- a/control-plane/Makefile
+++ b/control-plane/Makefile
@@ -32,16 +32,16 @@ ci.dev-tree:
 # should only run in CI and not locally.
 ci.dev-docker:
 	@echo "Building consul-k8s Development container - $(CI_DEV_DOCKER_IMAGE_NAME)"
-	@docker build -t '$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT)' \
+	@echo $(DOCKER_PASS) | docker login -u="$(DOCKER_USER)" --password-stdin
+	@docker buildx build -t '$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT)' \
+	--platform linux/amd64,linux/arm64 \
 	--target=dev \
-	--build-arg ARCH=amd64 \
+	--push \
 	--label COMMIT_SHA=$(CIRCLE_SHA1) \
 	--label PULL_REQUEST=$(CIRCLE_PULL_REQUEST) \
 	--label CIRCLE_BUILD_URL=$(CIRCLE_BUILD_URL) \
 	$(CI_DEV_DOCKER_WORKDIR) -f $(CURDIR)/Dockerfile
-	@echo $(DOCKER_PASS) | docker login -u="$(DOCKER_USER)" --password-stdin
-	@echo "Pushing dev image to: https://cloud.docker.com/u/$(CI_DEV_DOCKER_NAMESPACE)/repository/docker/$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME)"
-	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT)
+	@echo "Pushed dev image to: $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT)"
 ifeq ($(CIRCLE_BRANCH), main)
 	@docker tag $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT) $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
 	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest


### PR DESCRIPTION
Changes proposed in this PR:
- Add new makefile target to build multi-arch dev images locally 
- Update ci dev image build to build multi-arch images

How I've tested this PR:
Built it locally or in the pipeline ran `docker manifest inspect` on the image to see that it has both architectures

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

