### PR TITLE
Fix sync partitions acceptance test

### DIFF
--- a/acceptance/tests/partitions/partitions_sync_test.go
+++ b/acceptance/tests/partitions/partitions_sync_test.go
@@ -140,7 +140,7 @@ func TestPartitions_Sync(t *testing.T) {
 				k8s.CopySecret(t, primaryClusterContext, secondaryClusterContext, partitionToken)
 			}
 
-			partitionServiceName := fmt.Sprintf("%s-consul-partition", releaseName)
+			partitionServiceName := fmt.Sprintf("%s-consul-expose-servers", releaseName)
 			partitionSvcAddress := k8s.ServiceHost(t, cfg, primaryClusterContext, partitionServiceName)
 
 			k8sAuthMethodHost := k8s.KubernetesAPIServerHost(t, cfg, secondaryClusterContext)


### PR DESCRIPTION
Changes proposed in this PR:
- Fix service name for the servers in the partitions sync test

How I've tested this PR:
acceptance tests: they all failed because of the server-acl-init changes, but partitions sync non-secure test passed!

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

