### PR TITLE
Show server statuses only when they are deployed into the Kubernetes cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ FEATURES:
 IMPROVEMENTS:
 * Helm:
   * API Gateway: Allow controller to read MeshServices for use as a route backend. [[GH-1574](https://github.com/hashicorp/consul-k8s/pull/1574)]
+* CLI:
+  * `consul-k8s status` command will only show status of clients and servers if they are expected to be present in the Kubernetes cluster. [[GH-1603](https://github.com/hashicorp/consul-k8s/pull/1603)]
 
 ## 1.0.0-beta2 (October 7, 2022)
 BREAKING CHANGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ IMPROVEMENTS:
 * Helm:
   * API Gateway: Allow controller to read MeshServices for use as a route backend. [[GH-1574](https://github.com/hashicorp/consul-k8s/pull/1574)]
 * CLI:
-  * `consul-k8s status` command will only show status of clients and servers if they are expected to be present in the Kubernetes cluster. [[GH-1603](https://github.com/hashicorp/consul-k8s/pull/1603)]
+  * `consul-k8s status` command will only show status of servers if they are expected to be present in the Kubernetes cluster. [[GH-1603](https://github.com/hashicorp/consul-k8s/pull/1603)]
 
 ## 1.0.0-beta2 (October 7, 2022)
 BREAKING CHANGES:

--- a/cli/cmd/status/status.go
+++ b/cli/cmd/status/status.go
@@ -120,7 +120,7 @@ func (c *Command) Run(args []string) int {
 	}
 
 	if err := c.checkConsulAgents(namespace); err != nil {
-		c.UI.Output("Unable to check Kubernetes cluster for Consul clients: %v", err)
+		c.UI.Output("Unable to check Kubernetes cluster for Consul agents: %v", err)
 		return 1
 	}
 

--- a/cli/cmd/status/status.go
+++ b/cli/cmd/status/status.go
@@ -119,11 +119,9 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	if s, err := c.checkConsulServers(namespace); err != nil {
-		c.UI.Output(err.Error(), terminal.WithErrorStyle())
+	if err := c.checkConsulAgents(namespace); err != nil {
+		c.UI.Output("Unable to check Kubernetes cluster for Consul clients: %v", err)
 		return 1
-	} else {
-		c.UI.Output(s, terminal.WithSuccessStyle())
 	}
 
 	return 0
@@ -216,24 +214,39 @@ func validEvent(events []release.HookEvent) bool {
 	return false
 }
 
-// checkConsulServers uses the Kubernetes list function to report if the consul servers are healthy.
-func (c *Command) checkConsulServers(namespace string) (string, error) {
-	servers, err := c.kubernetes.AppsV1().StatefulSets(namespace).List(c.Ctx,
-		metav1.ListOptions{LabelSelector: "app=consul,chart=consul-helm,component=server"})
+// checkConsulAgents prints the status of Consul servers and clients if they
+// are expected to be found in the Kubernetes cluster. It does not check for
+// server status if they are not running within the Kubernetes cluster.
+func (c *Command) checkConsulAgents(namespace string) error {
+	// Check clients (TODO this can be removed when more users are using Agentless Consul - t-eckert 7 Oct 22)
+	clients, err := c.kubernetes.AppsV1().DaemonSets(namespace).List(c.Ctx, metav1.ListOptions{LabelSelector: "app=consul,chart=consul-helm"})
 	if err != nil {
-		return "", err
-	} else if len(servers.Items) == 0 {
-		return "", errors.New("no server stateful set found")
-	} else if len(servers.Items) > 1 {
-		return "", errors.New("found multiple server stateful sets")
+		return err
+	}
+	if len(clients.Items) != 0 {
+		desiredClients, readyClients := int(clients.Items[0].Status.DesiredNumberScheduled), int(clients.Items[0].Status.NumberReady)
+		if readyClients < desiredClients {
+			c.UI.Output("Consul Clients Healthy %d/%d", readyClients, desiredClients, terminal.WithErrorStyle())
+		} else {
+			c.UI.Output("Consul Clients Healthy %d/%d", readyClients, desiredClients)
+		}
 	}
 
-	desiredReplicas := int(*servers.Items[0].Spec.Replicas)
-	readyReplicas := int(servers.Items[0].Status.ReadyReplicas)
-	if readyReplicas < desiredReplicas {
-		return "", fmt.Errorf("%d/%d Consul servers unhealthy", desiredReplicas-readyReplicas, desiredReplicas)
+	// Check servers if deployed within Kubernetes cluster.
+	servers, err := c.kubernetes.AppsV1().StatefulSets(namespace).List(c.Ctx, metav1.ListOptions{LabelSelector: "app=consul,chart=consul-helm,component=server"})
+	if err != nil {
+		return err
 	}
-	return fmt.Sprintf("Consul servers healthy (%d/%d)", readyReplicas, desiredReplicas), nil
+	if len(servers.Items) != 0 {
+		desiredServers, readyServers := int(*servers.Items[0].Spec.Replicas), int(servers.Items[0].Status.ReadyReplicas)
+		if readyServers < desiredServers {
+			c.UI.Output("Consul Servers Healthy %d/%d", readyServers, desiredServers, terminal.WithErrorStyle())
+		} else {
+			c.UI.Output("Consul Servers Healthy %d/%d", readyServers, desiredServers)
+		}
+	}
+
+	return nil
 }
 
 // setupKubeClient to use for non Helm SDK calls to the Kubernetes API The Helm SDK will use

--- a/cli/cmd/status/status.go
+++ b/cli/cmd/status/status.go
@@ -120,7 +120,7 @@ func (c *Command) Run(args []string) int {
 	}
 
 	if err := c.checkConsulServers(namespace); err != nil {
-		c.UI.Output("Unable to check Kubernetes cluster for Consul agents: %v", err)
+		c.UI.Output("Unable to check Kubernetes cluster for Consul servers: %v", err)
 		return 1
 	}
 

--- a/cli/cmd/status/status_test.go
+++ b/cli/cmd/status/status_test.go
@@ -173,7 +173,7 @@ func TestStatus(t *testing.T) {
 			input: []string{},
 			messages: []string{
 				fmt.Sprintf("\n==> Consul Status Summary\nName\tNamespace\tStatus\tChart Version\tAppVersion\tRevision\tLast Updated            \n    \t         \tREADY \t1.0.0        \t          \t0       \t%s\t\n", notImeStr),
-				"\n==> Config:\n    {}\n    \n ✓ Consul servers healthy (3/3)\n",
+				"\n==> Config:\n    {}\n    \nConsul Clients Healthy 3/3\nConsul Servers Healthy 3/3\n",
 			},
 			preProcessingFunc: func(k8s kubernetes.Interface) {
 				createDaemonset("consul-client-test1", "consul", 3, 3, k8s)
@@ -195,39 +195,14 @@ func TestStatus(t *testing.T) {
 			},
 			expectedReturnCode: 0,
 		},
-		"status with no servers returns error": {
-			input: []string{},
-			messages: []string{
-				fmt.Sprintf("\n==> Consul Status Summary\nName\tNamespace\tStatus\tChart Version\tAppVersion\tRevision\tLast Updated            \n    \t         \tREADY \t1.0.0        \t          \t0       \t%s\t\n", notImeStr),
-				"\n==> Config:\n    {}\n    \n ! no server stateful set found\n",
-			},
-			preProcessingFunc: func(k8s kubernetes.Interface) {
-				createDaemonset("consul-client-test1", "consul", 3, 3, k8s)
-			},
-			helmActionsRunner: &helm.MockActionRunner{
-				GetStatusFunc: func(status *action.Status, name string) (*helmRelease.Release, error) {
-					return &helmRelease.Release{
-						Name: "consul", Namespace: "consul",
-						Info: &helmRelease.Info{LastDeployed: nowTime, Status: "READY"},
-						Chart: &chart.Chart{
-							Metadata: &chart.Metadata{
-								Version: "1.0.0",
-							},
-						},
-						Config: make(map[string]interface{})}, nil
-				},
-			},
-			expectedReturnCode: 1,
-		},
 		"status with pre-install and pre-upgrade hooks returns success and outputs hook status": {
 			input: []string{},
 			messages: []string{
 				fmt.Sprintf("\n==> Consul Status Summary\nName\tNamespace\tStatus\tChart Version\tAppVersion\tRevision\tLast Updated            \n    \t         \tREADY \t1.0.0        \t          \t0       \t%s\t\n", notImeStr),
 				"\n==> Config:\n    {}\n    \n",
-				"\n==> Status Of Helm Hooks:\npre-install-hook pre-install: Succeeded\npre-upgrade-hook pre-upgrade: Succeeded\n ✓ Consul servers healthy (3/3)\n",
+				"\n==> Status Of Helm Hooks:\npre-install-hook pre-install: Succeeded\npre-upgrade-hook pre-upgrade: Succeeded\nConsul Servers Healthy 3/3\n",
 			},
 			preProcessingFunc: func(k8s kubernetes.Interface) {
-				createDaemonset("consul-client-test1", "consul", 3, 3, k8s)
 				createStatefulSet("consul-server-test1", "consul", 3, 3, k8s)
 			},
 

--- a/cli/common/terminal/basic.go
+++ b/cli/common/terminal/basic.go
@@ -79,7 +79,7 @@ func (ui *basicUI) Interactive() bool {
 	return isatty.IsTerminal(os.Stdin.Fd())
 }
 
-// Output implements UI.
+// Output prints the given message using the formatting options passed in.
 func (ui *basicUI) Output(msg string, raw ...interface{}) {
 	msg, style, w := ui.parse(msg, raw...)
 
@@ -115,7 +115,6 @@ func (ui *basicUI) Output(msg string, raw ...interface{}) {
 		msg = strings.Join(lines, "\n")
 	}
 
-	// Write it
 	fmt.Fprintln(w, msg)
 }
 

--- a/cli/common/terminal/ui.go
+++ b/cli/common/terminal/ui.go
@@ -7,6 +7,36 @@ import (
 	"github.com/fatih/color"
 )
 
+const (
+	HeaderStyle        = "header"
+	ErrorStyle         = "error"
+	ErrorBoldStyle     = "error-bold"
+	WarningStyle       = "warning"
+	WarningBoldStyle   = "warning-bold"
+	InfoStyle          = "info"
+	LibraryStyle       = "library"
+	SuccessStyle       = "success"
+	SuccessBoldStyle   = "success-bold"
+	DiffUnchangedStyle = "diff-unchanged"
+	DiffAddedStyle     = "diff-added"
+	DiffRemovedStyle   = "diff-removed"
+)
+
+var (
+	colorHeader        = color.New(color.Bold)
+	colorInfo          = color.New()
+	colorError         = color.New(color.FgRed)
+	colorErrorBold     = color.New(color.FgRed, color.Bold)
+	colorLibrary       = color.New(color.FgCyan)
+	colorSuccess       = color.New(color.FgGreen)
+	colorSuccessBold   = color.New(color.FgGreen, color.Bold)
+	colorWarning       = color.New(color.FgYellow)
+	colorWarningBold   = color.New(color.FgYellow, color.Bold)
+	colorDiffUnchanged = color.New()
+	colorDiffAdded     = color.New(color.FgGreen)
+	colorDiffRemoved   = color.New(color.FgRed)
+)
+
 // ErrNonInteractive is returned when Input is called on a non-Interactive UI.
 var ErrNonInteractive = errors.New("noninteractive UI doesn't support this operation")
 
@@ -64,21 +94,6 @@ type Input struct {
 	// True if this input is a secret. The input will be masked.
 	Secret bool
 }
-
-const (
-	HeaderStyle        = "header"
-	ErrorStyle         = "error"
-	ErrorBoldStyle     = "error-bold"
-	WarningStyle       = "warning"
-	WarningBoldStyle   = "warning-bold"
-	InfoStyle          = "info"
-	LibraryStyle       = "library"
-	SuccessStyle       = "success"
-	SuccessBoldStyle   = "success-bold"
-	DiffUnchangedStyle = "diff-unchanged"
-	DiffAddedStyle     = "diff-added"
-	DiffRemovedStyle   = "diff-removed"
-)
 
 type config struct {
 	// Writer is where the message will be written to.
@@ -167,18 +182,3 @@ func WithStyle(style string) Option {
 func WithWriter(w io.Writer) Option {
 	return func(c *config) { c.Writer = w }
 }
-
-var (
-	colorHeader        = color.New(color.Bold)
-	colorInfo          = color.New()
-	colorError         = color.New(color.FgRed)
-	colorErrorBold     = color.New(color.FgRed, color.Bold)
-	colorLibrary       = color.New(color.FgCyan)
-	colorSuccess       = color.New(color.FgGreen)
-	colorSuccessBold   = color.New(color.FgGreen, color.Bold)
-	colorWarning       = color.New(color.FgYellow)
-	colorWarningBold   = color.New(color.FgYellow, color.Bold)
-	colorDiffUnchanged = color.New()
-	colorDiffAdded     = color.New(color.FgGreen)
-	colorDiffRemoved   = color.New(color.FgRed)
-)


### PR DESCRIPTION
Previously, if a user had servers deployed outside of a given K8s cluster, the `status` command would fail when it attempted to show the health status of servers. We recently removed a similar feature for clients which had the same problem when we moved to the "agentless" architecture. 

This PR changes the status command to only print the health status of clients and servers if they are expected to be present in the K8s cluster. If the user is running with the agentless architecture or has servers deployed outside of the cluster (e.g. HCP). The `status` command will simply not show the health status instead of failing.

Changes proposed in this PR:
- Only show health status for servers if they are expected to be present in the K8s cluster.
- Move some constants and vars up to the top of a file where I think it makes more sense for them to be. 
- Fix any tests broken as a result of this change.

<details>
  <summary>Screenshots</summary>
  <strong>Agentless status with unhealthy servers</strong>
  <img width="1021" alt="no-clients-yes-servers-unhealthy" src="https://user-images.githubusercontent.com/29112081/194903981-1326c568-7537-46de-8eea-6d9231c82210.png">

  <strong>Agentless status with healthy servers</strong>
  <img width="1021" alt="no-clients-yes-servers-healthy" src="https://user-images.githubusercontent.com/29112081/194904163-037bef2f-cf15-49e6-a1c2-7d26fe231f84.png">

  <strong>0.48.0 unhealthy clients and servers</strong>
  <img width="1021" alt="clients-and-servers-unhealthy" src="https://user-images.githubusercontent.com/29112081/194904291-ce01b26f-dde4-4cb1-881b-4b8f23a78e3e.png">

  <strong>0.48.0 unhealthy clients and healthy servers</strong>
  <img width="1021" alt="clients-and-servers-semi-healthy" src="https://user-images.githubusercontent.com/29112081/194904329-e08c8b87-efb4-4114-813d-4d698770e353.png">

  <strong>0.48.0 healthy clients a
  <img width="1021" alt="clients-and-servers-healthy" src="https://user-images.githubusercontent.com/29112081/194904397-d30a98f4-56dd-48f2-92e8-19ff2262fad9.png">
nd servers</strong>

</details>

How I've tested this PR:
- Unit tests for the CLI cover this change.
- Deployed Consul to a Kind cluster and ran the status command both when the clients/servers were not ready and as they came online.

How I expect reviewers to test this PR:
- Running unit tests to check the behavior is expected.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

