### PR TITLE
Enable TLS on Consul Peering

### DIFF
--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -283,6 +283,31 @@ spec:
                 {{- end }}
                 -hcl='leave_on_terminate = true' \
                 {{- if .Values.global.tls.enabled }}
+                {{- if .Values.global.peering.enabled }}
+                {{- if .Values.global.secretsBackend.vault.enabled }}
+                -hcl='tls { defaults { ca_file = "/vault/secrets/serverca.crt" }}' \
+                {{- else }}
+                -hcl='tls { defaults { ca_file = "/consul/tls/ca/tls.crt" }}' \
+                {{- end }}
+                {{- if .Values.global.tls.enableAutoEncrypt }}
+                -hcl='auto_encrypt = {tls = true}' \
+                -hcl="auto_encrypt = {ip_san = [\"$HOST_IP\",\"$POD_IP\"]}" \
+                {{- else }}
+                -hcl='tls { defaults { cert_file = "/consul/tls/client/tls.crt" }}' \
+                -hcl='tls { defaults { key_file = "/consul/tls/client/tls.key" }}' \
+                {{- end }}
+                {{- if .Values.global.tls.verify }}
+                -hcl='tls { defaults { verify_outgoing = true }}' \
+                {{- if not .Values.global.tls.enableAutoEncrypt }}
+                -hcl='tls { internal_rpc { verify_incoming = true }}' \
+                -hcl='tls { internal_rpc { verify_server_hostname = true }}' \
+                {{- end }}
+                {{- end }}
+                -hcl='ports { https = 8501 }' \
+                {{- if .Values.global.tls.httpsOnly }}
+                -hcl='ports { http = -1 }' \
+                {{- end }}
+                {{- else}}
                 {{- if .Values.global.secretsBackend.vault.enabled }}
                 -hcl='ca_file = "/vault/secrets/serverca.crt"' \
                 {{- else }}
@@ -305,6 +330,7 @@ spec:
                 -hcl='ports { https = 8501 }' \
                 {{- if .Values.global.tls.httpsOnly }}
                 -hcl='ports { http = -1 }' \
+                {{- end }}
                 {{- end }}
                 {{- end }}
                 {{- if .Values.client.grpc }}

--- a/charts/consul/templates/server-config-configmap.yaml
+++ b/charts/consul/templates/server-config-configmap.yaml
@@ -110,7 +110,8 @@ data:
         {{- if .Values.global.tls.httpsOnly }}
         "http": -1,
         {{- end }}
-        "https": 8501
+        "https": 8501,
+        "grpc":8503
       }
     }
   {{- end }}

--- a/charts/consul/templates/server-config-configmap.yaml
+++ b/charts/consul/templates/server-config-configmap.yaml
@@ -87,14 +87,52 @@ data:
   {{- if .Values.global.tls.enabled }}
   tls-config.json: |-
     {
-       {{- if .Values.global.secretsBackend.vault.enabled }}
-       "ca_file": "/vault/secrets/serverca.crt",
-       "cert_file": "/vault/secrets/servercert.crt",
-       "key_file": "/vault/secrets/servercert.key",
+      {{- if .Values.global.peering.enabled }}
+      "tls": {
+        {{- if .Values.global.tls.verify }}
+        "internal_rpc": {
+          "verify_incoming": true,
+          "verify_server_hostname": true
+        },
+        "grpc": {
+          "verify_incoming": false
+        },
+        {{- end }}
+        "defaults": {
+          {{- if .Values.global.tls.verify }}
+          "verify_outgoing": true,
+          {{- end }}
+          {{- if .Values.global.secretsBackend.vault.enabled }}
+          "ca_file": "/vault/secrets/serverca.crt",
+          "cert_file": "/vault/secrets/servercert.crt",
+          "key_file": "/vault/secrets/servercert.key"
+          {{- else }}
+          "ca_file": "/consul/tls/ca/tls.crt",
+          "cert_file": "/consul/tls/server/tls.crt",
+          "key_file": "/consul/tls/server/tls.key"
+          {{- end }}
+        }
+      },
+      {{- if .Values.global.tls.enableAutoEncrypt }}
+      "auto_encrypt": {
+        "allow_tls": true
+      },
+      {{- end }}
+      "ports": {
+        {{- if .Values.global.tls.httpsOnly }}
+        "http": -1,
+        {{- end }}
+        "https": 8501
+      }
+      {{- else }}
+      {{- if .Values.global.secretsBackend.vault.enabled }}
+      "ca_file": "/vault/secrets/serverca.crt",
+      "cert_file": "/vault/secrets/servercert.crt",
+      "key_file": "/vault/secrets/servercert.key",
        {{- else }}
-       "ca_file": "/consul/tls/ca/tls.crt",
-       "cert_file": "/consul/tls/server/tls.crt",
-       "key_file": "/consul/tls/server/tls.key",
+      "ca_file": "/consul/tls/ca/tls.crt",
+      "cert_file": "/consul/tls/server/tls.crt",
+      "key_file": "/consul/tls/server/tls.key",
        {{- end }}
       {{- if .Values.global.tls.enableAutoEncrypt }}
       "auto_encrypt": {
@@ -110,9 +148,9 @@ data:
         {{- if .Values.global.tls.httpsOnly }}
         "http": -1,
         {{- end }}
-        "https": 8501,
-        "grpc":8503
+        "https": 8501
       }
+      {{- end }}
     }
   {{- end }}
   {{- if .Values.ui.enabled }}

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -296,7 +296,6 @@ spec:
                 -config-dir=/consul/userconfig/{{ .name }} \
                 {{- end }}
                 {{- end }}
-                -hcl='ports { grpc = 8503 }' \
                 -config-file=/consul/extra-config/extra-from-values.json
           volumeMounts:
             - name: data-{{ .Release.Namespace | trunc 58 | trimSuffix "-" }}

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -296,6 +296,7 @@ spec:
                 -config-dir=/consul/userconfig/{{ .name }} \
                 {{- end }}
                 {{- end }}
+                -hcl='ports { grpc = 8503 }' \
                 -config-file=/consul/extra-config/extra-from-values.json
           volumeMounts:
             - name: data-{{ .Release.Namespace | trunc 58 | trimSuffix "-" }}


### PR DESCRIPTION
Changes proposed in this PR:
- Allow TLS to be enabled with peering tests.
- Use updated TLS config on Servers and Clients when peering is enabled.

How I've tested this PR:
- Acceptance tests & updates BATS tests.
The updated TLS config was work that had already been done that needed to be reverted in order to continue to support Consul 1.11.

How I expect reviewers to test this PR:
- 👀 

Checklist:
- [x] Tests added
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

