### PR TITLE
Notify #feed-consul-k8s-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
     environment:
       TEST_RESULTS: /tmp/test-results # path to where test results are saved
 
-slack-channel: &slack-channel CBXF3CGAF
+slack-channel: &slack-channel C0421KHNAV9 #feed-consul-k8s-ci channel ID
 control-plane-path: &control-plane-path control-plane
 cli-path: &cli-path cli
 acceptance-mod-path: &acceptance-mod-path acceptance


### PR DESCRIPTION
Changes proposed in this PR:
- Use `#feed-consul-k8s-ci` for notifications about Consul on Kubernetes CI failures

How I've tested this PR:
- I have not. Should be simple enough that it should just work.

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

