### PR TITLE
Update inaccurate example for API gateway's copyAnnotations

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2976,8 +2976,9 @@ apiGateway:
       # Example:
       #
       # ```yaml
-      # service: |
-      # - external-dns.alpha.kubernetes.io/hostname
+      # service:
+      #   annotations: |
+      #   - external-dns.alpha.kubernetes.io/hostname
       # ```
       #
       # @type: string


### PR DESCRIPTION
**Changes proposed in this PR:**
The provided example for `apiGateway.managedGatewayClass.copyAnnotations` doesn't work. If you use the example, the Helm installation fails.

This PR fixes it.

**How I've tested this PR:**

1. add a copy-list of annotations to your `values.yaml` in the format of the updated example
2. helm install
3. create a `Gateway` w/ the copy-listed annotation
4. the resulting K8s `Service` should have the annotation from the `Gateway

<details>

<summary>Example</summary>

```yaml
# values.yaml
global:
  name: consul
  datacenter: dc1
  tls:
    enabled: true
  image: hashicorppreview/consul:1.14-dev
server:
  replicas: 1
ui:
  enabled: true
  service:
    type: NodePort
connectInject:
  enabled: true
  default: true
controller:
  enabled: true
apiGateway:
  enabled: true
  image: "hashicorppreview/consul-api-gateway:0.5-dev"
  managedGatewayClass:
    copyAnnotations:
      service:
        annotations: |
          - networking.gke.io/load-balancer-type
```

```yaml
# gateway.yaml
apiVersion: gateway.networking.k8s.io/v1beta1
kind: Gateway
metadata:
  name: api-gateway
  namespace: consul
  annotations:
    networking.gke.io/load-balancer-type: Internal
spec:
  gatewayClassName: consul-api-gateway
  listeners:
  - protocol: HTTPS
    port: 8443
    name: https
    allowedRoutes:
      namespaces:
        from: Same
    tls:
      certificateRefs:
        - name: consul-server-cert
```

</details>

**How I expect reviewers to test this PR:**
See above

**Checklist:**
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

