### PR TITLE
Setting server affinity to null in coud preset to allow easier local kubernetes installations of GNM.

### DIFF
--- a/cli/preset/cloud_preset.go
+++ b/cli/preset/cloud_preset.go
@@ -214,6 +214,7 @@ global:
     %s
 server:
   replicas: %d
+  affinity: null
   serverCert: 
     secretName: %s
 connectInject:

--- a/cli/preset/cloud_preset_test.go
+++ b/cli/preset/cloud_preset_test.go
@@ -487,6 +487,7 @@ global:
     enableAutoEncrypt: true
     enabled: true
 server:
+  affinity: null
   replicas: 3
   serverCert:
     secretName: consul-server-cert
@@ -524,6 +525,7 @@ global:
     enableAutoEncrypt: true
     enabled: true
 server:
+  affinity: null
   replicas: 3
   serverCert:
     secretName: consul-server-cert


### PR DESCRIPTION
Background:
The cloud preset is solely used for installing HCP self managed clusters.  We want this to be as seamless for the user to do a one click install so that they can get to the value moment as soon as possible.  A common scenario for kicking the tires on a new feature is to use a local isntallation of k8s with kind/minikube/etc which by default only have 1 virtual host configured.  

HCP self managed clusters already expects 3 replicas will get created (it is configured in HCP and passed down in a bootstarp_expect value).  So currently when you try to install an HCP self managed cluster with 3 replicas into a cluster configured with 1 host, then you will get a scenario where the helm install fails because 1 replicas was created and the other 2 are pending waiting for two more hosts.

This change is to make it easy for any user to install an HCP self managed cluster without having to think too hard or debug local installation issues.

Changes proposed in this PR:
- Setting server affinity to null in coud preset to allow easier local kubernetes installations of GNM.

How I've tested this PR:
- unit tests
- manually installed a cluster with 3 replicas on kind where there was only one virtual node.  (normally server affinity would require having a node for each replicas and would timeout in this scenario.)

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- ~[] CHANGELOG entry added~ N/A - I think this is covered by the this feature being added and this being a kink that is ironed out during beta.
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

