### PR TITLE
Add flag to disable dns tests on AKS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -829,7 +829,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -consul-image=hashicorppreview/consul-enterprise:1.14-dev
+          additional-flags: -use-aks -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -consul-image=hashicorppreview/consul-enterprise:1.14-dev
 
       - store_test_results:
           path: /tmp/test-results
@@ -886,7 +886,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-transparent-proxy -enable-cni -consul-image=hashicorppreview/consul-enterprise:1.14-dev
+          additional-flags: -use-aks -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-transparent-proxy -enable-cni -consul-image=hashicorppreview/consul-enterprise:1.14-dev
 
       - store_test_results:
           path: /tmp/test-results

--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -53,8 +53,9 @@ type TestConfig struct {
 	NoCleanupOnFailure bool
 	DebugDirectory     string
 
-	UseKind bool
+	UseAKS  bool
 	UseGKE  bool
+	UseKind bool
 
 	helmChartPath string
 }

--- a/acceptance/framework/flags/flags.go
+++ b/acceptance/framework/flags/flags.go
@@ -41,8 +41,9 @@ type TestFlags struct {
 
 	flagDebugDirectory string
 
-	flagUseKind bool
+	flagUseAKS  bool
 	flagUseGKE  bool
+	flagUseKind bool
 
 	flagDisablePeering bool
 
@@ -105,10 +106,12 @@ func (t *TestFlags) init() {
 	flag.StringVar(&t.flagDebugDirectory, "debug-directory", "", "The directory where to write debug information about failed test runs, "+
 		"such as logs and pod definitions. If not provided, a temporary directory will be created by the tests.")
 
-	flag.BoolVar(&t.flagUseKind, "use-kind", false,
-		"If true, the tests will assume they are running against a local kind cluster(s).")
+	flag.BoolVar(&t.flagUseAKS, "use-aks", false,
+		"If true, the tests will assume they are running against an AKS cluster(s).")
 	flag.BoolVar(&t.flagUseGKE, "use-gke", false,
 		"If true, the tests will assume they are running against a GKE cluster(s).")
+	flag.BoolVar(&t.flagUseKind, "use-kind", false,
+		"If true, the tests will assume they are running against a local kind cluster(s).")
 
 	flag.BoolVar(&t.flagDisablePeering, "disable-peering", false,
 		"If true, the peering tests will not run.")
@@ -168,7 +171,8 @@ func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 
 		NoCleanupOnFailure: t.flagNoCleanupOnFailure,
 		DebugDirectory:     tempDir,
-		UseKind:            t.flagUseKind,
+		UseAKS:             t.flagUseAKS,
 		UseGKE:             t.flagUseGKE,
+		UseKind:            t.flagUseKind,
 	}
 }

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -21,6 +21,11 @@ func TestConsulDNS(t *testing.T) {
 	if cfg.EnableCNI {
 		t.Skipf("skipping because -enable-cni is set")
 	}
+
+	if cfg.UseAKS {
+		t.Skipf("skipping because -use-aks is set")
+	}
+
 	for _, secure := range []bool{false, true} {
 		name := fmt.Sprintf("secure: %t", secure)
 		t.Run(name, func(t *testing.T) {
@@ -55,7 +60,7 @@ func TestConsulDNS(t *testing.T) {
 			}
 
 			dnsTestPodArgs := []string{
-				"run", "-i", podName, "--restart", "Never", "--image", "anubhavmishra/tiny-tools", "--", "dig", fmt.Sprintf("@%s-consul-dns", releaseName), "consul.service.consul",
+				"run", "-i", podName, "--restart", "Never", "--image", "anubhavmishra/tiny-tools", "--", "sh", "-c", "dig", fmt.Sprintf("@%s-consul-dns", releaseName), "consul.service.consul",
 			}
 
 			helpers.Cleanup(t, suite.Config().NoCleanupOnFailure, func() {

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -60,7 +60,7 @@ func TestConsulDNS(t *testing.T) {
 			}
 
 			dnsTestPodArgs := []string{
-				"run", "-i", podName, "--restart", "Never", "--image", "anubhavmishra/tiny-tools", "--", "sh", "-c", "dig", fmt.Sprintf("@%s-consul-dns", releaseName), "consul.service.consul",
+				"run", "-i", podName, "--restart", "Never", "--image", "anubhavmishra/tiny-tools", "--", "dig", fmt.Sprintf("@%s-consul-dns", releaseName), "consul.service.consul",
 			}
 
 			helpers.Cleanup(t, suite.Config().NoCleanupOnFailure, func() {


### PR DESCRIPTION
The consul dns tests have been flaky ever since we upgraded AKS from 1.21.14 to 1.22.11 on August 24th. I have been able to reproduce the problem on a new AKS cluster and one that has sat around for a while thus eliminating the chance that this was caused by something kube not starting.

Sometimes the tests pass, sometimes they fail and I do not know why.

Research:

- The problem still happens on newer versions of AKS (1.23.12)
- I could not find anything in the Kubernetes or AKS release notes/CHANGELOGs
- I have not been able to find any issues in Github for both Kubernetes and AKS related to the problem.
- Added `sh -c` to the dig command so that the TTY wasn't swallowed but it didn't make a difference. Reverted because it is probably not a good idea to output networking things in tests.

Changes proposed in this PR:
- Add a flag to the acceptance framework for `use-aks`
- Disable the dns test when config.UseAKS is set
- Add the flag to the acceptance tests in CircleCI

How I've tested this PR:

- Ran the tests locally against an AKS cluster with the flag set or not

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

