### PR TITLE
[wip] Update default server replicas to 1

### DIFF
--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -133,12 +133,6 @@ load _helpers
   local actual
   actual=$(echo $command | jq -r '. | any(contains("-server-address=\"${CONSUL_FULLNAME}-server-0.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
-
-  actual=$(echo $command | jq -r '. | any(contains("-server-address=\"${CONSUL_FULLNAME}-server-1.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc\""))' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-
-  actual=$(echo $command | jq -r '. | any(contains("-server-address=\"${CONSUL_FULLNAME}-server-2.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc\""))' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/test/unit/server-config-configmap.bats
+++ b/charts/consul/test/unit/server-config-configmap.bats
@@ -118,7 +118,7 @@ load _helpers
       -s templates/server-config-configmap.yaml  \
       . | tee /dev/stderr |
       yq -r '.data["server.json"]' | jq .bootstrap_expect | tee /dev/stderr)
-  [ "${actual}" = "3" ]
+  [ "${actual}" = "1" ]
 }
 
 @test "server/ConfigMap: bootstrap_expect can be set by server.bootstrapExpect" {

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -45,6 +45,7 @@ load _helpers
   cd `chart_dir`
   run helm template \
       -s templates/server-statefulset.yaml  \
+      --set 'server.replicas=3' \
       --set 'server.bootstrapExpect=1' .
   [ "$status" -eq 1 ]
   [[ "$output" =~ "server.bootstrapExpect cannot be less than server.replicas" ]]
@@ -678,7 +679,7 @@ load _helpers
       -s templates/server-statefulset.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = b13fbd9214f5131aaf1bc234c5e307db1e9be3f29a66f14a994c2a73175ab29c ]
+  [ "${actual}" = f3b00edc16ec09e90b7a20e379be5ddc1b10121ce60f602809a44130d2dc7aca ]
 }
 
 @test "server/StatefulSet: adds config-checksum annotation when extraConfig is provided" {
@@ -688,7 +689,7 @@ load _helpers
       --set 'server.extraConfig="{\"hello\": \"world\"}"' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = a32421961a4d6086483ce99d496b8fc34730bc476a0245d3b7762f6d5557cef2 ]
+  [ "${actual}" = b51ac0ef8e40d138e197f4ea86e55f3ceebb91fa07d15998809d8904d5a69606 ]
 }
 
 @test "server/StatefulSet: adds config-checksum annotation when config is updated" {
@@ -698,7 +699,7 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = a68b3056d1b756d09163f5104d13a201d1e577e7c08c2ea44163eb03b0ca98b8 ]
+  [ "${actual}" = a37768452067ddd3a0ab44d1da18e167fe093946b14e43e915f094fa8c86c37f ]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -667,7 +667,7 @@ server:
   # The number of server agents to run. This determines the fault tolerance of
   # the cluster. Please see the deployment table (https://consul.io/docs/internals/consensus#deployment-table)
   # for more information.
-  replicas: 3
+  replicas: 1
 
   # The number of servers that are expected to be running.
   # It defaults to server.replicas.


### PR DESCRIPTION
This has been a fairly requested change from practitioners who are trying out Consul for the first time and run into basic deployment problems due to running against a single node Kubernetes cluster such as `Kind`.

Changes proposed in this PR:
- Changes the default server replicas to `1`

How I've tested this PR:
unit and acceptance tests should pass.

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

