### PR TITLE
api-gateway: Allow controller to read MeshService resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+IMPROVEMENTS:
+* Helm:
+  * API Gateway: Allow controller to read MeshServices for use as a route backend. [[GH-1574](https://github.com/hashicorp/consul-k8s/pull/1574)]
+
 ## 1.0.0-beta1 (October 4, 2022)
 FEATURES:
 * CLI:

--- a/charts/consul/templates/api-gateway-controller-clusterrole.yaml
+++ b/charts/consul/templates/api-gateway-controller-clusterrole.yaml
@@ -27,6 +27,14 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - api-gateway.consul.hashicorp.com
+  resources:
+  - meshservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments


### PR DESCRIPTION
**Changes proposed in this PR:**
Allow the API Gateway controller to `get`, `list` and `watch` the `MeshService` resource. This allows the controller to verify that a `MeshService` referenced as a route backend actually exists.

**How I've tested this PR:**
Set up a `Gateway` with `HTTPRoute` targeting a `MeshService` as a backend. This is especially useful in a peering setup where you need to reference an imported Consul service.

**How I expect reviewers to test this PR:**
:eyes:

Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

