### PR TITLE
CNI: Add support for OpenShift and Multus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ commands:
             chmod +x ./kubectl
             sudo mv ./kubectl /usr/local/bin/kubectl
 
-            wget https://get.helm.sh/helm-v3.9.4-linux-amd64.tar.gz
-            tar -zxvf helm-v3.9.4-linux-amd64.tar.gz
+            wget https://get.helm.sh/helm-v3.7.0-linux-amd64.tar.gz
+            tar -zxvf helm-v3.7.0-linux-amd64.tar.gz
             sudo mv linux-amd64/helm /usr/local/bin/helm
   create-kind-clusters:
     parameters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 FEATURES:
 * CLI:
   * Add support for tab autocompletion [[GH-1437](https://github.com/hashicorp/consul-k8s/pull/1501)]
+* Consul CNI Plugin
+  * Support for OpenShift and Multus CNI plugin [[GH-1527](https://github.com/hashicorp/consul-k8s/pull/1527)]
 
 BUG FIXES:
 * Control plane

--- a/charts/consul/templates/cni-clusterrole.yaml
+++ b/charts/consul/templates/cni-clusterrole.yaml
@@ -27,4 +27,12 @@ rules:
   - {{ template "consul.fullname" . }}-cni
   verbs:
   - use
+{{- if .Values.global.openshift.enabled}}
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  resourceNames:
+  - {{ template "consul.fullname" . }}-cni
+  verbs:
+  - use
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -63,6 +63,7 @@ spec:
             - -log-level={{ default .Values.global.logLevel .Values.connectInject.cni.logLevel }}
             - -cni-bin-dir={{ .Values.connectInject.cni.cniBinDir }}
             - -cni-net-dir={{ .Values.connectInject.cni.cniNetDir }}
+            - -multus={{ .Values.connectInject.cni.multus }}
           {{- with .Values.connectInject.cni.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/consul/templates/cni-networkattachmentdefinition.yaml
+++ b/charts/consul/templates/cni-networkattachmentdefinition.yaml
@@ -1,0 +1,25 @@
+{{- if (and (.Values.connectInject.cni.enabled) (.Values.connectInject.cni.multus)) }}
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: {{ template "consul.fullname" . }}-cni
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: cni 
+spec:
+  config: '{
+            "cniVersion": "0.3.1",
+            "type": "consul-cni",
+            "cni_bin_dir": "{{ .Values.connectInject.cni.cniBinDir }}",
+            "cni_net_dir": "{{ .Values.connectInject.cni.cniNetDir }}",
+            "kubeconfig": "ZZZ-consul-cni-kubeconfig",
+            "log_level": "{{ default .Values.global.logLevel .Values.connectInject.cni.logLevel }}",
+            "multus": true,
+            "name": "consul-cni",
+            "type": "consul-cni"
+        }'
+{{- end }}

--- a/charts/consul/templates/cni-securitycontextconstraints.yaml
+++ b/charts/consul/templates/cni-securitycontextconstraints.yaml
@@ -1,0 +1,50 @@
+{{- if (and (.Values.connectInject.cni.enabled) (.Values.global.openshift.enabled)) }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ template "consul.fullname" . }}-cni
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: cni
+  annotations:
+    kubernetes.io/description: {{ template "consul.fullname" . }}-cni are the security context constraints required
+      to run consul-cni.
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: MustRunAs
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+- hostPath
+{{- end }}

--- a/charts/consul/templates/cni-securitycontextconstraints.yaml
+++ b/charts/consul/templates/cni-securitycontextconstraints.yaml
@@ -15,9 +15,9 @@ metadata:
       to run consul-cni.
 allowHostDirVolumePlugin: true
 allowHostIPC: false
-allowHostNetwork: true
+allowHostNetwork: false
 allowHostPID: false
-allowHostPorts: true
+allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
 allowedCapabilities: null

--- a/charts/consul/test/unit/cni-daemonset.bats
+++ b/charts/consul/test/unit/cni-daemonset.bats
@@ -63,6 +63,7 @@ load _helpers
       --set 'connectInject.cni.logLevel=bar' \
       --set 'connectInject.cni.cniBinDir=baz' \
       --set 'connectInject.cni.cniNetDir=foo' \
+      --set 'connectInject.cni.multus=false' \
       bar \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
@@ -85,6 +86,10 @@ load _helpers
 
   local actual=$(echo "$cmd" |
     yq 'any(contains("cni-net-dir=foo"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("multus=false"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/charts/consul/test/unit/cni-networkattachmentdefinition.bats
+++ b/charts/consul/test/unit/cni-networkattachmentdefinition.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "cni/NetworkAttachmentDefinition: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-networkattachmentdefinition.yaml  \
+      .
+}
+
+@test "cni/NetworkAttachmentDefinition: disabled when cni enabled and multus disabled" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-securitycontextconstraints.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.multus=false' \
+      .
+}
+
+@test "cni/NetworkAttachmentDefinition: enabled when cni enabled and multus enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-networkattachmentdefinition.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.multus=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "cni/NetworkAttachmentDefinition: config is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/cni-networkattachmentdefinition.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.cni.multus=true' \
+      --set 'connectInject.cni.logLevel=bar' \
+      --set 'connectInject.cni.cniBinDir=baz' \
+      --set 'connectInject.cni.cniNetDir=foo' \
+      bar \
+      . | tee /dev/stderr |
+      yq -rc '.spec.config' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq '.log_level' | tee /dev/stderr)
+  [ "${actual}" = '"bar"' ]
+
+  local actual=$(echo "$cmd" |
+    yq '.cni_bin_dir' | tee /dev/stderr)
+  [ "${actual}" = '"baz"' ]
+
+  local actual=$(echo "$cmd" |
+    yq '.cni_net_dir' | tee /dev/stderr)
+  [ "${actual}" = '"foo"' ]
+
+}
+

--- a/charts/consul/test/unit/cni-securitycontextcontstraints.bats
+++ b/charts/consul/test/unit/cni-securitycontextcontstraints.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "cni/SecurityContextConstraints: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-securitycontextconstraints.yaml  \
+      .
+}
+
+@test "cni/SecurityContextConstraints: disabled when cni disabled and global.openshift.enabled=true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/cni-securitycontextconstraints.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.cni.enabled=false' \
+      --set 'global.openshift.enabled=true' \
+      .
+}
+
+@test "cni/SecurityContextConstraints: enabled when cni enabled and global.openshift.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-securitycontextconstraints.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'global.openshift.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1960,7 +1960,20 @@ connectInject:
     # Location on the kubernetes node of all CNI configuration. Should be the absolute path and start with a '/'
     # @type: string
     cniNetDir: "/etc/cni/net.d"
- 
+
+    # If multus CNI plugin is enabled with consul-cni. When enabled, consul-cni will not be installed as a chained
+    # CNI plugin. Instead, a NetworkAttachementDefinition CustomResourceDefinition (CRD) will be created in the helm
+    # release namespace. Following multus plugin standards, an annotation is required in order for the consul-cni plugin
+    # to be executed and for your service to be added to the Consul Service Mesh. 
+    #
+    # Add the annotation `'k8s.v1.cni.cncf.io/networks': '[{ "name":"consul-cni","namespace": "consul" }]'` to your pod
+    # to use the default installed NetworkAttachementDefinition CRD.
+    #
+    # Please refer to the [Multus Quickstart Guide](https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/quickstart.md)
+    # for more information about using multus. 
+    # @type: string
+    multus: false 
+
     # The resource settings for CNI installer daemonset.
     # @recurse: false
     # @type: map

--- a/control-plane/subcommand/install-cni/cniconfig_test.go
+++ b/control-plane/subcommand/install-cni/cniconfig_test.go
@@ -26,10 +26,11 @@ func TestDefaultCNIConfigFile_NoFiles(t *testing.T) {
 // TestDefaultCNIConfigFile tests finding the correct config file in the cniNetDir directory.
 func TestDefaultCNIConfigFile(t *testing.T) {
 	cases := []struct {
-		name        string
-		cfgFile     string
-		dir         func(string) string
-		expectedErr error
+		name         string
+		cfgFile      string
+		dir          func(string) string
+		expectedFile string
+		expectedErr  error
 	}{
 		{
 			name:    "valid .conflist file found",
@@ -42,7 +43,8 @@ func TestDefaultCNIConfigFile(t *testing.T) {
 				}
 				return tempDir
 			},
-			expectedErr: nil,
+			expectedFile: "10-kindnet.conflist",
+			expectedErr:  nil,
 		},
 		{
 			name:    "several files, should choose .conflist file",
@@ -60,7 +62,8 @@ func TestDefaultCNIConfigFile(t *testing.T) {
 
 				return tempDir
 			},
-			expectedErr: nil,
+			expectedFile: "10-kindnet.conflist",
+			expectedErr:  nil,
 		},
 	}
 	for _, c := range cases {
@@ -68,12 +71,36 @@ func TestDefaultCNIConfigFile(t *testing.T) {
 			tempDir := c.dir(c.cfgFile)
 			actual, err := defaultCNIConfigFile(tempDir)
 
-			filename := filepath.Base(c.cfgFile)
-			filepath := filepath.Join(tempDir, filename)
+			filepath := filepath.Join(tempDir, c.expectedFile)
 			require.Equal(t, filepath, actual)
 			require.Equal(t, c.expectedErr, err)
 		})
 	}
+}
+
+func TestConfListFromConfFile(t *testing.T) {
+
+	cfgFile := "testdata/00-single-plugin.conf"
+	expectedCfgFile := "testdata/00-chained-plugins.conflist"
+
+	tempDir := t.TempDir()
+	err := copyFile(cfgFile, tempDir)
+	require.NoError(t, err)
+
+	filename := filepath.Base(cfgFile)
+	tempCfgFile := filepath.Join(tempDir, filename)
+
+	actualFile, err := confListFileFromConfFile(tempCfgFile)
+	require.NoError(t, err)
+
+	actual, err := ioutil.ReadFile(actualFile)
+	require.NoError(t, err)
+
+	expected, err := ioutil.ReadFile(expectedCfgFile)
+	require.NoError(t, err)
+
+	require.Equal(t, string(expected), string(actual))
+
 }
 
 // TestCreateCNIConfigFile tests the writing of the config file.
@@ -111,6 +138,20 @@ func TestAppendCNIConfig(t *testing.T) {
 			},
 			cfgFile:    "testdata/10-calico.conflist",
 			goldenFile: "testdata/10-calico.conflist.golden",
+		},
+		{
+			name: "chained plugin file",
+			consulConfig: &config.CNIConfig{
+				Name:       config.DefaultPluginName,
+				Type:       config.DefaultPluginType,
+				CNIBinDir:  "/var/lib/cni/bin",
+				CNINetDir:  "/etc/kubernetes/cni/net.d",
+				Kubeconfig: config.DefaultKubeconfig,
+				LogLevel:   config.DefaultLogLevel,
+				Multus:     config.DefaultMultus,
+			},
+			cfgFile:    "testdata/00-chained-plugins.conflist",
+			goldenFile: "testdata/00-chained-plugins.conflist.golden",
 		},
 	}
 	for _, c := range cases {

--- a/control-plane/subcommand/install-cni/testdata/00-chained-plugins.conflist
+++ b/control-plane/subcommand/install-cni/testdata/00-chained-plugins.conflist
@@ -1,0 +1,23 @@
+{
+  "cniVersion": "0.3.1",
+  "name": "k8s-pod-network",
+  "plugins": [
+    {
+      "binDir": "/opt/multus/bin",
+      "delegates": [
+        {
+          "cniVersion": "0.3.1",
+          "name": "openshift-sdn",
+          "type": "openshift-sdn"
+        }
+      ],
+      "globalNamespaces": "default,openshift-multus,openshift-sriov-network-operator",
+      "kubeconfig": "/etc/kubernetes/cni/net.d/multus.d/multus.kubeconfig",
+      "logLevel": "verbose",
+      "name": "multus-cni-network",
+      "namespaceIsolation": true,
+      "readinessindicatorfile": "/var/run/multus/cni/net.d/80-openshift-network.conf",
+      "type": "multus"
+    }
+  ]
+}

--- a/control-plane/subcommand/install-cni/testdata/00-chained-plugins.conflist.golden
+++ b/control-plane/subcommand/install-cni/testdata/00-chained-plugins.conflist.golden
@@ -1,0 +1,32 @@
+{
+  "cniVersion": "0.3.1",
+  "name": "k8s-pod-network",
+  "plugins": [
+    {
+      "binDir": "/opt/multus/bin",
+      "delegates": [
+        {
+          "cniVersion": "0.3.1",
+          "name": "openshift-sdn",
+          "type": "openshift-sdn"
+        }
+      ],
+      "globalNamespaces": "default,openshift-multus,openshift-sriov-network-operator",
+      "kubeconfig": "/etc/kubernetes/cni/net.d/multus.d/multus.kubeconfig",
+      "logLevel": "verbose",
+      "name": "multus-cni-network",
+      "namespaceIsolation": true,
+      "readinessindicatorfile": "/var/run/multus/cni/net.d/80-openshift-network.conf",
+      "type": "multus"
+    },
+    {
+      "cni_bin_dir": "/var/lib/cni/bin",
+      "cni_net_dir": "/etc/kubernetes/cni/net.d",
+      "kubeconfig": "ZZZ-consul-cni-kubeconfig",
+      "log_level": "info",
+      "multus": false,
+      "name": "consul-cni",
+      "type": "consul-cni"
+    }
+  ]
+}

--- a/control-plane/subcommand/install-cni/testdata/00-single-plugin.conf
+++ b/control-plane/subcommand/install-cni/testdata/00-single-plugin.conf
@@ -1,0 +1,18 @@
+{
+  "cniVersion": "0.3.1",
+  "name": "multus-cni-network",
+  "type": "multus",
+  "namespaceIsolation": true,
+  "globalNamespaces": "default,openshift-multus,openshift-sriov-network-operator",
+  "logLevel": "verbose",
+  "binDir": "/opt/multus/bin",
+  "readinessindicatorfile": "/var/run/multus/cni/net.d/80-openshift-network.conf",
+  "kubeconfig": "/etc/kubernetes/cni/net.d/multus.d/multus.kubeconfig",
+  "delegates": [
+    {
+      "cniVersion": "0.3.1",
+      "name": "openshift-sdn",
+      "type": "openshift-sdn"
+    }
+  ]
+}


### PR DESCRIPTION
Changes proposed in this PR:

This PR adds support for OpenShift and Multus in CNI. OpenShift uses Multus as the base CNI plugin.

- Added SecurityContextConstraints CRD so that CNI has the permissions to run on OpenShift and gave the consul-cni service account permissions to reach OpenShifts SCC CRD.
- Added a --multus flag to the CNI installer so that the flag can be used by the CNI plugin.
- When --multus flag is set, create a default Network Attachment Definition CRD for Multus to use. Note, Pods require an annotation in order for Multus to run the consul-cni plugin. Please see [Multus documentation](https://github.com/k8snetworkplumbingwg/multus-cni) for more information about how to use Multus.
- Fix: Fixed installer to rename .conf file .conflist file when consul-cni is added to a base plugin.
- Improvement: The plugin is now more consistent at updating annotations. 

How I've tested this PR:

- Manual testing of Multus on OpenShift
- Manual testing of Multus on Kind
- Acceptance and unit tests.

How I expect reviewers to test this PR:

:eyes:

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

