### PR TITLE
README: bump Helm CLI requirement to 3.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ use Consul with Kubernetes, please see the
 [Consul and Kubernetes documentation](https://www.consul.io/docs/platform/k8s/index.html).
 
 ### Prerequisites
-  * **Helm 3.2+** (Helm 2 is not supported)
+  * **Helm 3.6+** 
   * **Kubernetes 1.21-1.24** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions, but it is
     untested.

--- a/charts/consul/README.md
+++ b/charts/consul/README.md
@@ -30,7 +30,7 @@ by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
     non-Kubernetes nodes to easily discover and access Kubernetes services.
 
 ### Prerequisites
-  * **Helm 3.2+** (Helm 2 is not supported)
+  * **Helm 3.6+** 
   * **Kubernetes 1.21-1.24** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is
     untested.


### PR DESCRIPTION
Changes proposed in this PR:
- Bump Helm CLI requirement to 3.6+ to match Vault Helm requirements

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

