### PR TITLE
Enable CRT based security scans

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,14 +1,14 @@
 container {
-	dependencies = false
-	alpine_secdb = false
-	secrets      = false
+	dependencies = true
+	alpine_secdb = true
+	secrets      = true
 }
 
 binary {
-	secrets      = false
-	go_modules   = false
-	osv          = false
-	oss_index    = false
-	nvd          = false
+	secrets      = true
+	go_modules   = true
+	osv          = true
+	oss_index    = true
+	nvd          = true
 }
 


### PR DESCRIPTION
Changes proposed in this PR:
- Enable vulnerability scanning as disabled per: https://github.com/hashicorp/consul-k8s/pull/1160
- At minimum we need binary.osv and binary.go_modules to be true as per https://github.com/hashicorp/security-scanner/issues/278#issuecomment-1222479784. But would like to know how this goes, so we can get ahead of CVEs that are low hanging fruit. 

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

