### PR TITLE
test: egress destination tests

### DIFF
--- a/acceptance/tests/fixtures/bases/static-server-https/anyuid-scc-rolebinding.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-https/anyuid-scc-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: static-server-openshift-anyuid
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+  - kind: ServiceAccount
+    name: static-server

--- a/acceptance/tests/fixtures/bases/static-server-https/configmap.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-https/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: static-server-config
+data:
+  config: |
+    {
+      local_certs
+      skip_install_trust
+      auto_https disable_redirects
+    }
+    static-server.default {
+      log
+      respond  "hello world"
+    }
+    :80 {
+      log
+      respond  "hello world"
+    }

--- a/acceptance/tests/fixtures/bases/static-server-https/deployment.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-https/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: static-server
+  template:
+    metadata:
+      labels:
+        app: static-server
+    spec:
+      containers:
+        - name: caddy
+          image: caddy:latest
+          ports:
+            - name: https-port
+              containerPort: 443
+            - name: http-port
+              containerPort: 80
+          volumeMounts:
+            - name: data
+              mountPath: "/data"
+            - name: config
+              mountPath: /etc/caddy/
+              readOnly: true
+      volumes:
+        - name: data
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: static-server-config
+            items:
+              - key: "config"
+                path: "Caddyfile"

--- a/acceptance/tests/fixtures/bases/static-server-https/kustomization.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-https/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+  - deployment.yaml
+  - configmap.yaml
+  - service.yaml
+  - serviceaccount.yaml
+  - psp-rolebinding.yaml
+  - anyuid-scc-rolebinding.yaml
+  - privileged-scc-rolebinding.yaml

--- a/acceptance/tests/fixtures/bases/static-server-https/privileged-scc-rolebinding.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-https/privileged-scc-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: static-server-openshift-privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+  - kind: ServiceAccount
+    name: static-server

--- a/acceptance/tests/fixtures/bases/static-server-https/psp-rolebinding.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-https/psp-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: static-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-psp
+subjects:
+  - kind: ServiceAccount
+    name: static-server

--- a/acceptance/tests/fixtures/bases/static-server-https/service.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-https/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: static-server
+  labels:
+    app: static-server
+spec:
+  ports:
+    - name: https-port
+      port: 443
+      targetPort: https-port
+      protocol: TCP
+    - name: http-port
+      port: 80
+      targetPort: http-port
+      protocol: TCP
+  selector:
+    app: static-server

--- a/acceptance/tests/fixtures/bases/static-server-https/serviceaccount.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-https/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: static-server

--- a/acceptance/tests/terminating-gateway/common.go
+++ b/acceptance/tests/terminating-gateway/common.go
@@ -1,0 +1,96 @@
+package terminatinggateway
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	staticClientName         = "static-client"
+	staticServerName         = "static-server"
+	staticServerLocalAddress = "http://localhost:1234"
+)
+
+func addIntention(t *testing.T, consulClient *api.Client, sourceNS, sourceService, destinationNS, destinationsService string) {
+	t.Helper()
+
+	logger.Log(t, fmt.Sprintf("creating %s => %s intention", sourceService, destinationsService))
+	_, _, err := consulClient.ConfigEntries().Set(&api.ServiceIntentionsConfigEntry{
+		Kind:      api.ServiceIntentions,
+		Name:      destinationsService,
+		Namespace: destinationNS,
+		Sources: []*api.SourceIntention{
+			{
+				Name:      sourceService,
+				Namespace: sourceNS,
+				Action:    api.IntentionActionAllow,
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+}
+
+func createTerminatingGatewayConfigEntry(t *testing.T, consulClient *api.Client, gwNamespace, serviceNamespace string, serviceNames ...string) {
+	t.Helper()
+
+	logger.Log(t, "creating config entry")
+
+	if serviceNamespace != "" {
+		logger.Logf(t, "creating the %s namespace in Consul", serviceNamespace)
+		_, _, err := consulClient.Namespaces().Create(&api.Namespace{
+			Name: serviceNamespace,
+		}, nil)
+		require.NoError(t, err)
+	}
+
+	var gatewayServices []api.LinkedService
+	for _, serviceName := range serviceNames {
+		linkedService := api.LinkedService{Name: serviceName, Namespace: serviceNamespace}
+		gatewayServices = append(gatewayServices, linkedService)
+	}
+
+	configEntry := &api.TerminatingGatewayConfigEntry{
+		Kind:      api.TerminatingGateway,
+		Name:      "terminating-gateway",
+		Namespace: gwNamespace,
+		Services:  gatewayServices,
+	}
+
+	created, _, err := consulClient.ConfigEntries().Set(configEntry, nil)
+	require.NoError(t, err)
+	require.True(t, created, "failed to create config entry")
+}
+
+func updateTerminatingGatewayRole(t *testing.T, consulClient *api.Client, rules string) {
+	t.Helper()
+
+	logger.Log(t, "creating a write policy for the static-server")
+	_, _, err := consulClient.ACL().PolicyCreate(&api.ACLPolicy{
+		Name:  "static-server-write-policy",
+		Rules: rules,
+	}, nil)
+	require.NoError(t, err)
+
+	logger.Log(t, "getting the terminating gateway role")
+	roles, _, err := consulClient.ACL().RoleList(nil)
+	require.NoError(t, err)
+	terminatingGatewayRoleID := ""
+	for _, role := range roles {
+		if strings.Contains(role.Name, "terminating-gateway") {
+			terminatingGatewayRoleID = role.ID
+			break
+		}
+	}
+
+	logger.Log(t, "update role with policy")
+	termGwRole, _, err := consulClient.ACL().RoleRead(terminatingGatewayRoleID, nil)
+	require.NoError(t, err)
+	termGwRole.Policies = append(termGwRole.Policies, &api.ACLTokenPolicyLink{Name: "static-server-write-policy"})
+	_, _, err = consulClient.ACL().RoleUpdate(termGwRole, nil)
+	require.NoError(t, err)
+}

--- a/acceptance/tests/terminating-gateway/terminating_gateway_destinations_test.go
+++ b/acceptance/tests/terminating-gateway/terminating_gateway_destinations_test.go
@@ -1,0 +1,183 @@
+package terminatinggateway
+
+import (
+	"fmt"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
+)
+
+// Test that egress Destinations route through terminating gateways.
+// Destinations are only valid when operating in transparent mode.
+func TestTerminatingGatewayDestinations(t *testing.T) {
+	cfg := suite.Config()
+	if !cfg.EnableTransparentProxy {
+		t.Skipf("skipping this test because -enable-transparent-proxy is not set")
+	}
+
+	ver, err := version.NewVersion("1.13.0")
+	require.NoError(t, err)
+	if cfg.ConsulVersion != nil && cfg.ConsulVersion.LessThan(ver) {
+		t.Skipf("skipping this test because Destinations are not supported in version %v", cfg.ConsulVersion.String())
+	}
+
+	const (
+		staticServerServiceName = "static-server.default"
+		staticServerHostnameID  = "static-server-hostname"
+		staticServerIPID        = "static-server-ip"
+		terminatingGatewayRules = `service_prefix "static-server" {
+		  policy = "write"
+		}`
+	)
+
+	cases := []struct {
+		secure bool
+	}{
+		{
+			secure: false,
+		},
+		{
+			secure: true,
+		},
+	}
+	for _, c := range cases {
+		name := fmt.Sprintf("secure: %t", c.secure)
+		t.Run(name, func(t *testing.T) {
+			ctx := suite.Environment().DefaultContext(t)
+
+			helmValues := map[string]string{
+				"connectInject.enabled":                    "true",
+				"terminatingGateways.enabled":              "true",
+				"terminatingGateways.gateways[0].name":     "terminating-gateway",
+				"terminatingGateways.gateways[0].replicas": "1",
+
+				"global.acls.manageSystemACLs": strconv.FormatBool(c.secure),
+				"global.tls.enabled":           strconv.FormatBool(c.secure),
+				"global.tls.autoEncrypt":       strconv.FormatBool(c.secure),
+			}
+
+			logger.Log(t, "creating consul cluster")
+			releaseName := helpers.RandomName()
+			consulCluster := consul.NewHelmCluster(t, helmValues, ctx, cfg, releaseName)
+			consulCluster.Create(t)
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
+
+			// Deploy a static-server that will play the role of an external service.
+			logger.Log(t, "creating static-server deployment")
+			k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/bases/static-server-https")
+
+			// If ACLs are enabled we need to update the role of the terminating gateway
+			// with service:write permissions to the static-server service
+			// so that it can request Connect certificates for it.
+			if c.secure {
+				updateTerminatingGatewayRole(t, consulClient, terminatingGatewayRules)
+			}
+
+			// Since we are using the transparent kube DNS, disable the ability
+			// of the service to dial the server directly through the sidecar
+			createMeshConfigEntry(t, consulClient, "")
+
+			// Create the config entry for the terminating gateway.
+			createTerminatingGatewayConfigEntry(t, consulClient, "", "", staticServerHostnameID, staticServerIPID)
+
+			// Deploy the static client
+			logger.Log(t, "deploying static client")
+			k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-tproxy")
+
+			staticServerIP, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "get", "po", "-l", "app=static-server", `-o=jsonpath={.items[0].status.podIP}`)
+			require.NoError(t, err)
+			require.NotEmpty(t, staticServerIP)
+
+			staticServerHostnameURL := fmt.Sprintf("https://%s", staticServerServiceName)
+			staticServerIPURL := fmt.Sprintf("http://%s", staticServerIP)
+
+			// Create the service default declaring the external service (aka Destination)
+			logger.Log(t, "creating tcp-based service defaults")
+			createServiceDefaultDestination(t, consulClient, "", staticServerHostnameID, "", 443, staticServerServiceName)
+			createServiceDefaultDestination(t, consulClient, "", staticServerIPID, "", 80, staticServerIP)
+
+			// If ACLs are enabled, test that intentions prevent connections.
+			if c.secure {
+				// With the terminating gateway up, we test that we can make a call to it
+				// via the static-server. It should fail to connect with the
+				// static-server pod because of intentions.
+				logger.Log(t, "testing intentions prevent connections through the terminating gateway")
+				k8s.CheckStaticServerConnectionFailing(t, ctx.KubectlOptions(t), staticClientName, staticServerIPURL)
+				k8s.CheckStaticServerConnectionFailing(t, ctx.KubectlOptions(t), staticClientName, "-k", staticServerHostnameURL)
+
+				logger.Log(t, "adding intentions to allow traffic from client ==> server")
+				addIntention(t, consulClient, "", staticClientName, "", staticServerHostnameID)
+				addIntention(t, consulClient, "", staticClientName, "", staticServerIPID)
+			}
+
+			// Test that we can make a call to the terminating gateway.
+			logger.Log(t, "trying calls to terminating gateway")
+			k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, staticServerIPURL)
+			k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, "-k", staticServerHostnameURL)
+
+			// Try running some different scenarios
+			staticServerHostnameURL = fmt.Sprintf("http://%s", staticServerServiceName)
+			staticServerIPURL = fmt.Sprintf("http://%s", staticServerIP)
+
+			// Update the service default declaring the external service (aka Destination)
+			logger.Log(t, "updating service defaults to try other scenarios")
+
+			// You can't use TLS w/ protocol set to anything L7; Envoy can't snoop the traffic when the client encrypts it
+			createServiceDefaultDestination(t, consulClient, "", staticServerHostnameID, "http", 80, staticServerServiceName)
+			createServiceDefaultDestination(t, consulClient, "", staticServerIPID, "http", 80, staticServerIP)
+
+			logger.Log(t, "trying calls to terminating gateway")
+			k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, staticServerIPURL)
+			k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, staticServerHostnameURL)
+		})
+	}
+}
+func createServiceDefaultDestination(t *testing.T, consulClient *api.Client, serviceNamespace string, name string, protocol string, port int, addresses ...string) {
+	t.Helper()
+
+	logger.Log(t, "creating config entry")
+
+	if serviceNamespace != "" {
+		logger.Logf(t, "creating the %s namespace in Consul", serviceNamespace)
+		_, _, err := consulClient.Namespaces().Create(&api.Namespace{
+			Name: serviceNamespace,
+		}, nil)
+		require.NoError(t, err)
+	}
+
+	configEntry := &api.ServiceConfigEntry{
+		Kind:      api.ServiceDefaults,
+		Name:      name,
+		Namespace: serviceNamespace,
+		Protocol:  protocol,
+		Destination: &api.DestinationConfig{
+			Addresses: addresses,
+			Port:      port,
+		},
+	}
+
+	created, _, err := consulClient.ConfigEntries().Set(configEntry, nil)
+	require.NoError(t, err)
+	require.True(t, created, "failed to create config entry")
+}
+
+func createMeshConfigEntry(t *testing.T, consulClient *api.Client, namespace string) {
+	t.Helper()
+
+	logger.Log(t, "creating mesh config entry to enable MeshDestinationOnly")
+	created, _, err := consulClient.ConfigEntries().Set(&api.MeshConfigEntry{
+		Namespace: namespace,
+		TransparentProxy: api.TransparentProxyMeshConfig{
+			MeshDestinationsOnly: true,
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.True(t, created, "failed to create config entry")
+}

--- a/acceptance/tests/terminating-gateway/terminating_gateway_test.go
+++ b/acceptance/tests/terminating-gateway/terminating_gateway_test.go
@@ -3,10 +3,8 @@ package terminatinggateway
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"testing"
 
-	terratestk8s "github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
@@ -14,9 +12,6 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 )
-
-const StaticClientName = "static-client"
-const staticServerName = "static-server"
 
 // Test that terminating gateways work in a default and secure installations.
 func TestTerminatingGateway(t *testing.T) {
@@ -71,13 +66,13 @@ func TestTerminatingGateway(t *testing.T) {
 
 			// If ACLs are enabled we need to update the role of the terminating gateway
 			// with service:write permissions to the static-server service
-			// so that it can can request Connect certificates for it.
+			// so that it can request Connect certificates for it.
 			if c.secure {
 				updateTerminatingGatewayRole(t, consulClient, staticServerPolicyRules)
 			}
 
 			// Create the config entry for the terminating gateway.
-			createTerminatingGatewayConfigEntry(t, consulClient, "", "")
+			createTerminatingGatewayConfigEntry(t, consulClient, "", "", staticServerName)
 
 			// Deploy the static client
 			logger.Log(t, "deploying static client")
@@ -88,12 +83,16 @@ func TestTerminatingGateway(t *testing.T) {
 				// With the terminating gateway up, we test that we can make a call to it
 				// via the static-server. It should fail to connect with the
 				// static-server pod because of intentions.
-				assertNoConnectionAndAddIntention(t, consulClient, ctx.KubectlOptions(t), "", "")
+				logger.Log(t, "testing intentions prevent connections through the terminating gateway")
+				k8s.CheckStaticServerConnectionFailing(t, ctx.KubectlOptions(t), staticClientName, staticServerLocalAddress)
+
+				logger.Log(t, "adding intentions to allow traffic from client ==> server")
+				addIntention(t, consulClient, "", staticClientName, "", staticServerName)
 			}
 
 			// Test that we can make a call to the terminating gateway.
 			logger.Log(t, "trying calls to terminating gateway")
-			k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), StaticClientName, "http://localhost:1234")
+			k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), staticClientName, staticServerLocalAddress)
 		})
 	}
 }
@@ -129,82 +128,6 @@ func registerExternalService(t *testing.T, consulClient *api.Client, namespace s
 		Address:  address,
 		NodeMeta: map[string]string{"external-node": "true", "external-probe": "true"},
 		Service:  service,
-	}, nil)
-	require.NoError(t, err)
-}
-
-func updateTerminatingGatewayRole(t *testing.T, consulClient *api.Client, rules string) {
-	t.Helper()
-
-	logger.Log(t, "creating a write policy for the static-server")
-	_, _, err := consulClient.ACL().PolicyCreate(&api.ACLPolicy{
-		Name:  "static-server-write-policy",
-		Rules: rules,
-	}, nil)
-	require.NoError(t, err)
-
-	logger.Log(t, "getting the terminating gateway role")
-	roles, _, err := consulClient.ACL().RoleList(nil)
-	require.NoError(t, err)
-	terminatingGatewayRoleID := ""
-	for _, role := range roles {
-		if strings.Contains(role.Name, "terminating-gateway") {
-			terminatingGatewayRoleID = role.ID
-			break
-		}
-	}
-
-	logger.Log(t, "update role with policy")
-	termGwRole, _, err := consulClient.ACL().RoleRead(terminatingGatewayRoleID, nil)
-	require.NoError(t, err)
-	termGwRole.Policies = append(termGwRole.Policies, &api.ACLTokenPolicyLink{Name: "static-server-write-policy"})
-	_, _, err = consulClient.ACL().RoleUpdate(termGwRole, nil)
-	require.NoError(t, err)
-}
-
-func createTerminatingGatewayConfigEntry(t *testing.T, consulClient *api.Client, gwNamespace, serviceNamespace string) {
-	t.Helper()
-
-	logger.Log(t, "creating config entry")
-
-	if serviceNamespace != "" {
-		logger.Logf(t, "creating the %s namespace in Consul", serviceNamespace)
-		_, _, err := consulClient.Namespaces().Create(&api.Namespace{
-			Name: serviceNamespace,
-		}, nil)
-		require.NoError(t, err)
-	}
-
-	configEntry := &api.TerminatingGatewayConfigEntry{
-		Kind:      api.TerminatingGateway,
-		Name:      "terminating-gateway",
-		Namespace: gwNamespace,
-		Services:  []api.LinkedService{{Name: staticServerName, Namespace: serviceNamespace}},
-	}
-
-	created, _, err := consulClient.ConfigEntries().Set(configEntry, nil)
-	require.NoError(t, err)
-	require.True(t, created, "failed to create config entry")
-}
-
-func assertNoConnectionAndAddIntention(t *testing.T, consulClient *api.Client, k8sOptions *terratestk8s.KubectlOptions, sourceNS, destinationNS string) {
-	t.Helper()
-
-	logger.Log(t, "testing intentions prevent connections through the terminating gateway")
-	k8s.CheckStaticServerConnectionFailing(t, k8sOptions, StaticClientName, "http://localhost:1234")
-
-	logger.Log(t, "creating static-client => static-server intention")
-	_, _, err := consulClient.ConfigEntries().Set(&api.ServiceIntentionsConfigEntry{
-		Kind:      api.ServiceIntentions,
-		Name:      staticServerName,
-		Namespace: destinationNS,
-		Sources: []*api.SourceIntention{
-			{
-				Name:      StaticClientName,
-				Namespace: sourceNS,
-				Action:    api.IntentionActionAllow,
-			},
-		},
 	}, nil)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Changes proposed in this PR:
- Adds acceptance tests for the egress Destinations #1352 
- Some refactoring to support extended usage of common functions in the t-gateway acceptance tests
- Adds a server that supports HTTPS, because right now we need an SNI or IP address to route the traffic. HTTP-only will be added before the 1.13 release.

How I've tested this PR:
- I've been running the acceptance test against a 3-node k3d cluster with some development images for Consul 1.13. All the necessary changes should be in the Consul 1.13 release branch.

How I expect reviewers to test this PR:
- Running the tests

Checklist:
- [X] Tests added
- [ ] ~CHANGELOG entry added~ (n/a)


