### PR TITLE
Add `tolerations` and `nodeSelector` to Server ACL init jobs and `nodeSelector` to Webhook cert manager

### DIFF
--- a/charts/consul/templates/server-acl-init-cleanup-job.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-job.yaml
@@ -62,6 +62,14 @@ spec:
             limits:
               memory: "50Mi"
               cpu: "50m"
+          {{- if .Values.global.acls.job.tolerations }}
+          tolerations:
+            {{ tpl .Values.global.acls.job.tolerations . | indent 12 | trim }}
+          {{- end }}
+          {{- if .Values.global.acls.job.nodeSelector }}
+          nodeSelector:
+            {{ tpl .Values.global.acls.job.nodeSelector . | indent 12 | trim }}
+          {{- end }}
   {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/consul/templates/server-acl-init-cleanup-job.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-job.yaml
@@ -62,14 +62,14 @@ spec:
             limits:
               memory: "50Mi"
               cpu: "50m"
-          {{- if .Values.global.acls.job.tolerations }}
-          tolerations:
-            {{ tpl .Values.global.acls.job.tolerations . | indent 12 | trim }}
-          {{- end }}
-          {{- if .Values.global.acls.job.nodeSelector }}
-          nodeSelector:
-            {{ tpl .Values.global.acls.job.nodeSelector . | indent 12 | trim }}
-          {{- end }}
+      {{- if .Values.global.acls.job.tolerations }}
+      tolerations:
+        {{ tpl .Values.global.acls.job.tolerations . | indent 12 | trim }}
+      {{- end }}
+      {{- if .Values.global.acls.job.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.global.acls.job.nodeSelector . | indent 12 | trim }}
+      {{- end }}
   {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/consul/templates/server-acl-init-cleanup-job.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-job.yaml
@@ -62,13 +62,13 @@ spec:
             limits:
               memory: "50Mi"
               cpu: "50m"
-      {{- if .Values.global.acls.job.tolerations }}
+      {{- if .Values.global.acls.tolerations }}
       tolerations:
-        {{ tpl .Values.global.acls.job.tolerations . | indent 12 | trim }}
+        {{ tpl .Values.global.acls.tolerations . | indent 12 | trim }}
       {{- end }}
-      {{- if .Values.global.acls.job.nodeSelector }}
+      {{- if .Values.global.acls.nodeSelector }}
       nodeSelector:
-        {{ tpl .Values.global.acls.job.nodeSelector . | indent 12 | trim }}
+        {{ tpl .Values.global.acls.nodeSelector . | indent 12 | trim }}
       {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/consul/templates/server-acl-init-cleanup-job.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-job.yaml
@@ -64,11 +64,11 @@ spec:
               cpu: "50m"
       {{- if .Values.global.acls.tolerations }}
       tolerations:
-        {{ tpl .Values.global.acls.tolerations . | indent 12 | trim }}
+        {{ tpl .Values.global.acls.tolerations . | indent 8 | trim }}
       {{- end }}
       {{- if .Values.global.acls.nodeSelector }}
       nodeSelector:
-        {{ tpl .Values.global.acls.nodeSelector . | indent 12 | trim }}
+        {{ tpl .Values.global.acls.nodeSelector . | indent 8 | trim }}
       {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -336,14 +336,14 @@ spec:
             limits:
               memory: "50Mi"
               cpu: "50m"
-          {{- if .Values.global.acls.job.tolerations }}
-          tolerations:
-            {{ tpl .Values.global.acls.job.tolerations . | indent 12 | trim }}
-          {{- end }}
-          {{- if .Values.global.acls.job.nodeSelector }}
-          nodeSelector:
-            {{ tpl .Values.global.acls.job.nodeSelector . | indent 12 | trim }}
-          {{- end }}
+      {{- if .Values.global.acls.job.tolerations }}
+      tolerations:
+        {{ tpl .Values.global.acls.job.tolerations . | indent 12 | trim }}
+      {{- end }}
+      {{- if .Values.global.acls.job.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.global.acls.job.nodeSelector . | indent 12 | trim }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -338,11 +338,11 @@ spec:
               cpu: "50m"
       {{- if .Values.global.acls.tolerations }}
       tolerations:
-        {{ tpl .Values.global.acls.tolerations . | indent 12 | trim }}
+        {{ tpl .Values.global.acls.tolerations . | indent 8 | trim }}
       {{- end }}
       {{- if .Values.global.acls.nodeSelector }}
       nodeSelector:
-        {{ tpl .Values.global.acls.nodeSelector . | indent 12 | trim }}
+        {{ tpl .Values.global.acls.nodeSelector . | indent 8 | trim }}
       {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -336,13 +336,13 @@ spec:
             limits:
               memory: "50Mi"
               cpu: "50m"
-      {{- if .Values.global.acls.job.tolerations }}
+      {{- if .Values.global.acls.tolerations }}
       tolerations:
-        {{ tpl .Values.global.acls.job.tolerations . | indent 12 | trim }}
+        {{ tpl .Values.global.acls.tolerations . | indent 12 | trim }}
       {{- end }}
-      {{- if .Values.global.acls.job.nodeSelector }}
+      {{- if .Values.global.acls.nodeSelector }}
       nodeSelector:
-        {{ tpl .Values.global.acls.job.nodeSelector . | indent 12 | trim }}
+        {{ tpl .Values.global.acls.nodeSelector . | indent 12 | trim }}
       {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -336,6 +336,14 @@ spec:
             limits:
               memory: "50Mi"
               cpu: "50m"
+          {{- if .Values.global.acls.job.tolerations }}
+          tolerations:
+            {{ tpl .Values.global.acls.job.tolerations . | indent 12 | trim }}
+          {{- end }}
+          {{- if .Values.global.acls.job.nodeSelector }}
+          nodeSelector:
+            {{ tpl .Values.global.acls.job.nodeSelector . | indent 12 | trim }}
+          {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/webhook-cert-manager-deployment.yaml
+++ b/charts/consul/templates/webhook-cert-manager-deployment.yaml
@@ -64,6 +64,10 @@ spec:
       {{- if .Values.webhookCertManager.tolerations }}
       tolerations:
         {{ tpl .Values.webhookCertManager.tolerations . | indent 8 | trim }}
-      {{- end}}
+      {{- end }}
+      {{- if .Values.webhookCertManager.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.webhookCertManager.nodeSelector . | indent 8 | trim }}
+      {{- end }}
 
 {{- end }}

--- a/charts/consul/test/unit/server-acl-init-cleanup-job.bats
+++ b/charts/consul/test/unit/server-acl-init-cleanup-job.bats
@@ -80,7 +80,7 @@ load _helpers
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].tolerations' | tee /dev/stderr)
+      yq -r '.spec.template.spec.tolerations' | tee /dev/stderr)
   [ "${actual}" = "null" ]
 }
 
@@ -91,7 +91,7 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.job.tolerations=- key: value' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].tolerations[0].key' | tee /dev/stderr)
+      yq -r '.spec.template.spec.tolerations[0].key' | tee /dev/stderr)
   [ "${actual}" = "value" ]
 }
 
@@ -101,7 +101,7 @@ load _helpers
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].nodeSelector' | tee /dev/stderr)
+      yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
   [ "${actual}" = "null" ]
 }
 
@@ -112,6 +112,6 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.job.nodeSelector=- key: value' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].nodeSelector[0].key' | tee /dev/stderr)
+      yq -r '.spec.template.spec.nodeSelector[0].key' | tee /dev/stderr)
   [ "${actual}" = "value" ]
 }

--- a/charts/consul/test/unit/server-acl-init-cleanup-job.bats
+++ b/charts/consul/test/unit/server-acl-init-cleanup-job.bats
@@ -95,7 +95,7 @@ load _helpers
   [ "${actual}" = "value" ]
 }
 
-@test "serverACLInit/Job: nodeSelector not set by default" {
+@test "serverACLInitCleanup/Job: nodeSelector not set by default" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
@@ -105,7 +105,7 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
-@test "serverACLInit/Job: nodeSelector can be set" {
+@test "serverACLInitCleanup/Job: nodeSelector can be set" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \

--- a/charts/consul/test/unit/server-acl-init-cleanup-job.bats
+++ b/charts/consul/test/unit/server-acl-init-cleanup-job.bats
@@ -70,3 +70,48 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.acls.job
+
+@test "serverACLInitCleanup/Job: tolerations not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].tolerations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "serverACLInitCleanup/Job: tolerations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.job.tolerations=- key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].tolerations[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "serverACLInit/Job: nodeSelector not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "serverACLInit/Job: nodeSelector can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.job.nodeSelector=- key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].nodeSelector[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}

--- a/charts/consul/test/unit/server-acl-init-cleanup-job.bats
+++ b/charts/consul/test/unit/server-acl-init-cleanup-job.bats
@@ -72,7 +72,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.acls.job
+# global.acls.tolerations and global.acls.nodeSelector
 
 @test "serverACLInitCleanup/Job: tolerations not set by default" {
   cd `chart_dir`
@@ -89,7 +89,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
-      --set 'global.acls.job.tolerations=- key: value' \
+      --set 'global.acls.tolerations=- key: value' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.tolerations[0].key' | tee /dev/stderr)
   [ "${actual}" = "value" ]
@@ -110,7 +110,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
-      --set 'global.acls.job.nodeSelector=- key: value' \
+      --set 'global.acls.nodeSelector=- key: value' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.nodeSelector[0].key' | tee /dev/stderr)
   [ "${actual}" = "value" ]

--- a/charts/consul/test/unit/server-acl-init-cleanup-job.bats
+++ b/charts/consul/test/unit/server-acl-init-cleanup-job.bats
@@ -77,7 +77,7 @@ load _helpers
 @test "serverACLInitCleanup/Job: tolerations not set by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-cleanup-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.tolerations' | tee /dev/stderr)
@@ -87,7 +87,7 @@ load _helpers
 @test "serverACLInitCleanup/Job: tolerations can be set" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-cleanup-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.tolerations=- key: value' \
       . | tee /dev/stderr |
@@ -98,7 +98,7 @@ load _helpers
 @test "serverACLInitCleanup/Job: nodeSelector not set by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-cleanup-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
@@ -108,7 +108,7 @@ load _helpers
 @test "serverACLInitCleanup/Job: nodeSelector can be set" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-cleanup-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.nodeSelector=- key: value' \
       . | tee /dev/stderr |

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -1561,7 +1561,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# global.acls.job
+# global.acls.tolerations and global.acls.nodeSelector
 
 @test "serverACLInit/Job: tolerations not set by default" {
   cd `chart_dir`
@@ -1578,7 +1578,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
-      --set 'global.acls.job.tolerations=- key: value' \
+      --set 'global.acls.tolerations=- key: value' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.tolerations[0].key' | tee /dev/stderr)
   [ "${actual}" = "value" ]
@@ -1599,7 +1599,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
-      --set 'global.acls.job.nodeSelector=- key: value' \
+      --set 'global.acls.nodeSelector=- key: value' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.nodeSelector[0].key' | tee /dev/stderr)
   [ "${actual}" = "value" ]

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -1569,7 +1569,7 @@ load _helpers
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].tolerations' | tee /dev/stderr)
+      yq -r '.spec.template.spec.tolerations' | tee /dev/stderr)
   [ "${actual}" = "null" ]
 }
 
@@ -1580,7 +1580,7 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.job.tolerations=- key: value' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].tolerations[0].key' | tee /dev/stderr)
+      yq -r '.spec.template.spec.tolerations[0].key' | tee /dev/stderr)
   [ "${actual}" = "value" ]
 }
 
@@ -1590,7 +1590,7 @@ load _helpers
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].nodeSelector' | tee /dev/stderr)
+      yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
   [ "${actual}" = "null" ]
 }
 
@@ -1601,7 +1601,7 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.job.nodeSelector=- key: value' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].nodeSelector[0].key' | tee /dev/stderr)
+      yq -r '.spec.template.spec.nodeSelector[0].key' | tee /dev/stderr)
   [ "${actual}" = "value" ]
 }
 

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -1561,6 +1561,51 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# global.acls.job
+
+@test "serverACLInit/Job: tolerations not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].tolerations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "serverACLInit/Job: tolerations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.job.tolerations=- key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].tolerations[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "serverACLInit/Job: nodeSelector not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "serverACLInit/Job: nodeSelector can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.job.nodeSelector=- key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].nodeSelector[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+#--------------------------------------------------------------------
 # externalServers.enabled
 
 @test "serverACLInit/Job: fails if external servers are enabled but externalServers.hosts are not set" {

--- a/charts/consul/test/unit/webhook-cert-manager-deployment.bats
+++ b/charts/consul/test/unit/webhook-cert-manager-deployment.bats
@@ -63,6 +63,29 @@ load _helpers
   [ "${actual}" = "value" ]
 }
 
+@test "webhookCertManager/Deployment: no nodeSelector by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-deployment.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "webhookCertManager/Deployment: nodeSelector can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/webhook-cert-manager-deployment.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'webhookCertManager.nodeSelector=- key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
 #--------------------------------------------------------------------
 # Vault
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -516,12 +516,12 @@ global:
       secretKey: null
 
     # tolerations configures the taints and tolerations for the server-acl-init
-    # and server-acl-cleanup jobs. This should be a multi-line string matching the
+    # and server-acl-init-cleanup jobs. This should be a multi-line string matching the
     # Tolerations (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) array in a Pod spec.
     tolerations: ""
 
     # This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
-    # labels for the server-acl-init and server-acl-cleanup jobs pod assignment, formatted as a multi-line string.
+    # labels for the server-acl-init and server-acl-init-cleanup jobs pod assignment, formatted as a multi-line string.
     #
     # Example:
     #
@@ -3061,7 +3061,7 @@ webhookCertManager:
   tolerations: null
 
   # This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
-  # labels for webhook cert manager pod assignment, formatted as a multi-line string.
+  # labels for the webhook-cert-manager pod assignment, formatted as a multi-line string.
   #
   # Example:
   #

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -515,25 +515,23 @@ global:
       # @type: string
       secretKey: null
 
-    # job configures settings for the server-acl-init and server-acl-cleanup jobs
-    job:
-      # tolerations configures the taints and tolerations for the server-acl-init
-      # and server-acl-cleanup jobs. This should be a multi-line string matching the
-      # Tolerations (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) array in a Pod spec.
-      tolerations: ""
+    # tolerations configures the taints and tolerations for the server-acl-init
+    # and server-acl-cleanup jobs. This should be a multi-line string matching the
+    # Tolerations (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) array in a Pod spec.
+    tolerations: ""
 
-      # This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
-      # labels for the server-acl-init and server-acl-cleanup jobs pod assignment, formatted as a multi-line string.
-      #
-      # Example:
-      #
-      # ```yaml
-      # nodeSelector: |
-      #   beta.kubernetes.io/arch: amd64
-      # ```
-      #
-      # @type: string
-      nodeSelector: null
+    # This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
+    # labels for the server-acl-init and server-acl-cleanup jobs pod assignment, formatted as a multi-line string.
+    #
+    # Example:
+    #
+    # ```yaml
+    # nodeSelector: |
+    #   beta.kubernetes.io/arch: amd64
+    # ```
+    #
+    # @type: string
+    nodeSelector: null
 
   # [Enterprise Only] This value refers to a Kubernetes or Vault secret that you have created
   # that contains your enterprise license. It is required if you are using an

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -515,6 +515,25 @@ global:
       # @type: string
       secretKey: null
 
+    # job configures settings for the server-acl-init and server-acl-cleanup jobs
+    job:
+      # tolerations configures the taints and tolerations for the server-acl-init
+      # and server-acl-cleanup jobs. This should be a multi-line string matching the
+      # Tolerations (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) array in a Pod spec.
+      tolerations: ""
+
+      # This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
+      # labels for the server-acl-init and server-acl-cleanup jobs pod assignment, formatted as a multi-line string.
+      #
+      # Example:
+      #
+      # ```yaml
+      # nodeSelector: |
+      #   beta.kubernetes.io/arch: amd64
+      # ```
+      #
+      # @type: string
+      nodeSelector: null
 
   # [Enterprise Only] This value refers to a Kubernetes or Vault secret that you have created
   # that contains your enterprise license. It is required if you are using an

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -3062,6 +3062,19 @@ webhookCertManager:
   # @type: string
   tolerations: null
 
+  # This value defines `nodeSelector` (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
+  # labels for webhook cert manager pod assignment, formatted as a multi-line string.
+  #
+  # Example:
+  #
+  # ```yaml
+  # nodeSelector: |
+  #   beta.kubernetes.io/arch: amd64
+  # ```
+  #
+  # @type: string
+  nodeSelector: null
+
 # Configures a demo Prometheus installation.
 prometheus:
   # When true, the Helm chart will install a demo Prometheus server instance


### PR DESCRIPTION
This solution is in response to an ask from a customer who wants to set `nodeSelector` for all Pods in their cluster. This adds that capability to `server-acl-init` jobs and `webhook-cert-manager`.

Changes proposed in this PR:
- Add a Helm stanza, `global.acls.job` for configuring `server-acl-init` and `server-acl-init-cleanup` jobs.
- Add the Helm value `global.acls.job.tolerations` for setting tolerations on `server-acl-init` and `server-acl-init-cleanup` jobs.
- Add the Helm value `global.acls.job.nodeSelector` for setting the nodeSelector on `server-acl-init` and `server-acl-init-cleanup` jobs.
- Add the Helm value `webhookCertManager.nodeSelector` for setting the nodeSelector on `webhook-cert-manager-deployment`.
- Add BATS tests for all of the above changes.

How I've tested this PR:
- I deployed the following Helm values into an AKS account to ensure that Consul runs normally when `server-acl-init` and `webhook-cert-manager` are deployed on a particular node. There is no _anticipated_ reason why they shouldn't.

How I expect reviewers to test this PR:
- :eyes:
- Run a Helm chart that sets `nodeSelector`.

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

