### PR TITLE
Replacing strings.Title with cases.Title to make broken CI linting pass

### DIFF
--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -21,6 +21,8 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/mapstructure"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -755,7 +757,7 @@ func (c *Command) configureGateway(gatewayParams ConfigureGatewayParams, consulC
 	for _, name := range gatewayParams.GatewayNames {
 		if name == "" {
 			errMessage := fmt.Sprintf("%s gateway name cannot be empty",
-				strings.Title(strings.ToLower(gatewayParams.GatewayType)))
+				cases.Title(language.English).String(gatewayParams.GatewayType))
 			c.log.Error(errMessage)
 			return errors.New(errMessage)
 		}


### PR DESCRIPTION
Changes proposed in this PR:
- Replacing strings.Title with cases.Title as it is deprecated

How I've tested this PR:
- linting passing/CI

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

