### PR TITLE
Skip peering tests on AKS and update AKS version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -701,7 +701,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig"
+          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -disable-peering
 
       - store_test_results:
           path: /tmp/test-results

--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -40,6 +40,8 @@ type TestConfig struct {
 
 	EnableTransparentProxy bool
 
+	DisablePeering bool
+
 	ConsulImage    string
 	ConsulK8SImage string
 	ConsulVersion  *version.Version

--- a/acceptance/framework/flags/flags.go
+++ b/acceptance/framework/flags/flags.go
@@ -40,6 +40,8 @@ type TestFlags struct {
 
 	flagUseKind bool
 
+	flagDisablePeering bool
+
 	once sync.Once
 }
 
@@ -96,6 +98,8 @@ func (t *TestFlags) init() {
 
 	flag.BoolVar(&t.flagUseKind, "use-kind", false,
 		"If true, the tests will assume they are running against a local kind cluster(s).")
+	flag.BoolVar(&t.flagDisablePeering, "disable-peering", false,
+		"If true, the peering tests will not run.")
 
 	if t.flagEnterpriseLicense == "" {
 		t.flagEnterpriseLicense = os.Getenv("CONSUL_ENT_LICENSE")
@@ -139,6 +143,8 @@ func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 		EnablePodSecurityPolicies: t.flagEnablePodSecurityPolicies,
 
 		EnableTransparentProxy: t.flagEnableTransparentProxy,
+
+		DisablePeering: t.flagDisablePeering,
 
 		ConsulImage:    t.flagConsulImage,
 		ConsulK8SImage: t.flagConsulK8sImage,

--- a/acceptance/tests/peering/main_test.go
+++ b/acceptance/tests/peering/main_test.go
@@ -13,10 +13,10 @@ var suite testsuite.Suite
 func TestMain(m *testing.M) {
 	suite = testsuite.NewSuite(m)
 
-	if suite.Config().EnableMultiCluster {
+	if suite.Config().EnableMultiCluster && !suite.Config().DisablePeering {
 		os.Exit(suite.Run())
 	} else {
-		fmt.Println("Skipping peering tests because -enable-multi-cluster is not set")
+		fmt.Println("Skipping peering tests because either -enable-multi-cluster is not set or -disable-peering is set")
 		os.Exit(0)
 	}
 }

--- a/charts/consul/test/terraform/aks/main.tf
+++ b/charts/consul/test/terraform/aks/main.tf
@@ -45,7 +45,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   location            = azurerm_resource_group.default[count.index].location
   resource_group_name = azurerm_resource_group.default[count.index].name
   dns_prefix          = "consul-k8s-${random_id.suffix[count.index].dec}"
-  kubernetes_version  = "1.21.7"
+  kubernetes_version  = "1.21.14"
 
   // We're setting the network plugin and other network properties explicitly
   // here even though they are the same as defaults to ensure that none of these CIDRs


### PR DESCRIPTION
* On AKS, we cannot run peering tests yet because the pod network is not flat
* Add a flag to acceptance tests framework to disable peering tests (to be removed once non-flat networks are supported)
* Update AKS version to the supported 1.21.x version (1.21.7 is no longer supported)
* Run AKS nightly acceptance tests with -disable-peering flag

How I've tested this PR:
ran tests in the pipeline: https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/6636/workflows/b7132391-db97-41af-b2f0-a75a0ab447b7/jobs/55267

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

