### PR TITLE
Populate primary dc flag for APIGW controller in secondary federated dc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ BUG FIXES:
 * Control plane
   * Use global ACL auth method to provision ACL tokens for API Gateway in secondary datacenter [[GH-1481](https://github.com/hashicorp/consul-k8s/pull/1481)]
 
+IMPROVEMENTS:
+* Helm:
+  * API Gateway: Configure primary-datacenter when deploying controller into secondary datacenter with federation enabled [[GH-1511](https://github.com/hashicorp/consul-k8s/pull/1511)]
+
 ## 0.48.0 (September 01, 2022)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ BUG FIXES:
 
 IMPROVEMENTS:
 * Helm:
-  * API Gateway: Configure primary-datacenter when deploying controller into secondary datacenter with federation enabled [[GH-1511](https://github.com/hashicorp/consul-k8s/pull/1511)]
+  * API Gateway: Set primary datacenter flag when deploying controller into secondary datacenter with federation enabled [[GH-1511](https://github.com/hashicorp/consul-k8s/pull/1511)]
 
 ## 0.48.0 (September 01, 2022)
 

--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -90,6 +90,9 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
+            {{- if and .Values.global.federation.enabled .Values.global.federation.primaryDatacenter }}
+            -primary-datacenter={{ .Values.global.federation.primaryDatacenter }} \
+            {{- end }}
             -log-level {{ default .Values.global.logLevel .Values.apiGateway.logLevel }} \
             -log-json={{ .Values.global.logJSON }}
         volumeMounts:


### PR DESCRIPTION
> **Note** This is the third of three in the chain of PRs required to get Consul API Gateway working in a secondary federated datacenter:
> - https://github.com/hashicorp/consul-k8s/pull/1481
> - https://github.com/hashicorp/consul-api-gateway/pull/368
> - https://github.com/hashicorp/consul-k8s/pull/1511

**Changes proposed in this PR:**
- When deployed into a secondary datacenter with federation enabled, populate the `primary-datacenter` flag added to Consul API Gateway's controller in https://github.com/hashicorp/consul-api-gateway/pull/368

**How I've tested this PR:**
Install a federated setup as described in [this guide](https://developer.hashicorp.com/consul/docs/k8s/deployment-configurations/multi-cluster/kubernetes), making sure that API Gateway is enabled in both datacenters and using the latest build from `main`:
```yaml
apiGateway:
  enabled: true
  image: "hashicorppreview/consul-api-gateway:0.5-dev"
```

Once completed, install a `Gateway` into the secondated datacenter and ensure it works. [This guide](https://developer.hashicorp.com/consul/tutorials/kubernetes/kubernetes-api-gateway) sufficiently exercises this behavior.

**How I expect reviewers to test this PR:**
See above

**Checklist:**
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

