### PR TITLE
set consul-k8s-image directly through consul-k8s-image parameter for consul nightly tests instead of setting it through additional flags.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1279,13 +1279,13 @@ workflows:
 #            - acceptance-aks-1-22
 
   nightly-acceptance-tests-consul:
-    # triggers:
-    #   - schedule:
-    #       cron: "0 0 * * *"
-    #       filters:
-    #         branches:
-    #           only:
-    #             - main
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
     jobs:
       - acceptance-kind-1-23-consul-nightly-1-11
       - acceptance-kind-1-23-consul-nightly-1-12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1112,7 +1112,8 @@ jobs:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -consul-k8s-image=$CONSUL_K8S_IMAGE -consul-image=$CONSUL_IMAGE -consul-version="1.11" -envoy-image=$ENVOY_IMAGE -helm-chart-version=$HELM_CHART_VERSION
+          consul-k8s-image: $CONSUL_K8S_IMAGE
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -consul-image=$CONSUL_IMAGE -consul-version="1.11" -envoy-image=$ENVOY_IMAGE -helm-chart-version=$HELM_CHART_VERSION
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -1150,7 +1151,8 @@ jobs:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -consul-k8s-image=$CONSUL_K8S_IMAGE -consul-image=$CONSUL_IMAGE -consul-version="1.12" -envoy-image=$ENVOY_IMAGE -helm-chart-version=$HELM_CHART_VERSION
+          consul-k8s-image: $CONSUL_K8S_IMAGE
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -consul-image=$CONSUL_IMAGE -consul-version="1.12" -envoy-image=$ENVOY_IMAGE -helm-chart-version=$HELM_CHART_VERSION
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -1188,7 +1190,8 @@ jobs:
             - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -consul-k8s-image=$CONSUL_K8S_IMAGE -consul-image=$CONSUL_IMAGE -consul-version="1.13" -envoy-image=$ENVOY_IMAGE -helm-chart-version=$HELM_CHART_VERSION
+          consul-k8s-image: $CONSUL_K8S_IMAGE
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -consul-image=$CONSUL_IMAGE -consul-version="1.13" -envoy-image=$ENVOY_IMAGE -helm-chart-version=$HELM_CHART_VERSION
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -1276,13 +1279,13 @@ workflows:
 #            - acceptance-aks-1-22
 
   nightly-acceptance-tests-consul:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
+    # triggers:
+    #   - schedule:
+    #       cron: "0 0 * * *"
+    #       filters:
+    #         branches:
+    #           only:
+    #             - main
     jobs:
       - acceptance-kind-1-23-consul-nightly-1-11
       - acceptance-kind-1-23-consul-nightly-1-12


### PR DESCRIPTION
Background:
Ci for nightly-acceptance-tests-consul are failing because it is using a current control-plane that no longer has consul-api-timeout specified for inject-connector-deployment.

This fixes, version mismatches as you can see here the failed tests go from 12 to 6 (there are still 3more failed tests/subtests that have individual reasons for failing that need to be investigated individually.)

Changes proposed in this PR:
- set consul-k8s-image directly through consul-k8s-image parameter for consul nightly tests instead of setting it through additional flags.
-

How I've tested this PR:
CI

How I expect reviewers to test this PR:
👀 