### PR TITLE
api-gateway: configure ACL auth appropriately in secondary dc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ IMPROVEMENTS:
   * Display a message when `proxy list` returns no results. [[GH-1412](https://github.com/hashicorp/consul-k8s/pull/1412)]
   * Display a warning when a user passes a field and table filter combination to `proxy read` where the given field is not present in any of the output tables. [[GH-1412](https://github.com/hashicorp/consul-k8s/pull/1412)]
 
+BUG FIXES:
+* Helm
+  * API Gateway: Configure ACL auth for controller correctly when deployed in secondary datacenter [[GH-1462](https://github.com/hashicorp/consul-k8s/pull/1462)]
 
 ## 0.47.1 (August 12, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 * Helm
-  * API Gateway: Configure ACL auth for controller correctly when deployed in secondary datacenter [[GH-1462](https://github.com/hashicorp/consul-k8s/pull/1462)]
+  * API Gateway: Configure ACL auth for controller correctly when deployed in secondary datacenter with federation enabled [[GH-1462](https://github.com/hashicorp/consul-k8s/pull/1462)]
 
 ## 0.47.1 (August 12, 2022)
 

--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -204,7 +204,12 @@ spec:
         - |
           consul-k8s-control-plane acl-init \
             -component-name=api-gateway-controller \
+            {{- if and .Values.global.federation.enabled .Values.global.federation.primaryDatacenter }}
+            -acl-auth-method={{ template "consul.fullname" . }}-k8s-component-auth-method-{{ .Values.global.datacenter }} \
+            -primary-datacenter={{ .Values.global.federation.primaryDatacenter }} \
+            {{- else }}
             -acl-auth-method={{ template "consul.fullname" . }}-k8s-component-auth-method \
+            {{- end }}
             {{- if .Values.global.adminPartitions.enabled }}
             -partition={{ .Values.global.adminPartitions.name }} \
             {{- end }}

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -406,6 +406,8 @@ load _helpers
       -s templates/api-gateway-controller-deployment.yaml \
       --set 'apiGateway.enabled=true' \
       --set 'apiGateway.image=foo' \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.enableAutoEncrypt=true' \
       --set 'global.acls.manageSystemACLs=true' \

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -400,6 +400,34 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "apiGateway/Deployment: init container is created when global.acls.manageSystemACLs=true and has correct command when federation enabled in non-primary datacenter" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/api-gateway-controller-deployment.yaml \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=foo' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.datacenter=dc2' \
+      --set 'global.federation.enabled=true' \
+      --set 'global.federation.primaryDatacenter=dc1' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers[] | select(.name == "api-gateway-controller-acl-init")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("consul-k8s-control-plane acl-init"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("-acl-auth-method=release-name-consul-k8s-component-auth-method-dc2"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+      yq -r '.command | any(contains("-primary-datacenter=dc1"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 @test "apiGateway/Deployment: init container is created when global.acls.manageSystemACLs=true and has correct command and environment with tls enabled and autoencrypt enabled" {
   cd `chart_dir`
   local object=$(helm template \


### PR DESCRIPTION
Fixes #1344 

**Changes proposed in this PR:**
When federation is enabled and the API Gateway controller is deployed in a secondary datacenter:
- use correct `acl-auth-method`
- configure the `primary-datacenter`

This matches what we do today for [mesh gateway](https://github.com/hashicorp/consul-k8s/blob/4b630fc687c82860a5fece2a148f82db6f495ab9/charts/consul/templates/mesh-gateway-deployment.yaml#L157-L162) and [consul controller](https://github.com/hashicorp/consul-k8s/blob/a16c4ee0a02320c812f78bc2f33d192f409f62be/charts/consul/templates/controller-deployment.yaml#L110-L115) deployments.

Shout out to @t-eckert for pointing me in the right direction. Since he sent me this patch, I've included him as a co-author on the change commit.

**How I've tested this PR:**

**How I expect reviewers to test this PR:**


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

