### PR TITLE
Add CNI to CRT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
       - main
       # Push events to branches matching refs/heads/release/**
       - "release/**"
+      - "curtbushko/add-cni-to-crt"
 
 env:
   PKG_NAME: "consul-k8s"
@@ -90,6 +91,19 @@ jobs:
           - {go: "${{ needs.get-go-version.outputs.go-version }}", goos: "windows", goarch: "amd64", component: "control-plane", pkg_name: "consul-k8s-control-plane", "bin_name": "consul-k8s-control-plane.exe" }
           - {go: "${{ needs.get-go-version.outputs.go-version }}", goos: "darwin", goarch: "amd64", component: "control-plane", pkg_name: "consul-k8s-control-plane", "bin_name": "consul-k8s-control-plane" }
           - {go: "${{ needs.get-go-version.outputs.go-version }}", goos: "darwin", goarch: "arm64", component: "control-plane", pkg_name: "consul-k8s-control-plane", "bin_name": "consul-k8s-control-plane" }
+        # consul-cni
+          - {go: "${{ needs.get-go-version.outputs.go-version }}", goos: "freebsd", goarch: "386", component: "control-plane/cni", pkg_name: "consul-cni", "bin_name": "consul-cni" }
+          - {go: "${{ needs.get-go-version.outputs.go-version }}", goos: "freebsd", goarch: "amd64", component: "control-plane/cni", pkg_name: "consul-cni", "bin_name": "consul-cni" }
+          - {go: "${{ needs.get-go-version.outputs.go-version }}", goos: "linux", goarch: "386", component: "control-plane/cni", pkg_name: "consul-cni", "bin_name": "consul-cni" }
+          - {go: "${{ needs.get-go-version.outputs.go-version }}", goos: "linux", goarch: "amd64", component: "control-plane/cni", pkg_name: "consul-cni", "bin_name": "consul-cni" }
+          - {go: "${{ needs.get-go-version.outputs.go-version }}", goos: "linux", goarch: "arm", component: "control-plane/cni", pkg_name: "consul-cni", "bin_name": "consul-cni" }
+          - {go: "${{ needs.get-go-version.outputs.go-version }}", goos: "linux", goarch: "arm64", component: "control-plane/cni", pkg_name: "consul-cni", "bin_name": "consul-cni" }
+          - {go: "${{ needs.get-go-version.outputs.go-version }}", goos: "solaris", goarch: "amd64", component: "control-plane/cni", pkg_name: "consul-cni", "bin_name": "consul-cni" }
+          - {go: "${{ needs.get-go-version.outputs.go-version }}", goos: "windows", goarch: "386", component: "control-plane/cni", pkg_name: "consul-cni", "bin_name": "consul-cni.exe" }
+          - {go: "${{ needs.get-go-version.outputs.go-version }}", goos: "windows", goarch: "amd64", component: "control-plane/cni", pkg_name: "consul-cni", "bin_name": "consul-cni.exe" }
+          - {go: "${{ needs.get-go-version.outputs.go-version }}", goos: "darwin", goarch: "amd64", component: "control-plane/cni", pkg_name: "consul-cni", "bin_name": "consul-cni" }
+          - {go: "${{ needs.get-go-version.outputs.go-version }}", goos: "darwin", goarch: "arm64", component: "control-plane/cni", pkg_name: "consul-cni", "bin_name": "consul-cni" }
+
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} ${{ matrix.component }} build    
@@ -207,6 +221,17 @@ jobs:
       version: ${{ needs.get-product-version.outputs.product-version }}
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
+        with:
+          name: consul-cni_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
+          path: control-plane/dist/cni/linux/${{ matrix.arch }}
+      - name: extract consul-cni zip
+        env:
+          ZIP_LOCATION: control-plane/dist/cni/linux/${{ matrix.arch }}
+          ZIP_NAME: consul-cni_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip"
+        run: |
+          cd "${ZIP_LOCATION}"
+          unzip -j ${ZIP_NAME}
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1
         with:
@@ -241,6 +266,17 @@ jobs:
       version: ${{ needs.get-product-version.outputs.product-version }}
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
+        with:
+          name: consul-cni_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
+          path: control-plane/dist/cni/linux/${{ matrix.arch }}
+      - name: extract consul-cni zip
+        env:
+          ZIP_LOCATION: control-plane/dist/cni/linux/${{ matrix.arch }}
+          ZIP_NAME: consul-cni_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip"
+        run: |
+          cd "${ZIP_LOCATION}"
+          unzip -j ${ZIP_NAME}
       - name: Copy LICENSE.md
         run:
          cp LICENSE.md ./control-plane
@@ -273,6 +309,17 @@ jobs:
       version: ${{ needs.get-product-version.outputs.product-version }}
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
+        with:
+          name: consul-cni_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
+          path: control-plane/dist/cni/linux/${{ matrix.arch }}
+      - name: extract consul-cni zip
+        env:
+          ZIP_LOCATION: control-plane/dist/cni/linux/${{ matrix.arch }}
+          ZIP_NAME: consul-cni_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip"
+        run: |
+          cd ${ZIP_LOCATION}
+          unzip -j ${ZIP_NAME}
       - name: Copy LICENSE.md
         run:
           cp LICENSE.md ./control-plane

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
       - main
       # Push events to branches matching refs/heads/release/**
       - "release/**"
+      - "curtbushko/add-cni-to-crt"
 
 env:
   PKG_NAME: "consul-k8s"
@@ -227,10 +228,9 @@ jobs:
       - name: extract consul-cni zip
         env:
           ZIP_LOCATION: control-plane/dist/cni/linux/${{ matrix.arch }}
-          ZIP_NAME: consul-cni_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip"
         run: |
           cd "${ZIP_LOCATION}"
-          unzip -j ${ZIP_NAME}
+          unzip -j *.zip
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1
         with:
@@ -272,10 +272,9 @@ jobs:
       - name: extract consul-cni zip
         env:
           ZIP_LOCATION: control-plane/dist/cni/linux/${{ matrix.arch }}
-          ZIP_NAME: consul-cni_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip"
         run: |
           cd "${ZIP_LOCATION}"
-          unzip -j ${ZIP_NAME}
+          unzip -j *.zip
       - name: Copy LICENSE.md
         run:
          cp LICENSE.md ./control-plane
@@ -315,10 +314,9 @@ jobs:
       - name: extract consul-cni zip
         env:
           ZIP_LOCATION: control-plane/dist/cni/linux/${{ matrix.arch }}
-          ZIP_NAME: consul-cni_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip"
         run: |
           cd ${ZIP_LOCATION}
-          unzip -j ${ZIP_NAME}
+          unzip -j *.zip
       - name: Copy LICENSE.md
         run:
           cp LICENSE.md ./control-plane

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:
       - main
       # Push events to branches matching refs/heads/release/**
       - "release/**"
-      - "curtbushko/add-cni-to-crt"
 
 env:
   PKG_NAME: "consul-k8s"

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -8,7 +8,7 @@ project "consul-k8s" {
   github {
     organization = "hashicorp"
     repository = "consul-k8s"
-    release_branches = ["curtbushko/add-cni-to-crt"]
+    release_branches = ["main"]
   }
 }
 

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -8,7 +8,7 @@ project "consul-k8s" {
   github {
     organization = "hashicorp"
     repository = "consul-k8s"
-    release_branches = ["main"]
+    release_branches = ["curtbushko/add-cni-to-crt"]
   }
 }
 

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -95,7 +95,7 @@ RUN addgroup ${BIN_NAME} && \
     adduser -S -G ${BIN_NAME} 100
 
 COPY dist/${TARGETOS}/${TARGETARCH}/${BIN_NAME} /bin/
-COPY cni/dist/${TARGETOS}/${TARGETARCH}/${CNI_BIN_NAME} /bin/
+COPY dist/cni/${TARGETOS}/${TARGETARCH}/${CNI_BIN_NAME} /bin/
 
 USER 100
 CMD /bin/${BIN_NAME}
@@ -156,7 +156,7 @@ RUN groupadd --gid 1000 ${BIN_NAME} && \
     usermod -a -G root ${BIN_NAME}
 
 COPY dist/${TARGETOS}/${TARGETARCH}/${BIN_NAME} /bin/
-COPY cni/dist/${TARGETOS}/${TARGETARCH}/${CNI_BIN_NAME} /bin/
+COPY dist/cni/${TARGETOS}/${TARGETARCH}/${CNI_BIN_NAME} /bin/
 
 USER 100
 CMD /bin/${BIN_NAME}


### PR DESCRIPTION
This PR is an attempt to get the CNI added to the release process using CRT.

Changes proposed in this PR:

 - Use the current build matrix for control-plane to also build the CNI plugin
 - The build generates a separate zip file for the CNI plugin
 - Add a step to the docker build that downloads the consul-cni artifact so that the docker build can COPY it

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

