### PR TITLE
update docs for helm for global.syncCatalog.aclSyncToken

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1795,12 +1795,12 @@ syncCatalog:
 
   # Refers to a Kubernetes secret that you have created that contains
   # an ACL token for your Consul cluster which allows the sync process the correct
-  # permissions. This is only needed if ACLs are enabled on the Consul cluster.
+  # permissions. This is only needed if ACLs are managed manually within the Consul cluster.
   aclSyncToken:
-    # The name of the Vault secret that holds the acl sync token.
+    # The name of the Kubernetes secret that holds the acl sync token.
     # @type: string
     secretName: null
-    # The key within the Vault secret that holds the acl sync.
+    # The key within the Kubernetes secret that holds the acl sync token.
     # @type: string
     secretKey: null
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1795,7 +1795,7 @@ syncCatalog:
 
   # Refers to a Kubernetes secret that you have created that contains
   # an ACL token for your Consul cluster which allows the sync process the correct
-  # permissions. This is only needed if ACLs are managed manually within the Consul cluster.
+  # permissions. This is only needed if ACLs are managed manually within the Consul cluster, i.e. `global.acls.manageSystemACLs` is `false`.
   aclSyncToken:
     # The name of the Kubernetes secret that holds the acl sync token.
     # @type: string


### PR DESCRIPTION
Changes proposed in this PR:
- Update value.yaml for syncCatalog.aclSyncToken stanza so that it references Kubernetes secrets since this is only supported for BYO ACL tokens.

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

