### PR TITLE
Helm: Support minAvailable on connect injector PDB

### DIFF
--- a/charts/consul/templates/connect-injector-disruptionbudget.yaml
+++ b/charts/consul/templates/connect-injector-disruptionbudget.yaml
@@ -17,7 +17,11 @@ metadata:
     release: {{ .Release.Name }}
     component: connect-injector
 spec:
+  {{- if .Values.connectInject.disruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.connectInject.disruptionBudget.minAvailable }}
+  {{- else }}
   maxUnavailable: {{ template "consul.pdb.connectInject.maxUnavailable" . }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "consul.name" . }}

--- a/charts/consul/test/unit/connect-injector-disruptionbudget.bats
+++ b/charts/consul/test/unit/connect-injector-disruptionbudget.bats
@@ -159,3 +159,35 @@ load _helpers
 # no flag to *remove* an API version so some Helm versions will always have
 # policy/v1 support and will always use that API version.
 
+
+#--------------------------------------------------------------------
+# minAvailable
+
+@test "connect-injector/DisruptionBudget: correct minAvailable when set" {
+  cd `chart_dir`
+  local tpl=$(helm template \
+      -s templates/connect-injector-disruptionbudget.yaml  \
+      --set 'connectInject.replicas=1' \
+      --set 'global.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.disruptionBudget.enabled=true' \
+      --set 'connectInject.disruptionBudget.minAvailable=1' \
+      . | tee /dev/stderr)
+  [ $(echo "$tpl" | yq '.spec.minAvailable') = "1" ]
+  [ $(echo "$tpl" | yq '.spec.maxUnavailable') = "null" ]
+}
+
+@test "connect-injector/DisruptionBudget: correct minAvailable when set with maxUnavailable" {
+  cd `chart_dir`
+  local tpl=$(helm template \
+      -s templates/connect-injector-disruptionbudget.yaml  \
+      --set 'connectInject.replicas=1' \
+      --set 'global.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.disruptionBudget.enabled=true' \
+      --set 'connectInject.disruptionBudget.minAvailable=1' \
+      --set 'connectInject.disruptionBudget.maxUnavailable=2' \
+      . | tee /dev/stderr)
+  [ $(echo "$tpl" | yq '.spec.minAvailable') = "1" ]
+  [ $(echo "$tpl" | yq '.spec.maxUnavailable') = "null" ]
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1937,6 +1937,11 @@ connectInject:
     # @type: integer
     maxUnavailable: null
 
+    # The minimum number of available pods.
+    # Takes precedence over maxUnavailable if set.
+    # @type: integer
+    minAvailable: null
+
   # Configures consul-cni plugin for Consul Service mesh services
   cni:
     # If true, then all traffic redirection setup will use the consul-cni plugin. 


### PR DESCRIPTION
It looks like the PDB for the connect injector has copied the logic from the Server PDB.
In that it is extremely conservative and attempts to maintain n+1 pods, which makes complete sense for Consul Servers as you do want to maintain a quorum at all times.

The injector deployment uses leader election and only 1 pod is actually active at any one time, requiring n/2-1 pods to be available is unnecessary.

Furthermore, with the default 2 replicas `maxUnavailable` is set at 0, which requires manual human operator intervention to, for example, drain a node running an injector pod.
See [Single-instance Stateful Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#think-about-how-your-application-reacts-to-disruptions) 

For the connect injector deployment a `minAvailable` configuration makes much more sense.

These changes do not change the default behaviour, although I think the default behaviour probably *should* be changed.
This is opt-in only, users must configure the new value explicitly.

Changes proposed in this PR:
- Add `connectInject.disruptionBudget.minAvailable` to values
- `minAvailable` is null by default
- `minAvailable` takes precedence over the `maxUnavailable` configuration

How I've tested this PR:
* Added tests

How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

