### PR TITLE
update Kubernetes versions throughout CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ executors:
     environment:
       TEST_RESULTS: /tmp/test-results # path to where test results are saved
 
-slack-channel: &slack-channel CBXF3CGAF
+slack-channel: &slack-channel AAAAAAAAA
+#slack-channel: &slack-channel CBXF3CGAF
 control-plane-path: &control-plane-path control-plane
 cli-path: &cli-path cli
 acceptance-mod-path: &acceptance-mod-path acceptance

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -654,7 +654,7 @@ jobs:
   ########################
   # ACCEPTANCE TESTS
   ########################
-  acceptance-gke-1-21:
+  acceptance-gke-1-23:
     parallelism: 3
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -722,7 +722,7 @@ jobs:
           fail_only: true
           failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-gke-cni-1-21:
+  acceptance-gke-cni-1-23:
     parallelism: 3
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -903,7 +903,7 @@ jobs:
           fail_only: true
           failure_message: "AKS CNI acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-eks-1-23:
+  acceptance-eks-1-21:
     parallelism: 3
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -966,7 +966,7 @@ jobs:
           fail_only: true
           failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-eks-cni-1-23:
+  acceptance-eks-cni-1-21:
     parallelism: 3
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -1249,19 +1249,19 @@ workflows:
       # - acceptance-openshift:
       #    requires:
       #      - cleanup-azure-resources
-      - acceptance-gke-1-21:
+      - acceptance-gke-1-23:
           requires:
             - cleanup-gcp-resources
             - dev-upload-docker
-      - acceptance-gke-cni-1-21:
+      - acceptance-gke-cni-1-23:
           requires:
             - cleanup-gcp-resources
             - dev-upload-docker
-      - acceptance-eks-1-23:
+      - acceptance-eks-1-21:
           requires:
             - cleanup-eks-resources
             - dev-upload-docker
-      - acceptance-eks-cni-1-23:
+      - acceptance-eks-cni-1-21:
           requires:
             - cleanup-eks-resources
             - dev-upload-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -538,7 +538,7 @@ jobs:
       - checkout
       - install-prereqs
       - create-kind-clusters:
-          version: "v1.22.4"
+          version: "v1.24.0"
       - restore_cache:
           keys:
             - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
@@ -570,7 +570,7 @@ jobs:
       - checkout
       - install-prereqs
       - create-kind-clusters:
-          version: "v1.22.4"
+          version: "v1.24.0"
       - restore_cache:
           keys:
             - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
@@ -653,7 +653,7 @@ jobs:
   ########################
   # ACCEPTANCE TESTS
   ########################
-  acceptance-gke-1-20:
+  acceptance-gke-1-21:
     parallelism: 6
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -721,7 +721,7 @@ jobs:
           fail_only: true
           failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-gke-cni-1-20:
+  acceptance-gke-cni-1-21:
     parallelism: 3
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -789,7 +789,7 @@ jobs:
           fail_only: true
           failure_message: "GKE CNI acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-aks-1-21:
+  acceptance-aks-1-22:
     parallelism: 6
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -846,7 +846,7 @@ jobs:
           fail_only: true
           failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-aks-cni-1-21:
+  acceptance-aks-cni-1-22:
     parallelism: 3
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -902,7 +902,7 @@ jobs:
           fail_only: true
           failure_message: "AKS CNI acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-eks-1-19:
+  acceptance-eks-1-23:
     parallelism: 6
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -965,7 +965,7 @@ jobs:
           fail_only: true
           failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-eks-cni-1-19:
+  acceptance-eks-cni-1-23:
     parallelism: 3
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -1081,76 +1081,6 @@ jobs:
           channel: *slack-channel
           fail_only: true
           failure_message: "OpenShift acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
-
-  acceptance-kind-1-23:
-    parallelism: 6
-    environment:
-      - TEST_RESULTS: /tmp/test-results
-    machine:
-      image: ubuntu-2004:202010-01
-    resource_class: xlarge
-    steps:
-      - checkout
-      - install-prereqs
-      - create-kind-clusters:
-          version: "v1.23.0"
-      - restore_cache:
-          keys:
-            - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
-      - run:
-          name: go mod download
-          working_directory: *acceptance-mod-path
-          command: go mod download
-      - save_cache:
-          key: consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
-          paths:
-            - ~/.go_workspace/pkg/mod
-      - run: mkdir -p $TEST_RESULTS
-      - run-acceptance-tests:
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy
-      - store_test_results:
-          path: /tmp/test-results
-      - store_artifacts:
-          path: /tmp/test-results
-      - slack/status:
-          channel: *slack-channel
-          fail_only: true
-          failure_message: "Acceptance tests against Kind with Kubernetes v1.23 failed. Check the logs at: ${CIRCLE_BUILD_URL}"
-
-  acceptance-kind-cni-1-23:
-    parallelism: 3
-    environment:
-      - TEST_RESULTS: /tmp/test-results
-    machine:
-      image: ubuntu-2004:202010-01
-    resource_class: xlarge
-    steps:
-      - checkout
-      - install-prereqs
-      - create-kind-cni-clusters:
-          version: "v1.23.0"
-      - restore_cache:
-          keys:
-            - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
-      - run:
-          name: go mod download
-          working_directory: *acceptance-mod-path
-          command: go mod download
-      - save_cache:
-          key: consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
-          paths:
-            - ~/.go_workspace/pkg/mod
-      - run: mkdir -p $TEST_RESULTS
-      - run-acceptance-tests:
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -enable-cni
-      - store_test_results:
-          path: /tmp/test-results
-      - store_artifacts:
-          path: /tmp/test-results
-      - slack/status:
-          channel: *slack-channel
-          fail_only: true
-          failure_message: "Acceptance tests for CNI against Kind with Kubernetes v1.23 failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-kind-1-23-consul-nightly-1-11:
     environment:
@@ -1296,13 +1226,13 @@ workflows:
           requires:
             - dev-upload-docker
   nightly-acceptance-tests:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
+    #triggers:
+    #  - schedule:
+    #      cron: "0 0 * * *"
+    #      filters:
+    #        branches:
+    #          only:
+    #            - main
     jobs:
       - build-distro:
           OS: "linux"
@@ -1318,35 +1248,29 @@ workflows:
       # - acceptance-openshift:
       #    requires:
       #      - cleanup-azure-resources
-      - acceptance-gke-1-20:
+      - acceptance-gke-1-21:
           requires:
             - cleanup-gcp-resources
             - dev-upload-docker
-      - acceptance-gke-cni-1-20:
+      - acceptance-gke-cni-1-21:
           requires:
             - cleanup-gcp-resources
             - dev-upload-docker
-      - acceptance-eks-1-19:
+      - acceptance-eks-1-23:
           requires:
             - cleanup-eks-resources
             - dev-upload-docker
-      - acceptance-eks-cni-1-19:
+      - acceptance-eks-cni-1-23:
           requires:
             - cleanup-eks-resources
             - dev-upload-docker
-      - acceptance-aks-1-21:
+      - acceptance-aks-1-22:
           requires:
             - cleanup-azure-resources
             - dev-upload-docker
-      - acceptance-aks-cni-1-21:
+      - acceptance-aks-cni-1-22:
           requires:
             - cleanup-azure-resources
-            - dev-upload-docker
-      - acceptance-kind-1-23:
-          requires:
-            - dev-upload-docker
-      - acceptance-kind-cni-1-23:
-          requires:
             - dev-upload-docker
 
   nightly-acceptance-tests-consul:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -655,7 +655,7 @@ jobs:
   # ACCEPTANCE TESTS
   ########################
   acceptance-gke-1-21:
-    parallelism: 6
+    parallelism: 3
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -791,7 +791,7 @@ jobs:
           failure_message: "GKE CNI acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-aks-1-22:
-    parallelism: 6
+    parallelism: 3
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -904,7 +904,7 @@ jobs:
           failure_message: "AKS CNI acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-eks-1-23:
-    parallelism: 6
+    parallelism: 3
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -655,7 +655,7 @@ jobs:
   # ACCEPTANCE TESTS
   ########################
   acceptance-gke-1-23:
-    parallelism: 3
+    parallelism: 2
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:
@@ -723,7 +723,7 @@ jobs:
           failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-gke-cni-1-23:
-    parallelism: 3
+    parallelism: 2
     environment:
       - TEST_RESULTS: /tmp/test-results
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,7 @@ executors:
     environment:
       TEST_RESULTS: /tmp/test-results # path to where test results are saved
 
-slack-channel: &slack-channel AAAAAAAAA
-#slack-channel: &slack-channel CBXF3CGAF
+slack-channel: &slack-channel CBXF3CGAF
 control-plane-path: &control-plane-path control-plane
 cli-path: &cli-path cli
 acceptance-mod-path: &acceptance-mod-path acceptance
@@ -1227,13 +1226,13 @@ workflows:
           requires:
             - dev-upload-docker
   nightly-acceptance-tests:
-    #triggers:
-    #  - schedule:
-    #      cron: "0 0 * * *"
-    #      filters:
-    #        branches:
-    #          only:
-    #            - main
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
     jobs:
       - build-distro:
           OS: "linux"

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -67,11 +67,7 @@ func TestConsulDNS(t *testing.T) {
 			})
 
 			retry.Run(t, func(r *retry.R) {
-				// Testing to see if this bug is in fact causing the problem:
-				// https://github.com/kubernetes/kubectl/issues/1098
-				options := ctx.KubectlOptions(t)
-				options.Env["KUBECTL_COMMAND_HEADERS"] = "false"
-				logs, err := k8s.RunKubectlAndGetOutputE(t, options, dnsTestPodArgs...)
+				logs, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), dnsTestPodArgs...)
 				require.NoError(r, err)
 
 				// When the `dig` request is successful, a section of it's response looks like the following:

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -67,7 +67,11 @@ func TestConsulDNS(t *testing.T) {
 			})
 
 			retry.Run(t, func(r *retry.R) {
-				logs, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), dnsTestPodArgs...)
+				// Testing to see if this bug is in fact causing the problem:
+				// https://github.com/kubernetes/kubectl/issues/1098
+				options := ctx.KubectlOptions(t)
+				options.Env["KUBECTL_COMMAND_HEADERS"] = "false"
+				logs, err := k8s.RunKubectlAndGetOutputE(t, options, dnsTestPodArgs...)
 				require.NoError(r, err)
 
 				// When the `dig` request is successful, a section of it's response looks like the following:

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -57,7 +57,7 @@ module "eks" {
   version = "17.20.0"
 
   cluster_name    = "consul-k8s-${random_id.suffix[count.index].dec}"
-  cluster_version = "1.20"
+  cluster_version = "1.23"
   subnets         = module.vpc[count.index].private_subnets
 
   vpc_id = module.vpc[count.index].vpc_id

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -57,7 +57,7 @@ module "eks" {
   version = "17.20.0"
 
   cluster_name    = "consul-k8s-${random_id.suffix[count.index].dec}"
-  cluster_version = "1.23"
+  cluster_version = "1.21"
   subnets         = module.vpc[count.index].private_subnets
 
   vpc_id = module.vpc[count.index].vpc_id

--- a/charts/consul/test/terraform/gke/main.tf
+++ b/charts/consul/test/terraform/gke/main.tf
@@ -10,7 +10,7 @@ resource "random_id" "suffix" {
 
 data "google_container_engine_versions" "main" {
   location       = var.zone
-  version_prefix = "1.21."
+  version_prefix = "1.23."
 }
 
 resource "google_container_cluster" "cluster" {


### PR DESCRIPTION
Changes proposed in this PR:
- Update Kube versions + job names so that we test Kubernetes 1.21, 1.22, 1.23, 1.24 only.
- Remove excess nightly jobs as it is already covered by per-commit jobs.
- Lowers parallelism due to resource issues.

How I've tested this PR:
many many times on CI.

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

