### PR TITLE
create-federation-secret job runs only when server.updatePartition is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ FEATURES:
 BUG FIXES:
 * Control plane
   * Use global ACL auth method to provision ACL tokens for API Gateway in secondary datacenter [[GH-1481](https://github.com/hashicorp/consul-k8s/pull/1481)]
+* Helm
+  * Only create Federation Secret Job when server.updatePartition is 0 [[GH-1512](https://github.com/hashicorp/consul-k8s/pull/1512)]
 
 ## 0.48.0 (September 01, 2022)
 

--- a/charts/consul/templates/create-federation-secret-job.yaml
+++ b/charts/consul/templates/create-federation-secret-job.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.global.federation.createFederationSecret }}
 {{- if not .Values.global.federation.enabled }}{{ fail "global.federation.enabled must be true when global.federation.createFederationSecret is true" }}{{ end }}
 {{- if and (not .Values.global.acls.createReplicationToken) .Values.global.acls.manageSystemACLs }}{{ fail "global.acls.createReplicationToken must be true when global.acls.manageSystemACLs is true because the federation secret must include the replication token" }}{{ end }}
+{{- if eq (int .Values.server.updatePartition) 0 }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -156,4 +157,5 @@ spec:
             limits:
               memory: "50Mi"
               cpu: "50m"
+{{- end }}
 {{- end }}

--- a/charts/consul/test/unit/create-federation-secret-job.bats
+++ b/charts/consul/test/unit/create-federation-secret-job.bats
@@ -61,6 +61,21 @@ load _helpers
   [[ "$output" =~ "global.acls.createReplicationToken must be true when global.acls.manageSystemACLs is true because the federation secret must include the replication token" ]]
 }
 
+@test "createFederationSecret/Job: disabled by updatepartition != 0" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/create-federation-secret-job.yaml  \
+      --set 'global.federation.enabled=true' \
+      --set 'global.federation.createFederationSecret=true' \
+      --set 'global.acls.createReplicationToken=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'server.updatePartition=1' \
+      .
+}
+
 @test "createFederationSecret/Job: mounts auto-created ca secrets by default" {
   cd `chart_dir`
   local volumes=$(helm template \


### PR DESCRIPTION
fixes #1466

Changes proposed in this PR:
- CreateFederationSecret Job should not run when UpdatePartition is not 0.

How I've tested this PR:

I ran the below commands to verify  the change

1. job does not run when updatePartition is 1.
```
helm template \
      -s templates/create-federation-secret-job.yaml  \
      --set 'global.federation.enabled=true' \
      --set 'global.federation.createFederationSecret=true' \
      --set 'global.acls.createReplicationToken=true' \
      --set 'global.acls.manageSystemACLs=true' \
      --set 'global.tls.enabled=true' \
      --set 'meshGateway.enabled=true' \
      --set 'connectInject.enabled=true' \
      --set 'server.updatePartition=1' \
      .
```

2. CreateFederationSecret job runs, when updatePartition is 0.
```
helm template \
      -s templates/create-federation-secret-job.yaml  \
      --set 'global.federation.enabled=true' \
      --set 'global.federation.createFederationSecret=true' \
      --set 'global.acls.createReplicationToken=true' \
      --set 'global.acls.manageSystemACLs=true' \
      --set 'global.tls.enabled=true' \
      --set 'meshGateway.enabled=true' \
      --set 'connectInject.enabled=true' \
      --set 'server.updatePartition=0' \
      .
```
How I expect reviewers to test this PR:

Please follow the above to test

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

