### PR TITLE
consul nightly acceptance tests - checkout the acceptance tests from the v0.49.0 tag when running against helm v0.49.0 and 1.11/12/13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1108,18 +1108,17 @@ jobs:
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
-      - restore_cache:
-            paths:
-              - ~/.go_workspace/pkg/modkeys:
-            - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
+      # - restore_cache:
+      #     keys:
+      #       - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
       - run:
           name: go mod download
           working_directory: *acceptance-mod-path
           command: go mod download
-      - save_cache:
-          key: consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
-          paths:
-            - ~/.go_workspace/pkg/mod
+      # - save_cache:
+      #     key: consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
+      #     paths:
+      #       - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           consul-k8s-image: $CONSUL_K8S_IMAGE
@@ -1157,17 +1156,17 @@ jobs:
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
-      - restore_cache:
-          keys:
-            - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
+      # - restore_cache:
+      #     keys:
+      #       - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
       - run:
           name: go mod download
           working_directory: *acceptance-mod-path
           command: go mod download
-      - save_cache:
-          key: consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
-          paths:
-            - ~/.go_workspace/pkg/mod
+      # - save_cache:
+      #     key: consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
+      #     paths:
+      #       - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           consul-k8s-image: $CONSUL_K8S_IMAGE
@@ -1205,17 +1204,17 @@ jobs:
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
-      - restore_cache:
-          keys:
-            - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
+      # - restore_cache:
+      #     keys:
+      #       - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
       - run:
           name: go mod download
           working_directory: *acceptance-mod-path
           command: go mod download
-      - save_cache:
-          key: consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
-          paths:
-            - ~/.go_workspace/pkg/mod
+      # - save_cache:
+      #     key: consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
+      #     paths:
+      #       - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           consul-k8s-image: $CONSUL_K8S_IMAGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1089,8 +1089,8 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
       - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.11-dev"
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.20.2"
-      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.48.0"
-      - HELM_CHART_VERSION: "0.48.0"
+      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.49.0"
+      - HELM_CHART_VERSION: "0.49.0"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
@@ -1150,8 +1150,8 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
       - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.12-dev"
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.22.2"
-      - HELM_CHART_VERSION: "0.48.0"
-      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.48.0"
+      - HELM_CHART_VERSION: "0.49.0"
+      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.49.0"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
@@ -1211,8 +1211,8 @@ jobs:
       - TEST_RESULTS: /tmp/test-results
       - CONSUL_IMAGE: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.13-dev"
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.23.1"
-      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.48.0"
-      - HELM_CHART_VERSION: "0.48.0"
+      - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.49.0"
+      - HELM_CHART_VERSION: "0.49.0"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1099,26 +1099,39 @@ jobs:
           name: checkout code
           command: |
             if [ -e '/home/circleci/project/.git' ] ; then
+              echo 'Fetching into existing repository'
+              existing_repo='true'
               cd '/home/circleci/project'
+              git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
             else
+              echo 'Cloning git repository'
+              existing_repo='false'
               mkdir -p '/home/circleci/project'
               cd '/home/circleci/project'
+              git clone --no-checkout "$CIRCLE_REPOSITORY_URL" .
             fi
-            git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
+
+            if [ "$existing_repo" = 'true' ] || [ 'false' = 'true' ]; then
+              echo 'Fetching from remote repository'
+                git fetch --force --tags origin
+            fi
+
+            echo 'Checking out tag'
+            git checkout --force "v$HELM_CHART_VERSION"
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
-      # - restore_cache:
-      #     keys:
-      #       - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
+      - restore_cache:
+          keys:
+            - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
       - run:
           name: go mod download
           working_directory: *acceptance-mod-path
           command: go mod download
-      # - save_cache:
-      #     key: consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
-      #     paths:
-      #       - ~/.go_workspace/pkg/mod
+      - save_cache:
+          key: consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
+          paths:
+            - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           consul-k8s-image: $CONSUL_K8S_IMAGE
@@ -1147,26 +1160,39 @@ jobs:
           name: checkout code
           command: |
             if [ -e '/home/circleci/project/.git' ] ; then
+              echo 'Fetching into existing repository'
+              existing_repo='true'
               cd '/home/circleci/project'
+              git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
             else
+              echo 'Cloning git repository'
+              existing_repo='false'
               mkdir -p '/home/circleci/project'
               cd '/home/circleci/project'
+              git clone --no-checkout "$CIRCLE_REPOSITORY_URL" .
             fi
-            git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
+
+            if [ "$existing_repo" = 'true' ] || [ 'false' = 'true' ]; then
+              echo 'Fetching from remote repository'
+                git fetch --force --tags origin
+            fi
+
+            echo 'Checking out tag'
+            git checkout --force "v$HELM_CHART_VERSION"
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
-      # - restore_cache:
-      #     keys:
-      #       - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
+      - restore_cache:
+          keys:
+            - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
       - run:
           name: go mod download
           working_directory: *acceptance-mod-path
           command: go mod download
-      # - save_cache:
-      #     key: consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
-      #     paths:
-      #       - ~/.go_workspace/pkg/mod
+      - save_cache:
+          key: consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
+          paths:
+            - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           consul-k8s-image: $CONSUL_K8S_IMAGE
@@ -1195,26 +1221,39 @@ jobs:
           name: checkout code
           command: |
             if [ -e '/home/circleci/project/.git' ] ; then
+              echo 'Fetching into existing repository'
+              existing_repo='true'
               cd '/home/circleci/project'
+              git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
             else
+              echo 'Cloning git repository'
+              existing_repo='false'
               mkdir -p '/home/circleci/project'
               cd '/home/circleci/project'
+              git clone --no-checkout "$CIRCLE_REPOSITORY_URL" .
             fi
-            git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
+
+            if [ "$existing_repo" = 'true' ] || [ 'false' = 'true' ]; then
+              echo 'Fetching from remote repository'
+                git fetch --force --tags origin
+            fi
+
+            echo 'Checking out tag'
+            git checkout --force "v$HELM_CHART_VERSION"
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
-      # - restore_cache:
-      #     keys:
-      #       - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
+      - restore_cache:
+          keys:
+            - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
       - run:
           name: go mod download
           working_directory: *acceptance-mod-path
           command: go mod download
-      # - save_cache:
-      #     key: consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
-      #     paths:
-      #       - ~/.go_workspace/pkg/mod
+      - save_cache:
+          key: consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
+          paths:
+            - ~/.go_workspace/pkg/mod
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           consul-k8s-image: $CONSUL_K8S_IMAGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1095,7 +1095,16 @@ jobs:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
     steps:
-      - run: git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
+      - run: 
+          name: checkout code
+          command: |
+            if [ -e '/home/circleci/project/.git' ] ; then
+              cd '/home/circleci/project'
+            else
+              mkdir -p '/home/circleci/project'
+              cd '/home/circleci/project'
+            fi
+            git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
@@ -1134,7 +1143,16 @@ jobs:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
     steps:
-      - run: git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
+      - run: 
+          name: checkout code
+          command: |
+            if [ -e '/home/circleci/project/.git' ] ; then
+              cd '/home/circleci/project'
+            else
+              mkdir -p '/home/circleci/project'
+              cd '/home/circleci/project'
+            fi
+            git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
@@ -1173,7 +1191,16 @@ jobs:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
     steps:
-      - run: git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
+      - run: 
+          name: checkout code
+          command: |
+            if [ -e '/home/circleci/project/.git' ] ; then
+              cd '/home/circleci/project'
+            else
+              mkdir -p '/home/circleci/project'
+              cd '/home/circleci/project'
+            fi
+            git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1282,13 +1282,13 @@ workflows:
 #            - acceptance-aks-1-22
 
   nightly-acceptance-tests-consul:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
+    # triggers:
+    #   - schedule:
+    #       cron: "0 0 * * *"
+    #       filters:
+    #         branches:
+    #           only:
+    #             - main
     jobs:
       - acceptance-kind-1-23-consul-nightly-1-11
       - acceptance-kind-1-23-consul-nightly-1-12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1095,7 +1095,7 @@ jobs:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
     steps:
-      - checkout
+      - run: git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
@@ -1134,7 +1134,7 @@ jobs:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
     steps:
-      - checkout
+      - run: git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
@@ -1173,7 +1173,7 @@ jobs:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
     steps:
-      - checkout
+      - run: git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
@@ -1279,13 +1279,13 @@ workflows:
 #            - acceptance-aks-1-22
 
   nightly-acceptance-tests-consul:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
+    # triggers:
+    #   - schedule:
+    #       cron: "0 0 * * *"
+    #       filters:
+    #         branches:
+    #           only:
+    #             - main
     jobs:
       - acceptance-kind-1-23-consul-nightly-1-11
       - acceptance-kind-1-23-consul-nightly-1-12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1345,13 +1345,13 @@ workflows:
 #            - acceptance-aks-1-22
 
   nightly-acceptance-tests-consul:
-    # triggers:
-    #   - schedule:
-    #       cron: "0 0 * * *"
-    #       filters:
-    #         branches:
-    #           only:
-    #             - main
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
     jobs:
       - acceptance-kind-1-23-consul-nightly-1-11
       - acceptance-kind-1-23-consul-nightly-1-12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1109,7 +1109,8 @@ jobs:
       - create-kind-clusters:
           version: "v1.23.0"
       - restore_cache:
-          keys:
+            paths:
+              - ~/.go_workspace/pkg/modkeys:
             - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
       - run:
           name: go mod download

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1091,11 +1091,12 @@ jobs:
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.20.2"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.48.0"
       - HELM_CHART_VERSION: "0.48.0"
+      - CIRCLE_TAG: "v0.48.0"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
     steps:
-      - run: git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
+      - checkout
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
@@ -1130,11 +1131,12 @@ jobs:
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.22.2"
       - HELM_CHART_VERSION: "0.48.0"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.48.0"
+      - CIRCLE_TAG: "v0.48.0"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
     steps:
-      - run: git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
+      - checkout
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
@@ -1169,11 +1171,12 @@ jobs:
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.23.1"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.48.0"
       - HELM_CHART_VERSION: "0.48.0"
+      - CIRCLE_TAG: "v0.48.0"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
     steps:
-      - run: git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
+      - checkout
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
@@ -1279,13 +1282,13 @@ workflows:
 #            - acceptance-aks-1-22
 
   nightly-acceptance-tests-consul:
-    # triggers:
-    #   - schedule:
-    #       cron: "0 0 * * *"
-    #       filters:
-    #         branches:
-    #           only:
-    #             - main
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
     jobs:
       - acceptance-kind-1-23-consul-nightly-1-11
       - acceptance-kind-1-23-consul-nightly-1-12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1091,12 +1091,11 @@ jobs:
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.20.2"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.48.0"
       - HELM_CHART_VERSION: "0.48.0"
-      - CIRCLE_TAG: "v0.48.0"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
     steps:
-      - checkout
+      - run: git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
@@ -1131,12 +1130,11 @@ jobs:
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.22.2"
       - HELM_CHART_VERSION: "0.48.0"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.48.0"
-      - CIRCLE_TAG: "v0.48.0"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
     steps:
-      - checkout
+      - run: git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"
@@ -1171,12 +1169,11 @@ jobs:
       - ENVOY_IMAGE: "envoyproxy/envoy:v1.23.1"
       - CONSUL_K8S_IMAGE: "docker.mirror.hashicorp.services/hashicorp/consul-k8s-control-plane:0.48.0"
       - HELM_CHART_VERSION: "0.48.0"
-      - CIRCLE_TAG: "v0.48.0"
     machine:
       image: ubuntu-2004:202010-01
     resource_class: xlarge
     steps:
-      - checkout
+      - run: git clone -b "v$HELM_CHART_VERSION" "$CIRCLE_REPOSITORY_URL"
       - install-prereqs
       - create-kind-clusters:
           version: "v1.23.0"


### PR DESCRIPTION
Background:
We currently download the acceptance tests from main and then run them against these combinations:
- helm v0.48 / consul 1.11
- helm v0.48 / consul 1.12
- helm v0.48 / consul 1.13

When we went to agentless, some test got revised to no longer set things like `client.enabled`.  Then when these run against old versions, they error because the old chart requires things like that.

In getting checking the acceptance test code out by tag, we are effectively saying "we want to make sure that the tests that were active when this version was release still work."

Changes proposed in this PR:
- update tests to use helm 0.49
- update CI to check out acceptance test code base on 0.49.0



How I've tested this PR:
- ran it on push in this branch.  it passes here (minus one flakey test): https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/8229/workflows/16efe795-cf0a-49a2-b719-bcb19d08164e

How I expect reviewers to test this PR:
👀 

