### PR TITLE
Add PodSecurityPolicy for Consul API Gateway controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ IMPROVEMENTS:
   * Remove deprecated annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"` in the `server-service` template. [[GH-1619](https://github.com/hashicorp/consul-k8s/pull/1619)]
   * Support `minAvailable` on connect injector `PodDisruptionBudget`. [[GH-1557](https://github.com/hashicorp/consul-k8s/pull/1557)]
   * Add `tolerations` and `nodeSelector` to Server ACL init jobs and `nodeSelector` to Webhook cert manager. [[GH-1581](https://github.com/hashicorp/consul-k8s/pull/1581)]
+  * API Gateway: Create PodSecurityPolicy for controller when `global.enablePodSecurityPolicies=true`. [[GH-1656](https://github.com/hashicorp/consul-k8s/pull/1656)]
 
 ## 1.0.0-beta3 (October 12, 2022)
 

--- a/charts/consul/templates/api-gateway-controller-clusterrole.yaml
+++ b/charts/consul/templates/api-gateway-controller-clusterrole.yaml
@@ -244,4 +244,12 @@ rules:
   - get
   - patch
   - update
+{{- if .Values.global.enablePodSecurityPolicies }}
+- apiGroups: ["policy"]
+  resources: ["podsecuritypolicies"]
+  resourceNames:
+    - {{ template "consul.fullname" . }}-api-gateway-controller
+  verbs:
+    - use
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/api-gateway-controller-podsecuritypolicy.yaml
+++ b/charts/consul/templates/api-gateway-controller-podsecuritypolicy.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.apiGateway.enabled .Values.global.enablePodSecurityPolicies }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "consul.fullname" . }}-api-gateway-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: api-gateway-controller
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: true
+{{- end }}

--- a/charts/consul/test/unit/api-gateway-controller-clusterrole.bats
+++ b/charts/consul/test/unit/api-gateway-controller-clusterrole.bats
@@ -23,11 +23,11 @@ load _helpers
 @test "apiGateway/ClusterRole: uses PodSecurityPolicy with apiGateway.enabled=true and global.enablePodSecurityPolicies=true" {
   cd `chart_dir`
   local actual=$(helm template \
-    -s templates/api-gateway-controller-clusterrole.yaml \
-    --set 'global.enablePodSecurityPolicies=true' \
-    --set 'apiGateway.enabled=true' \
-    --set 'apiGateway.image=foo' \
-    . | tee /dev/stderr |
-    yq '.rules[] | select(.resourceNames[] == "release-name-consul-api-gateway-controller") | select(.resources[] == "podsecuritypolicies") | length > 0' | tee /dev/stderr)
+      -s templates/api-gateway-controller-clusterrole.yaml \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=foo' \
+      . | tee /dev/stderr |
+      yq '.rules[] | select((.resourceNames[0] == "release-name-consul-api-gateway-controller") and (.resources[0] == "podsecuritypolicies")) | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }

--- a/charts/consul/test/unit/api-gateway-controller-clusterrole.bats
+++ b/charts/consul/test/unit/api-gateway-controller-clusterrole.bats
@@ -19,3 +19,15 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "apiGateway/ClusterRole: uses PodSecurityPolicy with apiGateway.enabled=true and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+    -s templates/api-gateway-controller-clusterrole.yaml \
+    --set 'global.enablePodSecurityPolicies=true' \
+    --set 'apiGateway.enabled=true' \
+    --set 'apiGateway.image=foo' \
+    . | tee /dev/stderr |
+    yq '.rules[] | select(.resourceNames[] == "release-name-consul-api-gateway-controller") | select(.resources[] == "podsecuritypolicies") | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/api-gateway-controller-podsecuritypolicy.bats
+++ b/charts/consul/test/unit/api-gateway-controller-podsecuritypolicy.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "apiGateway/PodSecurityPolicy: disabled by default" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/api-gateway-controller-podsecuritypolicy.yaml  \
+      .
+}
+
+@test "apiGateway/PodSecurityPolicy: enabled with apiGateway.enabled=true and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-controller-podsecuritypolicy.yaml  \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=foo' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}


### PR DESCRIPTION
**Changes proposed in this PR:**
- Add a `PodSecurityPolicy` for the API gateway controller when both
  - API Gateway is enabled in `values.yaml`
  - PodSecurityPolicies are enabled in `values.yaml`
- Policy mimics the one already in place for the controller at `controller-podsecuritypolicy.yaml`
- Slight adjustment to disable write access to the local file system since the API gateway controller does not require this

> **Note** `PodSecurityPolicy` was removed with Kubernetes 1.25, so this change must be tested on <= 1.24. I'm planning to work with @kschoche on supporting Pod Security Admission, the 1.25-friendly replacement, in the coming weeks.

> **Note** This adds a `PodSecurityPolicy` for the API gateway controller but not for the `Deployments` created by the controller for every `Gateway`. That will be done in future PR(s).

**How I've tested this PR:**
Create a Kubernetes cluster that requires `PodSecurityPolicies`. For GKE:
```shell
# Create the Kubernetes cluster
$ gcloud container clusters create cluster-1

# Require PodSecurityPolicy - this will take a while, approx. 30 minutes in my case
$ gcloud beta container clusters update cluster-1 --enable-pod-security-policy
```

Install Consul using consul-k8s `0.49.0` with Consul API Gateway enabled. Notice that the `consul-api-gateway-controller` Deployment is unable to admit any pods due to the missing `PodSecurityPolicy`:
```shell
$ kubectl get deployment consul-api-gateway-controller --output yaml
...
status:
  conditions:
    ...
    - lastTransitionTime: "2022-10-27T22:30:00Z"
      lastUpdateTime: "2022-10-27T22:30:00Z"
      message: 'pods "consul-api-gateway-controller-5bccc6b66d-" is forbidden: PodSecurityPolicy: unable to admit pod: []'
      reason: FailedCreate
      status: "True"
      type: ReplicaFailure
```

Now, install Consul into the same cluster using this version of the Helm chart with Consul API Gateway and PodSecurityPolicies enabled. Then create a `Gateway`, some services, and one or more `HTTPRoutes`. I pretty much follow [this guide](https://developer.hashicorp.com/consul/tutorials/kubernetes/kubernetes-api-gateway) but use this branch of consul-k8s.

> **Warning** You probably need to delete the consul-api-gateway-controller `Deployment` before doing the Helm upgrade to the version in this PR; otherwise, the changes to the `ClusterRole` won't be picked up and it will still be failing.

<details>
<summary>Example values.yaml</summary>

```yaml
global:
  name: consul
  datacenter: dc1
  tls:
    enabled: true
  image: hashicorppreview/consul:1.14-dev
  enablePodSecurityPolicies: true
server:
  replicas: 1
ui:
  enabled: true
  service:
    type: NodePort
connectInject:
  enabled: true
controller:
  enabled: true
apiGateway:
  enabled: true
  image: "hashicorppreview/consul-api-gateway:0.5-dev"
  managedGatewayClass:
    serviceType: NodePort
    useHostPorts: true
```

</details>

**How I expect reviewers to test this PR:**
- Compare to the policy for the base controller [here](https://github.com/hashicorp/consul-k8s/blob/main/charts/consul/templates/controller-podsecuritypolicy.yaml)
- Can exercise functionality by following the instructions above

**Checklist:**
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

