### PR TITLE
Use HashiCorp Actions Go Build for Consul K8s CLI

### DIFF
--- a/.github/workflows/reusable-acceptance.yml
+++ b/.github/workflows/reusable-acceptance.yml
@@ -62,20 +62,17 @@ jobs:
         with:
           ref: ${{ inputs.checkout-ref }}
       
-      - name: Setup go
-        uses: actions/setup-go@v3
+      - name: Build Consul K8s CLI
+        uses: hashicorp/actions-go-build@v0.1.3
         with:
-          go-version: ${{ inputs.go-version }}
-
-      - name: Setup go mod cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          product_name: consul-k8s
+          go_version: ${{ inputs.go-version }}
+          os: linux
+          arch: amd64
+          reproducible: assert
+          instructions: |
+            sudo make cli-dev
+            consul-k8s version
 
       - name: Install pre-requisites # Install gotestsum, kind, kubectl, and helm
         run: |
@@ -97,10 +94,6 @@ jobs:
 
       - run: mkdir -p ${{ env.TEST_RESULTS }}
 
-      - name: go mod download
-        working-directory: ${{ inputs.directory }}
-        run: go mod download
-      
       - name: Create kind clusters
         run: |
           kind create cluster --name dc1 --image kindest/node:${{ inputs.kind-version }}

--- a/.github/workflows/reusable-acceptance.yml
+++ b/.github/workflows/reusable-acceptance.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Extract CLI and add to PATH
         run: |
-          unzip -j consul-k8s_${{ input.product-version }}_linux_amd64.zip
+          unzip -j consul-k8s_1.0.0-dev_linux_amd64.zip
           ls -a
 
       - name: Install pre-requisites # Install gotestsum, kind, kubectl, and helm

--- a/.github/workflows/reusable-acceptance.yml
+++ b/.github/workflows/reusable-acceptance.yml
@@ -74,7 +74,7 @@ jobs:
           # Build and add to GOPATH
           instructions: |
             go build -o ./dist/consul-k8s
-            cp ./dist/consul-k8s ${GOPATH}/bin/
+            "export PATH=./dist/consul-k8s:$PATH"
 
 
       - name: Install pre-requisites # Install gotestsum, kind, kubectl, and helm

--- a/.github/workflows/reusable-acceptance.yml
+++ b/.github/workflows/reusable-acceptance.yml
@@ -66,13 +66,16 @@ jobs:
         uses: hashicorp/actions-go-build@v0.1.6
         with:
           product_name: consul-k8s
-          product_version: 1.0.0-dev
+          product_version: ${{ needs.get-product-version.outputs.product-version }}
           go_version: ${{ inputs.go-version }}
           os: linux
           arch: amd64
-          reproducible: assert
           work_dir: ./cli
-          instructions: CGO_ENABLED=0 go build -trimpath -buildvcs=false
+          # Build and add to GOPATH
+          instructions: |
+            go build -o ./dist/consul-k8s
+            cp ./dist/consul-k8s ${GOPATH}/bin/
+
 
       - name: Install pre-requisites # Install gotestsum, kind, kubectl, and helm
         run: |

--- a/.github/workflows/reusable-acceptance.yml
+++ b/.github/workflows/reusable-acceptance.yml
@@ -71,9 +71,8 @@ jobs:
           os: linux
           arch: amd64
           reproducible: assert
-          instructions: |
-            sudo make cli-dev
-            consul-k8s version
+          work_dir: ./cli
+          instructions: CGO_ENABLED=0 go build -trimpath -buildvcs=false
 
       - name: Install pre-requisites # Install gotestsum, kind, kubectl, and helm
         run: |

--- a/.github/workflows/reusable-acceptance.yml
+++ b/.github/workflows/reusable-acceptance.yml
@@ -6,6 +6,9 @@ on:
       name:
         required: true
         type: string
+      product-version:
+        required: true
+        type: string
       additional-flags:
         required: false
         type: string
@@ -66,12 +69,11 @@ jobs:
         uses: hashicorp/actions-go-build@v0.1.6
         with:
           product_name: consul-k8s
-          product_version: ${{ needs.get-product-version.outputs.product-version }}
+          product_version: ${{ inputs.product-version }}
           go_version: ${{ inputs.go-version }}
           os: linux
           arch: amd64
           work_dir: ./cli
-          # Build and add to GOPATH
           instructions: go build -o ./dist/consul-k8s
 
       - name: Add CLI to path

--- a/.github/workflows/reusable-acceptance.yml
+++ b/.github/workflows/reusable-acceptance.yml
@@ -19,9 +19,6 @@ on:
       directory:
         required: true
         type: string
-      go-version:
-        required: true
-        type: string
       gotestsum-version:
         required: true
         type: string
@@ -64,20 +61,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.checkout-ref }}
-      
-      - name: Build Consul K8s CLI
-        uses: hashicorp/actions-go-build@v0.1.6
-        with:
-          product_name: consul-k8s
-          product_version: ${{ inputs.product-version }}
-          go_version: ${{ inputs.go-version }}
-          os: linux
-          arch: amd64
-          work_dir: ./cli
-          instructions: go build -o ./dist/consul-k8s
 
-      - name: Add CLI to path
-        run: export PATH=./consul-k8s/dist/consul-k8s:$PATH
+      - name: Download CLI bin
+        uses: actions/download-artifact@v3
+        with:
+          name: consul-k8s_${{ input.product-version }}_linux_amd64.zip
+          path: ./
+
+      - name: Extract CLI and add to PATH
+        run: |
+          unzip -j consul-k8s_${{ input.product-version }}_linux_amd64.zip
+          ls -a
 
       - name: Install pre-requisites # Install gotestsum, kind, kubectl, and helm
         run: |

--- a/.github/workflows/reusable-acceptance.yml
+++ b/.github/workflows/reusable-acceptance.yml
@@ -66,7 +66,7 @@ jobs:
         uses: hashicorp/actions-go-build@v0.1.3
         with:
           product_name: consul-k8s
-          product_version: ${{ needs.get-product-version.outputs.product-version }}
+          product_version: 1.0.0-dev
           go_version: ${{ inputs.go-version }}
           os: linux
           arch: amd64

--- a/.github/workflows/reusable-acceptance.yml
+++ b/.github/workflows/reusable-acceptance.yml
@@ -66,6 +66,7 @@ jobs:
         uses: hashicorp/actions-go-build@v0.1.3
         with:
           product_name: consul-k8s
+          product_version: ${{ needs.get-product-version.outputs.product-version }}
           go_version: ${{ inputs.go-version }}
           os: linux
           arch: amd64

--- a/.github/workflows/reusable-acceptance.yml
+++ b/.github/workflows/reusable-acceptance.yml
@@ -72,10 +72,10 @@ jobs:
           arch: amd64
           work_dir: ./cli
           # Build and add to GOPATH
-          instructions: |
-            go build -o ./dist/consul-k8s
-            "export PATH=./dist/consul-k8s:$PATH"
+          instructions: go build -o ./dist/consul-k8s
 
+      - name: Add CLI to path
+        run: export PATH=./consul-k8s/dist/consul-k8s:$PATH
 
       - name: Install pre-requisites # Install gotestsum, kind, kubectl, and helm
         run: |

--- a/.github/workflows/reusable-acceptance.yml
+++ b/.github/workflows/reusable-acceptance.yml
@@ -63,7 +63,7 @@ jobs:
           ref: ${{ inputs.checkout-ref }}
       
       - name: Build Consul K8s CLI
-        uses: hashicorp/actions-go-build@v0.1.3
+        uses: hashicorp/actions-go-build@v0.1.6
         with:
           product_name: consul-k8s
           product_version: 1.0.0-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,7 +344,7 @@ jobs:
 
   acceptance:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@te/use-hc-actions-build
     with:
       name: acceptance
       directory: acceptance/tests
@@ -357,7 +357,7 @@ jobs:
 
   acceptance-tproxy:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@te/use-hc-actions-build
     with:
       name: acceptance-tproxy
       directory: acceptance/tests
@@ -370,7 +370,7 @@ jobs:
 
   acceptance-cni:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@te/use-hc-actions-build
     with:
       name: acceptance
       directory: acceptance/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -342,14 +342,33 @@ jobs:
           target: release-default
           tags: docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.version }}-pr-${{ github.sha }}
 
+  # Build and upload CLI to GH artifacts
+  dev-upload-cli:
+    if: github.repository_owner == 'hashicorp' # Do not run on forks 
+    needs: [ get-product-version, build-distros, get-go-version ]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ["amd64"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/actions-go-build@v0.1.6
+        with:
+          product_name: consul-k8s
+          product_version: ${{ needs.get-product-version.outputs.product-version }}
+          go_version: ${{ needs.get-go-version.outputs.go-version }}
+          os: linux
+          arch: amd64
+          work_dir: ./cli
+          instructions: go build -o ./dist/consul-k8s
+
   acceptance:
-    needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@fa87bb03e102475235e58011da736eddfecb0371
+    needs: [ get-product-version, dev-upload-docker, get-go-version, dev-upload-cli ]
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@dfc4ea40790fba671f87a1a79a27a98b83b91215
     with:
       name: acceptance
-      product-version: 1.0.0-dev
+      product-version: ${{ needs.get-product-version.outputs.product-version }}
       directory: acceptance/tests
-      go-version: ${{ needs.get-go-version.outputs.go-version }}
       additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
       gotestsum-version: 1.8.2
       consul-k8s-image: docker.io/hashicorppreview/${{ github.event.repository.name }}-control-plane:${{ needs.get-product-version.outputs.product-version }}-pr-${{ github.sha }}
@@ -357,13 +376,12 @@ jobs:
       CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
 
   acceptance-tproxy:
-    needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@fa87bb03e102475235e58011da736eddfecb0371
+    needs: [ get-product-version, dev-upload-docker, get-go-version, dev-upload-cli ]
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@dfc4ea40790fba671f87a1a79a27a98b83b91215
     with:
       name: acceptance-tproxy
-      product-version: 1.0.0-dev
+      product-version: ${{ needs.get-product-version.outputs.product-version }}
       directory: acceptance/tests
-      go-version: ${{ needs.get-go-version.outputs.go-version }}
       additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
       gotestsum-version: 1.8.2
       consul-k8s-image: docker.io/hashicorppreview/${{ github.event.repository.name }}-control-plane:${{ needs.get-product-version.outputs.product-version }}-pr-${{ github.sha }}
@@ -371,13 +389,12 @@ jobs:
       CONSUL_ENT_LICENSE: ${{ secrets.CONSUL_ENT_LICENSE }}
 
   acceptance-cni:
-    needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@fa87bb03e102475235e58011da736eddfecb0371
+    needs: [ get-product-version, dev-upload-docker, dev-upload-cli ]
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@dfc4ea40790fba671f87a1a79a27a98b83b91215
     with:
       name: acceptance
-      product-version: 1.0.0-dev
+      product-version: ${{ needs.get-product-version.outputs.product-version }}
       directory: acceptance/tests
-      go-version: ${{ needs.get-go-version.outputs.go-version }}
       additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -enable-cni -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
       gotestsum-version: 1.8.2
       consul-k8s-image: docker.io/hashicorppreview/${{ github.event.repository.name }}-control-plane:${{ needs.get-product-version.outputs.product-version }}-pr-${{ github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,7 +344,7 @@ jobs:
 
   acceptance:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e243f5804606bdbe115327bf1e4b73b3bfcdbdca
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@06c1af5ff933c320389d1a4381cc5a4b40038dc0
     with:
       name: acceptance
       directory: acceptance/tests
@@ -357,7 +357,7 @@ jobs:
 
   acceptance-tproxy:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e243f5804606bdbe115327bf1e4b73b3bfcdbdca
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@06c1af5ff933c320389d1a4381cc5a4b40038dc0
     with:
       name: acceptance-tproxy
       directory: acceptance/tests
@@ -370,7 +370,7 @@ jobs:
 
   acceptance-cni:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e243f5804606bdbe115327bf1e4b73b3bfcdbdca
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@06c1af5ff933c320389d1a4381cc5a4b40038dc0
     with:
       name: acceptance
       directory: acceptance/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,7 +344,7 @@ jobs:
 
   acceptance:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@a80061b7edac226e2b48af45e60fbd3443897230
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@11bb01c728604d38c54d5d23001cad32b1c10343
     with:
       name: acceptance
       directory: acceptance/tests
@@ -357,7 +357,7 @@ jobs:
 
   acceptance-tproxy:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@a80061b7edac226e2b48af45e60fbd3443897230
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@11bb01c728604d38c54d5d23001cad32b1c10343
     with:
       name: acceptance-tproxy
       directory: acceptance/tests
@@ -370,8 +370,7 @@ jobs:
 
   acceptance-cni:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@a80061b7edac226e2b48af45e60fbd3443897230
-
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@11bb01c728604d38c54d5d23001cad32b1c10343
     with:
       name: acceptance
       directory: acceptance/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,7 +344,7 @@ jobs:
 
   acceptance:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e6a67089a7edaeb19c8b831716be0847f7935f81
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@2a6af7551c0add4ad21639c8ad4051ca0a37cba8
     with:
       name: acceptance
       directory: acceptance/tests
@@ -357,7 +357,7 @@ jobs:
 
   acceptance-tproxy:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e6a67089a7edaeb19c8b831716be0847f7935f81
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@2a6af7551c0add4ad21639c8ad4051ca0a37cba8
     with:
       name: acceptance-tproxy
       directory: acceptance/tests
@@ -370,7 +370,7 @@ jobs:
 
   acceptance-cni:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e6a67089a7edaeb19c8b831716be0847f7935f81
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@2a6af7551c0add4ad21639c8ad4051ca0a37cba8
     with:
       name: acceptance
       directory: acceptance/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,7 +344,7 @@ jobs:
 
   acceptance:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@aa8685c32943e59812197f29024840a56503e543
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e6a67089a7edaeb19c8b831716be0847f7935f81
     with:
       name: acceptance
       directory: acceptance/tests
@@ -357,7 +357,7 @@ jobs:
 
   acceptance-tproxy:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@aa8685c32943e59812197f29024840a56503e543
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e6a67089a7edaeb19c8b831716be0847f7935f81
     with:
       name: acceptance-tproxy
       directory: acceptance/tests
@@ -370,7 +370,7 @@ jobs:
 
   acceptance-cni:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@aa8685c32943e59812197f29024840a56503e543
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e6a67089a7edaeb19c8b831716be0847f7935f81
     with:
       name: acceptance
       directory: acceptance/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,7 +344,7 @@ jobs:
 
   acceptance:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e3601d96ef8c8534eb58a993aa21fb32a5315e40
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@a80061b7edac226e2b48af45e60fbd3443897230
     with:
       name: acceptance
       directory: acceptance/tests
@@ -357,7 +357,7 @@ jobs:
 
   acceptance-tproxy:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e3601d96ef8c8534eb58a993aa21fb32a5315e40
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@a80061b7edac226e2b48af45e60fbd3443897230
     with:
       name: acceptance-tproxy
       directory: acceptance/tests
@@ -370,7 +370,8 @@ jobs:
 
   acceptance-cni:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e3601d96ef8c8534eb58a993aa21fb32a5315e40
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@a80061b7edac226e2b48af45e60fbd3443897230
+
     with:
       name: acceptance
       directory: acceptance/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,9 +344,10 @@ jobs:
 
   acceptance:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@06c1af5ff933c320389d1a4381cc5a4b40038dc0
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@fa87bb03e102475235e58011da736eddfecb0371
     with:
       name: acceptance
+      product-version: 1.0.0-dev
       directory: acceptance/tests
       go-version: ${{ needs.get-go-version.outputs.go-version }}
       additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
@@ -357,9 +358,10 @@ jobs:
 
   acceptance-tproxy:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@06c1af5ff933c320389d1a4381cc5a4b40038dc0
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@fa87bb03e102475235e58011da736eddfecb0371
     with:
       name: acceptance-tproxy
+      product-version: 1.0.0-dev
       directory: acceptance/tests
       go-version: ${{ needs.get-go-version.outputs.go-version }}
       additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
@@ -370,9 +372,10 @@ jobs:
 
   acceptance-cni:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@06c1af5ff933c320389d1a4381cc5a4b40038dc0
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@fa87bb03e102475235e58011da736eddfecb0371
     with:
       name: acceptance
+      product-version: 1.0.0-dev
       directory: acceptance/tests
       go-version: ${{ needs.get-go-version.outputs.go-version }}
       additional-flags: "-use-kind -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-transparent-proxy -enable-cni -consul-image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -364,7 +364,7 @@ jobs:
 
   acceptance:
     needs: [ get-product-version, dev-upload-docker, get-go-version, dev-upload-cli ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@93eaf91510171d23a1d88c346efd280cb7e45b87
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@34ec6d2fd1398e0e7a942ce043e3834bc1ac1b81
     with:
       name: acceptance
       product-version: ${{ needs.get-product-version.outputs.product-version }}
@@ -377,7 +377,7 @@ jobs:
 
   acceptance-tproxy:
     needs: [ get-product-version, dev-upload-docker, get-go-version, dev-upload-cli ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@93eaf91510171d23a1d88c346efd280cb7e45b87
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@34ec6d2fd1398e0e7a942ce043e3834bc1ac1b81
     with:
       name: acceptance-tproxy
       product-version: ${{ needs.get-product-version.outputs.product-version }}
@@ -390,7 +390,7 @@ jobs:
 
   acceptance-cni:
     needs: [ get-product-version, dev-upload-docker, dev-upload-cli ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@93eaf91510171d23a1d88c346efd280cb7e45b87
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@34ec6d2fd1398e0e7a942ce043e3834bc1ac1b81
     with:
       name: acceptance
       product-version: ${{ needs.get-product-version.outputs.product-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,7 +344,7 @@ jobs:
 
   acceptance:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@2a6af7551c0add4ad21639c8ad4051ca0a37cba8
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e243f5804606bdbe115327bf1e4b73b3bfcdbdca
     with:
       name: acceptance
       directory: acceptance/tests
@@ -357,7 +357,7 @@ jobs:
 
   acceptance-tproxy:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@2a6af7551c0add4ad21639c8ad4051ca0a37cba8
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e243f5804606bdbe115327bf1e4b73b3bfcdbdca
     with:
       name: acceptance-tproxy
       directory: acceptance/tests
@@ -370,7 +370,7 @@ jobs:
 
   acceptance-cni:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@2a6af7551c0add4ad21639c8ad4051ca0a37cba8
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e243f5804606bdbe115327bf1e4b73b3bfcdbdca
     with:
       name: acceptance
       directory: acceptance/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,7 +344,7 @@ jobs:
 
   acceptance:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@536f034d6647fdadca8892036d0b06e28d1c9a57    
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e3601d96ef8c8534eb58a993aa21fb32a5315e40
     with:
       name: acceptance
       directory: acceptance/tests
@@ -357,7 +357,7 @@ jobs:
 
   acceptance-tproxy:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@536f034d6647fdadca8892036d0b06e28d1c9a57
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e3601d96ef8c8534eb58a993aa21fb32a5315e40
     with:
       name: acceptance-tproxy
       directory: acceptance/tests
@@ -370,7 +370,7 @@ jobs:
 
   acceptance-cni:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@536f034d6647fdadca8892036d0b06e28d1c9a57
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@e3601d96ef8c8534eb58a993aa21fb32a5315e40
     with:
       name: acceptance
       directory: acceptance/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -364,7 +364,7 @@ jobs:
 
   acceptance:
     needs: [ get-product-version, dev-upload-docker, get-go-version, dev-upload-cli ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@dfc4ea40790fba671f87a1a79a27a98b83b91215
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@93eaf91510171d23a1d88c346efd280cb7e45b87
     with:
       name: acceptance
       product-version: ${{ needs.get-product-version.outputs.product-version }}
@@ -377,7 +377,7 @@ jobs:
 
   acceptance-tproxy:
     needs: [ get-product-version, dev-upload-docker, get-go-version, dev-upload-cli ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@dfc4ea40790fba671f87a1a79a27a98b83b91215
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@93eaf91510171d23a1d88c346efd280cb7e45b87
     with:
       name: acceptance-tproxy
       product-version: ${{ needs.get-product-version.outputs.product-version }}
@@ -390,7 +390,7 @@ jobs:
 
   acceptance-cni:
     needs: [ get-product-version, dev-upload-docker, dev-upload-cli ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@dfc4ea40790fba671f87a1a79a27a98b83b91215
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@93eaf91510171d23a1d88c346efd280cb7e45b87
     with:
       name: acceptance
       product-version: ${{ needs.get-product-version.outputs.product-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,7 +344,7 @@ jobs:
 
   acceptance:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@te/use-hc-actions-build
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@536f034d6647fdadca8892036d0b06e28d1c9a57    
     with:
       name: acceptance
       directory: acceptance/tests
@@ -357,7 +357,7 @@ jobs:
 
   acceptance-tproxy:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@te/use-hc-actions-build
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@536f034d6647fdadca8892036d0b06e28d1c9a57
     with:
       name: acceptance-tproxy
       directory: acceptance/tests
@@ -370,7 +370,7 @@ jobs:
 
   acceptance-cni:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@te/use-hc-actions-build
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@536f034d6647fdadca8892036d0b06e28d1c9a57
     with:
       name: acceptance
       directory: acceptance/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,7 +344,7 @@ jobs:
 
   acceptance:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@11bb01c728604d38c54d5d23001cad32b1c10343
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@aa8685c32943e59812197f29024840a56503e543
     with:
       name: acceptance
       directory: acceptance/tests
@@ -357,7 +357,7 @@ jobs:
 
   acceptance-tproxy:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@11bb01c728604d38c54d5d23001cad32b1c10343
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@aa8685c32943e59812197f29024840a56503e543
     with:
       name: acceptance-tproxy
       directory: acceptance/tests
@@ -370,7 +370,7 @@ jobs:
 
   acceptance-cni:
     needs: [ get-product-version, dev-upload-docker, get-go-version ]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@11bb01c728604d38c54d5d23001cad32b1c10343
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@aa8685c32943e59812197f29024840a56503e543
     with:
       name: acceptance
       directory: acceptance/tests


### PR DESCRIPTION
There is a bug in the GH Actions for running acceptance tests. The Go binary that gets set up is not the same version of Go that gets used in subsequent calls to `go`. I have a feeling this is because the downloaded one is lower on the PATH. You can see this issue occurring here: https://github.com/hashicorp/consul-k8s/actions/runs/3331265834/jobs/5510872576

Changes proposed in this PR:
- Use the HashiCorp Go Build Action to build the Consul K8s CLI

How I've tested this PR:
- I will watch it run in GH actions. I had to make a modification to tell it to not run from `main`.

How I expect reviewers to test this PR:
- You can watch it with me.


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

