### PR TITLE
reverted addition of squash to backport assistant

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,7 +14,7 @@ jobs:
     container: hashicorpdev/backport-assistant:0.2.5
     steps:
       - name: Run Backport Assistant
-        run: backport-assistant backport -automerge -merge-method=squash
+        run: backport-assistant backport -automerge
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.x)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"


### PR DESCRIPTION
Changes proposed in this PR:
- The squash command for the backport assistant created unexpected issues when auto-creating PRs involving merge conflicts when backporting. Recommendation from Rel-Eng is to remove the squash command.

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

