### PR TITLE
Add extraLabels to connectInject and serverACLInit pods

### DIFF
--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -38,6 +38,9 @@ spec:
         chart: {{ template "consul.chart" . }}
         release: {{ .Release.Name }}
         component: connect-injector
+        {{- if .Values.connectInject.extraLabels }}
+          {{- toYaml .Values.connectInject.extraLabels | nindent 8 }}
+        {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
         {{- if .Values.connectInject.annotations }}

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -36,6 +36,9 @@ spec:
         chart: {{ template "consul.chart" . }}
         release: {{ .Release.Name }}
         component: server-acl-init
+        {{- if .Values.serverACLInit.extraLabels }}
+          {{- toYaml .Values.serverACLInit.extraLabels | nindent 8 }}
+        {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
         {{- if .Values.global.secretsBackend.vault.enabled }}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1935,6 +1935,19 @@ connectInject:
   # @type: string
   annotations: null
   
+  # Extra labels to attach to the connect injector pods. This should be a YAML map.
+  #
+  # Example:
+  #
+  # ```yaml
+  # extraLabels:
+  #   labelKey: label-value
+  #   anotherLabelKey: another-label-value
+  # ```
+  #
+  # @type: map
+  extraLabels: null
+  
   # The Docker image for Consul to use when performing Connect injection.
   # Defaults to global.image.
   # @type: string
@@ -2934,3 +2947,17 @@ prometheus:
 # is only useful when running helm template.
 tests:
   enabled: true
+
+serverACLInit:
+  # Extra labels to attach to the server-acl-init pods. This should be a YAML map.
+  #
+  # Example:
+  #
+  # ```yaml
+  # extraLabels:
+  #   labelKey: label-value
+  #   anotherLabelKey: another-label-value
+  # ```
+  #
+  # @type: map
+  extraLabels: null


### PR DESCRIPTION
Changes proposed in this PR:
Added extraLabels to connectInject and serverACLInit in values.yaml so if declared in the values file then these additional labels will be added to the pods

How I've tested this PR:
Tested the helm chart on my kubernetes cluster with and without declaring the extraLabels to ensure everything works as expected.

How I expect reviewers to test this PR:
Same as how I tested

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

