### PR TITLE
Add filters to debugging output.

### DIFF
--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -121,7 +121,7 @@ func (c *ReadCommand) init() {
 	f.IntVar(&flag.IntVar{
 		Name:    "port",
 		Target:  &c.flagPort,
-		Usage:   "Filter endpoints output to only endpoints with the given port number.",
+		Usage:   "Filter endpoints and listeners output to only addresses with the given port number.",
 		Default: -1,
 	})
 

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -410,7 +410,7 @@ func (c *ReadCommand) outputRaw(configs map[string]*EnvoyConfig) error {
 	return nil
 =======
 func (c *ReadCommand) outputAsTables(config *EnvoyConfig) {
-	c.UI.Output(fmt.Sprintf("Envoy configuration for %s in Namespace %s:", c.flagPodName, c.flagNamespace))
+	c.UI.Output(fmt.Sprintf("Envoy configuration for %s in namespace %s:", c.flagPodName, c.flagNamespace))
 	if c.flagFQDN != "" || c.flagAddress != "" || c.flagPort != -1 {
 		c.UI.Output("Filters applied", terminal.WithHeaderStyle())
 

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -403,29 +403,6 @@ func (c *ReadCommand) outputRaw(configs map[string]*EnvoyConfig) error {
 	return nil
 }
 
-func (c *ReadCommand) outputAsTables(config *EnvoyConfig) {
-	c.UI.Output(fmt.Sprintf("Envoy configuration for %s in namespace %s:", c.flagPodName, c.flagNamespace))
-	if c.flagFQDN != "" || c.flagAddress != "" || c.flagPort != -1 {
-		c.UI.Output("Filters applied", terminal.WithHeaderStyle())
-
-		if c.flagFQDN != "" {
-			c.UI.Output(fmt.Sprintf("Fully qualified domain names containing: %s", c.flagFQDN), terminal.WithInfoStyle())
-		}
-		if c.flagAddress != "" {
-			c.UI.Output(fmt.Sprintf("Endpoint addresses containing: %s", c.flagAddress), terminal.WithInfoStyle())
-		}
-		if c.flagPort != -1 {
-			c.UI.Output(fmt.Sprintf("Endpoint addresses with port number: %d", c.flagPort), terminal.WithInfoStyle())
-		}
-	}
-
-	c.outputClustersTable(FilterClusters(config.Clusters, c.flagFQDN, c.flagAddress, c.flagPort))
-	c.outputEndpointsTable(FilterEndpoints(config.Endpoints, c.flagAddress, c.flagPort))
-	c.outputListenersTable(FilterListeners(config.Listeners, c.flagAddress, c.flagPort))
-	c.outputRoutesTable(config.Routes)
-	c.outputSecretsTable(config.Secrets)
-}
-
 func (c *ReadCommand) outputClustersTable(clusters []Cluster) {
 	if c.areTablesFiltered() && !c.flagClusters {
 		return

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -226,9 +226,8 @@ func (c *ReadCommand) validateFlags() error {
 	return nil
 }
 
-// tableFiltersPassed returns true if a flag which filters the
-// set of tables output is passed.
-func (c *ReadCommand) tableFiltersPassed() bool {
+// areTablesFiltered returns true if a table filtering flag was passed in.
+func (c *ReadCommand) areTablesFiltered() bool {
 	return c.flagClusters || c.flagEndpoints || c.flagListeners || c.flagRoutes || c.flagSecrets
 }
 
@@ -335,19 +334,19 @@ func (c *ReadCommand) outputTables(configs map[string]*EnvoyConfig) error {
 =======
 func (c *ReadCommand) outputAsJSON(config *EnvoyConfig) error {
 	cfg := make(map[string]interface{})
-	if !c.tableFiltersPassed() || c.flagClusters {
+	if !c.areTablesFiltered() || c.flagClusters {
 		cfg["clusters"] = FilterClusters(config.Clusters, c.flagFQDN, c.flagAddress, c.flagPort)
 	}
-	if !c.tableFiltersPassed() || c.flagEndpoints {
+	if !c.areTablesFiltered() || c.flagEndpoints {
 		cfg["endpoints"] = FilterEndpoints(config.Endpoints, c.flagAddress, c.flagPort)
 	}
-	if !c.tableFiltersPassed() || c.flagListeners {
+	if !c.areTablesFiltered() || c.flagListeners {
 		cfg["listeners"] = FilterListeners(config.Listeners, c.flagAddress, c.flagPort)
 	}
-	if !c.tableFiltersPassed() || c.flagRoutes {
+	if !c.areTablesFiltered() || c.flagRoutes {
 		cfg["routes"] = config.Routes
 	}
-	if !c.tableFiltersPassed() || c.flagSecrets {
+	if !c.areTablesFiltered() || c.flagSecrets {
 		cfg["secrets"] = config.Secrets
 >>>>>>> f11c95d0 (Add port filtering)
 	}
@@ -434,7 +433,7 @@ func (c *ReadCommand) outputAsTables(config *EnvoyConfig) {
 }
 
 func (c *ReadCommand) outputClustersTable(clusters []Cluster) {
-	if c.tableFiltersPassed() && !c.flagClusters {
+	if c.areTablesFiltered() && !c.flagClusters {
 		return
 	}
 
@@ -449,7 +448,7 @@ func (c *ReadCommand) outputClustersTable(clusters []Cluster) {
 }
 
 func (c *ReadCommand) outputEndpointsTable(endpoints []Endpoint) {
-	if c.tableFiltersPassed() && !c.flagEndpoints {
+	if c.areTablesFiltered() && !c.flagEndpoints {
 		return
 	}
 
@@ -458,7 +457,7 @@ func (c *ReadCommand) outputEndpointsTable(endpoints []Endpoint) {
 }
 
 func (c *ReadCommand) outputListenersTable(listeners []Listener) {
-	if c.tableFiltersPassed() && !c.flagListeners {
+	if c.areTablesFiltered() && !c.flagListeners {
 		return
 	}
 
@@ -467,7 +466,7 @@ func (c *ReadCommand) outputListenersTable(listeners []Listener) {
 }
 
 func (c *ReadCommand) outputRoutesTable(routes []Route) {
-	if c.tableFiltersPassed() && !c.flagRoutes {
+	if c.areTablesFiltered() && !c.flagRoutes {
 		return
 	}
 
@@ -476,7 +475,7 @@ func (c *ReadCommand) outputRoutesTable(routes []Route) {
 }
 
 func (c *ReadCommand) outputSecretsTable(secrets []Secret) {
-	if c.tableFiltersPassed() && !c.flagSecrets {
+	if c.areTablesFiltered() && !c.flagSecrets {
 		return
 	}
 

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -333,6 +333,8 @@ func (c *ReadCommand) outputTables(configs map[string]*EnvoyConfig) error {
 		if c.flagPort != -1 {
 			c.UI.Output(fmt.Sprintf("Endpoint addresses with port number: %d", c.flagPort), terminal.WithInfoStyle())
 		}
+
+		c.UI.Output("")
 	}
 
 	for name, config := range configs {

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -320,35 +320,30 @@ func (c *ReadCommand) outputConfigs(configs map[string]*EnvoyConfig) error {
 	return nil
 }
 
-<<<<<<< HEAD
 func (c *ReadCommand) outputTables(configs map[string]*EnvoyConfig) error {
+	if c.flagFQDN != "" || c.flagAddress != "" || c.flagPort != -1 {
+		c.UI.Output("Filters applied", terminal.WithHeaderStyle())
+
+		if c.flagFQDN != "" {
+			c.UI.Output(fmt.Sprintf("Fully qualified domain names containing: %s", c.flagFQDN), terminal.WithInfoStyle())
+		}
+		if c.flagAddress != "" {
+			c.UI.Output(fmt.Sprintf("Endpoint addresses containing: %s", c.flagAddress), terminal.WithInfoStyle())
+		}
+		if c.flagPort != -1 {
+			c.UI.Output(fmt.Sprintf("Endpoint addresses with port number: %d", c.flagPort), terminal.WithInfoStyle())
+		}
+	}
+
 	for name, config := range configs {
 		c.UI.Output(fmt.Sprintf("Envoy configuration for %s in namespace %s:", name, c.flagNamespace))
 
-		c.outputClustersTable(FilterFQDN(config.Clusters, c.flagFQDN))
-		c.outputEndpointsTable(config.Endpoints)
-		c.outputListenersTable(config.Listeners)
+		c.outputClustersTable(FilterClusters(config.Clusters, c.flagFQDN, c.flagAddress, c.flagPort))
+		c.outputEndpointsTable(FilterEndpoints(config.Endpoints, c.flagAddress, c.flagPort))
+		c.outputListenersTable(FilterListeners(config.Listeners, c.flagAddress, c.flagPort))
 		c.outputRoutesTable(config.Routes)
 		c.outputSecretsTable(config.Secrets)
 		c.UI.Output("\n")
-=======
-func (c *ReadCommand) outputAsJSON(config *EnvoyConfig) error {
-	cfg := make(map[string]interface{})
-	if !c.areTablesFiltered() || c.flagClusters {
-		cfg["clusters"] = FilterClusters(config.Clusters, c.flagFQDN, c.flagAddress, c.flagPort)
-	}
-	if !c.areTablesFiltered() || c.flagEndpoints {
-		cfg["endpoints"] = FilterEndpoints(config.Endpoints, c.flagAddress, c.flagPort)
-	}
-	if !c.areTablesFiltered() || c.flagListeners {
-		cfg["listeners"] = FilterListeners(config.Listeners, c.flagAddress, c.flagPort)
-	}
-	if !c.areTablesFiltered() || c.flagRoutes {
-		cfg["routes"] = config.Routes
-	}
-	if !c.areTablesFiltered() || c.flagSecrets {
-		cfg["secrets"] = config.Secrets
->>>>>>> f11c95d0 (Add port filtering)
 	}
 
 	return nil
@@ -358,19 +353,19 @@ func (c *ReadCommand) outputJSON(configs map[string]*EnvoyConfig) error {
 	cfgs := make(map[string]interface{})
 	for name, config := range configs {
 		cfg := make(map[string]interface{})
-		if !c.tableFiltersPassed() || c.flagClusters {
-			cfg["clusters"] = FilterFQDN(config.Clusters, c.flagFQDN)
+		if !c.areTablesFiltered() || c.flagClusters {
+			cfg["clusters"] = FilterClusters(config.Clusters, c.flagFQDN, c.flagAddress, c.flagPort)
 		}
-		if !c.tableFiltersPassed() || c.flagEndpoints {
-			cfg["endpoints"] = config.Endpoints
+		if !c.areTablesFiltered() || c.flagEndpoints {
+			cfg["endpoints"] = FilterEndpoints(config.Endpoints, c.flagAddress, c.flagPort)
 		}
-		if !c.tableFiltersPassed() || c.flagListeners {
-			cfg["listeners"] = config.Listeners
+		if !c.areTablesFiltered() || c.flagListeners {
+			cfg["listeners"] = FilterListeners(config.Listeners, c.flagAddress, c.flagPort)
 		}
-		if !c.tableFiltersPassed() || c.flagRoutes {
+		if !c.areTablesFiltered() || c.flagRoutes {
 			cfg["routes"] = config.Routes
 		}
-		if !c.tableFiltersPassed() || c.flagSecrets {
+		if !c.areTablesFiltered() || c.flagSecrets {
 			cfg["secrets"] = config.Secrets
 		}
 
@@ -387,7 +382,6 @@ func (c *ReadCommand) outputJSON(configs map[string]*EnvoyConfig) error {
 	return nil
 }
 
-<<<<<<< HEAD
 func (c *ReadCommand) outputRaw(configs map[string]*EnvoyConfig) error {
 	cfgs := make(map[string]interface{}, 0)
 	for name, config := range configs {
@@ -407,7 +401,8 @@ func (c *ReadCommand) outputRaw(configs map[string]*EnvoyConfig) error {
 	c.UI.Output(string(out))
 
 	return nil
-=======
+}
+
 func (c *ReadCommand) outputAsTables(config *EnvoyConfig) {
 	c.UI.Output(fmt.Sprintf("Envoy configuration for %s in namespace %s:", c.flagPodName, c.flagNamespace))
 	if c.flagFQDN != "" || c.flagAddress != "" || c.flagPort != -1 {
@@ -429,7 +424,6 @@ func (c *ReadCommand) outputAsTables(config *EnvoyConfig) {
 	c.outputListenersTable(FilterListeners(config.Listeners, c.flagAddress, c.flagPort))
 	c.outputRoutesTable(config.Routes)
 	c.outputSecretsTable(config.Secrets)
->>>>>>> f11c95d0 (Add port filtering)
 }
 
 func (c *ReadCommand) outputClustersTable(clusters []Cluster) {

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -330,7 +330,7 @@ func (c *ReadCommand) outputTables(configs map[string]*EnvoyConfig) error {
 func (c *ReadCommand) outputAsJSON(config *EnvoyConfig) error {
 	cfg := make(map[string]interface{})
 	if !c.tableFiltersPassed() || c.flagClusters {
-		cfg["clusters"] = FilterPort(FilterFQDN(config.Clusters, c.flagFQDN), c.flagPort)
+		cfg["clusters"] = FilterClustersByPort(FilterClustersByFQDN(config.Clusters, c.flagFQDN), c.flagPort)
 	}
 	if !c.tableFiltersPassed() || c.flagEndpoints {
 		cfg["endpoints"] = config.Endpoints
@@ -405,7 +405,7 @@ func (c *ReadCommand) outputRaw(configs map[string]*EnvoyConfig) error {
 =======
 func (c *ReadCommand) outputAsTables(config *EnvoyConfig) {
 	c.UI.Output(fmt.Sprintf("Envoy configuration for %s in Namespace %s:", c.flagPodName, c.flagNamespace))
-	c.outputClustersTable(FilterPort(FilterFQDN(config.Clusters, c.flagFQDN), c.flagPort))
+	c.outputClustersTable(FilterClustersByPort(FilterClustersByFQDN(config.Clusters, c.flagFQDN), c.flagPort))
 	c.outputEndpointsTable(config.Endpoints)
 	c.outputListenersTable(config.Listeners)
 	c.outputRoutesTable(config.Routes)

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -111,17 +111,17 @@ func (c *ReadCommand) init() {
 	f.StringVar(&flag.StringVar{
 		Name:   "fqdn",
 		Target: &c.flagFQDN,
-		Usage:  "Filter cluster output to only clusters with a fully qualified domain name which contains the given value.",
+		Usage:  "Filter cluster output to clusters with a fully qualified domain name which contains the given value. May be combined with -address and -port.",
 	})
 	f.StringVar(&flag.StringVar{
 		Name:   "address",
 		Target: &c.flagAddress,
-		Usage:  "Filter clusters, endpoints, and listeners output to only those with addresses which contain the given value.",
+		Usage:  "Filter clusters, endpoints, and listeners output to those with addresses which contain the given value. May be combined with -fqdn and -port",
 	})
 	f.IntVar(&flag.IntVar{
 		Name:    "port",
 		Target:  &c.flagPort,
-		Usage:   "Filter endpoints and listeners output to only addresses with the given port number.",
+		Usage:   "Filter endpoints and listeners output to addresses with the given port number. May be combined with -fqdn and -address.",
 		Default: -1,
 	})
 

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -414,13 +414,13 @@ func (c *ReadCommand) outputAsTables(config *EnvoyConfig) {
 		c.UI.Output("Filters applied", terminal.WithHeaderStyle())
 
 		if c.flagFQDN != "" {
-			c.UI.Output(fmt.Sprintf("Fully qualified domain names must contain `%s`", c.flagFQDN), terminal.WithInfoStyle())
+			c.UI.Output(fmt.Sprintf("Fully qualified domain names containing: %s", c.flagFQDN), terminal.WithInfoStyle())
 		}
 		if c.flagAddress != "" {
-			c.UI.Output(fmt.Sprintf("Endpoint addresses must contain `%s`", c.flagAddress), terminal.WithInfoStyle())
+			c.UI.Output(fmt.Sprintf("Endpoint addresses containing: %s", c.flagAddress), terminal.WithInfoStyle())
 		}
 		if c.flagPort != -1 {
-			c.UI.Output(fmt.Sprintf("Endpoint addresses must have the port `%d`", c.flagPort), terminal.WithInfoStyle())
+			c.UI.Output(fmt.Sprintf("Endpoint addresses with port number: %d", c.flagPort), terminal.WithInfoStyle())
 		}
 	}
 

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -116,7 +116,7 @@ func (c *ReadCommand) init() {
 	f.StringVar(&flag.StringVar{
 		Name:   "address",
 		Target: &c.flagAddress,
-		Usage:  "Filter clusters, endpoints, and listeners output to only those with endpoint addresses which contain the given value.",
+		Usage:  "Filter clusters, endpoints, and listeners output to only those with addresses which contain the given value.",
 	})
 	f.IntVar(&flag.IntVar{
 		Name:    "port",

--- a/cli/cmd/proxy/read/command_test.go
+++ b/cli/cmd/proxy/read/command_test.go
@@ -60,11 +60,7 @@ func TestReadCommandOutput(t *testing.T) {
 
 	// These regular expressions must be present in the output.
 	expected := []string{
-<<<<<<< HEAD
 		fmt.Sprintf("Envoy configuration for %s in namespace default:", podName),
-=======
-		"Envoy configuration for podName in namespace default:",
->>>>>>> 2d37a627 (Fix test output)
 
 		"==> Clusters \\(6\\)",
 		"Name.*FQDN.*Endpoints.*Type.*Last Updated",

--- a/cli/cmd/proxy/read/command_test.go
+++ b/cli/cmd/proxy/read/command_test.go
@@ -89,11 +89,11 @@ func TestReadCommandOutput(t *testing.T) {
 
 		"==> Listeners \\(2\\)",
 		"Name.*Address:Port.*Direction.*Filter Chain Match.*Filters.*Last Updated",
-		"public_listener.*192\\.168\\.69\\.179:20000.*INBOUND.*Any.*\\* -> local_app/.*2022-06-09T00:39:27\\.668Z",
-		"outbound_listener.*127.0.0.1:15001.*OUTBOUND.*10\\.100\\.134\\.173/32, 240\\.0\\.0\\.3/32.*-> client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul.*2022-05-24T17:41:59\\.079Z",
-		"10\\.100\\.254\\.176/32, 240\\.0\\.0\\.4/32.*\\* -> server\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul/",
-		"10\\.100\\.31\\.2/32, 240\\.0\\.0\\.2/32.*-> frontend\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul",
-		"Any.*-> original-destination",
+		"public_listener.*192\\.168\\.69\\.179:20000.*INBOUND.*Any.*\\* to local_app/.*2022-06-09T00:39:27\\.668Z",
+		"outbound_listener.*127.0.0.1:15001.*OUTBOUND.*10\\.100\\.134\\.173/32, 240\\.0\\.0\\.3/32.*to client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul.*2022-05-24T17:41:59\\.079Z",
+		"10\\.100\\.254\\.176/32, 240\\.0\\.0\\.4/32.*\\* to server\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul/",
+		"10\\.100\\.31\\.2/32, 240\\.0\\.0\\.2/32.*to frontend\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul",
+		"Any.*to original-destination",
 
 		"==> Routes \\(2\\)",
 		"Name.*Destination Cluster.*Last Updated",

--- a/cli/cmd/proxy/read/command_test.go
+++ b/cli/cmd/proxy/read/command_test.go
@@ -59,47 +59,57 @@ func TestReadCommandOutput(t *testing.T) {
 	podName := "fakePod"
 
 	// These regular expressions must be present in the output.
-	expected := []string{
-		fmt.Sprintf("Envoy configuration for %s in namespace default:", podName),
+	expectedHeader := fmt.Sprintf("Envoy configuration for %s in namespace default:", podName)
+	expected := map[string][]string{
+		"-clusters": {"==> Clusters \\(6\\)",
+			"Name.*FQDN.*Endpoints.*Type.*Last Updated",
+			"local_agent.*local_agent.*192\\.168\\.79\\.187:8502.*STATIC.*2022-05-13T04:22:39\\.553Z",
+			"local_app.*local_app.*127\\.0\\.0\\.1:8080.*STATIC.*2022-05-13T04:22:39\\.655Z",
+			"client.*client\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul.*EDS.*2022-06-09T00:39:12\\.948Z",
+			"frontend.*frontend\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul.*EDS.*2022-06-09T00:39:12\\.855Z",
+			"original-destination.*original-destination.*ORIGINAL_DST.*2022-05-13T04:22:39.743Z",
+			"server.*server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul.*EDS.*2022-06-09T00:39:12\\.754Z"},
 
-		"==> Clusters \\(6\\)",
-		"Name.*FQDN.*Endpoints.*Type.*Last Updated",
-		"local_agent.*local_agent.*192\\.168\\.79\\.187:8502.*STATIC.*2022-05-13T04:22:39\\.553Z",
-		"local_app.*local_app.*127\\.0\\.0\\.1:8080.*STATIC.*2022-05-13T04:22:39\\.655Z",
-		"client.*client\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul.*EDS.*2022-06-09T00:39:12\\.948Z",
-		"frontend.*frontend\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul.*EDS.*2022-06-09T00:39:12\\.855Z",
-		"original-destination.*original-destination.*ORIGINAL_DST.*2022-05-13T04:22:39.743Z",
-		"server.*server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul.*EDS.*2022-06-09T00:39:12\\.754Z",
+		"-endpoints": {"==> Endpoints \\(9\\)",
+			"Address:Port.*Cluster.*Weight.*Status",
+			"192.168.79.187:8502.*local_agent.*1.00.*HEALTHY",
+			"127.0.0.1:8080.*local_app.*1.00.*HEALTHY",
+			"192.168.31.201:20000.*1.00.*HEALTHY",
+			"192.168.47.235:20000.*1.00.*HEALTHY",
+			"192.168.71.254:20000.*1.00.*HEALTHY",
+			"192.168.63.120:20000.*1.00.*HEALTHY",
+			"192.168.18.110:20000.*1.00.*HEALTHY",
+			"192.168.52.101:20000.*1.00.*HEALTHY",
+			"192.168.65.131:20000.*1.00.*HEALTHY"},
 
-		"==> Endpoints \\(9\\)",
-		"Address:Port.*Cluster.*Weight.*Status",
-		"192.168.79.187:8502.*local_agent.*1.00.*HEALTHY",
-		"127.0.0.1:8080.*local_app.*1.00.*HEALTHY",
-		"192.168.31.201:20000.*1.00.*HEALTHY",
-		"192.168.47.235:20000.*1.00.*HEALTHY",
-		"192.168.71.254:20000.*1.00.*HEALTHY",
-		"192.168.63.120:20000.*1.00.*HEALTHY",
-		"192.168.18.110:20000.*1.00.*HEALTHY",
-		"192.168.52.101:20000.*1.00.*HEALTHY",
-		"192.168.65.131:20000.*1.00.*HEALTHY",
+		"-listeners": {"==> Listeners \\(2\\)",
+			"Name.*Address:Port.*Direction.*Filter Chain Match.*Filters.*Last Updated",
+			"public_listener.*192\\.168\\.69\\.179:20000.*INBOUND.*Any.*\\* to local_app/.*2022-06-09T00:39:27\\.668Z",
+			"outbound_listener.*127.0.0.1:15001.*OUTBOUND.*10\\.100\\.134\\.173/32, 240\\.0\\.0\\.3/32.*to client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul.*2022-05-24T17:41:59\\.079Z",
+			"10\\.100\\.254\\.176/32, 240\\.0\\.0\\.4/32.*\\* to server\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul/",
+			"10\\.100\\.31\\.2/32, 240\\.0\\.0\\.2/32.*to frontend\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul",
+			"Any.*to original-destination"},
 
-		"==> Listeners \\(2\\)",
-		"Name.*Address:Port.*Direction.*Filter Chain Match.*Filters.*Last Updated",
-		"public_listener.*192\\.168\\.69\\.179:20000.*INBOUND.*Any.*\\* to local_app/.*2022-06-09T00:39:27\\.668Z",
-		"outbound_listener.*127.0.0.1:15001.*OUTBOUND.*10\\.100\\.134\\.173/32, 240\\.0\\.0\\.3/32.*to client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul.*2022-05-24T17:41:59\\.079Z",
-		"10\\.100\\.254\\.176/32, 240\\.0\\.0\\.4/32.*\\* to server\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul/",
-		"10\\.100\\.31\\.2/32, 240\\.0\\.0\\.2/32.*to frontend\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul",
-		"Any.*to original-destination",
+		"-routes": {"==> Routes \\(2\\)",
+			"Name.*Destination Cluster.*Last Updated",
+			"public_listener.*local_app/.*2022-06-09T00:39:27.667Z",
+			"server.*server\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul/.*2022-05-24T17:41:59\\.078Z"},
 
-		"==> Routes \\(2\\)",
-		"Name.*Destination Cluster.*Last Updated",
-		"public_listener.*local_app/.*2022-06-09T00:39:27.667Z",
-		"server.*server\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul/.*2022-05-24T17:41:59\\.078Z",
+		"-secrets": {"==> Secrets \\(2\\)",
+			"Name.*Type.*Last Updated",
+			"default.*Dynamic Active.*2022-05-24T17:41:59.078Z",
+			"ROOTCA.*Dynamic Warming.*2022-03-15T05:14:22.868Z"},
+	}
 
-		"==> Secrets \\(2\\)",
-		"Name.*Type.*Last Updated",
-		"default.*Dynamic Active.*2022-05-24T17:41:59.078Z",
-		"ROOTCA.*Dynamic Warming.*2022-03-15T05:14:22.868Z",
+	cases := map[string][]string{
+		"No filters":             {},
+		"Clusters":               {"-clusters"},
+		"Endpoints":              {"-endpoints"},
+		"Listeners":              {"-listeners"},
+		"Routes":                 {"-routes"},
+		"Secrets":                {"-secrets"},
+		"Clusters and routes":    {"-clusters", "-routes"},
+		"Secrets then listeners": {"-secrets", "-listeners"},
 	}
 
 	fakePod := v1.Pod{
@@ -118,13 +128,21 @@ func TestReadCommandOutput(t *testing.T) {
 		return testEnvoyConfig, nil
 	}
 
-	out := c.Run([]string{podName})
-	require.Equal(t, 0, out)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			args := append([]string{podName}, tc...)
+			out := c.Run(args)
+			require.Equal(t, 0, out)
 
-	actual := buf.String()
+			actual := buf.String()
 
-	for _, expression := range expected {
-		require.Regexp(t, expression, actual)
+			require.Regexp(t, expectedHeader, actual)
+			for _, table := range tc {
+				for _, expression := range expected[table] {
+					require.Regexp(t, expression, actual)
+				}
+			}
+		})
 	}
 }
 

--- a/cli/cmd/proxy/read/command_test.go
+++ b/cli/cmd/proxy/read/command_test.go
@@ -60,7 +60,11 @@ func TestReadCommandOutput(t *testing.T) {
 
 	// These regular expressions must be present in the output.
 	expected := []string{
+<<<<<<< HEAD
 		fmt.Sprintf("Envoy configuration for %s in namespace default:", podName),
+=======
+		"Envoy configuration for podName in namespace default:",
+>>>>>>> 2d37a627 (Fix test output)
 
 		"==> Clusters \\(6\\)",
 		"Name.*FQDN.*Endpoints.*Type.*Last Updated",

--- a/cli/cmd/proxy/read/config.go
+++ b/cli/cmd/proxy/read/config.go
@@ -363,7 +363,7 @@ func formatFilters(filterChain filterChain) (filters []string) {
 }
 
 func formatFilterTCPProxy(config typedConfig) (filter string) {
-	return "-> " + config.Cluster
+	return "to " + config.Cluster
 }
 
 func formatFilterRBAC(cfg typedConfig) (filter string) {
@@ -378,7 +378,7 @@ func formatFilterRBAC(cfg typedConfig) (filter string) {
 func formatFilterHTTPConnectionManager(cfg typedConfig) (filter string) {
 	for _, host := range cfg.RouteConfig.VirtualHosts {
 		filter += strings.Join(host.Domains, ", ")
-		filter += " -> "
+		filter += " to "
 
 		routes := ""
 		for _, route := range host.Routes {

--- a/cli/cmd/proxy/read/config_test.go
+++ b/cli/cmd/proxy/read/config_test.go
@@ -182,7 +182,7 @@ var testEnvoyConfig = &EnvoyConfig{
 			FilterChain: []FilterChain{
 				{
 					FilterChainMatch: "Any",
-					Filters:          []string{"* -> local_app/"},
+					Filters:          []string{"* to local_app/"},
 				},
 			},
 			Direction:   "INBOUND",
@@ -194,21 +194,21 @@ var testEnvoyConfig = &EnvoyConfig{
 			FilterChain: []FilterChain{
 				{
 					FilterChainMatch: "10.100.134.173/32, 240.0.0.3/32",
-					Filters:          []string{"-> client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul"},
+					Filters:          []string{"to client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul"},
 				},
 				{
 					FilterChainMatch: "10.100.254.176/32, 240.0.0.4/32",
-					Filters:          []string{"* -> server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul/"},
+					Filters:          []string{"* to server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul/"},
 				},
 				{
 					FilterChainMatch: "10.100.31.2/32, 240.0.0.2/32",
 					Filters: []string{
-						"-> frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+						"to frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
 					},
 				},
 				{
 					FilterChainMatch: "Any",
-					Filters:          []string{"-> original-destination"},
+					Filters:          []string{"to original-destination"},
 				},
 			},
 			Direction:   "OUTBOUND",

--- a/cli/cmd/proxy/read/filters.go
+++ b/cli/cmd/proxy/read/filters.go
@@ -44,3 +44,33 @@ func FilterClustersByPort(clusters []Cluster, port int) []Cluster {
 
 	return filtered
 }
+
+func FilterEndpointsByPort(endpoints []Endpoint, port int) []Endpoint {
+	if port == -1 {
+		return endpoints
+	}
+
+	filtered := make([]Endpoint, 0)
+
+	return filtered
+}
+
+func FilterListenersByPort(listeners []Listener, port int) []Listener {
+	if port == -1 {
+		return listeners
+	}
+
+	filtered := make([]Listener, 0)
+
+	return filtered
+}
+
+func FilterListenersByAddress(listeners []Listener, substring string) []Listener {
+	if substring == "" {
+		return listeners
+	}
+
+	filtered := make([]Listener, 0)
+
+	return filtered
+}

--- a/cli/cmd/proxy/read/filters.go
+++ b/cli/cmd/proxy/read/filters.go
@@ -26,6 +26,7 @@ func FilterClustersByFQDN(clusters []Cluster, substring string) []Cluster {
 // FilterClustersByPort takes a slice of clusters along with a port number
 // and filters the clusters to only those with endpoints whose
 // ports match the given port.
+// If -1 is passed as a port, no filtering will occur.
 func FilterClustersByPort(clusters []Cluster, port int) []Cluster {
 	if port == -1 {
 		return clusters
@@ -45,6 +46,9 @@ func FilterClustersByPort(clusters []Cluster, port int) []Cluster {
 	return filtered
 }
 
+// FilterEndpointsByPort takes a slice of endpoints along with a port number
+// and filters the endpoints to only those whose port matches the given port.
+// If -1 is passed as a port, no filtering will occur.
 func FilterEndpointsByPort(endpoints []Endpoint, port int) []Endpoint {
 	if port == -1 {
 		return endpoints
@@ -55,6 +59,10 @@ func FilterEndpointsByPort(endpoints []Endpoint, port int) []Endpoint {
 	return filtered
 }
 
+// FilterListenersByPort takes a slice of listeners along with a port number
+// and filters the listeners to only those with an address whose port matches
+// the given port.
+// If -1 is passed as a port, no filtering will occur.
 func FilterListenersByPort(listeners []Listener, port int) []Listener {
 	if port == -1 {
 		return listeners
@@ -65,6 +73,9 @@ func FilterListenersByPort(listeners []Listener, port int) []Listener {
 	return filtered
 }
 
+// FilterListenersByAddress takes a slice of listeners along with a substring
+// and filters the listeners to only those with an address that contains the
+// given substring.
 func FilterListenersByAddress(listeners []Listener, substring string) []Listener {
 	if substring == "" {
 		return listeners

--- a/cli/cmd/proxy/read/filters.go
+++ b/cli/cmd/proxy/read/filters.go
@@ -1,15 +1,44 @@
 package read
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 // FilterFQDN takes a slice of clusters along with a substring
 // and filters the clusters to only those with fully qualified
 // domain names which contain the given substring.
 func FilterFQDN(clusters []Cluster, substring string) []Cluster {
+	if substring == "" {
+		return clusters
+	}
+
 	filtered := make([]Cluster, 0)
 	for _, cluster := range clusters {
 		if strings.Contains(cluster.FullyQualifiedDomainName, substring) {
 			filtered = append(filtered, cluster)
+		}
+	}
+
+	return filtered
+}
+
+// FilterPort takes a slice of clusters along with a port number
+// and filters the clusters to only those with endpoints whose
+// ports match the given port.
+func FilterPort(clusters []Cluster, port int) []Cluster {
+	if port == -1 {
+		return clusters
+	}
+
+	portStr := strconv.Itoa(port)
+
+	filtered := make([]Cluster, 0)
+	for _, cluster := range clusters {
+		for _, endpoint := range cluster.Endpoints {
+			if strings.HasSuffix(endpoint, portStr) {
+				filtered = append(filtered, cluster)
+			}
 		}
 	}
 

--- a/cli/cmd/proxy/read/filters.go
+++ b/cli/cmd/proxy/read/filters.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 )
 
-// FilterFQDN takes a slice of clusters along with a substring
+// FilterClustersByFQDN takes a slice of clusters along with a substring
 // and filters the clusters to only those with fully qualified
 // domain names which contain the given substring.
-func FilterFQDN(clusters []Cluster, substring string) []Cluster {
+func FilterClustersByFQDN(clusters []Cluster, substring string) []Cluster {
 	if substring == "" {
 		return clusters
 	}
@@ -23,10 +23,10 @@ func FilterFQDN(clusters []Cluster, substring string) []Cluster {
 	return filtered
 }
 
-// FilterPort takes a slice of clusters along with a port number
+// FilterClustersByPort takes a slice of clusters along with a port number
 // and filters the clusters to only those with endpoints whose
 // ports match the given port.
-func FilterPort(clusters []Cluster, port int) []Cluster {
+func FilterClustersByPort(clusters []Cluster, port int) []Cluster {
 	if port == -1 {
 		return clusters
 	}

--- a/cli/cmd/proxy/read/filters.go
+++ b/cli/cmd/proxy/read/filters.go
@@ -5,83 +5,93 @@ import (
 	"strings"
 )
 
-// FilterClustersByFQDN takes a slice of clusters along with a substring
-// and filters the clusters to only those with fully qualified
-// domain names which contain the given substring.
-func FilterClustersByFQDN(clusters []Cluster, substring string) []Cluster {
-	if substring == "" {
+// FilterClusters takes a slice of clusters along with parameters for filtering
+// those clusters.
+//
+// - `fqdn` filters clusters to only those with fully qualified domain names
+//   which contain the given value.
+// - `address` filters clusters to only those with endpoint addresses which
+//   contain the given value.
+// - `port` filters clusters to only those with endpoint addresses with ports
+//   that match the given value. If -1 is passed, no filtering will occur.
+//
+// The filters are applied in combination such that a cluster must adhere to
+// all of the filtering values which are passed in.
+func FilterClusters(clusters []Cluster, fqdn, address string, port int) []Cluster {
+	// No filtering no-op.
+	if fqdn == "" && address == "" && port == -1 {
 		return clusters
 	}
 
+	portStr := ":" + strconv.Itoa(port)
+
 	filtered := make([]Cluster, 0)
 	for _, cluster := range clusters {
-		if strings.Contains(cluster.FullyQualifiedDomainName, substring) {
-			filtered = append(filtered, cluster)
+		if !strings.Contains(cluster.FullyQualifiedDomainName, fqdn) {
+			continue
 		}
+
+		endpoints := strings.Join(cluster.Endpoints, "")
+		if !strings.Contains(endpoints, address) || (port != -1 && !strings.Contains(endpoints, portStr)) {
+			continue
+		}
+
+		filtered = append(filtered, cluster)
 	}
 
 	return filtered
 }
 
-// FilterClustersByPort takes a slice of clusters along with a port number
-// and filters the clusters to only those with endpoints whose
-// ports match the given port.
-// If -1 is passed as a port, no filtering will occur.
-func FilterClustersByPort(clusters []Cluster, port int) []Cluster {
-	if port == -1 {
-		return clusters
-	}
-
-	portStr := strconv.Itoa(port)
-
-	filtered := make([]Cluster, 0)
-	for _, cluster := range clusters {
-		for _, endpoint := range cluster.Endpoints {
-			if strings.HasSuffix(endpoint, portStr) {
-				filtered = append(filtered, cluster)
-			}
-		}
-	}
-
-	return filtered
-}
-
-// FilterEndpointsByPort takes a slice of endpoints along with a port number
-// and filters the endpoints to only those whose port matches the given port.
-// If -1 is passed as a port, no filtering will occur.
-func FilterEndpointsByPort(endpoints []Endpoint, port int) []Endpoint {
-	if port == -1 {
+// FilterEndpoints takes a slice of endpoints along with parameters for filtering
+// those endpoints:
+//
+// - `address` filters endpoints to only those with an address which contains
+//   the given value.
+// - `port` filters endpoints to only those with an address which has a port
+//   that matches the given value. If -1 is passed, no filtering will occur.
+//
+// The filters are applied in combination such that an endpoint must adhere to
+// all of the filtering values which are passed in.
+func FilterEndpoints(endpoints []Endpoint, address string, port int) []Endpoint {
+	if address == "" && port == -1 {
 		return endpoints
 	}
 
+	portStr := ":" + strconv.Itoa(port)
+
 	filtered := make([]Endpoint, 0)
+	for _, endpoint := range endpoints {
+		if strings.Contains(endpoint.Address, address) && (port == -1 || strings.Contains(endpoint.Address, portStr)) {
+			filtered = append(filtered, endpoint)
+		}
+	}
 
 	return filtered
 }
 
-// FilterListenersByPort takes a slice of listeners along with a port number
-// and filters the listeners to only those with an address whose port matches
-// the given port.
-// If -1 is passed as a port, no filtering will occur.
-func FilterListenersByPort(listeners []Listener, port int) []Listener {
-	if port == -1 {
+// FilterListeners takes a slice of listeners along with parameters for filtering
+// those endpoints:
+//
+// - `address` filters listeners to only those with an address which contains
+//   the given value.
+// - `port` filters listeners to only those with an address which has a port
+//   that matches the given value. If -1 is passed, no filtering will occur.
+//
+// The filters are applied in combination such that an listener must adhere to
+// all of the filtering values which are passed in.
+func FilterListeners(listeners []Listener, address string, port int) []Listener {
+	if address == "" && port == -1 {
 		return listeners
 	}
 
+	portStr := ":" + strconv.Itoa(port)
+
 	filtered := make([]Listener, 0)
-
-	return filtered
-}
-
-// FilterListenersByAddress takes a slice of listeners along with a substring
-// and filters the listeners to only those with an address that contains the
-// given substring.
-func FilterListenersByAddress(listeners []Listener, substring string) []Listener {
-	if substring == "" {
-		return listeners
+	for _, listener := range listeners {
+		if strings.Contains(listener.Address, address) && (port == -1 || strings.Contains(listener.Address, portStr)) {
+			filtered = append(filtered, listener)
+		}
 	}
-
-	filtered := make([]Listener, 0)
 
 	return filtered
 }

--- a/cli/cmd/proxy/read/filters.go
+++ b/cli/cmd/proxy/read/filters.go
@@ -1,0 +1,17 @@
+package read
+
+import "strings"
+
+// FilterFQDN takes a slice of clusters along with a substring
+// and filters the clusters to only those with fully qualified
+// domain names which contain the given substring.
+func FilterFQDN(clusters []Cluster, substring string) []Cluster {
+	filtered := make([]Cluster, 0)
+	for _, cluster := range clusters {
+		if strings.Contains(cluster.FullyQualifiedDomainName, substring) {
+			filtered = append(filtered, cluster)
+		}
+	}
+
+	return filtered
+}

--- a/cli/cmd/proxy/read/filters.go
+++ b/cli/cmd/proxy/read/filters.go
@@ -31,7 +31,7 @@ func FilterClusters(clusters []Cluster, fqdn, address string, port int) []Cluste
 			continue
 		}
 
-		endpoints := strings.Join(cluster.Endpoints, "")
+		endpoints := strings.Join(cluster.Endpoints, " ")
 		if !strings.Contains(endpoints, address) || (port != -1 && !strings.Contains(endpoints, portStr)) {
 			continue
 		}

--- a/cli/cmd/proxy/read/filters.go
+++ b/cli/cmd/proxy/read/filters.go
@@ -36,7 +36,13 @@ func FilterClusters(clusters []Cluster, fqdn, address string, port int) []Cluste
 			continue
 		}
 
-		filtered = append(filtered, cluster)
+		hasFQDN := strings.Contains(cluster.FullyQualifiedDomainName, fqdn)
+		hasAddress := strings.Contains(endpoints, address)
+		hasPort := port == -1 || strings.Contains(endpoints, portStr)
+
+		if hasFQDN && hasAddress && hasPort {
+			filtered = append(filtered, cluster)
+		}
 	}
 
 	return filtered

--- a/cli/cmd/proxy/read/filters_test.go
+++ b/cli/cmd/proxy/read/filters_test.go
@@ -1,0 +1,141 @@
+package read
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterFQDN(t *testing.T) {
+	given := []Cluster{
+		{
+			Name:                     "local_agent",
+			FullyQualifiedDomainName: "local_agent",
+			Endpoints:                []string{"192.168.79.187:8502"},
+			Type:                     "STATIC",
+			LastUpdated:              "2022-05-13T04:22:39.553Z",
+		},
+		{
+			Name:                     "client",
+			FullyQualifiedDomainName: "client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+			Endpoints:                []string{},
+			Type:                     "EDS",
+			LastUpdated:              "2022-06-09T00:39:12.948Z",
+		},
+		{
+			Name:                     "frontend",
+			FullyQualifiedDomainName: "frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+			Endpoints:                []string{},
+			Type:                     "EDS",
+			LastUpdated:              "2022-06-09T00:39:12.855Z",
+		},
+		{
+			Name:                     "local_app",
+			FullyQualifiedDomainName: "local_app",
+			Endpoints:                []string{"127.0.0.1:8080"},
+			Type:                     "STATIC",
+			LastUpdated:              "2022-05-13T04:22:39.655Z",
+		},
+		{
+			Name:                     "original-destination",
+			FullyQualifiedDomainName: "original-destination",
+			Endpoints:                []string{},
+			Type:                     "ORIGINAL_DST",
+			LastUpdated:              "2022-05-13T04:22:39.743Z",
+		},
+		{
+			Name:                     "server",
+			FullyQualifiedDomainName: "server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+			Endpoints:                []string{},
+			Type:                     "EDS",
+			LastUpdated:              "2022-06-09T00:39:12.754Z",
+		},
+	}
+
+	cases := map[string]struct {
+		substring string
+		expected  []Cluster
+	}{
+		"No filter": {
+			substring: "",
+			expected: []Cluster{
+				{
+					Name:                     "local_agent",
+					FullyQualifiedDomainName: "local_agent",
+					Endpoints:                []string{"192.168.79.187:8502"},
+					Type:                     "STATIC",
+					LastUpdated:              "2022-05-13T04:22:39.553Z",
+				},
+				{
+					Name:                     "client",
+					FullyQualifiedDomainName: "client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+					Endpoints:                []string{},
+					Type:                     "EDS",
+					LastUpdated:              "2022-06-09T00:39:12.948Z",
+				},
+				{
+					Name:                     "frontend",
+					FullyQualifiedDomainName: "frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+					Endpoints:                []string{},
+					Type:                     "EDS",
+					LastUpdated:              "2022-06-09T00:39:12.855Z",
+				},
+				{
+					Name:                     "local_app",
+					FullyQualifiedDomainName: "local_app",
+					Endpoints:                []string{"127.0.0.1:8080"},
+					Type:                     "STATIC",
+					LastUpdated:              "2022-05-13T04:22:39.655Z",
+				},
+				{
+					Name:                     "original-destination",
+					FullyQualifiedDomainName: "original-destination",
+					Endpoints:                []string{},
+					Type:                     "ORIGINAL_DST",
+					LastUpdated:              "2022-05-13T04:22:39.743Z",
+				},
+				{
+					Name:                     "server",
+					FullyQualifiedDomainName: "server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+					Endpoints:                []string{},
+					Type:                     "EDS",
+					LastUpdated:              "2022-06-09T00:39:12.754Z",
+				},
+			},
+		},
+		"Filter default": {
+			substring: "default",
+			expected: []Cluster{
+				{
+					Name:                     "client",
+					FullyQualifiedDomainName: "client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+					Endpoints:                []string{},
+					Type:                     "EDS",
+					LastUpdated:              "2022-06-09T00:39:12.948Z",
+				},
+				{
+					Name:                     "frontend",
+					FullyQualifiedDomainName: "frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+					Endpoints:                []string{},
+					Type:                     "EDS",
+					LastUpdated:              "2022-06-09T00:39:12.855Z",
+				},
+				{
+					Name:                     "server",
+					FullyQualifiedDomainName: "server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+					Endpoints:                []string{},
+					Type:                     "EDS",
+					LastUpdated:              "2022-06-09T00:39:12.754Z",
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := FilterFQDN(given, tc.substring)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+
+}

--- a/cli/cmd/proxy/read/filters_test.go
+++ b/cli/cmd/proxy/read/filters_test.go
@@ -184,7 +184,7 @@ func TestFilterClusters(t *testing.T) {
 				},
 			},
 		},
-		"Filter combo": {
+		"Filter fqdn and address": {
 			fqdn:    "local",
 			address: "127.0.0.1",
 			port:    -1,
@@ -202,6 +202,48 @@ func TestFilterClusters(t *testing.T) {
 					Endpoints:                []string{"127.0.0.1:5000"},
 					Type:                     "STATIC",
 					LastUpdated:              "2022-05-13T04:22:39.655Z",
+				},
+			},
+		},
+		"Filter fqdn and port": {
+			fqdn:    "local",
+			address: "",
+			port:    8080,
+			expected: []Cluster{
+				{
+					Name:                     "local_app",
+					FullyQualifiedDomainName: "local_app",
+					Endpoints:                []string{"127.0.0.1:8080"},
+					Type:                     "STATIC",
+					LastUpdated:              "2022-05-13T04:22:39.655Z",
+				},
+			},
+		},
+		"Filter port and address": {
+			fqdn:    "",
+			address: "127.0.0.1",
+			port:    8080,
+			expected: []Cluster{
+				{
+					Name:                     "local_app",
+					FullyQualifiedDomainName: "local_app",
+					Endpoints:                []string{"127.0.0.1:8080"},
+					Type:                     "STATIC",
+					LastUpdated:              "2022-05-13T04:22:39.655Z",
+				},
+			},
+		},
+		"Filter fqdn, address, and port": {
+			fqdn:    "local",
+			address: "192.168.79.187",
+			port:    8502,
+			expected: []Cluster{
+				{
+					Name:                     "local_agent",
+					FullyQualifiedDomainName: "local_agent",
+					Endpoints:                []string{"192.168.79.187:8502"},
+					Type:                     "STATIC",
+					LastUpdated:              "2022-05-13T04:22:39.553Z",
 				},
 			},
 		},

--- a/cli/cmd/proxy/read/filters_test.go
+++ b/cli/cmd/proxy/read/filters_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFilterFQDN(t *testing.T) {
+func TestFilterClustersByFQDN(t *testing.T) {
 	given := []Cluster{
 		{
 			Name:                     "local_agent",
@@ -133,13 +133,13 @@ func TestFilterFQDN(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			actual := FilterFQDN(given, tc.substring)
+			actual := FilterClustersByFQDN(given, tc.substring)
 			require.Equal(t, tc.expected, actual)
 		})
 	}
 }
 
-func TestFilterPort(t *testing.T) {
+func TestFilterClustersByPort(t *testing.T) {
 	given := []Cluster{
 		{
 			Name:                     "local_agent",
@@ -256,7 +256,7 @@ func TestFilterPort(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			actual := FilterPort(given, tc.port)
+			actual := FilterClustersByPort(given, tc.port)
 			require.Equal(t, tc.expected, actual)
 		})
 	}

--- a/cli/cmd/proxy/read/filters_test.go
+++ b/cli/cmd/proxy/read/filters_test.go
@@ -121,7 +121,7 @@ func TestFilterClusters(t *testing.T) {
 				},
 			},
 		},
-		"Filter FQDN default": {
+		"Filter FQDN": {
 			fqdn:    "default",
 			address: "",
 			port:    -1,
@@ -149,7 +149,7 @@ func TestFilterClusters(t *testing.T) {
 				},
 			},
 		},
-		"Filter address 127.0.": {
+		"Filter address": {
 			fqdn:    "",
 			address: "127.0.",
 			port:    -1,
@@ -170,7 +170,7 @@ func TestFilterClusters(t *testing.T) {
 				},
 			},
 		},
-		"Filter port 8080": {
+		"Filter port": {
 			fqdn:    "",
 			address: "",
 			port:    8080,
@@ -219,7 +219,7 @@ func TestFilterClusters(t *testing.T) {
 				},
 			},
 		},
-		"Filter port and address": {
+		"Filter address and port": {
 			fqdn:    "",
 			address: "127.0.0.1",
 			port:    8080,
@@ -293,7 +293,7 @@ func TestFilterEndpoints(t *testing.T) {
 		port     int
 		expected []Endpoint
 	}{
-		"No filters": {
+		"No filter": {
 			address: "",
 			port:    -1,
 			expected: []Endpoint{
@@ -326,7 +326,7 @@ func TestFilterEndpoints(t *testing.T) {
 				},
 			},
 		},
-		"Filter address 127.0.0.1": {
+		"Filter address": {
 			address: "127.0.0.1",
 			port:    -1,
 			expected: []Endpoint{
@@ -338,7 +338,7 @@ func TestFilterEndpoints(t *testing.T) {
 				},
 			},
 		},
-		"Filter port 20000": {
+		"Filter port": {
 			address: "",
 			port:    20000,
 			expected: []Endpoint{
@@ -359,7 +359,7 @@ func TestFilterEndpoints(t *testing.T) {
 				},
 			},
 		},
-		"Filter combo": {
+		"Filter address and port": {
 			address: "235",
 			port:    20000,
 			expected: []Endpoint{
@@ -443,7 +443,7 @@ func TestFilterListeners(t *testing.T) {
 				},
 			},
 		},
-		"Filter address 127.0.0.1": {
+		"Filter address": {
 			address: "127.0.0.1",
 			port:    -1,
 			expected: []Listener{
@@ -461,8 +461,26 @@ func TestFilterListeners(t *testing.T) {
 				},
 			},
 		},
-		"Filter port 20000": {
+		"Filter port": {
 			address: "",
+			port:    20000,
+			expected: []Listener{
+				{
+					Name:    "public_listener",
+					Address: "192.168.69.179:20000",
+					FilterChain: []FilterChain{
+						{
+							FilterChainMatch: "Any",
+							Filters:          []string{"* -> local_app/"},
+						},
+					},
+					Direction:   "INBOUND",
+					LastUpdated: "2022-06-09T00:39:27.668Z",
+				},
+			},
+		},
+		"Filter address and port": {
+			address: "192.168.69.179",
 			port:    20000,
 			expected: []Listener{
 				{

--- a/cli/cmd/proxy/read/filters_test.go
+++ b/cli/cmd/proxy/read/filters_test.go
@@ -137,5 +137,127 @@ func TestFilterFQDN(t *testing.T) {
 			require.Equal(t, tc.expected, actual)
 		})
 	}
+}
 
+func TestFilterPort(t *testing.T) {
+	given := []Cluster{
+		{
+			Name:                     "local_agent",
+			FullyQualifiedDomainName: "local_agent",
+			Endpoints:                []string{"192.168.79.187:8502"},
+			Type:                     "STATIC",
+			LastUpdated:              "2022-05-13T04:22:39.553Z",
+		},
+		{
+			Name:                     "client",
+			FullyQualifiedDomainName: "client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+			Endpoints:                []string{},
+			Type:                     "EDS",
+			LastUpdated:              "2022-06-09T00:39:12.948Z",
+		},
+		{
+			Name:                     "frontend",
+			FullyQualifiedDomainName: "frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+			Endpoints:                []string{},
+			Type:                     "EDS",
+			LastUpdated:              "2022-06-09T00:39:12.855Z",
+		},
+		{
+			Name:                     "local_app",
+			FullyQualifiedDomainName: "local_app",
+			Endpoints:                []string{"127.0.0.1:8080"},
+			Type:                     "STATIC",
+			LastUpdated:              "2022-05-13T04:22:39.655Z",
+		},
+		{
+			Name:                     "original-destination",
+			FullyQualifiedDomainName: "original-destination",
+			Endpoints:                []string{},
+			Type:                     "ORIGINAL_DST",
+			LastUpdated:              "2022-05-13T04:22:39.743Z",
+		},
+		{
+			Name:                     "server",
+			FullyQualifiedDomainName: "server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+			Endpoints:                []string{},
+			Type:                     "EDS",
+			LastUpdated:              "2022-06-09T00:39:12.754Z",
+		},
+	}
+
+	cases := map[string]struct {
+		port     int
+		expected []Cluster
+	}{
+		"No filtering": {
+			port: -1,
+			expected: []Cluster{
+				{
+					Name:                     "local_agent",
+					FullyQualifiedDomainName: "local_agent",
+					Endpoints:                []string{"192.168.79.187:8502"},
+					Type:                     "STATIC",
+					LastUpdated:              "2022-05-13T04:22:39.553Z",
+				},
+				{
+					Name:                     "client",
+					FullyQualifiedDomainName: "client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+					Endpoints:                []string{},
+					Type:                     "EDS",
+					LastUpdated:              "2022-06-09T00:39:12.948Z",
+				},
+				{
+					Name:                     "frontend",
+					FullyQualifiedDomainName: "frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+					Endpoints:                []string{},
+					Type:                     "EDS",
+					LastUpdated:              "2022-06-09T00:39:12.855Z",
+				},
+				{
+					Name:                     "local_app",
+					FullyQualifiedDomainName: "local_app",
+					Endpoints:                []string{"127.0.0.1:8080"},
+					Type:                     "STATIC",
+					LastUpdated:              "2022-05-13T04:22:39.655Z",
+				},
+				{
+					Name:                     "original-destination",
+					FullyQualifiedDomainName: "original-destination",
+					Endpoints:                []string{},
+					Type:                     "ORIGINAL_DST",
+					LastUpdated:              "2022-05-13T04:22:39.743Z",
+				},
+				{
+					Name:                     "server",
+					FullyQualifiedDomainName: "server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+					Endpoints:                []string{},
+					Type:                     "EDS",
+					LastUpdated:              "2022-06-09T00:39:12.754Z",
+				},
+			},
+		},
+		"Port that exists": {
+			port: 8502,
+			expected: []Cluster{
+				{
+					Name:                     "local_agent",
+					FullyQualifiedDomainName: "local_agent",
+					Endpoints:                []string{"192.168.79.187:8502"},
+					Type:                     "STATIC",
+					LastUpdated:              "2022-05-13T04:22:39.553Z",
+				},
+			},
+		},
+		"Port that doesn't exist": {
+			port:     14000000,
+			expected: []Cluster{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := FilterPort(given, tc.port)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
 }

--- a/cli/cmd/proxy/read/filters_test.go
+++ b/cli/cmd/proxy/read/filters_test.go
@@ -34,7 +34,7 @@ func TestFilterClusters(t *testing.T) {
 		},
 		{
 			FullyQualifiedDomainName: "server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
-			Endpoints:                []string{},
+			Endpoints:                []string{"123.45.67.890:8080", "111.30.2.39:8080"},
 		},
 	}
 
@@ -75,7 +75,7 @@ func TestFilterClusters(t *testing.T) {
 				},
 				{
 					FullyQualifiedDomainName: "server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
-					Endpoints:                []string{},
+					Endpoints:                []string{"123.45.67.890:8080", "111.30.2.39:8080"},
 				},
 			},
 		},
@@ -94,7 +94,7 @@ func TestFilterClusters(t *testing.T) {
 				},
 				{
 					FullyQualifiedDomainName: "server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
-					Endpoints:                []string{},
+					Endpoints:                []string{"123.45.67.890:8080", "111.30.2.39:8080"},
 				},
 			},
 		},
@@ -121,6 +121,10 @@ func TestFilterClusters(t *testing.T) {
 				{
 					FullyQualifiedDomainName: "local_app",
 					Endpoints:                []string{"127.0.0.1:8080"},
+				},
+				{
+					FullyQualifiedDomainName: "server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+					Endpoints:                []string{"123.45.67.890:8080", "111.30.2.39:8080"},
 				},
 			},
 		},

--- a/cli/cmd/proxy/read/filters_test.go
+++ b/cli/cmd/proxy/read/filters_test.go
@@ -9,53 +9,32 @@ import (
 func TestFilterClusters(t *testing.T) {
 	given := []Cluster{
 		{
-			Name:                     "local_agent",
 			FullyQualifiedDomainName: "local_agent",
 			Endpoints:                []string{"192.168.79.187:8502"},
-			Type:                     "STATIC",
-			LastUpdated:              "2022-05-13T04:22:39.553Z",
 		},
 		{
-			Name:                     "client",
 			FullyQualifiedDomainName: "client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
 			Endpoints:                []string{},
-			Type:                     "EDS",
-			LastUpdated:              "2022-06-09T00:39:12.948Z",
 		},
 		{
-			Name:                     "frontend",
 			FullyQualifiedDomainName: "frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
 			Endpoints:                []string{},
-			Type:                     "EDS",
-			LastUpdated:              "2022-06-09T00:39:12.855Z",
 		},
 		{
-			Name:                     "local_app",
 			FullyQualifiedDomainName: "local_app",
 			Endpoints:                []string{"127.0.0.1:8080"},
-			Type:                     "STATIC",
-			LastUpdated:              "2022-05-13T04:22:39.655Z",
 		},
 		{
-			Name:                     "local_admin",
 			FullyQualifiedDomainName: "local_admin",
 			Endpoints:                []string{"127.0.0.1:5000"},
-			Type:                     "STATIC",
-			LastUpdated:              "2022-05-13T04:22:39.655Z",
 		},
 		{
-			Name:                     "original-destination",
 			FullyQualifiedDomainName: "original-destination",
 			Endpoints:                []string{},
-			Type:                     "ORIGINAL_DST",
-			LastUpdated:              "2022-05-13T04:22:39.743Z",
 		},
 		{
-			Name:                     "server",
 			FullyQualifiedDomainName: "server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
 			Endpoints:                []string{},
-			Type:                     "EDS",
-			LastUpdated:              "2022-06-09T00:39:12.754Z",
 		},
 	}
 
@@ -71,53 +50,32 @@ func TestFilterClusters(t *testing.T) {
 			port:    -1,
 			expected: []Cluster{
 				{
-					Name:                     "local_agent",
 					FullyQualifiedDomainName: "local_agent",
 					Endpoints:                []string{"192.168.79.187:8502"},
-					Type:                     "STATIC",
-					LastUpdated:              "2022-05-13T04:22:39.553Z",
 				},
 				{
-					Name:                     "client",
 					FullyQualifiedDomainName: "client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
 					Endpoints:                []string{},
-					Type:                     "EDS",
-					LastUpdated:              "2022-06-09T00:39:12.948Z",
 				},
 				{
-					Name:                     "frontend",
 					FullyQualifiedDomainName: "frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
 					Endpoints:                []string{},
-					Type:                     "EDS",
-					LastUpdated:              "2022-06-09T00:39:12.855Z",
 				},
 				{
-					Name:                     "local_app",
 					FullyQualifiedDomainName: "local_app",
 					Endpoints:                []string{"127.0.0.1:8080"},
-					Type:                     "STATIC",
-					LastUpdated:              "2022-05-13T04:22:39.655Z",
 				},
 				{
-					Name:                     "local_admin",
 					FullyQualifiedDomainName: "local_admin",
 					Endpoints:                []string{"127.0.0.1:5000"},
-					Type:                     "STATIC",
-					LastUpdated:              "2022-05-13T04:22:39.655Z",
 				},
 				{
-					Name:                     "original-destination",
 					FullyQualifiedDomainName: "original-destination",
 					Endpoints:                []string{},
-					Type:                     "ORIGINAL_DST",
-					LastUpdated:              "2022-05-13T04:22:39.743Z",
 				},
 				{
-					Name:                     "server",
 					FullyQualifiedDomainName: "server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
 					Endpoints:                []string{},
-					Type:                     "EDS",
-					LastUpdated:              "2022-06-09T00:39:12.754Z",
 				},
 			},
 		},
@@ -127,25 +85,16 @@ func TestFilterClusters(t *testing.T) {
 			port:    -1,
 			expected: []Cluster{
 				{
-					Name:                     "client",
 					FullyQualifiedDomainName: "client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
 					Endpoints:                []string{},
-					Type:                     "EDS",
-					LastUpdated:              "2022-06-09T00:39:12.948Z",
 				},
 				{
-					Name:                     "frontend",
 					FullyQualifiedDomainName: "frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
 					Endpoints:                []string{},
-					Type:                     "EDS",
-					LastUpdated:              "2022-06-09T00:39:12.855Z",
 				},
 				{
-					Name:                     "server",
 					FullyQualifiedDomainName: "server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
 					Endpoints:                []string{},
-					Type:                     "EDS",
-					LastUpdated:              "2022-06-09T00:39:12.754Z",
 				},
 			},
 		},
@@ -155,18 +104,12 @@ func TestFilterClusters(t *testing.T) {
 			port:    -1,
 			expected: []Cluster{
 				{
-					Name:                     "local_app",
 					FullyQualifiedDomainName: "local_app",
 					Endpoints:                []string{"127.0.0.1:8080"},
-					Type:                     "STATIC",
-					LastUpdated:              "2022-05-13T04:22:39.655Z",
 				},
 				{
-					Name:                     "local_admin",
 					FullyQualifiedDomainName: "local_admin",
 					Endpoints:                []string{"127.0.0.1:5000"},
-					Type:                     "STATIC",
-					LastUpdated:              "2022-05-13T04:22:39.655Z",
 				},
 			},
 		},
@@ -176,11 +119,8 @@ func TestFilterClusters(t *testing.T) {
 			port:    8080,
 			expected: []Cluster{
 				{
-					Name:                     "local_app",
 					FullyQualifiedDomainName: "local_app",
 					Endpoints:                []string{"127.0.0.1:8080"},
-					Type:                     "STATIC",
-					LastUpdated:              "2022-05-13T04:22:39.655Z",
 				},
 			},
 		},
@@ -190,18 +130,12 @@ func TestFilterClusters(t *testing.T) {
 			port:    -1,
 			expected: []Cluster{
 				{
-					Name:                     "local_app",
 					FullyQualifiedDomainName: "local_app",
 					Endpoints:                []string{"127.0.0.1:8080"},
-					Type:                     "STATIC",
-					LastUpdated:              "2022-05-13T04:22:39.655Z",
 				},
 				{
-					Name:                     "local_admin",
 					FullyQualifiedDomainName: "local_admin",
 					Endpoints:                []string{"127.0.0.1:5000"},
-					Type:                     "STATIC",
-					LastUpdated:              "2022-05-13T04:22:39.655Z",
 				},
 			},
 		},
@@ -211,11 +145,8 @@ func TestFilterClusters(t *testing.T) {
 			port:    8080,
 			expected: []Cluster{
 				{
-					Name:                     "local_app",
 					FullyQualifiedDomainName: "local_app",
 					Endpoints:                []string{"127.0.0.1:8080"},
-					Type:                     "STATIC",
-					LastUpdated:              "2022-05-13T04:22:39.655Z",
 				},
 			},
 		},
@@ -225,11 +156,8 @@ func TestFilterClusters(t *testing.T) {
 			port:    8080,
 			expected: []Cluster{
 				{
-					Name:                     "local_app",
 					FullyQualifiedDomainName: "local_app",
 					Endpoints:                []string{"127.0.0.1:8080"},
-					Type:                     "STATIC",
-					LastUpdated:              "2022-05-13T04:22:39.655Z",
 				},
 			},
 		},
@@ -239,11 +167,8 @@ func TestFilterClusters(t *testing.T) {
 			port:    8502,
 			expected: []Cluster{
 				{
-					Name:                     "local_agent",
 					FullyQualifiedDomainName: "local_agent",
 					Endpoints:                []string{"192.168.79.187:8502"},
-					Type:                     "STATIC",
-					LastUpdated:              "2022-05-13T04:22:39.553Z",
 				},
 			},
 		},
@@ -261,30 +186,18 @@ func TestFilterEndpoints(t *testing.T) {
 	given := []Endpoint{
 		{
 			Address: "192.168.79.187:8502",
-			Cluster: "local_agent",
-			Weight:  1,
-			Status:  "HEALTHY",
 		},
 		{
 			Address: "127.0.0.1:8080",
-			Cluster: "local_app",
-			Weight:  1,
-			Status:  "HEALTHY",
 		},
 		{
 			Address: "192.168.31.201:20000",
-			Weight:  1,
-			Status:  "HEALTHY",
 		},
 		{
 			Address: "192.168.47.235:20000",
-			Weight:  1,
-			Status:  "HEALTHY",
 		},
 		{
 			Address: "192.168.71.254:20000",
-			Weight:  1,
-			Status:  "HEALTHY",
 		},
 	}
 
@@ -299,30 +212,18 @@ func TestFilterEndpoints(t *testing.T) {
 			expected: []Endpoint{
 				{
 					Address: "192.168.79.187:8502",
-					Cluster: "local_agent",
-					Weight:  1,
-					Status:  "HEALTHY",
 				},
 				{
 					Address: "127.0.0.1:8080",
-					Cluster: "local_app",
-					Weight:  1,
-					Status:  "HEALTHY",
 				},
 				{
 					Address: "192.168.31.201:20000",
-					Weight:  1,
-					Status:  "HEALTHY",
 				},
 				{
 					Address: "192.168.47.235:20000",
-					Weight:  1,
-					Status:  "HEALTHY",
 				},
 				{
 					Address: "192.168.71.254:20000",
-					Weight:  1,
-					Status:  "HEALTHY",
 				},
 			},
 		},
@@ -332,9 +233,6 @@ func TestFilterEndpoints(t *testing.T) {
 			expected: []Endpoint{
 				{
 					Address: "127.0.0.1:8080",
-					Cluster: "local_app",
-					Weight:  1,
-					Status:  "HEALTHY",
 				},
 			},
 		},
@@ -344,18 +242,12 @@ func TestFilterEndpoints(t *testing.T) {
 			expected: []Endpoint{
 				{
 					Address: "192.168.31.201:20000",
-					Weight:  1,
-					Status:  "HEALTHY",
 				},
 				{
 					Address: "192.168.47.235:20000",
-					Weight:  1,
-					Status:  "HEALTHY",
 				},
 				{
 					Address: "192.168.71.254:20000",
-					Weight:  1,
-					Status:  "HEALTHY",
 				},
 			},
 		},
@@ -365,8 +257,6 @@ func TestFilterEndpoints(t *testing.T) {
 			expected: []Endpoint{
 				{
 					Address: "192.168.47.235:20000",
-					Weight:  1,
-					Status:  "HEALTHY",
 				},
 			},
 		},
@@ -383,28 +273,10 @@ func TestFilterEndpoints(t *testing.T) {
 func TestFilterListeners(t *testing.T) {
 	given := []Listener{
 		{
-			Name:    "public_listener",
 			Address: "192.168.69.179:20000",
-			FilterChain: []FilterChain{
-				{
-					FilterChainMatch: "Any",
-					Filters:          []string{"* -> local_app/"},
-				},
-			},
-			Direction:   "INBOUND",
-			LastUpdated: "2022-06-09T00:39:27.668Z",
 		},
 		{
-			Name:    "outbound_listener",
 			Address: "127.0.0.1:15001",
-			FilterChain: []FilterChain{
-				{
-					FilterChainMatch: "10.100.134.173/32, 240.0.0.3/32",
-					Filters:          []string{"-> client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul"},
-				},
-			},
-			Direction:   "OUTBOUND",
-			LastUpdated: "2022-05-24T17:41:59.079Z",
 		},
 	}
 
@@ -418,28 +290,10 @@ func TestFilterListeners(t *testing.T) {
 			port:    -1,
 			expected: []Listener{
 				{
-					Name:    "public_listener",
 					Address: "192.168.69.179:20000",
-					FilterChain: []FilterChain{
-						{
-							FilterChainMatch: "Any",
-							Filters:          []string{"* -> local_app/"},
-						},
-					},
-					Direction:   "INBOUND",
-					LastUpdated: "2022-06-09T00:39:27.668Z",
 				},
 				{
-					Name:    "outbound_listener",
 					Address: "127.0.0.1:15001",
-					FilterChain: []FilterChain{
-						{
-							FilterChainMatch: "10.100.134.173/32, 240.0.0.3/32",
-							Filters:          []string{"-> client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul"},
-						},
-					},
-					Direction:   "OUTBOUND",
-					LastUpdated: "2022-05-24T17:41:59.079Z",
 				},
 			},
 		},
@@ -448,16 +302,7 @@ func TestFilterListeners(t *testing.T) {
 			port:    -1,
 			expected: []Listener{
 				{
-					Name:    "outbound_listener",
 					Address: "127.0.0.1:15001",
-					FilterChain: []FilterChain{
-						{
-							FilterChainMatch: "10.100.134.173/32, 240.0.0.3/32",
-							Filters:          []string{"-> client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul"},
-						},
-					},
-					Direction:   "OUTBOUND",
-					LastUpdated: "2022-05-24T17:41:59.079Z",
 				},
 			},
 		},
@@ -466,16 +311,7 @@ func TestFilterListeners(t *testing.T) {
 			port:    20000,
 			expected: []Listener{
 				{
-					Name:    "public_listener",
 					Address: "192.168.69.179:20000",
-					FilterChain: []FilterChain{
-						{
-							FilterChainMatch: "Any",
-							Filters:          []string{"* -> local_app/"},
-						},
-					},
-					Direction:   "INBOUND",
-					LastUpdated: "2022-06-09T00:39:27.668Z",
 				},
 			},
 		},
@@ -484,16 +320,7 @@ func TestFilterListeners(t *testing.T) {
 			port:    20000,
 			expected: []Listener{
 				{
-					Name:    "public_listener",
 					Address: "192.168.69.179:20000",
-					FilterChain: []FilterChain{
-						{
-							FilterChainMatch: "Any",
-							Filters:          []string{"* -> local_app/"},
-						},
-					},
-					Direction:   "INBOUND",
-					LastUpdated: "2022-06-09T00:39:27.668Z",
 				},
 			},
 		},


### PR DESCRIPTION
🎥 Demo!

https://user-images.githubusercontent.com/29112081/179610040-87e38340-4f40-49db-a069-743d2c59bfcc.mov

Changes proposed in this PR:

- Add functions for filtering by FQDN, port, and address.
- Use those functions in the output.
- Add a note to the header that shows which filters are being applied.

How I've tested this PR:

- Unit tests!

How I expect reviewers to test this PR:

- If you pull and build this branch's CLI, you can pass `-fqdn`, `-port`, and/or `-address` to filter the output.

Checklist:
- [x] Tests added

