### PR TITLE
[RELENG-20] set PRODUCT_VERSION for default docker build

### DIFF
--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -66,22 +66,20 @@ CMD /bin/${BIN_NAME}
 # reproducible currently.
 FROM alpine:3.16 AS release-default
 
-# NAME and VERSION are the name of the software in releases.hashicorp.com
-# and the version to download. Example: NAME=consul VERSION=1.2.3.
 ARG BIN_NAME=consul-k8s-control-plane
-ARG VERSION
+ARG PRODUCT_VERSION
 
 LABEL name=${BIN_NAME} \
       maintainer="Team Consul Kubernetes <team-consul-kubernetes@hashicorp.com>" \
       vendor="HashiCorp" \
-      version=${VERSION} \
-      release=${VERSION} \
+      version=${PRODUCT_VERSION} \
+      release=${PRODUCT_VERSION} \
       summary="consul-k8s-control-plane provides first-class integrations between Consul and Kubernetes." \
       description="consul-k8s-control-plane provides first-class integrations between Consul and Kubernetes."
 
 # Set ARGs as ENV so that they can be used in ENTRYPOINT/CMD
 ENV BIN_NAME=${BIN_NAME}
-ENV VERSION=${VERSION}
+ENV VERSION=${PRODUCT_VERSION}
 
 RUN apk add --no-cache ca-certificates curl gnupg libcap openssl su-exec iputils libc6-compat iptables
 
@@ -132,7 +130,7 @@ LABEL name=$PRODUCT_NAME \
 
 # Set ARGs as ENV so that they can be used in ENTRYPOINT/CMD
 ENV NAME=${BIN_NAME}
-ENV VERSION=${VERSION}
+ENV VERSION=${PRODUCT_VERSION}
 
 # TARGETOS and TARGETARCH are set automatically when --platform is provided.
 ARG TARGETOS


### PR DESCRIPTION
Changes proposed in this PR:

In `actions-docker-build` we [pass](https://github.com/hashicorp/actions-docker-build/blob/05c370a26e61b06be46c5095d6e914c9f0ea4f3d/scripts/docker_build#L49) `PRODUCT_VERSION` to the docker build command. Since this was not set, the label did not populate properly which is used in a comparison to determine the `minor-latest` and `latest` docker image tags. 

```
docker inspect hashicorp/consul-k8s-control-plane:latest -f={{json '.Config.Labels'}} | jq
{
  "description": "consul-k8s-control-plane provides first-class integrations between Consul and Kubernetes.",
  "maintainer": "Team Consul Kubernetes <team-consul-kubernetes@hashicorp.com>",
  "name": "consul-k8s-control-plane",
  "release": "",
  "summary": "consul-k8s-control-plane provides first-class integrations between Consul and Kubernetes.",
  "vendor": "HashiCorp",
  "version": ""

```

How I've tested this PR:
 - build the image up to the point of label creation and pass in `--build-arg PRODUCT_VERSION=1.2.3`
 - inspect the image for the label with the above command

How I expect reviewers to test this PR:
- same as above

