### PR TITLE
Add stanza to ci.hcl to trigger helm pipeline

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -251,3 +251,16 @@ event "promote-production-packaging" {
     on = "always"
   }
 }
+
+event "promote-production-helm" {
+  depends = ["promote-production-packaging"]
+  action "promote-production-helm" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "promote-production-helm"
+  }
+
+  notification {
+    on = "always"
+  }
+}


### PR DESCRIPTION
Changes proposed in this PR:
- Trigger release pipeline via CRT process

How I've tested this PR:
- The new workflow has been tested generate the same parameters when invoking the existing pipeline for publishing helm charts