### PR TITLE
Envoy debugging multiport support

### DIFF
--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -156,7 +156,7 @@ func (c *ReadCommand) Run(args []string) int {
 		return 1
 	}
 
-	c.outputConfigs(configs)
+	err = c.outputConfigs(configs)
 	if err != nil {
 		c.UI.Output(err.Error(), terminal.WithErrorStyle())
 		return 1

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -207,7 +207,7 @@ func (c *ReadCommand) validateFlags() error {
 	return nil
 }
 
-// filtersPassed returns true if the user has passed a flag which filters th
+// filtersPassed returns true if the user has passed a flag which filters the
 // output.
 func (c *ReadCommand) filtersPassed() bool {
 	return c.flagClusters || c.flagEndpoints || c.flagListeners || c.flagRoutes || c.flagSecrets

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -207,7 +207,7 @@ func (c *ReadCommand) validateFlags() error {
 	return nil
 }
 
-// filtersPassed returns true if the user has passed a flag which filters the
+// filtersPassed returns true if the user has passed a flag which filters th
 // output.
 func (c *ReadCommand) filtersPassed() bool {
 	return c.flagClusters || c.flagEndpoints || c.flagListeners || c.flagRoutes || c.flagSecrets
@@ -290,6 +290,18 @@ func (c *ReadCommand) fetchConfigs(adminPorts map[string]int) (map[string]*Envoy
 }
 
 func (c *ReadCommand) outputConfigs(configs map[string]*EnvoyConfig) error {
+	for name, config := range configs {
+		fmt.Println(name)
+		err := c.outputConfig(config)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *ReadCommand) outputConfig(config *EnvoyConfig) error {
 	switch c.flagOutput {
 	case Table:
 		return c.outputTables(configs)

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -266,52 +266,6 @@ func (c *ReadCommand) fetchAdminPorts() (map[string]int, error) {
 	return adminPorts, nil
 }
 
-func (c *ReadCommand) outputConfigs(configs map[string]*EnvoyConfig) error {
-	for name, config := range configs {
-		fmt.Println(name)
-		err := c.outputConfig(config)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (c *ReadCommand) outputConfig(config *EnvoyConfig) error {
-	switch c.flagOutput {
-	case Table:
-		c.outputAsTables(config)
-	case JSON:
-		return c.outputAsJSON(config)
-	case Raw:
-		c.UI.Output(string(config.rawCfg))
-	}
-
-	return nil
-}
-
-func (c *ReadCommand) outputAsJSON(config *EnvoyConfig) error {
-	cfg := make(map[string]interface{})
-	if !c.filtersPassed() || c.flagClusters {
-		cfg["clusters"] = config.Clusters
-	}
-	if !c.filtersPassed() || c.flagEndpoints {
-		cfg["endpoints"] = config.Endpoints
-	}
-	if !c.filtersPassed() || c.flagListeners {
-		cfg["listeners"] = config.Listeners
-	}
-	if !c.filtersPassed() || c.flagRoutes {
-		cfg["routes"] = config.Routes
-	}
-	if !c.filtersPassed() || c.flagSecrets {
-		cfg["secrets"] = config.Secrets
-	}
-
-	out, err := json.MarshalIndent(cfg, "", "\t")
-}
-
 func (c *ReadCommand) fetchConfigs(adminPorts map[string]int) (map[string]*EnvoyConfig, error) {
 	configs := make(map[string]*EnvoyConfig, 0)
 
@@ -336,18 +290,6 @@ func (c *ReadCommand) fetchConfigs(adminPorts map[string]int) (map[string]*Envoy
 }
 
 func (c *ReadCommand) outputConfigs(configs map[string]*EnvoyConfig) error {
-	for name, config := range configs {
-		fmt.Println(name)
-		err := c.outputConfig(config)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (c *ReadCommand) outputConfig(config *EnvoyConfig) error {
 	switch c.flagOutput {
 	case Table:
 		return c.outputTables(configs)

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -266,6 +266,52 @@ func (c *ReadCommand) fetchAdminPorts() (map[string]int, error) {
 	return adminPorts, nil
 }
 
+func (c *ReadCommand) outputConfigs(configs map[string]*EnvoyConfig) error {
+	for name, config := range configs {
+		fmt.Println(name)
+		err := c.outputConfig(config)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *ReadCommand) outputConfig(config *EnvoyConfig) error {
+	switch c.flagOutput {
+	case Table:
+		c.outputAsTables(config)
+	case JSON:
+		return c.outputAsJSON(config)
+	case Raw:
+		c.UI.Output(string(config.rawCfg))
+	}
+
+	return nil
+}
+
+func (c *ReadCommand) outputAsJSON(config *EnvoyConfig) error {
+	cfg := make(map[string]interface{})
+	if !c.filtersPassed() || c.flagClusters {
+		cfg["clusters"] = config.Clusters
+	}
+	if !c.filtersPassed() || c.flagEndpoints {
+		cfg["endpoints"] = config.Endpoints
+	}
+	if !c.filtersPassed() || c.flagListeners {
+		cfg["listeners"] = config.Listeners
+	}
+	if !c.filtersPassed() || c.flagRoutes {
+		cfg["routes"] = config.Routes
+	}
+	if !c.filtersPassed() || c.flagSecrets {
+		cfg["secrets"] = config.Secrets
+	}
+
+	out, err := json.MarshalIndent(cfg, "", "\t")
+}
+
 func (c *ReadCommand) fetchConfigs(adminPorts map[string]int) (map[string]*EnvoyConfig, error) {
 	configs := make(map[string]*EnvoyConfig, 0)
 

--- a/cli/cmd/proxy/read/format.go
+++ b/cli/cmd/proxy/read/format.go
@@ -1,0 +1,76 @@
+package read
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/consul-k8s/cli/common/terminal"
+)
+
+func formatClusters(clusters []Cluster) *terminal.Table {
+	table := terminal.NewTable("Name", "FQDN", "Endpoints", "Type", "Last Updated")
+	for _, cluster := range clusters {
+		table.AddRow([]string{cluster.Name, cluster.FullyQualifiedDomainName, strings.Join(cluster.Endpoints, ", "),
+			cluster.Type, cluster.LastUpdated}, []string{})
+	}
+
+	return table
+}
+
+func formatEndpoints(endpoints []Endpoint) *terminal.Table {
+	table := terminal.NewTable("Address:Port", "Cluster", "Weight", "Status")
+	for _, endpoint := range endpoints {
+		var statusColor string
+		if endpoint.Status == "HEALTHY" {
+			statusColor = "green"
+		} else {
+			statusColor = "red"
+		}
+
+		table.AddRow(
+			[]string{endpoint.Address, endpoint.Cluster, fmt.Sprintf("%.2f", endpoint.Weight), endpoint.Status},
+			[]string{"", "", "", statusColor})
+	}
+
+	return table
+}
+
+func formatListeners(listeners []Listener) *terminal.Table {
+	table := terminal.NewTable("Name", "Address:Port", "Direction", "Filter Chain Match", "Filters", "Last Updated")
+	for _, listener := range listeners {
+		for index, filter := range listener.FilterChain {
+			// Print each element of the filter chain in a separate line
+			// without repeating the name, address, etc.
+			filters := strings.Join(filter.Filters, "\n")
+			if index == 0 {
+				table.AddRow(
+					[]string{listener.Name, listener.Address, listener.Direction, filter.FilterChainMatch, filters, listener.LastUpdated},
+					[]string{})
+			} else {
+				table.AddRow(
+					[]string{"", "", "", filter.FilterChainMatch, filters},
+					[]string{})
+			}
+		}
+	}
+
+	return table
+}
+
+func formatRoutes(routes []Route) *terminal.Table {
+	table := terminal.NewTable("Name", "Destination Cluster", "Last Updated")
+	for _, route := range routes {
+		table.AddRow([]string{route.Name, route.DestinationCluster, route.LastUpdated}, []string{})
+	}
+
+	return table
+}
+
+func formatSecrets(secrets []Secret) *terminal.Table {
+	table := terminal.NewTable("Name", "Type", "Last Updated")
+	for _, secret := range secrets {
+		table.AddRow([]string{secret.Name, secret.Type, secret.LastUpdated}, []string{})
+	}
+
+	return table
+}

--- a/cli/cmd/proxy/read/format_test.go
+++ b/cli/cmd/proxy/read/format_test.go
@@ -1,12 +1,26 @@
 package read
 
 import (
+	"bytes"
+	"context"
 	"testing"
 
+	"github.com/hashicorp/consul-k8s/cli/common/terminal"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFormatClusters(t *testing.T) {
+	// These regular expressions must be present in the output.
+	expected := []string{
+		"Name.*FQDN.*Endpoints.*Type.*Last Updated",
+		"local_agent.*local_agent.*192\\.168\\.79\\.187:8502.*STATIC.*2022-05-13T04:22:39\\.553Z",
+		"local_app.*local_app.*127\\.0\\.0\\.1:8080.*STATIC.*2022-05-13T04:22:39\\.655Z",
+		"client.*client\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul.*EDS.*2022-06-09T00:39:12\\.948Z",
+		"frontend.*frontend\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul.*EDS.*2022-06-09T00:39:12\\.855Z",
+		"original-destination.*original-destination.*ORIGINAL_DST.*2022-05-13T04:22:39.743Z",
+		"server.*server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul.*EDS.*2022-06-09T00:39:12\\.754Z",
+	}
+
 	given := []Cluster{
 		{
 			Name:                     "local_agent",
@@ -54,13 +68,35 @@ func TestFormatClusters(t *testing.T) {
 
 	expectedHeaders := []string{"Name", "FQDN", "Endpoints", "Type", "Last Updated"}
 
-	actual := formatClusters(given)
+	table := formatClusters(given)
 
-	require.Equal(t, expectedHeaders, actual.Headers)
-	require.Equal(t, len(given), len(actual.Rows))
+	require.Equal(t, expectedHeaders, table.Headers)
+	require.Equal(t, len(given), len(table.Rows))
+
+	buf := new(bytes.Buffer)
+	terminal.NewUI(context.Background(), buf).Table(table)
+
+	actual := buf.String()
+	for _, expression := range expected {
+		require.Regexp(t, expression, actual)
+	}
 }
 
 func TestFormatEndpoints(t *testing.T) {
+	// These regular expressions must be present in the output.
+	expected := []string{
+		"Address:Port.*Cluster.*Weight.*Status",
+		"192.168.79.187:8502.*local_agent.*1.00.*HEALTHY",
+		"127.0.0.1:8080.*local_app.*1.00.*HEALTHY",
+		"192.168.31.201:20000.*1.00.*HEALTHY",
+		"192.168.47.235:20000.*1.00.*HEALTHY",
+		"192.168.71.254:20000.*1.00.*HEALTHY",
+		"192.168.63.120:20000.*1.00.*HEALTHY",
+		"192.168.18.110:20000.*1.00.*HEALTHY",
+		"192.168.52.101:20000.*1.00.*HEALTHY",
+		"192.168.65.131:20000.*1.00.*HEALTHY",
+	}
+
 	given := []Endpoint{
 		{
 			Address: "192.168.79.187:8502",
@@ -113,13 +149,31 @@ func TestFormatEndpoints(t *testing.T) {
 
 	expectedHeaders := []string{"Address:Port", "Cluster", "Weight", "Status"}
 
-	actual := formatEndpoints(given)
+	table := formatEndpoints(given)
 
-	require.Equal(t, expectedHeaders, actual.Headers)
-	require.Equal(t, len(given), len(actual.Rows))
+	require.Equal(t, expectedHeaders, table.Headers)
+	require.Equal(t, len(given), len(table.Rows))
+
+	buf := new(bytes.Buffer)
+	terminal.NewUI(context.Background(), buf).Table(table)
+
+	actual := buf.String()
+	for _, expression := range expected {
+		require.Regexp(t, expression, actual)
+	}
 }
 
 func TestFormatListeners(t *testing.T) {
+	// These regular expressions must be present in the output.
+	expected := []string{
+		"Name.*Address:Port.*Direction.*Filter Chain Match.*Filters.*Last Updated",
+		"public_listener.*192\\.168\\.69\\.179:20000.*INBOUND.*Any.*\\* -> local_app/.*2022-06-09T00:39:27\\.668Z",
+		"outbound_listener.*127.0.0.1:15001.*OUTBOUND.*10\\.100\\.134\\.173/32, 240\\.0\\.0\\.3/32.*-> client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul.*2022-05-24T17:41:59\\.079Z",
+		"10\\.100\\.254\\.176/32, 240\\.0\\.0\\.4/32.*\\* -> server\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul/",
+		"10\\.100\\.31\\.2/32, 240\\.0\\.0\\.2/32.*-> frontend\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul",
+		"Any.*-> original-destination",
+	}
+
 	given := []Listener{
 		{
 			Name:    "public_listener",
@@ -169,13 +223,28 @@ func TestFormatListeners(t *testing.T) {
 		expectedRowCount += len(element.FilterChain)
 	}
 
-	actual := formatListeners(given)
+	table := formatListeners(given)
 
-	require.Equal(t, expectedHeaders, actual.Headers)
-	require.Equal(t, expectedRowCount, len(actual.Rows))
+	require.Equal(t, expectedHeaders, table.Headers)
+	require.Equal(t, expectedRowCount, len(table.Rows))
+
+	buf := new(bytes.Buffer)
+	terminal.NewUI(context.Background(), buf).Table(table)
+
+	actual := buf.String()
+	for _, expression := range expected {
+		require.Regexp(t, expression, actual)
+	}
 }
 
 func TestFormatRoutes(t *testing.T) {
+	// These regular expressions must be present in the output.
+	expected := []string{
+		"Name.*Destination Cluster.*Last Updated",
+		"public_listener.*local_app/.*2022-06-09T00:39:27.667Z",
+		"server.*server\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul/.*2022-05-24T17:41:59\\.078Z",
+	}
+
 	given := []Route{
 		{
 			Name:               "public_listener",
@@ -191,13 +260,28 @@ func TestFormatRoutes(t *testing.T) {
 
 	expectedHeaders := []string{"Name", "Destination Cluster", "Last Updated"}
 
-	actual := formatRoutes(given)
+	table := formatRoutes(given)
 
-	require.Equal(t, expectedHeaders, actual.Headers)
-	require.Equal(t, len(given), len(actual.Rows))
+	require.Equal(t, expectedHeaders, table.Headers)
+	require.Equal(t, len(given), len(table.Rows))
+
+	buf := new(bytes.Buffer)
+	terminal.NewUI(context.Background(), buf).Table(table)
+
+	actual := buf.String()
+	for _, expression := range expected {
+		require.Regexp(t, expression, actual)
+	}
 }
 
 func TestFormatSecrets(t *testing.T) {
+	// These regular expressions must be present in the output.
+	expected := []string{
+		"Name.*Type.*Last Updated",
+		"default.*Dynamic Active.*2022-05-24T17:41:59.078Z",
+		"ROOTCA.*Dynamic Warming.*2022-03-15T05:14:22.868Z",
+	}
+
 	given := []Secret{
 		{
 			Name:        "default",
@@ -213,8 +297,16 @@ func TestFormatSecrets(t *testing.T) {
 
 	expectedHeaders := []string{"Name", "Type", "Last Updated"}
 
-	actual := formatSecrets(given)
+	table := formatSecrets(given)
 
-	require.Equal(t, expectedHeaders, actual.Headers)
-	require.Equal(t, len(given), len(actual.Rows))
+	require.Equal(t, expectedHeaders, table.Headers)
+	require.Equal(t, len(given), len(table.Rows))
+
+	buf := new(bytes.Buffer)
+	terminal.NewUI(context.Background(), buf).Table(table)
+
+	actual := buf.String()
+	for _, expression := range expected {
+		require.Regexp(t, expression, actual)
+	}
 }

--- a/cli/cmd/proxy/read/format_test.go
+++ b/cli/cmd/proxy/read/format_test.go
@@ -1,0 +1,220 @@
+package read
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatClusters(t *testing.T) {
+	given := []Cluster{
+		{
+			Name:                     "local_agent",
+			FullyQualifiedDomainName: "local_agent",
+			Endpoints:                []string{"192.168.79.187:8502"},
+			Type:                     "STATIC",
+			LastUpdated:              "2022-05-13T04:22:39.553Z",
+		},
+		{
+			Name:                     "client",
+			FullyQualifiedDomainName: "client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+			Endpoints:                []string{},
+			Type:                     "EDS",
+			LastUpdated:              "2022-06-09T00:39:12.948Z",
+		},
+		{
+			Name:                     "frontend",
+			FullyQualifiedDomainName: "frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+			Endpoints:                []string{},
+			Type:                     "EDS",
+			LastUpdated:              "2022-06-09T00:39:12.855Z",
+		},
+		{
+			Name:                     "local_app",
+			FullyQualifiedDomainName: "local_app",
+			Endpoints:                []string{"127.0.0.1:8080"},
+			Type:                     "STATIC",
+			LastUpdated:              "2022-05-13T04:22:39.655Z",
+		},
+		{
+			Name:                     "original-destination",
+			FullyQualifiedDomainName: "original-destination",
+			Endpoints:                []string{},
+			Type:                     "ORIGINAL_DST",
+			LastUpdated:              "2022-05-13T04:22:39.743Z",
+		},
+		{
+			Name:                     "server",
+			FullyQualifiedDomainName: "server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+			Endpoints:                []string{},
+			Type:                     "EDS",
+			LastUpdated:              "2022-06-09T00:39:12.754Z",
+		},
+	}
+
+	expectedHeaders := []string{"Name", "FQDN", "Endpoints", "Type", "Last Updated"}
+
+	actual := formatClusters(given)
+
+	require.Equal(t, expectedHeaders, actual.Headers)
+	require.Equal(t, len(given), len(actual.Rows))
+}
+
+func TestFormatEndpoints(t *testing.T) {
+	given := []Endpoint{
+		{
+			Address: "192.168.79.187:8502",
+			Cluster: "local_agent",
+			Weight:  1,
+			Status:  "HEALTHY",
+		},
+		{
+			Address: "127.0.0.1:8080",
+			Cluster: "local_app",
+			Weight:  1,
+			Status:  "HEALTHY",
+		},
+		{
+			Address: "192.168.31.201:20000",
+			Weight:  1,
+			Status:  "HEALTHY",
+		},
+		{
+			Address: "192.168.47.235:20000",
+			Weight:  1,
+			Status:  "HEALTHY",
+		},
+		{
+			Address: "192.168.71.254:20000",
+			Weight:  1,
+			Status:  "HEALTHY",
+		},
+		{
+			Address: "192.168.63.120:20000",
+			Weight:  1,
+			Status:  "HEALTHY",
+		},
+		{
+			Address: "192.168.18.110:20000",
+			Weight:  1,
+			Status:  "HEALTHY",
+		},
+		{
+			Address: "192.168.52.101:20000",
+			Weight:  1,
+			Status:  "HEALTHY",
+		},
+		{
+			Address: "192.168.65.131:20000",
+			Weight:  1,
+			Status:  "HEALTHY",
+		},
+	}
+
+	expectedHeaders := []string{"Address:Port", "Cluster", "Weight", "Status"}
+
+	actual := formatEndpoints(given)
+
+	require.Equal(t, expectedHeaders, actual.Headers)
+	require.Equal(t, len(given), len(actual.Rows))
+}
+
+func TestFormatListeners(t *testing.T) {
+	given := []Listener{
+		{
+			Name:    "public_listener",
+			Address: "192.168.69.179:20000",
+			FilterChain: []FilterChain{
+				{
+					FilterChainMatch: "Any",
+					Filters:          []string{"* -> local_app/"},
+				},
+			},
+			Direction:   "INBOUND",
+			LastUpdated: "2022-06-09T00:39:27.668Z",
+		},
+		{
+			Name:    "outbound_listener",
+			Address: "127.0.0.1:15001",
+			FilterChain: []FilterChain{
+				{
+					FilterChainMatch: "10.100.134.173/32, 240.0.0.3/32",
+					Filters:          []string{"-> client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul"},
+				},
+				{
+					FilterChainMatch: "10.100.254.176/32, 240.0.0.4/32",
+					Filters:          []string{"* -> server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul/"},
+				},
+				{
+					FilterChainMatch: "10.100.31.2/32, 240.0.0.2/32",
+					Filters: []string{
+						"-> frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+					},
+				},
+				{
+					FilterChainMatch: "Any",
+					Filters:          []string{"-> original-destination"},
+				},
+			},
+			Direction:   "OUTBOUND",
+			LastUpdated: "2022-05-24T17:41:59.079Z",
+		},
+	}
+
+	expectedHeaders := []string{"Name", "Address:Port", "Direction", "Filter Chain Match", "Filters", "Last Updated"}
+
+	// Listeners tables split filter chain information across rows.
+	expectedRowCount := 0
+	for _, element := range given {
+		expectedRowCount += len(element.FilterChain)
+	}
+
+	actual := formatListeners(given)
+
+	require.Equal(t, expectedHeaders, actual.Headers)
+	require.Equal(t, expectedRowCount, len(actual.Rows))
+}
+
+func TestFormatRoutes(t *testing.T) {
+	given := []Route{
+		{
+			Name:               "public_listener",
+			DestinationCluster: "local_app/",
+			LastUpdated:        "2022-06-09T00:39:27.667Z",
+		},
+		{
+			Name:               "server",
+			DestinationCluster: "server.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul/",
+			LastUpdated:        "2022-05-24T17:41:59.078Z",
+		},
+	}
+
+	expectedHeaders := []string{"Name", "Destination Cluster", "Last Updated"}
+
+	actual := formatRoutes(given)
+
+	require.Equal(t, expectedHeaders, actual.Headers)
+	require.Equal(t, len(given), len(actual.Rows))
+}
+
+func TestFormatSecrets(t *testing.T) {
+	given := []Secret{
+		{
+			Name:        "default",
+			Type:        "Dynamic Active",
+			LastUpdated: "2022-05-24T17:41:59.078Z",
+		},
+		{
+			Name:        "ROOTCA",
+			Type:        "Dynamic Warming",
+			LastUpdated: "2022-03-15T05:14:22.868Z",
+		},
+	}
+
+	expectedHeaders := []string{"Name", "Type", "Last Updated"}
+
+	actual := formatSecrets(given)
+
+	require.Equal(t, expectedHeaders, actual.Headers)
+	require.Equal(t, len(given), len(actual.Rows))
+}

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/consul-k8s/cli/cmd/upgrade"
 	cmdversion "github.com/hashicorp/consul-k8s/cli/cmd/version"
 	"github.com/hashicorp/consul-k8s/cli/common"
+	"github.com/hashicorp/consul-k8s/cli/common/terminal"
 	"github.com/hashicorp/consul-k8s/cli/version"
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
@@ -22,6 +23,7 @@ func initializeCommands(ctx context.Context, log hclog.Logger) (*common.BaseComm
 	baseCommand := &common.BaseCommand{
 		Ctx: ctx,
 		Log: log,
+		UI:  terminal.NewBasicUI(ctx),
 	}
 
 	commands := map[string]cli.CommandFactory{


### PR DESCRIPTION
📹 Demo


https://user-images.githubusercontent.com/29112081/180005754-694d5aa4-7c81-44fb-b07a-a7d63d2b4995.mov

Changes proposed in this PR:

- Get admin port for all services
- Add UI to all commands
- Output config for each service
- Separate out formatting of tables
- Add fake pod to fix command_test
- Add tests for formatting

How I've tested this PR:

- New unit tests, and I ran this on a multiport pod.

How I expect reviewers to test this PR:

- Unit tests or multiport pod manual tests.

Checklist:
- [x] Tests added
