### PR TITLE
Fix Listener Filter bugs and cover more Envoy Listener Filter Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,14 @@ IMPROVEMENTS:
   * Display clusters by their short names rather than FQDNs for the `proxy read` command. [[GH-1412](https://github.com/hashicorp/consul-k8s/pull/1412)]
   * Display a message when `proxy list` returns no results. [[GH-1412](https://github.com/hashicorp/consul-k8s/pull/1412)]
   * Display a warning when a user passes a field and table filter combination to `proxy read` where the given field is not present in any of the output tables. [[GH-1412](https://github.com/hashicorp/consul-k8s/pull/1412)]
+  * Extend the timeout for `consul-k8s proxy read` to establish a connection from 5s to 10s.
+  * Expand the set of Envoy Listener Filters that may be parsed and output to the Listeners table.
 
 BUG FIXES:
 * Helm
   * API Gateway: Configure ACL auth for controller correctly when deployed in secondary datacenter with federation enabled [[GH-1462](https://github.com/hashicorp/consul-k8s/pull/1462)]
+* CLI
+  * Fix issue where SNI filters for Terminating Gateways showed up as blank lines.
 
 ## 0.47.1 (August 12, 2022)
 

--- a/acceptance/tests/connect/connect_inject_test.go
+++ b/acceptance/tests/connect/connect_inject_test.go
@@ -114,7 +114,7 @@ func TestConnectInject(t *testing.T) {
 					// Static Client must have Static Server as a cluster and endpoint.
 					if strings.Contains(podName, "static-client") {
 						require.Regexp(r, "static-server.*static-server\\.default\\.dc1\\.internal.*EDS", output)
-						require.Regexp(r, ipv4RegEx+".*static-server.default.dc1.internal", output)
+						require.Regexp(r, ipv4RegEx+".*static-server", output)
 					}
 
 				}

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -413,12 +413,15 @@ func (c *ReadCommand) outputJSON(configs map[string]*EnvoyConfig) error {
 		cfgs[name] = cfg
 	}
 
-	out, err := json.MarshalIndent(cfgs, "", "\t")
+	escaped, err := json.MarshalIndent(cfgs, "", "\t")
 	if err != nil {
 		return err
 	}
 
-	c.UI.Output(string(out))
+	// Unescape `>` the cheap way.
+	out := strings.ReplaceAll(string(escaped), "\\u003e", ">")
+
+	c.UI.Output(out)
 
 	return nil
 }

--- a/cli/cmd/proxy/read/command_test.go
+++ b/cli/cmd/proxy/read/command_test.go
@@ -81,9 +81,9 @@ func TestReadCommandOutput(t *testing.T) {
 		"-listeners": {"==> Listeners \\(2\\)",
 			"Name.*Address:Port.*Direction.*Filter Chain Match.*Filters.*Last Updated",
 			"public_listener.*192\\.168\\.69\\.179:20000.*INBOUND.*Any.*\\* -> local_app/",
-			"outbound_listener.*127.0.0.1:15001.*OUTBOUND.*10\\.100\\.134\\.173/32, 240\\.0\\.0\\.3/32.*-> client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
-			"10\\.100\\.31\\.2/32, 240\\.0\\.0\\.5/32.*-> frontend\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul",
-			"Any.*-> original-destination"},
+			"outbound_listener.*127.0.0.1:15001.*OUTBOUND.*10\\.100\\.134\\.173/32, 240\\.0\\.0\\.3/32.*TCP: -> client",
+			"10\\.100\\.31\\.2/32, 240\\.0\\.0\\.5/32.*TCP: -> frontend",
+			"Any.*TCP: -> original-destination"},
 
 		"-routes": {"==> Routes \\(1\\)",
 			"Name.*Destination Cluster.*Last Updated",

--- a/cli/cmd/proxy/read/command_test.go
+++ b/cli/cmd/proxy/read/command_test.go
@@ -80,10 +80,10 @@ func TestReadCommandOutput(t *testing.T) {
 
 		"-listeners": {"==> Listeners \\(2\\)",
 			"Name.*Address:Port.*Direction.*Filter Chain Match.*Filters.*Last Updated",
-			"public_listener.*192\\.168\\.69\\.179:20000.*INBOUND.*Any.*\\* to local_app/",
-			"outbound_listener.*127.0.0.1:15001.*OUTBOUND.*10\\.100\\.134\\.173/32, 240\\.0\\.0\\.3/32.*to client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
-			"10\\.100\\.31\\.2/32, 240\\.0\\.0\\.5/32.*to frontend\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul",
-			"Any.*to original-destination"},
+			"public_listener.*192\\.168\\.69\\.179:20000.*INBOUND.*Any.*\\* -> local_app/",
+			"outbound_listener.*127.0.0.1:15001.*OUTBOUND.*10\\.100\\.134\\.173/32, 240\\.0\\.0\\.3/32.*-> client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul",
+			"10\\.100\\.31\\.2/32, 240\\.0\\.0\\.5/32.*-> frontend\\.default\\.dc1\\.internal\\.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00\\.consul",
+			"Any.*-> original-destination"},
 
 		"-routes": {"==> Routes \\(1\\)",
 			"Name.*Destination Cluster.*Last Updated",

--- a/cli/cmd/proxy/read/config.go
+++ b/cli/cmd/proxy/read/config.go
@@ -396,7 +396,7 @@ func parseSecrets(rawCfg map[string]interface{}) ([]Secret, error) {
 	return secrets, nil
 }
 
-func formatFilters(filters []filter) (formatted []string) {
+func formatFilters(filters []filter) []string {
 	// Filters can have many custom configurations, each must be handled differently.
 	// [List of known extensions](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener_components.proto).
 	formatters := map[string]func(filter) string{

--- a/cli/cmd/proxy/read/config.go
+++ b/cli/cmd/proxy/read/config.go
@@ -397,6 +397,8 @@ func parseSecrets(rawCfg map[string]interface{}) ([]Secret, error) {
 }
 
 func formatFilters(filters []filter) []string {
+	formatted := []string{}
+
 	// Filters can have many custom configurations, each must be handled differently.
 	// [List of known extensions](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener_components.proto).
 	formatters := map[string]func(filter) string{

--- a/cli/cmd/proxy/read/config_test.go
+++ b/cli/cmd/proxy/read/config_test.go
@@ -268,7 +268,7 @@ func TestFormatFilters(t *testing.T) {
 					},
 				},
 			},
-			expected: "Rate limit: database-ratelimit PATH /users 42 req per minute",
+			expected: "Rate limit: database-ratelimit PATH:/users 42 req per minute",
 		},
 		"Ratelimit with EnvoyGrpc definted limiter allowing failures": {
 			filter: filter{
@@ -285,20 +285,23 @@ func TestFormatFilters(t *testing.T) {
 					},
 				},
 			},
-			expected: "Rate limit: database-ratelimit using ratelimiter.service with failures allowed.",
+			expected: "Rate limit: database-ratelimit using ratelimiter.service will deny if unreachable",
 		},
 		"Ratelimit with GoogleGrpc defined limiter": {
 			filter: filter{
 				TypedConfig: filterTypedConfig{
-					Type:            "type.googleapis.com/envoy.extensions.filters.network.ratelimit.v3.RateLimit",
-					Domain:          "database-ratelimit",
-					FailureModeDeny: true,
+					Type:   "type.googleapis.com/envoy.extensions.filters.network.ratelimit.v3.RateLimit",
+					Domain: "database-ratelimit",
 					RateLimitService: filterRateLimitServiceConfig{
-						GrpcService: filterGrpcService{},
+						GrpcService: filterGrpcService{
+							GoogleGrpc: filterGoogleGrpc{
+								TargetUri: "ratelimiter.service",
+							},
+						},
 					},
 				},
 			},
-			expected: "Rate limit: database-ratelimit using ratelimiter.service with failures allowed.",
+			expected: "Rate limit: database-ratelimit using ratelimiter.service",
 		},
 		"RBAC": {
 			filter: filter{

--- a/cli/cmd/proxy/read/config_test.go
+++ b/cli/cmd/proxy/read/config_test.go
@@ -253,7 +253,7 @@ func TestFormatFilters(t *testing.T) {
 					Type:   "type.googleapis.com/envoy.extensions.filters.network.ratelimit.v3.RateLimit",
 					Domain: "database-ratelimit",
 					Descriptors: []filterRateLimitDescriptor{
-						filterRateLimitDescriptor{
+						{
 							Entries: []filterRateLimitDescriptorEntry{
 								{
 									Key:   "PATH",
@@ -294,9 +294,7 @@ func TestFormatFilters(t *testing.T) {
 					Domain:          "database-ratelimit",
 					FailureModeDeny: true,
 					RateLimitService: filterRateLimitServiceConfig{
-						GrpcService: filterGrpcService{
-							GoogleGrpc: ,
-						},
+						GrpcService: filterGrpcService{},
 					},
 				},
 			},

--- a/cli/cmd/proxy/read/envoy_types.go
+++ b/cli/cmd/proxy/read/envoy_types.go
@@ -125,7 +125,7 @@ type filterTypedConfig struct {
 	GrpcService      filterGrpcService            `json:"grpc_service"`
 	TokenBucket      filterTokenBucket            `json:"token_bucket"`
 	Domain           string                       `json:"domain"`
-	Descriptors      []filterRateLimitDescriptors `json:"descriptors"`
+	Descriptors      []filterRateLimitDescriptor  `json:"descriptors"`
 	FailureModeDeny  bool                         `json:"failure_mode_deny"`
 	RateLimitService filterRateLimitServiceConfig `json:"rate_limit_service"`
 }

--- a/cli/cmd/proxy/read/envoy_types.go
+++ b/cli/cmd/proxy/read/envoy_types.go
@@ -106,16 +106,29 @@ type filterChain struct {
 }
 
 type filter struct {
-	Name        string      `json:"name"`
-	TypedConfig typedConfig `json:"typed_config"`
+	Name        string            `json:"name"`
+	TypedConfig filterTypedConfig `json:"typed_config"`
 }
 
-type typedConfig struct {
-	Type        string            `json:"@type"`
-	Cluster     string            `json:"cluster"`
-	RouteConfig filterRouteConfig `json:"route_config"`
-	HttpFilters []httpFilter      `json:"http_filters"`
-	Rules       rules             `json:"rules"`
+type filterTypedConfig struct {
+	Type                       string                    `json:"@type"`
+	Cluster                    string                    `json:"cluster"`
+	RouteConfig                filterRouteConfig         `json:"route_config"`
+	HttpFilters                []httpFilter              `json:"http_filters"`
+	Rules                      filterRules               `json:"rules"`
+	StatPrefix                 string                    `json:"stat_prefix"`
+	MaxConnections             int64                     `json:"max_connections"`
+	Delay                      string                    `json:"delay"`
+	Response                   filterResponse            `json:"reponse"`
+	GrpcService                filterGrpcService         `json:"grpc_service"`
+	FailureModeAllow           bool                      `json:"failure_mode_allow"`
+	IncludePeerCertificate     bool                      `json:"include_peer_certificate"`
+	TransportApiVersion        filterTransportApiVersion `json:"transport_api_version"`
+	FilterEnabledMetadata      filterEnabledMetadata     `json:"filter_enabled_metadata"`
+	BootstrapMetadataLabelsKey string                    `json:"bootstrap_metadata_labels_key"`
+	TokenBucket                filterTokenBucket         `json:"token_bucket"`
+	RuntimeEnabled             filterRuntimeEnabled      `json:"runtime_enabled"`
+	ShareKey                   string                    `json:"share_key"`
 }
 
 type filterRouteConfig struct {
@@ -156,19 +169,19 @@ type httpFilter struct {
 }
 
 type httpTypedConfig struct {
-	Rules rules `json:"rules"`
+	Rules filterRules `json:"rules"`
 }
 
-type rules struct {
-	Action   string                  `json:"action"`
-	Policies httpTypedConfigPolicies `json:"policies"`
+type filterRules struct {
+	Action   string                        `json:"action"`
+	Policies filterHttpTypedConfigPolicies `json:"policies"`
 }
 
-type httpTypedConfigPolicies struct {
-	ConsulIntentions httpTypedConfigConsulIntentions `json:"consul-intentions-layer4"`
+type filterHttpTypedConfigPolicies struct {
+	ConsulIntentions filterHttpTypedConfigConsulIntentions `json:"consul-intentions-layer4"`
 }
 
-type httpTypedConfigConsulIntentions struct {
+type filterHttpTypedConfigConsulIntentions struct {
 	Principals []principal `json:"principals"`
 }
 
@@ -219,6 +232,23 @@ type routeMatch struct {
 type routeRoute struct {
 	Cluster string `json:"cluster"`
 }
+
+type filterResponse struct {
+	Filename            string `json:"filename"`
+	InlineBytes         []byte `json:"inline_bytes"`
+	InlineString        string `json:"inline_string"`
+	EnvironmentVariable string `json:"environment_variable"`
+}
+
+type filterGrpcService struct{}
+
+type filterTransportApiVersion struct{}
+
+type filterEnabledMetadata struct{}
+
+type filterTokenBucket struct{}
+
+type filterRuntimeEnabled struct{}
 
 type secretsConfigDump struct {
 	ConfigType            string            `json:"@type"`

--- a/cli/cmd/proxy/read/envoy_types.go
+++ b/cli/cmd/proxy/read/envoy_types.go
@@ -110,25 +110,24 @@ type filter struct {
 	TypedConfig filterTypedConfig `json:"typed_config"`
 }
 
+// Not all filters have all of these values. This is extensive to cover the
+// numerous configuration types for filters.
 type filterTypedConfig struct {
-	Type                       string                    `json:"@type"`
-	Cluster                    string                    `json:"cluster"`
-	RouteConfig                filterRouteConfig         `json:"route_config"`
-	HttpFilters                []httpFilter              `json:"http_filters"`
-	Rules                      filterRules               `json:"rules"`
-	StatPrefix                 string                    `json:"stat_prefix"`
-	MaxConnections             int64                     `json:"max_connections"`
-	Delay                      string                    `json:"delay"`
-	Response                   filterResponse            `json:"reponse"`
-	GrpcService                filterGrpcService         `json:"grpc_service"`
-	FailureModeAllow           bool                      `json:"failure_mode_allow"`
-	IncludePeerCertificate     bool                      `json:"include_peer_certificate"`
-	TransportApiVersion        filterTransportApiVersion `json:"transport_api_version"`
-	FilterEnabledMetadata      filterEnabledMetadata     `json:"filter_enabled_metadata"`
-	BootstrapMetadataLabelsKey string                    `json:"bootstrap_metadata_labels_key"`
-	TokenBucket                filterTokenBucket         `json:"token_bucket"`
-	RuntimeEnabled             filterRuntimeEnabled      `json:"runtime_enabled"`
-	ShareKey                   string                    `json:"share_key"`
+	Type             string                       `json:"@type"`
+	Cluster          string                       `json:"cluster"`
+	RouteConfig      filterRouteConfig            `json:"route_config"`
+	HttpFilters      []httpFilter                 `json:"http_filters"`
+	Rules            filterRules                  `json:"rules"`
+	StatPrefix       string                       `json:"stat_prefix"`
+	MaxConnections   int64                        `json:"max_connections"`
+	Delay            string                       `json:"delay"`
+	Response         filterResponse               `json:"reponse"`
+	GrpcService      filterGrpcService            `json:"grpc_service"`
+	TokenBucket      filterTokenBucket            `json:"token_bucket"`
+	Domain           string                       `json:"domain"`
+	Descriptors      []filterRateLimitDescriptors `json:"descriptors"`
+	FailureModeDeny  bool                         `json:"failure_mode_deny"`
+	RateLimitService filterRateLimitServiceConfig `json:"rate_limit_service"`
 }
 
 type filterRouteConfig struct {
@@ -240,15 +239,43 @@ type filterResponse struct {
 	EnvironmentVariable string `json:"environment_variable"`
 }
 
-type filterGrpcService struct{}
+type filterGrpcService struct {
+	EnvoyGrpc  filterEnvoyGrpc  `json:"envoy_grpc"`
+	GoogleGrpc filterGoogleGrpc `json:"google_grpc"`
+}
 
-type filterTransportApiVersion struct{}
+type filterEnvoyGrpc struct {
+	ClusterName string `json:"cluster_name"`
+}
 
-type filterEnabledMetadata struct{}
+type filterGoogleGrpc struct {
+	TargetUri string `json:"target_uri"`
+}
 
-type filterTokenBucket struct{}
+type filterTokenBucket struct {
+	MaxTokens     int    `json:"max_tokens"`
+	TokensPerFill int    `json:"tokens_per_fill"`
+	FillInterval  string `json:"fill_interval"`
+}
 
-type filterRuntimeEnabled struct{}
+type filterRateLimitDescriptor struct {
+	Entries []filterRateLimitDescriptorEntry `json:"entries"`
+	Limit   filterRateLimitOverride          `json:"limit"`
+}
+
+type filterRateLimitDescriptorEntry struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type filterRateLimitOverride struct {
+	RequestsPerUnit int    `json:"requests_per_unit"`
+	Unit            string `json:"unit"`
+}
+
+type filterRateLimitServiceConfig struct {
+	GrpcService filterGrpcService `json:"grpc_service"`
+}
 
 type secretsConfigDump struct {
 	ConfigType            string            `json:"@type"`

--- a/cli/common/portforward.go
+++ b/cli/common/portforward.go
@@ -103,7 +103,7 @@ func (pf *PortForward) Open(ctx context.Context) (string, error) {
 	case <-ctx.Done():
 		pf.Close()
 		return "", fmt.Errorf("port forward cancelled")
-	case <-time.After(time.Second * 5):
+	case <-time.After(time.Second * 10):
 		pf.Close()
 		return "", fmt.Errorf("port forward timed out")
 	}


### PR DESCRIPTION
Changes proposed in this PR:
- Extend the timeout for port-forward (I was seeing some unneeded failures when connecting to AWS).
- Expand the set of [Envoy Listener Filters](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener_components.proto) that may be parsed and output to the Listeners table.
- Fix [Proxy read: terminating gateway listeners show up weird](https://hashicorp.atlassian.net/browse/NET-707?atlOrigin=eyJpIjoiNGM4OGMzYzhhZDgxNGEzNTlkZDVhNzdjMzllZWYwODAiLCJwIjoiaiJ9)
- Fix [Proxy read: blank filters being displayed](https://hashicorp.atlassian.net/browse/NET-709?atlOrigin=eyJpIjoiMWZiZGY2NTM2ZmZkNDkzNzljN2U0MzZjOTVlNTBiZDciLCJwIjoiaiJ9)
- Change `to` back to `->` in filter formatting output.
- Unescape `>` in JSON output so it doesn't show up weird.

How I've tested this PR:
- Added at least one unit test for each of the filter extensions.
- Tested the code against a terminating gateway to ensure it behaves properly.

How I expect reviewers to test this PR:
- Unit tests
- Testing against a terminating gateway if you like!


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

