### PR TITLE
Fix acceptance tests passing "-config" instead of "-kubeconfig" to CLI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1000,11 +1000,6 @@ workflows:
           requires:
             - build-distros-linux
       # Run acceptance tests using the docker image built for the control plane
-      - cleanup-gcp-resources
-      - acceptance-gke-1-20:
-          requires:
-            - cleanup-gcp-resources
-            - dev-upload-docker
       - acceptance:
           context: consul-ci
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1000,6 +1000,11 @@ workflows:
           requires:
             - build-distros-linux
       # Run acceptance tests using the docker image built for the control plane
+      - cleanup-gcp-resources
+      - acceptance-gke-1-20:
+          requires:
+            - cleanup-gcp-resources
+            - dev-upload-docker
       - acceptance:
           context: consul-ci
           requires:

--- a/acceptance/framework/cli/cli.go
+++ b/acceptance/framework/cli/cli.go
@@ -33,7 +33,7 @@ func (c *CLI) Run(t *testing.T, options *k8s.KubectlOptions, args ...string) ([]
 
 	// Append configuration from `options` to the command.
 	if options.ConfigPath != "" {
-		args = append(args, "-config", options.ConfigPath)
+		args = append(args, "-kubeconfig", options.ConfigPath)
 	}
 	if options.ContextName != "" {
 		args = append(args, "-context", options.ContextName)


### PR DESCRIPTION
Changes proposed in this PR:
- This fixes the root cause of this [error](https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/7053/workflows/c79a773b-2ba0-4b8a-9192-d19c70550bd4/jobs/57273) where the Kubeconfig was being passed to the CLI as `-config path` when it should be `-kubeconfig path`.

How I've tested this PR:
- Running an acceptance test suite for a public cloud host on this PR (Kind acceptance tests don't set a kubeconfig, that's why this got missed).
[GKE Acceptance Test run](https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/7063/workflows/2596f37d-6b54-4ad7-bf1e-85a56c3950e8/jobs/57311)

How I expect reviewers to test this PR:
- Watch the acceptance tests to verify correctness.

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

