### PR TITLE
Install gke-gcloud-auth-plugin into acceptance test image to fix warnings on GKE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,8 @@ commands:
                           ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -debug-directory="$TEST_RESULTS/debug" \
                           -consul-image=hashicorppreview/consul-enterprise:1.14-dev \
-                          -consul-k8s-image=<< parameters.consul-k8s-image >>
+                          -consul-k8s-image=<< parameters.consul-k8s-image >> \
+                          -run ^TestBasicInstallation$
                     then
                       echo "Tests in ${pkg} failed, aborting early"
                       exit_code=1
@@ -145,7 +146,8 @@ commands:
                       ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -enable-multi-cluster \
                       -debug-directory="$TEST_RESULTS/debug" \
-                      -consul-k8s-image=<< parameters.consul-k8s-image >>
+                      -consul-k8s-image=<< parameters.consul-k8s-image >> \
+                      -run ^TestBasicInstallation$
 
 jobs:
   go-fmt-and-vet-control-plane:
@@ -486,7 +488,7 @@ jobs:
 
   unit-test-helm-templates:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.13.0
+      - image: jmurrethc/test-dockerfile:0.1.6
 
     steps:
       - checkout
@@ -597,7 +599,7 @@ jobs:
   ##########################
   cleanup-gcp-resources:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.13.0
+      - image: jmurrethc/test-dockerfile:0.1.6
     steps:
       - run:
           name: cleanup leftover resources
@@ -615,7 +617,7 @@ jobs:
 
   cleanup-azure-resources:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.13.0
+      - image: jmurrethc/test-dockerfile:0.1.6
     steps:
       - run:
           name: cleanup leftover resources
@@ -633,7 +635,7 @@ jobs:
 
   cleanup-eks-resources:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.13.0
+      - image: jmurrethc/test-dockerfile:0.1.6
     steps:
       - checkout
       - run:
@@ -658,9 +660,10 @@ jobs:
     parallelism: 2
     environment:
       - TEST_RESULTS: /tmp/test-results
+      - USE_GKE_GCLOUD_AUTH_PLUGIN: true
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.13.0
+      - image: jmurrethc/test-dockerfile:0.1.6
 
     steps:
       - run:
@@ -726,9 +729,10 @@ jobs:
     parallelism: 2
     environment:
       - TEST_RESULTS: /tmp/test-results
+      - USE_GKE_GCLOUD_AUTH_PLUGIN: true
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.13.0
+      - image: jmurrethc/test-dockerfile:0.1.6
 
     steps:
       - run:
@@ -796,7 +800,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.13.0
+      - image: jmurrethc/test-dockerfile:0.1.6
 
     steps:
       - checkout
@@ -853,7 +857,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.13.0
+      - image: jmurrethc/test-dockerfile:0.1.6
 
     steps:
       - checkout
@@ -909,7 +913,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.13.0
+      - image: jmurrethc/test-dockerfile:0.1.6
 
     steps:
       - checkout
@@ -972,7 +976,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.13.0
+      - image: jmurrethc/test-dockerfile:0.1.6
 
     steps:
       - checkout
@@ -1035,7 +1039,7 @@ jobs:
     parallelism: 1
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.13.0
+      - image: jmurrethc/test-dockerfile:0.1.6
 
     steps:
       - checkout
@@ -1199,41 +1203,41 @@ jobs:
 
 workflows:
   version: 2
-  test-and-build:
-    jobs:
-      # Build this one control-plane binary so that acceptance and acceptance-tproxy will run
-      # The rest of these CircleCI jobs have been migrated to Github Actions. We need to wait until
-      # the summer of 2022 for larger puplic Github Action VMs be available before the acceptance tests can
-      # be moved
-      - build-distro:
-          OS: "linux"
-          ARCH: "amd64 arm64"
-          name: build-distros-linux
-      - dev-upload-docker:
-          context: consul-ci
-          requires:
-            - build-distros-linux
-      # Run acceptance tests using the docker image built for the control plane
-      - acceptance:
-          context: consul-ci
-          requires:
-            - dev-upload-docker
-#      - acceptance-tproxy-cni:
-#          context: consul-ci
-#          requires:
-#            - dev-upload-docker
-#      - acceptance-tproxy:
-#          context: consul-ci
-#          requires:
-#            - dev-upload-docker
+#   test-and-build:
+#     jobs:
+#       # Build this one control-plane binary so that acceptance and acceptance-tproxy will run
+#       # The rest of these CircleCI jobs have been migrated to Github Actions. We need to wait until
+#       # the summer of 2022 for larger puplic Github Action VMs be available before the acceptance tests can
+#       # be moved
+#       - build-distro:
+#           OS: "linux"
+#           ARCH: "amd64 arm64"
+#           name: build-distros-linux
+#       - dev-upload-docker:
+#           context: consul-ci
+#           requires:
+#             - build-distros-linux
+#       # Run acceptance tests using the docker image built for the control plane
+#       - acceptance:
+#           context: consul-ci
+#           requires:
+#             - dev-upload-docker
+# #      - acceptance-tproxy-cni:
+# #          context: consul-ci
+# #          requires:
+# #            - dev-upload-docker
+# #      - acceptance-tproxy:
+# #          context: consul-ci
+# #          requires:
+# #            - dev-upload-docker
   nightly-acceptance-tests:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
+    # triggers:
+    #   - schedule:
+    #       cron: "0 0 * * *"
+    #       filters:
+    #         branches:
+    #           only:
+    #             - main
     jobs:
       - build-distro:
           OS: "linux"
@@ -1256,20 +1260,20 @@ workflows:
       - acceptance-gke-cni-1-23:
           requires:
             - acceptance-gke-1-23
-      - acceptance-eks-1-21:
-          requires:
-            - cleanup-eks-resources
-            - dev-upload-docker
-      - acceptance-eks-cni-1-21:
-          requires:
-            - acceptance-eks-1-21
-      - acceptance-aks-1-22:
-          requires:
-            - cleanup-azure-resources
-            - dev-upload-docker
-      - acceptance-aks-cni-1-22:
-          requires:
-            - acceptance-aks-1-22
+      # - acceptance-eks-1-21:
+      #     requires:
+      #       - cleanup-eks-resources
+      #       - dev-upload-docker
+      # - acceptance-eks-cni-1-21:
+      #     requires:
+      #       - acceptance-eks-1-21
+      # - acceptance-aks-1-22:
+      #     requires:
+      #       - cleanup-azure-resources
+      #       - dev-upload-docker
+      # - acceptance-aks-cni-1-22:
+      #     requires:
+      #       - acceptance-aks-1-22
 
   nightly-acceptance-tests-consul:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,8 +114,7 @@ commands:
                           ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -debug-directory="$TEST_RESULTS/debug" \
                           -consul-image=hashicorppreview/consul-enterprise:1.14-dev \
-                          -consul-k8s-image=<< parameters.consul-k8s-image >> \
-                          -run ^TestBasicInstallation$
+                          -consul-k8s-image=<< parameters.consul-k8s-image >>
                     then
                       echo "Tests in ${pkg} failed, aborting early"
                       exit_code=1
@@ -146,8 +145,7 @@ commands:
                       ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -enable-multi-cluster \
                       -debug-directory="$TEST_RESULTS/debug" \
-                      -consul-k8s-image=<< parameters.consul-k8s-image >> \
-                      -run ^TestBasicInstallation$
+                      -consul-k8s-image=<< parameters.consul-k8s-image >>
 
 jobs:
   go-fmt-and-vet-control-plane:
@@ -488,7 +486,7 @@ jobs:
 
   unit-test-helm-templates:
     docker:
-      - image: jmurrethc/test-dockerfile:0.1.6
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.14.0
 
     steps:
       - checkout
@@ -599,7 +597,7 @@ jobs:
   ##########################
   cleanup-gcp-resources:
     docker:
-      - image: jmurrethc/test-dockerfile:0.1.6
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.14.0
     steps:
       - run:
           name: cleanup leftover resources
@@ -617,7 +615,7 @@ jobs:
 
   cleanup-azure-resources:
     docker:
-      - image: jmurrethc/test-dockerfile:0.1.6
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.14.0
     steps:
       - run:
           name: cleanup leftover resources
@@ -635,7 +633,7 @@ jobs:
 
   cleanup-eks-resources:
     docker:
-      - image: jmurrethc/test-dockerfile:0.1.6
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.14.0
     steps:
       - checkout
       - run:
@@ -663,7 +661,7 @@ jobs:
       - USE_GKE_GCLOUD_AUTH_PLUGIN: true
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: jmurrethc/test-dockerfile:0.1.6
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.14.0
 
     steps:
       - run:
@@ -732,7 +730,7 @@ jobs:
       - USE_GKE_GCLOUD_AUTH_PLUGIN: true
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: jmurrethc/test-dockerfile:0.1.6
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.14.0
 
     steps:
       - run:
@@ -800,7 +798,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: jmurrethc/test-dockerfile:0.1.6
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.14.0
 
     steps:
       - checkout
@@ -857,7 +855,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: jmurrethc/test-dockerfile:0.1.6
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.14.0
 
     steps:
       - checkout
@@ -913,7 +911,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: jmurrethc/test-dockerfile:0.1.6
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.14.0
 
     steps:
       - checkout
@@ -976,7 +974,7 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: jmurrethc/test-dockerfile:0.1.6
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.14.0
 
     steps:
       - checkout
@@ -1039,7 +1037,7 @@ jobs:
     parallelism: 1
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: jmurrethc/test-dockerfile:0.1.6
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-helm-test:0.14.0
 
     steps:
       - checkout
@@ -1203,41 +1201,41 @@ jobs:
 
 workflows:
   version: 2
-#   test-and-build:
-#     jobs:
-#       # Build this one control-plane binary so that acceptance and acceptance-tproxy will run
-#       # The rest of these CircleCI jobs have been migrated to Github Actions. We need to wait until
-#       # the summer of 2022 for larger puplic Github Action VMs be available before the acceptance tests can
-#       # be moved
-#       - build-distro:
-#           OS: "linux"
-#           ARCH: "amd64 arm64"
-#           name: build-distros-linux
-#       - dev-upload-docker:
-#           context: consul-ci
-#           requires:
-#             - build-distros-linux
-#       # Run acceptance tests using the docker image built for the control plane
-#       - acceptance:
-#           context: consul-ci
-#           requires:
-#             - dev-upload-docker
-# #      - acceptance-tproxy-cni:
-# #          context: consul-ci
-# #          requires:
-# #            - dev-upload-docker
-# #      - acceptance-tproxy:
-# #          context: consul-ci
-# #          requires:
-# #            - dev-upload-docker
+  test-and-build:
+    jobs:
+      # Build this one control-plane binary so that acceptance and acceptance-tproxy will run
+      # The rest of these CircleCI jobs have been migrated to Github Actions. We need to wait until
+      # the summer of 2022 for larger puplic Github Action VMs be available before the acceptance tests can
+      # be moved
+      - build-distro:
+          OS: "linux"
+          ARCH: "amd64 arm64"
+          name: build-distros-linux
+      - dev-upload-docker:
+          context: consul-ci
+          requires:
+            - build-distros-linux
+      # Run acceptance tests using the docker image built for the control plane
+      - acceptance:
+          context: consul-ci
+          requires:
+            - dev-upload-docker
+#      - acceptance-tproxy-cni:
+#          context: consul-ci
+#          requires:
+#            - dev-upload-docker
+#      - acceptance-tproxy:
+#          context: consul-ci
+#          requires:
+#            - dev-upload-docker
   nightly-acceptance-tests:
-    # triggers:
-    #   - schedule:
-    #       cron: "0 0 * * *"
-    #       filters:
-    #         branches:
-    #           only:
-    #             - main
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
     jobs:
       - build-distro:
           OS: "linux"
@@ -1260,20 +1258,20 @@ workflows:
       - acceptance-gke-cni-1-23:
           requires:
             - acceptance-gke-1-23
-      # - acceptance-eks-1-21:
-      #     requires:
-      #       - cleanup-eks-resources
-      #       - dev-upload-docker
-      # - acceptance-eks-cni-1-21:
-      #     requires:
-      #       - acceptance-eks-1-21
-      # - acceptance-aks-1-22:
-      #     requires:
-      #       - cleanup-azure-resources
-      #       - dev-upload-docker
-      # - acceptance-aks-cni-1-22:
-      #     requires:
-      #       - acceptance-aks-1-22
+      - acceptance-eks-1-21:
+          requires:
+            - cleanup-eks-resources
+            - dev-upload-docker
+      - acceptance-eks-cni-1-21:
+          requires:
+            - acceptance-eks-1-21
+      - acceptance-aks-1-22:
+          requires:
+            - cleanup-azure-resources
+            - dev-upload-docker
+      - acceptance-aks-cni-1-22:
+          requires:
+            - acceptance-aks-1-22
 
   nightly-acceptance-tests-consul:
     triggers:

--- a/charts/consul/test/docker/Test.dockerfile
+++ b/charts/consul/test/docker/Test.dockerfile
@@ -27,7 +27,11 @@ RUN apt-get install -y \
 RUN pip3 install yq
 
 # gcloud
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
+    apt-get update -y && \
+    apt-get install google-cloud-sdk -y && \
+    apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
 
 # terraform
 RUN curl -sSL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -o /tmp/tf.zip \


### PR DESCRIPTION
Changes proposed in this PR:
- build and publish consul-helm-test image with gke-gloud-auth-plugin
- use new image in CI

How I've tested this PR:
This passing nightly [GKE test](https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/8047/workflows/8d34b238-fc6b-47ec-8540-41e6a9ada4ff/jobs/61509/parallel-runs/1?filterBy=ALL) in my branch: 

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

