### PR TITLE
acceptance: cloud tests need the cli to be built

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -687,6 +687,7 @@ jobs:
 
       - checkout
 
+      - build-cli
       - run:
           name: terraform init & apply
           working_directory: *gke-terraform-path
@@ -755,6 +756,7 @@ jobs:
 
       - checkout
 
+      - build-cli
       - run:
           name: terraform init & apply
           working_directory: *gke-terraform-path
@@ -814,6 +816,7 @@ jobs:
     steps:
       - checkout
 
+      - build-cli
       - run:
           name: terraform init & apply
           working_directory: *aks-terraform-path
@@ -870,6 +873,7 @@ jobs:
     steps:
       - checkout
 
+      - build-cli
       - run:
           name: terraform init & apply
           working_directory: *aks-terraform-path
@@ -925,6 +929,7 @@ jobs:
     steps:
       - checkout
 
+      - build-cli
       - run:
           name: configure aws
           command: |
@@ -987,6 +992,7 @@ jobs:
     steps:
       - checkout
 
+      - build-cli
       - run:
           name: configure aws
           command: |
@@ -1048,6 +1054,7 @@ jobs:
 
     steps:
       - checkout
+      - build-cli
       - run:
           name: terraform init & apply
           working_directory: *openshift-terraform-path


### PR DESCRIPTION
Changes proposed in this PR:
- Since the build cli job was separated out, the clouds need the cli to be built so TestInstall will stop failing on main during the nightly acceptance tests.

This fix worked in another branch I was testing in: https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/9020/workflows/4c4c9c1d-e526-4ada-ad3c-f3b93948e74c 