### PR TITLE
Helm namespace mirroring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 FEATURES:
 * Peering: Add support for `PeerThroughMeshGateways` in Mesh CRD. [[GH-1478](https://github.com/hashicorp/consul-k8s/pull/1478)]
 
+BREAKING CHANGES:
+* Helm:
+  * `syncCatalog.consulNamespaces.mirroringK8S` now defaults to `true`. [[GH-1601](https://github.com/hashicorp/consul-k8s/pull/1601)]
+  * `connectInject.consulNamespaces.mirroringK8S` now defaults to `true`. [[GH-1601](https://github.com/hashicorp/consul-k8s/pull/1601)]
+
 ## 1.0.0-beta2 (October 7, 2022)
 BREAKING CHANGES:
 * Peering: Rename `PeerName` to `Peer` in ExportedServices CRD. [[GH-1596](https://github.com/hashicorp/consul-k8s/pull/1596)]

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -1,6 +1,5 @@
 {{- if and .Values.global.peering.enabled (not .Values.connectInject.enabled) }}{{ fail "setting global.peering.enabled to true requires connectInject.enabled to be true" }}{{ end }}
 {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if and .Values.connectInject.consulNamespaces.mirroringK8S (not .Values.global.enableConsulNamespaces) }}{{ fail "global.enableConsulNamespaces must be true if mirroringK8S=true" }}{{ end }}
 {{- if and .Values.global.adminPartitions.enabled (not .Values.global.enableConsulNamespaces) }}{{ fail "global.enableConsulNamespaces must be true if global.adminPartitions.enabled=true" }}{{ end }}
 {{ template "consul.validateVaultWebhookCertConfiguration" . }}
 {{- template "consul.reservedNamesFailer" (list .Values.connectInject.consulNamespaces.consulDestinationNamespace "connectInject.consulNamespaces.consulDestinationNamespace") }}
@@ -206,7 +205,7 @@ spec:
                 {{- if .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
                 -consul-destination-namespace={{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }} \
                 {{- end }}
-                {{- if .Values.connectInject.consulNamespaces.mirroringK8S }}
+                {{- if and .Values.global.enableConsulNamespaces .Values.connectInject.consulNamespaces.mirroringK8S }} // test this change
                 -enable-k8s-namespace-mirroring=true \
                 {{- if .Values.connectInject.consulNamespaces.mirroringK8SPrefix }}
                 -k8s-namespace-mirroring-prefix={{ .Values.connectInject.consulNamespaces.mirroringK8SPrefix }} \

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -205,7 +205,7 @@ spec:
                 {{- if .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
                 -consul-destination-namespace={{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }} \
                 {{- end }}
-                {{- if and .Values.global.enableConsulNamespaces .Values.connectInject.consulNamespaces.mirroringK8S }} // test this change
+                {{- if and .Values.global.enableConsulNamespaces .Values.connectInject.consulNamespaces.mirroringK8S }}
                 -enable-k8s-namespace-mirroring=true \
                 {{- if .Values.connectInject.consulNamespaces.mirroringK8SPrefix }}
                 -k8s-namespace-mirroring-prefix={{ .Values.connectInject.consulNamespaces.mirroringK8SPrefix }} \

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -704,13 +704,13 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "connectInject/Deployment: mirroring options set with .connectInject.consulNamespaces.mirroringK8S=false" {
+@test "connectInject/Deployment: mirroring options omitted with .connectInject.consulNamespaces.mirroringK8S=false" {
   cd `chart_dir`
   local object=$(helm template \
       -s templates/connect-inject-deployment.yaml  \
       --set 'connectInject.enabled=true' \
       --set 'global.enableConsulNamespaces=true' \
-      --set 'connectInject.consulNamespaces.mirroringK8S=true' \
+      --set 'connectInject.consulNamespaces.mirroringK8S=false' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 
@@ -724,7 +724,7 @@ load _helpers
 
   local actual=$(echo $object |
     yq 'any(contains("enable-k8s-namespace-mirroring=true"))' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
+  [ "${actual}" = "false" ]
 
   local actual=$(echo $object |
     yq 'any(contains("k8s-namespace-mirroring-prefix"))' | tee /dev/stderr)

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -653,17 +653,6 @@ load _helpers
 #--------------------------------------------------------------------
 # namespaces
 
-@test "connectInject/Deployment: fails if namespaces are disabled and mirroringK8S is true" {
-  cd `chart_dir`
-  run helm template \
-      -s templates/connect-inject-deployment.yaml  \
-      --set 'global.enableConsulNamespaces=false' \
-      --set 'connectInject.consulNamespaces.mirroringK8S=true' \
-      --set 'connectInject.enabled=true' .
-  [ "$status" -eq 1 ]
-  [[ "$output" =~ "global.enableConsulNamespaces must be true if mirroringK8S=true" ]]
-}
-
 @test "connectInject/Deployment: namespace options disabled by default" {
   cd `chart_dir`
   local object=$(helm template \
@@ -708,14 +697,14 @@ load _helpers
 
   local actual=$(echo $object |
     yq 'any(contains("enable-k8s-namespace-mirroring"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 
   local actual=$(echo $object |
     yq 'any(contains("k8s-namespace-mirroring-prefix"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "connectInject/Deployment: mirroring options set with .connectInject.consulNamespaces.mirroringK8S=true" {
+@test "connectInject/Deployment: mirroring options set with .connectInject.consulNamespaces.mirroringK8S=false" {
   cd `chart_dir`
   local object=$(helm template \
       -s templates/connect-inject-deployment.yaml  \

--- a/charts/consul/test/unit/controller-deployment.bats
+++ b/charts/consul/test/unit/controller-deployment.bats
@@ -229,7 +229,7 @@ load _helpers
 
   local actual=$(echo $object |
     yq 'any(contains("enable-k8s-namespace-mirroring"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 
   local actual=$(echo $object |
     yq 'any(contains("k8s-namespace-mirroring-prefix"))' | tee /dev/stderr)

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -1099,7 +1099,7 @@ load _helpers
 
   local actual=$(echo $object |
     yq 'any(contains("enable-sync-k8s-namespace-mirroring"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 
   local actual=$(echo $object |
     yq 'any(contains("sync-k8s-namespace-mirroring-prefix"))' | tee /dev/stderr)

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -1072,7 +1072,7 @@ load _helpers
 
   local actual=$(echo $object |
     yq 'any(contains("enable-inject-k8s-namespace-mirroring"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 
   local actual=$(echo $object |
     yq 'any(contains("inject-k8s-namespace-mirroring-prefix"))' | tee /dev/stderr)
@@ -1115,7 +1115,7 @@ load _helpers
 
   local actual=$(echo $object |
     yq 'any(contains("enable-inject-k8s-namespace-mirroring"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 
   local actual=$(echo $object |
     yq 'any(contains("inject-k8s-namespace-mirroring-prefix"))' | tee /dev/stderr)
@@ -1159,7 +1159,7 @@ load _helpers
 
   local actual=$(echo $object |
     yq 'any(contains("enable-inject-k8s-namespace-mirroring"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 
   local actual=$(echo $object |
     yq 'any(contains("inject-k8s-namespace-mirroring-prefix"))' | tee /dev/stderr)
@@ -1204,7 +1204,7 @@ load _helpers
 
   local actual=$(echo $object |
     yq 'any(contains("enable-inject-k8s-namespace-mirroring"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 
   local actual=$(echo $object |
     yq 'any(contains("inject-k8s-namespace-mirroring-prefix"))' | tee /dev/stderr)
@@ -1294,7 +1294,7 @@ load _helpers
 
   local actual=$(echo $object |
     yq 'any(contains("enable-inject-k8s-namespace-mirroring"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 
   local actual=$(echo $object |
     yq 'any(contains("inject-k8s-namespace-mirroring-prefix"))' | tee /dev/stderr)

--- a/charts/consul/test/unit/sync-catalog-deployment.bats
+++ b/charts/consul/test/unit/sync-catalog-deployment.bats
@@ -984,7 +984,7 @@ load _helpers
 
   local actual=$(echo $object |
     yq 'any(contains("enable-k8s-namespace-mirroring"))' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 
   local actual=$(echo $object |
     yq 'any(contains("k8s-namespace-mirroring-prefix"))' | tee /dev/stderr)

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2205,7 +2205,7 @@ connectInject:
     # `consulDestinationNamespace` setting. If mirroring is enabled, avoid creating any Consul 
     # resources in the following Kubernetes namespaces, as Consul currently reserves these 
     # namespaces for system use: "system", "universal", "operator", "root". 
-    mirroringK8S: false
+    mirroringK8S: true
 
     # If `mirroringK8S` is set to true, `mirroringK8SPrefix` allows each Consul namespace
     # to be given a prefix. For example, if `mirroringK8SPrefix` is set to "k8s-", a

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1755,7 +1755,7 @@ syncCatalog:
     # If mirroring is enabled, avoid creating any Consul resources in the following 
     # Kubernetes namespaces, as Consul currently reserves these namespaces for 
     # system use: "system", "universal", "operator", "root". 
-    mirroringK8S: false
+    mirroringK8S: true
 
     # If `mirroringK8S` is set to true, `mirroringK8SPrefix` allows each Consul namespace
     # to be given a prefix. For example, if `mirroringK8SPrefix` is set to "k8s-", a


### PR DESCRIPTION
Changes proposed in this PR:
- `syncCatalog.consulNamespaces.mirroringK8S` now defaults to `true`
- `connectInject.consulNamespaces.mirroringK8S` now defaults to `true`
- Instead of failing when `connectInject.consulNamespaces.mirrorK8S=true` and `global.enableConsulNamespaces=false`, the `connect-inject-deployment.yaml` template instead checks for both to be true in order to pass the `-enable-k8s-namespace-mirroring=true` flag. That means, `connectInject.consulNamespaces.mirrorK8S=true` and `global.enableConsulNamespaces=false` is now a valid deployment configuration that will simply not tell Consul to perform mirroring given that Consul namespaces is not `true`.
- Modified BATS tests to accommodate this change

How I've tested this PR:
- Modified BATS tests
- Run Acceptance tests

How I expect reviewers to test this PR:
- BATS and acceptance

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

