### PR TITLE
Update consul image in CI to match the image set when using failfast

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1230,13 +1230,13 @@ workflows:
 #          requires:
 #            - dev-upload-docker
   nightly-acceptance-tests:
-    # triggers:
-    #   - schedule:
-    #       cron: "0 0 * * *"
-    #       filters:
-    #         branches:
-    #           only:
-    #             - main
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
     jobs:
       - build-distro:
           OS: "linux"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ commands:
                       ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                       -enable-multi-cluster \
                       -debug-directory="$TEST_RESULTS/debug" \
+                      -consul-image=hashicorppreview/consul-enterprise:1.14-dev \
                       -consul-k8s-image=<< parameters.consul-k8s-image >>
 
 jobs:
@@ -1229,13 +1230,13 @@ workflows:
 #          requires:
 #            - dev-upload-docker
   nightly-acceptance-tests:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
+    # triggers:
+    #   - schedule:
+    #       cron: "0 0 * * *"
+    #       filters:
+    #         branches:
+    #           only:
+    #             - main
     jobs:
       - build-distro:
           OS: "linux"


### PR DESCRIPTION
Changes proposed in this PR:
- setting the consul image in CI.  It is currently set in the other [portion of CI where failfast is set](https://github.com/hashicorp/consul-k8s/compare/jm/nightly-image?expand=1#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R116)
-

How I've tested this PR:
- CI
- 👀 

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

