### PR TITLE
Set output with `-output` flag.

### DIFF
--- a/cli/cmd/proxy/command.go
+++ b/cli/cmd/proxy/command.go
@@ -10,7 +10,6 @@ import (
 // ProxyCommand  provides a synopsis for the proxy subcommands (e.g. read).
 type ProxyCommand struct {
 	*common.BaseCommand
-	help string
 }
 
 // Run prints out information about the subcommands.

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -240,21 +240,21 @@ func (c *ReadCommand) initKubernetes() (err error) {
 	return nil
 }
 
-func (c *ReadCommand) outputConfig(config *EnvoyConfig) {
+func (c *ReadCommand) outputConfig(config *EnvoyConfig) error {
 	if c.flagRawConfig {
 		c.UI.Output(string(config.rawCfg))
-		return
+		return nil
 	}
 
 	if c.flagJSON {
-		c.outputAsJSON(config)
-		return
+		return c.outputAsJSON(config)
 	}
 
 	c.outputAsTables(config)
+	return nil
 }
 
-func (c *ReadCommand) outputAsJSON(config *EnvoyConfig) {
+func (c *ReadCommand) outputAsJSON(config *EnvoyConfig) error {
 	cfg := make(map[string]interface{})
 	if !c.filtersPassed() || c.flagClusters {
 		cfg["clusters"] = config.Clusters
@@ -271,11 +271,14 @@ func (c *ReadCommand) outputAsJSON(config *EnvoyConfig) {
 	if !c.filtersPassed() || c.flagSecrets {
 		cfg["secrets"] = config.Secrets
 	}
+
 	out, err := json.MarshalIndent(cfg, "", "\t")
 	if err != nil {
-		panic(err)
+		return err
 	}
+
 	c.UI.Output(string(out))
+	return nil
 }
 
 func (c *ReadCommand) outputAsTables(config *EnvoyConfig) {

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -157,7 +157,11 @@ func (c *ReadCommand) Run(args []string) int {
 		return 1
 	}
 
-	c.outputConfig(config)
+	err = c.outputConfig(config)
+	if err != nil {
+		c.UI.Output(err.Error(), terminal.WithErrorStyle())
+		return 1
+	}
 	return 0
 }
 

--- a/cli/cmd/proxy/read/command_test.go
+++ b/cli/cmd/proxy/read/command_test.go
@@ -31,6 +31,10 @@ func TestArgumentParsing(t *testing.T) {
 			args: []string{"podName", "-namespace", "YOLO"},
 			out:  1,
 		},
+		"User tried to filter raw config": {
+			args: []string{"podName", "-raw-config", "-clusters"},
+			out:  1,
+		},
 	}
 
 	for name, tc := range cases {

--- a/cli/cmd/proxy/read/command_test.go
+++ b/cli/cmd/proxy/read/command_test.go
@@ -31,8 +31,8 @@ func TestArgumentParsing(t *testing.T) {
 			args: []string{"podName", "-namespace", "YOLO"},
 			out:  1,
 		},
-		"User tried to filter raw config": {
-			args: []string{"podName", "-raw-config", "-clusters"},
+		"User passed incorrect output": {
+			args: []string{"podName", "-output", "image"},
 			out:  1,
 		},
 	}

--- a/cli/cmd/proxy/read/config.go
+++ b/cli/cmd/proxy/read/config.go
@@ -154,7 +154,7 @@ func (c *EnvoyConfig) UnmarshalJSON(b []byte) error {
 }
 
 func parseClusters(rawCfg map[string]interface{}) ([]Cluster, error) {
-	clusters := make([]Cluster, 0, 0)
+	clusters := make([]Cluster, 0)
 
 	raw, err := json.Marshal(rawCfg)
 	if err != nil {
@@ -168,7 +168,7 @@ func parseClusters(rawCfg map[string]interface{}) ([]Cluster, error) {
 
 	for _, cluster := range append(clustersCD.StaticClusters, clustersCD.DynamicActiveClusters...) {
 		// Join nested endpoint data into a slice of strings.
-		endpoints := make([]string, 0, 0)
+		endpoints := make([]string, 0)
 		for _, endpoint := range cluster.Cluster.LoadAssignment.Endpoints {
 			for _, lbEndpoint := range endpoint.LBEndpoints {
 				endpoints = append(endpoints, fmt.Sprintf("%s:%d", lbEndpoint.Endpoint.Address.SocketAddress.Address,
@@ -189,7 +189,7 @@ func parseClusters(rawCfg map[string]interface{}) ([]Cluster, error) {
 }
 
 func parseEndpoints(rawCfg map[string]interface{}) ([]Endpoint, error) {
-	endpoints := make([]Endpoint, 0, 0)
+	endpoints := make([]Endpoint, 0)
 
 	raw, err := json.Marshal(rawCfg)
 	if err != nil {
@@ -219,7 +219,7 @@ func parseEndpoints(rawCfg map[string]interface{}) ([]Endpoint, error) {
 }
 
 func parseListeners(rawCfg map[string]interface{}) ([]Listener, error) {
-	listeners := make([]Listener, 0, 0)
+	listeners := make([]Listener, 0)
 
 	raw, err := json.Marshal(rawCfg)
 	if err != nil {
@@ -275,7 +275,7 @@ func parseListeners(rawCfg map[string]interface{}) ([]Listener, error) {
 }
 
 func parseRoutes(rawCfg map[string]interface{}) ([]Route, error) {
-	routes := make([]Route, 0, 0)
+	routes := make([]Route, 0)
 
 	raw, err := json.Marshal(rawCfg)
 	if err != nil {
@@ -307,7 +307,7 @@ func parseRoutes(rawCfg map[string]interface{}) ([]Route, error) {
 }
 
 func parseSecrets(rawCfg map[string]interface{}) ([]Secret, error) {
-	secrets := make([]Secret, 0, 0)
+	secrets := make([]Secret, 0)
 
 	raw, err := json.Marshal(rawCfg)
 	if err != nil {

--- a/cli/cmd/proxy/read/config.go
+++ b/cli/cmd/proxy/read/config.go
@@ -154,7 +154,7 @@ func (c *EnvoyConfig) UnmarshalJSON(b []byte) error {
 }
 
 func parseClusters(rawCfg map[string]interface{}) ([]Cluster, error) {
-	var clusters []Cluster
+	clusters := make([]Cluster, 0, 0)
 
 	raw, err := json.Marshal(rawCfg)
 	if err != nil {
@@ -168,7 +168,7 @@ func parseClusters(rawCfg map[string]interface{}) ([]Cluster, error) {
 
 	for _, cluster := range append(clustersCD.StaticClusters, clustersCD.DynamicActiveClusters...) {
 		// Join nested endpoint data into a slice of strings.
-		var endpoints []string
+		endpoints := make([]string, 0, 0)
 		for _, endpoint := range cluster.Cluster.LoadAssignment.Endpoints {
 			for _, lbEndpoint := range endpoint.LBEndpoints {
 				endpoints = append(endpoints, fmt.Sprintf("%s:%d", lbEndpoint.Endpoint.Address.SocketAddress.Address,
@@ -189,7 +189,7 @@ func parseClusters(rawCfg map[string]interface{}) ([]Cluster, error) {
 }
 
 func parseEndpoints(rawCfg map[string]interface{}) ([]Endpoint, error) {
-	var endpoints []Endpoint
+	endpoints := make([]Endpoint, 0, 0)
 
 	raw, err := json.Marshal(rawCfg)
 	if err != nil {
@@ -219,7 +219,7 @@ func parseEndpoints(rawCfg map[string]interface{}) ([]Endpoint, error) {
 }
 
 func parseListeners(rawCfg map[string]interface{}) ([]Listener, error) {
-	var listeners []Listener
+	listeners := make([]Listener, 0, 0)
 
 	raw, err := json.Marshal(rawCfg)
 	if err != nil {
@@ -275,7 +275,7 @@ func parseListeners(rawCfg map[string]interface{}) ([]Listener, error) {
 }
 
 func parseRoutes(rawCfg map[string]interface{}) ([]Route, error) {
-	var routes []Route
+	routes := make([]Route, 0, 0)
 
 	raw, err := json.Marshal(rawCfg)
 	if err != nil {
@@ -307,7 +307,7 @@ func parseRoutes(rawCfg map[string]interface{}) ([]Route, error) {
 }
 
 func parseSecrets(rawCfg map[string]interface{}) ([]Secret, error) {
-	var secrets []Secret
+	secrets := make([]Secret, 0, 0)
 
 	raw, err := json.Marshal(rawCfg)
 	if err != nil {

--- a/cli/cmd/proxy/read/config_test.go
+++ b/cli/cmd/proxy/read/config_test.go
@@ -93,12 +93,14 @@ var testEnvoyConfig = &EnvoyConfig{
 		{
 			Name:                     "client",
 			FullyQualifiedDomainName: "client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+			Endpoints:                []string{},
 			Type:                     "EDS",
 			LastUpdated:              "2022-06-09T00:39:12.948Z",
 		},
 		{
 			Name:                     "frontend",
 			FullyQualifiedDomainName: "frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+			Endpoints:                []string{},
 			Type:                     "EDS",
 			LastUpdated:              "2022-06-09T00:39:12.855Z",
 		},
@@ -112,12 +114,14 @@ var testEnvoyConfig = &EnvoyConfig{
 		{
 			Name:                     "original-destination",
 			FullyQualifiedDomainName: "original-destination",
+			Endpoints:                []string{},
 			Type:                     "ORIGINAL_DST",
 			LastUpdated:              "2022-05-13T04:22:39.743Z",
 		},
 		{
 			Name:                     "server",
 			FullyQualifiedDomainName: "server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+			Endpoints:                []string{},
 			Type:                     "EDS",
 			LastUpdated:              "2022-06-09T00:39:12.754Z",
 		},

--- a/cli/common/flag/set.go
+++ b/cli/common/flag/set.go
@@ -56,6 +56,22 @@ func (f *Sets) NewSet(name string) *Set {
 	return flagSet
 }
 
+// GetSetFlags returns a slice of flags for a given set.
+// If the requested set does not exist, this will return an empty slice.
+func (f *Sets) GetSetFlags(setName string) []string {
+	var setFlags []string
+	for _, set := range f.flagSets {
+		if set.name == setName {
+			set.flagSet.VisitAll(func(f *flag.Flag) {
+				setFlags = append(setFlags, fmt.Sprintf("-%s", f.Name))
+			})
+			return setFlags
+		}
+	}
+
+	return setFlags
+}
+
 // Completions returns the completions for this flag set.
 func (f *Sets) Completions() complete.Flags {
 	return f.completions


### PR DESCRIPTION
After clarifying with @david-yu on the best way forward for the JSON flag, we decided to have an `output` flag which takes `table`, `json`, or `raw` to set the output.

This matches with David's original intent in the PRD.

Changes proposed in this PR:
- Add GetSetFlags method which allows access to groups of flags.
- Add `-output` (`-o`) flag which takes `table`, `json`, or `raw` for configuring output.
- Set config values to empty slices by default.

How I've tested this PR:

- Added a unit test for the new flag.

How I expect reviewers to test this PR:

- Unit tests or manually.

Checklist:
- [x] Tests added

