### PR TITLE
Run API Gateway with no local agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ IMPROVEMENTS:
   * Expand the set of Envoy Listener Filters that may be parsed and output to the Listeners table. [[GH-1442](https://github.com/hashicorp/consul-k8s/pull/1442)]
 * Helm:
   * The default Envoy proxy image is now `envoyproxy/envoy:v1.23.1`. [[GH-1473](https://github.com/hashicorp/consul-k8s/pull/1473)]
+  * API Gateway: Allow API Gateway to run when using `externalServers` without agents on the local node [[GH-1509](https://github.com/hashicorp/consul-k8s/pull/1509)]
 
 BUG FIXES:
 * Helm

--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -67,10 +67,18 @@ spec:
           value: "/consul/login/acl-token"
         {{- end }}
         - name: CONSUL_HTTP_ADDR
+          {{- if (and .Values.externalServers.enabled (not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)))) }}
+          {{- if .Values.global.tls.enabled }}
+          value: https://{{ first .Values.externalServers.hosts }}:{{ .Values.externalServers.httpsPort }}
+          {{- else }}
+          value: http://{{ first .Values.externalServers.hosts }}:{{ .Values.externalServers.httpPort }}
+          {{- end }}
+          {{- else }}
           {{- if .Values.global.tls.enabled }}
           value: https://$(HOST_IP):8501
           {{- else }}
           value: http://$(HOST_IP):8500
+          {{- end }}
           {{- end }}
         command:
         - "/bin/sh"

--- a/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
+++ b/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
@@ -11,6 +11,9 @@ metadata:
     component: api-gateway
 spec:
   consul:
+    {{- if (and .Values.externalServers.enabled (not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)))) }}
+    address: {{ first .Values.externalServers.hosts }}
+    {{- end }}
     authentication:
       {{- if .Values.global.acls.manageSystemACLs }}
       managed: true
@@ -22,12 +25,21 @@ spec:
     scheme: http
     {{- end }}
     ports:
-      grpc: 8502
-    {{- if .Values.global.tls.enabled }}
-      http: 8501
+    {{- if (and .Values.externalServers.enabled (not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)))) }}
+      grpc: {{ .Values.externalServers.grpcPort }}
+      {{- if .Values.global.tls.enabled }}
+      http: {{ .Values.externalServers.httpsPort }}
+      {{- else }}
+      http: {{ .Values.externalServers.httpPort }}
+      {{- end }}
     {{- else }}
+      grpc: 8502
+      {{- if .Values.global.tls.enabled }}
+      http: 8501
+      {{- else }}
       http: 8500
-    {{- end }}
+      {{- end }}
+    {{- end}}
   {{- with .Values.apiGateway.managedGatewayClass.deployment }}
   deployment:
     {{- toYaml . | nindent 4 }}

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -915,7 +915,7 @@ load _helpers
 
 @test "apiGateway/Deployment: externalServers set and clients enabled" {
   cd `chart_dir`
-  local object=$(helm template \
+  local actual=$(helm template \
     -s templates/api-gateway-controller-deployment.yaml  \
     --set 'apiGateway.enabled=true' \
     --set 'apiGateway.image=foo' \
@@ -924,10 +924,6 @@ load _helpers
     --set 'externalServers.enabled=true' \
     --set 'client.enabled=true' \
     . | tee /dev/stderr |
-      yq -r '.spec.template' | tee /dev/stderr)
-
-  local actual=$(echo $object |
       yq '[.spec.template.spec.containers[0].env[1].value] | any(contains("http://$(HOST_IP):8500"))' | tee /dev/stderr)
-      echo $actual
   [ "${actual}" = "true" ]
 }

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -927,7 +927,7 @@ load _helpers
       yq -r '.spec.template' | tee /dev/stderr)
 
   local actual=$(echo $object |
-      yq '[.env[1].value] | any(contains("http://$(HOST_IP):8500"))' | tee /dev/stderr)
+      yq '[.spec.template.spec.containers[0].env[1].value] | any(contains("http://$(HOST_IP):8500"))' | tee /dev/stderr)
       echo $actual
   [ "${actual}" = "true" ]
 }

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -884,29 +884,23 @@ load _helpers
 
 @test "apiGateway/Deployment: externalServers set and clients disabled" {
   cd `chart_dir`
-  local object=$(helm template \
+  local actual=$(helm template \
     -s templates/api-gateway-controller-deployment.yaml  \
     --set 'apiGateway.enabled=true' \
     --set 'apiGateway.image=foo' \
-    --set 'global.tls.enabled=true' \
-    --set 'global.tls.enableAutoEncrypt=true' \
-    --set 'global.tls.caCert.secretName=foo'
-    --set 'server.enabled=false' \
+    --set 'global.tls.enabled=true'  \
     --set 'externalServers.hosts[0]=external-consul.host' \
     --set 'externalServers.enabled=true' \
+    --set 'server.enabled=false' \
     --set 'client.enabled=false' \
     . | tee /dev/stderr |
-      yq -r '.spec.template' | tee /dev/stderr)
-
-  local actual=$(echo $object |
-      yq '[.env[2].value] | any(contains("https://external-consul.host:8501"))' | tee /dev/stderr)
-      echo $actual
+      yq '[.spec.template.spec.containers[0].env[2].value] | any(contains("https://external-consul.host:8501"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
 @test "apiGateway/Deployment: non-tls externalServers set and clients disabled" {
   cd `chart_dir`
-  local object=$(helm template \
+  local actual=$(helm template \
     -s templates/api-gateway-controller-deployment.yaml  \
     --set 'apiGateway.enabled=true' \
     --set 'apiGateway.image=foo' \
@@ -915,11 +909,7 @@ load _helpers
     --set 'server.enabled=false' \
     --set 'client.enabled=false' \
     . | tee /dev/stderr |
-      yq -r '.spec.template' | tee /dev/stderr)
-
-  local actual=$(echo $object |
-      yq '[.env[2].value] | any(contains("http://external-consul.host:8500"))' | tee /dev/stderr)
-      echo $actual
+      yq '[.spec.template.spec.containers[0].env[1].value] | any(contains("http://external-consul.host:8500"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
@@ -929,18 +919,15 @@ load _helpers
     -s templates/api-gateway-controller-deployment.yaml  \
     --set 'apiGateway.enabled=true' \
     --set 'apiGateway.image=foo' \
-    --set 'global.tls.enabled=true' \
-    --set 'global.tls.enableAutoEncrypt=true' \
-    --set 'global.tls.caCert.secretName=foo'
     --set 'server.enabled=false' \
     --set 'externalServers.hosts[0]=external-consul.host' \
     --set 'externalServers.enabled=true' \
-    --set 'client.enabled=false' \
+    --set 'client.enabled=true' \
     . | tee /dev/stderr |
       yq -r '.spec.template' | tee /dev/stderr)
 
   local actual=$(echo $object |
-      yq '[.env[2].value] | any(contains("https://$(HOST_IP):8501"))' | tee /dev/stderr)
+      yq '[.env[2].value] | any(contains("http://$(HOST_IP):8500"))' | tee /dev/stderr)
       echo $actual
   [ "${actual}" = "true" ]
 }

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -927,7 +927,7 @@ load _helpers
       yq -r '.spec.template' | tee /dev/stderr)
 
   local actual=$(echo $object |
-      yq '[.env[2].value] | any(contains("http://$(HOST_IP):8500"))' | tee /dev/stderr)
+      yq '[.env[1].value] | any(contains("http://$(HOST_IP):8500"))' | tee /dev/stderr)
       echo $actual
   [ "${actual}" = "true" ]
 }

--- a/charts/consul/test/unit/api-gateway-gatewayclassconfig.bats
+++ b/charts/consul/test/unit/api-gateway-gatewayclassconfig.bats
@@ -66,3 +66,38 @@ load _helpers
       yq '.spec.deployment.minInstances == 3' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# externalServers
+
+@test "apiGateway/GatewayClassConfig: externalServers set and clients disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-gatewayclassconfig.yaml \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=foo' \
+      --set 'global.tls.enabled=true' \
+      --set 'server.enabled=false' \
+      --set 'externalServers.hosts[0]=external-consul.host' \
+      --set 'externalServers.enabled=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.consul.address == "external-consul.host"' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "apiGateway/GatewayClassConfig: externalServers set and clients enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-gatewayclassconfig.yaml \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=foo' \
+      --set 'global.tls.enabled=true' \
+      --set 'server.enabled=false' \
+      --set 'externalServers.hosts[0]=external-consul.host' \
+      --set 'externalServers.enabled=true' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.consul | has("address") | not' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/api-gateway-gatewayclassconfig.bats
+++ b/charts/consul/test/unit/api-gateway-gatewayclassconfig.bats
@@ -96,7 +96,7 @@ load _helpers
       --set 'server.enabled=false' \
       --set 'externalServers.hosts[0]=external-consul.host' \
       --set 'externalServers.enabled=true' \
-      --set 'client.enabled=false' \
+      --set 'client.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.consul | has("address") | not' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1089,6 +1089,9 @@ externalServers:
   # @type: array<string>
   hosts: []
 
+  # The HTTP port of the Consul servers.
+  httpPort: 8500
+
   # The HTTPS port of the Consul servers.
   httpsPort: 8501
 


### PR DESCRIPTION
Changes proposed in this PR:

- This adds the ability to run and api gateway when local clients are disabled. It coincides with TTL-based health checks being the norm for our deployment entrypoint [here](https://github.com/hashicorp/consul-api-gateway/pull/371).

How I've tested this PR:

- Unit tests and manually.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

