### PR TITLE
Use new GitHub Markdown note syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ for each feature will be noted below. By versioning this project separately,
 we can iterate on Kubernetes integrations more quickly and release new versions
 without forcing Consul users to do a full Consul upgrade.
 
-> :warning: **Please note**: We take Consul's security and our users' trust very seriously. If
+> **Note**  
+> We take Consul's security and our users' trust very seriously. If
 you believe you have found a security issue in Consul K8s, _please responsibly disclose_
 by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
 


### PR DESCRIPTION
Changes proposed in this PR:
- GitHub added a [new syntax for notes and warnings](https://github.com/community/community/discussions/16925). This PR uses that instead of the Emoji.

I think the note rendering looks prettier 💅🏻. Example:

> **Note**  
> This is a note!

> **Warning**  
> This is a warning!

