### PR TITLE
CLI - cloud preset - Disable transparent proxy by default during beta

### DIFF
--- a/cli/preset/cloud_preset.go
+++ b/cli/preset/cloud_preset.go
@@ -219,6 +219,8 @@ server:
     secretName: %s
 connectInject:
   enabled: true
+  transparentProxy:
+    defaultEnabled: false
 controller:
   enabled: true
 `, cfg.BootstrapResponse.Cluster.ID, secretNameServerCA, corev1.TLSCertKey,

--- a/cli/preset/cloud_preset_test.go
+++ b/cli/preset/cloud_preset_test.go
@@ -448,6 +448,8 @@ func TestGetHelmConfigWithMapSecretNames(t *testing.T) {
 
 	const expectedFull = `connectInject:
   enabled: true
+  transparentProxy:
+    defaultEnabled: false
 controller:
   enabled: true
 global:
@@ -495,6 +497,8 @@ server:
 
 	const expectedWithoutOptional = `connectInject:
   enabled: true
+  transparentProxy:
+    defaultEnabled: false
 controller:
   enabled: true
 global:


### PR DESCRIPTION
Changes proposed in this PR:
- set `connectInject.transparentProxy.defaultEnabled: false` in cloud preset since t-proxy work is still in progress.
-

How I've tested this PR:
- unit tests
- 👀 
- manual install of HCP self-managed clusters

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- ~[ ] CHANGELOG entry added~ N/A since this is s new feature in beta and this feature already has a changelog.
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

