### PR TITLE
Separate CLI tests into their own package

### DIFF
--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -139,7 +139,7 @@ func (t *TestConfig) entImage() (string, error) {
 		return v.Global.Image, nil
 	}
 
-	// Otherwise, assume that we have an image tag with a version in it.
+	//// Otherwise, assume that we have an image tag with a version in it.
 	consulImageSplits := strings.Split(v.Global.Image, ":")
 	if len(consulImageSplits) != 2 {
 		return "", fmt.Errorf("could not determine consul version from global.image: %s", v.Global.Image)
@@ -154,7 +154,7 @@ func (t *TestConfig) entImage() (string, error) {
 		preRelease = fmt.Sprintf("-%s", split[1])
 	}
 
-	return fmt.Sprintf("hashicorp/consul-enterprise:%s-ent%s", consulImageVersion, preRelease), nil
+	return fmt.Sprintf("hashicorp/consul-enterprise:%s%s-ent", consulImageVersion, preRelease), nil
 }
 
 // setIfNotEmpty sets key to val in map m if value is not empty.

--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -139,7 +139,7 @@ func (t *TestConfig) entImage() (string, error) {
 		return v.Global.Image, nil
 	}
 
-	//// Otherwise, assume that we have an image tag with a version in it.
+	// Otherwise, assume that we have an image tag with a version in it.
 	consulImageSplits := strings.Split(v.Global.Image, ":")
 	if len(consulImageSplits) != 2 {
 		return "", fmt.Errorf("could not determine consul version from global.image: %s", v.Global.Image)

--- a/acceptance/framework/config/config_test.go
+++ b/acceptance/framework/config/config_test.go
@@ -138,11 +138,11 @@ func TestConfig_HelmValuesFromConfig_EntImage(t *testing.T) {
 		},
 		{
 			consulImage: "hashicorp/consul:1.8.5-rc1",
-			expImage:    "hashicorp/consul-enterprise:1.8.5-ent-rc1",
+			expImage:    "hashicorp/consul-enterprise:1.8.5-rc1-ent",
 		},
 		{
 			consulImage: "hashicorp/consul:1.7.0-beta3",
-			expImage:    "hashicorp/consul-enterprise:1.7.0-ent-beta3",
+			expImage:    "hashicorp/consul-enterprise:1.7.0-beta3-ent",
 		},
 		{
 			consulImage: "invalid",
@@ -173,7 +173,7 @@ func TestConfig_HelmValuesFromConfig_EntImage(t *testing.T) {
 				require.EqualError(t, err, tt.expErr)
 			} else {
 				require.NoError(t, err)
-				require.Contains(t, values["global.image"], tt.expImage)
+				require.Equal(t, tt.expImage, values["global.image"])
 			}
 		})
 	}

--- a/acceptance/tests/cli/cli_install_test.go
+++ b/acceptance/tests/cli/cli_install_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul-k8s/acceptance/framework/cli"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/connhelper"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/stretchr/testify/require"
+)
+
+const ipv4RegEx = "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
+
+// TestInstall tests that we can install consul service mesh with the CLI
+// and see that services can connect.
+func TestInstall(t *testing.T) {
+	secureCases := []bool{false, true}
+
+	for _, secure := range secureCases {
+		name := fmt.Sprintf("secure: %t", secure)
+		t.Run(name, func(t *testing.T) {
+			cli, err := cli.NewCLI()
+			require.NoError(t, err)
+
+			cfg := suite.Config()
+			ctx := suite.Environment().DefaultContext(t)
+
+			connHelper := connhelper.ConnectHelper{
+				ClusterKind: consul.CLI,
+				Secure:      secure,
+				ReleaseName: consul.CLIReleaseName,
+				Ctx:         ctx,
+				Cfg:         cfg,
+			}
+
+			connHelper.Setup(t)
+
+			connHelper.Install(t)
+			connHelper.DeployClientAndServer(t)
+			if secure {
+				connHelper.TestConnectionFailureWithoutIntention(t)
+				connHelper.CreateIntention(t)
+			}
+
+			// Run proxy list and get the two results.
+			listOut, err := cli.Run(t, ctx.KubectlOptions(t), "proxy", "list")
+			require.NoError(t, err)
+			logger.Log(t, string(listOut))
+			list := translateListOutput(listOut)
+			require.Equal(t, 2, len(list))
+			for _, proxyType := range list {
+				require.Equal(t, "Sidecar", proxyType)
+			}
+
+			// Run proxy read and check that the connection is present in the output.
+			retrier := &retry.Timer{Timeout: 160 * time.Second, Wait: 2 * time.Second}
+			retry.RunWith(retrier, t, func(r *retry.R) {
+				for podName := range list {
+					out, err := cli.Run(t, ctx.KubectlOptions(t), "proxy", "read", podName)
+					require.NoError(t, err)
+
+					output := string(out)
+					logger.Log(t, output)
+
+					// Both proxies must see their own local agent and app as clusters.
+					require.Regexp(r, "consul-dataplane.*STATIC", output)
+					require.Regexp(r, "local_app.*STATIC", output)
+
+					// Static Client must have Static Server as a cluster and endpoint.
+					if strings.Contains(podName, "static-client") {
+						require.Regexp(r, "static-server.*static-server\\.default\\.dc1\\.internal.*EDS", output)
+						require.Regexp(r, ipv4RegEx+".*static-server", output)
+					}
+				}
+			})
+
+			connHelper.TestConnectionSuccess(t)
+			connHelper.TestConnectionFailureWhenUnhealthy(t)
+		})
+	}
+}
+
+// translateListOutput takes the raw output from the proxy list command and
+// translates the table into a map.
+func translateListOutput(raw []byte) map[string]string {
+	formatted := make(map[string]string)
+	for _, pod := range strings.Split(strings.TrimSpace(string(raw)), "\n")[3:] {
+		row := strings.Split(strings.TrimSpace(pod), "\t")
+
+		var name string
+		if len(row) == 3 { // Handle the case where namespace is present
+			name = fmt.Sprintf("%s/%s", strings.TrimSpace(row[0]), strings.TrimSpace(row[1]))
+		} else if len(row) == 2 {
+			name = strings.TrimSpace(row[0])
+		}
+		formatted[name] = row[len(row)-1]
+	}
+
+	return formatted
+}

--- a/acceptance/tests/cli/cli_install_test.go
+++ b/acceptance/tests/cli/cli_install_test.go
@@ -19,10 +19,14 @@ const ipv4RegEx = "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]
 // TestInstall tests that we can install consul service mesh with the CLI
 // and see that services can connect.
 func TestInstall(t *testing.T) {
-	secureCases := []bool{false, true}
+	cases := map[string]struct {
+		secure bool
+	}{
+		"not-secure": {secure: false},
+		"secure":     {secure: true},
+	}
 
-	for _, secure := range secureCases {
-		name := fmt.Sprintf("secure: %t", secure)
+	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			cli, err := cli.NewCLI()
 			require.NoError(t, err)
@@ -32,7 +36,7 @@ func TestInstall(t *testing.T) {
 
 			connHelper := connhelper.ConnectHelper{
 				ClusterKind: consul.CLI,
-				Secure:      secure,
+				Secure:      c.secure,
 				ReleaseName: consul.CLIReleaseName,
 				Ctx:         ctx,
 				Cfg:         cfg,
@@ -42,7 +46,7 @@ func TestInstall(t *testing.T) {
 
 			connHelper.Install(t)
 			connHelper.DeployClientAndServer(t)
-			if secure {
+			if c.secure {
 				connHelper.TestConnectionFailureWithoutIntention(t)
 				connHelper.CreateIntention(t)
 			}

--- a/acceptance/tests/cli/cli_upgrade_test.go
+++ b/acceptance/tests/cli/cli_upgrade_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/consul-k8s/acceptance/framework/connhelper"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestConnectInjectOnUpgrade tests that Connect works before and after an
+// upgrade is performed on the cluster.
+func TestUpgrade(t *testing.T) {
+	cfg := suite.Config()
+	ctx := suite.Environment().DefaultContext(t)
+
+	connHelper := connhelper.ConnectHelper{
+		ClusterKind: consul.CLI,
+		ReleaseName: consul.CLIReleaseName,
+		Ctx:         ctx,
+		Cfg:         cfg,
+	}
+
+	connHelper.Setup(t)
+
+	connHelper.Install(t)
+
+	// Change a value on the connect-injector to force an update.
+	connHelper.HelmValues = map[string]string{
+		"ingressGateways.enabled":           "true",
+		"ingressGateways.defaults.replicas": "1",
+	}
+
+	connHelper.Upgrade(t)
+
+	t.Log("checking that the upgrade was successful")
+	k8sClient := ctx.KubernetesClient(t)
+	igwPods, err := k8sClient.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{LabelSelector: "component=ingress-gateway"})
+	require.NoError(t, err)
+	require.Len(t, igwPods.Items, 1)
+}

--- a/acceptance/tests/cli/cli_upgrade_test.go
+++ b/acceptance/tests/cli/cli_upgrade_test.go
@@ -35,7 +35,7 @@ func TestUpgrade(t *testing.T) {
 
 	connHelper.Upgrade(t)
 
-	t.Log("checking that the upgrade was successful")
+	t.Log("checking that the ingress gateway was install as a result of the upgrade")
 	k8sClient := ctx.KubernetesClient(t)
 	igwPods, err := k8sClient.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{LabelSelector: "component=ingress-gateway"})
 	require.NoError(t, err)

--- a/acceptance/tests/cli/main_test.go
+++ b/acceptance/tests/cli/main_test.go
@@ -1,0 +1,15 @@
+package cli
+
+import (
+	"os"
+	"testing"
+
+	testsuite "github.com/hashicorp/consul-k8s/acceptance/framework/suite"
+)
+
+var suite testsuite.Suite
+
+func TestMain(m *testing.M) {
+	suite = testsuite.NewSuite(m)
+	os.Exit(suite.Run())
+}


### PR DESCRIPTION
Changes proposed in this PR:

Separate CLI tests into their own package for acceptance tests.

Having CLI tests to be in the same package as connect has become a bit hard to deal with for a few reasons:
- It's hard to run just the connect tests when you're working through some cross-cutting feature (e.g. agentless). You need to comment out the CLI tests just so they don't get in the way when you're just trying to check the basic service mesh functionality. 
- Having them run in one test makes the connect package take even longer to run and therefore tests harder to parallelize. 
- When we want to add more CLI features (like the CLI upgrade test which adds an ingress gateway on upgrade), it doesn't necessarily make sense to add them in the connect package.

How I've tested this PR:
acceptance tests

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

