### PR TITLE
Allow the API Gateway controller to create and update Secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ BUG FIXES:
 IMPROVEMENTS:
 * Helm:
   * API Gateway: Set primary datacenter flag when deploying controller into secondary datacenter with federation enabled [[GH-1511](https://github.com/hashicorp/consul-k8s/pull/1511)]
+  * API Gateway: Allow controller to create and update Secrets in order to support distroless Envoy images [[GH-1542](https://github.com/hashicorp/consul-k8s/pull/1542)]
 * Control-plane:
   * Support escaped commas in service tag annotations for pods which use `consul.hashicorp.com/connect-service-tags` or `consul.hashicorp.com/service-tags`. [[GH-1532](https://github.com/hashicorp/consul-k8s/pull/1532)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ BUG FIXES:
 IMPROVEMENTS:
 * Helm:
   * API Gateway: Set primary datacenter flag when deploying controller into secondary datacenter with federation enabled [[GH-1511](https://github.com/hashicorp/consul-k8s/pull/1511)]
-  * API Gateway: Allow controller to create and update Secrets in order to support distroless Envoy images [[GH-1542](https://github.com/hashicorp/consul-k8s/pull/1542)]
+  * API Gateway: Allow controller to create and update Secrets for storing Consul CA cert alongside gateway Deployments [[GH-1542](https://github.com/hashicorp/consul-k8s/pull/1542)]
 * Control-plane:
   * Support escaped commas in service tag annotations for pods which use `consul.hashicorp.com/connect-service-tags` or `consul.hashicorp.com/service-tags`. [[GH-1532](https://github.com/hashicorp/consul-k8s/pull/1532)]
 

--- a/charts/consul/templates/api-gateway-controller-clusterrole.yaml
+++ b/charts/consul/templates/api-gateway-controller-clusterrole.yaml
@@ -92,8 +92,10 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ""


### PR DESCRIPTION
**Changes proposed in this PR:**
- Allow the Consul API Gateway controller to create + update Secrets so that it can store the Consul CA cert alongside each Gateway deployment. Long-term, this enabled Consul API Gateway to run on "distroless" Envoy images once https://github.com/hashicorp/consul-api-gateway/pull/391 is released.

**How I've tested this PR:**
Deployed Consul API Gateway using this branch and https://github.com/hashicorp/consul-api-gateway/pull/391

**How I expect reviewers to test this PR:**
See above


**Checklist:**
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

