### PR TITLE
Bump default Envoy version to 1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+IMPROVEMENTS:
+* Helm
+  * Bump default Envoy version to 1.23.0. [[GH-1377](https://github.com/hashicorp/consul-k8s/pull/1377)]
+
 ## 0.46.1 (July 26, 2022)
 
 IMPROVEMENTS:

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -17,7 +17,7 @@ annotations:
     - name: consul-k8s-control-plane
       image: hashicorp/consul-k8s-control-plane:0.46.1
     - name: envoy
-      image: envoyproxy/envoy:v1.22.2
+      image: envoyproxy/envoy:v1.23.0
   artifacthub.io/license: MPL-2.0
   artifacthub.io/links: |
     - name: Documentation

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -613,7 +613,7 @@ global:
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
   # See https://www.consul.io/docs/connect/proxies/envoy for full compatibility matrix between Consul and Envoy.
   # @default: envoyproxy/envoy-alpine:<latest supported version>
-  imageEnvoy: "envoyproxy/envoy:v1.22.2"
+  imageEnvoy: "envoyproxy/envoy:v1.23.0"
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.


### PR DESCRIPTION
Changes proposed in this PR:
- Bump default Envoy version to 1.23.0 which was released on 15 July 2022.

How I've tested this PR:
- Relying on CI.

How I expect reviewers to test this PR:
- This mimics previous PRs such as #1276 to update a default value in the chart.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 

Signed-off-by: Evan Culver <eculver@hashicorp.com>

