### PR TITLE
ci: add backport pipeline

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,4 +18,4 @@ jobs:
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.x)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,21 @@
+---
+name: Backport Assistant Runner
+
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    container: hashicorpdev/backport-assistant:0.2.5
+    steps:
+      - name: Run Backport Assistant
+        run: backport-assistant backport
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.x)"
+          BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
+          GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,7 +14,7 @@ jobs:
     container: hashicorpdev/backport-assistant:0.2.5
     steps:
       - name: Run Backport Assistant
-        run: backport-assistant backport
+        run: backport-assistant backport -automerge
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.x)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"


### PR DESCRIPTION
Changes proposed in this PR:
- Add backport pipeline

Usage:
When you merge a PR into with the label such as `backport/0.48.x`, it will cherry pick the commits from the PR and create a new PR against the branch `release/0.48.x` with those commits. If the cherry pick fails, you'll need to manually cherry pick your commits into the appropriate release branches and make PRs. 

How I've tested this PR:
- Ran it against my consul-k8s fork to test it out with a personal PAT. We have an existing consul-ecosystem PAT which seems to have the same permissions I used in my fork, in the worst case we may need to create a new PAT with full "repo" and "workflow" permissions if this doesn't work the first time we run it.

How I expect reviewers to test this PR:
- 👀 

This can be merged as is, and it won't affect our current setup. Once we're ready to create a long lived release branch that we want to backport to, we just need to make sure to name it release/<MAJ>.<MIN>.x. 

## Michael Taking Over
- Reference Docs: https://github.com/hashicorp/backport-assistant
- Added automerge so that backport is automatically merged without creating a PR. A PR will be created automatically if there is any issues merging so that a user can perform manual intervention 
- Added a token with elevated permissions

### Testing
- Created a release branch `release/0.0.x` off of this branch and created a backport label `backport/0.0.x`. I then created two test branches A and B. Created a PR to merge B into A and added the backport label. After merging the PR, confirmed that the backport assistant ran and was successful, 
**NOTE**: it won't properly find differences, and cherry pick until this change is in main