### PR TITLE
Add cli autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+FEATURES:
+* CLI:
+  * Add support for tab autocompletion [[GH-1437](https://github.com/hashicorp/consul-k8s/pull/1501)]
+
 BUG FIXES:
 * Control plane
   * Use global ACL auth method to provision ACL tokens for API Gateway in secondary datacenter [[GH-1481](https://github.com/hashicorp/consul-k8s/pull/1481)]

--- a/cli/cmd/install/install_test.go
+++ b/cli/cmd/install/install_test.go
@@ -2,13 +2,18 @@ package install
 
 import (
 	"context"
+	"flag"
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/hashicorp/consul-k8s/cli/common"
+	cmnFlag "github.com/hashicorp/consul-k8s/cli/common/flag"
 	"github.com/hashicorp/consul-k8s/cli/helm"
 	"github.com/hashicorp/consul-k8s/cli/release"
 	"github.com/hashicorp/go-hclog"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -247,4 +252,34 @@ func TestCheckValidEnterprise(t *testing.T) {
 	err = c.checkValidEnterprise(secret2.Name)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "please make sure that the secret exists")
+}
+
+func TestTaskCreateCommand_AutocompleteFlags(t *testing.T) {
+	t.Parallel()
+	cmd := getInitializedCommand(t)
+
+	predictor := cmd.AutocompleteFlags()
+
+	// Test that we get the expected number of predictions
+	args := complete.Args{Last: "-"}
+	res := predictor.Predict(args)
+
+	// Grab the list of flags from the Flag object
+	flags := make([]string, 0)
+	cmd.set.VisitSets(func(name string, set *cmnFlag.Set) {
+		set.VisitAll(func(flag *flag.Flag) {
+			flags = append(flags, fmt.Sprintf("-%s", flag.Name))
+		})
+	})
+
+	// Verify that there is a prediction for each flag associated with the command
+	assert.Equal(t, len(flags), len(res))
+	assert.ElementsMatch(t, flags, res, "flags and predictions didn't match, make sure to add "+
+		"new flags to the command AutoCompleteFlags function")
+}
+
+func TestTaskCreateCommand_AutocompleteArgs(t *testing.T) {
+	cmd := getInitializedCommand(t)
+	c := cmd.AutocompleteArgs()
+	assert.Equal(t, complete.PredictNothing, c)
 }

--- a/cli/cmd/proxy/command.go
+++ b/cli/cmd/proxy/command.go
@@ -13,7 +13,7 @@ type ProxyCommand struct {
 }
 
 // Run prints out information about the subcommands.
-func (c *ProxyCommand) Run(args []string) int {
+func (c *ProxyCommand) Run([]string) int {
 	return cli.RunResultHelp
 }
 

--- a/cli/cmd/proxy/list/command_test.go
+++ b/cli/cmd/proxy/list/command_test.go
@@ -3,13 +3,18 @@ package list
 import (
 	"bytes"
 	"context"
+	"flag"
+	"fmt"
 	"io"
 	"os"
 	"testing"
 
 	"github.com/hashicorp/consul-k8s/cli/common"
+	cmnFlag "github.com/hashicorp/consul-k8s/cli/common/flag"
 	"github.com/hashicorp/consul-k8s/cli/common/terminal"
 	"github.com/hashicorp/go-hclog"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -358,4 +363,36 @@ func setupCommand(buf io.Writer) *ListCommand {
 	command.init()
 
 	return command
+}
+
+func TestTaskCreateCommand_AutocompleteFlags(t *testing.T) {
+	t.Parallel()
+	buf := new(bytes.Buffer)
+	cmd := setupCommand(buf)
+
+	predictor := cmd.AutocompleteFlags()
+
+	// Test that we get the expected number of predictions
+	args := complete.Args{Last: "-"}
+	res := predictor.Predict(args)
+
+	// Grab the list of flags from the Flag object
+	flags := make([]string, 0)
+	cmd.set.VisitSets(func(name string, set *cmnFlag.Set) {
+		set.VisitAll(func(flag *flag.Flag) {
+			flags = append(flags, fmt.Sprintf("-%s", flag.Name))
+		})
+	})
+
+	// Verify that there is a prediction for each flag associated with the command
+	assert.Equal(t, len(flags), len(res))
+	assert.ElementsMatch(t, flags, res, "flags and predictions didn't match, make sure to add "+
+		"new flags to the command AutoCompleteFlags function")
+}
+
+func TestTaskCreateCommand_AutocompleteArgs(t *testing.T) {
+	buf := new(bytes.Buffer)
+	cmd := setupCommand(buf)
+	c := cmd.AutocompleteArgs()
+	assert.Equal(t, complete.PredictNothing, c)
 }

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/consul-k8s/cli/common"
 	"github.com/hashicorp/consul-k8s/cli/common/flag"
 	"github.com/hashicorp/consul-k8s/cli/common/terminal"
+	"github.com/posener/complete"
 	helmCLI "helm.sh/helm/v3/pkg/cli"
 	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,6 +26,19 @@ const (
 	Table = "table"
 	JSON  = "json"
 	Raw   = "raw"
+
+	flagNameNamespace   = "namespace"
+	flagNameOutput      = "output"
+	flagNameClusters    = "clusters"
+	flagNameListeners   = "listeners"
+	flagNameRoutes      = "routes"
+	flagNameEndpoints   = "endpoints"
+	flagNameSecrets     = "secrets"
+	flagNameFQDN        = "fqdn"
+	flagNameAddress     = "address"
+	flagNamePort        = "port"
+	flagNameKubeConfig  = "kubeconfig"
+	flagNameKubeContext = "context"
 )
 
 type ReadCommand struct {
@@ -69,13 +83,13 @@ func (c *ReadCommand) init() {
 	c.set = flag.NewSets()
 	f := c.set.NewSet("Command Options")
 	f.StringVar(&flag.StringVar{
-		Name:    "namespace",
+		Name:    flagNameNamespace,
 		Target:  &c.flagNamespace,
 		Usage:   "The namespace where the target Pod can be found.",
 		Aliases: []string{"n"},
 	})
 	f.StringVar(&flag.StringVar{
-		Name:    "output",
+		Name:    flagNameOutput,
 		Target:  &c.flagOutput,
 		Usage:   "Output the Envoy configuration as 'table', 'json', or 'raw'.",
 		Default: Table,
@@ -84,42 +98,42 @@ func (c *ReadCommand) init() {
 
 	f = c.set.NewSet("Output Filtering Options")
 	f.BoolVar(&flag.BoolVar{
-		Name:   "clusters",
+		Name:   flagNameClusters,
 		Target: &c.flagClusters,
 		Usage:  "Filter output to only show clusters.",
 	})
 	f.BoolVar(&flag.BoolVar{
-		Name:   "listeners",
+		Name:   flagNameListeners,
 		Target: &c.flagListeners,
 		Usage:  "Filter output to only show listeners.",
 	})
 	f.BoolVar(&flag.BoolVar{
-		Name:   "routes",
+		Name:   flagNameRoutes,
 		Target: &c.flagRoutes,
 		Usage:  "Filter output to only show routes.",
 	})
 	f.BoolVar(&flag.BoolVar{
-		Name:   "endpoints",
+		Name:   flagNameEndpoints,
 		Target: &c.flagEndpoints,
 		Usage:  "Filter output to only show endpoints.",
 	})
 	f.BoolVar(&flag.BoolVar{
-		Name:   "secrets",
+		Name:   flagNameSecrets,
 		Target: &c.flagSecrets,
 		Usage:  "Filter output to only show secrets.",
 	})
 	f.StringVar(&flag.StringVar{
-		Name:   "fqdn",
+		Name:   flagNameFQDN,
 		Target: &c.flagFQDN,
 		Usage:  "Filter cluster output to clusters with a fully qualified domain name which contains the given value. May be combined with -address and -port.",
 	})
 	f.StringVar(&flag.StringVar{
-		Name:   "address",
+		Name:   flagNameAddress,
 		Target: &c.flagAddress,
 		Usage:  "Filter clusters, endpoints, and listeners output to those with addresses which contain the given value. May be combined with -fqdn and -port",
 	})
 	f.IntVar(&flag.IntVar{
-		Name:    "port",
+		Name:    flagNamePort,
 		Target:  &c.flagPort,
 		Usage:   "Filter endpoints and listeners output to addresses with the given port number. May be combined with -fqdn and -address.",
 		Default: -1,
@@ -127,13 +141,13 @@ func (c *ReadCommand) init() {
 
 	f = c.set.NewSet("GlobalOptions")
 	f.StringVar(&flag.StringVar{
-		Name:    "kubeconfig",
+		Name:    flagNameKubeConfig,
 		Aliases: []string{"c"},
 		Target:  &c.flagKubeConfig,
 		Usage:   "Set the path to kubeconfig file.",
 	})
 	f.StringVar(&flag.StringVar{
-		Name:   "context",
+		Name:   flagNameKubeContext,
 		Target: &c.flagKubeContext,
 		Usage:  "Set the Kubernetes context to use.",
 	})
@@ -191,6 +205,33 @@ func (c *ReadCommand) Help() string {
 
 func (c *ReadCommand) Synopsis() string {
 	return "Inspect the Envoy configuration for a given Pod."
+}
+
+// AutocompleteFlags returns a mapping of supported flags and autocomplete
+// options for this command. The map key for the Flags map should be the
+// complete flag such as "-foo" or "--foo".
+func (c *ReadCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		fmt.Sprintf("-%s", flagNameNamespace):   complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameOutput):      complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameClusters):    complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameListeners):   complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameRoutes):      complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameEndpoints):   complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameSecrets):     complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameFQDN):        complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameAddress):     complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNamePort):        complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameKubeConfig):  complete.PredictFiles("*"),
+		fmt.Sprintf("-%s", flagNameKubeContext): complete.PredictNothing,
+	}
+}
+
+// AutocompleteArgs returns the argument predictor for this command.
+// Since argument completion is not supported, this will return
+// complete.PredictNothing.
+func (c *ReadCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
 }
 
 func (c *ReadCommand) parseFlags(args []string) error {

--- a/cli/cmd/uninstall/uninstall_test.go
+++ b/cli/cmd/uninstall/uninstall_test.go
@@ -2,12 +2,17 @@ package uninstall
 
 import (
 	"context"
+	"flag"
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/hashicorp/consul-k8s/cli/common"
+	cmnFlag "github.com/hashicorp/consul-k8s/cli/common/flag"
 	"github.com/hashicorp/consul-k8s/cli/common/terminal"
 	"github.com/hashicorp/go-hclog"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -91,7 +96,7 @@ func TestDeleteSecrets(t *testing.T) {
 	require.NoError(t, err)
 	_, err = c.kubernetes.CoreV1().Secrets("default").Create(context.Background(), secret3, metav1.CreateOptions{})
 	require.NoError(t, err)
-	err = c.deleteSecrets("consul", "default")
+	err = c.deleteSecrets("default")
 	require.NoError(t, err)
 	secrets, err := c.kubernetes.CoreV1().Secrets("default").List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
@@ -365,4 +370,34 @@ func getInitializedCommand(t *testing.T) *Command {
 	}
 	c.init()
 	return c
+}
+
+func TestTaskCreateCommand_AutocompleteFlags(t *testing.T) {
+	t.Parallel()
+	cmd := getInitializedCommand(t)
+
+	predictor := cmd.AutocompleteFlags()
+
+	// Test that we get the expected number of predictions
+	args := complete.Args{Last: "-"}
+	res := predictor.Predict(args)
+
+	// Grab the list of flags from the Flag object
+	flags := make([]string, 0)
+	cmd.set.VisitSets(func(name string, set *cmnFlag.Set) {
+		set.VisitAll(func(flag *flag.Flag) {
+			flags = append(flags, fmt.Sprintf("-%s", flag.Name))
+		})
+	})
+
+	// Verify that there is a prediction for each flag associated with the command
+	assert.Equal(t, len(flags), len(res))
+	assert.ElementsMatch(t, flags, res, "flags and predictions didn't match, make sure to add "+
+		"new flags to the command AutoCompleteFlags function")
+}
+
+func TestTaskCreateCommand_AutocompleteArgs(t *testing.T) {
+	cmd := getInitializedCommand(t)
+	c := cmd.AutocompleteArgs()
+	assert.Equal(t, complete.PredictNothing, c)
 }

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/consul-k8s/cli/common/terminal"
 	"github.com/hashicorp/consul-k8s/cli/config"
 	"github.com/hashicorp/consul-k8s/cli/helm"
+	"github.com/posener/complete"
 	"helm.sh/helm/v3/pkg/action"
 	helmCLI "helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/cli/values"
@@ -44,6 +45,9 @@ const (
 
 	flagNameWait = "wait"
 	defaultWait  = true
+
+	flagNameContext    = "context"
+	flagNameKubeconfig = "kubeconfig"
 )
 
 type Command struct {
@@ -143,14 +147,14 @@ func (c *Command) init() {
 
 	f = c.set.NewSet("Global Options")
 	f.StringVar(&flag.StringVar{
-		Name:    "kubeconfig",
+		Name:    flagNameKubeconfig,
 		Aliases: []string{"c"},
 		Target:  &c.flagKubeConfig,
 		Default: "",
 		Usage:   "Set the path to kubeconfig file.",
 	})
 	f.StringVar(&flag.StringVar{
-		Name:    "context",
+		Name:    flagNameContext,
 		Target:  &c.flagKubeContext,
 		Default: "",
 		Usage:   "Set the Kubernetes context to use.",
@@ -306,6 +310,33 @@ func (c *Command) Run(args []string) int {
 
 	c.UI.Output("Consul upgraded in namespace %q.", namespace, terminal.WithSuccessStyle())
 	return 0
+}
+
+// AutocompleteFlags returns a mapping of supported flags and autocomplete
+// options for this command. The map key for the Flags map should be the
+// complete flag such as "-foo" or "--foo".
+func (c *Command) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		fmt.Sprintf("-%s", flagNamePreset):          complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameConfigFile):      complete.PredictFiles("*"),
+		fmt.Sprintf("-%s", flagNameSetStringValues): complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameSetValues):       complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameFileValues):      complete.PredictFiles("*"),
+		fmt.Sprintf("-%s", flagNameDryRun):          complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameAutoApprove):     complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameTimeout):         complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameVerbose):         complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameWait):            complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameContext):         complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameKubeconfig):      complete.PredictFiles("*"),
+	}
+}
+
+// AutocompleteArgs returns the argument predictor for this command.
+// Since argument completion is not supported, this will return
+// complete.PredictNothing.
+func (c *Command) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
 }
 
 // validateFlags checks that the user's provided flags are valid.

--- a/cli/cmd/upgrade/upgrade_test.go
+++ b/cli/cmd/upgrade/upgrade_test.go
@@ -1,11 +1,16 @@
 package upgrade
 
 import (
+	"flag"
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/hashicorp/consul-k8s/cli/common"
+	cmnFlag "github.com/hashicorp/consul-k8s/cli/common/flag"
 	"github.com/hashicorp/go-hclog"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestValidateFlags tests the validate flags function.
@@ -65,4 +70,34 @@ func getInitializedCommand(t *testing.T) *Command {
 	}
 	c.init()
 	return c
+}
+
+func TestTaskCreateCommand_AutocompleteFlags(t *testing.T) {
+	t.Parallel()
+	cmd := getInitializedCommand(t)
+
+	predictor := cmd.AutocompleteFlags()
+
+	// Test that we get the expected number of predictions
+	args := complete.Args{Last: "-"}
+	res := predictor.Predict(args)
+
+	// Grab the list of flags from the Flag object
+	flags := make([]string, 0)
+	cmd.set.VisitSets(func(name string, set *cmnFlag.Set) {
+		set.VisitAll(func(flag *flag.Flag) {
+			flags = append(flags, fmt.Sprintf("-%s", flag.Name))
+		})
+	})
+
+	// Verify that there is a prediction for each flag associated with the command
+	assert.Equal(t, len(flags), len(res))
+	assert.ElementsMatch(t, flags, res, "flags and predictions didn't match, make sure to add "+
+		"new flags to the command AutoCompleteFlags function")
+}
+
+func TestTaskCreateCommand_AutocompleteArgs(t *testing.T) {
+	cmd := getInitializedCommand(t)
+	c := cmd.AutocompleteArgs()
+	assert.Equal(t, complete.PredictNothing, c)
 }

--- a/cli/common/flag/set.go
+++ b/cli/common/flag/set.go
@@ -43,23 +43,23 @@ func NewSets() *Sets {
 
 // NewSet creates a new single flag set. A set should be created for
 // any grouping of flags, for example "Common Options", "Auth Options", etc.
-func (f *Sets) NewSet(name string) *Set {
+func (s *Sets) NewSet(name string) *Set {
 	flagSet := NewSet(name)
 
 	// The union and completions are pointers to our own values
-	flagSet.unionSet = f.unionSet
-	flagSet.completions = f.completions
+	flagSet.unionSet = s.unionSet
+	flagSet.completions = s.completions
 
 	// Keep track of it for help generation
-	f.flagSets = append(f.flagSets, flagSet)
+	s.flagSets = append(s.flagSets, flagSet)
 	return flagSet
 }
 
 // GetSetFlags returns a slice of flags for a given set.
 // If the requested set does not exist, this will return an empty slice.
-func (f *Sets) GetSetFlags(setName string) []string {
+func (s *Sets) GetSetFlags(setName string) []string {
 	var setFlags []string
-	for _, set := range f.flagSets {
+	for _, set := range s.flagSets {
 		if set.name == setName {
 			set.flagSet.VisitAll(func(f *flag.Flag) {
 				setFlags = append(setFlags, fmt.Sprintf("-%s", f.Name))
@@ -72,36 +72,36 @@ func (f *Sets) GetSetFlags(setName string) []string {
 }
 
 // Completions returns the completions for this flag set.
-func (f *Sets) Completions() complete.Flags {
-	return f.completions
+func (s *Sets) Completions() complete.Flags {
+	return s.completions
 }
 
 // Parse parses the given flags, returning any errors.
-func (f *Sets) Parse(args []string) error {
-	return f.unionSet.Parse(args)
+func (s *Sets) Parse(args []string) error {
+	return s.unionSet.Parse(args)
 }
 
 // Parsed reports whether the command-line flags have been parsed.
-func (f *Sets) Parsed() bool {
-	return f.unionSet.Parsed()
+func (s *Sets) Parsed() bool {
+	return s.unionSet.Parsed()
 }
 
 // Args returns the remaining args after parsing.
-func (f *Sets) Args() []string {
-	return f.unionSet.Args()
+func (s *Sets) Args() []string {
+	return s.unionSet.Args()
 }
 
 // Visit visits the flags in lexicographical order, calling fn for each. It
 // visits only those flags that have been set.
-func (f *Sets) Visit(fn func(*flag.Flag)) {
-	f.unionSet.Visit(fn)
+func (s *Sets) Visit(fn func(*flag.Flag)) {
+	s.unionSet.Visit(fn)
 }
 
 // Help builds custom help for this command, grouping by flag set.
-func (fs *Sets) Help() string {
+func (s *Sets) Help() string {
 	var out bytes.Buffer
 
-	for _, set := range fs.flagSets {
+	for _, set := range s.flagSets {
 		printFlagTitle(&out, set.name+":")
 		set.VisitAll(func(f *flag.Flag) {
 			// Skip any hidden flags
@@ -115,9 +115,10 @@ func (fs *Sets) Help() string {
 	return strings.TrimRight(out.String(), "\n")
 }
 
-// Help builds custom help for this command, grouping by flag set.
-func (fs *Sets) VisitSets(fn func(name string, set *Set)) {
-	for _, set := range fs.flagSets {
+// VisitSets visits each set and performs action based on the passed in
+// function.
+func (s *Sets) VisitSets(fn func(name string, set *Set)) {
+	for _, set := range s.flagSets {
 		fn(set.name, set)
 	}
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -15,6 +15,9 @@ func main() {
 	c := cli.NewCLI("consul-k8s", version.GetHumanVersion())
 	c.Args = os.Args[1:]
 
+	// Enable CLI autocomplete
+	c.Autocomplete = true
+
 	log := hclog.New(&hclog.LoggerOptions{
 		Name:   "cli",
 		Level:  hclog.Info,


### PR DESCRIPTION
Changes proposed in this PR:

- see description

How I've tested this PR:
- ran through auto-completions tabbing through commands
- unit tests written to make sure that number of flags matches the number of auto-completion suggestions

How I expect reviewers to test this PR:
- run consul-k8s, activate autocomplete, and try it out

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

## Description
- Added tab autocompletion to the `consul-k8s` CLI. Commands are automatically supported, but flags require implementing the completion interface per command

example for `consul-k8s install`:

```Go
// AutocompleteFlags returns a mapping of supported flags and autocomplete
// options for this command. The map key for the Flags map should be the
// complete flag such as "-foo" or "--foo".
func (c *Command) AutocompleteFlags() complete.Flags {
	return complete.Flags{
		fmt.Sprintf("-%s", flagNamePreset):          complete.PredictNothing,
		fmt.Sprintf("-%s", flagNameNamespace):       complete.PredictNothing,
		fmt.Sprintf("-%s", flagNameDryRun):          complete.PredictNothing,
		fmt.Sprintf("-%s", flagNameAutoApprove):     complete.PredictNothing,
		fmt.Sprintf("-%s", flagNameConfigFile):      complete.PredictFiles("*"),
		fmt.Sprintf("-%s", flagNameSetStringValues): complete.PredictNothing,
		fmt.Sprintf("-%s", flagNameSetValues):       complete.PredictNothing,
		fmt.Sprintf("-%s", flagNameFileValues):      complete.PredictFiles("*"),
		fmt.Sprintf("-%s", flagNameTimeout):         complete.PredictNothing,
		fmt.Sprintf("-%s", flagNameVerbose):         complete.PredictNothing,
		fmt.Sprintf("-%s", flagNameWait):            complete.PredictNothing,
		fmt.Sprintf("-%s", flagNameContext):         complete.PredictNothing,
		fmt.Sprintf("-%s", flagNameKubeconfig):      complete.PredictNothing,
	}
}

// AutocompleteArgs returns the argument predictor for this command.
// Since argument completion is not supported, this will return
// complete.PredictNothing.
func (c *Command) AutocompleteArgs() complete.Predictor {
	return complete.PredictNothing
}
```
- `complete.PredictNothing` instructs that no completion should be offered
- `complete.PredictFiles("*")` instructs that completion should suggest any file in the running directory

### Usage
Enable autocompletion by running:

```shell-session
$ consul-k8s -autocomplete-install
```

You need to open a new console for this to take effect.

Disable autocompletion by running:

```shell-session
$ consul-k8s -autocomplete-install
```
You need to open a new console for this to take effect.

When you start typing a consul-k8s command, press the `<tab>` character to show a list of available completions. Type `-<tab>` to show available flag completions.

#### Example command complete
<img width="705" alt="image" src="https://user-images.githubusercontent.com/62034708/190282229-5ea531d6-c7af-47b9-a2ea-af34948425f0.png">

#### Example flag complete
<img width="791" alt="image" src="https://user-images.githubusercontent.com/62034708/190282304-52faafb9-53c7-41db-b501-14b59aa0dbfb.png">


### Shell Support
Autocompletion is supported via the [posener/complete](https://github.com/posener/complete) library which is included in the [mitchell/cli library](https://github.com/mitchellh/cli). This library supports bash, zsh and fish. 

## Future Support
Right now we only support basic completions (commands, flags, or files) add more complex completions for example:
- parse flags and make pod suggestions i.e. `consul-k8s proxy read -n consul <tab>` will provide a list of pods in the consul namespace
- provide set value suggestions based on those in the helm values file

