### PR TITLE
Various acceptance tests fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ commands:
 
                   pkgs=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
                   echo "Running $pkgs"
-                  gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- $pkgs -p 1 -timeout 2h \
+                  gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- $pkgs -p 1 -timeout 2h -failfast \
                       << parameters.additional-flags >> \
                       -enable-multi-cluster \
                       -run TestPeering* \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,6 @@ commands:
                   gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- $pkgs -p 1 -timeout 2h -failfast \
                       << parameters.additional-flags >> \
                       -enable-multi-cluster \
-                      -run TestPeering* \
                       -debug-directory="$TEST_RESULTS/debug" \
                       -consul-image=ishustava/consul-dev:latest \
                       -consul-k8s-image=<< parameters.consul-k8s-image >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -672,7 +672,8 @@ jobs:
 #          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-21:
-    parallelism: 1
+    parallelism: 6
+    resource_class: 2xlarge
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -673,7 +673,7 @@ jobs:
 #          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-21:
-    parallelism: 6
+    parallelism: 3
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,6 +606,7 @@ jobs:
   # ACCEPTANCE TESTS
   ########################
   acceptance-gke-1-20:
+    parallelism: 6
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -667,11 +668,12 @@ jobs:
             terraform destroy -var project=${CLOUDSDK_CORE_PROJECT} -auto-approve
           when: always
 
-      - slack/status:
-          fail_only: true
-          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-21:
+    parallelism: 6
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -722,11 +724,12 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-      - slack/status:
-          fail_only: true
-          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-eks-1-19:
+    parallelism: 6
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -783,9 +786,9 @@ jobs:
             terraform destroy -var cluster_count=2 -auto-approve
           when: always
 
-      - slack/status:
-          fail_only: true
-          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-openshift:
     environment:
@@ -841,6 +844,7 @@ jobs:
           failure_message: "OpenShift acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-kind-1-23:
+    parallelism: 6
     environment:
       - TEST_RESULTS: /tmp/test-results
     machine:
@@ -869,9 +873,9 @@ jobs:
           path: /tmp/test-results
       - store_artifacts:
           path: /tmp/test-results
-      - slack/status:
-          fail_only: true
-          failure_message: "Acceptance tests against Kind with Kubernetes v1.23 failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+#      - slack/status:
+#          fail_only: true
+#          failure_message: "Acceptance tests against Kind with Kubernetes v1.23 failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-kind-1-23-consul-nightly-1-11:
     environment:
@@ -1007,13 +1011,13 @@ workflows:
           requires:
             - dev-upload-docker
   nightly-acceptance-tests:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
+#    triggers:
+#      - schedule:
+#          cron: "0 0 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - main
     jobs:
       - build-distro:
           OS: "linux"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -607,7 +607,6 @@ jobs:
   ########################
   acceptance-gke-1-20:
     parallelism: 6
-    resource_class: large
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -675,7 +674,6 @@ jobs:
 
   acceptance-aks-1-21:
     parallelism: 6
-    resource_class: large
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -732,7 +730,6 @@ jobs:
 
   acceptance-eks-1-19:
     parallelism: 6
-    resource_class: large
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ commands:
                   # Enterprise tests can't run on fork PRs because they require
                   # a secret.
                   if [ -z "$CIRCLE_PR_NUMBER" ]; then
-                    ENABLE_ENTERPRISE=true
+                    ENABLE_ENTERPRISE=false
                   fi
 
                   pkgs=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
@@ -133,7 +133,7 @@ commands:
                       -enable-multi-cluster \
                       ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -debug-directory="$TEST_RESULTS/debug" \
-                      -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.13-dev \
+                      -consul-image=ishustava/consul-dev:latest \
                       -consul-k8s-image=<< parameters.consul-k8s-image >>
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,6 @@ commands:
                   do
                     if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 2h -failfast \
                           << parameters.additional-flags >> \
-                          ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -enable-multi-cluster \
                           -debug-directory="$TEST_RESULTS/debug" \
                           -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.13-dev \
@@ -123,7 +122,7 @@ commands:
                   # Enterprise tests can't run on fork PRs because they require
                   # a secret.
                   if [ -z "$CIRCLE_PR_NUMBER" ]; then
-                    ENABLE_ENTERPRISE=false
+                    ENABLE_ENTERPRISE=true
                   fi
 
                   pkgs=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
@@ -132,7 +131,6 @@ commands:
                       << parameters.additional-flags >> \
                       -enable-multi-cluster \
                       -run TestPeering* \
-                      ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -debug-directory="$TEST_RESULTS/debug" \
                       -consul-image=ishustava/consul-dev:latest \
                       -consul-k8s-image=<< parameters.consul-k8s-image >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,7 @@ commands:
                   do
                     if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 2h -failfast \
                           << parameters.additional-flags >> \
+                          ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -enable-multi-cluster \
                           -debug-directory="$TEST_RESULTS/debug" \
                           -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.13-dev \
@@ -129,9 +130,10 @@ commands:
                   echo "Running $pkgs"
                   gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- $pkgs -p 1 -timeout 2h -failfast \
                       << parameters.additional-flags >> \
+                      ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -enable-multi-cluster \
                       -debug-directory="$TEST_RESULTS/debug" \
-                      -consul-image=ishustava/consul-dev:latest \
+                      -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.13-dev \
                       -consul-k8s-image=<< parameters.consul-k8s-image >>
 
 jobs:
@@ -671,8 +673,8 @@ jobs:
 #          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-21:
-    parallelism: 6
-    resource_class: 2xlarge
+    parallelism: 3
+    resource_class: 2xlarge+
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,7 @@ commands:
                   gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- $pkgs -p 1 -timeout 2h -failfast \
                       << parameters.additional-flags >> \
                       -enable-multi-cluster \
+                      -run TestPeering* \
                       ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -debug-directory="$TEST_RESULTS/debug" \
                       -consul-image=ishustava/consul-dev:latest \
@@ -1026,24 +1027,24 @@ workflows:
       - dev-upload-docker:
           requires:
             - build-distros-linux
-      - cleanup-gcp-resources
-      - cleanup-azure-resources
-      - cleanup-eks-resources
+#      - cleanup-gcp-resources
+#      - cleanup-azure-resources
+#      - cleanup-eks-resources
       # Disable until we can use UBI images.
       #      - acceptance-openshift:
       #          requires:
       #          - cleanup-azure-resources
       - acceptance-gke-1-20:
           requires:
-            - cleanup-gcp-resources
+#            - cleanup-gcp-resources
             - dev-upload-docker
       - acceptance-eks-1-19:
           requires:
-            - cleanup-eks-resources
+#            - cleanup-eks-resources
             - dev-upload-docker
       - acceptance-aks-1-21:
           requires:
-            - cleanup-azure-resources
+#            - cleanup-azure-resources
             - dev-upload-docker
       - acceptance-kind-1-23:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -607,6 +607,7 @@ jobs:
   ########################
   acceptance-gke-1-20:
     parallelism: 6
+    resource_class: large
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -674,6 +675,7 @@ jobs:
 
   acceptance-aks-1-21:
     parallelism: 6
+    resource_class: large
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -730,6 +732,7 @@ jobs:
 
   acceptance-eks-1-19:
     parallelism: 6
+    resource_class: large
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -673,7 +673,7 @@ jobs:
 #          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-21:
-    parallelism: 3
+    parallelism: 6
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -672,7 +672,7 @@ jobs:
 #          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-21:
-    parallelism: 3
+    parallelism: 1
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -668,9 +668,9 @@ jobs:
             terraform destroy -var project=${CLOUDSDK_CORE_PROJECT} -auto-approve
           when: always
 
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-21:
     parallelism: 6
@@ -724,9 +724,9 @@ jobs:
             terraform destroy -auto-approve
           when: always
 
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-eks-1-19:
     parallelism: 6
@@ -786,9 +786,9 @@ jobs:
             terraform destroy -var cluster_count=2 -auto-approve
           when: always
 
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-openshift:
     environment:
@@ -873,9 +873,9 @@ jobs:
           path: /tmp/test-results
       - store_artifacts:
           path: /tmp/test-results
-#      - slack/status:
-#          fail_only: true
-#          failure_message: "Acceptance tests against Kind with Kubernetes v1.23 failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+      - slack/status:
+          fail_only: true
+          failure_message: "Acceptance tests against Kind with Kubernetes v1.23 failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-kind-1-23-consul-nightly-1-11:
     environment:
@@ -1011,13 +1011,13 @@ workflows:
           requires:
             - dev-upload-docker
   nightly-acceptance-tests:
-#    triggers:
-#      - schedule:
-#          cron: "0 0 * * *"
-#          filters:
-#            branches:
-#              only:
-#                - main
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
     jobs:
       - build-distro:
           OS: "linux"
@@ -1026,24 +1026,24 @@ workflows:
       - dev-upload-docker:
           requires:
             - build-distros-linux
-#      - cleanup-gcp-resources
-#      - cleanup-azure-resources
-#      - cleanup-eks-resources
+      - cleanup-gcp-resources
+      - cleanup-azure-resources
+      - cleanup-eks-resources
       # Disable until we can use UBI images.
       #      - acceptance-openshift:
       #          requires:
       #          - cleanup-azure-resources
       - acceptance-gke-1-20:
           requires:
-#            - cleanup-gcp-resources
+            - cleanup-gcp-resources
             - dev-upload-docker
       - acceptance-eks-1-19:
           requires:
-#            - cleanup-eks-resources
+            - cleanup-eks-resources
             - dev-upload-docker
       - acceptance-aks-1-21:
           requires:
-#            - cleanup-azure-resources
+            - cleanup-azure-resources
             - dev-upload-docker
       - acceptance-kind-1-23:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -673,8 +673,7 @@ jobs:
 #          failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-21:
-    parallelism: 3
-    resource_class: 2xlarge+
+    parallelism: 6
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ commands:
 
                   pkgs=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
                   echo "Running $pkgs"
-                  gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- $pkgs -p 1 -timeout 2h -failfast \
+                  gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- $pkgs -p 1 -timeout 2h \
                       << parameters.additional-flags >> \
                       -enable-multi-cluster \
                       -run TestPeering* \

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -311,6 +311,7 @@ func (h *HelmCluster) CreatePortForwardTunnelToResourcePort(t *testing.T, resour
 
 func (h *HelmCluster) monitorPortForwardedServer(t *testing.T, port int, tunnel *terratestk8s.Tunnel, doneChan chan bool, resourceName string, remotePort int) {
 	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
 
 	for {
 		select {
@@ -320,9 +321,8 @@ func (h *HelmCluster) monitorPortForwardedServer(t *testing.T, port int, tunnel 
 			return
 		case <-ticker.C:
 			conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
-			logger.Log(t, "lost connection to port-forwarded server", "port", port)
 			if err != nil {
-				logger.Log(t, "restarting port-forwarding", "port", port)
+				logger.Log(t, "lost connection to port-forwarded server; restarting port-forwarding", "port", port)
 				tunnel.Close()
 				tunnel = terratestk8s.NewTunnelWithLogger(
 					h.helmOptions.KubectlOptions,

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -297,12 +298,51 @@ func (h *HelmCluster) CreatePortForwardTunnelToResourcePort(t *testing.T, resour
 		require.NoError(r, tunnel.ForwardPortE(t))
 	})
 
+	doneChan := make(chan bool)
+
 	t.Cleanup(func() {
-		tunnel.Close()
+		close(doneChan)
 	})
 
-	return fmt.Sprintf("127.0.0.1:%d", localPort)
+	go h.monitorPortForwardedServer(t, localPort, tunnel, doneChan, resourceName, remotePort)
 
+	return fmt.Sprintf("127.0.0.1:%d", localPort)
+}
+
+func (h *HelmCluster) monitorPortForwardedServer(t *testing.T, port int, tunnel *terratestk8s.Tunnel, doneChan chan bool, resourceName string, remotePort int) {
+	ticker := time.NewTicker(1 * time.Second)
+
+	for {
+		select {
+		case <-doneChan:
+			logger.Log(t, "stopping monitor of the port-forwarded server")
+			tunnel.Close()
+			return
+		case <-ticker.C:
+			conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+			logger.Log(t, "lost connection to port-forwarded server", "port", port)
+			if err != nil {
+				logger.Log(t, "restarting port-forwarding", "port", port)
+				tunnel.Close()
+				tunnel = terratestk8s.NewTunnelWithLogger(
+					h.helmOptions.KubectlOptions,
+					terratestk8s.ResourceTypePod,
+					resourceName,
+					port,
+					remotePort,
+					h.logger)
+				err = tunnel.ForwardPortE(t)
+				if err != nil {
+					// If we couldn't establish a port forwarding channel, continue, so we can try again.
+					continue
+				}
+			}
+			if conn != nil {
+				// Ignore error because we don't care if connection is closed successfully or not.
+				_ = conn.Close()
+			}
+		}
+	}
 }
 
 func (h *HelmCluster) SetupConsulClient(t *testing.T, secure bool) (client *api.Client, configAddress string) {

--- a/acceptance/framework/k8s/helpers.go
+++ b/acceptance/framework/k8s/helpers.go
@@ -109,7 +109,7 @@ func ServiceHost(t *testing.T, cfg *config.TestConfig, ctx environment.TestConte
 	} else {
 		var host string
 		// It can take some time for the load balancers to be ready and have an IP/Hostname.
-		// Wait for 60 seconds before failing.
+		// Wait for 5 minutes before failing.
 		retry.RunWith(&retry.Counter{Wait: 1 * time.Second, Count: 600}, t, func(r *retry.R) {
 			svc, err := ctx.KubernetesClient(t).CoreV1().Services(ctx.KubectlOptions(t).Namespace).Get(context.Background(), serviceName, metav1.GetOptions{})
 			require.NoError(t, err)

--- a/acceptance/framework/k8s/helpers.go
+++ b/acceptance/framework/k8s/helpers.go
@@ -110,7 +110,7 @@ func ServiceHost(t *testing.T, cfg *config.TestConfig, ctx environment.TestConte
 		var host string
 		// It can take some time for the load balancers to be ready and have an IP/Hostname.
 		// Wait for 60 seconds before failing.
-		retry.RunWith(&retry.Counter{Wait: 1 * time.Second, Count: 60}, t, func(r *retry.R) {
+		retry.RunWith(&retry.Counter{Wait: 1 * time.Second, Count: 600}, t, func(r *retry.R) {
 			svc, err := ctx.KubernetesClient(t).CoreV1().Services(ctx.KubectlOptions(t).Namespace).Get(context.Background(), serviceName, metav1.GetOptions{})
 			require.NoError(t, err)
 			require.NotEmpty(r, svc.Status.LoadBalancer.Ingress)

--- a/acceptance/tests/peering/peering_connect_test.go
+++ b/acceptance/tests/peering/peering_connect_test.go
@@ -258,7 +258,6 @@ func TestPeering_Connect(t *testing.T) {
 			} else {
 				k8s.CheckStaticServerConnectionSuccessful(t, staticClientOpts, staticClientName, "http://localhost:1234")
 			}
-			t.FailNow()
 		})
 	}
 }

--- a/acceptance/tests/peering/peering_connect_test.go
+++ b/acceptance/tests/peering/peering_connect_test.go
@@ -259,5 +259,6 @@ func TestPeering_Connect(t *testing.T) {
 				k8s.CheckStaticServerConnectionSuccessful(t, staticClientOpts, staticClientName, "http://localhost:1234")
 			}
 		})
+		t.FailNow()
 	}
 }

--- a/acceptance/tests/peering/peering_connect_test.go
+++ b/acceptance/tests/peering/peering_connect_test.go
@@ -259,6 +259,5 @@ func TestPeering_Connect(t *testing.T) {
 				k8s.CheckStaticServerConnectionSuccessful(t, staticClientOpts, staticClientName, "http://localhost:1234")
 			}
 		})
-		t.FailNow()
 	}
 }

--- a/acceptance/tests/peering/peering_connect_test.go
+++ b/acceptance/tests/peering/peering_connect_test.go
@@ -258,6 +258,7 @@ func TestPeering_Connect(t *testing.T) {
 			} else {
 				k8s.CheckStaticServerConnectionSuccessful(t, staticClientOpts, staticClientName, "http://localhost:1234")
 			}
+			t.FailNow()
 		})
 	}
 }

--- a/hack/aws-acceptance-test-cleanup/main.go
+++ b/hack/aws-acceptance-test-cleanup/main.go
@@ -413,12 +413,19 @@ func realMain(ctx context.Context) error {
 		})
 		for _, subnet := range subnets.Subnets {
 			fmt.Printf("Subnet: Destroying... [id=%s]\n", *subnet.SubnetId)
-			_, err := ec2Client.DeleteSubnetWithContext(ctx, &ec2.DeleteSubnetInput{
-				SubnetId: subnet.SubnetId,
-			})
-			if err != nil {
+			if err := destroyBackoff(ctx, "Subnet", *subnet.SubnetId, func() error {
+				_, err := ec2Client.DeleteSubnetWithContext(ctx, &ec2.DeleteSubnetInput{
+					SubnetId: subnet.SubnetId,
+				})
+				if err != nil {
+					return err
+				}
+
+				return nil
+			}); err != nil {
 				return err
 			}
+
 			fmt.Printf("Subnet: Destroyed [id=%s]\n", *subnet.SubnetId)
 		}
 

--- a/hack/aws-acceptance-test-cleanup/main.go
+++ b/hack/aws-acceptance-test-cleanup/main.go
@@ -363,8 +363,6 @@ func realMain(ctx context.Context) error {
 			}); err != nil {
 				return err
 			}
-			// Allow time for ELB deletion to propagate so that we can detach the internet gateway.
-			time.Sleep(30 * time.Second)
 			fmt.Printf("ELB: Destroyed [id=%s]\n", *elbDescrip.LoadBalancerName)
 		}
 
@@ -379,11 +377,17 @@ func realMain(ctx context.Context) error {
 		})
 		for _, igw := range igws.InternetGateways {
 			fmt.Printf("Internet gateway: Detaching from VPC... [id=%s]\n", *igw.InternetGatewayId)
-			_, err := ec2Client.DetachInternetGatewayWithContext(ctx, &ec2.DetachInternetGatewayInput{
-				InternetGatewayId: igw.InternetGatewayId,
-				VpcId:             vpcID,
-			})
-			if err != nil {
+			if err := destroyBackoff(ctx, "Internet Gateway", *igw.InternetGatewayId, func() error {
+				_, err := ec2Client.DetachInternetGatewayWithContext(ctx, &ec2.DetachInternetGatewayInput{
+					InternetGatewayId: igw.InternetGatewayId,
+					VpcId:             vpcID,
+				})
+				if err != nil {
+					return err
+				}
+
+				return nil
+			}); err != nil {
 				return err
 			}
 			fmt.Printf("Internet gateway: Detached [id=%s]\n", *igw.InternetGatewayId)


### PR DESCRIPTION
Changes proposed in this PR:
- parallelize nightly tests (they now take ~5h which is the max time circleci will allow us to run w/o output)
- re-establish port forwarding if we lose connection. Sometimes, we lose port-forwarding connection and never re-establish it, which leads to any calls to consul to fail. Instead, we now monitor the local port, and if we can't connect to it, we re-establish port-forwarding
- Add retries to aws cleanup script

How I've tested this PR:
ran them in ci: https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/7036/workflows/0f11f813-0c69-4090-a9ae-63ba844e101e

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

