### PR TITLE
enable nightlies for 1.11 and 1.12 and 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,7 +506,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2"
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -helm-chart-version="0.47.1"
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -880,7 +880,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
       - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.11-dev"
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.20.2"
-      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.45.0"
+      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.47.1"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
@@ -909,14 +909,14 @@ jobs:
           path: /tmp/test-results
       - slack/status:
           fail_only: true
-          failure_message: "Acceptance tests against Kind with Kubernetes v1.23 with Consul 1.11.x nightly failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+          failure_message: "Acceptance tests against Kind with Kubernetes v1.23 with Consul 1.11 nightly failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-kind-1-23-consul-nightly-1-12:
     environment:
       - TEST_RESULTS: /tmp/test-results
       - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.12-dev"
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.22.2"
-      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.45.0"
+      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.47.1"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
@@ -952,7 +952,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
       - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.13-dev"
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.22.2"
-      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.45.0"
+      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.47.1"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
@@ -1047,15 +1047,15 @@ workflows:
           requires:
             - dev-upload-docker
 
-#  nightly-acceptance-tests-consul:
-#    triggers:
-#      - schedule:
-#          cron: "0 0 * * *"
-#          filters:
-#            branches:
-#              only:
-#                - main
-#    jobs:
-#      - acceptance-kind-1-23-consul-nightly-1-11
-#      - acceptance-kind-1-23-consul-nightly-1-12
-#      - acceptance-kind-1-23-consul-nightly-1-13
+  nightly-acceptance-tests-consul:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - acceptance-kind-1-23-consul-nightly-1-11
+      - acceptance-kind-1-23-consul-nightly-1-12
+      - acceptance-kind-1-23-consul-nightly-1-13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,7 +506,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -helm-chart-version="0.47.1"
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2"
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -881,6 +881,7 @@ jobs:
       - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.11-dev"
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.20.2"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.47.1"
+      - HELM_CHART_VERSION: "0.47.1"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
@@ -902,7 +903,7 @@ jobs:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -consul-k8s-image=$CONSUL_K8S_IMAGE -consul-image=$CONSUL_IMAGE -consul-version="1.11" -envoy-image=$ENVOY_IMAGE
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -consul-k8s-image=$CONSUL_K8S_IMAGE -consul-image=$CONSUL_IMAGE -consul-version="1.11" -envoy-image=$ENVOY_IMAGE -helm-chart-version=$HELM_CHART_VERSION
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -916,6 +917,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
       - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.12-dev"
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.22.2"
+      - HELM_CHART_VERSION: "0.47.1"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.47.1"
     machine:
       image: ubuntu-2004:202010-01
@@ -938,7 +940,7 @@ jobs:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -consul-k8s-image=$CONSUL_K8S_IMAGE -consul-image=$CONSUL_IMAGE -consul-version="1.12" -envoy-image=$ENVOY_IMAGE
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -consul-k8s-image=$CONSUL_K8S_IMAGE -consul-image=$CONSUL_IMAGE -consul-version="1.12" -envoy-image=$ENVOY_IMAGE -helm-chart-version=$HELM_CHART_VERSION
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -953,6 +955,7 @@ jobs:
       - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.13-dev"
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.22.2"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.47.1"
+      - HELM_CHART_VERSION: "0.47.1"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
@@ -974,7 +977,7 @@ jobs:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -consul-k8s-image=$CONSUL_K8S_IMAGE -consul-image=$CONSUL_IMAGE -consul-version="1.13" -envoy-image=$ENVOY_IMAGE
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -consul-k8s-image=$CONSUL_K8S_IMAGE -consul-image=$CONSUL_IMAGE -consul-version="1.13" -envoy-image=$ENVOY_IMAGE -helm-chart-version=$HELM_CHART_VERSION
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:

--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -42,10 +42,11 @@ type TestConfig struct {
 
 	DisablePeering bool
 
-	ConsulImage    string
-	ConsulK8SImage string
-	ConsulVersion  *version.Version
-	EnvoyImage     string
+	HelmChartVersion string
+	ConsulImage      string
+	ConsulK8SImage   string
+	ConsulVersion    *version.Version
+	EnvoyImage       string
 
 	NoCleanupOnFailure bool
 	DebugDirectory     string

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -86,6 +86,7 @@ func NewHelmCluster(
 		KubectlOptions: ctx.KubectlOptions(t),
 		Logger:         logger,
 		ExtraArgs:      extraArgs,
+		Version:        cfg.HelmChartVersion,
 	}
 	return &HelmCluster{
 		ctx:                ctx,

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -111,7 +111,11 @@ func (h *HelmCluster) Create(t *testing.T) {
 	// Fail if there are any existing installations of the Helm chart.
 	helpers.CheckForPriorInstallations(t, h.kubernetesClient, h.helmOptions, "consul-helm", "chart=consul-helm")
 
-	helm.Install(t, h.helmOptions, config.HelmChartPath, h.releaseName)
+	chartName := "hashicorp/consul"
+	if h.helmOptions.Version == config.HelmChartPath {
+		chartName = config.HelmChartPath
+	}
+	helm.Install(t, h.helmOptions, chartName, h.releaseName)
 
 	k8s.WaitForAllPodsToBeReady(t, h.kubernetesClient, h.helmOptions.KubectlOptions.Namespace, fmt.Sprintf("release=%s", h.releaseName))
 }
@@ -272,7 +276,11 @@ func (h *HelmCluster) Upgrade(t *testing.T, helmValues map[string]string) {
 	t.Helper()
 
 	helpers.MergeMaps(h.helmOptions.SetValues, helmValues)
-	helm.Upgrade(t, h.helmOptions, config.HelmChartPath, h.releaseName)
+	chartName := "hashicorp/consul"
+	if h.helmOptions.Version == config.HelmChartPath {
+		chartName = config.HelmChartPath
+	}
+	helm.Upgrade(t, h.helmOptions, chartName, h.releaseName)
 	k8s.WaitForAllPodsToBeReady(t, h.kubernetesClient, h.helmOptions.KubectlOptions.Namespace, fmt.Sprintf("release=%s", h.releaseName))
 }
 

--- a/acceptance/framework/flags/flags.go
+++ b/acceptance/framework/flags/flags.go
@@ -29,10 +29,11 @@ type TestFlags struct {
 
 	flagEnableTransparentProxy bool
 
-	flagConsulImage    string
-	flagConsulK8sImage string
-	flagConsulVersion  string
-	flagEnvoyImage     string
+	flagHelmChartVersion string
+	flagConsulImage      string
+	flagConsulK8sImage   string
+	flagConsulVersion    string
+	flagEnvoyImage       string
 
 	flagNoCleanupOnFailure bool
 
@@ -62,6 +63,7 @@ func (t *TestFlags) init() {
 	flag.StringVar(&t.flagConsulImage, "consul-image", "", "The Consul image to use for all tests.")
 	flag.StringVar(&t.flagConsulK8sImage, "consul-k8s-image", "", "The consul-k8s image to use for all tests.")
 	flag.StringVar(&t.flagConsulVersion, "consul-version", "", "The consul version used for all tests.")
+	flag.StringVar(&t.flagHelmChartVersion, "helm-chart-version", config.HelmChartPath, "The helm chart used for all tests.")
 	flag.StringVar(&t.flagEnvoyImage, "envoy-image", "", "The Envoy image to use for all tests.")
 
 	flag.BoolVar(&t.flagEnableMultiCluster, "enable-multi-cluster", false,
@@ -146,10 +148,11 @@ func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 
 		DisablePeering: t.flagDisablePeering,
 
-		ConsulImage:    t.flagConsulImage,
-		ConsulK8SImage: t.flagConsulK8sImage,
-		ConsulVersion:  consulVersion,
-		EnvoyImage:     t.flagEnvoyImage,
+		HelmChartVersion: t.flagHelmChartVersion,
+		ConsulImage:      t.flagConsulImage,
+		ConsulK8SImage:   t.flagConsulK8sImage,
+		ConsulVersion:    consulVersion,
+		EnvoyImage:       t.flagEnvoyImage,
 
 		NoCleanupOnFailure: t.flagNoCleanupOnFailure,
 		DebugDirectory:     tempDir,

--- a/acceptance/tests/snapshot-agent/snapshot_agent_vault_test.go
+++ b/acceptance/tests/snapshot-agent/snapshot_agent_vault_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/vault"
 	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -30,6 +31,12 @@ func TestSnapshotAgent_Vault(t *testing.T) {
 	ctx := suite.Environment().DefaultContext(t)
 	kubectlOptions := ctx.KubectlOptions(t)
 	ns := kubectlOptions.Namespace
+
+	ver, err := version.NewVersion("1.12.0")
+	require.NoError(t, err)
+	if cfg.ConsulVersion != nil && cfg.ConsulVersion.LessThan(ver) {
+		t.Skipf("skipping this test because vault secrets backend is not supported in version %v", cfg.ConsulVersion.String())
+	}
 
 	consulReleaseName := helpers.RandomName()
 	vaultReleaseName := helpers.RandomName()


### PR DESCRIPTION
Changes proposed in this PR:
- disable snapshot-agent-vault acceptance test for consul < 1.12
- enable nightlies for 1.11 and 1.12 and 1.13

How I've tested this PR:
* 1.11 passes: https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/7104/workflows/d708428f-e5f3-4e77-b767-57f2612ab970
* 1.12 passes: https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/7103/workflows/78e25a2b-bdcc-447e-8339-8bb013a79a31 
* 1.13 passes: https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/7102/workflows/84394645-d4af-4107-adb3-6f5ee950bf02

Manually tested the new flags:
```
$ go test ./tests/connect/... -p 1 -timeout 2h -failfast -use-kind -no-cleanup-on-failure -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-enterprise -enable-multi-cluster -debug-directory=/tmp/debug -consul-k8s-image=kyleschochenmaier/consul-k8s-dev -helm-chart-version="0.46.1" -consul-version="1.12" -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.12-dev
demo $ helm list --kube-context=kind-dc1
NAME       	NAMESPACE	REVISION	UPDATED                             	STATUS  	CHART        	APP VERSION
test-2z4dwr	default  	1       	2022-08-23 13:20:29.734117 -0500 CDT	deployed	consul-0.46.1	1.12.3

..and without :
demo $ go test ./tests/connect/... -p 1 -timeout 2h -failfast -use-kind -no-cleanup-on-failure -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-enterprise -enable-multi-cluster -debug-directory=/tmp/debug -consul-k8s-image=kyleschochenmaier/consul-k8s-dev -consul-version="1.12" -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.12-dev
demo $ helm list --kube-context=kind-dc1
NAME       	NAMESPACE	REVISION	UPDATED                             	STATUS  	CHART        	APP VERSION
test-v2bpuy	default  	1       	2022-08-23 13:32:04.541871 -0500 CDT	deployed	consul-0.47.1	1.13.1

demo $ k exec -it test-v2bpuy-consul-server-0 -- sh
/ $ consul version
Consul v1.12.5-dev+ent
Revision 601e6ebe
Protocol 2 spoken by default, understands 2 to 3 (agent will automatically use protocol >2 when speaking to compatible agents)
```

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

