### PR TITLE
add `release/**` wild card to ci.hcl

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -8,7 +8,10 @@ project "consul-k8s" {
   github {
     organization = "hashicorp"
     repository = "consul-k8s"
-    release_branches = ["main"]
+    release_branches = [
+      "main",
+      "release/**",
+    ]
   }
 }
 

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -3,7 +3,7 @@ schema = "1"
 project "consul-k8s" {
   team = "consul-k8s"
   slack {
-    notification_channel = "CBXF3CGAF" # team-consul-kubernetes
+    notification_channel = "C0421KHNAV9" # feed-consul-k8s-ci
   }
   github {
     organization = "hashicorp"


### PR DESCRIPTION
Changes proposed in this PR:
- branches with a leading `release/` will be categorized as release branches

How I've tested this PR:
- Will be tested with next release

How I expect reviewers to test this PR:
- N/A

Checklist:
- [N/A] Tests added
- [N/A] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

