### PR TITLE
Support peering on agentless

### DIFF
--- a/acceptance/tests/peering/peering_connect_namespaces_test.go
+++ b/acceptance/tests/peering/peering_connect_namespaces_test.go
@@ -27,8 +27,6 @@ const staticClientNamespace = "ns2"
 
 // Test that Connect works in installations for X-Peers networking.
 func TestPeering_ConnectNamespaces(t *testing.T) {
-	t.Skipf("currently unsupported in agentless")
-
 	env := suite.Environment()
 	cfg := suite.Config()
 

--- a/acceptance/tests/peering/peering_connect_test.go
+++ b/acceptance/tests/peering/peering_connect_test.go
@@ -22,8 +22,6 @@ import (
 
 // Test that Connect works in installations for X-Peers networking.
 func TestPeering_Connect(t *testing.T) {
-	t.Skipf("currently unsupported in agentless")
-
 	env := suite.Environment()
 	cfg := suite.Config()
 

--- a/charts/consul/templates/expose-servers-service.yaml
+++ b/charts/consul/templates/expose-servers-service.yaml
@@ -52,7 +52,7 @@ spec:
       {{- end }}
     - name: grpc
       port: 8502
-      targetPort: 8503
+      targetPort: 8502
       {{ if (and (eq .Values.server.exposeService.type "NodePort") .Values.server.exposeService.nodePort.grpc) }}
       nodePort: {{ .Values.server.exposeService.nodePort.grpc }}
       {{- end }}

--- a/charts/consul/templates/server-podsecuritypolicy.yaml
+++ b/charts/consul/templates/server-podsecuritypolicy.yaml
@@ -35,8 +35,8 @@ spec:
     max: {{ .Values.server.ports.serflan.port }}
   - min: 8302
     max: 8302
-  - min: 8503
-    max: 8503
+  - min: 8502
+    max: 8502
   {{- end }}
   hostIPC: false
   hostPID: false

--- a/charts/consul/templates/server-service.yaml
+++ b/charts/consul/templates/server-service.yaml
@@ -40,8 +40,8 @@ spec:
       targetPort: 8501
     {{- end }}
     - name: grpc
-      port: 8503
-      targetPort: 8503
+      port: 8502
+      targetPort: 8502
     - name: serflan-tcp
       protocol: "TCP"
       port: 8301

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -1839,10 +1839,10 @@ EOF
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command')
 
-  local actual=$(echo $command | jq -r ' . | any(contains("-token-server-address=\"1.2.3.4:8503\""))' | tee /dev/stderr)
+  local actual=$(echo $command | jq -r ' . | any(contains("-token-server-address=\"1.2.3.4:8502\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
-  local actual=$(echo $command | jq -r ' . | any(contains("-token-server-address=\"2.2.3.4:8503\""))' | tee /dev/stderr)
+  local actual=$(echo $command | jq -r ' . | any(contains("-token-server-address=\"2.2.3.4:8502\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/charts/consul/test/unit/server-podsecuritypolicy.bats
+++ b/charts/consul/test/unit/server-podsecuritypolicy.bats
@@ -39,7 +39,7 @@ load _helpers
       --set 'server.exposeGossipAndRPCPorts=true' \
       . | tee /dev/stderr |
       yq -c '.spec.hostPorts' | tee /dev/stderr)
-  [ "${actual}" = '[{"min":8300,"max":8300},{"min":8301,"max":8301},{"min":8302,"max":8302},{"min":8503,"max":8503}]' ]
+  [ "${actual}" = '[{"min":8300,"max":8300},{"min":8301,"max":8301},{"min":8302,"max":8302},{"min":8502,"max":8502}]' ]
 }
 
 @test "server/PodSecurityPolicy: hostPort 8300, server.ports.serflan.port and 8302 allowed when exposeGossipAndRPCPorts=true" {
@@ -51,5 +51,5 @@ load _helpers
       --set 'server.ports.serflan.port=8333' \
       . | tee /dev/stderr |
       yq -c '.spec.hostPorts' | tee /dev/stderr)
-  [ "${actual}" = '[{"min":8300,"max":8300},{"min":8333,"max":8333},{"min":8302,"max":8302},{"min":8503,"max":8503}]' ]
+  [ "${actual}" = '[{"min":8300,"max":8300},{"min":8333,"max":8333},{"min":8302,"max":8302},{"min":8502,"max":8502}]' ]
 }

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1098,7 +1098,7 @@ externalServers:
   httpsPort: 8501
 
   # The GRPC port of the Consul servers.
-  grpcPort: 8503
+  grpcPort: 8502
 
   # The server name to use as the SNI host header when connecting with HTTPS.
   # @type: string

--- a/control-plane/connect-inject/container_init_test.go
+++ b/control-plane/connect-inject/container_init_test.go
@@ -961,7 +961,7 @@ func TestHandlerContainerInit_WithTLSAndCustomPorts(t *testing.T) {
 				ConsulAddress:    "10.0.0.0",
 				TLSEnabled:       true,
 				ConsulHTTPPort:   "443",
-				ConsulGRPCPort:   "8503",
+				ConsulGRPCPort:   "8502",
 			}
 			if caProvided {
 				w.ConsulCACert = "consul-ca-cert"

--- a/control-plane/connect-inject/peering_acceptor_controller_test.go
+++ b/control-plane/connect-inject/peering_acceptor_controller_test.go
@@ -92,7 +92,7 @@ func TestReconcile_CreateUpdatePeeringAcceptor(t *testing.T) {
 		{
 			name:                    "PeeringAcceptor generates a token with expose server addresses",
 			readServerExposeService: true,
-			expectedTokenAddresses:  []string{"1.1.1.1:8503"},
+			expectedTokenAddresses:  []string{"1.1.1.1:8502"},
 			k8sObjects: func() []runtime.Object {
 				service := &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
@@ -158,8 +158,8 @@ func TestReconcile_CreateUpdatePeeringAcceptor(t *testing.T) {
 		},
 		{
 			name:                   "PeeringAcceptor generates a token with external addresses specified",
-			externalAddresses:      []string{"1.1.1.1:8503", "2.2.2.2:8503"},
-			expectedTokenAddresses: []string{"1.1.1.1:8503", "2.2.2.2:8503"},
+			externalAddresses:      []string{"1.1.1.1:8502", "2.2.2.2:8502"},
+			expectedTokenAddresses: []string{"1.1.1.1:8502", "2.2.2.2:8502"},
 			k8sObjects: func() []runtime.Object {
 				acceptor := &v1alpha1.PeeringAcceptor{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Changes proposed in this PR:
- Update the configuration to support peering with agentless. This required migrating all the grpc ports that were configured to use 8503 to use 8502.

How I've tested this PR:
- Ran the acceptance tests locally on GKE.

How I expect reviewers to test this PR:
- Approve if the acceptance test for Peering goes 🟢 


