### PR TITLE
Correct partitionServiceName in TestPartitions_Connect to fix failures in nightly acceptance runs.

### DIFF
--- a/acceptance/tests/partitions/partitions_connect_test.go
+++ b/acceptance/tests/partitions/partitions_connect_test.go
@@ -146,7 +146,7 @@ func TestPartitions_Connect(t *testing.T) {
 				k8s.CopySecret(t, defaultPartitionClusterContext, secondaryPartitionClusterContext, partitionToken)
 			}
 
-			partitionServiceName := fmt.Sprintf("%s-expose-servers", releaseName)
+			partitionServiceName := fmt.Sprintf("%s-consul-expose-servers", releaseName)
 			partitionSvcAddress := k8s.ServiceHost(t, cfg, defaultPartitionClusterContext, partitionServiceName)
 
 			k8sAuthMethodHost := k8s.KubernetesAPIServerHost(t, cfg, secondaryPartitionClusterContext)


### PR DESCRIPTION


Changes proposed in this PR:
- change service name in TestPartitions_Connect to have `<release name>-<chart.Name>-expose-servers` to match the `template.fullName` helm template function and also [what is in CI](https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/8088/workflows/12f63bd2-b37d-4718-91d7-572e986cc1dc/jobs/61643) and what is in [other tests that use the ServiceHost function](https://github.com/hashicorp/consul-k8s/blob/b40b8a1893c493b704fdff106b28fa5568967950/acceptance/tests/partitions/partitions_sync_test.go#L149).
-

How I've tested this PR:
- run acceptance tests

How I expect reviewers to test this PR:
👀 


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

