### PR TITLE
Fix issue where API gateways were being mis-labeled as Sidecar proxies

### DIFF
--- a/cli/cmd/proxy/list/command.go
+++ b/cli/cmd/proxy/list/command.go
@@ -204,6 +204,8 @@ func (c *ListCommand) output(pods []v1.Pod) {
 
 	for _, pod := range pods {
 		var proxyType string
+
+		// Get the type for ingress, mesh, and terminating gateways.
 		switch pod.Labels["component"] {
 		case "ingress-gateway":
 			proxyType = "Ingress Gateway"
@@ -211,9 +213,15 @@ func (c *ListCommand) output(pods []v1.Pod) {
 			proxyType = "Mesh Gateway"
 		case "terminating-gateway":
 			proxyType = "Terminating Gateway"
-		case "api-gateway":
+		}
+
+		// Determine if the pod is an API Gateway.
+		if pod.Labels["api-gateway.consul.hashicorp.com/managed"] == "true" {
 			proxyType = "API Gateway"
-		default:
+		}
+
+		// Fallback to "Sidecar" as a default
+		if proxyType == "" {
 			proxyType = "Sidecar"
 		}
 

--- a/cli/cmd/proxy/list/command_test.go
+++ b/cli/cmd/proxy/list/command_test.go
@@ -225,7 +225,7 @@ func TestListCommandOutput(t *testing.T) {
 		"consul.*mesh-gateway.*Mesh Gateway",
 		"consul.*terminating-gateway.*Terminating Gateway",
 		"default.*ingress-gateway.*Ingress Gateway",
-		"consul.*api-gateway.*Sidecar",
+		"consul.*api-gateway.*API Gateway",
 		"default.*pod1.*Sidecar",
 	}
 	notExpected := []string{


### PR DESCRIPTION
Changes proposed in this PR:
- Fix an issue where pods running API Gateway were being mis-labeled as "Sidecar" pods

How I've tested this PR:
- Edited the unit test to test the correct behavior.
- Manual testing against a cluster

How I expect reviewers to test this PR:
- Running the unit tests


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

