### PR TITLE
api-gateway: allow controller to bind PodSecurityPolicy to ServiceAccounts that it creates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ IMPROVEMENTS:
   * Add `tolerations` and `nodeSelector` to Server ACL init jobs and `nodeSelector` to Webhook cert manager. [[GH-1581](https://github.com/hashicorp/consul-k8s/pull/1581)]
   * API Gateway: Add `tolerations` to `apiGateway.managedGatewayClass` and `apiGateway.controller` [[GH-1650](https://github.com/hashicorp/consul-k8s/pull/1650)]
   * API Gateway: Create PodSecurityPolicy for controller when `global.enablePodSecurityPolicies=true`. [[GH-1656](https://github.com/hashicorp/consul-k8s/pull/1656)]
-
+  * API Gateway: Create PodSecurityPolicy and allow controller to bind it to ServiceAccounts that it creates for Gateway Deployments when `global.enablePodSecurityPolicies=true`. [[GH-1672](https://github.com/hashicorp/consul-k8s/pull/1672)]
 
 ## 1.0.0-beta4 (October 28, 2022)
 

--- a/charts/consul/templates/api-gateway-controller-clusterrole.yaml
+++ b/charts/consul/templates/api-gateway-controller-clusterrole.yaml
@@ -11,6 +11,24 @@ metadata:
     release: {{ .Release.Name }}
     component: api-gateway-controller
 rules:
+{{- if .Values.global.enablePodSecurityPolicies }}
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+{{- end}}
 - apiGroups:
   - api-gateway.consul.hashicorp.com
   resources:

--- a/charts/consul/templates/api-gateway-controller-clusterrole.yaml
+++ b/charts/consul/templates/api-gateway-controller-clusterrole.yaml
@@ -11,24 +11,6 @@ metadata:
     release: {{ .Release.Name }}
     component: api-gateway-controller
 rules:
-{{- if .Values.global.enablePodSecurityPolicies }}
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - roles
-  - rolebindings
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - policy
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
-{{- end}}
 - apiGroups:
   - api-gateway.consul.hashicorp.com
   resources:
@@ -263,11 +245,21 @@ rules:
   - patch
   - update
 {{- if .Values.global.enablePodSecurityPolicies }}
-- apiGroups: ["policy"]
-  resources: ["podsecuritypolicies"]
-  resourceNames:
-    - {{ template "consul.fullname" . }}-api-gateway-controller
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
   verbs:
-    - use
+  - use
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - watch
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
+++ b/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
@@ -15,6 +15,9 @@ spec:
       {{- if .Values.global.acls.manageSystemACLs }}
       managed: true
       method: {{ template "consul.fullname" . }}-k8s-auth-method
+      {{- if .Values.global.enablePodSecurityPolicies }}
+      podSecurityPolicy: {{ template "consul.fullname" . }}-api-gateway
+      {{- end }}
       {{- end }}
     {{- if .Values.global.tls.enabled }}
     scheme: https

--- a/charts/consul/templates/api-gateway-podsecuritypolicy.yaml
+++ b/charts/consul/templates/api-gateway-podsecuritypolicy.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.apiGateway.enabled .Values.global.enablePodSecurityPolicies }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "consul.fullname" . }}-api-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: api-gateway-controller
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  allowedCapabilities:
+    - NET_BIND_SERVICE
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  hostPorts:
+    - max: 65535
+      min: 1025
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: true
+{{- end }}

--- a/charts/consul/test/unit/api-gateway-controller-clusterrole.bats
+++ b/charts/consul/test/unit/api-gateway-controller-clusterrole.bats
@@ -31,3 +31,15 @@ load _helpers
       yq '.rules[] | select((.resourceNames[0] == "release-name-consul-api-gateway-controller") and (.resources[0] == "podsecuritypolicies")) | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "apiGateway/ClusterRole: uses PodSecurityPolicy with apiGateway.enabled=true and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-controller-clusterrole.yaml \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=foo' \
+      . | tee /dev/stderr |
+      yq '.rules[] | select((.resourceNames[0] == "release-name-consul-api-gateway-controller") and (.resources[0] == "podsecuritypolicies")) | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/api-gateway-controller-clusterrole.bats
+++ b/charts/consul/test/unit/api-gateway-controller-clusterrole.bats
@@ -40,6 +40,6 @@ load _helpers
       --set 'apiGateway.enabled=true' \
       --set 'apiGateway.image=foo' \
       . | tee /dev/stderr |
-      yq '.rules[] | select((.resources[0] == "roles") and (.resources[1] == "rolebindings") and (.verbs[0] == "create")) | length > 0' | tee /dev/stderr)
+      yq '.rules[] | select((.resources[0] == "roles") and (.resources[1] == "rolebindings") and (.verbs | contains(["create","get","list","watch"]))) | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }

--- a/charts/consul/test/unit/api-gateway-controller-clusterrole.bats
+++ b/charts/consul/test/unit/api-gateway-controller-clusterrole.bats
@@ -20,7 +20,7 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "apiGateway/ClusterRole: uses PodSecurityPolicy with apiGateway.enabled=true and global.enablePodSecurityPolicies=true" {
+@test "apiGateway/ClusterRole: can use podsecuritypolicies with apiGateway.enabled=true and global.enablePodSecurityPolicies=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/api-gateway-controller-clusterrole.yaml \
@@ -28,11 +28,11 @@ load _helpers
       --set 'apiGateway.enabled=true' \
       --set 'apiGateway.image=foo' \
       . | tee /dev/stderr |
-      yq '.rules[] | select((.resourceNames[0] == "release-name-consul-api-gateway-controller") and (.resources[0] == "podsecuritypolicies")) | length > 0' | tee /dev/stderr)
+      yq '.rules[] | select((.resources[0] == "podsecuritypolicies") and (.verbs[0] == "use")) | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "apiGateway/ClusterRole: uses PodSecurityPolicy with apiGateway.enabled=true and global.enablePodSecurityPolicies=true" {
+@test "apiGateway/ClusterRole: can create roles and rolebindings with apiGateway.enabled=true and global.enablePodSecurityPolicies=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/api-gateway-controller-clusterrole.yaml \
@@ -40,6 +40,6 @@ load _helpers
       --set 'apiGateway.enabled=true' \
       --set 'apiGateway.image=foo' \
       . | tee /dev/stderr |
-      yq '.rules[] | select((.resourceNames[0] == "release-name-consul-api-gateway-controller") and (.resources[0] == "podsecuritypolicies")) | length > 0' | tee /dev/stderr)
+      yq '.rules[] | select((.resources[0] == "roles") and (.resources[1] == "rolebindings") and (.verbs[0] == "create")) | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }


### PR DESCRIPTION
> **Note** This builds on #1656 

**Changes proposed in this PR:**

When a user has both `global.enablePodSecurityPolicies=true` and `apiGateway.enabled=true`:
- Create a `PodSecurityPolicy` for use by all `Deployments` that the API gateway controller creates to back a `Gateway`
- Allow the API gateway controller to use `PodSecurityPolicies`

When `global.acls.manageSystemACLs=true` is also set:
- Provide the name of the `PodSecurityPolicy` to the `GatewayClassConfig` so that the API gateway controller can bind the policy to the `ServiceAccount` created for each `Gateway`. It does this by creating a `Gateway`-specific `Role` and `RoleBinding`.

The API gateway controller could create the `PodSecurityPolicy` itself; however, this isn't nearly as flexible as any user requiring a slight change in the `PSP` would need a code release from us. This way, they can modify the `PSP` created by the Helm chart however they wish, or they can create their own `PSP` and reference it in the `GatewayClassConfig`.

**How I've tested this PR:**

Create a K8s cluster that requires `PodSecurityPolicies`. On GKE, for example:
```shell
$ gcloud beta container clusters create cluster-1 --enable-pod-security-policy --region us-east1
```

Then install this version of the Helm chart, verifying that the `PodSecurityPolicy` is created and the `ClusterRole` for the API gateway controller has the modified set of permissions.
```yaml
global:
  enablePodSecurityPolicies: true
  acls:
    manageSystemACLs: true
...
apiGateway:
  enabled: true
  ...
```

**How I expect reviewers to test this PR:**
👀 verify that the permissions added here are as restricted as they can possibly be while meeting requirements

**Checklist:**
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

