### PR TITLE
Use correct file name for license

### DIFF
--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -144,7 +144,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 # Copy license for Red Hat certification.
-COPY LICENSE.md /licenses/mozilla.txt
+COPY LICENSE /licenses/mozilla.txt
 
 RUN microdnf install -y ca-certificates gnupg libcap openssl shadow-utils iptables
 


### PR DESCRIPTION
Changes proposed in this PR:
- It looks like our license file changed, so updating our UBI dockerfile to use correct file.

How I've tested this PR:
in CI: https://github.com/hashicorp/consul-k8s/actions/runs/3379774271

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

