### PR TITLE
Fix License name in build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,9 +274,9 @@ jobs:
         run: |
           cd "${ZIP_LOCATION}"
           unzip -j *.zip
-      - name: Copy LICENSE.md
+      - name: Copy LICENSE
         run:
-         cp LICENSE.md ./control-plane
+         cp LICENSE ./control-plane
       - uses: hashicorp/actions-docker-build@v1
         with:
           smoke_test: |
@@ -316,9 +316,9 @@ jobs:
         run: |
           cd ${ZIP_LOCATION}
           unzip -j *.zip
-      - name: Copy LICENSE.md
+      - name: Copy LICENSE
         run:
-          cp LICENSE.md ./control-plane
+          cp LICENSE ./control-plane
       - uses: hashicorp/actions-docker-build@v1
         with:
           smoke_test: |


### PR DESCRIPTION
Changes proposed in this PR:
- [LICENSE.md was renamed to LICENSE](https://github.com/hashicorp/consul-k8s/commit/86c3baa3a6098b605cd9d8d405cb2a42618fc9ae) causing the builds on main to fail (eg. https://github.com/hashicorp/consul-k8s/actions/runs/3237929430/jobs/5305787047). This modifies the builds to use `LICENSE` instead of `LICENSE.md`

How I've tested this PR:
👀
How I expect reviewers to test this PR:
👀

Checklist:
- [N/A] Tests added
- [N/A] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

