### PR TITLE
Make CNI tests dependent on non-CNI tests passing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1254,24 +1254,21 @@ workflows:
             - dev-upload-docker
       - acceptance-gke-cni-1-23:
           requires:
-            - cleanup-gcp-resources
-            - dev-upload-docker
+            - acceptance-gke-1-23
       - acceptance-eks-1-21:
           requires:
             - cleanup-eks-resources
             - dev-upload-docker
       - acceptance-eks-cni-1-21:
           requires:
-            - cleanup-eks-resources
-            - dev-upload-docker
+            - acceptance-eks-1-21
       - acceptance-aks-1-22:
           requires:
             - cleanup-azure-resources
             - dev-upload-docker
       - acceptance-aks-cni-1-22:
           requires:
-            - cleanup-azure-resources
-            - dev-upload-docker
+            - acceptance-aks-1-22
 
   nightly-acceptance-tests-consul:
     triggers:


### PR DESCRIPTION
Changes proposed in this PR:
- Only run CNI nightly tests if the non-CNI nightly tests pass. This is done to cut down on seeing errors twice when the CNI is not the differentiating factor.

How I've tested this PR:
- We'll see. 

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

