### PR TITLE
peering: add code blocks for helm docs

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -40,7 +40,7 @@ global:
         #
         # "" is the default source. If servers are enabled, it will check if `server.exposeService` is enabled, and read
         # the addresses from that service to use as the peering token server addresses. If using admin partitions and
-        # only Consul client agents are enabled, the addresses in externalServers.hosts and externalServers.grpcPort
+        # only Consul client agents are enabled, the addresses in `externalServers.hosts` and `externalServers.grpcPort`
         # will be used.
         #
         # "consul" will use the Consul advertise addresses in the peering token.


### PR DESCRIPTION
realized I forgot to add ticks for the helm values docs :( 

