### PR TITLE
Update consul-helm-test image and CI to go 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -485,7 +485,7 @@ jobs:
 
   unit-test-helm-templates:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.11.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.12.0
 
     steps:
       - checkout
@@ -596,7 +596,7 @@ jobs:
   ##########################
   cleanup-gcp-resources:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.11.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.12.0
     steps:
       - run:
           name: cleanup leftover resources
@@ -614,7 +614,7 @@ jobs:
 
   cleanup-azure-resources:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.11.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.12.0
     steps:
       - run:
           name: cleanup leftover resources
@@ -632,7 +632,7 @@ jobs:
 
   cleanup-eks-resources:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.11.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.12.0
     steps:
       - checkout
       - run:
@@ -659,7 +659,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.11.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.12.0
 
     steps:
       - run:
@@ -727,7 +727,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.11.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.12.0
 
     steps:
       - run:
@@ -795,7 +795,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.11.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.12.0
 
     steps:
       - checkout
@@ -852,7 +852,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.11.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.12.0
 
     steps:
       - checkout
@@ -908,7 +908,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.11.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.12.0
 
     steps:
       - checkout
@@ -971,7 +971,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.11.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.12.0
 
     steps:
       - checkout
@@ -1034,7 +1034,7 @@ jobs:
     parallelism: 1
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.11.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.12.0
 
     steps:
       - checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       - unit-helm-gen
     runs-on: ubuntu-latest
     container: 
-      image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.11.0
+      image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.12.0
       options: --user 1001
     steps:
       - name: Checkout code

--- a/charts/consul/test/docker/Test.dockerfile
+++ b/charts/consul/test/docker/Test.dockerfile
@@ -6,7 +6,7 @@
 # a script to configure kubectl, potentially install Helm, and run the tests
 # manually. This image only has the dependencies pre-installed.
 
-FROM circleci/golang:1.18
+FROM cimg/go:1.18
 
 # change the user to root so we can install stuff
 USER root


### PR DESCRIPTION
NOTE: consul-helm-test v0.12.0 has already been published.

Changes proposed in this PR:
- Update consul-helm-test image and CI to go 1.18

How I've tested this PR:
👀 && CI

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added

