### PR TITLE
Ingress Gateways integration with Agentless and Consul Dataplane

### DIFF
--- a/acceptance/tests/ingress-gateway/ingress_gateway_namespaces_test.go
+++ b/acceptance/tests/ingress-gateway/ingress_gateway_namespaces_test.go
@@ -31,10 +31,10 @@ func TestIngressGatewaySingleNamespace(t *testing.T) {
 		secure bool
 	}{
 		{
-			false,
+			secure: false,
 		},
 		{
-			true,
+			secure: true,
 		},
 	}
 	for _, c := range cases {
@@ -42,8 +42,7 @@ func TestIngressGatewaySingleNamespace(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := suite.Environment().DefaultContext(t)
 
-			// Install the Helm chart without the ingress gateway first
-			// so that we can create the namespace for it.
+			igName := "ingress-gateway"
 			helmValues := map[string]string{
 				"connectInject.enabled": "true",
 				"connectInject.consulNamespaces.consulDestinationNamespace": testNamespace,
@@ -51,6 +50,11 @@ func TestIngressGatewaySingleNamespace(t *testing.T) {
 				"global.enableConsulNamespaces": "true",
 				"global.acls.manageSystemACLs":  strconv.FormatBool(c.secure),
 				"global.tls.enabled":            strconv.FormatBool(c.secure),
+
+				"ingressGateways.enabled":                     "true",
+				"ingressGateways.gateways[0].name":            igName,
+				"ingressGateways.gateways[0].replicas":        "1",
+				"ingressGateways.gateways[0].consulNamespace": testNamespace,
 			}
 
 			releaseName := helpers.RandomName()
@@ -59,25 +63,6 @@ func TestIngressGatewaySingleNamespace(t *testing.T) {
 			consulCluster.Create(t)
 
 			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
-
-			// Create the destination namespace in the non-secure case.
-			// In the secure installation, this namespace is created by the server-acl-init job.
-			if !c.secure {
-				logger.Logf(t, "creating the %s namespace in Consul", testNamespace)
-				_, _, err := consulClient.Namespaces().Create(&api.Namespace{
-					Name: testNamespace,
-				}, nil)
-				require.NoError(t, err)
-			}
-
-			igName := "ingress-gateway"
-			logger.Log(t, "upgrading with ingress gateways enabled")
-			consulCluster.Upgrade(t, map[string]string{
-				"ingressGateways.enabled":                     "true",
-				"ingressGateways.gateways[0].name":            igName,
-				"ingressGateways.gateways[0].replicas":        "1",
-				"ingressGateways.gateways[0].consulNamespace": testNamespace,
-			})
 
 			logger.Logf(t, "creating Kubernetes namespace %s", testNamespace)
 			k8s.RunKubectl(t, ctx.KubectlOptions(t), "create", "ns", testNamespace)
@@ -158,9 +143,6 @@ func TestIngressGatewaySingleNamespace(t *testing.T) {
 
 // Test we can connect through the ingress gateway when both
 // the ingress gateway and the connect service are in different namespaces.
-// These tests currently only test non-secure and secure without auto-encrypt installations
-// because in the case of namespaces there isn't a significant distinction in code between auto-encrypt
-// and non-auto-encrypt secure installations, so testing just one is enough.
 func TestIngressGatewayNamespaceMirroring(t *testing.T) {
 	cfg := suite.Config()
 	if !cfg.EnableEnterprise {
@@ -171,10 +153,10 @@ func TestIngressGatewayNamespaceMirroring(t *testing.T) {
 		secure bool
 	}{
 		{
-			false,
+			secure: false,
 		},
 		{
-			true,
+			secure: true,
 		},
 	}
 	for _, c := range cases {
@@ -183,8 +165,6 @@ func TestIngressGatewayNamespaceMirroring(t *testing.T) {
 			ctx := suite.Environment().DefaultContext(t)
 
 			igName := "ingress"
-			// Install the Helm chart without the ingress gateway first
-			// so that we can create the namespace for it.
 			helmValues := map[string]string{
 				"connectInject.enabled":                       "true",
 				"connectInject.consulNamespaces.mirroringK8S": "true",

--- a/acceptance/tests/ingress-gateway/ingress_gateway_test.go
+++ b/acceptance/tests/ingress-gateway/ingress_gateway_test.go
@@ -18,24 +18,17 @@ const StaticClientName = "static-client"
 // Test that ingress gateways work in a default installation and a secure installation.
 func TestIngressGateway(t *testing.T) {
 	cases := []struct {
-		secure      bool
-		autoEncrypt bool
+		secure bool
 	}{
 		{
-			false,
-			false,
+			secure: false,
 		},
 		{
-			true,
-			false,
-		},
-		{
-			true,
-			true,
+			secure: true,
 		},
 	}
 	for _, c := range cases {
-		name := fmt.Sprintf("secure: %t; auto-encrypt: %t", c.secure, c.autoEncrypt)
+		name := fmt.Sprintf("secure: %t", c.secure)
 		t.Run(name, func(t *testing.T) {
 			ctx := suite.Environment().DefaultContext(t)
 			cfg := suite.Config()
@@ -48,7 +41,6 @@ func TestIngressGateway(t *testing.T) {
 
 				"global.acls.manageSystemACLs": strconv.FormatBool(c.secure),
 				"global.tls.enabled":           strconv.FormatBool(c.secure),
-				"global.tls.autoEncrypt":       strconv.FormatBool(c.autoEncrypt),
 			}
 
 			releaseName := helpers.RandomName()

--- a/acceptance/tests/ingress-gateway/main_test.go
+++ b/acceptance/tests/ingress-gateway/main_test.go
@@ -1,7 +1,6 @@
 package ingressgateway
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -11,8 +10,6 @@ import (
 var suite testsuite.Suite
 
 func TestMain(m *testing.M) {
-	fmt.Println("Skipping ingress gateway tests because it's not supported with agentless yet")
-	os.Exit(0)
-	//suite = testsuite.NewSuite(m)
-	//os.Exit(suite.Run())
+	suite = testsuite.NewSuite(m)
+	os.Exit(suite.Run())
 }

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -120,6 +120,9 @@ spec:
             - "-ec"
             - |
               consul-k8s-control-plane inject-connect \
+                {{- if .Values.global.federation.enabled }}
+                -enable-federation \
+                {{- end }}
                 -log-level={{ default .Values.global.logLevel .Values.connectInject.logLevel }} \
                 -log-json={{ .Values.global.logJSON }} \
                 -default-inject={{ .Values.connectInject.default }} \

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -63,7 +63,47 @@ spec:
         release: {{ $root.Release.Name }}
         component: ingress-gateway
         ingress-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
+        consul.hashicorp.com/connect-inject-managed-by: consul-k8s-endpoints-controller
       annotations:
+        "consul.hashicorp.com/connect-inject": "false"
+        "consul.hashicorp.com/gateway-kind": "ingress-gateway"
+        "consul.hashicorp.com/gateway-consul-service-name": "{{ .name }}"
+        {{- if $root.Values.global.enableConsulNamespaces }}
+        "consul.hashicorp.com/gateway-namespace": {{ (default $defaults.consulNamespace .consulNamespace) }}
+        {{- end }}
+        "consul.hashicorp.com/gateway-wan-address-source": "Service"
+        {{- $serviceType := (default $defaults.service.type $service.type) }}
+        {{- if (eq $serviceType "NodePort") }}
+        {{- if $service.ports }}
+        {{- $firstPort := first $service.ports}}
+        {{- if $firstPort.nodePort }}
+        "consul.hashicorp.com/gateway-wan-port": "{{ $firstPort.nodePort }}"
+        {{- else }}{{ fail "if ingressGateways .service.type=NodePort and defining ingressGateways.gateways.service.ports, the first port entry must include a nodePort" }}
+        {{- end }}
+        {{- else if $defaults.service.ports }}
+        {{- $firstDefaultPort := first $defaults.service.ports}}
+        {{- if $firstDefaultPort.nodePort }}
+        "consul.hashicorp.com/gateway-wan-port": "{{ $firstDefaultPort.nodePort }}"
+        {{- else }}{{ fail "if ingressGateways .service.type=NodePort and using ingressGateways.defaults.service.ports, the first port entry must include a nodePort" }}
+        {{- end }}
+        {{- else }}{{ fail "if ingressGateways .service.type=NodePort, the first port entry in either the defaults or specific gateway must include a nodePort" }}
+        {{- end }}
+        {{- else }}
+        {{- if $service.ports }}
+        {{- $firstPort := first $service.ports}}
+        {{- if $firstPort.port }}
+        "consul.hashicorp.com/gateway-wan-port": "{{ $firstPort.port }}"
+        {{- else }}{{ fail "if ingressGateways .service.type is not NodePort and defining ingressGateways.gateways.service.ports, the first port entry must include a port" }}
+        {{- end }}
+        {{- else if $defaults.service.ports }}
+        {{- $firstDefaultPort := first $defaults.service.ports}}
+        {{- if $firstDefaultPort.port }}
+        "consul.hashicorp.com/gateway-wan-port": "{{ $firstDefaultPort.port }}"
+        {{- else }}{{ fail "if ingressGateways .service.type is not NodePort and using ingressGateways.defaults.service.ports, the first port entry must include a port" }}
+        {{- end }}
+        {{- else }}{{ fail "if ingressGateways .service.type is not NodePort, the first port entry in either the defaults or specific gateway must include a port" }}
+        {{- end }}
+        {{- end }}
         {{- if (and $root.Values.global.secretsBackend.vault.enabled $root.Values.global.tls.enabled) }}
         "vault.hashicorp.com/agent-init-first": "true"
         "vault.hashicorp.com/agent-inject": "true"
@@ -78,7 +118,6 @@ spec:
         {{ tpl $root.Values.global.secretsBackend.vault.agentAnnotations $root | nindent 8 | trim }}
         {{- end }}
         {{- end }}
-        "consul.hashicorp.com/connect-inject": "false"
         {{- if (and $root.Values.global.metrics.enabled $root.Values.global.metrics.enableGatewayMetrics) }}
         "prometheus.io/scrape": "true"
         "prometheus.io/path": "/metrics"
@@ -107,374 +146,172 @@ spec:
       terminationGracePeriodSeconds: {{ default $defaults.terminationGracePeriodSeconds .terminationGracePeriodSeconds }}
       serviceAccountName: {{ template "consul.fullname" $root }}-{{ .name }}
       volumes:
-        - name: consul-bin
-          emptyDir: {}
-        - name: consul-service
-          emptyDir:
-            medium: "Memory"
-        {{- if $root.Values.global.tls.enabled }}
-        {{- if not (and $root.Values.externalServers.enabled $root.Values.externalServers.useSystemRoots) }}
-        - name: consul-ca-cert
-          secret:
-            {{- if $root.Values.global.tls.caCert.secretName }}
-            secretName: {{ $root.Values.global.tls.caCert.secretName }}
-            {{- else }}
-            secretName: {{ template "consul.fullname" $root }}-ca-cert
-            {{- end }}
-            items:
-            - key: {{ default "tls.crt" $root.Values.global.tls.caCert.secretKey }}
-              path: tls.crt
-        {{- end }}
-        {{- if $root.Values.global.tls.enableAutoEncrypt }}
-        - name: consul-auto-encrypt-ca-cert
-          emptyDir:
-            medium: "Memory"
-        {{- end }}
-        {{- end }}
+      - name: consul-service
+        emptyDir:
+          medium: "Memory"
+      {{- if $root.Values.global.tls.enabled }}
+      {{- if not (and $root.Values.externalServers.enabled $root.Values.externalServers.useSystemRoots) }}
+      - name: consul-ca-cert
+        secret:
+          {{- if $root.Values.global.tls.caCert.secretName }}
+          secretName: {{ $root.Values.global.tls.caCert.secretName }}
+          {{- else }}
+          secretName: {{ template "consul.fullname" $root }}-ca-cert
+          {{- end }}
+          items:
+          - key: {{ default "tls.crt" $root.Values.global.tls.caCert.secretKey }}
+            path: tls.crt
+      {{- end }}
+      {{- end }}
       initContainers:
-        # We use the Envoy image as our base image so we use an init container to
-        # copy the Consul binary to a shared directory that can be used when
-        # starting Envoy.
-        - name: copy-consul-bin
-          image: {{ $root.Values.global.image | quote }}
-          command:
-          - cp
-          - /bin/consul
-          - /consul-bin/consul
-          volumeMounts:
-          - name: consul-bin
-            mountPath: /consul-bin
-          {{- $initContainer := .initCopyConsulContainer }}
-          {{- if (or $initContainer $defaults.initCopyConsulContainer) }}
-          {{- if (default $defaults.initCopyConsulContainer.resources $initContainer.resources) }}
-          resources: {{ toYaml (default $defaults.initCopyConsulContainer.resources $initContainer.resources) | nindent 12 }}
-          {{- end }}
-          {{- end }}
-        {{- if (and $root.Values.global.tls.enabled $root.Values.global.tls.enableAutoEncrypt) }}
-        {{- include "consul.getAutoEncryptClientCA" $root | nindent 8 }}
+      # ingress-gateway-init registers the ingress gateway service with Consul.
+      - name: ingress-gateway-init
+        image: {{ $root.Values.global.imageK8S }}
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        {{- include "consul.consulK8sConsulServerEnvVars" $root | nindent 8 }}
+        {{- if $root.Values.global.enableConsulNamespaces }}
+        - name: CONSUL_NAMESPACE
+          value: {{ (default $defaults.consulNamespace .consulNamespace) }}
         {{- end }}
-        # ingress-gateway-init registers the ingress gateway service with Consul.
-        - name: ingress-gateway-init
-          image: {{ $root.Values.global.imageK8S }}
-          env:
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            {{- if $root.Values.global.tls.enabled }}
-            - name: CONSUL_HTTP_ADDR
-              value: https://$(HOST_IP):8501
-            - name: CONSUL_CACERT
-              value: /consul/tls/ca/tls.crt
-            {{- else }}
-            - name: CONSUL_HTTP_ADDR
-              value: http://$(HOST_IP):8500
-            {{- end }}
-          command:
-            - "/bin/sh"
-            - "-ec"
-            - |
-                {{- if $root.Values.global.acls.manageSystemACLs }}
-                consul-k8s-control-plane acl-init \
-                  -component-name=ingress-gateway/{{ template "consul.fullname" $root }}-{{ .name }} \
-                  -acl-auth-method={{ template "consul.fullname" $root }}-k8s-component-auth-method \
-                  {{- if $root.Values.global.adminPartitions.enabled }}
-                  -partition={{ $root.Values.global.adminPartitions.name }} \
-                  {{- end }}
-                  -token-sink-file=/consul/service/acl-token \
-                  -consul-api-timeout={{ $root.Values.global.consulAPITimeout }} \
-                  -log-level={{ default $root.Values.global.logLevel }} \
-                  -log-json={{ $root.Values.global.logJSON }}
-                {{ end }}
-
-                {{- $serviceType := (default $defaults.service.type $service.type) }}
-                {{- if (eq $serviceType "NodePort") }}
-                WAN_ADDR="${HOST_IP}"
-                {{- else if (or (eq $serviceType "ClusterIP") (eq $serviceType "LoadBalancer")) }}
-                consul-k8s-control-plane service-address \
-                  -log-level={{ $root.Values.global.logLevel }} \
-                  -log-json={{ $root.Values.global.logJSON }} \
-                  -k8s-namespace={{ $root.Release.Namespace }} \
-                  -name={{ template "consul.fullname" $root }}-{{ .name }} \
-                  -output-file=/tmp/address.txt
-                WAN_ADDR="$(cat /tmp/address.txt)"
-                {{- else }}
-                {{- fail "currently set ingressGateway value service.type is not supported" }}
-                {{- end }}
-
-          {{- if (eq $serviceType "NodePort") }}
-            {{- if $service.ports }}
-                {{- $firstPort := first $service.ports}}
-              {{- if $firstPort.nodePort }}
-                WAN_PORT={{ $firstPort.nodePort }}
-              {{- else }}{{ fail "if ingressGateways .service.type=NodePort and defining ingressGateways.gateways.service.ports, the first port entry must include a nodePort" }}
-              {{- end }}
-            {{- else if $defaults.service.ports }}
-              {{- $firstDefaultPort := first $defaults.service.ports}}
-              {{- if $firstDefaultPort.nodePort }}
-                  WAN_PORT={{ $firstDefaultPort.nodePort }}
-              {{- else }}{{ fail "if ingressGateways .service.type=NodePort and using ingressGateways.defaults.service.ports, the first port entry must include a nodePort" }}
-              {{- end }}
-            {{- else }}{{ fail "if ingressGateways .service.type=NodePort, the first port entry in either the defaults or specific gateway must include a nodePort" }}
-            {{- end }}
-
-          {{- else }}
-            {{- if $service.ports }}
-                {{- $firstPort := first $service.ports}}
-              {{- if $firstPort.port }}
-                WAN_PORT={{ $firstPort.port }}
-              {{- else }}{{ fail "if ingressGateways .service.type is not NodePort and defining ingressGateways.gateways.service.ports, the first port entry must include a port" }}
-              {{- end }}
-            {{- else if $defaults.service.ports }}
-                {{- $firstDefaultPort := first $defaults.service.ports}}
-              {{- if $firstDefaultPort.port }}
-                WAN_PORT={{ $firstDefaultPort.port }}
-              {{- else }}{{ fail "if ingressGateways .service.type is not NodePort and using ingressGateways.defaults.service.ports, the first port entry must include a port" }}
-              {{- end }}
-            {{- else }}{{ fail "if ingressGateways .service.type is not NodePort, the first port entry in either the defaults or specific gateway must include a port" }}
-            {{- end }}
-          {{- end }}
-
-                cat > /consul/service/service.hcl << EOF
-                service {
-                  kind = "ingress-gateway"
-                  name = "{{ .name }}"
-                  id = "${POD_NAME}"
-                  {{- if $root.Values.global.enableConsulNamespaces }}
-                  namespace = "{{ (default $defaults.consulNamespace .consulNamespace) }}"
-                  {{- end }}
-                  {{- if $root.Values.global.adminPartitions.enabled }}
-                  partition = "{{ $root.Values.global.adminPartitions.name }}"
-                  {{- end }}
-                  port = ${WAN_PORT}
-                  address = "${WAN_ADDR}"
-                  tagged_addresses {
-                    lan {
-                      address = "${POD_IP}"
-                      port = 21000
-                    }
-                    wan {
-                      address = "${WAN_ADDR}"
-                      port = ${WAN_PORT}
-                    }
-                  }
-                  proxy {
-                    config {
-                      {{- if (and $root.Values.global.metrics.enabled $root.Values.global.metrics.enableGatewayMetrics) }}
-                      envoy_prometheus_bind_addr = "${POD_IP}:20200"
-                      {{- end }}
-                      envoy_gateway_no_default_bind = true
-                      envoy_gateway_bind_addresses {
-                        all-interfaces {
-                          address = "0.0.0.0"
-                        }
-                      }
-                    }
-                  }
-                  checks = [
-                    {
-                      name = "Ingress Gateway Listening"
-                      interval = "10s"
-                      tcp = "${POD_IP}:21000"
-                      deregister_critical_service_after = "6h"
-                    }
-                  ]
-                }
-                EOF
-
-                /consul-bin/consul services register \
-                  {{- if $root.Values.global.acls.manageSystemACLs }}
-                  -token-file=/consul/service/acl-token \
-                  {{- end }}
-                  /consul/service/service.hcl
-          volumeMounts:
-            - name: consul-service
-              mountPath: /consul/service
-            - name: consul-bin
-              mountPath: /consul-bin
-            {{- if $root.Values.global.tls.enabled }}
-            {{- if $root.Values.global.tls.enableAutoEncrypt }}
-            - name: consul-auto-encrypt-ca-cert
-            {{- else }}
-            - name: consul-ca-cert
-            {{- end }}
-              mountPath: /consul/tls/ca
-              readOnly: true
-            {{- end }}
-          resources:
-            requests:
-              memory: "50Mi"
-              cpu: "50m"
-            limits:
-              memory: "50Mi"
-              cpu: "50m"
+        {{- if $root.Values.global.acls.manageSystemACLs }}
+        - name: CONSUL_LOGIN_AUTH_METHOD
+          value: {{ template "consul.fullname" $root }}-k8s-component-auth-method
+        - name: CONSUL_LOGIN_DATACENTER
+          value: {{ $root.Values.global.datacenter }}
+        - name: CONSUL_LOGIN_META
+          value: "component=ingress-gateway,pod=$(NAMESPACE)/$(POD_NAME)"
+       {{- end }}
+        command:
+        - "/bin/sh"
+        - "-ec"
+        - |
+          consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${NAMESPACE} \
+          -gateway-kind="ingress-gateway" \
+          -consul-node-name="k8s-service-mesh" \
+          -proxy-id-file=/consul/service/proxy-id \
+          -service-name={{ template "consul.fullname" $root }}-{{ .name }} \
+          -log-level={{ default $root.Values.global.logLevel }} \
+          -log-json={{ $root.Values.global.logJSON }}
+        volumeMounts:
+        - name: consul-service
+          mountPath: /consul/service
+        {{- if and $root.Values.global.tls.enabled (not (and $root.Values.externalServers.enabled $root.Values.externalServers.useSystemRoots)) }}
+        - name: consul-ca-cert
+          mountPath: /consul/tls/ca
+          readOnly: true
+        {{- end }}
+        resources:
+          requests:
+            memory: "50Mi"
+            cpu: "50m"
+          limits:
+            memory: "50Mi"
+            cpu: "50m"
       containers:
-        - name: ingress-gateway
-          image: {{ $root.Values.global.imageEnvoy | quote }}
-          {{- if (default $defaults.resources .resources) }}
-          resources: {{ toYaml (default $defaults.resources .resources) | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-          - name: consul-bin
-            mountPath: /consul-bin
-          - name: consul-service
-            mountPath: /consul/service
-            readOnly: true
-          {{- if $root.Values.global.tls.enabled }}
-          {{- if $root.Values.global.tls.enableAutoEncrypt }}
-          - name: consul-auto-encrypt-ca-cert
-          {{- else }}
-          - name: consul-ca-cert
-          {{- end }}
-            mountPath: /consul/tls/ca
-            readOnly: true
-          {{- end }}
-          env:
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            {{- if $root.Values.global.acls.manageSystemACLs }}
-            - name: CONSUL_HTTP_TOKEN_FILE
-              value: "/consul/service/acl-token"
-            {{- end}}
-            {{- if $root.Values.global.tls.enabled }}
-            - name: CONSUL_HTTP_ADDR
-              value: https://$(HOST_IP):8501
-            - name: CONSUL_GRPC_ADDR
-              value: https://$(HOST_IP):8502
-            - name: CONSUL_CACERT
-              value: /consul/tls/ca/tls.crt
+      - name: ingress-gateway
+        image: {{ $root.Values.global.imageConsulDataplane | quote }}
+        {{- if (default $defaults.resources .resources) }}
+        resources: {{ toYaml (default $defaults.resources .resources) | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        {{- if and $root.Values.global.tls.enabled (not (and $root.Values.externalServers.enabled $root.Values.externalServers.useSystemRoots)) }}
+        - name: consul-ca-cert
+          mountPath: /consul/tls/ca
+          readOnly: true
+        {{- end }}
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        command:
+        - /bin/sh
+        - -ec
+        - |
+          consul-dataplane \
+            -envoy-ready-bind-address=$POD_IP \
+            -envoy-ready-bind-port=21000 \
+            {{- if $root.Values.externalServers.enabled }}
+            -addresses={{ $root.Values.externalServers.hosts | first | quote }} \
             {{- else }}
-            - name: CONSUL_HTTP_ADDR
-              value: http://$(HOST_IP):8500
-            - name: CONSUL_GRPC_ADDR
-              value: $(HOST_IP):8502
+            -addresses="{{ template "consul.fullname" $root }}-server.{{ $root.Release.Namespace }}.svc" \
             {{- end }}
-          command:
-            - /consul-bin/consul
-            - connect
-            - envoy
-            - -gateway=ingress
-            - -proxy-id=$(POD_NAME)
-            - -address=$(POD_IP):21000
+            {{- if $root.Values.externalServers.enabled }}
+            -grpc-port={{ $root.Values.externalServers.grpcPort }} \
+            {{- else }}
+            -grpc-port=8502 \
+            {{- end }}
+            -proxy-service-id=$POD_NAME \
+            -service-node-name="k8s-service-mesh" \
             {{- if $root.Values.global.enableConsulNamespaces }}
-            - -namespace={{ default $defaults.consulNamespace .consulNamespace }}
+            -service-namespace={{ (default $defaults.consulNamespace .consulNamespace) }} \
+            {{- end }}
+            {{- if and $root.Values.global.tls.enabled }}
+            {{- if (not (and $root.Values.externalServers.enabled $root.Values.externalServers.useSystemRoots)) }}
+            -ca-certs=/consul/tls/ca/tls.crt \
+            {{- end }}
+            {{- if and $root.Values.externalServers.enabled $root.Values.externalServers.tlsServerName }}
+            -tls-server-name={{$root.Values.externalServers.tlsServerName }} \
+            {{- else }}
+            -tls-server-name=server.{{ $root.Values.global.datacenter }}.{{ $root.Values.global.domain }} \
+            {{- end }}
+            {{- else }}
+            -tls-disabled \
+            {{- end }}
+            {{- if $root.Values.global.acls.manageSystemACLs }}
+            -credential-type=login \
+            -login-bearer-path=/var/run/secrets/kubernetes.io/serviceaccount/token \
+            -login-meta=component=ingress-gateway \
+            -login-meta=pod=${NAMESPACE}/${POD_NAME} \
+            -login-method={{ template "consul.fullname" $root }}-k8s-component-auth-method \
+            {{- if $root.Values.global.adminPartitions.enabled }}
+            -login-partition={{ $root.Values.global.adminPartitions.name }} \
+            {{- end }}
             {{- end }}
             {{- if $root.Values.global.adminPartitions.enabled }}
-            - -partition={{ $root.Values.global.adminPartitions.name }}
+            -service-partition={{ $root.Values.global.adminPartitions.name }} \
             {{- end }}
-          livenessProbe:
-            tcpSocket:
-              port: 21000
-            failureThreshold: 3
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
-          readinessProbe:
-            tcpSocket:
-              port: 21000
-            failureThreshold: 3
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
-          ports:
-            - name: gateway-health
-              containerPort: 21000
-            {{- range $index, $allPorts := (default $defaults.service.ports $service.ports) }}
-            - name: gateway-{{ $index }}
-              containerPort: {{ $allPorts.port }}
-            {{- end }}
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  - "/bin/sh"
-                  - "-ec"
-                  - |
-                      /consul-bin/consul services deregister \
-                        {{- if $root.Values.global.enableConsulNamespaces }}
-                        -namespace={{ default $defaults.consulNamespace .consulNamespace }} \
-                        {{- end }}
-                        {{- if $root.Values.global.adminPartitions.enabled }}
-                        -partition={{ $root.Values.global.adminPartitions.name }} \
-                        {{- end }}
-                        -id="${POD_NAME}"
-                  {{- if $root.Values.global.acls.manageSystemACLs }}
-                  - "/consul-bin/consul logout"
-                  {{- end}}
-
-        # consul-sidecar ensures the ingress gateway is always registered with
-        # the local Consul agent, even if it loses the initial registration.
-        - name: consul-sidecar
-          image: {{ $root.Values.global.imageK8S }}
-          volumeMounts:
-            - name: consul-service
-              mountPath: /consul/service
-              readOnly: true
-            - name: consul-bin
-              mountPath: /consul-bin
-            {{- if $root.Values.global.tls.enabled }}
-            {{- if $root.Values.global.tls.enableAutoEncrypt }}
-            - name: consul-auto-encrypt-ca-cert
-            {{- else }}
-            - name: consul-ca-cert
-            {{- end }}
-              mountPath: /consul/tls/ca
-              readOnly: true
-            {{- end }}
-          {{- if  $root.Values.global.consulSidecarContainer }}
-          {{- if $root.Values.global.consulSidecarContainer.resources }}
-          resources: {{ toYaml $root.Values.global.consulSidecarContainer.resources | nindent 12 }}
-          {{- end }}
-          {{- end }}
-          env:
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            {{- if $root.Values.global.tls.enabled }}
-            - name: CONSUL_HTTP_ADDR
-              value: https://$(HOST_IP):8501
-            - name: CONSUL_CACERT
-              value: /consul/tls/ca/tls.crt
-            {{- else }}
-            - name: CONSUL_HTTP_ADDR
-              value: http://$(HOST_IP):8500
-            {{- end }}
-          command:
-            - consul-k8s-control-plane
-            - consul-sidecar
-            - -log-level={{ $root.Values.global.logLevel }}
-            - -log-json={{ $root.Values.global.logJSON }}
-            - -service-config=/consul/service/service.hcl
-            - -consul-binary=/consul-bin/consul
-            - -consul-api-timeout={{ $root.Values.global.consulAPITimeout }}
-            {{- if $root.Values.global.acls.manageSystemACLs }}
-            - -token-file=/consul/service/acl-token
-            {{- end }}
+            -log-level={{ default $root.Values.global.logLevel }} \
+            -log-json={{ $root.Values.global.logJSON }}
+        livenessProbe:
+          tcpSocket:
+            port: 21000
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          tcpSocket:
+            port: 21000
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        ports:
+        - name: gateway-health
+          containerPort: 21000
+        {{- range $index, $allPorts := (default $defaults.service.ports $service.ports) }}
+        - name: gateway-{{ $index }}
+          containerPort: {{ $allPorts.port }}
+        {{- end }}
       {{- if (default $defaults.priorityClassName .priorityClassName) }}
       priorityClassName: {{ default $defaults.priorityClassName .priorityClassName | quote }}
       {{- end }}

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -35,18 +35,18 @@ spec:
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
         "consul.hashicorp.com/gateway-kind": "mesh-gateway"
-        "consul.hashicorp.com/mesh-gateway-consul-service-name": "{{ .Values.meshGateway.consulServiceName }}"
-        "consul.hashicorp.com/mesh-gateway-wan-address-source": "{{ .Values.meshGateway.wanAddress.source }}"
+        "consul.hashicorp.com/gateway-consul-service-name": "{{ .Values.meshGateway.consulServiceName }}"
         "consul.hashicorp.com/mesh-gateway-container-port": "{{ .Values.meshGateway.containerPort }}"
-        "consul.hashicorp.com/mesh-gateway-wan-address-static": "{{ .Values.meshGateway.wanAddress.static }}"
+        "consul.hashicorp.com/gateway-wan-address-source": "{{ .Values.meshGateway.wanAddress.source }}"
+        "consul.hashicorp.com/gateway-wan-address-static": "{{ .Values.meshGateway.wanAddress.static }}"
         {{- if eq .Values.meshGateway.wanAddress.source "Service" }}
         {{- if eq .Values.meshGateway.service.type "NodePort" }}
-        "consul.hashicorp.com/mesh-gateway-wan-port": "{{ .Values.meshGateway.service.nodePort }}"
+        "consul.hashicorp.com/gateway-wan-port": "{{ .Values.meshGateway.service.nodePort }}"
         {{- else }}
-        "consul.hashicorp.com/mesh-gateway-wan-port": "{{ .Values.meshGateway.service.port }}"
+        "consul.hashicorp.com/gateway-wan-port": "{{ .Values.meshGateway.service.port }}"
         {{- end }}
         {{- else }}
-        "consul.hashicorp.com/mesh-gateway-wan-port": "{{ .Values.meshGateway.wanAddress.port }}"
+        "consul.hashicorp.com/gateway-wan-port": "{{ .Values.meshGateway.wanAddress.port }}"
         {{- end }}
         {{- if (and .Values.global.secretsBackend.vault.enabled .Values.global.tls.enabled) }}
         "vault.hashicorp.com/agent-init-first": "true"
@@ -206,7 +206,7 @@ spec:
             {{- end }}
             -proxy-service-id=$POD_NAME \
             -service-node-name="k8s-service-mesh" \
-            {{- if and .Values.global.tls.enabled }}
+            {{- if .Values.global.tls.enabled }}
             {{- if (not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots)) }}
             -ca-certs=/consul/tls/ca/tls.crt \
             {{- end }}

--- a/charts/consul/test/unit/mesh-gateway-deployment.bats
+++ b/charts/consul/test/unit/mesh-gateway-deployment.bats
@@ -948,10 +948,10 @@ key2: value2' \
     local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-container-port"]' | tee /dev/stderr)
     [ "${actual}" = "8888" ]
 
-    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-wan-address-source"]' | tee /dev/stderr)
+    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/gateway-wan-address-source"]' | tee /dev/stderr)
     [ "${actual}" = "NodeIP" ]
 
-    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-wan-port"]' | tee /dev/stderr)
+    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/gateway-wan-port"]' | tee /dev/stderr)
     [ "${actual}" = "9999" ]
 }
 
@@ -968,10 +968,10 @@ key2: value2' \
     local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-container-port"]' | tee /dev/stderr)
     [ "${actual}" = "8443" ]
 
-    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-wan-address-source"]' | tee /dev/stderr)
+    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/gateway-wan-address-source"]' | tee /dev/stderr)
     [ "${actual}" = "NodeIP" ]
 
-    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-wan-port"]' | tee /dev/stderr)
+    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/gateway-wan-port"]' | tee /dev/stderr)
     [ "${actual}" = "443" ]
 }
 
@@ -988,10 +988,10 @@ key2: value2' \
     local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-container-port"]' | tee /dev/stderr)
     [ "${actual}" = "8443" ]
 
-    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-wan-address-source"]' | tee /dev/stderr)
+    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/gateway-wan-address-source"]' | tee /dev/stderr)
     [ "${actual}" = "NodeName" ]
 
-    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-wan-port"]' | tee /dev/stderr)
+    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/gateway-wan-port"]' | tee /dev/stderr)
     [ "${actual}" = "443" ]
 }
 
@@ -1023,13 +1023,13 @@ key2: value2' \
     local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-container-port"]' | tee /dev/stderr)
     [ "${actual}" = "8443" ]
 
-    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-wan-address-source"]' | tee /dev/stderr)
+    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/gateway-wan-address-source"]' | tee /dev/stderr)
     [ "${actual}" = "Static" ]
 
-    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-wan-address-static"]' | tee /dev/stderr)
+    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/gateway-wan-address-static"]' | tee /dev/stderr)
     [ "${actual}" = "example.com" ]
 
-    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-wan-port"]' | tee /dev/stderr)
+    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/gateway-wan-port"]' | tee /dev/stderr)
     [ "${actual}" = "443" ]
 }
 
@@ -1048,10 +1048,10 @@ key2: value2' \
     local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-container-port"]' | tee /dev/stderr)
     [ "${actual}" = "8443" ]
 
-    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-wan-address-source"]' | tee /dev/stderr)
+    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/gateway-wan-address-source"]' | tee /dev/stderr)
     [ "${actual}" = "Service" ]
 
-    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-wan-port"]' | tee /dev/stderr)
+    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/gateway-wan-port"]' | tee /dev/stderr)
     [ "${actual}" = "443" ]
 }
 
@@ -1070,10 +1070,10 @@ key2: value2' \
     local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-container-port"]' | tee /dev/stderr)
     [ "${actual}" = "8443" ]
 
-    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-wan-address-source"]' | tee /dev/stderr)
+    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/gateway-wan-address-source"]' | tee /dev/stderr)
     [ "${actual}" = "Service" ]
 
-    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-wan-port"]' | tee /dev/stderr)
+    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/gateway-wan-port"]' | tee /dev/stderr)
     [ "${actual}" = "9999" ]
 }
 
@@ -1106,10 +1106,10 @@ key2: value2' \
     local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-container-port"]' | tee /dev/stderr)
     [ "${actual}" = "8443" ]
 
-    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-wan-address-source"]' | tee /dev/stderr)
+    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/gateway-wan-address-source"]' | tee /dev/stderr)
     [ "${actual}" = "Service" ]
 
-    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/mesh-gateway-wan-port"]' | tee /dev/stderr)
+    local actual=$(echo $annotations | yq -r '.["consul.hashicorp.com/gateway-wan-port"]' | tee /dev/stderr)
     [ "${actual}" = "443" ]
 }
 
@@ -1381,7 +1381,7 @@ key2: value2' \
       --set 'global.tls.caCert.secretName=foo' \
       --set 'global.secretsBackend.vault.consulCARole=carole' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."vault.hashicorp.com/agent-inject") | del(."vault.hashicorp.com/role") | del(."consul.hashicorp.com/gateway-kind") | del(."consul.hashicorp.com/mesh-gateway-wan-address-source") | del(."consul.hashicorp.com/mesh-gateway-container-port") | del(."consul.hashicorp.com/mesh-gateway-wan-address-static") | del(."consul.hashicorp.com/mesh-gateway-wan-port") | del(."consul.hashicorp.com/mesh-gateway-consul-service-name")' | tee /dev/stderr)
+      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."vault.hashicorp.com/agent-inject") | del(."vault.hashicorp.com/role") | del(."consul.hashicorp.com/gateway-kind") | del(."consul.hashicorp.com/gateway-wan-address-source") | del(."consul.hashicorp.com/mesh-gateway-container-port") | del(."consul.hashicorp.com/gateway-wan-address-static") | del(."consul.hashicorp.com/gateway-wan-port") | del(."consul.hashicorp.com/gateway-consul-service-name")' | tee /dev/stderr)
   [ "${actual}" = "{}" ]
 }
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2665,18 +2665,6 @@ ingressGateways:
         memory: "100Mi"
         cpu: "100m"
 
-    # The resource settings for the `copy-consul-bin` init container.
-    # @recurse: false
-    # @type: map
-    initCopyConsulContainer:
-      resources:
-        requests:
-          memory: "25Mi"
-          cpu: "50m"
-        limits:
-          memory: "150Mi"
-          cpu: "50m"
-
     # By default, we set an anti-affinity so that two of the same gateway pods
     # won't be on the same node. NOTE: Gateways require that Consul client agents are
     # also running on the nodes alongside each gateway pod.

--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -25,27 +25,27 @@ const (
 	// value that is either "mesh", "ingress" or "terminating".
 	annotationGatewayKind = "consul.hashicorp.com/gateway-kind"
 
-	// annotationMeshGatewayConsulServiceName is the key of the annotation whose value
+	// annotationGatewayConsulServiceName is the key of the annotation whose value
 	// is the service name with which the mesh gateway is registered.
-	annotationMeshGatewayConsulServiceName = "consul.hashicorp.com/mesh-gateway-consul-service-name"
+	annotationGatewayConsulServiceName = "consul.hashicorp.com/gateway-consul-service-name"
 
 	// annotationMeshGatewayContainerPort is the key of the annotation whose value is
 	// used as the port and also registered as the LAN port when the mesh-gateway
 	// service is registered.
 	annotationMeshGatewayContainerPort = "consul.hashicorp.com/mesh-gateway-container-port"
 
-	// annotationMeshGatewaySource is the key of the annotation that determines which
+	// annotationGatewayWANSource is the key of the annotation that determines which
 	// source to use to determine the wan address and wan port for the mesh-gateway
 	// service registration.
-	annotationMeshGatewaySource = "consul.hashicorp.com/mesh-gateway-wan-address-source"
+	annotationGatewayWANSource = "consul.hashicorp.com/gateway-wan-address-source"
 
-	// annotationMeshGatewayWANAddress is the key of the annotation that when the source
+	// annotationGatewayWANAddress is the key of the annotation that when the source
 	// of the mesh-gateway is 'Static', is the value of the WAN address for the gateway.
-	annotationMeshGatewayWANAddress = "consul.hashicorp.com/mesh-gateway-wan-address-static"
+	annotationGatewayWANAddress = "consul.hashicorp.com/gateway-wan-address-static"
 
-	// annotationMeshGatewayWANPort is the key of the annotation whose value is the
+	// annotationGatewayWANPort is the key of the annotation whose value is the
 	// WAN port for the mesh-gateway service registration.
-	annotationMeshGatewayWANPort = "consul.hashicorp.com/mesh-gateway-wan-port"
+	annotationGatewayWANPort = "consul.hashicorp.com/gateway-wan-port"
 
 	// annotationGatewayNamespace is the key of the annotation that indicates the
 	// Consul namespace where a Terminating or Ingress Gateway pod is deployed.

--- a/control-plane/connect-inject/endpoints_controller.go
+++ b/control-plane/connect-inject/endpoints_controller.go
@@ -43,7 +43,6 @@ const (
 	kubernetesSuccessReasonMsg = "Kubernetes health checks passing"
 	envoyPrometheusBindAddr    = "envoy_prometheus_bind_addr"
 	sidecarContainer           = "consul-dataplane"
-	wildcardNamespace          = "*"
 	defaultNS                  = "default"
 
 	// clusterIPTaggedAddressName is the key for the tagged address to store the service's cluster IP and service port
@@ -313,6 +312,13 @@ func (r *EndpointsController) registerGateway(apiClient *api.Client, pod corev1.
 		if err != nil {
 			r.Log.Error(err, "failed to create service registrations for endpoints", "name", serviceEndpoints.Name, "ns", serviceEndpoints.Namespace)
 			return err
+		}
+
+		if r.EnableConsulNamespaces {
+			if _, err := namespaces.EnsureExists(apiClient, serviceRegistration.Service.Namespace, r.CrossNSACLPolicy); err != nil {
+				r.Log.Error(err, "failed to ensure Consul namespace exists", "name", serviceEndpoints.Name, "ns", serviceEndpoints.Namespace, "consul ns", serviceRegistration.Service.Namespace)
+				return err
+			}
 		}
 
 		// Register the service instance with Consul.
@@ -636,7 +642,6 @@ func (r *EndpointsController) createGatewayRegistrations(pod corev1.Pod, service
 	switch pod.Annotations[annotationGatewayKind] {
 	case MeshGateway:
 		service.Kind = api.ServiceKindMeshGateway
-		service.Service = MeshGateway
 		if r.EnableConsulNamespaces {
 			service.Namespace = defaultNS
 			consulNS = defaultNS
@@ -652,11 +657,11 @@ func (r *EndpointsController) createGatewayRegistrations(pod corev1.Pod, service
 			meta[MetaKeyConsulWANFederation] = "1"
 		}
 
-		meshGatewayServiceName, ok := pod.Annotations[annotationMeshGatewayConsulServiceName]
+		gatewayServiceName, ok := pod.Annotations[annotationGatewayConsulServiceName]
 		if !ok {
-			return nil, fmt.Errorf("failed to read annontation %s from pod %s/%s", annotationMeshGatewayConsulServiceName, pod.Namespace, pod.Name)
+			return nil, fmt.Errorf("failed to read annontation %s from pod %s/%s", annotationGatewayConsulServiceName, pod.Namespace, pod.Name)
 		}
-		service.Service = meshGatewayServiceName
+		service.Service = gatewayServiceName
 
 		wanAddr, wanPort, err := r.getWanData(pod, serviceEndpoints)
 		if err != nil {
@@ -676,20 +681,62 @@ func (r *EndpointsController) createGatewayRegistrations(pod corev1.Pod, service
 		service.Kind = api.ServiceKindTerminatingGateway
 		service.Service = serviceEndpoints.Name
 		service.Port = 8443
+		if ns, ok := pod.Annotations[annotationGatewayNamespace]; ok && r.EnableConsulNamespaces {
+			service.Namespace = ns
+			consulNS = ns
+		}
+	case IngressGateway:
+		service.Kind = api.ServiceKindIngressGateway
+		gatewayServiceName, ok := pod.Annotations[annotationGatewayConsulServiceName]
+		if !ok {
+			return nil, fmt.Errorf("failed to read annontation %s from pod %s/%s", annotationGatewayConsulServiceName, pod.Namespace, pod.Name)
+		}
+		service.Service = gatewayServiceName
 
 		if ns, ok := pod.Annotations[annotationGatewayNamespace]; ok && r.EnableConsulNamespaces {
 			service.Namespace = ns
 			consulNS = ns
 		}
+
+		wanAddr, wanPort, err := r.getWanData(pod, serviceEndpoints)
+		if err != nil {
+			return nil, err
+		}
+		service.Port = 21000
+		service.TaggedAddresses = map[string]api.ServiceAddress{
+			"lan": {
+				Address: pod.Status.PodIP,
+				Port:    21000,
+			},
+			"wan": {
+				Address: wanAddr,
+				Port:    wanPort,
+			},
+		}
+		service.Proxy = &api.AgentServiceConnectProxyConfig{
+			Config: map[string]interface{}{
+				"envoy_gateway_no_default_bind": true,
+				"envoy_gateway_bind_addresses": map[string]interface{}{
+					"all-interfaces": map[string]interface{}{
+						"address": "0.0.0.0",
+					},
+				},
+			},
+		}
+
 	default:
 		return nil, fmt.Errorf("%s must be one of %s, %s, or %s", annotationGatewayKind, MeshGateway, TerminatingGateway, IngressGateway)
 	}
 
 	if r.MetricsConfig.DefaultEnableMetrics && r.MetricsConfig.EnableGatewayMetrics {
-		service.Proxy = &api.AgentServiceConnectProxyConfig{
-			Config: map[string]interface{}{
-				"envoy_prometheus_bind_addr": fmt.Sprintf("%s:20200", pod.Status.PodIP),
-			},
+		if pod.Annotations[annotationGatewayKind] == IngressGateway {
+			service.Proxy.Config["envoy_prometheus_bind_addr"] = fmt.Sprintf("%s:20200", pod.Status.PodIP)
+		} else {
+			service.Proxy = &api.AgentServiceConnectProxyConfig{
+				Config: map[string]interface{}{
+					"envoy_prometheus_bind_addr": fmt.Sprintf("%s:20200", pod.Status.PodIP),
+				},
+			}
 		}
 	}
 
@@ -714,10 +761,9 @@ func (r *EndpointsController) createGatewayRegistrations(pod corev1.Pod, service
 
 func (r *EndpointsController) getWanData(pod corev1.Pod, endpoints corev1.Endpoints) (string, int, error) {
 	var wanAddr string
-	var wanPort int
-	source, ok := pod.Annotations[annotationMeshGatewaySource]
+	source, ok := pod.Annotations[annotationGatewayWANSource]
 	if !ok {
-		return "", 0, fmt.Errorf("failed to read annotation %s", annotationMeshGatewaySource)
+		return "", 0, fmt.Errorf("failed to read annotation %s", annotationGatewayWANSource)
 	}
 	switch source {
 	case "NodeName":
@@ -725,7 +771,7 @@ func (r *EndpointsController) getWanData(pod corev1.Pod, endpoints corev1.Endpoi
 	case "NodeIP":
 		wanAddr = pod.Status.HostIP
 	case "Static":
-		wanAddr = pod.Annotations[annotationMeshGatewayWANAddress]
+		wanAddr = pod.Annotations[annotationGatewayWANAddress]
 	case "Service":
 		svc, err := r.getService(endpoints)
 		if err != nil {
@@ -752,9 +798,9 @@ func (r *EndpointsController) getWanData(pod corev1.Pod, endpoints corev1.Endpoi
 		}
 	}
 
-	wanPort, err := strconv.Atoi(pod.Annotations[annotationMeshGatewayWANPort])
+	wanPort, err := strconv.Atoi(pod.Annotations[annotationGatewayWANPort])
 	if err != nil {
-		return "", 0, fmt.Errorf("failed to parse WAN port from value %s", pod.Annotations[annotationMeshGatewayWANPort])
+		return "", 0, fmt.Errorf("failed to parse WAN port from value %s", pod.Annotations[annotationGatewayWANPort])
 	}
 	return wanAddr, wanPort, nil
 }
@@ -989,7 +1035,7 @@ func (r *EndpointsController) serviceInstancesForK8SServiceNameAndNamespace(apiC
 	filter := fmt.Sprintf(`Meta[%q] == %q and Meta[%q] == %q and Meta[%q] == %q`,
 		MetaKeyKubeServiceName, k8sServiceName, MetaKeyKubeNS, k8sServiceNamespace, MetaKeyManagedBy, managedByValue)
 	if r.EnableConsulNamespaces {
-		serviceList, _, err = apiClient.Catalog().NodeServiceList(ConsulNodeName, &api.QueryOptions{Filter: filter, Namespace: wildcardNamespace})
+		serviceList, _, err = apiClient.Catalog().NodeServiceList(ConsulNodeName, &api.QueryOptions{Filter: filter, Namespace: namespaces.WildcardNamespace})
 	} else {
 		serviceList, _, err = apiClient.Catalog().NodeServiceList(ConsulNodeName, &api.QueryOptions{Filter: filter})
 	}

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20220831174802-b8af65262de8
+	github.com/hashicorp/consul-server-connection-manager v0.0.0-20220922180412-01c5be1c636f
 	github.com/hashicorp/consul/api v1.10.1-0.20220822180451-60c82757ea35
 	github.com/hashicorp/consul/sdk v0.11.0
 	github.com/hashicorp/go-discover v0.0.0-20200812215701-c4b85f6ed31f
@@ -70,7 +71,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/gophercloud/gophercloud v0.1.0 // indirect
-	github.com/hashicorp/consul-server-connection-manager v0.0.0-20220922180412-01c5be1c636f // indirect
 	github.com/hashicorp/consul/proto-public v0.1.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -341,8 +341,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20220831174802-b8af65262de8 h1:TQY0oKtLV15UNYWeSkTxi4McBIyLecsEtbc/VfxvbYA=
 github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20220831174802-b8af65262de8/go.mod h1:aw35GB76URgbtxaSSMxbOetbG7YEHHPkIX3/SkTBaWc=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20220916195343-d2746a5bd45d h1:oBA40cvSnE3uKnQokjXm2wLMHN36TI8qQI5Zjq07lf4=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20220916195343-d2746a5bd45d/go.mod h1:I56VZ1V7WN8/oPHswKDywfepvD7rB1RrTE4fRrNz3Wc=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20220922180412-01c5be1c636f h1:niyK8S2Vb48YumFkxsqzSl+72tDXgvpAEO6KrL3WwAw=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20220922180412-01c5be1c636f/go.mod h1:I56VZ1V7WN8/oPHswKDywfepvD7rB1RrTE4fRrNz3Wc=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -388,6 +388,14 @@ func (c *Command) Run(args []string) int {
 	go watcher.Run()
 	defer watcher.Stop()
 
+	// This is a blocking command that is run in order to ensure we only start the
+	// connect-inject controllers only after we have access to the Consul server.
+	_, err = watcher.State()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("unable to start Consul server watcher: %s", err))
+		return 1
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		LeaderElection:         true,


### PR DESCRIPTION
Changes proposed in this PR:
- Register Ingress Gateways using the endpoints controller.
- Use Consul Dataplane instead of Envoy

How I've tested this PR:
- Acceptance tests
- Unit and BATS tests.

How I expect reviewers to test this PR:
- Code Review

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

