### PR TITLE
agentless: migrate server-acl-init to use server connection manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bin/
 pkg/
 .idea/
 .vscode
+.bob/

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -70,7 +70,7 @@ spec:
         {{- end }}
         {{- if .Values.global.acls.replicationToken.secretName }}
         "vault.hashicorp.com/agent-inject-secret-replication-token": "{{ .Values.global.acls.replicationToken.secretName }}"
-        "vault.hashicorp.com/agent-inject-template-replication-token":  {{ template "consul.vaultReplicationTokenTemplate" . }}
+        "vault.hashicorp.com/agent-inject-template-replication-token": {{ template "consul.vaultReplicationTokenTemplate" . }}
         {{- end }}
         {{- if .Values.global.secretsBackend.vault.agentAnnotations }}
         {{ tpl .Values.global.secretsBackend.vault.agentAnnotations . | nindent 8 | trim }}
@@ -81,261 +81,230 @@ spec:
       serviceAccountName: {{ template "consul.fullname" . }}-server-acl-init
       {{- if (or .Values.global.tls.enabled .Values.global.acls.replicationToken.secretName .Values.global.acls.bootstrapToken.secretName) }}
       volumes:
+      {{- if and .Values.global.tls.enabled (not .Values.global.secretsBackend.vault.enabled) }}
+      {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
+      - name: consul-ca-cert
+        secret:
+          {{- if .Values.global.tls.caCert.secretName }}
+          secretName: {{ .Values.global.tls.caCert.secretName }}
+          {{- else }}
+          secretName: {{ template "consul.fullname" . }}-ca-cert
+          {{- end }}
+          items:
+          - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
+            path: tls.crt
+      {{- end }}
+      {{- end }}
+      {{- if (and .Values.global.acls.bootstrapToken.secretName (not .Values.global.secretsBackend.vault.enabled)) }}
+      - name: bootstrap-token
+        secret:
+          secretName: {{ .Values.global.acls.bootstrapToken.secretName }}
+          items:
+          - key: {{ .Values.global.acls.bootstrapToken.secretKey }}
+            path: bootstrap-token
+      {{- else if and .Values.global.acls.replicationToken.secretName (not .Values.global.secretsBackend.vault.enabled) }}
+      - name: acl-replication-token
+        secret:
+          secretName: {{ .Values.global.acls.replicationToken.secretName }}
+          items:
+          - key: {{ .Values.global.acls.replicationToken.secretKey }}
+            path: acl-replication-token
+      {{- end }}
+      {{- end }}
+      containers:
+      - name: server-acl-init-job
+        image: {{ .Values.global.imageK8S }}
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        {{- include "consul.consulK8sConsulServerEnvVars" . | nindent 8 }}
+        {{- if (or .Values.global.tls.enabled .Values.global.acls.replicationToken.secretName .Values.global.acls.bootstrapToken.secretName) }}
+        volumeMounts:
         {{- if and .Values.global.tls.enabled (not .Values.global.secretsBackend.vault.enabled) }}
         {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
         - name: consul-ca-cert
-          secret:
-            {{- if .Values.global.tls.caCert.secretName }}
-            secretName: {{ .Values.global.tls.caCert.secretName }}
-            {{- else }}
-            secretName: {{ template "consul.fullname" . }}-ca-cert
-            {{- end }}
-            items:
-              - key: {{ default "tls.crt" .Values.global.tls.caCert.secretKey }}
-                path: tls.crt
+          mountPath: /consul/tls/ca
+          readOnly: true
         {{- end }}
         {{- end }}
         {{- if (and .Values.global.acls.bootstrapToken.secretName (not .Values.global.secretsBackend.vault.enabled)) }}
         - name: bootstrap-token
-          secret:
-            secretName: {{ .Values.global.acls.bootstrapToken.secretName }}
-            items:
-              - key: {{ .Values.global.acls.bootstrapToken.secretKey }}
-                path: bootstrap-token
+          mountPath: /consul/acl/tokens
+          readOnly: true
         {{- else if and .Values.global.acls.replicationToken.secretName (not .Values.global.secretsBackend.vault.enabled) }}
         - name: acl-replication-token
-          secret:
-            secretName: {{ .Values.global.acls.replicationToken.secretName }}
-            items:
-              - key: {{ .Values.global.acls.replicationToken.secretKey }}
-                path: acl-replication-token
+          mountPath: /consul/acl/tokens
+          readOnly: true
         {{- end }}
-      {{- end }}
-      containers:
-        - name: post-install-job
-          image: {{ .Values.global.imageK8S }}
-          env:
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-          {{- if (or .Values.global.tls.enabled .Values.global.acls.replicationToken.secretName .Values.global.acls.bootstrapToken.secretName) }}
-          volumeMounts:
-            {{- if and .Values.global.tls.enabled (not .Values.global.secretsBackend.vault.enabled) }}
-            {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
-            - name: consul-ca-cert
-              mountPath: /consul/tls/ca
-              readOnly: true
+        {{- end }}
+        command:
+        - "/bin/sh"
+        - "-ec"
+        - |
+          CONSUL_FULLNAME="{{template "consul.fullname" . }}"
+
+          consul-k8s-control-plane server-acl-init \
+            -log-level={{ .Values.global.logLevel }} \
+            -log-json={{ .Values.global.logJSON }} \
+            -resource-prefix=${CONSUL_FULLNAME} \
+            -k8s-namespace={{ .Release.Namespace }} \
+            -set-server-tokens={{ $serverEnabled }} \
+
+            {{- if .Values.global.acls.bootstrapToken.secretName }}
+            {{- if .Values.global.secretsBackend.vault.enabled }}
+            -bootstrap-token-file=/vault/secrets/bootstrap-token \
+            {{- else }}
+            -bootstrap-token-file=/consul/acl/tokens/bootstrap-token \
             {{- end }}
             {{- end }}
-            {{- if (and .Values.global.acls.bootstrapToken.secretName (not .Values.global.secretsBackend.vault.enabled)) }}
-            - name: bootstrap-token
-              mountPath: /consul/acl/tokens
-              readOnly: true
-            {{- else if and .Values.global.acls.replicationToken.secretName (not .Values.global.secretsBackend.vault.enabled) }}
-            - name: acl-replication-token
-              mountPath: /consul/acl/tokens
-              readOnly: true
+
+            {{- if .Values.syncCatalog.enabled }}
+            -sync-catalog=true \
+            {{- if .Values.syncCatalog.consulNodeName }}
+            -sync-consul-node-name={{ .Values.syncCatalog.consulNodeName }} \
             {{- end }}
-           {{- end }}
-          command:
-            - "/bin/sh"
-            - "-ec"
-            - |
-              CONSUL_FULLNAME="{{template "consul.fullname" . }}"
+            {{- end }}
 
-              consul-k8s-control-plane server-acl-init \
-                -log-level={{ .Values.global.logLevel }} \
-                -log-json={{ .Values.global.logJSON }} \
-                -resource-prefix=${CONSUL_FULLNAME} \
-                -k8s-namespace={{ .Release.Namespace }} \
-                -set-server-tokens={{ $serverEnabled }} \
-                -consul-api-timeout={{ .Values.global.consulAPITimeout }} \
+            {{- if .Values.global.peering.enabled }}
+            -enable-peering=true \
+            {{- end }}
+            {{- if (or (and (ne (.Values.dns.enabled | toString) "-") .Values.dns.enabled) (and (eq (.Values.dns.enabled | toString) "-") .Values.global.enabled)) }}
+            -allow-dns=true \
+            {{- end }}
 
-                {{- if .Values.externalServers.enabled }}
-                {{- if and .Values.externalServers.enabled (not .Values.externalServers.hosts) }}{{ fail "externalServers.hosts must be set if externalServers.enabled is true" }}{{ end -}}
-                {{- range .Values.externalServers.hosts }}
-                -server-address={{ quote . }} \
-                {{- end }}
-                -server-port={{ .Values.externalServers.httpsPort }} \
-                {{- else }}
-                {{- range $index := until (.Values.server.replicas | int) }}
-                -server-address="${CONSUL_FULLNAME}-server-{{ $index }}.${CONSUL_FULLNAME}-server.${NAMESPACE}.svc" \
-                {{- end }}
-                {{- end }}
+            {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
+            -connect-inject=true \
+            {{- end }}
+            {{- if and .Values.externalServers.enabled .Values.externalServers.k8sAuthMethodHost }}
+            -auth-method-host={{ .Values.externalServers.k8sAuthMethodHost }} \
+            {{- end }}
 
-                {{- if .Values.global.tls.enabled }}
-                -use-https \
-                {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
-                {{- if .Values.global.secretsBackend.vault.enabled }}
-                -consul-ca-cert=/vault/secrets/serverca.crt \
-                {{- else }}
-                -consul-ca-cert=/consul/tls/ca/tls.crt \
-                {{- end }}
-                {{- end }}
-                {{- if not .Values.externalServers.enabled }}
-                -server-port=8501 \
-                {{- end }}
-                {{- if .Values.externalServers.tlsServerName }}
-                -tls-server-name={{ .Values.externalServers.tlsServerName }} \
-                {{- else if .Values.global.cloud.enabled }}
-                -tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
-                {{- end }}
-                {{- end }}
+            {{- if .Values.global.federation.k8sAuthMethodHost }}
+            -auth-method-host={{ .Values.global.federation.k8sAuthMethodHost }} \
+            {{- end }}
 
-                {{- if .Values.syncCatalog.enabled }}
-                -sync-catalog=true \
-                {{- if .Values.syncCatalog.consulNodeName }}
-                -sync-consul-node-name={{ .Values.syncCatalog.consulNodeName }} \
-                {{- end }}
-                {{- end }}
-                {{- if .Values.global.adminPartitions.enabled }}
-                -enable-partitions=true \
-                -partition={{ .Values.global.adminPartitions.name }} \
-                {{- end }}
-                {{- if .Values.global.peering.enabled }}
-                -enable-peering=true \
-                {{- end }}
-                {{- if (or (and (ne (.Values.dns.enabled | toString) "-") .Values.dns.enabled) (and (eq (.Values.dns.enabled | toString) "-") .Values.global.enabled)) }}
-                -allow-dns=true \
-                {{- end }}
+            {{- if .Values.meshGateway.enabled }}
+            -mesh-gateway=true \
+            {{- end }}
 
-                {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
-                -connect-inject=true \
-                {{- end }}
-                {{- if and .Values.externalServers.enabled .Values.externalServers.k8sAuthMethodHost }}
-                -auth-method-host={{ .Values.externalServers.k8sAuthMethodHost }} \
-                {{- end }}
+            {{- if .Values.ingressGateways.enabled }}
+            {{- if .Values.global.enableConsulNamespaces }}
+            {{- $root := . }}
+            {{- range .Values.ingressGateways.gateways }}
+            {{- if (or $root.Values.ingressGateways.defaults.consulNamespace .consulNamespace) }}
+            -ingress-gateway-name="{{ .name }}.{{ (default $root.Values.ingressGateways.defaults.consulNamespace .consulNamespace) }}" \
+            {{- else }}
+            -ingress-gateway-name="{{ .name }}" \
+            {{- end }}
+            {{- end }}
+            {{- else }}
+            {{- range .Values.ingressGateways.gateways }}
+            -ingress-gateway-name="{{ .name }}" \
+            {{- end }}
+            {{- end }}
+            {{- end }}
 
-                {{- if .Values.global.federation.k8sAuthMethodHost }}
-                -auth-method-host={{ .Values.global.federation.k8sAuthMethodHost }} \
-                {{- end }}
+            {{- if .Values.terminatingGateways.enabled }}
+            {{- if .Values.global.enableConsulNamespaces }}
+            {{- $root := . }}
+            {{- range .Values.terminatingGateways.gateways }}
+            {{- if (or $root.Values.terminatingGateways.defaults.consulNamespace .consulNamespace) }}
+            -terminating-gateway-name="{{ .name }}.{{ (default $root.Values.terminatingGateways.defaults.consulNamespace .consulNamespace) }}" \
+            {{- else }}
+            -terminating-gateway-name="{{ .name }}" \
+            {{- end }}
+            {{- end }}
+            {{- else }}
+            {{- range .Values.terminatingGateways.gateways }}
+            -terminating-gateway-name="{{ .name }}" \
+            {{- end }}
+            {{- end }}
+            {{- end }}
 
-                {{- if .Values.meshGateway.enabled }}
-                -mesh-gateway=true \
-                {{- end }}
+            {{- if .Values.connectInject.aclBindingRuleSelector }}
+            -acl-binding-rule-selector={{ .Values.connectInject.aclBindingRuleSelector }} \
+            {{- end }}
 
-                {{- if .Values.ingressGateways.enabled }}
-                {{- if .Values.global.enableConsulNamespaces }}
-                {{- $root := . }}
-                {{- range .Values.ingressGateways.gateways }}
-                {{- if (or $root.Values.ingressGateways.defaults.consulNamespace .consulNamespace) }}
-                -ingress-gateway-name="{{ .name }}.{{ (default $root.Values.ingressGateways.defaults.consulNamespace .consulNamespace) }}" \
-                {{- else }}
-                -ingress-gateway-name="{{ .name }}" \
-                {{- end }}
-                {{- end }}
-                {{- else }}
-                {{- range .Values.ingressGateways.gateways }}
-                -ingress-gateway-name="{{ .name }}" \
-                {{- end }}
-                {{- end }}
-                {{- end }}
+            {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey) }}
+            -create-enterprise-license-token=true \
+            {{- end }}
 
-                {{- if .Values.terminatingGateways.enabled }}
-                {{- if .Values.global.enableConsulNamespaces }}
-                {{- $root := . }}
-                {{- range .Values.terminatingGateways.gateways }}
-                {{- if (or $root.Values.terminatingGateways.defaults.consulNamespace .consulNamespace) }}
-                -terminating-gateway-name="{{ .name }}.{{ (default $root.Values.terminatingGateways.defaults.consulNamespace .consulNamespace) }}" \
-                {{- else }}
-                -terminating-gateway-name="{{ .name }}" \
-                {{- end }}
-                {{- end }}
-                {{- else }}
-                {{- range .Values.terminatingGateways.gateways }}
-                -terminating-gateway-name="{{ .name }}" \
-                {{- end }}
-                {{- end }}
-                {{- end }}
+            {{- if .Values.server.snapshotAgent.enabled }}
+            -snapshot-agent=true \
+            {{- end }}
 
-                {{- if .Values.connectInject.aclBindingRuleSelector }}
-                -acl-binding-rule-selector={{ .Values.connectInject.aclBindingRuleSelector }} \
-                {{- end }}
+            {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+            -client=false \
+            {{- end }}
 
-                {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey) }}
-                -create-enterprise-license-token=true \
-                {{- end }}
+            {{- if .Values.global.acls.createReplicationToken }}
+            -create-acl-replication-token=true \
+            {{- end }}
 
-                {{- if .Values.server.snapshotAgent.enabled }}
-                -snapshot-agent=true \
-                {{- end }}
+            {{- if .Values.global.federation.enabled }}
+            -federation=true \
+            {{- end }}
 
-                {{- if not (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
-                -client=false \
-                {{- end }}
+            {{- if .Values.global.acls.replicationToken.secretName }}
+            {{- if .Values.global.secretsBackend.vault.enabled }}
+            -acl-replication-token-file=/vault/secrets/replication-token \
+            {{- else }}
+            -acl-replication-token-file=/consul/acl/tokens/acl-replication-token \
+            {{- end }}
+            {{- end }}
+            {{- if and .Values.global.secretsBackend.vault.enabled .Values.global.acls.partitionToken.secretName }}
+            -partition-token-file=/vault/secrets/partition-token \
+            {{- end }}
 
-                {{- if .Values.global.acls.createReplicationToken }}
-                -create-acl-replication-token=true \
-                {{- end }}
+            {{- if .Values.controller.enabled }}
+            -controller=true \
+            {{- end }}
 
-                {{- if .Values.global.federation.enabled }}
-                -federation=true \
-                {{- end }}
+            {{- if .Values.apiGateway.enabled }}
+            -api-gateway-controller=true \
+            {{- end }}
 
-                {{- if .Values.global.acls.bootstrapToken.secretName }}
-                {{- if .Values.global.secretsBackend.vault.enabled }}
-                -bootstrap-token-file=/vault/secrets/bootstrap-token \
-                {{- else }}
-                -bootstrap-token-file=/consul/acl/tokens/bootstrap-token \
-                {{- end }}
-                {{- end }}
-                {{- if .Values.global.acls.replicationToken.secretName }}
-                {{- if .Values.global.secretsBackend.vault.enabled }}
-                -acl-replication-token-file=/vault/secrets/replication-token \
-                {{- else }}
-                -acl-replication-token-file=/consul/acl/tokens/acl-replication-token \
-                {{- end }}
-                {{- end }}
-                {{- if and .Values.global.secretsBackend.vault.enabled .Values.global.acls.partitionToken.secretName }}
-                -partition-token-file=/vault/secrets/partition-token \
-                {{- end }}
+            {{- if .Values.global.enableConsulNamespaces }}
+            -enable-namespaces=true \
+            {{- /* syncCatalog must be enabled to set sync flags */}}
+            {{- if (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
+            {{- if .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }}
+            -consul-sync-destination-namespace={{ .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }} \
+            {{- end }}
+            {{- if .Values.syncCatalog.consulNamespaces.mirroringK8S }}
+            -enable-sync-k8s-namespace-mirroring=true \
+              {{- if .Values.syncCatalog.consulNamespaces.mirroringK8SPrefix }}
+            -sync-k8s-namespace-mirroring-prefix={{ .Values.syncCatalog.consulNamespaces.mirroringK8SPrefix }} \
+            {{- end }}
+            {{- end }}
+            {{- end }}
 
-                {{- if .Values.controller.enabled }}
-                -controller=true \
-                {{- end }}
-
-                {{- if .Values.apiGateway.enabled }}
-                -api-gateway-controller=true \
-                {{- end }}
-
-                {{- if .Values.global.enableConsulNamespaces }}
-                -enable-namespaces=true \
-
-                {{- /* syncCatalog must be enabled to set sync flags */}}
-                {{- if (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
-                {{- if .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }}
-                -consul-sync-destination-namespace={{ .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }} \
-                {{- end }}
-                {{- if .Values.syncCatalog.consulNamespaces.mirroringK8S }}
-                -enable-sync-k8s-namespace-mirroring=true \
-                {{- if .Values.syncCatalog.consulNamespaces.mirroringK8SPrefix }}
-                -sync-k8s-namespace-mirroring-prefix={{ .Values.syncCatalog.consulNamespaces.mirroringK8SPrefix }} \
-                {{- end }}
-                {{- end }}
-                {{- end }}
-
-                {{- /* connectInject must be enabled to set inject flags */}}
-                {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
-                {{- if .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
-                -consul-inject-destination-namespace={{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }} \
-                {{- end }}
-                {{- if .Values.connectInject.consulNamespaces.mirroringK8S }}
-                -enable-inject-k8s-namespace-mirroring=true \
-                {{- if .Values.connectInject.consulNamespaces.mirroringK8SPrefix }}
-                -inject-k8s-namespace-mirroring-prefix={{ .Values.connectInject.consulNamespaces.mirroringK8SPrefix }} \
-                {{- end }}
-                {{- end }}
-                {{- end }}
-
-                {{- end }}
-          resources:
-            requests:
-              memory: "50Mi"
-              cpu: "50m"
-            limits:
-              memory: "50Mi"
-              cpu: "50m"
+            {{- /* connectInject must be enabled to set inject flags */}}
+            {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
+            {{- if .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
+            -consul-inject-destination-namespace={{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }} \
+            {{- end }}
+            {{- if .Values.connectInject.consulNamespaces.mirroringK8S }}
+            -enable-inject-k8s-namespace-mirroring=true \
+            {{- if .Values.connectInject.consulNamespaces.mirroringK8SPrefix }}
+            -inject-k8s-namespace-mirroring-prefix={{ .Values.connectInject.consulNamespaces.mirroringK8SPrefix }} \
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+        resources:
+          requests:
+            memory: "50Mi"
+            cpu: "50m"
+          limits:
+            memory: "50Mi"
+            cpu: "50m"
       {{- if .Values.global.acls.tolerations }}
       tolerations:
         {{ tpl .Values.global.acls.tolerations . | indent 8 | trim }}

--- a/control-plane/consul/consul.go
+++ b/control-plane/consul/consul.go
@@ -10,7 +10,7 @@ import (
 	capi "github.com/hashicorp/consul/api"
 )
 
-//go:generate mockery --name ServerConnectionManager --inpackage
+//go:generate mockery --name ServerConnectionManager --inpkg
 type ServerConnectionManager interface {
 	State() (discovery.State, error)
 	Run()

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hashicorp/go-discover v0.0.0-20200812215701-c4b85f6ed31f
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-netaddrs v0.0.0-20220509001840-90ed9d26ec46
 	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/serf v0.10.1
 	github.com/kr/text v0.2.0
@@ -76,7 +77,6 @@ require (
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect
-	github.com/hashicorp/go-netaddrs v0.0.0-20220509001840-90ed9d26ec46 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/mdns v1.0.4 // indirect

--- a/control-plane/helper/test/test_util.go
+++ b/control-plane/helper/test/test_util.go
@@ -66,13 +66,16 @@ func TestServerWithMockConnMgrWatcher(t *testing.T, callback testutil.ServerConf
 func MockConnMgrForIPAndPort(ip string, port int) *consul.MockServerConnectionManager {
 	parsedIP := net.ParseIP(ip)
 	connMgr := &consul.MockServerConnectionManager{}
-	mockState := discovery.State{Address: discovery.Addr{
-		TCPAddr: net.TCPAddr{
-			IP:   parsedIP,
-			Port: port,
-		},
-	}}
+	mockState := discovery.State{
+		Address: discovery.Addr{
+			TCPAddr: net.TCPAddr{
+				IP:   parsedIP,
+				Port: port,
+			},
+		}}
 	connMgr.On("State").Return(mockState, nil)
+	connMgr.On("Run").Return(nil)
+	connMgr.On("Stop").Return(nil)
 	return connMgr
 }
 
@@ -109,9 +112,9 @@ func GenerateServerCerts(t *testing.T) (string, string, string) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		_ = os.Remove(caFile.Name())
-		_ = os.Remove(certFile.Name())
-		_ = os.Remove(certKeyFile.Name())
+		_ = os.RemoveAll(caFile.Name())
+		_ = os.RemoveAll(certFile.Name())
+		_ = os.RemoveAll(certKeyFile.Name())
 	})
 	return caFile.Name(), certFile.Name(), certKeyFile.Name()
 }

--- a/control-plane/subcommand/acl-init/command_test.go
+++ b/control-plane/subcommand/acl-init/command_test.go
@@ -250,7 +250,7 @@ func TestRun_WithAclAuthMethodDefined_WritesConfigJson_WithTokenMatchingSinkFile
 	tmpDir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		os.Remove(tokenFile)
+		os.RemoveAll(tokenFile)
 		os.RemoveAll(tmpDir)
 	})
 

--- a/control-plane/subcommand/common/common.go
+++ b/control-plane/subcommand/common/common.go
@@ -207,7 +207,7 @@ func WriteFileWithPerms(outputFile, payload string, mode os.FileMode) error {
 	// os.WriteFile truncates existing files and overwrites them, but only if they are writable.
 	// If the file exists it will already likely be read-only. Remove it first.
 	if _, err := os.Stat(outputFile); err == nil {
-		if err = os.Remove(outputFile); err != nil {
+		if err = os.RemoveAll(outputFile); err != nil {
 			return fmt.Errorf("unable to delete existing file: %s", err)
 		}
 	}

--- a/control-plane/subcommand/common/common_test.go
+++ b/control-plane/subcommand/common/common_test.go
@@ -210,7 +210,7 @@ func TestWriteFileWithPerms_InvalidOutputFile(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	randFileName := fmt.Sprintf("/tmp/tmp/tmp/%d", rand.Int())
 	t.Cleanup(func() {
-		os.Remove(randFileName)
+		os.RemoveAll(randFileName)
 	})
 	err := WriteFileWithPerms(randFileName, "", os.FileMode(0444))
 	require.Errorf(t, err, "unable to create file: %s", randFileName)
@@ -223,7 +223,7 @@ func TestWriteFileWithPerms_OutputFileExists(t *testing.T) {
 	err := os.WriteFile(randFileName, []byte("foo"), os.FileMode(0444))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		os.Remove(randFileName)
+		os.RemoveAll(randFileName)
 	})
 	payload := "abcd"
 	err = WriteFileWithPerms(randFileName, payload, os.FileMode(0444))
@@ -239,7 +239,7 @@ func TestWriteFileWithPerms(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	randFileName := fmt.Sprintf("/tmp/%d", rand.Int())
 	t.Cleanup(func() {
-		os.Remove(randFileName)
+		os.RemoveAll(randFileName)
 	})
 	// Issue the write.
 	mode := os.FileMode(0444)

--- a/control-plane/subcommand/common/test_util.go
+++ b/control-plane/subcommand/common/test_util.go
@@ -17,7 +17,7 @@ func WriteTempFile(t *testing.T, contents string) string {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		os.Remove(file.Name())
+		os.RemoveAll(file.Name())
 	})
 	return file.Name()
 }

--- a/control-plane/subcommand/connect-init/command_ent_test.go
+++ b/control-plane/subcommand/connect-init/command_ent_test.go
@@ -41,8 +41,8 @@ func TestRun_WithNamespaces(t *testing.T) {
 			tokenFile := fmt.Sprintf("/tmp/%d1", rand.Int())
 			proxyFile := fmt.Sprintf("/tmp/%d2", rand.Int())
 			t.Cleanup(func() {
-				_ = os.Remove(proxyFile)
-				_ = os.Remove(tokenFile)
+				_ = os.RemoveAll(proxyFile)
+				_ = os.RemoveAll(tokenFile)
 			})
 
 			// Start Consul server with ACLs enabled and default deny policy.

--- a/control-plane/subcommand/connect-init/command_test.go
+++ b/control-plane/subcommand/connect-init/command_test.go
@@ -119,8 +119,8 @@ func TestRun_ConnectServices(t *testing.T) {
 			tokenFile := fmt.Sprintf("/tmp/%d1", rand.Int())
 			proxyFile := fmt.Sprintf("/tmp/%d2", rand.Int())
 			t.Cleanup(func() {
-				_ = os.Remove(proxyFile)
-				_ = os.Remove(tokenFile)
+				_ = os.RemoveAll(proxyFile)
+				_ = os.RemoveAll(tokenFile)
 			})
 
 			// Start Consul server with ACLs enabled and default deny policy.
@@ -277,7 +277,7 @@ func TestRun_Gateways(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			proxyFile := fmt.Sprintf("/tmp/%d2", rand.Int())
 			t.Cleanup(func() {
-				_ = os.Remove(proxyFile)
+				_ = os.RemoveAll(proxyFile)
 			})
 
 			// Start Consul server with ACLs enabled and default deny policy.
@@ -488,7 +488,7 @@ func TestRun_ConnectServices_Errors(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			proxyFile := fmt.Sprintf("/tmp/%d", rand.Int())
 			t.Cleanup(func() {
-				os.Remove(proxyFile)
+				os.RemoveAll(proxyFile)
 			})
 
 			// Start Consul server.
@@ -584,7 +584,7 @@ func TestRun_Gateways_Errors(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			proxyFile := fmt.Sprintf("/tmp/%d", rand.Int())
 			t.Cleanup(func() {
-				os.Remove(proxyFile)
+				os.RemoveAll(proxyFile)
 			})
 
 			// Start Consul server.

--- a/control-plane/subcommand/consul-logout/command_test.go
+++ b/control-plane/subcommand/consul-logout/command_test.go
@@ -63,7 +63,7 @@ func TestRun_InvalidSinkFile(t *testing.T) {
 func Test_UnableToLogoutDueToInvalidToken(t *testing.T) {
 	tokenFile := fmt.Sprintf("/tmp/%d1", rand.Int())
 	t.Cleanup(func() {
-		os.Remove(tokenFile)
+		os.RemoveAll(tokenFile)
 	})
 
 	var caFile, certFile, keyFile string
@@ -118,7 +118,7 @@ func Test_RunUsingLogin(t *testing.T) {
 	// This is the test file that we will write the token to so consul-logout can read it.
 	tokenFile := fmt.Sprintf("/tmp/%d1", rand.Int())
 	t.Cleanup(func() {
-		os.Remove(tokenFile)
+		os.RemoveAll(tokenFile)
 	})
 
 	// Start Consul server with ACLs enabled and default deny policy.

--- a/control-plane/subcommand/create-federation-secret/command_test.go
+++ b/control-plane/subcommand/create-federation-secret/command_test.go
@@ -28,7 +28,7 @@ func TestRun_FlagValidation(t *testing.T) {
 	t.Parallel()
 	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
-	defer os.Remove(f.Name())
+	defer os.RemoveAll(f.Name())
 
 	cases := []struct {
 		flags  []string
@@ -101,7 +101,7 @@ func TestRun_CAFileMissing(t *testing.T) {
 	t.Parallel()
 	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
-	defer os.Remove(f.Name())
+	defer os.RemoveAll(f.Name())
 
 	ui := cli.NewMockUi()
 	cmd := Command{
@@ -124,7 +124,7 @@ func TestRun_ServerCACertFileMissing(t *testing.T) {
 	t.Parallel()
 	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
-	defer os.Remove(f.Name())
+	defer os.RemoveAll(f.Name())
 
 	ui := cli.NewMockUi()
 	cmd := Command{
@@ -147,7 +147,7 @@ func TestRun_ServerCAKeyFileMissing(t *testing.T) {
 	t.Parallel()
 	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
-	defer os.Remove(f.Name())
+	defer os.RemoveAll(f.Name())
 
 	ui := cli.NewMockUi()
 	cmd := Command{
@@ -170,7 +170,7 @@ func TestRun_GossipEncryptionKeyFileMissing(t *testing.T) {
 	t.Parallel()
 	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
-	defer os.Remove(f.Name())
+	defer os.RemoveAll(f.Name())
 
 	ui := cli.NewMockUi()
 	cmd := Command{
@@ -194,7 +194,7 @@ func TestRun_GossipEncryptionKeyFileEmpty(t *testing.T) {
 	t.Parallel()
 	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
-	defer os.Remove(f.Name())
+	defer os.RemoveAll(f.Name())
 
 	ui := cli.NewMockUi()
 	cmd := Command{
@@ -220,7 +220,7 @@ func TestRun_ReplicationTokenMissingExpectedKey(t *testing.T) {
 	t.Parallel()
 	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
-	defer os.Remove(f.Name())
+	defer os.RemoveAll(f.Name())
 
 	ui := cli.NewMockUi()
 	k8s := fake.NewSimpleClientset()

--- a/control-plane/subcommand/flags/consul_test.go
+++ b/control-plane/subcommand/flags/consul_test.go
@@ -219,7 +219,7 @@ func TestConsulFlags_ConsulServerConnMgrConfig(t *testing.T) {
 				tokenFile, err := os.CreateTemp("", "")
 				require.NoError(t, err)
 				t.Cleanup(func() {
-					_ = os.Remove(tokenFile.Name())
+					_ = os.RemoveAll(tokenFile.Name())
 				})
 				_, err = tokenFile.WriteString("bearer-token")
 				require.NoError(t, err)
@@ -228,7 +228,7 @@ func TestConsulFlags_ConsulServerConnMgrConfig(t *testing.T) {
 				tokenFile, err := os.CreateTemp("", "")
 				require.NoError(t, err)
 				t.Cleanup(func() {
-					_ = os.Remove(tokenFile.Name())
+					_ = os.RemoveAll(tokenFile.Name())
 				})
 				_, err = tokenFile.WriteString(c.flags.TokenFile)
 				require.NoError(t, err)
@@ -244,7 +244,7 @@ func TestConsulFlags_ConsulServerConnMgrConfig(t *testing.T) {
 func TestConsulFlags_ConsulServerConnMgrConfig_TLS(t *testing.T) {
 	caFile, err := os.CreateTemp("", "")
 	t.Cleanup(func() {
-		_ = os.Remove(caFile.Name())
+		_ = os.RemoveAll(caFile.Name())
 	})
 	require.NoError(t, err)
 	_, err = caFile.WriteString(testCA)

--- a/control-plane/subcommand/get-consul-client-ca/command_test.go
+++ b/control-plane/subcommand/get-consul-client-ca/command_test.go
@@ -76,7 +76,7 @@ func TestRun(t *testing.T) {
 	t.Parallel()
 	outputFile, err := os.CreateTemp("", "ca")
 	require.NoError(t, err)
-	defer os.Remove(outputFile.Name())
+	defer os.RemoveAll(outputFile.Name())
 
 	caFile, certFile, keyFile := test.GenerateServerCerts(t)
 
@@ -138,7 +138,7 @@ func TestRun_ConsulServerAvailableLater(t *testing.T) {
 	t.Parallel()
 	outputFile, err := os.CreateTemp("", "ca")
 	require.NoError(t, err)
-	defer os.Remove(outputFile.Name())
+	defer os.RemoveAll(outputFile.Name())
 
 	caFile, certFile, keyFile := test.GenerateServerCerts(t)
 
@@ -225,7 +225,7 @@ func TestRun_GetsOnlyActiveRoot(t *testing.T) {
 	t.Parallel()
 	outputFile, err := os.CreateTemp("", "ca")
 	require.NoError(t, err)
-	defer os.Remove(outputFile.Name())
+	defer os.RemoveAll(outputFile.Name())
 
 	caFile, certFile, keyFile := test.GenerateServerCerts(t)
 
@@ -308,7 +308,7 @@ func TestRun_WithProvider(t *testing.T) {
 	t.Parallel()
 	outputFile, err := os.CreateTemp("", "ca")
 	require.NoError(t, err)
-	defer os.Remove(outputFile.Name())
+	defer os.RemoveAll(outputFile.Name())
 
 	ui := cli.NewMockUi()
 

--- a/control-plane/subcommand/install-cni/binary.go
+++ b/control-plane/subcommand/install-cni/binary.go
@@ -49,7 +49,7 @@ func removeFile(path string) error {
 		return nil
 	}
 
-	if err := os.Remove(path); err != nil {
+	if err := os.RemoveAll(path); err != nil {
 		return fmt.Errorf("error removing file %s: %w", path, err)
 	}
 	return nil

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -5,20 +5,23 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/hashicorp/consul-k8s/control-plane/consul"
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand"
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/flags"
 	k8sflags "github.com/hashicorp/consul-k8s/control-plane/subcommand/flags"
+	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/go-discover"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-netaddrs"
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/mapstructure"
 	"golang.org/x/text/cases"
@@ -31,8 +34,9 @@ import (
 type Command struct {
 	UI cli.Ui
 
-	flags *flag.FlagSet
-	k8s   *k8sflags.K8SFlags
+	flags       *flag.FlagSet
+	k8s         *k8sflags.K8SFlags
+	consulFlags *flags.ConsulFlags
 
 	flagResourcePrefix string
 	flagK8sNamespace   string
@@ -63,20 +67,13 @@ type Command struct {
 	flagAPIGatewayController bool
 
 	// Flags to configure Consul connection.
-	flagServerAddresses     []string
-	flagServerPort          uint
-	flagConsulCACert        string
-	flagConsulTLSServerName string
-	flagUseHTTPS            bool
-	flagConsulAPITimeout    time.Duration
+	flagServerPort uint
 
 	// Flags for ACL replication.
 	flagCreateACLReplicationToken bool
 	flagACLReplicationTokenFile   string
 
 	// Flags to support partitions.
-	flagEnablePartitions   bool   // true if Admin Partitions are enabled
-	flagPartitionName      string // name of the Admin Partition
 	flagPartitionTokenFile string
 
 	// Flags to support peering.
@@ -105,6 +102,8 @@ type Command struct {
 
 	clientset kubernetes.Interface
 
+	watcher consul.ServerConnectionManager
+
 	// ctx is cancelled when the command timeout is reached.
 	ctx           context.Context
 	retryDuration time.Duration
@@ -112,10 +111,10 @@ type Command struct {
 	// log
 	log hclog.Logger
 
+	state discovery.State
+
 	once sync.Once
 	help string
-
-	providers map[string]discover.Provider
 }
 
 func (c *Command) init() {
@@ -166,21 +165,8 @@ func (c *Command) init() {
 	c.flags.BoolVar(&c.flagAPIGatewayController, "api-gateway-controller", false,
 		"Toggle for configuring ACL login for the API gateway controller.")
 
-	c.flags.Var((*flags.AppendSliceValue)(&c.flagServerAddresses), "server-address",
-		"The IP, DNS name or the cloud auto-join string of the Consul server(s). If providing IPs or DNS names, may be specified multiple times. "+
-			"At least one value is required.")
 	c.flags.UintVar(&c.flagServerPort, "server-port", 8500, "The HTTP or HTTPS port of the Consul server. Defaults to 8500.")
-	c.flags.StringVar(&c.flagConsulCACert, "consul-ca-cert", "",
-		"Path to the PEM-encoded CA certificate of the Consul cluster.")
-	c.flags.StringVar(&c.flagConsulTLSServerName, "tls-server-name", "",
-		"The server name to set as the SNI header when sending HTTPS requests to Consul.")
-	c.flags.BoolVar(&c.flagUseHTTPS, "use-https", false,
-		"Toggle for using HTTPS for all API calls to Consul.")
 
-	c.flags.BoolVar(&c.flagEnablePartitions, "enable-partitions", false,
-		"[Enterprise Only] Enables Admin Partitions")
-	c.flags.StringVar(&c.flagPartitionName, "partition", "",
-		"[Enterprise Only] Name of the Admin Partition")
 	c.flags.StringVar(&c.flagPartitionTokenFile, "partition-token-file", "",
 		"[Enterprise Only] Path to file containing ACL token to be used in non-default partitions.")
 
@@ -225,11 +211,10 @@ func (c *Command) init() {
 	c.flags.BoolVar(&c.flagLogJSON, "log-json", false,
 		"Enable or disable JSON output format for logging.")
 
-	c.flags.DurationVar(&c.flagConsulAPITimeout, "consul-api-timeout", 0,
-		"The time in seconds that the consul API client will wait for a response from the API before cancelling the request.")
-
 	c.k8s = &k8sflags.K8SFlags{}
+	c.consulFlags = &flags.ConsulFlags{}
 	flags.Merge(c.flags, c.k8s.Flags())
+	flags.Merge(c.flags, c.consulFlags.Flags())
 	c.help = flags.Usage(help, c.flags)
 
 	// Default retry to 1s. This is exposed for setting in tests.
@@ -314,14 +299,16 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
-	serverAddresses, err := common.GetResolvedServerAddresses(c.flagServerAddresses, c.providers, c.log)
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("Unable to discover any Consul addresses from %q: %s", c.flagServerAddresses[0], err))
-		return 1
-	}
-	scheme := "http"
-	if c.flagUseHTTPS {
-		scheme = "https"
+	var ipAddrs []net.IPAddr
+	if err := backoff.Retry(func() error {
+		ipAddrs, err = netaddrs.IPAddrs(c.ctx, c.consulFlags.Addresses, c.log)
+		if err != nil {
+			c.log.Error("Error resolving IP Address", "err", err)
+			return err
+		}
+		return nil
+	}, exponentialBackoffWithMaxInterval()); err != nil {
+		c.UI.Error(err.Error())
 	}
 
 	var bootstrapToken string
@@ -348,30 +335,44 @@ func (c *Command) Run(args []string) int {
 			}
 		}
 
-		bootstrapToken, err = c.bootstrapServers(serverAddresses, bootstrapToken, bootTokenSecretName, scheme)
+		bootstrapToken, err = c.bootstrapServers(ipAddrs, bootstrapToken, bootTokenSecretName)
 		if err != nil {
 			c.log.Error(err.Error())
 			return 1
 		}
 	}
 
-	// For all of the next operations we'll need a Consul client.
-	serverAddr := fmt.Sprintf("%s:%d", serverAddresses[0], c.flagServerPort)
-	clientConfig := api.DefaultConfig()
-	clientConfig.Address = serverAddr
-	clientConfig.Scheme = scheme
-	clientConfig.Token = bootstrapToken
-	clientConfig.TLSConfig = api.TLSConfig{
-		Address: c.flagConsulTLSServerName,
-		CAFile:  c.flagConsulCACert,
+	// Start Consul server Connection manager
+	var watcher consul.ServerConnectionManager
+	serverConnMgrCfg, err := c.consulFlags.ConsulServerConnMgrConfig()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("unable to create config for consul-server-connection-manager: %s", err))
+		return 1
+	}
+	serverConnMgrCfg.Credentials.Type = discovery.CredentialsTypeStatic
+	serverConnMgrCfg.Credentials.Static = discovery.StaticTokenCredential{Token: bootstrapToken}
+	if c.watcher == nil {
+		watcher, err = discovery.NewWatcher(c.ctx, serverConnMgrCfg, c.log.Named("consul-server-connection-manager"))
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("unable to create Consul server watcher: %s", err))
+			return 1
+		}
+	} else {
+		watcher = c.watcher
 	}
 
-	if c.flagEnablePartitions {
-		clientConfig.Partition = c.flagPartitionName
-	}
-	consulClient, err := consul.NewClient(clientConfig, c.flagConsulAPITimeout)
+	go watcher.Run()
+	defer watcher.Stop()
+
+	c.state, err = watcher.State()
 	if err != nil {
-		c.log.Error(fmt.Sprintf("Error creating Consul client for addr %q: %s", serverAddr, err))
+		c.UI.Error(fmt.Sprintf("unable to get Consul server addresses from watcher: %s", err))
+		return 1
+	}
+
+	consulClient, err := consul.NewClientFromConnMgrState(c.consulFlags.ConsulClientConfig(), c.state)
+	if err != nil {
+		c.log.Error(fmt.Sprintf("Error creating Consul client for addr %q: %s", c.state.Address, err))
 		return 1
 	}
 	consulDC, primaryDC, err := c.consulDatacenterList(consulClient)
@@ -382,7 +383,7 @@ func (c *Command) Run(args []string) int {
 	c.log.Info("Current datacenter", "datacenter", consulDC, "primaryDC", primaryDC)
 	primary := consulDC == primaryDC
 
-	if c.flagEnablePartitions && c.flagPartitionName == consulDefaultPartition && primary {
+	if c.consulFlags.Partition == consulDefaultPartition && primary {
 		// Partition token is local because only the Primary datacenter can have Admin Partitions.
 		if c.flagPartitionTokenFile != "" {
 			err = c.createACLWithSecretID("partitions", partitionRules, consulDC, primary, consulClient, partitionToken, true)
@@ -482,11 +483,11 @@ func (c *Command) Run(args []string) int {
 		// DNS lookups. The anonymous policy in the default partition needs to be updated in order to
 		// support this use-case. Creating a separate anonymous token client that updates the anonymous
 		// policy and token in the default partition ensures this works.
-		anonTokenConfig := clientConfig
-		if c.flagEnablePartitions {
-			anonTokenConfig.Partition = consulDefaultPartition
+		anonTokenConfig := c.consulFlags.ConsulClientConfig()
+		if c.consulFlags.Partition != "" {
+			anonTokenConfig.APIClientConfig.Partition = consulDefaultPartition
 		}
-		anonTokenClient, err := consul.NewClient(anonTokenConfig, c.flagConsulAPITimeout)
+		anonTokenClient, err := consul.NewClientFromConnMgrState(anonTokenConfig, c.state)
 		if err != nil {
 			c.log.Error(err.Error())
 			return 1
@@ -566,7 +567,7 @@ func (c *Command) Run(args []string) int {
 
 	if c.flagCreateEntLicenseToken {
 		var err error
-		if c.flagEnablePartitions {
+		if c.consulFlags.Partition != "" {
 			err = c.createLocalACL("enterprise-license", entPartitionLicenseRules, consulDC, primary, consulClient)
 		} else {
 			err = c.createLocalACL("enterprise-license", entLicenseRules, consulDC, primary, consulClient)
@@ -706,6 +707,16 @@ func (c *Command) Run(args []string) int {
 	}
 	c.log.Info("server-acl-init completed successfully")
 	return 0
+}
+
+// exponentialBackoffWithMaxInterval creates an exponential backoff but limits the
+// maximum backoff to 10 seconds so that we don't find ourselves in a situation
+// where we are waiting for minutes before retries.
+func exponentialBackoffWithMaxInterval() *backoff.ExponentialBackOff {
+	backoff := backoff.NewExponentialBackOff()
+	backoff.MaxInterval = 10 * time.Second
+	backoff.Reset()
+	return backoff
 }
 
 // configureGlobalComponentAuthMethod sets up an AuthMethod in the primary datacenter,
@@ -952,8 +963,8 @@ func (c *Command) createAnonymousPolicy(isPrimary bool) bool {
 }
 
 func (c *Command) validateFlags() error {
-	if len(c.flagServerAddresses) == 0 {
-		return errors.New("-server-address must be set at least once")
+	if c.consulFlags.Addresses == "" {
+		return errors.New("-addresses must be set")
 	}
 
 	if c.flagResourcePrefix == "" {
@@ -981,14 +992,7 @@ func (c *Command) validateFlags() error {
 		)
 	}
 
-	if c.flagEnablePartitions && c.flagPartitionName == "" {
-		return errors.New("-partition must be set if -enable-partitions is true")
-	}
-	if !c.flagEnablePartitions && c.flagPartitionName != "" {
-		return errors.New("-enable-partitions must be 'true' if -partition is set")
-	}
-
-	if c.flagConsulAPITimeout <= 0 {
+	if c.consulFlags.APITimeout <= 0 {
 		return errors.New("-consul-api-timeout must be set to a value greater than 0")
 	}
 

--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -366,7 +366,7 @@ partition "default" {
 {{- end }}
     acl = "write"
     service_prefix "" {
-      policy = "read"
+      policy = "write"
       intentions = "read"
     }
 {{- if .EnableNamespaces }}
@@ -419,9 +419,9 @@ partition "{{ .PartitionName }}" {
 
 func (c *Command) rulesData() rulesData {
 	return rulesData{
-		EnablePartitions:        c.flagEnablePartitions,
+		EnablePartitions:        c.consulFlags.Partition != "",
 		EnablePeering:           c.flagEnablePeering,
-		PartitionName:           c.flagPartitionName,
+		PartitionName:           c.consulFlags.Partition,
 		EnableNamespaces:        c.flagEnableNamespaces,
 		SyncConsulDestNS:        c.flagConsulSyncDestinationNamespace,
 		SyncEnableNSMirroring:   c.flagEnableSyncK8SNSMirroring,

--- a/control-plane/subcommand/server-acl-init/rules_test.go
+++ b/control-plane/subcommand/server-acl-init/rules_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/consul-k8s/control-plane/subcommand/flags"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,8 +62,7 @@ partition "part-1" {
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			cmd := Command{
-				flagEnablePartitions: tt.EnablePartitions,
-				flagPartitionName:    tt.PartitionName,
+				consulFlags:          &flags.ConsulFlags{Partition: tt.PartitionName},
 				flagEnableNamespaces: tt.EnableNamespaces,
 			}
 
@@ -127,8 +127,7 @@ partition_prefix "" {
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			cmd := Command{
-				flagEnablePartitions: tt.EnablePartitions,
-				flagPartitionName:    tt.PartitionName,
+				consulFlags:          &flags.ConsulFlags{Partition: tt.PartitionName},
 				flagEnableNamespaces: tt.EnableNamespaces,
 			}
 
@@ -181,6 +180,7 @@ namespace_prefix "" {
 		t.Run(tt.Name, func(t *testing.T) {
 			cmd := Command{
 				flagEnableNamespaces: tt.EnableNamespaces,
+				consulFlags:          &flags.ConsulFlags{},
 			}
 
 			meshGatewayRules, err := cmd.apiGatewayControllerRules()
@@ -234,6 +234,7 @@ namespace_prefix "" {
 		t.Run(tt.Name, func(t *testing.T) {
 			cmd := Command{
 				flagEnableNamespaces: tt.EnableNamespaces,
+				consulFlags:          &flags.ConsulFlags{},
 			}
 
 			meshGatewayRules, err := cmd.meshGatewayRules()
@@ -353,8 +354,7 @@ partition "default" {
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			cmd := Command{
-				flagEnablePartitions: tt.EnablePartitions,
-				flagPartitionName:    tt.PartitionName,
+				consulFlags:          &flags.ConsulFlags{Partition: tt.PartitionName},
 				flagEnableNamespaces: tt.EnableNamespaces,
 			}
 
@@ -460,8 +460,7 @@ partition "default" {
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			cmd := Command{
-				flagEnablePartitions: tt.EnablePartitions,
-				flagPartitionName:    tt.PartitionName,
+				consulFlags:          &flags.ConsulFlags{Partition: tt.PartitionName},
 				flagEnableNamespaces: tt.EnableNamespaces,
 			}
 
@@ -822,8 +821,7 @@ partition "foo" {
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			cmd := Command{
-				flagEnablePartitions:               tt.EnablePartitions,
-				flagPartitionName:                  tt.PartitionName,
+				consulFlags:                        &flags.ConsulFlags{Partition: tt.PartitionName},
 				flagEnableNamespaces:               tt.EnableNamespaces,
 				flagConsulSyncDestinationNamespace: tt.ConsulSyncDestinationNamespace,
 				flagEnableSyncK8SNSMirroring:       tt.EnableSyncK8SNSMirroring,
@@ -940,8 +938,7 @@ partition "part-1" {
 		t.Run(caseName, func(t *testing.T) {
 
 			cmd := Command{
-				flagEnablePartitions: tt.EnablePartitions,
-				flagPartitionName:    tt.PartitionName,
+				consulFlags:          &flags.ConsulFlags{Partition: tt.PartitionName},
 				flagEnableNamespaces: tt.EnableNamespaces,
 				flagEnablePeering:    tt.EnablePeering,
 			}
@@ -974,7 +971,7 @@ func TestReplicationTokenRules(t *testing.T) {
   }
     acl = "write"
     service_prefix "" {
-      policy = "read"
+      policy = "write"
       intentions = "read"
     }`,
 		},
@@ -992,7 +989,7 @@ func TestReplicationTokenRules(t *testing.T) {
   namespace_prefix "" {
     acl = "write"
     service_prefix "" {
-      policy = "read"
+      policy = "write"
       intentions = "read"
     }
   }`,
@@ -1014,7 +1011,7 @@ partition "default" {
   namespace_prefix "" {
     acl = "write"
     service_prefix "" {
-      policy = "read"
+      policy = "write"
       intentions = "read"
     }
   }
@@ -1025,8 +1022,7 @@ partition "default" {
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			cmd := Command{
-				flagEnablePartitions: tt.EnablePartitions,
-				flagPartitionName:    tt.PartitionName,
+				consulFlags:          &flags.ConsulFlags{Partition: tt.PartitionName},
 				flagEnableNamespaces: tt.EnableNamespaces,
 			}
 			replicationTokenRules, err := cmd.aclReplicationRules()
@@ -1167,8 +1163,7 @@ partition "part-1" {
 				flagConsulInjectDestinationNamespace: tt.DestConsulNS,
 				flagEnableInjectK8SNSMirroring:       tt.Mirroring,
 				flagInjectK8SNSMirroringPrefix:       tt.MirroringPrefix,
-				flagEnablePartitions:                 tt.EnablePartitions,
-				flagPartitionName:                    tt.PartitionName,
+				consulFlags:                          &flags.ConsulFlags{Partition: tt.PartitionName},
 			}
 
 			rules, err := cmd.controllerRules()

--- a/control-plane/subcommand/webhook-cert-manager/command_test.go
+++ b/control-plane/subcommand/webhook-cert-manager/command_test.go
@@ -89,7 +89,7 @@ func testSignalHandling(sig os.Signal) func(*testing.T) {
 
 		file, err := os.CreateTemp("", "config.json")
 		require.NoError(t, err)
-		defer os.Remove(file.Name())
+		defer os.RemoveAll(file.Name())
 
 		_, err = file.Write([]byte(configFile))
 		require.NoError(t, err)
@@ -212,7 +212,7 @@ func TestRun_SecretDoesNotExist(t *testing.T) {
 
 	file, err := os.CreateTemp("", "config.json")
 	require.NoError(t, err)
-	defer os.Remove(file.Name())
+	defer os.RemoveAll(file.Name())
 
 	_, err = file.Write([]byte(configFile))
 	require.NoError(t, err)
@@ -340,7 +340,7 @@ func TestRun_SecretExists(t *testing.T) {
 
 	file, err := os.CreateTemp("", "config.json")
 	require.NoError(t, err)
-	defer os.Remove(file.Name())
+	defer os.RemoveAll(file.Name())
 
 	_, err = file.Write([]byte(configFile))
 	require.NoError(t, err)
@@ -440,7 +440,7 @@ func TestRun_SecretUpdates(t *testing.T) {
 
 	file, err := os.CreateTemp("", "config.json")
 	require.NoError(t, err)
-	defer os.Remove(file.Name())
+	defer os.RemoveAll(file.Name())
 
 	_, err = file.Write([]byte(configFileUpdates))
 	require.NoError(t, err)
@@ -630,7 +630,7 @@ func TestCertWatcher(t *testing.T) {
 
 	file, err := os.CreateTemp("", "config.json")
 	require.NoError(t, err)
-	defer os.Remove(file.Name())
+	defer os.RemoveAll(file.Name())
 
 	_, err = file.Write([]byte(configFileUpdates))
 	require.NoError(t, err)


### PR DESCRIPTION
Changes proposed in this PR:

- Integrate server-acl-init with consul-server-connection-manager to enable it to work in agentless environments
- Migrate usages of os.Remove() to os.RemoveAll()

How I've tested this PR:
acceptance and unit tests

How I expect reviewers to test this PR:
👀

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

