### PR TITLE
update the helm repo prior to running helm install in acceptance tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,7 +506,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2"
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -helm-chart-version="0.47.1"
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,7 +506,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -helm-chart-version="0.47.1"
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2"
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:


### PR DESCRIPTION
Nightlies were failing due to not being able to download the `hashicorp/consul` chart.

Changes proposed in this PR:
- Runs `helm repo add` and `helm repo update` prior to doing the helm install when  not using the chartDir as the helm template location.

How I've tested this PR:
CI fails when specifying a chart version, here is an example which includes the `-helm-chart-version` flag without the proposed fix:
https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/7237/workflows/0bf2a6c3-e8c3-4976-abd6-3ff567851432
CI passes with the proposed fix.

How I expect reviewers to test this PR:
This is identical to what we do for the Vault tests which use Helm to install vault.

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

