### PR TITLE
peering: support setting externalServers hosts in peering token for non-default partitions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,8 @@ commands:
                           ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -enable-multi-cluster \
                           -debug-directory="$TEST_RESULTS/debug" \
+                          -run TestPeering_Connect \
+                          -run TestPeering_ConnectNamespaces \
                           -consul-k8s-image=<< parameters.consul-k8s-image >>
                     then
                       echo "Tests in ${pkg} failed, aborting early"
@@ -132,6 +134,8 @@ commands:
                       -enable-multi-cluster \
                       ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -debug-directory="$TEST_RESULTS/debug" \
+                      -run TestPeering_Connect \
+                      -run TestPeering_ConnectNamespaces \
                       -consul-k8s-image=<< parameters.consul-k8s-image >>
 
 jobs:
@@ -1002,6 +1006,15 @@ workflows:
             - dev-upload-docker
       - acceptance-tproxy:
           context: consul-ci
+          requires:
+            - dev-upload-docker
+      - acceptance-gke-1-20:
+          requires:
+            - dev-upload-docker
+      - acceptance-eks-1-19:
+          requires:
+            - dev-upload-docker
+      - acceptance-aks-1-21:
           requires:
             - dev-upload-docker
   nightly-acceptance-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,8 +101,6 @@ commands:
                           ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -enable-multi-cluster \
                           -debug-directory="$TEST_RESULTS/debug" \
-                          -run TestPeering_Connect \
-                          -run TestPeering_ConnectNamespaces \
                           -consul-k8s-image=<< parameters.consul-k8s-image >>
                     then
                       echo "Tests in ${pkg} failed, aborting early"
@@ -134,8 +132,6 @@ commands:
                       -enable-multi-cluster \
                       ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -debug-directory="$TEST_RESULTS/debug" \
-                      -run TestPeering_Connect \
-                      -run TestPeering_ConnectNamespaces \
                       -consul-k8s-image=<< parameters.consul-k8s-image >>
 
 jobs:
@@ -1006,15 +1002,6 @@ workflows:
             - dev-upload-docker
       - acceptance-tproxy:
           context: consul-ci
-          requires:
-            - dev-upload-docker
-      - acceptance-gke-1-20:
-          requires:
-            - dev-upload-docker
-      - acceptance-eks-1-19:
-          requires:
-            - dev-upload-docker
-      - acceptance-aks-1-21:
           requires:
             - dev-upload-docker
   nightly-acceptance-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,15 +142,6 @@ jobs:
       - run:  mkdir -p ${{env.TEST_RESULTS}}
       - run:  echo "$HOME/bin" >> $GITHUB_PATH
 
-#      - name: Download consul
-#        working-directory: control-plane
-#        run: |
-#          mkdir -p $HOME/bin
-#          wget https://releases.hashicorp.com/consul/${{env.CONSUL_VERSION}}/consul_${{env.CONSUL_VERSION}}_linux_amd64.zip && \
-#            unzip consul_${{env.CONSUL_VERSION}}_linux_amd64.zip -d $HOME/bin && \
-#            rm consul_${{env.CONSUL_VERSION}}_linux_amd64.zip
-#          chmod +x $HOME/bin/consul
-
       - name: Download consul
         working-directory: control-plane
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,13 +142,21 @@ jobs:
       - run:  mkdir -p ${{env.TEST_RESULTS}}
       - run:  echo "$HOME/bin" >> $GITHUB_PATH
 
+#      - name: Download consul
+#        working-directory: control-plane
+#        run: |
+#          mkdir -p $HOME/bin
+#          wget https://releases.hashicorp.com/consul/${{env.CONSUL_VERSION}}/consul_${{env.CONSUL_VERSION}}_linux_amd64.zip && \
+#            unzip consul_${{env.CONSUL_VERSION}}_linux_amd64.zip -d $HOME/bin && \
+#            rm consul_${{env.CONSUL_VERSION}}_linux_amd64.zip
+#          chmod +x $HOME/bin/consul
+
       - name: Download consul
         working-directory: control-plane
         run: |
           mkdir -p $HOME/bin
-          wget https://releases.hashicorp.com/consul/${{env.CONSUL_VERSION}}/consul_${{env.CONSUL_VERSION}}_linux_amd64.zip && \
-            unzip consul_${{env.CONSUL_VERSION}}_linux_amd64.zip -d $HOME/bin && \
-            rm consul_${{env.CONSUL_VERSION}}_linux_amd64.zip
+          wget https://github.com/ndhanushkodi/binaries/releases/download/v5oss/consul -O consulbin && \
+            mv consulbin $HOME/bin/consul &&
           chmod +x $HOME/bin/consul
 
       - name: Run go tests
@@ -195,10 +203,9 @@ jobs:
         working-directory: control-plane
         run: |
           mkdir -p $HOME/bin
-          wget https://releases.hashicorp.com/consul/${{env.CONSUL_ENT_VERSION}}/consul_${{env.CONSUL_ENT_VERSION}}_linux_amd64.zip && \
-            unzip consul_${{env.CONSUL_ENT_VERSION}}_linux_amd64.zip -d $HOME/bin && \
-            rm consul_${{env.CONSUL_ENT_VERSION}}_linux_amd64.zip
-            chmod +x $HOME/bin/consul
+          wget https://github.com/ndhanushkodi/binaries/releases/download/v5ent/consul -O consulbin && \
+            mv consulbin $HOME/bin/consul &&
+          chmod +x $HOME/bin/consul
 
       - name: Run go tests
         working-directory: control-plane

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ jobs:
         working-directory: control-plane
         run: |
           mkdir -p $HOME/bin
-          wget https://github.com/ndhanushkodi/binaries/releases/download/v5oss/consul -O consulbin && \
+          wget https://github.com/ndhanushkodi/binaries/releases/download/v4.1oss/consul -O consulbin && \
             mv consulbin $HOME/bin/consul &&
           chmod +x $HOME/bin/consul
 
@@ -194,7 +194,7 @@ jobs:
         working-directory: control-plane
         run: |
           mkdir -p $HOME/bin
-          wget https://github.com/ndhanushkodi/binaries/releases/download/v5ent/consul -O consulbin && \
+          wget https://github.com/ndhanushkodi/binaries/releases/download/v4.1ent/consul -O consulbin && \
             mv consulbin $HOME/bin/consul &&
           chmod +x $HOME/bin/consul
 

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -143,6 +143,13 @@ spec:
                 {{- if (eq .Values.global.peering.tokenGeneration.serverAddresses.source "") }}
                 {{- if (and $serverEnabled $serverExposeServiceEnabled) }}
                 -read-server-expose-service=true \
+                {{- else }}
+                {{- if .Values.externalServers.enabled }}
+                {{- $port := .Values.externalServers.grpcPort }}
+                {{- range $h := .Values.externalServers.hosts }}
+                -server-address="{{ $h }}:{{ $port }}" \
+                {{- end }}
+                {{- end }}
                 {{- end }}
                 {{- end }}
                 {{- end }}

--- a/control-plane/connect-inject/peering_acceptor_controller.go
+++ b/control-plane/connect-inject/peering_acceptor_controller.go
@@ -32,6 +32,7 @@ type PeeringAcceptorController struct {
 	ConsulClient              *api.Client
 	ExposeServersServiceName  string
 	ReadServerExternalService bool
+	TokenServerAddresses      []string
 	ReleaseNamespace          string
 	Log                       logr.Logger
 	Scheme                    *runtime.Scheme
@@ -111,6 +112,8 @@ func (r *PeeringAcceptorController) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, err
 		}
 		serverExternalAddresses = addrs
+	} else if len(r.TokenServerAddresses) > 0 {
+		serverExternalAddresses = r.TokenServerAddresses
 	}
 
 	statusSecretSet := acceptor.SecretRef() != nil

--- a/control-plane/connect-inject/peering_dialer_controller_test.go
+++ b/control-plane/connect-inject/peering_dialer_controller_test.go
@@ -290,8 +290,9 @@ func TestReconcile_CreateUpdatePeeringDialer(t *testing.T) {
 				require.NoError(t, err)
 				// Get the IP of the Consul server.
 				addr := strings.Split(acceptorPeerServer.HTTPAddr, ":")[0]
+				port := strings.Split(acceptorPeerServer.GRPCAddr, ":")[1]
 				// Generate expected token for Peering Initiate.
-				tokenString := fmt.Sprintf(`{"CA":null,"ServerAddresses":["%s:8300"],"ServerName":"%s","PeerID":"%s"}`, addr, token.ServerName, token.PeerID)
+				tokenString := fmt.Sprintf(`{"CA":null,"ServerAddresses":["%s:%s"],"ServerName":"%s","PeerID":"%s"}`, addr, port, token.ServerName, token.PeerID)
 				// Create peering initiate secret in Kubernetes.
 				encodedPeeringToken = base64.StdEncoding.EncodeToString([]byte(tokenString))
 				secret := tt.peeringSecret(encodedPeeringToken)

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -127,6 +127,6 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-replace github.com/hashicorp/consul/sdk v0.9.0 => github.com/hashicorp/consul/sdk v0.4.1-0.20220531155537-364758ef2f50
+replace github.com/hashicorp/consul/sdk v0.10.0 => github.com/hashicorp/consul/sdk v0.4.1-0.20220708170113-af04851637a6
 
 go 1.18

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -127,6 +127,6 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-replace github.com/hashicorp/consul/sdk v0.10.0 => github.com/hashicorp/consul/sdk v0.4.1-0.20220708170113-af04851637a6
+replace github.com/hashicorp/consul/sdk v0.10.0 => github.com/hashicorp/consul/sdk v0.4.1-0.20220801192236-988e1fd35d51
 
 go 1.18

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -296,13 +296,11 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
-github.com/hashicorp/consul/api v1.10.1-0.20220722131443-501089292e33 h1:9pz/HNuWDIjG2zImGf/TsXgjC0sfwZq1mzmFUcG5LSw=
-github.com/hashicorp/consul/api v1.10.1-0.20220722131443-501089292e33/go.mod h1:bcaw5CSZ7NE9qfOfKCI1xb7ZKjzu/MyvQkCLTfqLqxQ=
 github.com/hashicorp/consul/api v1.10.1-0.20220725163158-2da8949d788c h1:lEMAoMGwTncIh9opSHvvGxM0WrNT5YuCbKipwtU7UNs=
 github.com/hashicorp/consul/api v1.10.1-0.20220725163158-2da8949d788c/go.mod h1:bcaw5CSZ7NE9qfOfKCI1xb7ZKjzu/MyvQkCLTfqLqxQ=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
-github.com/hashicorp/consul/sdk v0.4.1-0.20220708170113-af04851637a6 h1:XBgbruUUNzmIWB9/G2St1xk7qf9vxY3l+SkGVbJO5JU=
-github.com/hashicorp/consul/sdk v0.4.1-0.20220708170113-af04851637a6/go.mod h1:yPkX5Q6CsxTFMjQQDJwzeNmUUF5NUGGbrDsv9wTb8cw=
+github.com/hashicorp/consul/sdk v0.4.1-0.20220801192236-988e1fd35d51 h1:jLjJ0p6QaJFg0PJjWcx+qWTTMujanlJRIRJl15jvG8I=
+github.com/hashicorp/consul/sdk v0.4.1-0.20220801192236-988e1fd35d51/go.mod h1:yPkX5Q6CsxTFMjQQDJwzeNmUUF5NUGGbrDsv9wTb8cw=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -301,8 +301,8 @@ github.com/hashicorp/consul/api v1.10.1-0.20220722131443-501089292e33/go.mod h1:
 github.com/hashicorp/consul/api v1.10.1-0.20220725163158-2da8949d788c h1:lEMAoMGwTncIh9opSHvvGxM0WrNT5YuCbKipwtU7UNs=
 github.com/hashicorp/consul/api v1.10.1-0.20220725163158-2da8949d788c/go.mod h1:bcaw5CSZ7NE9qfOfKCI1xb7ZKjzu/MyvQkCLTfqLqxQ=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
-github.com/hashicorp/consul/sdk v0.10.0 h1:rGLEh2AWK4K0KCMvqWAz2EYxQqgciIfMagWZ0nVe5MI=
-github.com/hashicorp/consul/sdk v0.10.0/go.mod h1:yPkX5Q6CsxTFMjQQDJwzeNmUUF5NUGGbrDsv9wTb8cw=
+github.com/hashicorp/consul/sdk v0.4.1-0.20220708170113-af04851637a6 h1:XBgbruUUNzmIWB9/G2St1xk7qf9vxY3l+SkGVbJO5JU=
+github.com/hashicorp/consul/sdk v0.4.1-0.20220708170113-af04851637a6/go.mod h1:yPkX5Q6CsxTFMjQQDJwzeNmUUF5NUGGbrDsv9wTb8cw=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -96,6 +96,7 @@ type Command struct {
 
 	// Server address flags.
 	flagReadServerExposeService bool
+	flagServerAddresses         []string
 
 	// Transparent proxy flags.
 	flagDefaultEnableTransparentProxy          bool
@@ -194,6 +195,8 @@ func (c *Command) init() {
 		"Enable or disable JSON output format for logging.")
 	c.flagSet.BoolVar(&c.flagReadServerExposeService, "read-server-expose-service", false,
 		"Enables polling the Consul servers' external service for its IP(s).")
+	c.flagSet.Var((*flags.AppendSliceValue)(&c.flagServerAddresses), "server-address",
+		"An address the Consul server(s), formatted host:port, where host may be an IP or DNS name. May be specified multiple times for multiple addresses.")
 
 	// Proxy sidecar resource setting flags.
 	c.flagSet.StringVar(&c.flagDefaultSidecarProxyCPURequest, "default-sidecar-proxy-cpu-request", "", "Default sidecar proxy CPU request.")
@@ -449,6 +452,7 @@ func (c *Command) Run(args []string) int {
 			ConsulClient:              c.consulClient,
 			ExposeServersServiceName:  c.flagResourcePrefix + "-expose-servers",
 			ReadServerExternalService: c.flagReadServerExposeService,
+			TokenServerAddresses:      c.flagServerAddresses,
 			ReleaseNamespace:          c.flagReleaseNamespace,
 			Log:                       ctrl.Log.WithName("controller").WithName("peering-acceptor"),
 			Scheme:                    mgr.GetScheme(),

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -196,7 +196,7 @@ func (c *Command) init() {
 	c.flagSet.BoolVar(&c.flagReadServerExposeService, "read-server-expose-service", false,
 		"Enables polling the Consul servers' external service for its IP(s).")
 	c.flagSet.Var((*flags.AppendSliceValue)(&c.flagServerAddresses), "server-address",
-		"An address the Consul server(s), formatted host:port, where host may be an IP or DNS name. May be specified multiple times for multiple addresses.")
+		"An address of the Consul server(s), formatted host:port, where host may be an IP or DNS name and port must be a gRPC port. May be specified multiple times for multiple addresses.")
 
 	// Proxy sidecar resource setting flags.
 	c.flagSet.StringVar(&c.flagDefaultSidecarProxyCPURequest, "default-sidecar-proxy-cpu-request", "", "Default sidecar proxy CPU request.")


### PR DESCRIPTION
Changes proposed in this PR:
- Support setting externalServers hosts in peering token for non-default partitions

How I've tested this PR:
- Set up 4 clusters in 2 datacenters and tested peering across non-default partitions across datacenters with this [reference config and steps](https://github.com/ndhanushkodi/cluster-peering-demo/tree/main/non-default-non-flat)

How I expect reviewers to test this PR:
- 👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

