### PR TITLE
Add required UBI labels

### DIFF
--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -108,18 +108,25 @@ CMD /bin/${BIN_NAME}
 # We don't rebuild the software because we want the exact checksums and
 # binary signatures to match the software and our builds aren't fully
 # reproducible currently.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5 as ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 as ubi
 
-# NAME and VERSION are the name of the software in releases.hashicorp.com
-# and the version to download. Example: NAME=consul VERSION=1.2.3.
+ARG PRODUCT_NAME
+ARG PRODUCT_VERSION
+ARG PRODUCT_REVISION
 ARG BIN_NAME
-ARG VERSION
 
-LABEL name=${BIN_NAME} \
+# PRODUCT_NAME and PRODUCT_VERSION are the name of the software on releases.hashicorp.com
+# and the version to download. Example: PRODUCT_NAME=consul PRODUCT_VERSION=1.2.3.
+ENV BIN_NAME=$BIN_NAME
+ENV PRODUCT_VERSION=$PRODUCT_VERSION
+
+ARG PRODUCT_NAME=$BIN_NAME
+
+LABEL name=$PRODUCT_NAME \
       maintainer="Team Consul Kubernetes <team-consul-kubernetes@hashicorp.com>" \
       vendor="HashiCorp" \
-      version=${VERSION} \
-      release=${VERSION} \
+      version=$PRODUCT_VERSION \
+      release=$PRODUCT_VERSION \
       summary="consul-k8s-control-plane provides first-class integrations between Consul and Kubernetes." \
       description="consul-k8s-control-plane provides first-class integrations between Consul and Kubernetes."
 


### PR DESCRIPTION
Changes proposed in this PR:
- Add required Red Hat labels so that it will work with our prod release process (https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.45/html/red_hat_openshift_software_certification_policy_guide/assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction)
- Also bump ubi image to 8.6 (this is what we used to use before)

How I've tested this PR:
Ran `preflight` tool on a locally built image and saw it pass

How I expect reviewers to test this PR:
👀 


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

