### PR TITLE
use hashicorp mirror image for 1.0.0-dev

### DIFF
--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -15,7 +15,7 @@ annotations:
     - name: consul
       image: hashicorp/consul:1.13.2
     - name: consul-k8s-control-plane
-      image: hashicorp/consul-k8s-control-plane:1.0.0-dev
+      image: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.0.0-dev
     - name: envoy
       image: envoyproxy/envoy:v1.23.1
   artifacthub.io/license: MPL-2.0

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -129,7 +129,7 @@ global:
   # image that is used for functionality such as catalog sync.
   # This can be overridden per component.
   # @default: hashicorp/consul-k8s-control-plane:<latest version>
-  imageK8S: hashicorp/consul-k8s-control-plane:1.0.0-dev
+  imageK8S: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.0.0-dev
 
   # The name of the datacenter that the agents should
   # register as. This can't be changed once the Consul cluster is up and running


### PR DESCRIPTION
Currently the chart points to an invalid docker image:
```
  Failed to pull image "hashicorp/consul-k8s-control-plane:1.0.0-dev": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/hashicorp/consul-k8s-control-plane:1.0.0-dev": failed to resolve reference "docker.io/hashicorp/consul-k8s-control-plane:1.0.0-dev": docker.io/hashicorp/consul-k8s-control-plane:1.0.0-dev: not found
```
Changes proposed in this PR:
- use the correct image in our chart for 1.0.0-dev

How I've tested this PR:
acceptance should pass

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

