### PR TITLE
peering: set peering server config only when peering Helm value is true

### DIFF
--- a/charts/consul/templates/server-config-configmap.yaml
+++ b/charts/consul/templates/server-config-configmap.yaml
@@ -32,6 +32,11 @@ data:
       },
       "recursors": {{ .Values.global.recursors | toJson }},
       "retry_join": ["{{template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc:{{ .Values.server.ports.serflan.port }}"],
+      {{- if .Values.global.peering.enabled }}
+      "peering": {
+        "enabled": true
+      },
+      {{- end }}
       "server": true
     }
   {{- $vaultConnectCAEnabled := and .Values.global.secretsBackend.vault.connectCA.address .Values.global.secretsBackend.vault.connectCA.rootPKIPath .Values.global.secretsBackend.vault.connectCA.intermediatePKIPath -}}

--- a/charts/consul/test/unit/server-config-configmap.bats
+++ b/charts/consul/test/unit/server-config-configmap.bats
@@ -905,3 +905,28 @@ load _helpers
 
   [ "${actual}" = null ]
 }
+
+#--------------------------------------------------------------------
+# peering
+
+@test "server/ConfigMap: peering configuration is unspecified by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.data["server.json"]' | jq -r .peering | tee /dev/stderr)
+
+  [ "${actual}" = "null" ]
+}
+
+@test "server/ConfigMap: peering configuration is set by if global.peering.enabled is true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'global.peering.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.data["server.json"]' | jq -r .peering.enabled | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}


### PR DESCRIPTION
Changes proposed in this PR:
- set peering server config only when peering Helm value is true
- This is because Consul now defaults to false: https://github.com/hashicorp/consul/pull/13963

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

