### PR TITLE
Allow providing custom http port and using system roots to the connect-init container

### DIFF
--- a/control-plane/connect-inject/container_init.go
+++ b/control-plane/connect-inject/container_init.go
@@ -103,6 +103,15 @@ type initContainerCommandData struct {
 	// ConsulAPITimeout is the duration that the consul API client will
 	// wait for a response from the API before cancelling the request.
 	ConsulAPITimeout time.Duration
+
+	// TLSEnabled indicates whether we should use TLS for communicating to Consul.
+	TLSEnabled bool
+
+	// ConsulHTTPPort is the HTTP or HTTPs port we should use to talk to Consul.
+	ConsulHTTPPort string
+
+	// ConsulGRPCPort is the gRPC port we should use to talk to Consul.
+	ConsulGRPCPort string
 }
 
 // initCopyContainer returns the init container spec for the copy container which places
@@ -168,6 +177,9 @@ func (w *MeshWebhook) containerInit(namespace corev1.Namespace, pod corev1.Pod, 
 		ConsulNamespace:            w.consulNamespace(namespace.Name),
 		NamespaceMirroringEnabled:  w.EnableK8SNSMirroring,
 		ConsulCACert:               w.ConsulCACert,
+		TLSEnabled:                 w.TLSEnabled,
+		ConsulHTTPPort:             w.ConsulHTTPPort,
+		ConsulGRPCPort:             w.ConsulGRPCPort,
 		ConsulAddress:              w.ConsulAddress,
 		ConsulNodeName:             ConsulNodeName,
 		EnableTransparentProxy:     tproxyEnabled,
@@ -377,16 +389,18 @@ func splitCommaSeparatedItemsFromAnnotation(annotation string, pod corev1.Pod) [
 // initContainerCommandTpl is the template for the command executed by
 // the init container.
 const initContainerCommandTpl = `
-{{- if .ConsulCACert}}
-export CONSUL_HTTP_ADDR="https://{{ .ConsulAddress }}:8501"
-export CONSUL_GRPC_ADDR="https://{{ .ConsulAddress }}:8502"
+{{- if .TLSEnabled }}
+export CONSUL_HTTP_ADDR="https://{{ .ConsulAddress }}:{{ .ConsulHTTPPort }}"
+export CONSUL_GRPC_ADDR="https://{{ .ConsulAddress }}:{{ .ConsulGRPCPort }}"
+{{- if .ConsulCACert }}
 export CONSUL_CACERT=/consul/connect-inject/consul-ca.pem
 cat <<EOF >/consul/connect-inject/consul-ca.pem
 {{ .ConsulCACert }}
 EOF
+{{- end }}
 {{- else}}
-export CONSUL_HTTP_ADDR="{{ .ConsulAddress }}:8500"
-export CONSUL_GRPC_ADDR="{{ .ConsulAddress }}:8502"
+export CONSUL_HTTP_ADDR="{{ .ConsulAddress }}:{{ .ConsulHTTPPort }}"
+export CONSUL_GRPC_ADDR="{{ .ConsulAddress }}:{{ .ConsulGRPCPort }}"
 {{- end}}
 consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
   -consul-api-timeout={{ .ConsulAPITimeout }} \

--- a/control-plane/connect-inject/container_init_test.go
+++ b/control-plane/connect-inject/container_init_test.go
@@ -61,7 +61,9 @@ func TestHandlerContainerInit(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress: "10.0.0.0",
+				ConsulAddress:  "10.0.0.0",
+				ConsulHTTPPort: "8500",
+				ConsulGRPCPort: "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="10.0.0.0:8500"
@@ -96,6 +98,8 @@ consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD
 				AuthMethod:       "an-auth-method",
 				ConsulAPITimeout: 5 * time.Second,
 				ConsulAddress:    "10.0.0.0",
+				ConsulHTTPPort:   "8500",
+				ConsulGRPCPort:   "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="10.0.0.0:8500"
@@ -566,6 +570,8 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				ConsulPartition:            "",
 				ConsulAPITimeout:           5 * time.Second,
 				ConsulAddress:              "10.0.0.0",
+				ConsulHTTPPort:             "8500",
+				ConsulGRPCPort:             "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="10.0.0.0:8500"
@@ -594,6 +600,8 @@ consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD
 				ConsulPartition:            "default",
 				ConsulAPITimeout:           5 * time.Second,
 				ConsulAddress:              "10.0.0.0",
+				ConsulHTTPPort:             "8500",
+				ConsulGRPCPort:             "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="10.0.0.0:8500"
@@ -624,6 +632,8 @@ consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD
 				ConsulPartition:            "",
 				ConsulAPITimeout:           5 * time.Second,
 				ConsulAddress:              "10.0.0.0",
+				ConsulHTTPPort:             "8500",
+				ConsulGRPCPort:             "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="10.0.0.0:8500"
@@ -652,6 +662,8 @@ consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD
 				ConsulPartition:            "non-default-part",
 				ConsulAPITimeout:           5 * time.Second,
 				ConsulAddress:              "10.0.0.0",
+				ConsulHTTPPort:             "8500",
+				ConsulGRPCPort:             "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="10.0.0.0:8500"
@@ -683,6 +695,8 @@ consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD
 				ConsulPartition:            "default",
 				ConsulAPITimeout:           5 * time.Second,
 				ConsulAddress:              "10.0.0.0",
+				ConsulHTTPPort:             "8500",
+				ConsulGRPCPort:             "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="10.0.0.0:8500"
@@ -721,6 +735,8 @@ consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD
 				ConsulPartition:            "non-default",
 				ConsulAPITimeout:           5 * time.Second,
 				ConsulAddress:              "10.0.0.0",
+				ConsulHTTPPort:             "8500",
+				ConsulGRPCPort:             "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="10.0.0.0:8500"
@@ -758,6 +774,8 @@ consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD
 				EnableTransparentProxy:     true,
 				ConsulAPITimeout:           5 * time.Second,
 				ConsulAddress:              "10.0.0.0",
+				ConsulHTTPPort:             "8500",
+				ConsulGRPCPort:             "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="10.0.0.0:8500"
@@ -793,6 +811,8 @@ consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD
 				EnableTransparentProxy:     true,
 				ConsulAPITimeout:           5 * time.Second,
 				ConsulAddress:              "10.0.0.0",
+				ConsulHTTPPort:             "8500",
+				ConsulGRPCPort:             "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="10.0.0.0:8500"
@@ -834,6 +854,8 @@ consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD
 				EnableTransparentProxy:     true,
 				ConsulAPITimeout:           5 * time.Second,
 				ConsulAddress:              "10.0.0.0",
+				ConsulHTTPPort:             "8500",
+				ConsulGRPCPort:             "8502",
 			},
 			`/bin/sh -ec 
 export CONSUL_HTTP_ADDR="10.0.0.0:8500"
@@ -938,6 +960,8 @@ func TestHandlerContainerInit_Multiport(t *testing.T) {
 			MeshWebhook{
 				ConsulAPITimeout: 5 * time.Second,
 				ConsulAddress:    "10.0.0.0",
+				ConsulHTTPPort:   "8500",
+				ConsulGRPCPort:   "8502",
 			},
 			2,
 			[]multiPortInfo{
@@ -994,6 +1018,8 @@ consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD
 				AuthMethod:       "auth-method",
 				ConsulAPITimeout: 5 * time.Second,
 				ConsulAddress:    "10.0.0.0",
+				ConsulHTTPPort:   "8500",
+				ConsulGRPCPort:   "8502",
 			},
 			2,
 			[]multiPortInfo{
@@ -1112,43 +1138,60 @@ consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`)
 }
 
-// If Consul CA cert is set,
+// If TLSEnabled is set,
 // Consul addresses should use HTTPS
-// and CA cert should be set as env variable.
-func TestHandlerContainerInit_WithTLS(t *testing.T) {
-	w := MeshWebhook{
-		ConsulCACert:     "consul-ca-cert",
-		ConsulAPITimeout: 5 * time.Second,
-		ConsulAddress:    "10.0.0.0",
-	}
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				annotationService: "foo",
-			},
-		},
-
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name: "web",
+// and CA cert should be set as env variable if provided.
+// Additionally, test that the init container is correctly configured
+// when http or gRPC ports are different from defaults.
+func TestHandlerContainerInit_WithTLSAndCustomPorts(t *testing.T) {
+	for _, caProvided := range []bool{true, false} {
+		name := fmt.Sprintf("ca provided: %t", caProvided)
+		t.Run(name, func(t *testing.T) {
+			w := MeshWebhook{
+				ConsulAPITimeout: 5 * time.Second,
+				ConsulAddress:    "10.0.0.0",
+				TLSEnabled:       true,
+				ConsulHTTPPort:   "443",
+				ConsulGRPCPort:   "8503",
+			}
+			if caProvided {
+				w.ConsulCACert = "consul-ca-cert"
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotationService: "foo",
+					},
 				},
-			},
-		},
-	}
-	container, err := w.containerInit(testNS, *pod, multiPortInfo{})
-	require.NoError(t, err)
-	actual := strings.Join(container.Command, " ")
-	require.Contains(t, actual, `
-export CONSUL_HTTP_ADDR="https://10.0.0.0:8501"
-export CONSUL_GRPC_ADDR="https://10.0.0.0:8502"
+
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "web",
+						},
+					},
+				},
+			}
+			container, err := w.containerInit(testNS, *pod, multiPortInfo{})
+			require.NoError(t, err)
+			actual := strings.Join(container.Command, " ")
+			if caProvided {
+				require.Contains(t, actual, `
+export CONSUL_HTTP_ADDR="https://10.0.0.0:443"
+export CONSUL_GRPC_ADDR="https://10.0.0.0:8503"
 export CONSUL_CACERT=/consul/connect-inject/consul-ca.pem
 cat <<EOF >/consul/connect-inject/consul-ca.pem
 consul-ca-cert
 EOF`)
-	require.NotContains(t, actual, `
-export CONSUL_HTTP_ADDR="10.0.0.0:8500"
-export CONSUL_GRPC_ADDR="10.0.0.0:8502"`)
+			} else {
+				require.Contains(t, actual, `
+export CONSUL_HTTP_ADDR="https://10.0.0.0:443"
+export CONSUL_GRPC_ADDR="https://10.0.0.0:8503"
+`)
+			}
+
+		})
+	}
 }
 
 func TestHandlerContainerInit_Resources(t *testing.T) {

--- a/control-plane/connect-inject/mesh_webhook.go
+++ b/control-plane/connect-inject/mesh_webhook.go
@@ -64,6 +64,15 @@ type MeshWebhook struct {
 	// If not set, will use HTTP.
 	ConsulCACert string
 
+	// TLSEnabled indicates whether we should use TLS for communicating to Consul.
+	TLSEnabled bool
+
+	// ConsulHTTPPort is the HTTP or HTTPs port we should use to talk to Consul.
+	ConsulHTTPPort string
+
+	// ConsulGRPCPort is the gRPC port we should use to talk to Consul.
+	ConsulGRPCPort string
+
 	// ConsulAddress is the address of the Consul server. This should be only the
 	// host (i.e. not including port or protocol).
 	ConsulAddress string

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -377,14 +377,14 @@ func (c *Command) Run(args []string) int {
 		cfg.Address = serverAddr
 	}
 
-	consulURLRaw := cfg.Address
 	// cfg.Address may or may not be prefixed with scheme.
 	if !strings.Contains(cfg.Address, "://") {
-		consulURLRaw = fmt.Sprintf("%s://%s", cfg.Scheme, cfg.Address)
+		cfg.Address = fmt.Sprintf("%s://%s", cfg.Scheme, cfg.Address)
 	}
-	consulURL, err := url.Parse(consulURLRaw)
+
+	consulURL, err := url.Parse(cfg.Address)
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("error parsing consul address %q: %s", consulURLRaw, err))
+		c.UI.Error(fmt.Sprintf("error parsing consul address %q: %s", cfg.Address, err))
 		return 1
 	}
 
@@ -532,6 +532,9 @@ func (c *Command) Run(args []string) int {
 			RequireAnnotation:             !c.flagDefaultInject,
 			AuthMethod:                    c.flagACLAuthMethod,
 			ConsulCACert:                  string(consulCACert),
+			TLSEnabled:                    consulURL.Scheme == "https",
+			ConsulHTTPPort:                consulURL.Port(),
+			ConsulGRPCPort:                "8502", // todo(ishustava): should be passed via flag
 			ConsulAddress:                 consulURL.Hostname(),
 			DefaultProxyCPURequest:        sidecarProxyCPURequest,
 			DefaultProxyCPULimit:          sidecarProxyCPULimit,


### PR DESCRIPTION
Previously, if you have configured `externalServers.useSystemRoots` or provided a different https port for external servers, we would ignore because we were hard-coding http port and were determining if TLS is enabled only if CA cert is set. That made sense when we were talking to clients, but now that we're talking to servers we need to account for those values so that the init container is correctly configured to talk to the servers

How I've tested this PR:
- acceptance tests
- manual tests with HCP 

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

