### PR TITLE
1.0.0-beta3 post release - Put main back in dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## UNRELEASED
+
 ## 1.0.0-beta3 (October 12, 2022)
 
 FEATURES:

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: consul
-version: 1.0.0-beta3
+version: 1.0.0-dev
 appVersion: 1.14.0-beta1
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Consul Chart
@@ -15,7 +15,7 @@ annotations:
     - name: consul
       image: hashicorp/consul:1.14.0-beta1
     - name: consul-k8s-control-plane
-      image: hashicorp/consul-k8s-control-plane:1.0.0-beta3
+      image: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.0.0-dev
     - name: envoy
       image: envoyproxy/envoy:v1.23.1
   artifacthub.io/license: MPL-2.0

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -129,7 +129,7 @@ global:
   # image that is used for functionality such as catalog sync.
   # This can be overridden per component.
   # @default: hashicorp/consul-k8s-control-plane:<latest version>
-  imageK8S: hashicorp/consul-k8s-control-plane:1.0.0-beta3
+  imageK8S: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.0.0-dev
 
   # The name of the datacenter that the agents should
   # register as. This can't be changed once the Consul cluster is up and running

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -19,7 +19,7 @@ var (
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "beta3"
+	VersionPrerelease = "dev"
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable

--- a/control-plane/version/version.go
+++ b/control-plane/version/version.go
@@ -19,7 +19,7 @@ var (
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "beta3"
+	VersionPrerelease = "dev"
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
Changes proposed in this PR:
- PR from [this step](https://github.com/hashicorp/engineering-docs/blob/main/consul/consul-k8s/release-process.md#prepare-main-for-next-dev-cycle) in the release process

How I've tested this PR:
👀 

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

