### PR TITLE
update consul nightly tests to latest consul-k8s release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1087,8 +1087,8 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
       - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.11-dev"
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.20.2"
-      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.47.1"
-      - HELM_CHART_VERSION: "0.47.1"
+      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.48.0"
+      - HELM_CHART_VERSION: "0.48.0"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
@@ -1125,8 +1125,8 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
       - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.12-dev"
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.22.2"
-      - HELM_CHART_VERSION: "0.47.1"
-      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.47.1"
+      - HELM_CHART_VERSION: "0.48.0"
+      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.48.0"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
@@ -1162,9 +1162,9 @@ jobs:
     environment:
       - TEST_RESULTS: /tmp/test-results
       - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.13-dev"
-      - ENVOY_IMAGE: "envoyproxy/envoy:v1.22.2"
-      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.47.1"
-      - HELM_CHART_VERSION: "0.47.1"
+      - ENVOY_IMAGE: "envoyproxy/envoy:v1.23.1"
+      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.48.0"
+      - HELM_CHART_VERSION: "0.48.0"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge


### PR DESCRIPTION
Changes proposed in this PR:
- use the latest consul-k8s release for nightlies and update envoy for the 1.13 test

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

