### PR TITLE
Fix context handling for the CLI

### DIFF
--- a/acceptance/framework/cli/cli.go
+++ b/acceptance/framework/cli/cli.go
@@ -3,8 +3,12 @@ package cli
 import (
 	"fmt"
 	"os/exec"
+	"strings"
+	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/config"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
 )
 
 // CLI provides access to compile and execute commands with the `consul-k8s` CLI.
@@ -22,10 +26,20 @@ func NewCLI() (*CLI, error) {
 }
 
 // Run runs the CLI with the given args.
-func (c *CLI) Run(args ...string) ([]byte, error) {
+func (c *CLI) Run(t *testing.T, options *k8s.KubectlOptions, args ...string) ([]byte, error) {
 	if !c.initialized {
 		return nil, fmt.Errorf("CLI must be initialized before calling Run, use `cli.NewCLI()` to initialize.")
 	}
+
+	// Append configuration from `options` to the command.
+	if options.ConfigPath != "" {
+		args = append(args, "-config", options.ConfigPath)
+	}
+	if options.ContextName != "" {
+		args = append(args, "-context", options.ContextName)
+	}
+
+	logger.Logf(t, "Running `consul-k8s %s`", strings.Join(args, " "))
 	cmd := exec.Command("cli", args...)
 	return cmd.Output()
 }

--- a/acceptance/framework/consul/cli_cluster.go
+++ b/acceptance/framework/consul/cli_cluster.go
@@ -124,7 +124,6 @@ func (c *CLICluster) Create(t *testing.T) {
 
 	// Set the args for running the install command.
 	args := []string{"install"}
-	args = c.setKube(args)
 
 	for k, v := range c.values {
 		args = append(args, "-set", fmt.Sprintf("%s=%s", k, v))
@@ -134,7 +133,7 @@ func (c *CLICluster) Create(t *testing.T) {
 	args = append(args, "-timeout", "15m")
 	args = append(args, "-auto-approve")
 
-	out, err := c.cli.Run(args...)
+	out, err := c.cli.Run(t, c.kubectlOptions, args...)
 	if err != nil {
 		c.logger.Logf(t, "error running command `consul-k8s %s`: %s", strings.Join(args, " "), err.Error())
 		c.logger.Logf(t, "command stdout: %s", string(out))
@@ -167,7 +166,7 @@ func (c *CLICluster) Upgrade(t *testing.T, helmValues map[string]string) {
 	args = append(args, "-timeout", "15m")
 	args = append(args, "-auto-approve")
 
-	out, err := c.cli.Run(args...)
+	out, err := c.cli.Run(t, c.kubectlOptions, args...)
 	if err != nil {
 		c.logger.Logf(t, "error running command `consul-k8s %s`: %s", strings.Join(args, " "), err.Error())
 		c.logger.Logf(t, "command stdout: %s", string(out))
@@ -185,13 +184,12 @@ func (c *CLICluster) Destroy(t *testing.T) {
 
 	// Set the args for running the uninstall command.
 	args := []string{"uninstall"}
-	args = c.setKube(args)
 	args = append(args, "-auto-approve", "-wipe-data")
 
 	// Use `go run` so that the CLI is recompiled and therefore uses the local
 	// charts directory rather than the directory from whenever it was last
 	// compiled.
-	out, err := c.cli.Run(args...)
+	out, err := c.cli.Run(t, c.kubectlOptions, args...)
 	if err != nil {
 		c.logger.Logf(t, "error running command `consul-k8s %s`: %s", strings.Join(args, " "), err.Error())
 		c.logger.Logf(t, "command stdout: %s", string(out))

--- a/acceptance/tests/connect/connect_inject_test.go
+++ b/acceptance/tests/connect/connect_inject_test.go
@@ -88,7 +88,7 @@ func TestConnectInject(t *testing.T) {
 			}
 
 			// Run proxy list and get the two results.
-			listOut, err := cli.Run("proxy", "list")
+			listOut, err := cli.Run(t, ctx.KubectlOptions(t), "proxy", "list")
 			require.NoError(t, err)
 			logger.Log(t, string(listOut))
 			list := translateListOutput(listOut)
@@ -101,7 +101,7 @@ func TestConnectInject(t *testing.T) {
 			retrier := &retry.Timer{Timeout: 160 * time.Second, Wait: 2 * time.Second}
 			retry.RunWith(retrier, t, func(r *retry.R) {
 				for podName := range list {
-					out, err := cli.Run("proxy", "read", podName)
+					out, err := cli.Run(t, ctx.KubectlOptions(t), "proxy", "read", podName)
 					require.NoError(t, err)
 
 					output := string(out)

--- a/cli/cmd/proxy/list/command.go
+++ b/cli/cmd/proxy/list/command.go
@@ -134,6 +134,14 @@ func (c *ListCommand) validateFlags() error {
 func (c *ListCommand) initKubernetes() error {
 	settings := helmCLI.New()
 
+	if c.flagKubeConfig != "" {
+		settings.KubeConfig = c.flagKubeConfig
+	}
+
+	if c.flagKubeContext != "" {
+		settings.KubeContext = c.flagKubeContext
+	}
+
 	restConfig, err := settings.RESTClientGetter().ToRESTConfig()
 	if err != nil {
 		return fmt.Errorf("error retrieving Kubernetes authentication %v", err)

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -229,11 +229,11 @@ func (c *ReadCommand) validateFlags() error {
 func (c *ReadCommand) initKubernetes() (err error) {
 	settings := helmCLI.New()
 
-	if c.flagKubeConfig == "" {
+	if c.flagKubeConfig != "" {
 		settings.KubeConfig = c.flagKubeConfig
 	}
 
-	if c.flagKubeContext == "" {
+	if c.flagKubeContext != "" {
 		settings.KubeContext = c.flagKubeContext
 	}
 


### PR DESCRIPTION
Changes proposed in this PR:
- Use context as set by user for Kubernetes
- Pass in context using Kube options to CLI run commands

How I've tested this PR:
- Acceptance tests in CircleCI

How I expect reviewers to test this PR:
- Acceptance tests in CircleCI

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

