### PR TITLE
agentless: Multi-cluster tproxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,6 @@ commands:
                     if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 2h -failfast \
                           << parameters.additional-flags >> \
                           -enable-multi-cluster \
-                          ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -debug-directory="$TEST_RESULTS/debug" \
                           -consul-k8s-image=<< parameters.consul-k8s-image >>
                     then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,7 @@ commands:
                     if ! gotestsum --no-summary=all --jsonfile=jsonfile-${pkg////-} -- $pkg -p 1 -timeout 2h -failfast \
                           << parameters.additional-flags >> \
                           -enable-multi-cluster \
+                          ${ENABLE_ENTERPRISE:+-enable-enterprise} \
                           -debug-directory="$TEST_RESULTS/debug" \
                           -consul-k8s-image=<< parameters.consul-k8s-image >>
                     then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -583,7 +583,7 @@ jobs:
     steps:
       - checkout
       - install-prereqs
-      - create-kind-cni-clusters:
+      - create-kind-clusters:
           version: "v1.24.4"
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -582,7 +582,7 @@ jobs:
     steps:
       - checkout
       - install-prereqs
-      - create-kind-clusters:
+      - create-kind-cni-clusters:
           version: "v1.24.4"
       - restore_cache:
           keys:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ on:
 
 env:
   TEST_RESULTS: /tmp/test-results # path to where test results are saved
-  CONSUL_VERSION: 1.13.1 # Consul's OSS version to use in tests
-  CONSUL_ENT_VERSION: 1.13.1+ent # Consul's enterprise version to use in tests
+  CONSUL_VERSION: 1.14.0-beta1 # Consul's OSS version to use in tests
+  CONSUL_ENT_VERSION: 1.14.0-beta1+ent # Consul's enterprise version to use in tests
   GOTESTSUM_VERSION: 1.8.1 # You cannot use environment variables with workflows. The gotestsum version is hardcoded in the reusable workflows too.
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,10 @@ on:
 
 env:
   TEST_RESULTS: /tmp/test-results # path to where test results are saved
-  CONSUL_VERSION: 1.14.0-beta1 # Consul's OSS version to use in tests
-  CONSUL_ENT_VERSION: 1.14.0-beta1+ent # Consul's enterprise version to use in tests
   GOTESTSUM_VERSION: 1.8.2 # You cannot use environment variables with workflows. The gotestsum version is hardcoded in the reusable workflows too.
+  # We use docker images to copy the consul binary for unit tests.
+  CONSUL_OSS_DOCKER_IMAGE: hashicorppreview/consul:1.14-dev # Consul's OSS version to use in tests
+  CONSUL_ENT_DOCKER_IMAGE: hashicorppreview/consul-enterprise:1.14-dev # Consul's enterprise version to use in tests
 
 jobs:
   get-go-version:
@@ -158,7 +159,7 @@ jobs:
         working-directory: control-plane
         run: |
           mkdir -p $HOME/bin
-          container_id=$(docker create hashicorppreview/consul:1.14-dev)
+          container_id=$(docker create ${{env.CONSUL_OSS_DOCKER_IMAGE}})
           docker cp "$container_id:/bin/consul" $HOME/bin/consul
           docker rm "$container_id"
       - name: Run go tests
@@ -205,7 +206,7 @@ jobs:
         working-directory: control-plane
         run: |
           mkdir -p $HOME/bin
-          container_id=$(docker create hashicorppreview/consul-enterprise:1.14-dev)
+          container_id=$(docker create ${{env.CONSUL_ENT_DOCKER_IMAGE}})
           docker cp "$container_id:/bin/consul" $HOME/bin/consul
           docker rm "$container_id"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ env:
   TEST_RESULTS: /tmp/test-results # path to where test results are saved
   CONSUL_VERSION: 1.14.0-beta1 # Consul's OSS version to use in tests
   CONSUL_ENT_VERSION: 1.14.0-beta1+ent # Consul's enterprise version to use in tests
-  GOTESTSUM_VERSION: 1.8.1 # You cannot use environment variables with workflows. The gotestsum version is hardcoded in the reusable workflows too.
+  GOTESTSUM_VERSION: 1.8.2 # You cannot use environment variables with workflows. The gotestsum version is hardcoded in the reusable workflows too.
 
 jobs:
   get-go-version:
@@ -158,11 +158,9 @@ jobs:
         working-directory: control-plane
         run: |
           mkdir -p $HOME/bin
-          wget https://releases.hashicorp.com/consul/${{env.CONSUL_VERSION}}/consul_${{env.CONSUL_VERSION}}_linux_amd64.zip && \
-            unzip consul_${{env.CONSUL_VERSION}}_linux_amd64.zip -d $HOME/bin && \
-            rm consul_${{env.CONSUL_VERSION}}_linux_amd64.zip
-          chmod +x $HOME/bin/consul
-
+          container_id=$(docker create hashicorppreview/consul:1.14-dev)
+          docker cp "$container_id:/bin/consul" $HOME/bin/consul
+          docker rm "$container_id"
       - name: Run go tests
         working-directory: control-plane
         run: |
@@ -207,10 +205,9 @@ jobs:
         working-directory: control-plane
         run: |
           mkdir -p $HOME/bin
-          wget https://releases.hashicorp.com/consul/${{env.CONSUL_ENT_VERSION}}/consul_${{env.CONSUL_ENT_VERSION}}_linux_amd64.zip && \
-            unzip consul_${{env.CONSUL_ENT_VERSION}}_linux_amd64.zip -d $HOME/bin && \
-            rm consul_${{env.CONSUL_ENT_VERSION}}_linux_amd64.zip
-          chmod +x $HOME/bin/consul
+          container_id=$(docker create hashicorppreview/consul-enterprise:1.14-dev)
+          docker cp "$container_id:/bin/consul" $HOME/bin/consul
+          docker rm "$container_id"
 
       - name: Run go tests
         working-directory: control-plane

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@ on:
 
 env:
   TEST_RESULTS: /tmp/test-results # path to where test results are saved
-  CONSUL_VERSION: 1.13.1 # Consul's OSS version to use in tests
-  CONSUL_ENT_VERSION: 1.13.1+ent # Consul's enterprise version to use in tests
-  GOTESTSUM_VERSION: 1.8.2 # You cannot use environment variables with workflows. The gotestsum version is hardcoded in the reusable workflows too.
+  CONSUL_VERSION: 1.14.0-beta1 # Consul's OSS version to use in tests
+  CONSUL_ENT_VERSION: 1.14.0-beta1+ent # Consul's enterprise version to use in tests
+  GOTESTSUM_VERSION: 1.8.1 # You cannot use environment variables with workflows. The gotestsum version is hardcoded in the reusable workflows too.
 
 jobs:
   get-go-version:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ on:
 
 env:
   TEST_RESULTS: /tmp/test-results # path to where test results are saved
-  CONSUL_VERSION: 1.14.0-beta1 # Consul's OSS version to use in tests
-  CONSUL_ENT_VERSION: 1.14.0-beta1+ent # Consul's enterprise version to use in tests
+  CONSUL_VERSION: 1.13.1 # Consul's OSS version to use in tests
+  CONSUL_ENT_VERSION: 1.13.1+ent # Consul's enterprise version to use in tests
   GOTESTSUM_VERSION: 1.8.1 # You cannot use environment variables with workflows. The gotestsum version is hardcoded in the reusable workflows too.
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## UNRELEASED
 
+
+BREAKING_CHANGES:
+* Helm:
+  * Remove `global.consulSidecarContainer` from values file as there is no longer a consul sidecar. [[GH-1635](https://github.com/hashicorp/consul-k8s/pull/1635)]
+
+FEATURES:
+* Consul-dataplane:
+  * Support merged metrics with consul-dataplane. [[GH-1635](https://github.com/hashicorp/consul-k8s/pull/1635)]
+  * Support transparent proxying when using consul-dataplane. [[GH-1625](https://github.com/hashicorp/consul-k8s/pull/1478),[GH-1632](https://github.com/hashicorp/consul-k8s/pull/1632)]
+
 IMPROVEMENTS:
 * CLI
   * Update minimum go version for project to 1.19 [[GH-1633](https://github.com/hashicorp/consul-k8s/pull/1633)]
@@ -9,13 +19,6 @@ IMPROVEMENTS:
   * Remove deprecated annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"` in the `server-service` template. [[GH-1619](https://github.com/hashicorp/consul-k8s/pull/1619)]
   * Support `minAvailable` on connect injector `PodDisruptionBudget`. [[GH-1557](https://github.com/hashicorp/consul-k8s/pull/1557)]
   * Add `tolerations` and `nodeSelector` to Server ACL init jobs and `nodeSelector` to Webhook cert manager. [[GH-1581](https://github.com/hashicorp/consul-k8s/pull/1581)]
-* Control plane
-  * Support merged metrics with consul-dataplane. [[GH-1635](https://github.com/hashicorp/consul-k8s/pull/1635)]
-
-BREAKING_CHANGES:
-
-* Helm:
-  * Removal of `global.consulSidecarContainer` from values file as there is no longer a consul sidecar. [[GH-1635](https://github.com/hashicorp/consul-k8s/pull/1635)]
 
 ## 1.0.0-beta3 (October 12, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## UNRELEASED
 
-
 BREAKING_CHANGES:
 * Helm:
   * Remove `global.consulSidecarContainer` from values file as there is no longer a consul sidecar. [[GH-1635](https://github.com/hashicorp/consul-k8s/pull/1635)]

--- a/acceptance/framework/connhelper/connect_helper.go
+++ b/acceptance/framework/connhelper/connect_helper.go
@@ -208,6 +208,8 @@ func (c *ConnectHelper) helmValues() map[string]string {
 		"connectInject.enabled":        "true",
 		"global.tls.enabled":           strconv.FormatBool(c.Secure),
 		"global.acls.manageSystemACLs": strconv.FormatBool(c.Secure),
+		"dns.enabled":                  "true",
+		"dns.enableRedirection":        "true",
 	}
 
 	helpers.MergeMaps(helmValues, c.HelmValues)

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -141,7 +141,7 @@ func (h *HelmCluster) Destroy(t *testing.T) {
 	// Ignore the error returned by the helm delete here so that we can
 	// always idempotently clean up resources in the cluster.
 	h.helmOptions.ExtraArgs = map[string][]string{
-		"--wait":    nil,
+		"--wait": nil,
 	}
 	err := helm.DeleteE(t, h.helmOptions, h.releaseName, false)
 	require.NoError(t, err)

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -141,7 +141,7 @@ func (h *HelmCluster) Destroy(t *testing.T) {
 	// Ignore the error returned by the helm delete here so that we can
 	// always idempotently clean up resources in the cluster.
 	h.helmOptions.ExtraArgs = map[string][]string{
-		"--wait": nil,
+		"--wait":    nil,
 	}
 	err := helm.DeleteE(t, h.helmOptions, h.releaseName, false)
 	require.NoError(t, err)

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -14,8 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const podName = "dns-pod"
-
 func TestConsulDNS(t *testing.T) {
 	cfg := suite.Config()
 	if cfg.EnableCNI {
@@ -59,8 +57,9 @@ func TestConsulDNS(t *testing.T) {
 				serverIPs = append(serverIPs, serverPod.Status.PodIP)
 			}
 
+			dnsPodName := fmt.Sprintf("%s-dns-pod", releaseName)
 			dnsTestPodArgs := []string{
-				"run", "-i", podName, "--restart", "Never", "--image", "anubhavmishra/tiny-tools", "--", "dig", fmt.Sprintf("@%s-consul-dns", releaseName), "consul.service.consul",
+				"run", "-i", dnsPodName, "--restart", "Never", "--image", "anubhavmishra/tiny-tools", "--", "dig", fmt.Sprintf("@%s-consul-dns", releaseName), "consul.service.consul",
 			}
 
 			helpers.Cleanup(t, suite.Config().NoCleanupOnFailure, func() {
@@ -68,7 +67,7 @@ func TestConsulDNS(t *testing.T) {
 				// This shouldn't cause any test pollution because the underlying
 				// objects are deployments, and so when other tests create these
 				// they should have different pod names.
-				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "pod", podName)
+				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "pod", dnsPodName)
 			})
 
 			retry.Run(t, func(r *retry.R) {

--- a/acceptance/tests/partitions/main_test.go
+++ b/acceptance/tests/partitions/main_test.go
@@ -13,8 +13,7 @@ var suite testsuite.Suite
 func TestMain(m *testing.M) {
 	suite = testsuite.NewSuite(m)
 
-	// todo(agentless): Re-enable tproxy tests once we support it for multi-cluster.
-	if suite.Config().EnableMultiCluster && !suite.Config().EnableTransparentProxy {
+	if suite.Config().EnableMultiCluster {
 		os.Exit(suite.Run())
 	} else {
 		fmt.Println("Skipping partitions tests because -enable-multi-cluster is not set")

--- a/acceptance/tests/peering/main_test.go
+++ b/acceptance/tests/peering/main_test.go
@@ -13,8 +13,7 @@ var suite testsuite.Suite
 func TestMain(m *testing.M) {
 	suite = testsuite.NewSuite(m)
 
-	// todo(agentless): Re-enable tproxy tests once we support it for multi-cluster.
-	if suite.Config().EnableMultiCluster && !suite.Config().DisablePeering && !suite.Config().EnableTransparentProxy {
+	if suite.Config().EnableMultiCluster && !suite.Config().DisablePeering {
 		os.Exit(suite.Run())
 	} else {
 		fmt.Println("Skipping peering tests because either -enable-multi-cluster is not set or -disable-peering is set")

--- a/acceptance/tests/peering/peering_connect_test.go
+++ b/acceptance/tests/peering/peering_connect_test.go
@@ -31,10 +31,6 @@ func TestPeering_Connect(t *testing.T) {
 		t.Skipf("skipping this test because peering is not supported in version %v", cfg.ConsulVersion.String())
 	}
 
-	if cfg.EnableTransparentProxy {
-		t.Skipf("skipping because no t-proxy support")
-	}
-
 	const staticServerPeer = "server"
 	const staticClientPeer = "client"
 	cases := []struct {

--- a/acceptance/tests/wan-federation/main_test.go
+++ b/acceptance/tests/wan-federation/main_test.go
@@ -13,8 +13,7 @@ var suite testsuite.Suite
 func TestMain(m *testing.M) {
 	suite = testsuite.NewSuite(m)
 
-	// todo(agentless): Re-enable tproxy tests once we support it for multi-cluster.
-	if suite.Config().EnableMultiCluster && !suite.Config().EnableTransparentProxy {
+	if suite.Config().EnableMultiCluster {
 		os.Exit(suite.Run())
 	} else {
 		fmt.Println("Skipping wan federation tests because -enable-multi-cluster is not set")

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -149,19 +149,6 @@ is passed to consul as a -config-file param on command line.
 {{- end -}}
 
 {{/*
-Sets up a list of recusor flags for Consul agents by iterating over the IPs of every nameserver
-in /etc/resolv.conf and concatenating them into a string of arguments that can be passed directly
-to the consul agent command.
-*/}}
-{{- define "consul.recursors" -}}
-              recursor_flags=""
-              for ip in $(cat /etc/resolv.conf | grep nameserver | cut -d' ' -f2)
-              do
-                 recursor_flags="$recursor_flags -recursor=$ip"
-              done
-{{- end -}}
-
-{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "consul.chart" -}}

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -271,9 +271,6 @@ spec:
               {{- if and .Values.global.secretsBackend.vault.enabled .Values.global.gossipEncryption.secretName }}
               GOSSIP_KEY=`cat /vault/secrets/gossip.txt`
               {{- end }}
-              {{- if (and .Values.dns.enabled .Values.dns.enableRedirection) }}
-              {{ template "consul.recursors" }}
-              {{- end }}
 
               {{ template "consul.extraconfig" }}
 
@@ -378,9 +375,6 @@ spec:
                 {{- end }}
                 {{- range $value := .Values.global.recursors }}
                 -recursor={{ quote $value }} \
-                {{- end }}
-                {{- if (and .Values.dns.enabled .Values.dns.enableRedirection) }}
-                $recursor_flags \
                 {{- end }}
                 -config-file=/consul/extra-config/extra-from-values.json \
                 -domain={{ .Values.global.domain }}

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -312,10 +312,6 @@ spec:
               {{- if and .Values.global.secretsBackend.vault.enabled .Values.global.gossipEncryption.secretName }}
               GOSSIP_KEY=`cat /vault/secrets/gossip.txt`
               {{- end }}
-              
-              {{- if (and .Values.dns.enabled .Values.dns.enableRedirection) }}
-              {{ template "consul.recursors" }}
-              {{- end }}
 
               {{ template "consul.extraconfig" }}
 
@@ -331,9 +327,6 @@ spec:
                 {{- else }}
                 -hcl="acl { tokens { agent = \"${ACL_REPLICATION_TOKEN}\", replication = \"${ACL_REPLICATION_TOKEN}\" } }" \
                 {{- end }}
-                {{- end }}
-                {{- if (and .Values.dns.enabled .Values.dns.enableRedirection) }}
-                $recursor_flags \
                 {{- end }}
                 {{- if and .Values.global.secretsBackend.vault.enabled .Values.global.acls.bootstrapToken.secretName }}
                 -config-file=/vault/secrets/bootstrap-token-config.hcl \

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -1707,30 +1707,6 @@ local actual=$(echo $object |
 }
 
 #--------------------------------------------------------------------
-# DNS
-
-@test "client/DaemonSet: recursor flags is not set by default" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/client-daemonset.yaml \
-      --set 'client.enabled=true' \
-      . | tee /dev/stderr |
-      yq -c -r '.spec.template.spec.containers[0].command | join(" ") | contains("$recursor_flags")' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-@test "client/DaemonSet: add recursor flags if dns.enableRedirection is true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/client-daemonset.yaml \
-      --set 'client.enabled=true' \
-      --set 'dns.enableRedirection=true' \
-      . | tee /dev/stderr |
-      yq -c -r '.spec.template.spec.containers[0].command | join(" ") | contains("$recursor_flags")' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-#--------------------------------------------------------------------
 # hostNetwork
 
 @test "client/DaemonSet: hostNetwork not set by default" {

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -591,28 +591,6 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# DNS
-
-@test "server/StatefulSet: recursor flags unset by default" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/server-statefulset.yaml \
-      . | tee /dev/stderr |
-      yq -c -r '.spec.template.spec.containers[0].command | join(" ") | contains("$recursor_flags")' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
-@test "server/StatefulSet: add recursor flags if dns.enableRedirection is true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/server-statefulset.yaml \
-      --set 'dns.enableRedirection=true' \
-      . | tee /dev/stderr |
-      yq -c -r '.spec.template.spec.containers[0].command | join(" ") | contains("$recursor_flags")' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-#--------------------------------------------------------------------
 # annotations
 
 @test "server/StatefulSet: no annotations defined by default" {

--- a/control-plane/cni/go.mod
+++ b/control-plane/cni/go.mod
@@ -48,6 +48,6 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-replace github.com/hashicorp/consul/sdk v0.9.0 => github.com/hashicorp/consul/sdk v0.4.1-0.20220531155537-364758ef2f50
+replace github.com/hashicorp/consul/sdk => github.com/hashicorp/consul/sdk v0.4.1-0.20221021205723-cc843c4be892
 
 go 1.19

--- a/control-plane/cni/go.sum
+++ b/control-plane/cni/go.sum
@@ -131,8 +131,8 @@ github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
-github.com/hashicorp/consul/sdk v0.4.1-0.20220531155537-364758ef2f50 h1:GwbRRT+QxMRbYI608FGwTfcZ0iOVLX69B2ePjpQoyXw=
-github.com/hashicorp/consul/sdk v0.4.1-0.20220531155537-364758ef2f50/go.mod h1:yPkX5Q6CsxTFMjQQDJwzeNmUUF5NUGGbrDsv9wTb8cw=
+github.com/hashicorp/consul/sdk v0.4.1-0.20221021205723-cc843c4be892 h1:jw0NwPmNPr5CxAU04hACdj61JSaJBKZ0FdBo+kwfNp4=
+github.com/hashicorp/consul/sdk v0.4.1-0.20221021205723-cc843c4be892/go.mod h1:yPkX5Q6CsxTFMjQQDJwzeNmUUF5NUGGbrDsv9wTb8cw=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.16.1 h1:IVQwpTGNRRIHafnTs2dQLIk4ENtneRIEEJWOVDqz99o=

--- a/control-plane/connect-inject/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/consul_dataplane_sidecar.go
@@ -13,7 +13,10 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-const ConsulCAFile = "/consul/connect-inject/consul-ca.pem"
+const (
+	ConsulCAFile               = "/consul/connect-inject/consul-ca.pem"
+	ConsulDataplaneDNSBindPort = 8600
+)
 
 func (w *MeshWebhook) consulDataplaneSidecar(namespace corev1.Namespace, pod corev1.Pod, mpi multiPortInfo) (corev1.Container, error) {
 	resources, err := w.sidecarResources(pod)
@@ -251,6 +254,12 @@ func (w *MeshWebhook) getContainerSidecarCommand(namespace corev1.Namespace, mpi
 				"-telemetry-prom-cert-file="+prometheusCertFile,
 				"-telemetry-prom-key-file="+prometheusKeyFile)
 		}
+	}
+
+	// If Consul DNS is enabled, we want to configure consul-dataplane to be the DNS proxy
+	// for Consul DNS in the pod.
+	if w.EnableConsulDNS {
+		cmd = append(cmd, "-consul-dns-bind-port="+strconv.Itoa(ConsulDataplaneDNSBindPort))
 	}
 
 	var envoyExtraArgs []string

--- a/control-plane/connect-inject/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/consul_dataplane_sidecar.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	ConsulCAFile               = "/consul/connect-inject/consul-ca.pem"
+	ConsulDataplaneDNSBindHost = "127.0.0.1"
 	ConsulDataplaneDNSBindPort = 8600
 )
 

--- a/control-plane/connect-inject/consul_dataplane_sidecar_test.go
+++ b/control-plane/connect-inject/consul_dataplane_sidecar_test.go
@@ -272,6 +272,26 @@ func TestHandlerConsulDataplaneSidecar_Concurrency(t *testing.T) {
 	}
 }
 
+func TestHandlerConsulDataplaneSidecar_DNSProxy(t *testing.T) {
+	h := MeshWebhook{
+		ConsulConfig:    &consul.Config{HTTPPort: 8500, GRPCPort: 8502},
+		EnableConsulDNS: true,
+	}
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "web",
+				},
+			},
+		},
+	}
+	container, err := h.consulDataplaneSidecar(testNS, pod, multiPortInfo{})
+	require.NoError(t, err)
+	require.Contains(t, container.Command[2], "-consul-dns-bind-port=8600")
+}
+
 func TestHandlerConsulDataplaneSidecar_Multiport(t *testing.T) {
 	for _, aclsEnabled := range []bool{false, true} {
 		name := fmt.Sprintf("acls enabled: %t", aclsEnabled)

--- a/control-plane/connect-inject/container_init.go
+++ b/control-plane/connect-inject/container_init.go
@@ -17,7 +17,6 @@ const (
 	sidecarUserAndGroupID        = 5995
 	initContainersUserAndGroupID = 5996
 	netAdminCapability           = "NET_ADMIN"
-	dnsServiceHostEnvSuffix      = "DNS_SERVICE_HOST"
 )
 
 type initContainerCommandData struct {

--- a/control-plane/connect-inject/dns.go
+++ b/control-plane/connect-inject/dns.go
@@ -15,11 +15,14 @@ const (
 	defaultDNSOptionNdots    = 1
 	defaultDNSOptionTimeout  = 5
 	defaultDNSOptionAttempts = 2
+
+	// defaultEtcResolvConfFile is the default location of the /etc/resolv.conf file.
+	defaultEtcResolvConfFile = "/etc/resolv.conf"
 )
 
 func (w *MeshWebhook) configureDNS(pod *corev1.Pod, k8sNS string) error {
 	// First, we need to determine the nameservers configured in this cluster from /etc/resolv.conf.
-	etcResolvConf := "/etc/resolv.conf"
+	etcResolvConf := defaultEtcResolvConfFile
 	if w.etcResolvFile != "" {
 		etcResolvConf = w.etcResolvFile
 	}
@@ -36,8 +39,7 @@ func (w *MeshWebhook) configureDNS(pod *corev1.Pod, k8sNS string) error {
 	// configured in our /etc/resolv.conf. It's important to add Consul DNS as the first nameserver because
 	// if we put kube DNS first, it will return NXDOMAIN response and a DNS client will not fall back to other nameservers.
 	if pod.Spec.DNSConfig == nil {
-		consulDPAddress := "127.0.0.1"
-		nameservers := []string{consulDPAddress}
+		nameservers := []string{ConsulDataplaneDNSBindHost}
 		nameservers = append(nameservers, cfg.Servers...)
 		var options []corev1.PodDNSConfigOption
 		if cfg.Ndots != defaultDNSOptionNdots {

--- a/control-plane/connect-inject/dns.go
+++ b/control-plane/connect-inject/dns.go
@@ -1,0 +1,88 @@
+package connectinject
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/miekg/dns"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	// These defaults are taken from the /etc/resolv.conf man page
+	// and are used by the dns library.
+	defaultDNSOptionNdots    = 1
+	defaultDNSOptionTimeout  = 5
+	defaultDNSOptionAttempts = 2
+)
+
+func (w *MeshWebhook) configureDNS(pod *corev1.Pod, k8sNS string) error {
+	// First, we need to determine the nameservers configured in this cluster from /etc/resolv.conf.
+	etcResolvConf := "/etc/resolv.conf"
+	if w.etcResolvFile != "" {
+		etcResolvConf = w.etcResolvFile
+	}
+	cfg, err := dns.ClientConfigFromFile(etcResolvConf)
+	if err != nil {
+		return err
+	}
+
+	// Set DNS policy on the pod to None because we want DNS to work according to the config we will provide.
+	pod.Spec.DNSPolicy = corev1.DNSNone
+
+	// Set the consul-dataplane's DNS server as the first server in the list (i.e. localhost).
+	// We want to do that so that when consul cannot resolve the record, we will fall back to the nameservers
+	// configured in our /etc/resolv.conf. It's important to add Consul DNS as the first nameserver because
+	// if we put kube DNS first, it will return NXDOMAIN response and a DNS client will not fall back to other nameservers.
+	if pod.Spec.DNSConfig == nil {
+		consulDPAddress := "127.0.0.1"
+		nameservers := []string{consulDPAddress}
+		nameservers = append(nameservers, cfg.Servers...)
+		var options []corev1.PodDNSConfigOption
+		if cfg.Ndots != defaultDNSOptionNdots {
+			ndots := strconv.Itoa(cfg.Ndots)
+			options = append(options, corev1.PodDNSConfigOption{
+				Name:  "ndots",
+				Value: &ndots,
+			})
+		}
+		if cfg.Timeout != defaultDNSOptionTimeout {
+			options = append(options, corev1.PodDNSConfigOption{
+				Name:  "timeout",
+				Value: pointer.String(strconv.Itoa(cfg.Timeout)),
+			})
+		}
+		if cfg.Attempts != defaultDNSOptionAttempts {
+			options = append(options, corev1.PodDNSConfigOption{
+				Name:  "attempts",
+				Value: pointer.String(strconv.Itoa(cfg.Attempts)),
+			})
+		}
+
+		// Replace release namespace in the searches with the pod namespace.
+		// This is so that the searches we generate will be for the pod's namespace
+		// instead of the namespace of the connect-injector. E.g. instead of
+		// consul.svc.cluster.local it should be <pod ns>.svc.cluster.local.
+		var searches []string
+		// Kubernetes will add a search domain for <namespace>.svc.cluster.local so we can always
+		// expect it to be there. See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#namespaces-of-services.
+		consulReleaseNSSearchDomain := fmt.Sprintf("%s.svc.cluster.local", w.ReleaseNamespace)
+		for _, search := range cfg.Search {
+			if search == consulReleaseNSSearchDomain {
+				searches = append(searches, fmt.Sprintf("%s.svc.cluster.local", k8sNS))
+			} else {
+				searches = append(searches, search)
+			}
+		}
+
+		pod.Spec.DNSConfig = &corev1.PodDNSConfig{
+			Nameservers: nameservers,
+			Searches:    searches,
+			Options:     options,
+		}
+	} else {
+		return fmt.Errorf("DNS redirection to Consul is not supported with an already defined DNSConfig on the pod")
+	}
+	return nil
+}

--- a/control-plane/connect-inject/dns_test.go
+++ b/control-plane/connect-inject/dns_test.go
@@ -1,0 +1,102 @@
+package connectinject
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestMeshWebhook_configureDNS(t *testing.T) {
+	cases := map[string]struct {
+		etcResolv    string
+		expDNSConfig *corev1.PodDNSConfig
+	}{
+		"empty /etc/resolv.conf file": {
+			expDNSConfig: &corev1.PodDNSConfig{
+				Nameservers: []string{"127.0.0.1"},
+			},
+		},
+		"one nameserver": {
+			etcResolv: `nameserver 1.1.1.1`,
+			expDNSConfig: &corev1.PodDNSConfig{
+				Nameservers: []string{"127.0.0.1", "1.1.1.1"},
+			},
+		},
+		"mutiple nameservers, searches, and options": {
+			etcResolv: `
+nameserver 1.1.1.1
+nameserver 2.2.2.2
+search foo.bar bar.baz
+options ndots:5 timeout:6 attempts:3`,
+			expDNSConfig: &corev1.PodDNSConfig{
+				Nameservers: []string{"127.0.0.1", "1.1.1.1", "2.2.2.2"},
+				Searches:    []string{"foo.bar", "bar.baz"},
+				Options: []corev1.PodDNSConfigOption{
+					{
+						Name:  "ndots",
+						Value: pointer.String("5"),
+					},
+					{
+						Name:  "timeout",
+						Value: pointer.String("6"),
+					},
+					{
+						Name:  "attempts",
+						Value: pointer.String("3"),
+					},
+				},
+			},
+		},
+		"replaces release specific search domains": {
+			etcResolv: `
+nameserver 1.1.1.1
+nameserver 2.2.2.2
+search consul.svc.cluster.local svc.cluster.local cluster.local
+options ndots:5`,
+			expDNSConfig: &corev1.PodDNSConfig{
+				Nameservers: []string{"127.0.0.1", "1.1.1.1", "2.2.2.2"},
+				Searches:    []string{"default.svc.cluster.local", "svc.cluster.local", "cluster.local"},
+				Options: []corev1.PodDNSConfigOption{
+					{
+						Name:  "ndots",
+						Value: pointer.String("5"),
+					},
+				},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			etcResolvFile, err := os.CreateTemp("", "")
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = os.Remove(etcResolvFile.Name())
+			})
+			_, err = etcResolvFile.WriteString(c.etcResolv)
+			require.NoError(t, err)
+			w := MeshWebhook{
+				etcResolvFile:    etcResolvFile.Name(),
+				ReleaseNamespace: "consul",
+			}
+
+			pod := minimal()
+			err = w.configureDNS(pod, "default")
+			require.NoError(t, err)
+			require.Equal(t, corev1.DNSNone, pod.Spec.DNSPolicy)
+			require.Equal(t, c.expDNSConfig, pod.Spec.DNSConfig)
+		})
+	}
+}
+
+func TestMeshWebhook_configureDNS_error(t *testing.T) {
+	w := MeshWebhook{}
+
+	pod := minimal()
+	pod.Spec.DNSConfig = &corev1.PodDNSConfig{Nameservers: []string{"1.1.1.1"}}
+	err := w.configureDNS(pod, "default")
+	require.EqualError(t, err, "DNS redirection to Consul is not supported with an already defined DNSConfig on the pod")
+}

--- a/control-plane/connect-inject/peering_acceptor_controller_test.go
+++ b/control-plane/connect-inject/peering_acceptor_controller_test.go
@@ -566,7 +566,7 @@ func TestReconcile_CreateUpdatePeeringAcceptor(t *testing.T) {
 
 			require.Contains(t, string(decodedTokenData), "\"CA\":")
 			require.Contains(t, string(decodedTokenData), "\"ServerAddresses\"")
-			require.Contains(t, string(decodedTokenData), "\"ServerName\":\"server.dc1.consul\"")
+			require.Contains(t, string(decodedTokenData), "\"ServerName\":\"server.dc1.peering.11111111-2222-3333-4444-555555555555.consul\"")
 
 			// Get the reconciled PeeringAcceptor and make assertions on the status
 			acceptor := &v1alpha1.PeeringAcceptor{}

--- a/control-plane/connect-inject/peering_acceptor_controller_test.go
+++ b/control-plane/connect-inject/peering_acceptor_controller_test.go
@@ -564,7 +564,7 @@ func TestReconcile_CreateUpdatePeeringAcceptor(t *testing.T) {
 			decodedTokenData, err := base64.StdEncoding.DecodeString(string(createdSecret.Data["data"]))
 			require.NoError(t, err)
 
-			require.Contains(t, string(decodedTokenData), "\"CA\":")
+			require.Contains(t, string(decodedTokenData), "\"CA\":null")
 			require.Contains(t, string(decodedTokenData), "\"ServerAddresses\"")
 			require.Contains(t, string(decodedTokenData), "\"ServerName\":\"server.dc1.consul\"")
 

--- a/control-plane/connect-inject/peering_acceptor_controller_test.go
+++ b/control-plane/connect-inject/peering_acceptor_controller_test.go
@@ -564,7 +564,7 @@ func TestReconcile_CreateUpdatePeeringAcceptor(t *testing.T) {
 			decodedTokenData, err := base64.StdEncoding.DecodeString(string(createdSecret.Data["data"]))
 			require.NoError(t, err)
 
-			require.Contains(t, string(decodedTokenData), "\"CA\":null")
+			require.Contains(t, string(decodedTokenData), "\"CA\":")
 			require.Contains(t, string(decodedTokenData), "\"ServerAddresses\"")
 			require.Contains(t, string(decodedTokenData), "\"ServerName\":\"server.dc1.consul\"")
 
@@ -1101,7 +1101,6 @@ func TestAcceptorUpdateStatus(t *testing.T) {
 			require.Equal(t, tt.expStatus.SecretRef.Backend, acceptor.SecretRef().Backend)
 			require.Equal(t, tt.expStatus.SecretRef.ResourceVersion, acceptor.SecretRef().ResourceVersion)
 			require.Equal(t, tt.expStatus.Conditions[0].Message, acceptor.Status.Conditions[0].Message)
-
 		})
 	}
 }

--- a/control-plane/connect-inject/peering_acceptor_controller_test.go
+++ b/control-plane/connect-inject/peering_acceptor_controller_test.go
@@ -1016,7 +1016,7 @@ func TestAcceptorUpdateStatus(t *testing.T) {
 					},
 				},
 				Conditions: v1alpha1.Conditions{
-					{
+					v1alpha1.Condition{
 						Type:   v1alpha1.ConditionSynced,
 						Status: corev1.ConditionTrue,
 					},
@@ -1059,7 +1059,7 @@ func TestAcceptorUpdateStatus(t *testing.T) {
 					},
 				},
 				Conditions: v1alpha1.Conditions{
-					{
+					v1alpha1.Condition{
 						Type:   v1alpha1.ConditionSynced,
 						Status: corev1.ConditionTrue,
 					},
@@ -1133,7 +1133,7 @@ func TestAcceptorUpdateStatusError(t *testing.T) {
 			reconcileErr: errors.New("this is an error"),
 			expStatus: v1alpha1.PeeringAcceptorStatus{
 				Conditions: v1alpha1.Conditions{
-					{
+					v1alpha1.Condition{
 						Type:    v1alpha1.ConditionSynced,
 						Status:  corev1.ConditionFalse,
 						Reason:  InternalError,

--- a/control-plane/connect-inject/peering_acceptor_controller_test.go
+++ b/control-plane/connect-inject/peering_acceptor_controller_test.go
@@ -564,7 +564,7 @@ func TestReconcile_CreateUpdatePeeringAcceptor(t *testing.T) {
 			decodedTokenData, err := base64.StdEncoding.DecodeString(string(createdSecret.Data["data"]))
 			require.NoError(t, err)
 
-			require.Contains(t, string(decodedTokenData), "\"CA\":null")
+			require.Contains(t, string(decodedTokenData), "\"CA\":")
 			require.Contains(t, string(decodedTokenData), "\"ServerAddresses\"")
 			require.Contains(t, string(decodedTokenData), "\"ServerName\":\"server.dc1.consul\"")
 

--- a/control-plane/connect-inject/peering_dialer_controller_test.go
+++ b/control-plane/connect-inject/peering_dialer_controller_test.go
@@ -296,11 +296,8 @@ func TestReconcile_CreateUpdatePeeringDialer(t *testing.T) {
 
 			// If the peering is supposed to already exist in Consul, then establish a peering with the existing token, so the peering will exist on the dialing side.
 			if tt.peeringExists {
-				retry.Run(t, func(r *retry.R) {
-					_, _, err = dialerClient.Peerings().Establish(context.Background(), api.PeeringEstablishRequest{PeerName: tt.peeringName, PeeringToken: encodedPeeringToken}, nil)
-					require.NoError(r, err)
-				})
-
+				_, _, err := dialerClient.Peerings().Establish(context.Background(), api.PeeringEstablishRequest{PeerName: tt.peeringName, PeeringToken: encodedPeeringToken}, nil)
+				require.NoError(t, err)
 				k8sObjects = append(k8sObjects, createSecret("dialer-token-old", "default", "token", "old-token"))
 				// Create a new token to be used by Reconcile(). The original token has already been
 				// used once to simulate establishing an existing peering.
@@ -427,12 +424,9 @@ func TestReconcile_VersionAnnotationPeeringDialer(t *testing.T) {
 
 			// Create test consul server.
 			acceptorPeerServer, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
-				// We set different cluster id for the connect CA because the server name,
-				// typically formatted as server.dc1.peering.<cluster_id>.consul
+				// We set the datacenter because the server name, typically formatted as "server.<datacenter>.<domain>"
 				// must be unique on the acceptor and dialer peers.
-				c.Connect["ca_config"] = map[string]interface{}{
-					"cluster_id": "00000000-2222-3333-4444-555555555555",
-				}
+				c.Datacenter = "acceptor-dc"
 			})
 			require.NoError(t, err)
 			defer acceptorPeerServer.Stop()
@@ -505,11 +499,8 @@ func TestReconcile_VersionAnnotationPeeringDialer(t *testing.T) {
 			go watcher.Run()
 
 			// Establish a peering with the generated token.
-			retry.Run(t, func(r *retry.R) {
-				_, _, err = dialerClient.Peerings().Establish(context.Background(), api.PeeringEstablishRequest{PeerName: "peering", PeeringToken: generatedToken.PeeringToken}, nil)
-				require.NoError(r, err)
-			})
-
+			_, _, err = dialerClient.Peerings().Establish(context.Background(), api.PeeringEstablishRequest{PeerName: "peering", PeeringToken: generatedToken.PeeringToken}, nil)
+			require.NoError(t, err)
 			k8sObjects = append(k8sObjects, createSecret("dialer-token-old", "default", "token", "old-token"))
 
 			// Create a new token to be potentially used by Reconcile(). The original token has already been

--- a/control-plane/connect-inject/redirect_traffic.go
+++ b/control-plane/connect-inject/redirect_traffic.go
@@ -3,9 +3,7 @@ package connectinject
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
-	"strings"
 
 	"github.com/hashicorp/consul/sdk/iptables"
 	corev1 "k8s.io/api/core/v1"
@@ -94,16 +92,12 @@ func (w *MeshWebhook) iptablesConfigJSON(pod corev1.Pod, ns corev1.Namespace) (s
 		return "", err
 	}
 
-	var consulDNSClusterIP string
 	if dnsEnabled {
 		// If Consul DNS is enabled, we find the environment variable that has the value
 		// of the ClusterIP of the Consul DNS Service. constructDNSServiceHostName returns
 		// the name of the env variable whose value is the ClusterIP of the Consul DNS Service.
-		consulDNSClusterIP = os.Getenv(w.constructDNSServiceHostName())
-		if consulDNSClusterIP == "" {
-			return "", fmt.Errorf("environment variable %s not found", w.constructDNSServiceHostName())
-		}
-		cfg.ConsulDNSIP = consulDNSClusterIP
+		cfg.ConsulDNSIP = "127.0.0.1"
+		cfg.ConsulDNSPort = ConsulDataplaneDNSBindPort
 	}
 
 	iptablesConfigJson, err := json.Marshal(&cfg)
@@ -124,13 +118,4 @@ func (w *MeshWebhook) addRedirectTrafficConfigAnnotation(pod *corev1.Pod, ns cor
 	pod.Annotations[annotationRedirectTraffic] = iptablesConfig
 
 	return nil
-}
-
-// constructDNSServiceHostName use the resource prefix and the DNS Service hostname suffix to construct the
-// key of the env variable whose value is the cluster IP of the Consul DNS Service.
-// It translates "resource-prefix" into "RESOURCE_PREFIX_DNS_SERVICE_HOST".
-func (w *MeshWebhook) constructDNSServiceHostName() string {
-	upcaseResourcePrefix := strings.ToUpper(w.ResourcePrefix)
-	upcaseResourcePrefixWithUnderscores := strings.ReplaceAll(upcaseResourcePrefix, "-", "_")
-	return strings.Join([]string{upcaseResourcePrefixWithUnderscores, dnsServiceHostEnvSuffix}, "_")
 }

--- a/control-plane/connect-inject/redirect_traffic.go
+++ b/control-plane/connect-inject/redirect_traffic.go
@@ -96,7 +96,7 @@ func (w *MeshWebhook) iptablesConfigJSON(pod corev1.Pod, ns corev1.Namespace) (s
 		// If Consul DNS is enabled, we find the environment variable that has the value
 		// of the ClusterIP of the Consul DNS Service. constructDNSServiceHostName returns
 		// the name of the env variable whose value is the ClusterIP of the Consul DNS Service.
-		cfg.ConsulDNSIP = "127.0.0.1"
+		cfg.ConsulDNSIP = ConsulDataplaneDNSBindHost
 		cfg.ConsulDNSPort = ConsulDataplaneDNSBindPort
 	}
 

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/armon/go-metrics v0.3.10 // indirect
+	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.25.41 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -132,5 +132,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
+
+replace github.com/hashicorp/consul/sdk => github.com/hashicorp/consul/sdk v0.4.1-0.20221021205723-cc843c4be892
 
 go 1.19

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -96,8 +96,9 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
-github.com/armon/go-metrics v0.3.10 h1:FR+drcQStOe+32sYyJYyZ7FIdgoGGBnwLl+flodp8Uo=
 github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
+github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=
+github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -350,9 +351,8 @@ github.com/hashicorp/consul/api v1.10.1-0.20221005170644-13da2c5fad69 h1:IALuDSO
 github.com/hashicorp/consul/api v1.10.1-0.20221005170644-13da2c5fad69/go.mod h1:T09kWtKqm8j1S9yTd1r0hVhfOyPrvLb0zb6dPKpNXxQ=
 github.com/hashicorp/consul/proto-public v0.1.0 h1:O0LSmCqydZi363hsqc6n2v5sMz3usQMXZF6ziK3SzXU=
 github.com/hashicorp/consul/proto-public v0.1.0/go.mod h1:vs2KkuWwtjkIgA5ezp4YKPzQp4GitV+q/+PvksrA92k=
-github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
-github.com/hashicorp/consul/sdk v0.11.0 h1:HRzj8YSCln2yGgCumN5CL8lYlD3gBurnervJRJAZyC4=
-github.com/hashicorp/consul/sdk v0.11.0/go.mod h1:yPkX5Q6CsxTFMjQQDJwzeNmUUF5NUGGbrDsv9wTb8cw=
+github.com/hashicorp/consul/sdk v0.4.1-0.20221021205723-cc843c4be892 h1:jw0NwPmNPr5CxAU04hACdj61JSaJBKZ0FdBo+kwfNp4=
+github.com/hashicorp/consul/sdk v0.4.1-0.20221021205723-cc843c4be892/go.mod h1:yPkX5Q6CsxTFMjQQDJwzeNmUUF5NUGGbrDsv9wTb8cw=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -492,7 +492,6 @@ github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXx
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -487,7 +487,7 @@ func (c *Command) Run(args []string) int {
 	mgr.GetWebhookServer().Register("/mutate",
 		&webhook.Admission{Handler: &connectinject.MeshWebhook{
 			Clientset:                    c.clientset,
-			ReleaseNamespace:              c.flagReleaseNamespace,
+			ReleaseNamespace:             c.flagReleaseNamespace,
 			ConsulConfig:                 consulConfig,
 			ConsulServerConnMgr:          watcher,
 			ImageConsul:                  c.flagConsulImage,

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -487,6 +487,7 @@ func (c *Command) Run(args []string) int {
 	mgr.GetWebhookServer().Register("/mutate",
 		&webhook.Admission{Handler: &connectinject.MeshWebhook{
 			Clientset:                    c.clientset,
+			ReleaseNamespace:              c.flagReleaseNamespace,
 			ConsulConfig:                 consulConfig,
 			ConsulServerConnMgr:          watcher,
 			ImageConsul:                  c.flagConsulImage,
@@ -518,7 +519,6 @@ func (c *Command) Run(args []string) int {
 			EnableCNI:                    c.flagEnableCNI,
 			TProxyOverwriteProbes:        c.flagTransparentProxyDefaultOverwriteProbes,
 			EnableConsulDNS:              c.flagEnableConsulDNS,
-			ResourcePrefix:               c.flagResourcePrefix,
 			EnableOpenShift:              c.flagEnableOpenShift,
 			Log:                          ctrl.Log.WithName("handler").WithName("connect"),
 			LogLevel:                     c.flagLogLevel,
@@ -526,14 +526,14 @@ func (c *Command) Run(args []string) int {
 		}})
 
 	if c.flagEnableWebhookCAUpdate {
-		err := c.updateWebhookCABundle(ctx)
+		err = c.updateWebhookCABundle(ctx)
 		if err != nil {
 			setupLog.Error(err, "problem getting CA Cert")
 			return 1
 		}
 	}
 
-	if err := mgr.Start(ctx); err != nil {
+	if err = mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		return 1
 	}


### PR DESCRIPTION
Changes proposed in this PR:
- Redirect traffic to the consul-dataplane's DNS proxy when DNS redirection is enabled. This means we no longer need to configure recursors for the clients and servers
- To fall back to kube dns when consul cannot resolve names, we define our own DNSConfig on the pod that uses Consul first, but falls back to the config from `/etc/resolv.conf` in the cluster.

How I've tested this PR:
acceptance tests

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

