### PR TITLE
Add named metrics port to envoy sidecar

### DIFF
--- a/control-plane/connect-inject/envoy_sidecar_test.go
+++ b/control-plane/connect-inject/envoy_sidecar_test.go
@@ -636,3 +636,25 @@ func TestHandlerEnvoySidecar_Resources(t *testing.T) {
 		})
 	}
 }
+
+func TestHandlerEnvoySidecar_NamedPorts(t *testing.T) {
+	require := require.New(t)
+	w := MeshWebhook{
+		MetricsConfig: MetricsConfig{
+			DefaultPrometheusScrapePort: "1234",
+		},
+	}
+	pod := corev1.Pod{}
+
+	container, err := w.envoySidecar(testNS, pod, multiPortInfo{})
+	require.NoError(err)
+
+	require.Equal(container.Ports, []corev1.ContainerPort{
+		corev1.ContainerPort{
+			Name:          "envoy-metrics",
+			ContainerPort: 1234,
+			Protocol:      corev1.ProtocolTCP,
+		},
+	})
+
+}


### PR DESCRIPTION
Relates to #671 

Changes proposed in this PR:
- Adds a [containerPort](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerport-v1-core) configuration to the injected Envoy sidecar for the metrics port 
- TODO: A test! draft until i add that

The [targetPort](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#podmetricsendpoint) field on Prometheus Operator ports accepts a port **name**, using an integer port number is deprecated.

Without any named ports on the injected container it is not possible to configure a `ServiceMonitor` or `PodMonitor` resource (without using a deprecated feature) in order to scrape metrics from a Prometheus Operator managed Prometheus instance


How I've tested this PR:
I've been running this patch in production for nearly a year

How I expect reviewers to test this PR:
Confirm the injected envoy sidecar on a Connect enabled pod has a ports configuration:

```
  name: envoy-sidecar
  ports:
  - containerPort: 20200
    name: envoy-metrics
    protocol: TCP
```

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)


