### PR TITLE
fix a typo in the helper template for pdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ FEATURES:
 BUG FIXES:
 * Control plane
   * Use global ACL auth method to provision ACL tokens for API Gateway in secondary datacenter [[GH-1481](https://github.com/hashicorp/consul-k8s/pull/1481)]
+* Helm:
+  * Fixes a typo in the templating of `global.connectInject.disruptionBudget.maxUnavailable`. [[GH-1530](https://github.com/hashicorp/consul-k8s/pull/1530)].
 
 IMPROVEMENTS:
 * Helm:

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -200,7 +200,7 @@ Add a special case for replicas=1, where it should default to 0 as well.
 {{- if eq (int .Values.connectInject.replicas) 1 -}}
 {{ 0 }}
 {{- else if .Values.connectInject.disruptionBudget.maxUnavailable -}}
-{{ .Values.server.disruptionBudget.maxUnavailable -}}
+{{ .Values.connectInject.disruptionBudget.maxUnavailable -}}
 {{- else -}}
 {{- if eq (int .Values.connectInject.replicas) 3 -}}
 {{- 1 -}}


### PR DESCRIPTION
Changes proposed in this PR:
- Fixes a typo in the helper template for pod disruption budget for connectInject
- Fixes #1529.

How I've tested this PR:
👀 

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

