### PR TITLE
remove deprecated annotations in server-service template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+IMPROVEMENTS:
+* Helm:
+  * Remove use of deprecated annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"` in server-service template. [[GH-1619](https://github.com/hashicorp/consul-k8s/pull/1619)]
+
 ## 1.0.0-beta3 (October 12, 2022)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 IMPROVEMENTS:
 * Helm:
-  * Remove use of deprecated annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"` in server-service template. [[GH-1619](https://github.com/hashicorp/consul-k8s/pull/1619)]
+  * Remove deprecated annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"` in the `server-service` template. [[GH-1619](https://github.com/hashicorp/consul-k8s/pull/1619)]
 
 ## 1.0.0-beta3 (October 12, 2022)
 

--- a/charts/consul/templates/server-service.yaml
+++ b/charts/consul/templates/server-service.yaml
@@ -19,10 +19,6 @@ metadata:
     {{- if .Values.server.service.annotations }}
     {{ tpl .Values.server.service.annotations . | nindent 4 | trim }}
     {{- end }}
-    # This must be set in addition to publishNotReadyAddresses due
-    # to an open issue where it may not work:
-    # https://github.com/kubernetes/kubernetes/issues/58662
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   clusterIP: None
   # We want the servers to become available even if they're not ready

--- a/charts/consul/test/unit/server-service.bats
+++ b/charts/consul/test/unit/server-service.bats
@@ -98,6 +98,15 @@ load _helpers
 #--------------------------------------------------------------------
 # annotations
 
+@test "server/Service: no annotation by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-service.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations | length' | tee /dev/stderr)
+  [ "${actual}" = "0" ]
+}
+
 @test "server/Service: can set annotations" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/server-service.bats
+++ b/charts/consul/test/unit/server-service.bats
@@ -42,11 +42,6 @@ load _helpers
 # this is such an important part of making everything work we verify it here.
 @test "server/Service: tolerates unready endpoints" {
   cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/server-service.yaml  \
-      . | tee /dev/stderr |
-      yq -r '.metadata.annotations["service.alpha.kubernetes.io/tolerate-unready-endpoints"]' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
 
   local actual=$(helm template \
       -s templates/server-service.yaml  \
@@ -102,15 +97,6 @@ load _helpers
 
 #--------------------------------------------------------------------
 # annotations
-
-@test "server/Service: one annotation by default" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/server-service.yaml  \
-      . | tee /dev/stderr |
-      yq -r '.metadata.annotations | length' | tee /dev/stderr)
-  [ "${actual}" = "1" ]
-}
 
 @test "server/Service: can set annotations" {
   cd `chart_dir`


### PR DESCRIPTION
Changes proposed in this PR:
- We previously relied on setting an annotation ` service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"` which has been deprecated for 5 years and replaced with `spec.publicNotReadyAddresses` which we also already use.
- Remove it and continue to use the correct spec field on the server-service.yaml.

https://github.com/kubernetes/kubernetes/pull/63742
https://github.com/kubernetes/kubernetes/issues/63741

How I've tested this PR:
CI and Unit tests should pass.
Bats test updated.

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

