### PR TITLE
Add makefile cli

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,23 +108,17 @@ helm install consul --create-namespace -n consul -f ./values.dev.yaml ./charts/c
 
 ### Building and running the `consul-k8s` CLI
 
-Change directory into the `cli` folder where the golang code resides.
+Compile the `consul-k8s` CLI binary for your local machine:
 
 ```shell
-cd cli
+make cli-dev
 ```
+This will compile the `consul-k8s` binary into `cli/bin/consul-k8s` as well as your `$GOPATH`.
 
-Build the CLI binary using the following command
-
-```shell
-go build -o bin/consul-k8s
-```
-
-Run the CLI as follows
+Run the CLI as follows:
 
 ```shell
-./bin/consul-k8s version
-consul-k8s 0.36.0-dev
+consul-k8s version
 ```
 
 ### Making changes to consul-k8s

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,11 @@ kind-cni:
 
 # ===========> CLI Targets
 
+cli-dev:
+	@echo "==> Installing consul-k8s CLI tool for ${GOOS}/${GOARCH}"
+	@cd cli; go build -o ./bin/consul-k8s; cp ./bin/consul-k8s ${GOPATH}/bin/
+
+
 cli-lint: ## Run linter in the control-plane directory.
 	cd cli; golangci-lint run -c ../.golangci.yml
 
@@ -144,7 +149,7 @@ endif
 # ===========> Makefile config
 
 .DEFAULT_GOAL := help
-.PHONY: gen-helm-docs copy-crds-to-chart bats-tests help ci.aws-acceptance-test-cleanup version
+.PHONY: gen-helm-docs copy-crds-to-chart bats-tests help ci.aws-acceptance-test-cleanup version cli-dev
 SHELL = bash
 GOOS?=$(shell go env GOOS)
 GOARCH?=$(shell go env GOARCH)


### PR DESCRIPTION
Changes proposed in this PR:
- Create a make target for the CLI binary. This builds the `consul-k8s` CLI binary and adds it to `<consul-k8s_project_root>/cli/bin` and to your `$GOPATH`
- change instructions for building CLI binary in contributing documentation to use make

How I've tested this PR:
- built cli using `make cli-dev`
- confirmed version in path by running `consul-k8s version`

How I expect reviewers to test this PR:
- try out `make cli-dev` locally
- 👀 

Checklist:
- [N/A] Tests added
- [N/A] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

