### PR TITLE
agentless: enable transparent proxy when running within a single k8s cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,6 @@ commands:
                     if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 2h -failfast \
                           << parameters.additional-flags >> \
                           -enable-multi-cluster \
-                          ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -debug-directory="$TEST_RESULTS/debug" \
                           -consul-k8s-image=<< parameters.consul-k8s-image >>
                     then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,7 @@ commands:
                     if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 2h -failfast \
                           << parameters.additional-flags >> \
                           -enable-multi-cluster \
+                          ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -debug-directory="$TEST_RESULTS/debug" \
                           -consul-k8s-image=<< parameters.consul-k8s-image >>
                     then
@@ -533,7 +534,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -consul-image=ishustava/consul:latest@sha256:3985a25200ef3f593c75ffbbbadc9fcc3a1d07da4aafb2222ab65e9e893d468a
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -566,7 +567,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -consul-image=ishustava/consul:latest@sha256:3985a25200ef3f593c75ffbbbadc9fcc3a1d07da4aafb2222ab65e9e893d468a
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -599,7 +600,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -enable-cni -consul-image=ishustava/consul:latest@sha256:3985a25200ef3f593c75ffbbbadc9fcc3a1d07da4aafb2222ab65e9e893d468a
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -enable-cni -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -717,7 +717,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-pod-security-policies -consul-image=hashicorppreview/consul-enterprise:1.14-dev
+          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-pod-security-policies -enable-transparent-proxy -consul-image=hashicorppreview/consul-enterprise:1.14-dev
 
       - store_test_results:
           path: /tmp/test-results
@@ -841,7 +841,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -use-aks -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -consul-image=hashicorppreview/consul-enterprise:1.14-dev
+          additional-flags: -use-aks -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-transparent-proxy -consul-image=hashicorppreview/consul-enterprise:1.14-dev
 
       - store_test_results:
           path: /tmp/test-results
@@ -958,7 +958,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -consul-image=hashicorppreview/consul-enterprise:1.14-dev
+          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-transparent-proxy -consul-image=hashicorppreview/consul-enterprise:1.14-dev
 
       - store_test_results:
           path: /tmp/test-results
@@ -1144,7 +1144,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           consul-k8s-image: $CONSUL_K8S_IMAGE
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -consul-image=$CONSUL_IMAGE -consul-version="1.12" -envoy-image=$ENVOY_IMAGE -helm-chart-version=$HELM_CHART_VERSION
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -consul-image=$CONSUL_IMAGE -consul-version="1.12" -envoy-image=$ENVOY_IMAGE -helm-chart-version=$HELM_CHART_VERSION -enable-transparent-proxy
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -1206,7 +1206,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           consul-k8s-image: $CONSUL_K8S_IMAGE
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -consul-image=$CONSUL_IMAGE -consul-version="1.13" -envoy-image=$ENVOY_IMAGE -helm-chart-version=$HELM_CHART_VERSION
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -consul-image=$CONSUL_IMAGE -consul-version="1.13" -envoy-image=$ENVOY_IMAGE -helm-chart-version=$HELM_CHART_VERSION -enable-transparent-proxy
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -1237,14 +1237,14 @@ workflows:
           context: consul-ci
           requires:
             - dev-upload-docker
-#      - acceptance-tproxy-cni:
-#          context: consul-ci
-#          requires:
-#            - dev-upload-docker
-#      - acceptance-tproxy:
-#          context: consul-ci
-#          requires:
-#            - dev-upload-docker
+      - acceptance-tproxy-cni:
+          context: consul-ci
+          requires:
+            - dev-upload-docker
+      - acceptance-tproxy:
+          context: consul-ci
+          requires:
+            - dev-upload-docker
   nightly-acceptance-tests:
     triggers:
       - schedule:
@@ -1272,26 +1272,23 @@ workflows:
           requires:
             - cleanup-gcp-resources
             - dev-upload-docker
-# TODO (agentless): re-enable once tproxy is supported
-#      - acceptance-gke-cni-1-23:
-#          requires:
-#            - acceptance-gke-1-23
+      - acceptance-gke-cni-1-23:
+          requires:
+            - acceptance-gke-1-23
       - acceptance-eks-1-21:
           requires:
             - cleanup-eks-resources
             - dev-upload-docker
-# TODO (agentless): re-enable once tproxy is supported
-#      - acceptance-eks-cni-1-21:
-#          requires:
-#            - acceptance-eks-1-21
+      - acceptance-eks-cni-1-21:
+          requires:
+            - acceptance-eks-1-21
       - acceptance-aks-1-22:
           requires:
             - cleanup-azure-resources
             - dev-upload-docker
-# TODO (agentless): re-enable once tproxy is supported
-#      - acceptance-aks-cni-1-22:
-#          requires:
-#            - acceptance-aks-1-22
+      - acceptance-aks-cni-1-22:
+          requires:
+            - acceptance-aks-1-22
 
   nightly-acceptance-tests-consul:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -582,7 +582,7 @@ jobs:
     steps:
       - checkout
       - install-prereqs
-      - create-kind-clusters:
+      - create-kind-cni-clusters:
           version: "v1.24.4"
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,7 +534,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -consul-image=hashicorppreview/consul-enterprise:1.14-dev
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -consul-image=ishustava/consul:latest@sha256:3985a25200ef3f593c75ffbbbadc9fcc3a1d07da4aafb2222ab65e9e893d468a
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -567,7 +567,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -consul-image=hashicorppreview/consul-enterprise:1.14-dev
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -consul-image=ishustava/consul:latest@sha256:3985a25200ef3f593c75ffbbbadc9fcc3a1d07da4aafb2222ab65e9e893d468a
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
@@ -600,7 +600,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
       - run-acceptance-tests:
           failfast: true
-          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -enable-cni
+          additional-flags: -use-kind -kubecontext="kind-dc1" -secondary-kubecontext="kind-dc2" -enable-transparent-proxy -enable-cni -consul-image=ishustava/consul:latest@sha256:3985a25200ef3f593c75ffbbbadc9fcc3a1d07da4aafb2222ab65e9e893d468a
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:

--- a/.github/workflows/reusable-acceptance.yml
+++ b/.github/workflows/reusable-acceptance.yml
@@ -52,7 +52,8 @@ jobs:
           - {runner: "3", test-packages: "ingress-gateway"}
           - {runner: "4", test-packages: "partitions"}
           - {runner: "5", test-packages: "peering"}
-          - {runner: "6", test-packages: "snapshot-agent sync terminating-gateway vault wan-federation"}
+          - {runner: "6", test-packages: "snapshot-agent vault wan-federation"}
+          - {runner: "7", test-packages: "cli sync terminating-gateway"}
 
       fail-fast: false
     steps:      

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,19 +344,17 @@ jobs:
           target: release-default
           tags: docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.version }}-pr-${{ github.sha }}
 
-# TODO (agentless): re-enable once tproxy is supported
-#  acceptance-tproxy:
-#    #needs: [get-go-version, unit-cli, dev-upload-docker, unit-acceptance-framework, unit-test-helm-templates]
-#    needs: dev-upload-docker
-#    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
-#    with:
-#      name: acceptance-tproxy
-#      directory: acceptance/tests
-#      go-version: ${{ needs.get-go-version.outputs.go-version }}
-#      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -consul-image=hashicorppreview/consul-enterprise:1.14-dev"
-#      gotestsum-version: 1.8.2
-#    secrets:
-#      CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
+  acceptance-tproxy:
+    needs: [ get-product-version, dev-upload-docker, get-go-version ]
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
+    with:
+      name: acceptance-tproxy
+      directory: acceptance/tests
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -consul-image=hashicorppreview/consul-enterprise:1.14-dev"
+      gotestsum-version: 1.8.2
+    secrets:
+      CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
 
   acceptance:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
@@ -371,17 +369,16 @@ jobs:
     secrets:
       CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
 
-# TODO (agentless): re-enable once tproxy is supported
-#  acceptance-cni:
-#    needs: dev-upload-docker
-#    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
-#    with:
-#      name: acceptance
-#      directory: acceptance/tests
-#      go-version: ${{ needs.get-go-version.outputs.go-version }}
-#      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -enable-cni -consul-image=hashicorppreview/consul-enterprise:1.14-dev"
-#      gotestsum-version: 1.8.2
-#    secrets:
-#      CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
+  acceptance-cni:
+    needs: [ get-product-version, dev-upload-docker, get-go-version ]
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
+    with:
+      name: acceptance
+      directory: acceptance/tests
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -enable-cni -consul-image=hashicorppreview/consul-enterprise:1.14-dev"
+      gotestsum-version: 1.8.2
+    secrets:
+      CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,18 +344,6 @@ jobs:
           target: release-default
           tags: docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.version }}-pr-${{ github.sha }}
 
-  acceptance-tproxy:
-    needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
-    with:
-      name: acceptance-tproxy
-      directory: acceptance/tests
-      go-version: ${{ needs.get-go-version.outputs.go-version }}
-      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
-      gotestsum-version: 1.8.2
-    secrets:
-      CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
-
   acceptance:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
     uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
@@ -369,16 +357,29 @@ jobs:
     secrets:
       CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
 
-  acceptance-cni:
-    needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
-    with:
-      name: acceptance
-      directory: acceptance/tests
-      go-version: ${{ needs.get-go-version.outputs.go-version }}
-      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -enable-cni -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
-      gotestsum-version: 1.8.2
-    secrets:
-      CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
+# TODO: re-enable once github supports more concurrent runners
+#  acceptance-tproxy:
+#    needs: [ get-product-version, dev-upload-docker, get-go-version ]
+#    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
+#    with:
+#      name: acceptance-tproxy
+#      directory: acceptance/tests
+#      go-version: ${{ needs.get-go-version.outputs.go-version }}
+#      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
+#      gotestsum-version: 1.8.2
+#    secrets:
+#      CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
+#
+#  acceptance-cni:
+#    needs: [ get-product-version, dev-upload-docker, get-go-version ]
+#    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
+#    with:
+#      name: acceptance
+#      directory: acceptance/tests
+#      go-version: ${{ needs.get-go-version.outputs.go-version }}
+#      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -enable-cni -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
+#      gotestsum-version: 1.8.2
+#    secrets:
+#      CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -351,7 +351,7 @@ jobs:
       name: acceptance-tproxy
       directory: acceptance/tests
       go-version: ${{ needs.get-go-version.outputs.go-version }}
-      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -consul-image=hashicorppreview/consul-enterprise:1.14-dev"
+      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
       gotestsum-version: 1.8.2
     secrets:
       CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
@@ -363,7 +363,7 @@ jobs:
       name: acceptance
       directory: acceptance/tests
       go-version: ${{ needs.get-go-version.outputs.go-version }}
-      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -consul-image=hashicorppreview/consul-enterprise:1.14-dev"
+      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
       gotestsum-version: 1.8.2
       consul-k8s-image: docker.io/hashicorppreview/${{ github.event.repository.name }}-control-plane:${{ needs.get-product-version.outputs.product-version }}-pr-${{ github.sha }}
     secrets:
@@ -376,7 +376,7 @@ jobs:
       name: acceptance
       directory: acceptance/tests
       go-version: ${{ needs.get-go-version.outputs.go-version }}
-      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -enable-cni -consul-image=hashicorppreview/consul-enterprise:1.14-dev"
+      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -enable-cni -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
       gotestsum-version: 1.8.2
     secrets:
       CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -357,29 +357,30 @@ jobs:
     secrets:
       CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
 
-# TODO: re-enable once github supports more concurrent runners
-#  acceptance-tproxy:
-#    needs: [ get-product-version, dev-upload-docker, get-go-version ]
-#    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
-#    with:
-#      name: acceptance-tproxy
-#      directory: acceptance/tests
-#      go-version: ${{ needs.get-go-version.outputs.go-version }}
-#      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
-#      gotestsum-version: 1.8.2
-#    secrets:
-#      CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
-#
-#  acceptance-cni:
-#    needs: [ get-product-version, dev-upload-docker, get-go-version ]
-#    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
-#    with:
-#      name: acceptance
-#      directory: acceptance/tests
-#      go-version: ${{ needs.get-go-version.outputs.go-version }}
-#      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -enable-cni -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
-#      gotestsum-version: 1.8.2
-#    secrets:
-#      CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
+  acceptance-tproxy:
+    needs: [ get-product-version, dev-upload-docker, get-go-version ]
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
+    with:
+      name: acceptance-tproxy
+      directory: acceptance/tests
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
+      gotestsum-version: 1.8.2
+      consul-k8s-image: docker.io/hashicorppreview/${{ github.event.repository.name }}-control-plane:${{ needs.get-product-version.outputs.product-version }}-pr-${{ github.sha }}
+    secrets:
+      CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
+
+  acceptance-cni:
+    needs: [ get-product-version, dev-upload-docker, get-go-version ]
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
+    with:
+      name: acceptance
+      directory: acceptance/tests
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+      additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -enable-cni -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
+      gotestsum-version: 1.8.2
+      consul-k8s-image: docker.io/hashicorppreview/${{ github.event.repository.name }}-control-plane:${{ needs.get-product-version.outputs.product-version }}-pr-${{ github.sha }}
+    secrets:
+      CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
 
 

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -140,6 +140,10 @@ func (h *HelmCluster) Destroy(t *testing.T) {
 
 	// Ignore the error returned by the helm delete here so that we can
 	// always idempotently clean up resources in the cluster.
+	h.helmOptions.ExtraArgs = map[string][]string{
+		"--wait":    nil,
+		"--timeout": {"2min"},
+	}
 	_ = helm.DeleteE(t, h.helmOptions, h.releaseName, false)
 
 	// Retry because sometimes certain resources (like PVC) take time to delete

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -144,7 +144,8 @@ func (h *HelmCluster) Destroy(t *testing.T) {
 		"--wait":    nil,
 		"--timeout": {"2min"},
 	}
-	_ = helm.DeleteE(t, h.helmOptions, h.releaseName, false)
+	err := helm.DeleteE(t, h.helmOptions, h.releaseName, false)
+	require.NoError(t, err)
 
 	// Retry because sometimes certain resources (like PVC) take time to delete
 	// in cloud providers.

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -141,8 +141,7 @@ func (h *HelmCluster) Destroy(t *testing.T) {
 	// Ignore the error returned by the helm delete here so that we can
 	// always idempotently clean up resources in the cluster.
 	h.helmOptions.ExtraArgs = map[string][]string{
-		"--wait":    nil,
-		"--timeout": {"2min"},
+		"--wait": nil,
 	}
 	err := helm.DeleteE(t, h.helmOptions, h.releaseName, false)
 	require.NoError(t, err)

--- a/acceptance/tests/basic/basic_test.go
+++ b/acceptance/tests/basic/basic_test.go
@@ -50,6 +50,7 @@ func TestBasicInstallation(t *testing.T) {
 				"global.tls.enabled":                   strconv.FormatBool(c.secure),
 				"global.gossipEncryption.autoGenerate": strconv.FormatBool(c.secure),
 				"global.tls.enableAutoEncrypt":         strconv.FormatBool(c.autoEncrypt),
+				"client.enabled":                       "true",
 			}
 			consulCluster := consul.NewHelmCluster(t, helmValues, suite.Environment().DefaultContext(t), suite.Config(), releaseName)
 

--- a/acceptance/tests/connect/connect_external_servers_test.go
+++ b/acceptance/tests/connect/connect_external_servers_test.go
@@ -20,7 +20,10 @@ import (
 // It sets up an external Consul server in the same cluster but a different Helm installation
 // and then treats this server as external.
 func TestConnectInject_ExternalServers(t *testing.T) {
-	for _, secure := range []bool{false, true} {
+	for _, secure := range []bool{
+		false,
+		true,
+	} {
 		caseName := fmt.Sprintf("secure: %t", secure)
 		t.Run(caseName, func(t *testing.T) {
 			cfg := suite.Config()
@@ -31,7 +34,8 @@ func TestConnectInject_ExternalServers(t *testing.T) {
 				"global.tls.enabled":           strconv.FormatBool(secure),
 
 				// This prevents controllers from being installed twice, causing a failure.
-				"controller.enabled": "false",
+				"controller.enabled":    "false",
+				"connectInject.enabled": "false",
 			}
 			serverReleaseName := helpers.RandomName()
 			consulServerCluster := consul.NewHelmCluster(t, serverHelmValues, ctx, cfg, serverReleaseName)

--- a/acceptance/tests/connect/connect_external_servers_test.go
+++ b/acceptance/tests/connect/connect_external_servers_test.go
@@ -33,9 +33,10 @@ func TestConnectInject_ExternalServers(t *testing.T) {
 				"global.acls.manageSystemACLs": strconv.FormatBool(secure),
 				"global.tls.enabled":           strconv.FormatBool(secure),
 
-				// This prevents controllers from being installed twice, causing a failure.
-				"controller.enabled":    "false",
-				"connectInject.enabled": "false",
+				// Don't install injector, controller and cni on this cluster so that it's not installed twice.
+				"controller.enabled":        "false",
+				"connectInject.enabled":     "false",
+				"connectInject.cni.enabled": "false",
 			}
 			serverReleaseName := helpers.RandomName()
 			consulServerCluster := consul.NewHelmCluster(t, serverHelmValues, ctx, cfg, serverReleaseName)

--- a/acceptance/tests/metrics/metrics_test.go
+++ b/acceptance/tests/metrics/metrics_test.go
@@ -103,6 +103,9 @@ func TestAppMetrics(t *testing.T) {
 		"global.datacenter":      "dc1",
 		"global.metrics.enabled": "true",
 
+		// todo (agentless): remove once we have consul-dataplane image with these changes.
+		"global.imageConsulDataplane": "curtbushko/consul-dataplane:latest",
+
 		"connectInject.enabled":                      "true",
 		"connectInject.metrics.defaultEnableMerging": "true",
 	}

--- a/acceptance/tests/metrics/metrics_test.go
+++ b/acceptance/tests/metrics/metrics_test.go
@@ -104,7 +104,7 @@ func TestAppMetrics(t *testing.T) {
 		"global.metrics.enabled": "true",
 
 		// todo (agentless): remove once we have consul-dataplane image with these changes.
-		"global.imageConsulDataplane": "curtbushko/consul-dataplane:latest",
+		"global.imageConsulDataplane": "hashicorppreview/consul-dataplane:1.0-dev",
 
 		"connectInject.enabled":                      "true",
 		"connectInject.metrics.defaultEnableMerging": "true",

--- a/acceptance/tests/partitions/main_test.go
+++ b/acceptance/tests/partitions/main_test.go
@@ -13,7 +13,8 @@ var suite testsuite.Suite
 func TestMain(m *testing.M) {
 	suite = testsuite.NewSuite(m)
 
-	if suite.Config().EnableMultiCluster {
+	// todo(agentless): Re-enable tproxy tests once we support it for multi-cluster.
+	if suite.Config().EnableMultiCluster && !suite.Config().EnableTransparentProxy {
 		os.Exit(suite.Run())
 	} else {
 		fmt.Println("Skipping partitions tests because -enable-multi-cluster is not set")

--- a/acceptance/tests/peering/main_test.go
+++ b/acceptance/tests/peering/main_test.go
@@ -13,7 +13,8 @@ var suite testsuite.Suite
 func TestMain(m *testing.M) {
 	suite = testsuite.NewSuite(m)
 
-	if suite.Config().EnableMultiCluster && !suite.Config().DisablePeering {
+	// todo(agentless): Re-enable tproxy tests once we support it for multi-cluster.
+	if suite.Config().EnableMultiCluster && !suite.Config().DisablePeering && !suite.Config().EnableTransparentProxy {
 		os.Exit(suite.Run())
 	} else {
 		fmt.Println("Skipping peering tests because either -enable-multi-cluster is not set or -disable-peering is set")

--- a/acceptance/tests/wan-federation/main_test.go
+++ b/acceptance/tests/wan-federation/main_test.go
@@ -13,7 +13,8 @@ var suite testsuite.Suite
 func TestMain(m *testing.M) {
 	suite = testsuite.NewSuite(m)
 
-	if suite.Config().EnableMultiCluster {
+	// todo(agentless): Re-enable tproxy tests once we support it for multi-cluster.
+	if suite.Config().EnableMultiCluster && !suite.Config().EnableTransparentProxy {
 		os.Exit(suite.Run())
 	} else {
 		fmt.Println("Skipping wan federation tests because -enable-multi-cluster is not set")

--- a/control-plane/connect-inject/mesh_webhook.go
+++ b/control-plane/connect-inject/mesh_webhook.go
@@ -256,10 +256,6 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 		pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, containerEnvVars...)
 	}
 
-	// Add the init container which copies the Consul binary to /consul/connect-inject/.
-	initCopyContainer := w.initCopyContainer()
-	pod.Spec.InitContainers = append(pod.Spec.InitContainers, initCopyContainer)
-
 	// A user can enable/disable tproxy for an entire namespace via a label.
 	ns, err := w.Clientset.CoreV1().Namespaces().Get(ctx, req.Namespace, metav1.GetOptions{})
 	if err != nil {
@@ -409,7 +405,6 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 	// plugin can apply redirect traffic rules on the pod.
 	if w.EnableCNI && tproxyEnabled {
 		if err := w.addRedirectTrafficConfigAnnotation(&pod, *ns); err != nil {
-			// todo: update this error message
 			w.Log.Error(err, "error configuring annotation for CNI traffic redirection", "request name", req.Name)
 			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error configuring annotation for CNI traffic redirection: %s", err))
 		}

--- a/control-plane/connect-inject/redirect_traffic.go
+++ b/control-plane/connect-inject/redirect_traffic.go
@@ -11,7 +11,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// todo(ishustava): add docs
+// addRedirectTrafficConfigAnnotation creates an iptables.Config in JSON format based on proxy configuration.
+// iptables.Config:
+//
+//	ConsulDNSIP: an environment variable named RESOURCE_PREFIX_DNS_SERVICE_HOST where RESOURCE_PREFIX is the consul.fullname in helm.
+//	ProxyUserID: a constant set in Annotations
+//	ProxyInboundPort: the service port or bind port
+//	ProxyOutboundPort: default transparent proxy outbound port or transparent proxy outbound listener port
+//	ExcludeInboundPorts: prometheus, envoy stats, expose paths, checks and excluded pod annotations
+//	ExcludeOutboundPorts: pod annotations
+//	ExcludeOutboundCIDRs: pod annotations
+//	ExcludeUIDs: pod annotations
 func (w *MeshWebhook) iptablesConfigJSON(pod corev1.Pod, ns corev1.Namespace) (string, error) {
 	cfg := iptables.Config{
 		ProxyUserID: strconv.Itoa(sidecarUserAndGroupID),
@@ -104,17 +114,7 @@ func (w *MeshWebhook) iptablesConfigJSON(pod corev1.Pod, ns corev1.Namespace) (s
 	return string(iptablesConfigJson), nil
 }
 
-// addRedirectTrafficConfigAnnotation creates an iptables.Config based on proxy configuration.
-// iptables.Config:
-//
-//	ConsulDNSIP: an environment variable named RESOURCE_PREFIX_DNS_SERVICE_HOST where RESOURCE_PREFIX is the consul.fullname in helm.
-//	ProxyUserID: a constant set in Annotations
-//	ProxyInboundPort: the service port or bind port
-//	ProxyOutboundPort: default transparent proxy outbound port or transparent proxy outbound listener port
-//	ExcludeInboundPorts: prometheus, envoy stats, expose paths, checks and excluded pod annotations
-//	ExcludeOutboundPorts: pod annotations
-//	ExcludeOutboundCIDRs: pod annotations
-//	ExcludeUIDs: pod annotations
+// addRedirectTrafficConfigAnnotation add the created iptables JSON config as an annotation on the provided pod.
 func (w *MeshWebhook) addRedirectTrafficConfigAnnotation(pod *corev1.Pod, ns corev1.Namespace) error {
 	iptablesConfig, err := w.iptablesConfigJSON(*pod, ns)
 	if err != nil {

--- a/control-plane/connect-inject/redirect_traffic.go
+++ b/control-plane/connect-inject/redirect_traffic.go
@@ -5,23 +5,14 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/consul/sdk/iptables"
 	corev1 "k8s.io/api/core/v1"
 )
 
-// addRedirectTrafficConfigAnnotation creates an iptables.Config based on proxy configuration.
-// iptables.Config:
-//
-//	ConsulDNSIP: an environment variable named RESOURCE_PREFIX_DNS_SERVICE_HOST where RESOURCE_PREFIX is the consul.fullname in helm.
-//	ProxyUserID: a constant set in Annotations
-//	ProxyInboundPort: the service port or bind port
-//	ProxyOutboundPort: default transparent proxy outbound port or transparent proxy outbound listener port
-//	ExcludeInboundPorts: prometheus, envoy stats, expose paths, checks and excluded pod annotations
-//	ExcludeOutboundPorts: pod annotations
-//	ExcludeOutboundCIDRs: pod annotations
-//	ExcludeUIDs: pod annotations
-func (w *MeshWebhook) addRedirectTrafficConfigAnnotation(pod *corev1.Pod, ns corev1.Namespace) error {
+// todo(ishustava): add docs
+func (w *MeshWebhook) iptablesConfigJSON(pod corev1.Pod, ns corev1.Namespace) (string, error) {
 	cfg := iptables.Config{
 		ProxyUserID: strconv.Itoa(sidecarUserAndGroupID),
 	}
@@ -33,22 +24,22 @@ func (w *MeshWebhook) addRedirectTrafficConfigAnnotation(pod *corev1.Pod, ns cor
 	cfg.ProxyOutboundPort = iptables.DefaultTProxyOutboundPort
 
 	// If metrics are enabled, get the prometheusScrapePort and exclude it from the inbound ports
-	enableMetrics, err := w.MetricsConfig.enableMetrics(*pod)
+	enableMetrics, err := w.MetricsConfig.enableMetrics(pod)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if enableMetrics {
-		prometheusScrapePort, err := w.MetricsConfig.prometheusScrapePort(*pod)
+		prometheusScrapePort, err := w.MetricsConfig.prometheusScrapePort(pod)
 		if err != nil {
-			return err
+			return "", err
 		}
 		cfg.ExcludeInboundPorts = append(cfg.ExcludeInboundPorts, prometheusScrapePort)
 	}
 
 	// Exclude any overwritten liveness/readiness/startup ports from redirection.
-	overwriteProbes, err := shouldOverwriteProbes(*pod, w.TProxyOverwriteProbes)
+	overwriteProbes, err := shouldOverwriteProbes(pod, w.TProxyOverwriteProbes)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	if overwriteProbes {
@@ -70,27 +61,27 @@ func (w *MeshWebhook) addRedirectTrafficConfigAnnotation(pod *corev1.Pod, ns cor
 	}
 
 	// Inbound ports
-	excludeInboundPorts := splitCommaSeparatedItemsFromAnnotation(annotationTProxyExcludeInboundPorts, *pod)
+	excludeInboundPorts := splitCommaSeparatedItemsFromAnnotation(annotationTProxyExcludeInboundPorts, pod)
 	cfg.ExcludeInboundPorts = append(cfg.ExcludeInboundPorts, excludeInboundPorts...)
 
 	// Outbound ports
-	excludeOutboundPorts := splitCommaSeparatedItemsFromAnnotation(annotationTProxyExcludeOutboundPorts, *pod)
+	excludeOutboundPorts := splitCommaSeparatedItemsFromAnnotation(annotationTProxyExcludeOutboundPorts, pod)
 	cfg.ExcludeOutboundPorts = append(cfg.ExcludeOutboundPorts, excludeOutboundPorts...)
 
 	// Outbound CIDRs
-	excludeOutboundCIDRs := splitCommaSeparatedItemsFromAnnotation(annotationTProxyExcludeOutboundCIDRs, *pod)
+	excludeOutboundCIDRs := splitCommaSeparatedItemsFromAnnotation(annotationTProxyExcludeOutboundCIDRs, pod)
 	cfg.ExcludeOutboundCIDRs = append(cfg.ExcludeOutboundCIDRs, excludeOutboundCIDRs...)
 
 	// UIDs
-	excludeUIDs := splitCommaSeparatedItemsFromAnnotation(annotationTProxyExcludeUIDs, *pod)
+	excludeUIDs := splitCommaSeparatedItemsFromAnnotation(annotationTProxyExcludeUIDs, pod)
 	cfg.ExcludeUIDs = append(cfg.ExcludeUIDs, excludeUIDs...)
 
 	// Add init container user ID to exclude from traffic redirection.
 	cfg.ExcludeUIDs = append(cfg.ExcludeUIDs, strconv.Itoa(initContainersUserAndGroupID))
 
-	dnsEnabled, err := consulDNSEnabled(ns, *pod, w.EnableConsulDNS)
+	dnsEnabled, err := consulDNSEnabled(ns, pod, w.EnableConsulDNS)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	var consulDNSClusterIP string
@@ -100,17 +91,46 @@ func (w *MeshWebhook) addRedirectTrafficConfigAnnotation(pod *corev1.Pod, ns cor
 		// the name of the env variable whose value is the ClusterIP of the Consul DNS Service.
 		consulDNSClusterIP = os.Getenv(w.constructDNSServiceHostName())
 		if consulDNSClusterIP == "" {
-			return fmt.Errorf("environment variable %s not found", w.constructDNSServiceHostName())
+			return "", fmt.Errorf("environment variable %s not found", w.constructDNSServiceHostName())
 		}
 		cfg.ConsulDNSIP = consulDNSClusterIP
 	}
 
 	iptablesConfigJson, err := json.Marshal(&cfg)
 	if err != nil {
-		return fmt.Errorf("could not marshal iptables config: %w", err)
+		return "", fmt.Errorf("could not marshal iptables config: %w", err)
 	}
 
-	pod.Annotations[annotationRedirectTraffic] = string(iptablesConfigJson)
+	return string(iptablesConfigJson), nil
+}
+
+// addRedirectTrafficConfigAnnotation creates an iptables.Config based on proxy configuration.
+// iptables.Config:
+//
+//	ConsulDNSIP: an environment variable named RESOURCE_PREFIX_DNS_SERVICE_HOST where RESOURCE_PREFIX is the consul.fullname in helm.
+//	ProxyUserID: a constant set in Annotations
+//	ProxyInboundPort: the service port or bind port
+//	ProxyOutboundPort: default transparent proxy outbound port or transparent proxy outbound listener port
+//	ExcludeInboundPorts: prometheus, envoy stats, expose paths, checks and excluded pod annotations
+//	ExcludeOutboundPorts: pod annotations
+//	ExcludeOutboundCIDRs: pod annotations
+//	ExcludeUIDs: pod annotations
+func (w *MeshWebhook) addRedirectTrafficConfigAnnotation(pod *corev1.Pod, ns corev1.Namespace) error {
+	iptablesConfig, err := w.iptablesConfigJSON(*pod, ns)
+	if err != nil {
+		return err
+	}
+
+	pod.Annotations[annotationRedirectTraffic] = iptablesConfig
 
 	return nil
+}
+
+// constructDNSServiceHostName use the resource prefix and the DNS Service hostname suffix to construct the
+// key of the env variable whose value is the cluster IP of the Consul DNS Service.
+// It translates "resource-prefix" into "RESOURCE_PREFIX_DNS_SERVICE_HOST".
+func (w *MeshWebhook) constructDNSServiceHostName() string {
+	upcaseResourcePrefix := strings.ToUpper(w.ResourcePrefix)
+	upcaseResourcePrefixWithUnderscores := strings.ReplaceAll(upcaseResourcePrefix, "-", "_")
+	return strings.Join([]string{upcaseResourcePrefixWithUnderscores, dnsServiceHostEnvSuffix}, "_")
 }

--- a/control-plane/subcommand/connect-init/command.go
+++ b/control-plane/subcommand/connect-init/command.go
@@ -360,6 +360,9 @@ func (c *Command) Help() string {
 	return c.help
 }
 
+// This below implementation is loosely based on
+// https://github.com/hashicorp/consul/blob/fe2d41ddad9ba2b8ff86cbdebbd8f05855b1523c/command/connect/redirecttraffic/redirect_traffic.go#L136.
+
 // trafficRedirectProxyConfig is a snippet of xds/config.go
 // with only the configuration values that we need to parse from Proxy.Config
 // to apply traffic redirection rules.

--- a/control-plane/subcommand/connect-init/command.go
+++ b/control-plane/subcommand/connect-init/command.go
@@ -404,7 +404,12 @@ func (c *Command) applyTrafficRedirectionRules(svc *api.AgentService) error {
 	}
 
 	// Configure any relevant information from the proxy service
-	return iptables.Setup(c.iptablesConfig)
+	err = iptables.Setup(c.iptablesConfig)
+	if err != nil {
+		return err
+	}
+	c.logger.Info("Successfully applied traffic redirection rules")
+	return nil
 }
 
 const synopsis = "Inject connect init command."

--- a/control-plane/subcommand/connect-init/command.go
+++ b/control-plane/subcommand/connect-init/command.go
@@ -2,9 +2,11 @@ package connectinit
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"os/signal"
 	"sync"
@@ -19,8 +21,10 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/flags"
 	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/iptables"
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
+	"github.com/mitchellh/mapstructure"
 )
 
 const (
@@ -33,14 +37,15 @@ const (
 type Command struct {
 	UI cli.Ui
 
-	flagConsulNodeName     string
-	flagPodName            string // Pod name.
-	flagPodNamespace       string // Pod namespace.
-	flagServiceAccountName string // Service account name.
-	flagServiceName        string // Service name.
-	flagGatewayKind        string
-	flagLogLevel           string
-	flagLogJSON            bool
+	flagConsulNodeName        string
+	flagPodName               string // Pod name.
+	flagPodNamespace          string // Pod namespace.
+	flagServiceAccountName    string // Service account name.
+	flagServiceName           string // Service name.
+	flagGatewayKind           string
+	flagRedirectTrafficConfig string
+	flagLogLevel              string
+	flagLogJSON               bool
 
 	flagProxyIDFile string // Location to write the output proxyID. Default is defaultProxyIDFile.
 	flagMultiPort   bool
@@ -57,6 +62,10 @@ type Command struct {
 	watcher *discovery.Watcher
 
 	nonRetryableError error
+
+	// Only used in tests.
+	iptablesProvider iptables.Provider
+	iptablesConfig   iptables.Config
 }
 
 func (c *Command) init() {
@@ -69,6 +78,7 @@ func (c *Command) init() {
 	c.flagSet.StringVar(&c.flagProxyIDFile, "proxy-id-file", defaultProxyIDFile, "File name where proxy's Consul service ID should be saved.")
 	c.flagSet.BoolVar(&c.flagMultiPort, "multiport", false, "If the pod is a multi port pod.")
 	c.flagSet.StringVar(&c.flagGatewayKind, "gateway-kind", "", "Kind of gateway that is being registered: ingress-gateway, terminating-gateway, or mesh-gateway.")
+	c.flagSet.StringVar(&c.flagRedirectTrafficConfig, "redirect-traffic-config", os.Getenv("CONSUL_REDIRECT_TRAFFIC_CONFIG"), "Config (in JSON format) to configure iptables for this pod.")
 	c.flagSet.StringVar(&c.flagLogLevel, "log-level", "info",
 		"Log verbosity level. Supported values (in order of detail) are \"trace\", "+
 			"\"debug\", \"info\", \"warn\", and \"error\".")
@@ -149,6 +159,7 @@ func (c *Command) Run(args []string) int {
 		c.logger.Error("Unable to get client connection", "error", err)
 		return 1
 	}
+	proxyService := &api.AgentService{}
 	if c.flagGatewayKind != "" {
 		err = backoff.Retry(c.getGatewayRegistration(consulClient), backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), c.serviceRegistrationPollingAttempts))
 		if err != nil {
@@ -160,7 +171,7 @@ func (c *Command) Run(args []string) int {
 			return 1
 		}
 	} else {
-		err = backoff.Retry(c.getConnectServiceRegistrations(consulClient), backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), c.serviceRegistrationPollingAttempts))
+		var err = backoff.Retry(c.getConnectServiceRegistrations(consulClient, proxyService), backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), c.serviceRegistrationPollingAttempts))
 		if err != nil {
 			c.logger.Error("Timed out waiting for service registration", "error", err)
 			return 1
@@ -179,11 +190,19 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
+	if c.flagRedirectTrafficConfig != "" {
+		err = c.applyTrafficRedirectionRules(proxyService)
+		if err != nil {
+			c.logger.Error("error applying traffic redirection rules", "err", err)
+			return 1
+		}
+	}
+
 	c.logger.Info("Connect initialization completed")
 	return 0
 }
 
-func (c *Command) getConnectServiceRegistrations(consulClient *api.Client) backoff.Operation {
+func (c *Command) getConnectServiceRegistrations(consulClient *api.Client, proxyService *api.AgentService) backoff.Operation {
 	var proxyID string
 	registrationRetryCount := 0
 	return func() error {
@@ -195,7 +214,8 @@ func (c *Command) getConnectServiceRegistrations(consulClient *api.Client) backo
 			// this one Pod. If so, we want to ensure the service and proxy matching our expected name is registered.
 			filter += fmt.Sprintf(` and (Service == %q or Service == "%s-sidecar-proxy")`, c.flagServiceName, c.flagServiceName)
 		}
-		serviceList, _, err := consulClient.Catalog().NodeServiceList(c.flagConsulNodeName, &api.QueryOptions{Filter: filter})
+		serviceList, _, err := consulClient.Catalog().NodeServiceList(c.flagConsulNodeName,
+			&api.QueryOptions{Filter: filter, MergeCentralConfig: true})
 		if err != nil {
 			c.logger.Error("Unable to get services", "error", err)
 			return err
@@ -235,6 +255,7 @@ func (c *Command) getConnectServiceRegistrations(consulClient *api.Client) backo
 			if svc.Kind == api.ServiceKindConnectProxy {
 				// This is the proxy service ID.
 				proxyID = svc.ID
+				*proxyService = *svc
 			}
 		}
 
@@ -247,7 +268,7 @@ func (c *Command) getConnectServiceRegistrations(consulClient *api.Client) backo
 		}
 
 		// Write the proxy ID to the shared volume so `consul connect envoy` can use it for bootstrapping.
-		if err := common.WriteFileWithPerms(c.flagProxyIDFile, proxyID, os.FileMode(0444)); err != nil {
+		if err = common.WriteFileWithPerms(c.flagProxyIDFile, proxyID, os.FileMode(0444)); err != nil {
 			// Save an error but return nil so that we don't retry this step.
 			c.nonRetryableError = err
 			return nil
@@ -337,6 +358,50 @@ func (c *Command) Synopsis() string { return synopsis }
 func (c *Command) Help() string {
 	c.once.Do(c.init)
 	return c.help
+}
+
+// trafficRedirectProxyConfig is a snippet of xds/config.go
+// with only the configuration values that we need to parse from Proxy.Config
+// to apply traffic redirection rules.
+type trafficRedirectProxyConfig struct {
+	BindPort      int    `mapstructure:"bind_port"`
+	StatsBindAddr string `mapstructure:"envoy_stats_bind_addr"`
+}
+
+func (c *Command) applyTrafficRedirectionRules(svc *api.AgentService) error {
+	err := json.Unmarshal([]byte(c.flagRedirectTrafficConfig), &c.iptablesConfig)
+	if err != nil {
+		return err
+	}
+	if c.iptablesProvider != nil {
+		c.iptablesConfig.IptablesProvider = c.iptablesProvider
+	}
+
+	if svc.Proxy.TransparentProxy != nil && svc.Proxy.TransparentProxy.OutboundListenerPort != 0 {
+		c.iptablesConfig.ProxyOutboundPort = svc.Proxy.TransparentProxy.OutboundListenerPort
+	}
+
+	// Decode proxy's opaque config so that we can use it later to configure
+	// traffic redirection with iptables.
+	var trCfg trafficRedirectProxyConfig
+	if err = mapstructure.WeakDecode(svc.Proxy.Config, &trCfg); err != nil {
+		return fmt.Errorf("failed parsing Proxy.Config: %s", err)
+	}
+	if trCfg.BindPort != 0 {
+		c.iptablesConfig.ProxyInboundPort = trCfg.BindPort
+	}
+
+	if trCfg.StatsBindAddr != "" {
+		_, port, err := net.SplitHostPort(trCfg.StatsBindAddr)
+		if err != nil {
+			return fmt.Errorf("failed parsing host and port from envoy_stats_bind_addr: %s", err)
+		}
+
+		c.iptablesConfig.ExcludeInboundPorts = append(c.iptablesConfig.ExcludeInboundPorts, port)
+	}
+
+	// Configure any relevant information from the proxy service
+	return iptables.Setup(c.iptablesConfig)
 }
 
 const synopsis = "Inject connect init command."

--- a/control-plane/subcommand/connect-init/command_test.go
+++ b/control-plane/subcommand/connect-init/command_test.go
@@ -1,10 +1,12 @@
 package connectinit
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -13,6 +15,7 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/iptables"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
@@ -730,6 +733,158 @@ func TestRun_InvalidProxyFile(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestRun_TrafficRedirection(t *testing.T) {
+	cases := map[string]struct {
+		proxyConfig           map[string]interface{}
+		tproxyConfig          api.TransparentProxyConfig
+		registerProxyDefaults bool
+		expIptablesParamsFunc func(actual iptables.Config) (bool, string)
+	}{
+		"no extra proxy config provided": {},
+		"envoy bind port is provided in service proxy config": {
+			proxyConfig: map[string]interface{}{"bind_port": "21000"},
+			expIptablesParamsFunc: func(actual iptables.Config) (bool, string) {
+				if actual.ProxyInboundPort == 21000 {
+					return true, ""
+				} else {
+					return false, fmt.Sprintf("ProxyInboundPort in iptables.Config was %d, but should be 21000", actual.ProxyInboundPort)
+				}
+			},
+		},
+		// This test is to make sure that we use merge-central-config parameter when we query the service
+		// so that we get all config merged into the proxy configuration on the service.
+		"envoy bind port is provided in a config entry": {
+			proxyConfig:           map[string]interface{}{"bind_port": "21000"},
+			registerProxyDefaults: true,
+			expIptablesParamsFunc: func(actual iptables.Config) (bool, string) {
+				if actual.ProxyInboundPort == 21000 {
+					return true, ""
+				} else {
+					return false, fmt.Sprintf("ProxyInboundPort in iptables.Config was %d, but should be 21000", actual.ProxyInboundPort)
+				}
+			},
+		},
+		"tproxy outbound listener port is provided in service proxy config": {
+			tproxyConfig: api.TransparentProxyConfig{OutboundListenerPort: 16000},
+			expIptablesParamsFunc: func(actual iptables.Config) (bool, string) {
+				if actual.ProxyOutboundPort == 16000 {
+					return true, ""
+				} else {
+					return false, fmt.Sprintf("ProxyOutboundPort in iptables.Config was %d, but should be 16000", actual.ProxyOutboundPort)
+				}
+			},
+		},
+		"tproxy outbound listener port is provided in a config entry": {
+			tproxyConfig:          api.TransparentProxyConfig{OutboundListenerPort: 16000},
+			registerProxyDefaults: true,
+			expIptablesParamsFunc: func(actual iptables.Config) (bool, string) {
+				if actual.ProxyOutboundPort == 16000 {
+					return true, ""
+				} else {
+					return false, fmt.Sprintf("ProxyOutboundPort in iptables.Config was %d, but should be 16000", actual.ProxyOutboundPort)
+				}
+			},
+		},
+		"envoy stats addr is provided in service proxy config": {
+			proxyConfig: map[string]interface{}{"envoy_stats_bind_addr": "0.0.0.0:9090"},
+			expIptablesParamsFunc: func(actual iptables.Config) (bool, string) {
+				if len(actual.ExcludeInboundPorts) == 1 && actual.ExcludeInboundPorts[0] == "9090" {
+					return true, ""
+				} else {
+					return false, fmt.Sprintf("ExcludeInboundPorts in iptables.Config was %v, but should be [9090]", actual.ExcludeInboundPorts)
+				}
+			},
+		},
+		"envoy stats addr is provided in a config entry": {
+			proxyConfig:           map[string]interface{}{"envoy_stats_bind_addr": "0.0.0.0:9090"},
+			registerProxyDefaults: true,
+			expIptablesParamsFunc: func(actual iptables.Config) (bool, string) {
+				if len(actual.ExcludeInboundPorts) == 1 && actual.ExcludeInboundPorts[0] == "9090" {
+					return true, ""
+				} else {
+					return false, fmt.Sprintf("ExcludeInboundPorts in iptables.Config was %v, but should be [9090]", actual.ExcludeInboundPorts)
+				}
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			proxyFile := fmt.Sprintf("/tmp/%d", rand.Int())
+			t.Cleanup(func() {
+				_ = os.Remove(proxyFile)
+			})
+
+			// Start Consul server.
+			var serverCfg *testutil.TestServerConfig
+			server, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
+				serverCfg = c
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = server.Stop()
+			})
+			server.WaitForLeader(t)
+			consulClient, err := api.NewClient(&api.Config{Address: server.HTTPAddr})
+			require.NoError(t, err)
+
+			// Add additional proxy configuration either to a config entry or to the service itself.
+			if c.registerProxyDefaults {
+				_, _, err = consulClient.ConfigEntries().Set(&api.ProxyConfigEntry{
+					Name:             api.ProxyConfigGlobal,
+					Kind:             api.ProxyDefaults,
+					TransparentProxy: &c.tproxyConfig,
+					Config:           c.proxyConfig,
+				}, nil)
+				require.NoError(t, err)
+			} else {
+				consulCountingSvcSidecar.Proxy.TransparentProxy = &c.tproxyConfig
+				consulCountingSvcSidecar.Proxy.Config = c.proxyConfig
+			}
+			// Register Consul services.
+			testConsulServices := []api.AgentService{consulCountingSvc, consulCountingSvcSidecar}
+			for _, svc := range testConsulServices {
+				serviceRegistration := &api.CatalogRegistration{
+					Node:    connectinject.ConsulNodeName,
+					Address: "127.0.0.1",
+					Service: &svc,
+				}
+				_, err = consulClient.Catalog().Register(serviceRegistration, nil)
+				require.NoError(t, err)
+			}
+			ui := cli.NewMockUi()
+
+			iptablesProvider := &fakeIptablesProvider{}
+			iptablesCfg := iptables.Config{
+				ProxyUserID:      "5995",
+				ProxyInboundPort: 20000,
+			}
+			cmd := Command{
+				UI:                                 ui,
+				serviceRegistrationPollingAttempts: 3,
+				iptablesProvider:                   iptablesProvider,
+			}
+			iptablesCfgJSON, err := json.Marshal(iptablesCfg)
+			require.NoError(t, err)
+			flags := []string{
+				"-pod-name", testPodName,
+				"-pod-namespace", testPodNamespace,
+				"-consul-node-name", connectinject.ConsulNodeName,
+				"-addresses", "127.0.0.1",
+				"-http-port", strconv.Itoa(serverCfg.Ports.HTTP),
+				"-grpc-port", strconv.Itoa(serverCfg.Ports.GRPC),
+				"-proxy-id-file", proxyFile,
+				"-redirect-traffic-config", string(iptablesCfgJSON),
+			}
+			code := cmd.Run(flags)
+			require.Equal(t, 0, code, ui.ErrorWriter.String())
+			require.Truef(t, iptablesProvider.applyCalled, "redirect traffic rules were not applied")
+			actualIptablesConfigParamsEqualExpected, errMsg := c.expIptablesParamsFunc(cmd.iptablesConfig)
+			require.Truef(t, actualIptablesConfigParamsEqualExpected, errMsg)
+		})
+	}
+}
+
 const (
 	metaKeyPodName         = "pod-name"
 	metaKeyKubeNS          = "k8s-namespace"
@@ -757,8 +912,6 @@ var (
 		Proxy: &api.AgentServiceConnectProxyConfig{
 			DestinationServiceName: "counting",
 			DestinationServiceID:   "counting-counting",
-			Config:                 nil,
-			Upstreams:              nil,
 		},
 		Port:    9999,
 		Address: "127.0.0.1",
@@ -785,8 +938,6 @@ var (
 		Proxy: &api.AgentServiceConnectProxyConfig{
 			DestinationServiceName: "counting-admin",
 			DestinationServiceID:   "counting-admin-id",
-			Config:                 nil,
-			Upstreams:              nil,
 		},
 		Port:    9999,
 		Address: "127.0.0.1",
@@ -797,3 +948,21 @@ var (
 		},
 	}
 )
+
+type fakeIptablesProvider struct {
+	applyCalled bool
+	rules       []string
+}
+
+func (f *fakeIptablesProvider) AddRule(_ string, args ...string) {
+	f.rules = append(f.rules, strings.Join(args, " "))
+}
+
+func (f *fakeIptablesProvider) ApplyRules() error {
+	f.applyCalled = true
+	return nil
+}
+
+func (f *fakeIptablesProvider) Rules() []string {
+	return f.rules
+}

--- a/control-plane/subcommand/connect-init/command_test.go
+++ b/control-plane/subcommand/connect-init/command_test.go
@@ -879,8 +879,10 @@ func TestRun_TrafficRedirection(t *testing.T) {
 			code := cmd.Run(flags)
 			require.Equal(t, 0, code, ui.ErrorWriter.String())
 			require.Truef(t, iptablesProvider.applyCalled, "redirect traffic rules were not applied")
-			actualIptablesConfigParamsEqualExpected, errMsg := c.expIptablesParamsFunc(cmd.iptablesConfig)
-			require.Truef(t, actualIptablesConfigParamsEqualExpected, errMsg)
+			if c.expIptablesParamsFunc != nil {
+				actualIptablesConfigParamsEqualExpected, errMsg := c.expIptablesParamsFunc(cmd.iptablesConfig)
+				require.Truef(t, actualIptablesConfigParamsEqualExpected, errMsg)
+			}
 		})
 	}
 }

--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -178,10 +178,10 @@ func (c *Command) meshGatewayRules() (string, error) {
 	// Mesh gateways can only act as a proxy for services
 	// that its ACL token has access to. So, in the case of
 	// Consul namespaces, it needs access to all namespaces.
-	meshGatewayRulesTpl := `
-  agent_prefix "" {
-  	policy = "read"
-  }
+	meshGatewayRulesTpl := `mesh = "write"
+agent_prefix "" {
+  policy = "read"
+}
 {{- if .EnableNamespaces }}
 namespace "default" {
 {{- end }}

--- a/control-plane/subcommand/server-acl-init/rules_test.go
+++ b/control-plane/subcommand/server-acl-init/rules_test.go
@@ -199,9 +199,10 @@ func TestMeshGatewayRules(t *testing.T) {
 	}{
 		{
 			Name: "Namespaces are disabled",
-			Expected: `agent_prefix "" {
-  	policy = "read"
-  }
+			Expected: `mesh = "write"
+agent_prefix "" {
+  policy = "read"
+}
   service "mesh-gateway" {
      policy = "write"
   }
@@ -215,9 +216,10 @@ func TestMeshGatewayRules(t *testing.T) {
 		{
 			Name:             "Namespaces are enabled",
 			EnableNamespaces: true,
-			Expected: `agent_prefix "" {
-  	policy = "read"
-  }
+			Expected: `mesh = "write"
+agent_prefix "" {
+  policy = "read"
+}
 namespace "default" {
   service "mesh-gateway" {
      policy = "write"


### PR DESCRIPTION
Changes proposed in this PR:
- Make `connect-init` command apply traffic redirection rules instead of calling consul CLI. This allows us to get rid of the init container that copies the consul binary.
  - The `connect-init` command now accepts `iptables.Config` as JSON string in  a flag or env variable, parses it and calls `iptables.Setup` with that config
  - It also applies additional rules based on proxy configuration (partially adopted from consul's `redirect-traffic` command implementation)
- The webhook now provides the iptables configuration as json to the `connect-init` command at injection times. The rules are based on the work we've done as part of the Consul CNI plugin.

How I've tested this PR:
acceptance and unit tests

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

