### PR TITLE
Lint cleanup aug25

### DIFF
--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -2,7 +2,8 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
+
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -109,7 +110,7 @@ func (t *TestConfig) entImage() (string, error) {
 	}
 
 	// Unmarshal values.yaml to current global.image value.
-	valuesContents, err := ioutil.ReadFile(filepath.Join(t.helmChartPath, "values.yaml"))
+	valuesContents, err := os.ReadFile(filepath.Join(t.helmChartPath, "values.yaml"))
 	if err != nil {
 		return "", err
 	}

--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"os"
-
 	"path/filepath"
 	"strconv"
 	"strings"

--- a/acceptance/framework/config/config_test.go
+++ b/acceptance/framework/config/config_test.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+
 	"os"
 	"path/filepath"
 	"testing"
@@ -151,10 +151,10 @@ func TestConfig_HelmValuesFromConfig_EntImage(t *testing.T) {
 			valuesYAML := fmt.Sprintf(`global:
   image: %s
 `, tt.consulImage)
-			tmp, err := ioutil.TempDir("", "")
+			tmp, err := os.MkdirTemp("", "")
 			require.NoError(t, err)
 			defer os.RemoveAll(tmp)
-			require.NoError(t, ioutil.WriteFile(filepath.Join(tmp, "values.yaml"), []byte(valuesYAML), 0644))
+			require.NoError(t, os.WriteFile(filepath.Join(tmp, "values.yaml"), []byte(valuesYAML), 0644))
 
 			cfg := TestConfig{
 				EnableEnterprise: true,

--- a/acceptance/framework/config/config_test.go
+++ b/acceptance/framework/config/config_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-
 	"os"
 	"path/filepath"
 	"testing"

--- a/acceptance/framework/k8s/debug.go
+++ b/acceptance/framework/k8s/debug.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"context"
 	"fmt"
-
 	"os"
 	"path/filepath"
 	"testing"

--- a/acceptance/framework/k8s/debug.go
+++ b/acceptance/framework/k8s/debug.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,7 +46,7 @@ func WritePodsDebugInfoIfFailed(t *testing.T, kubectlOptions *k8s.KubectlOptions
 
 			// Write logs or err to file name <pod.Name>.log
 			logFilename := filepath.Join(testDebugDirectory, fmt.Sprintf("%s.log", pod.Name))
-			require.NoError(t, ioutil.WriteFile(logFilename, []byte(logs), 0600))
+			require.NoError(t, os.WriteFile(logFilename, []byte(logs), 0600))
 
 			// Describe pod and write it to a file.
 			writeResourceInfoToFile(t, pod.Name, "pod", testDebugDirectory, kubectlOptions)
@@ -71,8 +71,8 @@ func WritePodsDebugInfoIfFailed(t *testing.T, kubectlOptions *k8s.KubectlOptions
 			// Write config/clusters or err to file name <pod.Name>-envoy-[configdump/clusters].json
 			configDumpFilename := filepath.Join(testDebugDirectory, fmt.Sprintf("%s-envoy-configdump.json", mpod.Name))
 			clustersFilename := filepath.Join(testDebugDirectory, fmt.Sprintf("%s-envoy-clusters.json", mpod.Name))
-			require.NoError(t, ioutil.WriteFile(configDumpFilename, []byte(configDump), 0600))
-			require.NoError(t, ioutil.WriteFile(clustersFilename, []byte(clusters), 0600))
+			require.NoError(t, os.WriteFile(configDumpFilename, []byte(configDump), 0600))
+			require.NoError(t, os.WriteFile(clustersFilename, []byte(clusters), 0600))
 
 		}
 
@@ -146,5 +146,5 @@ func writeResourceInfoToFile(t *testing.T, resourceName, resourceType, testDebug
 		desc = fmt.Sprintf("Error describing %s/%s: %s: %s", resourceType, resourceType, err, desc)
 	}
 	descFilename := filepath.Join(testDebugDirectory, fmt.Sprintf("%s-%s.txt", resourceName, resourceType))
-	require.NoError(t, ioutil.WriteFile(descFilename, []byte(desc), 0600))
+	require.NoError(t, os.WriteFile(descFilename, []byte(desc), 0600))
 }

--- a/acceptance/framework/suite/suite.go
+++ b/acceptance/framework/suite/suite.go
@@ -3,7 +3,7 @@ package suite
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/consul-k8s/acceptance/framework/config"
@@ -49,7 +49,7 @@ func (s *suite) Run() int {
 	// Create test debug directory if it doesn't exist
 	if s.cfg.DebugDirectory == "" {
 		var err error
-		s.cfg.DebugDirectory, err = ioutil.TempDir("", "consul-test")
+		s.cfg.DebugDirectory, err = os.MkdirTemp("", "consul-test")
 		if err != nil {
 			fmt.Printf("Failed to create debug directory: %s\n", err)
 			return 1

--- a/cli/cmd/proxy/read/filters.go
+++ b/cli/cmd/proxy/read/filters.go
@@ -8,12 +8,12 @@ import (
 // FilterClusters takes a slice of clusters along with parameters for filtering
 // those clusters.
 //
-// - `fqdn` filters clusters to only those with fully qualified domain names
-//   which contain the given value.
-// - `address` filters clusters to only those with endpoint addresses which
-//   contain the given value.
-// - `port` filters clusters to only those with endpoint addresses with ports
-//   that match the given value. If -1 is passed, no filtering will occur.
+//   - `fqdn` filters clusters to only those with fully qualified domain names
+//     which contain the given value.
+//   - `address` filters clusters to only those with endpoint addresses which
+//     contain the given value.
+//   - `port` filters clusters to only those with endpoint addresses with ports
+//     that match the given value. If -1 is passed, no filtering will occur.
 //
 // The filters are applied in combination such that a cluster must adhere to
 // all of the filtering values which are passed in.
@@ -51,10 +51,10 @@ func FilterClusters(clusters []Cluster, fqdn, address string, port int) []Cluste
 // FilterEndpoints takes a slice of endpoints along with parameters for filtering
 // those endpoints:
 //
-// - `address` filters endpoints to only those with an address which contains
-//   the given value.
-// - `port` filters endpoints to only those with an address which has a port
-//   that matches the given value. If -1 is passed, no filtering will occur.
+//   - `address` filters endpoints to only those with an address which contains
+//     the given value.
+//   - `port` filters endpoints to only those with an address which has a port
+//     that matches the given value. If -1 is passed, no filtering will occur.
 //
 // The filters are applied in combination such that an endpoint must adhere to
 // all of the filtering values which are passed in.
@@ -78,10 +78,10 @@ func FilterEndpoints(endpoints []Endpoint, address string, port int) []Endpoint 
 // FilterListeners takes a slice of listeners along with parameters for filtering
 // those endpoints:
 //
-// - `address` filters listeners to only those with an address which contains
-//   the given value.
-// - `port` filters listeners to only those with an address which has a port
-//   that matches the given value. If -1 is passed, no filtering will occur.
+//   - `address` filters listeners to only those with an address which contains
+//     the given value.
+//   - `port` filters listeners to only those with an address which has a port
+//     that matches the given value. If -1 is passed, no filtering will occur.
 //
 // The filters are applied in combination such that an listener must adhere to
 // all of the filtering values which are passed in.

--- a/cli/common/flag/set.go
+++ b/cli/common/flag/set.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/posener/complete"
@@ -34,7 +33,7 @@ func NewSets() *Sets {
 	// Errors and usage are expected to be controlled externally by
 	// checking on the result of Parse.
 	unionSet.Usage = func() {}
-	unionSet.SetOutput(ioutil.Discard)
+	unionSet.SetOutput(io.Discard)
 
 	return &Sets{
 		unionSet:    unionSet,

--- a/cli/helm/chart_test.go
+++ b/cli/helm/chart_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 // Embed a test chart to test against.
+//
 //go:embed test_fixtures/consul/* test_fixtures/consul/templates/_helpers.tpl
 var testChartFiles embed.FS
 

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -1830,13 +1830,14 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 
 // Tests updating an Endpoints object.
 //   - Tests updates via the register codepath:
-//     - When an address in an Endpoint is updated, that the corresponding service instance in Consul is updated.
-//     - When an address is added to an Endpoint, an additional service instance in Consul is registered.
-//     - When an address in an Endpoint is updated - via health check change - the corresponding service instance is updated.
+//   - When an address in an Endpoint is updated, that the corresponding service instance in Consul is updated.
+//   - When an address is added to an Endpoint, an additional service instance in Consul is registered.
+//   - When an address in an Endpoint is updated - via health check change - the corresponding service instance is updated.
 //   - Tests updates via the deregister codepath:
-//     - When an address is removed from an Endpoint, the corresponding service instance in Consul is deregistered.
-//     - When an address is removed from an Endpoint *and there are no addresses left in the Endpoint*, the
+//   - When an address is removed from an Endpoint, the corresponding service instance in Consul is deregistered.
+//   - When an address is removed from an Endpoint *and there are no addresses left in the Endpoint*, the
 //     corresponding service instance in Consul is deregistered.
+//
 // For the register and deregister codepath, this also tests that they work when the Consul service name is different
 // from the K8s service name.
 // This test covers EndpointsController.deregisterServiceOnAllAgents when services should be selectively deregistered

--- a/control-plane/connect-inject/health_checks_test.go
+++ b/control-plane/connect-inject/health_checks_test.go
@@ -1,10 +1,11 @@
 package connectinject
 
 import (
-	"github.com/stretchr/testify/require"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestReady(t *testing.T) {
@@ -26,14 +27,14 @@ func TestReady(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", "")
+			tmpDir, err := os.MkdirTemp("", "")
 			require.NoError(t, err)
 			if tt.certFileContents != nil {
-				err := ioutil.WriteFile(filepath.Join(tmpDir, "tls.crt"), []byte(*tt.certFileContents), 0666)
+				err := os.WriteFile(filepath.Join(tmpDir, "tls.crt"), []byte(*tt.certFileContents), 0666)
 				require.NoError(t, err)
 			}
 			if tt.keyFileContents != nil {
-				err := ioutil.WriteFile(filepath.Join(tmpDir, "tls.key"), []byte(*tt.keyFileContents), 0666)
+				err := os.WriteFile(filepath.Join(tmpDir, "tls.key"), []byte(*tt.keyFileContents), 0666)
 				require.NoError(t, err)
 			}
 			rc := ReadinessCheck{tmpDir}

--- a/control-plane/connect-inject/peering_acceptor_controller.go
+++ b/control-plane/connect-inject/peering_acceptor_controller.go
@@ -56,11 +56,11 @@ const (
 // move the current state of the cluster closer to the desired state.
 // PeeringAcceptor resources determine whether to generate a new peering token in Consul and store it in the backend
 // specified in the spec.
-// - If the resource doesn't exist, the peering should be deleted in Consul.
-// - If the resource exists, and a peering doesn't exist in Consul, it should be created.
-// - If the resource exists, and a peering does exist in Consul, it should be reconciled.
-// - If the status of the resource does not match the current state of the specified secret, generate a new token
-//   and store it according to the spec.
+//   - If the resource doesn't exist, the peering should be deleted in Consul.
+//   - If the resource exists, and a peering doesn't exist in Consul, it should be created.
+//   - If the resource exists, and a peering does exist in Consul, it should be reconciled.
+//   - If the status of the resource does not match the current state of the specified secret, generate a new token
+//     and store it according to the spec.
 //
 // NOTE: It is possible that Reconcile is called multiple times concurrently because we're watching
 // two different resource kinds. As a result, we need to make sure that the code in this method

--- a/control-plane/helper/cert/source_gen_test.go
+++ b/control-plane/helper/cert/source_gen_test.go
@@ -2,7 +2,6 @@ package cert
 
 import (
 	"context"
-
 	"os"
 	"os/exec"
 	"path/filepath"

--- a/control-plane/helper/cert/source_gen_test.go
+++ b/control-plane/helper/cert/source_gen_test.go
@@ -2,7 +2,7 @@ package cert
 
 import (
 	"context"
-	"io/ioutil"
+
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -78,15 +78,15 @@ func testGenSource() *GenSource {
 func testBundleDir(t *testing.T, bundle *Bundle, dir string) string {
 	if dir == "" {
 		// Create a temporary directory for storing the certs
-		td, err := ioutil.TempDir("", "consul")
+		td, err := os.MkdirTemp("", "consul")
 		require.NoError(t, err)
 		dir = td
 	}
 
 	// Write the cert
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "ca.pem"), bundle.CACert, 0644))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "leaf.pem"), bundle.Cert, 0644))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "leaf.key.pem"), bundle.Key, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ca.pem"), bundle.CACert, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "leaf.pem"), bundle.Cert, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "leaf.key.pem"), bundle.Key, 0644))
 
 	return dir
 }

--- a/control-plane/helper/test/test_util.go
+++ b/control-plane/helper/test/test_util.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -26,13 +25,13 @@ const (
 func GenerateServerCerts(t *testing.T) (string, string, string) {
 	require := require.New(t)
 
-	caFile, err := ioutil.TempFile("", "ca")
+	caFile, err := os.CreateTemp("", "ca")
 	require.NoError(err)
 
-	certFile, err := ioutil.TempFile("", "cert")
+	certFile, err := os.CreateTemp("", "cert")
 	require.NoError(err)
 
-	certKeyFile, err := ioutil.TempFile("", "key")
+	certKeyFile, err := os.CreateTemp("", "key")
 	require.NoError(err)
 
 	// Generate CA

--- a/control-plane/subcommand/acl-init/command.go
+++ b/control-plane/subcommand/acl-init/command.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -237,7 +237,7 @@ func (c *Command) Run(args []string) int {
 		// Write the data out as a file.
 		// Must be 0644 because this is written by the consul-k8s user but needs
 		// to be readable by the consul user.
-		err = ioutil.WriteFile(filepath.Join(c.flagACLDir, "acl-config.json"), buf.Bytes(), 0644)
+		err = os.WriteFile(filepath.Join(c.flagACLDir, "acl-config.json"), buf.Bytes(), 0644)
 		if err != nil {
 			c.logger.Error("Error writing config file", "error", err)
 			return 1
@@ -247,7 +247,7 @@ func (c *Command) Run(args []string) int {
 	if c.flagTokenSinkFile != "" {
 		// Must be 0600 in case this command is re-run. In that case we need
 		// to have permissions to overwrite our file.
-		err := ioutil.WriteFile(c.flagTokenSinkFile, []byte(secret), 0600)
+		err := os.WriteFile(c.flagTokenSinkFile, []byte(secret), 0600)
 		if err != nil {
 			c.logger.Error("Error writing token to file", "file", c.flagTokenSinkFile, "error", err)
 			return 1

--- a/control-plane/subcommand/acl-init/command_test.go
+++ b/control-plane/subcommand/acl-init/command_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-
 	"os"
 	"path/filepath"
 	"strings"

--- a/control-plane/subcommand/acl-init/command_test.go
+++ b/control-plane/subcommand/acl-init/command_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,7 +54,7 @@ func TestRun_FlagValidation(t *testing.T) {
 func TestRun_TokenSinkFile(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	require.NoError(err)
 	defer os.RemoveAll(tmpDir)
 
@@ -90,7 +90,7 @@ func TestRun_TokenSinkFile(t *testing.T) {
 		"-consul-api-timeout", "5s",
 	})
 	require.Equal(0, code, ui.ErrorWriter.String())
-	bytes, err := ioutil.ReadFile(sinkFile)
+	bytes, err := os.ReadFile(sinkFile)
 	require.NoError(err)
 	require.Equal(token, string(bytes), "exp: %s, got: %s", token, string(bytes))
 }
@@ -140,7 +140,7 @@ func TestRun_TokenSinkFileErr(t *testing.T) {
 func TestRun_TokenSinkFileTwice(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	require.NoError(err)
 	defer os.RemoveAll(tmpDir)
 
@@ -180,7 +180,7 @@ func TestRun_TokenSinkFileTwice(t *testing.T) {
 		})
 		require.Equal(0, code, ui.ErrorWriter.String())
 
-		bytes, err := ioutil.ReadFile(sinkFile)
+		bytes, err := os.ReadFile(sinkFile)
 		require.NoError(err)
 		require.Equal(token, string(bytes), "exp: %s, got: %s", token, string(bytes))
 	}
@@ -233,7 +233,7 @@ func TestRun_PerformsConsulLogin(t *testing.T) {
 	})
 	require.Equal(t, 0, code, ui.ErrorWriter.String())
 	// Validate the Token got written.
-	tokenBytes, err := ioutil.ReadFile(tokenFile)
+	tokenBytes, err := os.ReadFile(tokenFile)
 	require.NoError(t, err)
 	require.Equal(t, 36, len(tokenBytes))
 	// Validate the Token and its Description.
@@ -248,7 +248,7 @@ func TestRun_PerformsConsulLogin(t *testing.T) {
 func TestRun_WithAclAuthMethodDefined_WritesConfigJson_WithTokenMatchingSinkFile(t *testing.T) {
 	tokenFile := common.WriteTempFile(t, "")
 	bearerFile := common.WriteTempFile(t, test.ServiceAccountJWTToken)
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.Remove(tokenFile)
@@ -298,10 +298,10 @@ func TestRun_WithAclAuthMethodDefined_WritesConfigJson_WithTokenMatchingSinkFile
 	})
 	require.Equal(t, 0, code, ui.ErrorWriter.String())
 	// Validate the ACL Config file got written.
-	aclConfigBytes, err := ioutil.ReadFile(fmt.Sprintf("%s/acl-config.json", tmpDir))
+	aclConfigBytes, err := os.ReadFile(fmt.Sprintf("%s/acl-config.json", tmpDir))
 	require.NoError(t, err)
 	// Validate the Token Sink File got written.
-	sinkFileToken, err := ioutil.ReadFile(tokenFile)
+	sinkFileToken, err := os.ReadFile(tokenFile)
 	require.NoError(t, err)
 	// Validate the Token Sink File Matches the ACL Cconfig Token by injecting
 	// the token secret into the template used by the ACL config file.
@@ -320,7 +320,7 @@ func TestRun_WithAclAuthMethodDefined_WritesConfigJson_WithTokenMatchingSinkFile
 func TestRun_WithoutAclAuthMethodDefined_WritesConfigJsonWithTokenMatchingSinkFile(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	require.NoError(err)
 
 	t.Cleanup(func() {
@@ -361,11 +361,11 @@ func TestRun_WithoutAclAuthMethodDefined_WritesConfigJsonWithTokenMatchingSinkFi
 		"-consul-api-timeout", "5s",
 	})
 	// Validate the ACL Config file got written.
-	aclConfigBytes, err := ioutil.ReadFile(fmt.Sprintf("%s/acl-config.json", tmpDir))
+	aclConfigBytes, err := os.ReadFile(fmt.Sprintf("%s/acl-config.json", tmpDir))
 	require.NoError(err)
 	// Validate the Token Sink File got written.
 	require.Equal(0, code, ui.ErrorWriter.String())
-	sinkFileToken, err := ioutil.ReadFile(sinkFile)
+	sinkFileToken, err := os.ReadFile(sinkFile)
 	require.NoError(err)
 	// Validate the Token Sink File Matches the ACL Cconfig Token by injecting
 	// the token secret into the template used by the ACL config file.

--- a/control-plane/subcommand/common/common.go
+++ b/control-plane/subcommand/common/common.go
@@ -3,7 +3,6 @@ package common
 
 import (
 	"fmt"
-
 	"os"
 	"strconv"
 	"strings"

--- a/control-plane/subcommand/common/common.go
+++ b/control-plane/subcommand/common/common.go
@@ -3,7 +3,7 @@ package common
 
 import (
 	"fmt"
-	"io/ioutil"
+
 	"os"
 	"strconv"
 	"strings"
@@ -108,7 +108,7 @@ type LoginParams struct {
 // The logic of this is taken from the `consul login` command.
 func ConsulLogin(client *api.Client, params LoginParams, log hclog.Logger) (string, error) {
 	// Read the bearerTokenFile.
-	data, err := ioutil.ReadFile(params.BearerTokenFile)
+	data, err := os.ReadFile(params.BearerTokenFile)
 	if err != nil {
 		return "", fmt.Errorf("unable to read bearer token file: %v, err: %v", params.BearerTokenFile, err)
 	}
@@ -198,7 +198,7 @@ func ConsulLogin(client *api.Client, params LoginParams, log hclog.Logger) (stri
 	return token.SecretID, nil
 }
 
-// WriteFileWithPerms will write payload as the contents of the outputFile and set permissions after writing the contents. This function is necessary since using ioutil.WriteFile() alone will create the new file with the requested permissions prior to actually writing the file, so you can't set read-only permissions.
+// WriteFileWithPerms will write payload as the contents of the outputFile and set permissions after writing the contents. This function is necessary since using os.WriteFile() alone will create the new file with the requested permissions prior to actually writing the file, so you can't set read-only permissions.
 func WriteFileWithPerms(outputFile, payload string, mode os.FileMode) error {
 	// os.WriteFile truncates existing files and overwrites them, but only if they are writable.
 	// If the file exists it will already likely be read-only. Remove it first.
@@ -207,7 +207,7 @@ func WriteFileWithPerms(outputFile, payload string, mode os.FileMode) error {
 			return fmt.Errorf("unable to delete existing file: %s", err)
 		}
 	}
-	if err := ioutil.WriteFile(outputFile, []byte(payload), os.ModePerm); err != nil {
+	if err := os.WriteFile(outputFile, []byte(payload), os.ModePerm); err != nil {
 		return fmt.Errorf("unable to write file: %s", err)
 	}
 	return os.Chmod(outputFile, mode)

--- a/control-plane/subcommand/common/common_test.go
+++ b/control-plane/subcommand/common/common_test.go
@@ -2,7 +2,7 @@ package common
 
 import (
 	"fmt"
-	"io/ioutil"
+
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -71,7 +71,7 @@ func TestConsulLogin(t *testing.T) {
 	_, err = ConsulLogin(client, params, log)
 	require.NoError(t, err)
 	// Validate that the token file was written to disk.
-	data, err := ioutil.ReadFile(tokenFile)
+	data, err := os.ReadFile(tokenFile)
 	require.NoError(t, err)
 	require.Equal(t, string(data), "b78d37c7-0ca7-5f4d-99ee-6d9975ce4586")
 }
@@ -119,7 +119,7 @@ func TestConsulLogin_Retries(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, numLoginCalls)
 	// Validate that the token file was written to disk.
-	data, err := ioutil.ReadFile(tokenFile)
+	data, err := os.ReadFile(tokenFile)
 	require.NoError(t, err)
 	require.Equal(t, string(data), "b78d37c7-0ca7-5f4d-99ee-6d9975ce4586")
 }
@@ -221,7 +221,7 @@ func TestWriteFileWithPerms_OutputFileExists(t *testing.T) {
 	t.Parallel()
 	rand.Seed(time.Now().UnixNano())
 	randFileName := fmt.Sprintf("/tmp/%d", rand.Int())
-	err := ioutil.WriteFile(randFileName, []byte("foo"), os.FileMode(0444))
+	err := os.WriteFile(randFileName, []byte("foo"), os.FileMode(0444))
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.Remove(randFileName)
@@ -229,7 +229,7 @@ func TestWriteFileWithPerms_OutputFileExists(t *testing.T) {
 	payload := "abcd"
 	err = WriteFileWithPerms(randFileName, payload, os.FileMode(0444))
 	require.NoError(t, err)
-	data, err := ioutil.ReadFile(randFileName)
+	data, err := os.ReadFile(randFileName)
 	require.NoError(t, err)
 	require.Equal(t, payload, string(data))
 }
@@ -252,7 +252,7 @@ func TestWriteFileWithPerms(t *testing.T) {
 	require.Equal(t, file.Mode(), mode)
 	require.Equal(t, file.Size(), int64(len(payload)))
 	// Validate the data was written correctly.
-	data, err := ioutil.ReadFile(randFileName)
+	data, err := os.ReadFile(randFileName)
 	require.NoError(t, err)
 	require.Equal(t, payload, string(data))
 }

--- a/control-plane/subcommand/common/common_test.go
+++ b/control-plane/subcommand/common/common_test.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-
 	"math/rand"
 	"net/http"
 	"net/http/httptest"

--- a/control-plane/subcommand/common/test_util.go
+++ b/control-plane/subcommand/common/test_util.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 // name. It will remove the file once the test completes.
 func WriteTempFile(t *testing.T, contents string) string {
 	t.Helper()
-	file, err := ioutil.TempFile("", "testName")
+	file, err := os.CreateTemp("", "testName")
 	require.NoError(t, err)
 	_, err = file.WriteString(contents)
 	require.NoError(t, err)

--- a/control-plane/subcommand/connect-init/command_ent_test.go
+++ b/control-plane/subcommand/connect-init/command_ent_test.go
@@ -4,7 +4,6 @@ package connectinit
 
 import (
 	"fmt"
-
 	"math/rand"
 	"os"
 	"testing"

--- a/control-plane/subcommand/connect-init/command_ent_test.go
+++ b/control-plane/subcommand/connect-init/command_ent_test.go
@@ -4,7 +4,7 @@ package connectinit
 
 import (
 	"fmt"
-	"io/ioutil"
+
 	"math/rand"
 	"os"
 	"testing"
@@ -211,7 +211,7 @@ func TestRun_ServicePollingWithACLsAndTLSWithNamespaces(t *testing.T) {
 
 			if c.acls {
 				// Validate the ACL token was written.
-				tokenData, err := ioutil.ReadFile(tokenFile)
+				tokenData, err := os.ReadFile(tokenFile)
 				require.NoError(t, err)
 				require.NotEmpty(t, tokenData)
 
@@ -224,7 +224,7 @@ func TestRun_ServicePollingWithACLsAndTLSWithNamespaces(t *testing.T) {
 			}
 
 			// Validate contents of proxyFile.
-			data, err := ioutil.ReadFile(proxyFile)
+			data, err := os.ReadFile(proxyFile)
 			require.NoError(t, err)
 			require.Contains(t, string(data), "counting-counting-sidecar-proxy")
 		})

--- a/control-plane/subcommand/connect-init/command_test.go
+++ b/control-plane/subcommand/connect-init/command_test.go
@@ -2,7 +2,6 @@ package connectinit
 
 import (
 	"fmt"
-
 	"math/rand"
 	"net/http"
 	"net/http/httptest"

--- a/control-plane/subcommand/connect-init/command_test.go
+++ b/control-plane/subcommand/connect-init/command_test.go
@@ -2,7 +2,7 @@ package connectinit
 
 import (
 	"fmt"
-	"io/ioutil"
+
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -218,7 +218,7 @@ func TestRun_ServicePollingWithACLsAndTLS(t *testing.T) {
 			require.Equal(t, 0, code, ui.ErrorWriter.String())
 
 			// Validate the ACL token was written.
-			tokenData, err := ioutil.ReadFile(tokenFile)
+			tokenData, err := os.ReadFile(tokenFile)
 			require.NoError(t, err)
 			require.NotEmpty(t, tokenData)
 
@@ -230,7 +230,7 @@ func TestRun_ServicePollingWithACLsAndTLS(t *testing.T) {
 			require.Equal(t, "token created via login: {\"pod\":\"default-ns/counting-pod\"}", token.Description)
 
 			// Validate contents of proxyFile.
-			data, err := ioutil.ReadFile(proxyFile)
+			data, err := os.ReadFile(proxyFile)
 			require.NoError(t, err)
 			if tt.multiport {
 				require.Contains(t, string(data), "counting-admin-sidecar-proxy-id")
@@ -340,7 +340,7 @@ func TestRun_ServicePollingOnly(t *testing.T) {
 			require.Equal(t, 0, code, ui.ErrorWriter.String())
 
 			// Validate contents of proxyFile.
-			data, err := ioutil.ReadFile(proxyFile)
+			data, err := os.ReadFile(proxyFile)
 			require.NoError(t, err)
 			if tt.multiport {
 				require.Contains(t, string(data), "counting-admin-sidecar-proxy-id")
@@ -576,7 +576,7 @@ func TestRun_RetryServicePolling(t *testing.T) {
 	require.Equal(t, 0, code)
 
 	// Validate contents of proxyFile.
-	data, err := ioutil.ReadFile(proxyFile)
+	data, err := os.ReadFile(proxyFile)
 	require.NoError(t, err)
 	require.Contains(t, string(data), "counting-counting-sidecar-proxy")
 }
@@ -766,11 +766,11 @@ func TestRun_LoginWithRetries(t *testing.T) {
 			// Cmd will return 1 after numACLLoginRetries, so bound LoginAttemptsCount if we exceeded it.
 			require.Equal(t, c.LoginAttemptsCount, counter)
 			// Validate that the token was written to disk if we succeeded.
-			tokenData, err := ioutil.ReadFile(tokenFile)
+			tokenData, err := os.ReadFile(tokenFile)
 			require.NoError(t, err)
 			require.Equal(t, "b78d37c7-0ca7-5f4d-99ee-6d9975ce4586", string(tokenData))
 			// Validate contents of proxyFile.
-			proxydata, err := ioutil.ReadFile(proxyFile)
+			proxydata, err := os.ReadFile(proxyFile)
 			require.NoError(t, err)
 			require.Equal(t, "counting-counting-sidecar-proxy", string(proxydata))
 		})

--- a/control-plane/subcommand/consul-sidecar/command.go
+++ b/control-plane/subcommand/consul-sidecar/command.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -285,7 +285,7 @@ func (c *Command) mergedMetricsHandler(rw http.ResponseWriter, _ *http.Request) 
 			c.logger.Error(fmt.Sprintf("Error closing envoy metrics body: %s", err.Error()))
 		}
 	}()
-	envoyMetricsBody, err := ioutil.ReadAll(envoyMetrics.Body)
+	envoyMetricsBody, err := io.ReadAll(envoyMetrics.Body)
 	if err != nil {
 		c.logger.Error("Could not read Envoy proxy metrics", "err", err)
 		http.Error(rw, fmt.Sprintf("Could not read Envoy proxy metrics: %s", err), http.StatusInternalServerError)
@@ -316,7 +316,7 @@ func (c *Command) mergedMetricsHandler(rw http.ResponseWriter, _ *http.Request) 
 			c.logger.Error(fmt.Sprintf("Error closing service metrics body: %s", err.Error()))
 		}
 	}()
-	serviceMetricsBody, err := ioutil.ReadAll(serviceMetrics.Body)
+	serviceMetricsBody, err := io.ReadAll(serviceMetrics.Body)
 	if err != nil {
 		c.logger.Error("Could not read service metrics", "err", err)
 		writeResponse(rw, serviceMetricSuccess(false), "service metrics success", c.logger)

--- a/control-plane/subcommand/controller/command.go
+++ b/control-plane/subcommand/controller/command.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sync"
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/common"
@@ -365,7 +365,7 @@ func (c *Command) updateWebhookCABundle() error {
 
 	webhookConfigName := fmt.Sprintf("%s-controller", c.flagResourcePrefix)
 	caPath := fmt.Sprintf("%s/%s", c.flagWebhookTLSCertDir, WebhookCAFilename)
-	caCert, err := ioutil.ReadFile(caPath)
+	caCert, err := os.ReadFile(caPath)
 	if err != nil {
 		return err
 	}

--- a/control-plane/subcommand/create-federation-secret/command.go
+++ b/control-plane/subcommand/create-federation-secret/command.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -137,7 +137,7 @@ func (c *Command) Run(args []string) int {
 	// Add gossip encryption key if it exists.
 	if c.flagGossipKeyFile != "" {
 		logger.Info("Retrieving gossip encryption key data")
-		gossipKey, err := ioutil.ReadFile(c.flagGossipKeyFile)
+		gossipKey, err := os.ReadFile(c.flagGossipKeyFile)
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error reading gossip encryption key file: %s", err))
 			return 1
@@ -152,7 +152,7 @@ func (c *Command) Run(args []string) int {
 
 	// Add server CA cert.
 	logger.Info("Retrieving server CA cert data")
-	caCert, err := ioutil.ReadFile(c.flagServerCACertFile)
+	caCert, err := os.ReadFile(c.flagServerCACertFile)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error reading server CA cert file: %s", err))
 		return 1
@@ -162,7 +162,7 @@ func (c *Command) Run(args []string) int {
 
 	// Add server CA key.
 	logger.Info("Retrieving server CA key data")
-	caKey, err := ioutil.ReadFile(c.flagServerCAKeyFile)
+	caKey, err := os.ReadFile(c.flagServerCAKeyFile)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error reading server CA key file: %s", err))
 		return 1
@@ -432,7 +432,7 @@ func (c *Command) validateCAFileFlag() error {
 	if cfg.TLSConfig.CAFile == "" {
 		return errors.New("-ca-file or CONSUL_CACERT must be set")
 	}
-	_, err := ioutil.ReadFile(cfg.TLSConfig.CAFile)
+	_, err := os.ReadFile(cfg.TLSConfig.CAFile)
 	if err != nil {
 		return fmt.Errorf("error reading CA file: %s", err)
 	}

--- a/control-plane/subcommand/create-federation-secret/command_test.go
+++ b/control-plane/subcommand/create-federation-secret/command_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
 	"os"
 	"strconv"
 	"strings"

--- a/control-plane/subcommand/create-federation-secret/command_test.go
+++ b/control-plane/subcommand/create-federation-secret/command_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+
 	"os"
 	"strconv"
 	"strings"
@@ -27,7 +27,7 @@ import (
 
 func TestRun_FlagValidation(t *testing.T) {
 	t.Parallel()
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 
@@ -100,7 +100,7 @@ func TestRun_FlagValidation(t *testing.T) {
 
 func TestRun_CAFileMissing(t *testing.T) {
 	t.Parallel()
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 
@@ -123,7 +123,7 @@ func TestRun_CAFileMissing(t *testing.T) {
 
 func TestRun_ServerCACertFileMissing(t *testing.T) {
 	t.Parallel()
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 
@@ -146,7 +146,7 @@ func TestRun_ServerCACertFileMissing(t *testing.T) {
 
 func TestRun_ServerCAKeyFileMissing(t *testing.T) {
 	t.Parallel()
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 
@@ -169,7 +169,7 @@ func TestRun_ServerCAKeyFileMissing(t *testing.T) {
 
 func TestRun_GossipEncryptionKeyFileMissing(t *testing.T) {
 	t.Parallel()
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 
@@ -193,7 +193,7 @@ func TestRun_GossipEncryptionKeyFileMissing(t *testing.T) {
 
 func TestRun_GossipEncryptionKeyFileEmpty(t *testing.T) {
 	t.Parallel()
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 
@@ -219,7 +219,7 @@ func TestRun_GossipEncryptionKeyFileEmpty(t *testing.T) {
 // token key, we return error.
 func TestRun_ReplicationTokenMissingExpectedKey(t *testing.T) {
 	t.Parallel()
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 
@@ -425,9 +425,9 @@ func TestRun_ACLs_K8SNamespaces_ResourcePrefixes(tt *testing.T) {
 			gossipEncryptionKey := "oGaLv60gQ0E+Uvn+Lokz9APjbu5fJaYx7kglOmg4jZc="
 			var gossipKeyFile string
 			if c.gossipKey {
-				f, err := ioutil.TempFile("", "")
+				f, err := os.CreateTemp("", "")
 				require.NoError(t, err)
-				err = ioutil.WriteFile(f.Name(), []byte(gossipEncryptionKey), 0644)
+				err = os.WriteFile(f.Name(), []byte(gossipEncryptionKey), 0644)
 				require.NoError(t, err)
 				gossipKeyFile = f.Name()
 			}
@@ -463,13 +463,13 @@ func TestRun_ACLs_K8SNamespaces_ResourcePrefixes(tt *testing.T) {
 
 			// CA Cert
 			require.Contains(t, secret.Data, "caCert")
-			caFileBytes, err := ioutil.ReadFile(caFile)
+			caFileBytes, err := os.ReadFile(caFile)
 			require.NoError(t, err)
 			require.Equal(t, string(caFileBytes), string(secret.Data["caCert"]))
 
 			// CA Key
 			require.Contains(t, secret.Data, "caKey")
-			keyFileBytes, err := ioutil.ReadFile(keyFile)
+			keyFileBytes, err := os.ReadFile(keyFile)
 			require.NoError(t, err)
 			require.Equal(t, string(keyFileBytes), string(secret.Data["caKey"]))
 
@@ -1119,7 +1119,7 @@ func TestRun_Autoencrypt(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Contains(t, secret.Data, "caCert")
-	keyFileBytes, err := ioutil.ReadFile(keyFile)
+	keyFileBytes, err := os.ReadFile(keyFile)
 	require.NoError(t, err)
 	require.Equal(t, string(keyFileBytes), string(secret.Data["caCert"]))
 }

--- a/control-plane/subcommand/flags/http.go
+++ b/control-plane/subcommand/flags/http.go
@@ -2,7 +2,7 @@ package flags
 
 import (
 	"flag"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -96,7 +96,7 @@ func (f *HTTPFlags) ReadTokenFile() (string, error) {
 		return "", nil
 	}
 
-	data, err := ioutil.ReadFile(tokenFile)
+	data, err := os.ReadFile(tokenFile)
 	if err != nil {
 		return "", err
 	}

--- a/control-plane/subcommand/get-consul-client-ca/command.go
+++ b/control-plane/subcommand/get-consul-client-ca/command.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -111,7 +111,7 @@ func (c *Command) Run(args []string) int {
 		return nil
 	}, backoff.NewConstantBackOff(1*time.Second))
 
-	err = ioutil.WriteFile(c.flagOutputFile, []byte(activeRoot), 0644)
+	err = os.WriteFile(c.flagOutputFile, []byte(activeRoot), 0644)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error writing CA file: %s", err))
 		return 1
@@ -154,11 +154,11 @@ func (c *Command) consulClient(logger hclog.Logger) (*api.Client, error) {
 // consulServerAddr returns the consul server address
 // as a string in the <server_ip_or_dns_name>:<server_port> format.
 //
-// 1. If the server address is a cloud auto-join URL,
-//    it calls go-discover library to discover server addresses,
-//    picks the first address from the list and uses the provided port.
-// 2. Otherwise, it uses the address provided by the -server-addr
-//    and the -server-port flags.
+//  1. If the server address is a cloud auto-join URL,
+//     it calls go-discover library to discover server addresses,
+//     picks the first address from the list and uses the provided port.
+//  2. Otherwise, it uses the address provided by the -server-addr
+//     and the -server-port flags.
 func (c *Command) consulServerAddr(logger hclog.Logger) (string, error) {
 
 	// First, check if the server address is a cloud auto-join string.

--- a/control-plane/subcommand/get-consul-client-ca/command_test.go
+++ b/control-plane/subcommand/get-consul-client-ca/command_test.go
@@ -2,7 +2,7 @@ package getconsulclientca
 
 import (
 	"fmt"
-	"io/ioutil"
+
 	"os"
 	"strings"
 	"sync"
@@ -75,7 +75,7 @@ func TestRun_FlagsValidation(t *testing.T) {
 // write it to a file.
 func TestRun(t *testing.T) {
 	t.Parallel()
-	outputFile, err := ioutil.TempFile("", "ca")
+	outputFile, err := os.CreateTemp("", "ca")
 	require.NoError(t, err)
 	defer os.Remove(outputFile.Name())
 
@@ -128,7 +128,7 @@ func TestRun(t *testing.T) {
 	expectedCARoot := roots.Roots[0].RootCertPEM
 
 	// read the file contents
-	actualCARoot, err := ioutil.ReadFile(outputFile.Name())
+	actualCARoot, err := os.ReadFile(outputFile.Name())
 	require.NoError(t, err)
 	require.Equal(t, expectedCARoot, string(actualCARoot))
 }
@@ -137,7 +137,7 @@ func TestRun(t *testing.T) {
 // we continue to poll it until it comes up.
 func TestRun_ConsulServerAvailableLater(t *testing.T) {
 	t.Parallel()
-	outputFile, err := ioutil.TempFile("", "ca")
+	outputFile, err := os.CreateTemp("", "ca")
 	require.NoError(t, err)
 	defer os.Remove(outputFile.Name())
 
@@ -214,7 +214,7 @@ func TestRun_ConsulServerAvailableLater(t *testing.T) {
 	})
 
 	// check that the file contents match the actual CA
-	actualCARoot, err := ioutil.ReadFile(outputFile.Name())
+	actualCARoot, err := os.ReadFile(outputFile.Name())
 	require.NoError(t, err)
 	require.Equal(t, expectedCARoot, string(actualCARoot))
 }
@@ -224,7 +224,7 @@ func TestRun_ConsulServerAvailableLater(t *testing.T) {
 // the inactive one.
 func TestRun_GetsOnlyActiveRoot(t *testing.T) {
 	t.Parallel()
-	outputFile, err := ioutil.TempFile("", "ca")
+	outputFile, err := os.CreateTemp("", "ca")
 	require.NoError(t, err)
 	defer os.Remove(outputFile.Name())
 
@@ -298,7 +298,7 @@ func TestRun_GetsOnlyActiveRoot(t *testing.T) {
 	})
 
 	// read the file contents
-	actualCARoot, err := ioutil.ReadFile(outputFile.Name())
+	actualCARoot, err := os.ReadFile(outputFile.Name())
 	require.NoError(t, err)
 	require.Equal(t, expectedCARoot, string(actualCARoot))
 }
@@ -307,7 +307,7 @@ func TestRun_GetsOnlyActiveRoot(t *testing.T) {
 // it uses the provider to get the address of the server.
 func TestRun_WithProvider(t *testing.T) {
 	t.Parallel()
-	outputFile, err := ioutil.TempFile("", "ca")
+	outputFile, err := os.CreateTemp("", "ca")
 	require.NoError(t, err)
 	defer os.Remove(outputFile.Name())
 
@@ -372,7 +372,7 @@ func TestRun_WithProvider(t *testing.T) {
 	expectedCARoot := roots.Roots[0].RootCertPEM
 
 	// read the file contents
-	actualCARoot, err := ioutil.ReadFile(outputFile.Name())
+	actualCARoot, err := os.ReadFile(outputFile.Name())
 	require.NoError(t, err)
 	require.Equal(t, expectedCARoot, string(actualCARoot))
 }

--- a/control-plane/subcommand/get-consul-client-ca/command_test.go
+++ b/control-plane/subcommand/get-consul-client-ca/command_test.go
@@ -2,7 +2,6 @@ package getconsulclientca
 
 import (
 	"fmt"
-
 	"os"
 	"strings"
 	"sync"

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -345,7 +345,7 @@ func (c *Command) Run(args []string) int {
 	var consulCACert []byte
 	if cfg.TLSConfig.CAFile != "" {
 		var err error
-		consulCACert, err = ioutil.ReadFile(cfg.TLSConfig.CAFile)
+		consulCACert, err = os.ReadFile(cfg.TLSConfig.CAFile)
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("error reading Consul's CA cert file %q: %s", cfg.TLSConfig.CAFile, err))
 			return 1
@@ -545,7 +545,7 @@ func (c *Command) Run(args []string) int {
 func (c *Command) updateWebhookCABundle(ctx context.Context) error {
 	webhookConfigName := fmt.Sprintf("%s-connect-injector", c.flagResourcePrefix)
 	caPath := fmt.Sprintf("%s/%s", c.flagCertDir, WebhookCAFilename)
-	caCert, err := ioutil.ReadFile(caPath)
+	caCert, err := os.ReadFile(caPath)
 	if err != nil {
 		return err
 	}

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -988,7 +988,7 @@ func (c *Command) validateFlags() error {
 
 func loadTokenFromFile(tokenFile string) (string, error) {
 	// Load the bootstrap token from file.
-	tokenBytes, err := ioutil.ReadFile(tokenFile)
+	tokenBytes, err := os.ReadFile(tokenFile)
 	if err != nil {
 		return "", fmt.Errorf("unable to read token from file %q: %s", tokenFile, err)
 	}

--- a/control-plane/subcommand/server-acl-init/command_ent_test.go
+++ b/control-plane/subcommand/server-acl-init/command_ent_test.go
@@ -5,7 +5,6 @@ package serveraclinit
 import (
 	"context"
 	"fmt"
-
 	"net/http"
 	"net/http/httptest"
 	"os"

--- a/control-plane/subcommand/server-acl-init/command_ent_test.go
+++ b/control-plane/subcommand/server-acl-init/command_ent_test.go
@@ -5,7 +5,7 @@ package serveraclinit
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1216,7 +1216,7 @@ func TestRun_PartitionTokenDefaultPartition_WithProvidedSecretID(t *testing.T) {
 	setUpK8sServiceAccount(t, k8s, ns)
 
 	partitionToken := "123e4567-e89b-12d3-a456-426614174000"
-	partitionTokenFile, err := ioutil.TempFile("", "partitiontoken")
+	partitionTokenFile, err := os.CreateTemp("", "partitiontoken")
 	require.NoError(t, err)
 	defer os.Remove(partitionTokenFile.Name())
 

--- a/control-plane/subcommand/server-acl-init/command_test.go
+++ b/control-plane/subcommand/server-acl-init/command_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -269,7 +269,7 @@ func TestRun_ReplicationTokenPrimaryDC_WithProvidedSecretID(t *testing.T) {
 	setUpK8sServiceAccount(t, k8s, ns)
 
 	replicationToken := "123e4567-e89b-12d3-a456-426614174000"
-	replicationTokenFile, err := ioutil.TempFile("", "replicationtoken")
+	replicationTokenFile, err := os.CreateTemp("", "replicationtoken")
 	require.NoError(t, err)
 	defer os.Remove(replicationTokenFile.Name())
 
@@ -524,7 +524,7 @@ func TestRun_AnonymousTokenPolicy(t *testing.T) {
 				k8s, consul, consulHTTPAddr, cleanup = mockReplicatedSetup(t, bootToken)
 				defer cleanup()
 
-				tmp, err := ioutil.TempFile("", "")
+				tmp, err := os.CreateTemp("", "")
 				require.NoError(t, err)
 				_, err = tmp.WriteString(bootToken)
 				require.NoError(t, err)
@@ -1560,7 +1560,7 @@ func TestRun_AlreadyBootstrapped(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				// Write token to a file.
-				bootTokenFile, err := ioutil.TempFile("", "")
+				bootTokenFile, err := os.CreateTemp("", "")
 				require.NoError(t, err)
 				defer os.Remove(bootTokenFile.Name())
 
@@ -1685,7 +1685,7 @@ func TestRun_AlreadyBootstrapped_ServerTokenExists(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				// Write token to a file.
-				bootTokenFile, err := ioutil.TempFile("", "")
+				bootTokenFile, err := os.CreateTemp("", "")
 				require.NoError(t, err)
 				defer os.Remove(bootTokenFile.Name())
 

--- a/control-plane/subcommand/server-acl-init/command_test.go
+++ b/control-plane/subcommand/server-acl-init/command_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-
 	"math/rand"
 	"net/http"
 	"net/http/httptest"

--- a/control-plane/subcommand/service-address/command.go
+++ b/control-plane/subcommand/service-address/command.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -143,7 +143,7 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// Write the address to file.
-	err = ioutil.WriteFile(c.flagOutputFile, []byte(address), 0600)
+	err = os.WriteFile(c.flagOutputFile, []byte(address), 0600)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Unable to write address to file: %s", err))
 		return 1

--- a/control-plane/subcommand/service-address/command_test.go
+++ b/control-plane/subcommand/service-address/command_test.go
@@ -3,7 +3,7 @@ package serviceaddress
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+
 	"os"
 	"path/filepath"
 	"testing"
@@ -97,7 +97,7 @@ func TestRun_UnresolvableHostname(t *testing.T) {
 		UI:        ui,
 		k8sClient: k8s,
 	}
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	require.NoError(err)
 	defer os.RemoveAll(tmpDir)
 	outputFile := filepath.Join(tmpDir, "address.txt")
@@ -198,7 +198,7 @@ func TestRun_ServiceTypes(t *testing.T) {
 				UI:        ui,
 				k8sClient: k8s,
 			}
-			tmpDir, err := ioutil.TempDir("", "")
+			tmpDir, err := os.MkdirTemp("", "")
 			require.NoError(err)
 			defer os.RemoveAll(tmpDir)
 			outputFile := filepath.Join(tmpDir, "address.txt")
@@ -217,7 +217,7 @@ func TestRun_ServiceTypes(t *testing.T) {
 				require.Contains(ui.ErrorWriter.String(), c.ExpErr)
 			} else {
 				require.Equal(0, responseCode, ui.ErrorWriter.String())
-				actAddressBytes, err := ioutil.ReadFile(outputFile)
+				actAddressBytes, err := os.ReadFile(outputFile)
 				require.NoError(err)
 				require.Equal(c.ExpAddress, string(actAddressBytes))
 			}
@@ -289,7 +289,7 @@ func TestRun_FileWrittenAfterRetry(t *testing.T) {
 				k8sClient:     k8s,
 				retryDuration: 10 * time.Millisecond,
 			}
-			tmpDir, err := ioutil.TempDir("", "")
+			tmpDir, err := os.MkdirTemp("", "")
 			require.NoError(t, err)
 			defer os.RemoveAll(tmpDir)
 			outputFile := filepath.Join(tmpDir, "address.txt")
@@ -300,7 +300,7 @@ func TestRun_FileWrittenAfterRetry(t *testing.T) {
 				"-output-file", outputFile,
 			})
 			require.Equal(t, 0, responseCode, ui.ErrorWriter.String())
-			actAddressBytes, err := ioutil.ReadFile(outputFile)
+			actAddressBytes, err := os.ReadFile(outputFile)
 			require.NoError(t, err)
 			require.Equal(t, ip, string(actAddressBytes))
 		})

--- a/control-plane/subcommand/service-address/command_test.go
+++ b/control-plane/subcommand/service-address/command_test.go
@@ -3,7 +3,6 @@ package serviceaddress
 import (
 	"context"
 	"fmt"
-
 	"os"
 	"path/filepath"
 	"testing"

--- a/control-plane/subcommand/tls-init/command.go
+++ b/control-plane/subcommand/tls-init/command.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -176,13 +176,13 @@ func (c *Command) Run(args []string) int {
 
 	if c.flagCaFile != "" && c.flagKeyFile != "" {
 		c.log.Info("reading CA certificate from provided file")
-		caBytes, err = ioutil.ReadFile(c.flagCaFile)
+		caBytes, err = os.ReadFile(c.flagCaFile)
 		if err != nil {
 			c.log.Error("error reading provided CA file", "err", err)
 			return 1
 		}
 		c.log.Info("reading CA private key from provided file")
-		keyBytes, err = ioutil.ReadFile(c.flagKeyFile)
+		keyBytes, err = os.ReadFile(c.flagKeyFile)
 		if err != nil {
 			c.log.Error("error reading provided private key file", "err", err)
 			return 1

--- a/control-plane/subcommand/tls-init/command_test.go
+++ b/control-plane/subcommand/tls-init/command_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
+
 	"net"
 	"os"
 	"testing"
@@ -89,16 +89,16 @@ func TestRun_CreatesServerCertificatesWithExistingCAAsFiles(t *testing.T) {
 			k8s := fake.NewSimpleClientset()
 			cmd.clientset = k8s
 
-			ca, err := ioutil.TempFile("", "")
+			ca, err := os.CreateTemp("", "")
 			require.NoError(t, err)
 			defer os.RemoveAll(ca.Name())
-			err = ioutil.WriteFile(ca.Name(), []byte(c.caCert), 0644)
+			err = os.WriteFile(ca.Name(), []byte(c.caCert), 0644)
 			require.NoError(t, err)
 
-			key, err := ioutil.TempFile("", "")
+			key, err := os.CreateTemp("", "")
 			require.NoError(t, err)
 			defer os.RemoveAll(key.Name())
-			err = ioutil.WriteFile(key.Name(), []byte(c.caKey), 0644)
+			err = os.WriteFile(key.Name(), []byte(c.caKey), 0644)
 			require.NoError(t, err)
 
 			flags := []string{"-name-prefix", "consul", "-ca", ca.Name(), "-key", key.Name()}
@@ -152,16 +152,16 @@ func TestRun_UpdatesServerCertificatesWithExistingCertsAsFiles(t *testing.T) {
 	}, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	ca, err := ioutil.TempFile("", "")
+	ca, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	defer os.RemoveAll(ca.Name())
-	err = ioutil.WriteFile(ca.Name(), []byte(caCertEC), 0644)
+	err = os.WriteFile(ca.Name(), []byte(caCertEC), 0644)
 	require.NoError(t, err)
 
-	key, err := ioutil.TempFile("", "")
+	key, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	defer os.RemoveAll(key.Name())
-	err = ioutil.WriteFile(key.Name(), []byte(caKeyEC), 0644)
+	err = os.WriteFile(key.Name(), []byte(caKeyEC), 0644)
 	require.NoError(t, err)
 
 	flags := []string{"-name-prefix", "consul", "-ca", ca.Name(), "-key", key.Name(), "-additional-dnsname", "test.dns.name"}

--- a/control-plane/subcommand/tls-init/command_test.go
+++ b/control-plane/subcommand/tls-init/command_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
-
 	"net"
 	"os"
 	"testing"

--- a/control-plane/subcommand/webhook-cert-manager/command.go
+++ b/control-plane/subcommand/webhook-cert-manager/command.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-
 	"os"
 	"os/signal"
 	"strings"

--- a/control-plane/subcommand/webhook-cert-manager/command.go
+++ b/control-plane/subcommand/webhook-cert-manager/command.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+
 	"os"
 	"os/signal"
 	"strings"
@@ -134,7 +134,7 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
-	configFile, err := ioutil.ReadFile(c.flagConfigFile)
+	configFile, err := os.ReadFile(c.flagConfigFile)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error reading config file from %s: %s", c.flagConfigFile, err))
 		return 1

--- a/control-plane/subcommand/webhook-cert-manager/command_test.go
+++ b/control-plane/subcommand/webhook-cert-manager/command_test.go
@@ -2,7 +2,7 @@ package webhookcertmanager
 
 import (
 	"context"
-	"io/ioutil"
+
 	"os"
 	"syscall"
 	"testing"
@@ -88,7 +88,7 @@ func testSignalHandling(sig os.Signal) func(*testing.T) {
 		}
 		cmd.init()
 
-		file, err := ioutil.TempFile("", "config.json")
+		file, err := os.CreateTemp("", "config.json")
 		require.NoError(t, err)
 		defer os.Remove(file.Name())
 
@@ -211,7 +211,7 @@ func TestRun_SecretDoesNotExist(t *testing.T) {
 	}
 	cmd.init()
 
-	file, err := ioutil.TempFile("", "config.json")
+	file, err := os.CreateTemp("", "config.json")
 	require.NoError(t, err)
 	defer os.Remove(file.Name())
 
@@ -339,7 +339,7 @@ func TestRun_SecretExists(t *testing.T) {
 	}
 	cmd.init()
 
-	file, err := ioutil.TempFile("", "config.json")
+	file, err := os.CreateTemp("", "config.json")
 	require.NoError(t, err)
 	defer os.Remove(file.Name())
 
@@ -439,7 +439,7 @@ func TestRun_SecretUpdates(t *testing.T) {
 	}
 	cmd.init()
 
-	file, err := ioutil.TempFile("", "config.json")
+	file, err := os.CreateTemp("", "config.json")
 	require.NoError(t, err)
 	defer os.Remove(file.Name())
 
@@ -629,7 +629,7 @@ func TestCertWatcher(t *testing.T) {
 	}
 	cmd.init()
 
-	file, err := ioutil.TempFile("", "config.json")
+	file, err := os.CreateTemp("", "config.json")
 	require.NoError(t, err)
 	defer os.Remove(file.Name())
 

--- a/control-plane/subcommand/webhook-cert-manager/command_test.go
+++ b/control-plane/subcommand/webhook-cert-manager/command_test.go
@@ -2,7 +2,6 @@ package webhookcertmanager
 
 import (
 	"context"
-
 	"os"
 	"syscall"
 	"testing"

--- a/hack/copy-crds-to-chart/main.go
+++ b/hack/copy-crds-to-chart/main.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-
 	"os"
 	"path/filepath"
 	"strings"

--- a/hack/copy-crds-to-chart/main.go
+++ b/hack/copy-crds-to-chart/main.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,7 +35,7 @@ func realMain(helmPath string) error {
 
 		printf("processing %s", filepath.Base(path))
 
-		contentBytes, err := ioutil.ReadFile(path)
+		contentBytes, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
@@ -68,7 +68,7 @@ func realMain(helmPath string) error {
 
 		// Write it.
 		printf("writing to %s", destinationPath)
-		return ioutil.WriteFile(destinationPath, []byte(contents), 0644)
+		return os.WriteFile(destinationPath, []byte(contents), 0644)
 	})
 }
 

--- a/hack/helm-reference-gen/main.go
+++ b/hack/helm-reference-gen/main.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-
 	"os"
 	"path/filepath"
 	"regexp"

--- a/hack/helm-reference-gen/main.go
+++ b/hack/helm-reference-gen/main.go
@@ -12,7 +12,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
+
 	"os"
 	"path/filepath"
 	"regexp"
@@ -99,7 +99,7 @@ func main() {
 	}
 
 	// Parse the values.yaml file.
-	inputBytes, err := ioutil.ReadFile("../../charts/consul/values.yaml")
+	inputBytes, err := os.ReadFile("../../charts/consul/values.yaml")
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
@@ -118,7 +118,7 @@ func main() {
 
 	// Otherwise we'll go on to write the changes to the helm docs.
 	helmReferenceFile := filepath.Join(consulRepoPath, "website/content/docs/k8s/helm.mdx")
-	helmReferenceBytes, err := ioutil.ReadFile(helmReferenceFile)
+	helmReferenceBytes, err := os.ReadFile(helmReferenceFile)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
@@ -140,7 +140,7 @@ func main() {
 	}
 
 	newMdx := helmReferenceContents[0:start+len(startStr)] + out + helmReferenceContents[end:]
-	err = ioutil.WriteFile(helmReferenceFile, []byte(newMdx), 0644)
+	err = os.WriteFile(helmReferenceFile, []byte(newMdx), 0644)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/hack/helm-reference-gen/main_test.go
+++ b/hack/helm-reference-gen/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -493,15 +492,15 @@ key:
 
 // Test against a full values file and compare against a golden file.
 func TestFullValues(t *testing.T) {
-	inputBytes, err := ioutil.ReadFile(filepath.Join("fixtures", "full-values.yaml"))
+	inputBytes, err := os.ReadFile(filepath.Join("fixtures", "full-values.yaml"))
 	require.NoError(t, err)
-	expBytes, err := ioutil.ReadFile(filepath.Join("fixtures", "full-values.golden"))
+	expBytes, err := os.ReadFile(filepath.Join("fixtures", "full-values.golden"))
 	require.NoError(t, err)
 
 	actual, err := GenerateDocs(string(inputBytes))
 	require.NoError(t, err)
 	if actual != string(expBytes) {
-		require.NoError(t, ioutil.WriteFile(filepath.Join("fixtures", "full-values.actual"), []byte(actual), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join("fixtures", "full-values.actual"), []byte(actual), 0644))
 		require.FailNow(t, "output not equal, actual output to full-values.actual")
 	}
 }

--- a/hack/helm-reference-gen/main_test.go
+++ b/hack/helm-reference-gen/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"


### PR DESCRIPTION
Changes proposed in this PR:
- Fixes all lint errors from `make lint`
- `ioutil` has been deprecated since go `1.16` and replaced by `io` and `os`.
- Fixes various comments via `gofmt -s`.

How I've tested this PR:
Lets see if everything passes :-) 

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

