### PR TITLE
Read created secrets from the API object

### DIFF
--- a/acceptance/tests/peering/peering_connect_test.go
+++ b/acceptance/tests/peering/peering_connect_test.go
@@ -2,7 +2,6 @@ package peering
 
 import (
 	"context"
-	"github.com/hashicorp/go-version"
 	"strconv"
 	"testing"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -111,6 +111,9 @@ func TestPeering_Connect(t *testing.T) {
 			helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
 				k8s.KubectlDelete(t, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
 			})
+			acceptorSecretResourceVersion, err := k8s.RunKubectlAndGetOutputE(t, staticClientPeerClusterContext.KubectlOptions(t), "get", "peering-acceptor", "server", "-o", "jsonpath={.status.secret.resourceVersion}")
+			require.NoError(t, err)
+			require.NotEmpty(t, acceptorSecretResourceVersion)
 
 			// Copy secret from client peer to server peer.
 			k8s.CopySecret(t, staticClientPeerClusterContext, staticServerPeerClusterContext, "api-token")

--- a/acceptance/tests/peering/peering_connect_test.go
+++ b/acceptance/tests/peering/peering_connect_test.go
@@ -111,7 +111,7 @@ func TestPeering_Connect(t *testing.T) {
 			helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
 				k8s.KubectlDelete(t, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
 			})
-			acceptorSecretResourceVersion, err := k8s.RunKubectlAndGetOutputE(t, staticClientPeerClusterContext.KubectlOptions(t), "get", "peering-acceptor", "server", "-o", "jsonpath={.status.secret.resourceVersion}")
+			acceptorSecretResourceVersion, err := k8s.RunKubectlAndGetOutputE(t, staticClientPeerClusterContext.KubectlOptions(t), "get", "peeringacceptor", "server", "-o", "jsonpath={.status.secret.resourceVersion}")
 			require.NoError(t, err)
 			require.NotEmpty(t, acceptorSecretResourceVersion)
 

--- a/charts/consul/templates/connect-inject-clusterrole.yaml
+++ b/charts/consul/templates/connect-inject-clusterrole.yaml
@@ -52,6 +52,7 @@ rules:
   - "list"
   - "watch"
   - "create"
+  - "update"
   - "delete"
 - apiGroups: ["consul.hashicorp.com"]
   resources: ["peeringacceptors"]

--- a/control-plane/connect-inject/peering_acceptor_controller.go
+++ b/control-plane/connect-inject/peering_acceptor_controller.go
@@ -314,13 +314,7 @@ func (r *PeeringAcceptorController) createOrUpdateK8sSecret(ctx context.Context,
 			return "", err
 		}
 	}
-	// The newly created or updated secret should exist at this point, so we can get it and return the resourceVersion.
-	newSecret := &corev1.Secret{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: secretNamespace}, newSecret); err != nil {
-		return "", err
-	}
-
-	return newSecret.ResourceVersion, nil
+	return secret.ResourceVersion, nil
 }
 
 func (r *PeeringAcceptorController) deleteK8sSecret(ctx context.Context, acceptor *consulv1alpha1.PeeringAcceptor) error {


### PR DESCRIPTION
Changes proposed in this PR:
- Avoid reading objects from the cache immediately after creating them as they are not guaranteed to exist. This leads to a bug caused by the race condition.
- Add update RBAC to the secrets for the connect inject controller.
- Assert that the created secret has a resource version upon creating.

How I've tested this PR:
- acceptance tests

How I expect reviewers to test this PR:
- 👀 and faith

Checklist:
- [x] Tests added
