### PR TITLE
add read/write/idle timeouts to the merged metrics sidecar

### DIFF
--- a/control-plane/subcommand/consul-sidecar/command.go
+++ b/control-plane/subcommand/consul-sidecar/command.go
@@ -243,7 +243,13 @@ func (c *Command) createMergedMetricsServer() *http.Server {
 	mux.HandleFunc("/stats/prometheus", c.mergedMetricsHandler)
 
 	mergedMetricsServerAddr := fmt.Sprintf("127.0.0.1:%s", c.flagMergedMetricsPort)
-	server := &http.Server{Addr: mergedMetricsServerAddr, Handler: mux}
+	server := &http.Server{
+		Addr:         mergedMetricsServerAddr,
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+		IdleTimeout:  30 * time.Second,
+	}
 
 	// http.Client satisfies the metricsGetter interface.
 	// The default http.Client timeout is indefinite, so adding a timeout makes


### PR DESCRIPTION
Changes proposed in this PR:
- Adding read/write/idle timeouts to the merged metrics sidecar `http.Server` to prevent malicious clients from abusing default configurations / DDoS'ing the sidecar.

How I've tested this PR:
Not yet, just testing.

How I expect reviewers to test this PR:
https://github.com/hashicorp/consul-k8s/security/code-scanning/42

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

