### PR TITLE
peering: support static addresses for exposing servers

### DIFF
--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -13,6 +13,7 @@
 {{- template "consul.reservedNamesFailer" (list .Values.connectInject.consulNamespaces.consulDestinationNamespace "connectInject.consulNamespaces.consulDestinationNamespace") }}
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- $serverExposeServiceEnabled := (or (and (ne (.Values.server.exposeService.enabled | toString) "-") .Values.server.exposeService.enabled) (and (eq (.Values.server.exposeService.enabled | toString) "-") (or .Values.global.peering.enabled .Values.global.adminPartitions.enabled))) -}}
+{{- if not (or (eq .Values.global.peering.tokenGeneration.serverAddresses.source "") (or (eq .Values.global.peering.tokenGeneration.serverAddresses.source "static") (eq .Values.global.peering.tokenGeneration.serverAddresses.source "consul"))) }}{{ fail "global.peering.tokenGeneration.serverAddresses.source must be one of empty string, 'consul' or 'static'" }}{{ end }}
 # The deployment for running the Connect sidecar injector
 apiVersion: apps/v1
 kind: Deployment
@@ -150,6 +151,11 @@ spec:
                 -server-address="{{ $h }}:{{ $port }}" \
                 {{- end }}
                 {{- end }}
+                {{- end }}
+                {{- end }}
+                {{- if (eq .Values.global.peering.tokenGeneration.serverAddresses.source "static") }}
+                {{- range $addr := .Values.global.peering.tokenGeneration.serverAddresses.static }}
+                -server-address="{{ $addr }}" \
                 {{- end }}
                 {{- end }}
                 {{- end }}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -36,13 +36,18 @@ global:
     enabled: false
     tokenGeneration:
       serverAddresses:
-        # Source can be set to "" or "consul".
+        # Source can be set to "","consul" or "static".
         #
-        # "" is the default source. If servers are enabled, it will check if server.exposeService is enabled, and read
+        # "" is the default source. If servers are enabled, it will check if `server.exposeService` is enabled, and read
         # the addresses from that service to use as the peering token server addresses.
         #
         # "consul" will use the Consul advertise addresses in the peering token.
+        #
+        # "static" will use the addresses specified in `global.peering.tokenGeneration.serverAddresses.static`.
         source: ""
+        # Static addresses must be formatted "hostname|ip:port" where the port is the Consul server(s)' grpc port.
+        # @type: array<string>
+        static: []
 
   # [Enterprise Only] Enabling `adminPartitions` allows creation of Admin Partitions in Kubernetes clusters.
   # It additionally indicates that you are running Consul Enterprise v1.11+ with a valid Consul Enterprise


### PR DESCRIPTION
Changes proposed in this PR:
- only requires helm changes because the logic to support non-default partitions also involves just passing in addresses to the token, so this only requires that we set the flags using the appropriate address source

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

