### PR TITLE
Pipeline fix makefile spacing issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ ifndef RELEASE_VERSION
 	$(error RELEASE_VERSION is required)
 endif
 ifndef RELEASE_DATE
-    $(error RELEASE_DATE is required, use format <Month> <Day>, <Year> (ex. October 4, 2022))
+	$(error RELEASE_DATE is required, use format <Month> <Day>, <Year> (ex. October 4, 2022))
 endif
 	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_release $(CURDIR) $(RELEASE_VERSION) "$(RELEASE_DATE)" $(PRERELEASE_VERSION)
 
@@ -153,7 +153,7 @@ ifndef RELEASE_VERSION
 	$(error RELEASE_VERSION is required)
 endif
 ifndef RELEASE_DATE
-    $(error RELEASE_DATE is required, use format <Month> <Day>, <Year> (ex. October 4, 2022))
+	$(error RELEASE_DATE is required, use format <Month> <Day>, <Year> (ex. October 4, 2022))
 endif
 ifndef NEXT_RELEASE_VERSION
 	$(error NEXT_RELEASE_VERSION is required)


### PR DESCRIPTION
Changes proposed in this PR:
- spacing issue with `ifndef` check in makefile was causing unexpected results

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ N/A] Tests added
- [ N/A] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

