### PR TITLE
configure -tls-server-name when global.cloud.enabled=true so that it matches the server certificate minted from HCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## UNRELEASED
+## 1.0.0-beta1 (October 4, 2022)
 FEATURES:
 * CLI:
   * Add the ability to install HCP self-managed clusters.  [[GH-1540](https://github.com/hashicorp/consul-k8s/pull/1540)]

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -269,6 +269,9 @@ spec:
                 -default-consul-sidecar-cpu-request={{ $consulSidecarResources.requests.cpu }} \
                 {{- end }}
                 {{- end }}
+                {{- if .Values.global.cloud.enabled }}
+                -tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
+                {{- end }}
           startupProbe:
             httpGet:
               path: /readyz/ready

--- a/charts/consul/templates/controller-deployment.yaml
+++ b/charts/consul/templates/controller-deployment.yaml
@@ -98,6 +98,9 @@ spec:
             -consul-cross-namespace-acl-policy=cross-namespace-policy \
             {{- end }}
             {{- end }}
+            {{- if .Values.global.cloud.enabled }}
+            -tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
+            {{- end }}
         env:
         - name: NAMESPACE
           valueFrom:

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -268,7 +268,9 @@ spec:
             -ca-certs=/consul/tls/ca/tls.crt \
             {{- end }}
             {{- if and $root.Values.externalServers.enabled $root.Values.externalServers.tlsServerName }}
-            -tls-server-name={{$root.Values.externalServers.tlsServerName }} \
+            -consul-tls-server-name={{ $root.Values.externalServers.tlsServerName }} \
+            {{- else if $root.Values.global.cloud.enabled }}
+            -consul-tls-server-name=server.{{ $root.Values.global.datacenter}}.{{ $root.Values.global.domain}} \
             {{- end }}
             {{- else }}
             -tls-disabled \

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -268,9 +268,9 @@ spec:
             -ca-certs=/consul/tls/ca/tls.crt \
             {{- end }}
             {{- if and $root.Values.externalServers.enabled $root.Values.externalServers.tlsServerName }}
-            -consul-tls-server-name={{ $root.Values.externalServers.tlsServerName }} \
+            -tls-server-name={{ $root.Values.externalServers.tlsServerName }} \
             {{- else if $root.Values.global.cloud.enabled }}
-            -consul-tls-server-name=server.{{ $root.Values.global.datacenter}}.{{ $root.Values.global.domain}} \
+            -tls-server-name=server.{{ $root.Values.global.datacenter}}.{{ $root.Values.global.domain}} \
             {{- end }}
             {{- else }}
             -tls-disabled \

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -213,6 +213,8 @@ spec:
             {{- end }}
             {{- if and .Values.externalServers.enabled .Values.externalServers.tlsServerName }}
             -tls-server-name={{.Values.externalServers.tlsServerName }} \
+            {{- else if .Values.global.cloud.enabled }}
+            -consul-tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
             {{- end }}
             {{- else }}
             -tls-disabled \

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -214,7 +214,7 @@ spec:
             {{- if and .Values.externalServers.enabled .Values.externalServers.tlsServerName }}
             -tls-server-name={{.Values.externalServers.tlsServerName }} \
             {{- else if .Values.global.cloud.enabled }}
-            -consul-tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
+            -tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
             {{- end }}
             {{- else }}
             -tls-disabled \

--- a/charts/consul/templates/partition-init-job.yaml
+++ b/charts/consul/templates/partition-init-job.yaml
@@ -104,6 +104,9 @@ spec:
               consul-k8s-control-plane partition-init \
                 -log-level={{ .Values.global.logLevel }} \
                 -log-json={{ .Values.global.logJSON }} \
+                {{- if .Values.global.cloud.enabled }}
+                -consul-tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
+                {{- end }}
           resources:
             requests:
               memory: "50Mi"

--- a/charts/consul/templates/partition-init-job.yaml
+++ b/charts/consul/templates/partition-init-job.yaml
@@ -105,7 +105,7 @@ spec:
                 -log-level={{ .Values.global.logLevel }} \
                 -log-json={{ .Values.global.logJSON }} \
                 {{- if .Values.global.cloud.enabled }}
-                -consul-tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
+                -tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
                 {{- end }}
           resources:
             requests:

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -149,9 +149,6 @@ spec:
                 -resource-prefix=${CONSUL_FULLNAME} \
                 -k8s-namespace={{ .Release.Namespace }} \
                 -set-server-tokens={{ $serverEnabled }} \
-                {{- if .Values.global.cloud.enabled }}
-                -consul-tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
-                {{- end}}
                 -consul-api-timeout={{ .Values.global.consulAPITimeout }} \
 
                 {{- if .Values.externalServers.enabled }}
@@ -180,6 +177,8 @@ spec:
                 {{- end }}
                 {{- if .Values.externalServers.tlsServerName }}
                 -consul-tls-server-name={{ .Values.externalServers.tlsServerName }} \
+                {{- else if .Values.global.cloud.enabled }}
+                -consul-tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
                 {{- end }}
                 {{- end }}
 

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -176,9 +176,9 @@ spec:
                 -server-port=8501 \
                 {{- end }}
                 {{- if .Values.externalServers.tlsServerName }}
-                -consul-tls-server-name={{ .Values.externalServers.tlsServerName }} \
+                -tls-server-name={{ .Values.externalServers.tlsServerName }} \
                 {{- else if .Values.global.cloud.enabled }}
-                -consul-tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
+                -tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
                 {{- end }}
                 {{- end }}
 

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -261,7 +261,7 @@ spec:
                 {{- if and $root.Values.externalServers.enabled $root.Values.externalServers.tlsServerName }}
                 -tls-server-name={{$root.Values.externalServers.tlsServerName }} \
                 {{- else if $root.Values.global.cloud.enabled }}
-                -consul-tls-server-name=server.{{ $root.Values.global.datacenter}}.{{ $root.Values.global.domain}} \
+                -tls-server-name=server.{{ $root.Values.global.datacenter}}.{{ $root.Values.global.domain}} \
                 {{- end }}
                 {{- else }}
                 -tls-disabled \

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -260,6 +260,8 @@ spec:
                 {{- end }}
                 {{- if and $root.Values.externalServers.enabled $root.Values.externalServers.tlsServerName }}
                 -tls-server-name={{$root.Values.externalServers.tlsServerName }} \
+                {{- else if $root.Values.global.cloud.enabled }}
+                -consul-tls-server-name=server.{{ $root.Values.global.datacenter}}.{{ $root.Values.global.domain}} \
                 {{- end }}
                 {{- else }}
                 -tls-disabled \

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -2352,3 +2352,17 @@ reservedNameTest() {
   [ "$status" -eq 1 ]
   [[ "$output" =~ "When global.cloud.enabled is true, global.cloud.secretName must also be set." ]]
 }
+
+@test "connectInject/Deployment: sets TLS server name if global.cloud.enabled is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'global.cloud.enabled=true' \
+      --set 'global.cloud.secretName=blah' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-tls-server-name=server.dc1.consul"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/controller-deployment.bats
+++ b/charts/consul/test/unit/controller-deployment.bats
@@ -859,3 +859,17 @@ load _helpers
   [ "$status" -eq 1 ]
   [[ "$output" =~ "When global.cloud.enabled is true, global.cloud.secretName must also be set." ]]
 }
+
+@test "controller/Deployment: sets TLS server name if global.cloud.enabled is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/controller-deployment.yaml  \
+      --set 'controller.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'global.cloud.enabled=true' \
+      --set 'global.cloud.secretName=blah' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-tls-server-name=server.dc1.consul"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/ingress-gateways-deployment.bats
+++ b/charts/consul/test/unit/ingress-gateways-deployment.bats
@@ -1162,3 +1162,20 @@ key2: value2' \
   [ "$status" -eq 1 ]
   [[ "$output" =~ "When global.cloud.enabled is true, global.cloud.secretName must also be set." ]]
 }
+
+@test "ingressGateways/Deployment: sets TLS server name if global.cloud.enabled is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'ingressGateways.defaults.terminationGracePeriodSeconds=5' \
+      --set 'ingressGateways.gateways[0].name=gateway1' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'global.cloud.enabled=true' \
+      --set 'global.cloud.secretName=blah' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-tls-server-name=server.dc1.consul"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/mesh-gateway-deployment.bats
+++ b/charts/consul/test/unit/mesh-gateway-deployment.bats
@@ -1353,3 +1353,18 @@ key2: value2' \
   [ "$status" -eq 1 ]
   [[ "$output" =~ "When global.cloud.enabled is true, global.cloud.secretName must also be set." ]]
 }
+
+@test "meshGateway/Deployment: sets TLS server name if global.cloud.enabled is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/mesh-gateway-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'meshGateway.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'global.cloud.enabled=true' \
+      --set 'global.cloud.secretName=blah' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-tls-server-name=server.dc1.consul"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/partition-init-job.bats
+++ b/charts/consul/test/unit/partition-init-job.bats
@@ -561,3 +561,27 @@ reservedNameTest() {
       yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 }
+
+#--------------------------------------------------------------------
+# global.cloud
+
+@test "partitionInit/Job: sets TLS server name if global.cloud.enabled is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+-s templates/partition-init-job.yaml  \
+      --set 'global.enabled=false' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set "global.adminPartitions.name=bar" \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=foo' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'global.tls.caCert.secretName=foo' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'global.cloud.enabled=true' \
+      --set 'global.cloud.secretName=blah' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-tls-server-name=server.dc1.consul"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -1694,7 +1694,7 @@ load _helpers
       --set 'global.tls.enabled=true' \
       --set 'externalServers.tlsServerName=foo' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-consul-tls-server-name=foo"))' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command | any(contains("-tls-server-name=foo"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
@@ -1921,6 +1921,6 @@ load _helpers
       --set 'global.cloud.enabled=true' \
       --set 'global.cloud.secretName=blah' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-consul-tls-server-name=server.dc1.consul"))' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command | any(contains("-tls-server-name=server.dc1.consul"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -1911,3 +1911,16 @@ load _helpers
   [ "$status" -eq 1 ]
   [[ "$output" =~ "When global.cloud.enabled is true, global.cloud.secretName must also be set." ]]
 }
+
+@test "serverACLInit/Job: sets TLS server name if global.cloud.enabled is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.cloud.enabled=true' \
+      --set 'global.cloud.secretName=blah' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-consul-tls-server-name=server.dc1.consul"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -1211,3 +1211,19 @@ key2: value2' \
   [ "$status" -eq 1 ]
   [[ "$output" =~ "When global.cloud.enabled is true, global.cloud.secretName must also be set." ]]
 }
+
+@test "terminatingGateways/Deployment: sets TLS server name if global.cloud.enabled is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'global.cloud.enabled=true' \
+      --set 'global.cloud.secretName=blah' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-tls-server-name=server.dc1.consul"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -19,7 +19,7 @@ var (
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = "beta1"
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -172,7 +172,7 @@ func (c *Command) init() {
 	c.flags.UintVar(&c.flagServerPort, "server-port", 8500, "The HTTP or HTTPS port of the Consul server. Defaults to 8500.")
 	c.flags.StringVar(&c.flagConsulCACert, "consul-ca-cert", "",
 		"Path to the PEM-encoded CA certificate of the Consul cluster.")
-	c.flags.StringVar(&c.flagConsulTLSServerName, "consul-tls-server-name", "",
+	c.flags.StringVar(&c.flagConsulTLSServerName, "tls-server-name", "",
 		"The server name to set as the SNI header when sending HTTPS requests to Consul.")
 	c.flags.BoolVar(&c.flagUseHTTPS, "use-https", false,
 		"Toggle for using HTTPS for all API calls to Consul.")

--- a/control-plane/subcommand/server-acl-init/command_test.go
+++ b/control-plane/subcommand/server-acl-init/command_test.go
@@ -1866,7 +1866,7 @@ func TestRun_HTTPS(t *testing.T) {
 		"-resource-prefix=" + resourcePrefix,
 		"-k8s-namespace=" + ns,
 		"-use-https",
-		"-consul-tls-server-name", "server.dc1.consul",
+		"-tls-server-name", "server.dc1.consul",
 		"-consul-ca-cert", caFile,
 		"-server-address=" + strings.Split(srv.HTTPSAddr, ":")[0],
 		"-server-port=" + strings.Split(srv.HTTPSAddr, ":")[1],

--- a/control-plane/version/version.go
+++ b/control-plane/version/version.go
@@ -19,7 +19,7 @@ var (
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = "beta1"
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
Changes proposed in this PR:
- configure -tls-server-name for consul-k8s components that use connection manager when global.cloud.enabled = true so that it matches the server certificate minted from HCP 
-

How I've tested this PR:
- bats tests
- manual integration testing with HCP

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

