### PR TITLE
downgrade helm version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ commands:
             chmod +x ./kubectl
             sudo mv ./kubectl /usr/local/bin/kubectl
 
-            wget https://get.helm.sh/helm-v3.9.4-linux-amd64.tar.gz
-            tar -zxvf helm-v3.9.4-linux-amd64.tar.gz
+            wget https://get.helm.sh/helm-v3.7.0-linux-amd64.tar.gz
+            tar -zxvf helm-v3.7.0-linux-amd64.tar.gz
             sudo mv linux-amd64/helm /usr/local/bin/helm
   create-kind-clusters:
     parameters:


### PR DESCRIPTION
Changes proposed in this PR:
- I'm not sure how this got upgraded after we downgraded it, maybe a merge conflict that wasnt caught. Anyways it's my fault so lets get it back to where it was.

How I've tested this PR:
CI should not throw 
```
Error: Kubernetes cluster unreachable: exec plugin: invalid apiVersion "[client.authentication.k8s.io/v1alpha1](http://client.authentication.k8s.io/v1alpha1)"
```

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

