### PR TITLE
Default install and upgrade to "Y" when no answer is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## UNRELEASED
 
 BREAKING_CHANGES:
+* CLI:
+  * Change default behavior of `consul-k8s install` to perform the installation when no answer is provided to the prompt. [[GH-1673](https://github.com/hashicorp/consul-k8s/pull/1673)]
 * Helm:
   * Remove `global.consulSidecarContainer` from values file as there is no longer a consul sidecar. [[GH-1635](https://github.com/hashicorp/consul-k8s/pull/1635)]
   * Consul snapshot-agent now runs as a sidecar with Consul servers. [[GH-1620](https://github.com/hashicorp/consul-k8s/pull/1620)]

--- a/cli/cmd/upgrade/upgrade_test.go
+++ b/cli/cmd/upgrade/upgrade_test.go
@@ -267,7 +267,7 @@ func TestUpgrade(t *testing.T) {
 			messages: []string{
 				"\n==> Checking if Consul can be upgraded\n ✓ Existing Consul installation found to be upgraded.\n    Name: consul\n    Namespace: consul\n",
 				"\n==> Checking if Consul demo application can be upgraded\n    No existing Consul demo application installation found.\n",
-				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    --------------------------------------------------------------\n  + global:\n  +   name: consul\n  \n",
+				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  + global:\n  +   name: consul\n  \n",
 				"\n==> Upgrading Consul\n ✓ Consul upgraded in namespace \"consul\".\n",
 			},
 			helmActionsRunner: &helm.MockActionRunner{
@@ -310,7 +310,7 @@ func TestUpgrade(t *testing.T) {
 			messages: []string{
 				"\n==> Checking if Consul can be upgraded\n ✓ Existing Consul installation found to be upgraded.\n    Name: consul\n    Namespace: consul\n",
 				"\n==> Checking if Consul demo application can be upgraded\n    No existing Consul demo application installation found.\n",
-				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    --------------------------------------------------------------\n  + global:\n  +   name: consul\n  \n\n==> Upgrading Consul\n ! Helm returned an error.\n",
+				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  + global:\n  +   name: consul\n  \n\n==> Upgrading Consul\n ! Helm returned an error.\n",
 			},
 			helmActionsRunner: &helm.MockActionRunner{
 				CheckForInstallationsFunc: func(options *helm.CheckForInstallationsOptions) (bool, string, string, error) {
@@ -337,7 +337,7 @@ func TestUpgrade(t *testing.T) {
 			messages: []string{
 				"\n==> Checking if Consul can be upgraded\n ✓ Existing Consul installation found to be upgraded.\n    Name: consul\n    Namespace: consul\n",
 				"\n==> Checking if Consul demo application can be upgraded\n    No existing consul-demo installation found, but -demo flag provided. consul-demo will be installed in namespace consul.\n",
-				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    --------------------------------------------------------------\n  + global:\n  +   name: consul\n  \n",
+				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  + global:\n  +   name: consul\n  \n",
 				"\n==> Upgrading Consul\n ✓ Consul upgraded in namespace \"consul\".\n",
 				"\n==> Consul Demo Application Installation Summary\n    Name: consul-demo\n    Namespace: consul\n    \n    \n",
 				"\n==> Installing Consul demo application\n ✓ Downloaded charts.\n ✓ Consul demo application installed in namespace \"consul\".\n",
@@ -366,9 +366,9 @@ func TestUpgrade(t *testing.T) {
 			messages: []string{
 				"\n==> Checking if Consul can be upgraded\n ✓ Existing Consul installation found to be upgraded.\n    Name: consul\n    Namespace: consul\n",
 				"\n==> Checking if Consul demo application can be upgraded\n ✓ Existing Consul demo application installation found to be upgraded.\n    Name: consul-demo\n    Namespace: consul-demo\n",
-				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    --------------------------------------------------------------\n  + global:\n  +   name: consul\n  \n",
+				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  + global:\n  +   name: consul\n  \n",
 				"\n==> Upgrading Consul\n ✓ Consul upgraded in namespace \"consul\".\n",
-				"\n==> Consul-Demo Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    --------------------------------------------------------------\n  \n",
+				"\n==> Consul-Demo Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  \n",
 				"\n==> Upgrading consul-demo\n ✓ Consul-Demo upgraded in namespace \"consul-demo\".\n",
 			},
 			helmActionsRunner: &helm.MockActionRunner{
@@ -392,9 +392,9 @@ func TestUpgrade(t *testing.T) {
 			messages: []string{
 				"\n==> Checking if Consul can be upgraded\n ✓ Existing Consul installation found to be upgraded.\n    Name: consul\n    Namespace: consul\n",
 				"\n==> Checking if Consul demo application can be upgraded\n ✓ Existing Consul demo application installation found to be upgraded.\n    Name: consul-demo\n    Namespace: consul-demo\n",
-				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    --------------------------------------------------------------\n  + global:\n  +   name: consul\n  \n",
+				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  + global:\n  +   name: consul\n  \n",
 				"\n==> Upgrading Consul\n ✓ Consul upgraded in namespace \"consul\".\n",
-				"\n==> Consul-Demo Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    --------------------------------------------------------------\n  \n",
+				"\n==> Consul-Demo Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  \n",
 				"\n==> Upgrading consul-demo\n ✓ Consul-Demo upgraded in namespace \"consul-demo\".\n",
 			},
 			helmActionsRunner: &helm.MockActionRunner{
@@ -418,9 +418,9 @@ func TestUpgrade(t *testing.T) {
 			messages: []string{
 				"\n==> Checking if Consul can be upgraded\n ✓ Existing Consul installation found to be upgraded.\n    Name: consul\n    Namespace: consul\n",
 				"\n==> Checking if Consul demo application can be upgraded\n ✓ Existing Consul demo application installation found to be upgraded.\n    Name: consul-demo\n    Namespace: consul-demo\n",
-				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    --------------------------------------------------------------\n  + global:\n  +   name: consul\n  \n",
+				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  + global:\n  +   name: consul\n  \n",
 				"\n==> Upgrading Consul\n ✓ Consul upgraded in namespace \"consul\".\n",
-				"\n==> Consul-Demo Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    --------------------------------------------------------------\n  \n",
+				"\n==> Consul-Demo Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  \n",
 				"\n==> Upgrading consul-demo\n ! Helm returned an error.\n",
 			},
 			helmActionsRunner: &helm.MockActionRunner{
@@ -452,7 +452,7 @@ func TestUpgrade(t *testing.T) {
 			messages: []string{
 				"\n==> Checking if Consul can be upgraded\n ✓ Existing Consul installation found to be upgraded.\n    Name: consul\n    Namespace: consul\n",
 				"\n==> Checking if Consul demo application can be upgraded\n    No existing Consul demo application installation found.\n",
-				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    --------------------------------------------------------------\n  + connectInject:\n  +   enabled: true\n  +   metrics:\n  +     defaultEnableMerging: true\n  +     defaultEnabled: true\n  +     enableGatewayMetrics: true\n  + controller:\n  +   enabled: true\n  + global:\n  +   metrics:\n  +     enableAgentMetrics: true\n  +     enabled: true\n  +   name: consul\n  + prometheus:\n  +   enabled: true\n  + server:\n  +   replicas: 1\n  + ui:\n  +   enabled: true\n  +   service:\n  +     enabled: true\n  \n",
+				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  + connectInject:\n  +   enabled: true\n  +   metrics:\n  +     defaultEnableMerging: true\n  +     defaultEnabled: true\n  +     enableGatewayMetrics: true\n  + controller:\n  +   enabled: true\n  + global:\n  +   metrics:\n  +     enableAgentMetrics: true\n  +     enabled: true\n  +   name: consul\n  + prometheus:\n  +   enabled: true\n  + server:\n  +   replicas: 1\n  + ui:\n  +   enabled: true\n  +   service:\n  +     enabled: true\n  \n",
 				"\n==> Upgrading Consul\n ✓ Consul upgraded in namespace \"consul\".\n",
 			},
 			helmActionsRunner: &helm.MockActionRunner{
@@ -477,7 +477,7 @@ func TestUpgrade(t *testing.T) {
 			messages: []string{
 				"\n==> Checking if Consul can be upgraded\n ✓ Existing Consul installation found to be upgraded.\n    Name: consul\n    Namespace: consul\n",
 				"\n==> Checking if Consul demo application can be upgraded\n    No existing Consul demo application installation found.\n",
-				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    --------------------------------------------------------------\n  + connectInject:\n  +   enabled: true\n  + controller:\n  +   enabled: true\n  + global:\n  +   acls:\n  +     manageSystemACLs: true\n  +   gossipEncryption:\n  +     autoGenerate: true\n  +   name: consul\n  +   tls:\n  +     enableAutoEncrypt: true\n  +     enabled: true\n  + server:\n  +   replicas: 1\n  \n",
+				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  + connectInject:\n  +   enabled: true\n  + controller:\n  +   enabled: true\n  + global:\n  +   acls:\n  +     manageSystemACLs: true\n  +   gossipEncryption:\n  +     autoGenerate: true\n  +   name: consul\n  +   tls:\n  +     enableAutoEncrypt: true\n  +     enabled: true\n  + server:\n  +   replicas: 1\n  \n",
 				"\n==> Upgrading Consul\n ✓ Consul upgraded in namespace \"consul\".\n",
 			},
 			helmActionsRunner: &helm.MockActionRunner{
@@ -503,7 +503,7 @@ func TestUpgrade(t *testing.T) {
 				"    Performing dry run upgrade. No changes will be made to the cluster.\n",
 				"\n==> Checking if Consul can be upgraded\n ✓ Existing Consul installation found to be upgraded.\n    Name: consul\n    Namespace: consul\n",
 				"\n==> Checking if Consul demo application can be upgraded\n    No existing Consul demo application installation found.\n",
-				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    --------------------------------------------------------------\n  + global:\n  +   name: consul\n  \n",
+				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  + global:\n  +   name: consul\n  \n",
 				"\n==> Performing Dry Run Upgrade\n    Dry run complete. No changes were made to the Kubernetes cluster.\n    Upgrade can proceed with this configuration.\n",
 			},
 			helmActionsRunner: &helm.MockActionRunner{

--- a/cli/helm/install.go
+++ b/cli/helm/install.go
@@ -99,6 +99,7 @@ func InstallHelmRelease(options *InstallOptions) error {
 		if err != nil {
 			return err
 		}
+		// The install will proceed if the user presses enter or responds with "y"/"yes" (case-insensitive).
 		if confirmation != "" && common.Abort(confirmation) {
 			options.UI.Output("Install aborted. Use the command `consul-k8s install -help` to learn how to customize your installation.",
 				terminal.WithInfoStyle())

--- a/cli/helm/install.go
+++ b/cli/helm/install.go
@@ -91,7 +91,7 @@ func InstallHelmRelease(options *InstallOptions) error {
 
 	if !options.AutoApprove {
 		confirmation, err := options.UI.Input(&terminal.Input{
-			Prompt: "Proceed with installation? (y/N)",
+			Prompt: "Proceed with installation? (Y/n)",
 			Style:  terminal.InfoStyle,
 			Secret: false,
 		})
@@ -99,7 +99,7 @@ func InstallHelmRelease(options *InstallOptions) error {
 		if err != nil {
 			return err
 		}
-		if common.Abort(confirmation) {
+		if confirmation != "" && common.Abort(confirmation) {
 			options.UI.Output("Install aborted. Use the command `consul-k8s install -help` to learn how to customize your installation.",
 				terminal.WithInfoStyle())
 			return err

--- a/cli/helm/upgrade.go
+++ b/cli/helm/upgrade.go
@@ -81,7 +81,7 @@ func UpgradeHelmRelease(options *UpgradeOptions) error {
 	// Check if the user is OK with the upgrade unless the auto approve or dry run flags are true.
 	if !options.AutoApprove && !options.DryRun {
 		confirmation, err := options.UI.Input(&terminal.Input{
-			Prompt: "Proceed with upgrade? (y/N)",
+			Prompt: "Proceed with upgrade? (Y/n)",
 			Style:  terminal.InfoStyle,
 			Secret: false,
 		})
@@ -89,7 +89,8 @@ func UpgradeHelmRelease(options *UpgradeOptions) error {
 		if err != nil {
 			return err
 		}
-		if common.Abort(confirmation) {
+		// The upgrade will proceed if the user presses enter or responds with "y"/"yes" (case-insensitive).
+		if confirmation != "" && common.Abort(confirmation) {
 			options.UI.Output("Upgrade aborted. Use the command `consul-k8s upgrade -help` to learn how to customize your upgrade.",
 				terminal.WithInfoStyle())
 			return err

--- a/cli/helm/upgrade.go
+++ b/cli/helm/upgrade.go
@@ -135,7 +135,7 @@ func printDiff(old, new map[string]interface{}, ui terminal.UI) error {
 	}
 
 	ui.Output("\nDifference between user overrides for current and upgraded charts"+
-		"\n--------------------------------------------------------------", terminal.WithInfoStyle())
+		"\n-----------------------------------------------------------------", terminal.WithInfoStyle())
 	for _, line := range strings.Split(diff, "\n") {
 		if strings.HasPrefix(line, "+") {
 			ui.Output(line, terminal.WithDiffAddedStyle())

--- a/cli/helm/upgrade_test.go
+++ b/cli/helm/upgrade_test.go
@@ -40,7 +40,7 @@ func TestUpgrade(t *testing.T) {
 	}
 
 	expectedMessages := []string{
-		"\n==>  Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    --------------------------------------------------------------\n  \n",
+		"\n==>  Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  \n",
 		"\n==> Upgrading \n ✓  upgraded in namespace \"consul-namespace\".\n",
 	}
 	err := UpgradeHelmRelease(options)
@@ -59,7 +59,7 @@ func TestUpgradeHelmRelease(t *testing.T) {
 	}{
 		"basic success": {
 			messages: []string{
-				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    --------------------------------------------------------------\n  \n",
+				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  \n",
 				"\n==> Upgrading Consul\n ✓ Consul upgraded in namespace \"consul-namespace\".\n",
 			},
 			helmActionsRunner: &MockActionRunner{},


### PR DESCRIPTION
Changes proposed in this PR:
- When a user is promped to install Consul, if they give no answer (e.g. just hit enter) the install will occur.

How I've tested this PR:
- Manually by running an install.

How I expect reviewers to test this PR:
- You may also run an install.

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

