### PR TITLE
Omit non-IP defined endpoints from clusters

### DIFF
--- a/cli/cmd/proxy/read/config.go
+++ b/cli/cmd/proxy/read/config.go
@@ -17,6 +17,8 @@ const (
 	ipv4RegEx = `^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4})`
 )
 
+var isIP = regexp.MustCompile(ipv4RegEx + "|" + ipv6RegEx)
+
 // EnvoyConfig represents the configuration retrieved from a config dump at the
 // admin endpoint. It wraps the Envoy ConfigDump struct to give us convenient
 // access to the different sections of the config.
@@ -205,12 +207,7 @@ func parseClusters(rawCfg map[string]interface{}, clusterMapping map[string][]st
 		for _, endpoint := range cluster.Cluster.LoadAssignment.Endpoints {
 			for _, lbEndpoint := range endpoint.LBEndpoints {
 				// Only add endpoints defined by IP addresses.
-				addr := lbEndpoint.Endpoint.Address.SocketAddress.Address
-				match, err := regexp.MatchString(ipv4RegEx+"|"+ipv6RegEx, addr)
-				if err != nil {
-					return clusters, err
-				}
-				if match {
+				if addr := lbEndpoint.Endpoint.Address.SocketAddress.Address; isIP.MatchString(addr) {
 					endpoints = append(endpoints, fmt.Sprintf("%s:%d", addr, int(lbEndpoint.Endpoint.Address.SocketAddress.PortValue)))
 				}
 			}

--- a/cli/cmd/proxy/read/config.go
+++ b/cli/cmd/proxy/read/config.go
@@ -6,9 +6,15 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/consul-k8s/cli/common"
+)
+
+const (
+	ipv6RegEx = `^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$`
+	ipv4RegEx = `^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4})`
 )
 
 // EnvoyConfig represents the configuration retrieved from a config dump at the
@@ -198,8 +204,15 @@ func parseClusters(rawCfg map[string]interface{}, clusterMapping map[string][]st
 		endpoints := make([]string, 0)
 		for _, endpoint := range cluster.Cluster.LoadAssignment.Endpoints {
 			for _, lbEndpoint := range endpoint.LBEndpoints {
-				endpoints = append(endpoints, fmt.Sprintf("%s:%d", lbEndpoint.Endpoint.Address.SocketAddress.Address,
-					int(lbEndpoint.Endpoint.Address.SocketAddress.PortValue)))
+				// Only add endpoints defined by IP addresses.
+				addr := lbEndpoint.Endpoint.Address.SocketAddress.Address
+				match, err := regexp.MatchString(ipv4RegEx+"|"+ipv6RegEx, addr)
+				if err != nil {
+					return clusters, err
+				}
+				if match {
+					endpoints = append(endpoints, fmt.Sprintf("%s:%d", addr, int(lbEndpoint.Endpoint.Address.SocketAddress.PortValue)))
+				}
 			}
 		}
 


### PR DESCRIPTION
Changes proposed in this PR:
- When a cluster uses Logical DNS, omit the endpoint defined by the domain. Fixes [Proxy read: logical DNS reports an endpoint that could be clearer](https://hashicorp.atlassian.net/browse/NET-708).

How I've tested this PR:
- Manually against a terminating gateway that uses logical DNS.

How I expect reviewers to test this PR:
- :eyes:

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

