### PR TITLE
agentless: update acl-init to use server-connection-manager-library

### DIFF
--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -353,6 +353,9 @@ Consul server environment variables for consul-k8s commands.
 {{- if and .Values.externalServers.enabled .Values.externalServers.tlsServerName }}
 - name: CONSUL_TLS_SERVER_NAME
   value: {{ .Values.externalServers.tlsServerName }}
+{{- else if .Values.global.cloud.enabled }}
+- name: CONSUL_TLS_SERVER_NAME
+  value: server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -353,9 +353,6 @@ Consul server environment variables for consul-k8s commands.
 {{- if and .Values.externalServers.enabled .Values.externalServers.tlsServerName }}
 - name: CONSUL_TLS_SERVER_NAME
   value: {{ .Values.externalServers.tlsServerName }}
-{{- else if .Values.global.cloud.enabled }}
-- name: CONSUL_TLS_SERVER_NAME
-  value: server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -493,38 +493,25 @@ spec:
         {{- if (and .Values.global.tls.enabled (not .Values.externalServers.useSystemRoots)) }}
         - name: CONSUL_CACERT
           {{- if .Values.global.secretsBackend.vault.enabled }}
-          value: "/vault/secrets/serverca.crt" 
+          value: "/vault/secrets/serverca.crt"
           {{- else }}
           value: "/consul/tls/ca/tls.crt"
           {{- end }}
+        {{- end }}
+        {{- include "consul.consulK8sConsulServerEnvVars" . | nindent 8 }}
+        {{- if .Values.global.acls.manageSystemACLs }}
+        - name: CONSUL_LOGIN_AUTH_METHOD
+          value: {{ template "consul.fullname" . }}-k8s-component-auth-method
+        - name: CONSUL_LOGIN_META
+          value: "component=client"
         {{- end }}
         command:
           - "/bin/sh"
           - "-ec"
           - |
             consul-k8s-control-plane acl-init \
-              -component-name=client \
-              -acl-auth-method="{{ template "consul.fullname" . }}-k8s-component-auth-method" \
-              {{- if .Values.global.adminPartitions.enabled }}
-              -partition={{ .Values.global.adminPartitions.name }} \
-              {{- end }}
               -log-level={{ default .Values.global.logLevel .Values.client.logLevel }} \
               -log-json={{ .Values.global.logJSON }} \
-              {{- if .Values.externalServers.enabled }}
-              {{- if .Values.global.tls.enabled }}
-              -use-https \
-              {{- end }}
-              {{- range .Values.externalServers.hosts }}
-              -server-address={{ quote . }} \
-              {{- end }}
-              -server-port={{ .Values.externalServers.httpsPort }} \
-              {{- if .Values.externalServers.tlsServerName }}
-              -tls-server-name={{ .Values.externalServers.tlsServerName }} \
-              {{- end }}
-              {{- else if .Values.global.cloud.enabled }}
-              -tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
-              {{- end }}
-              -consul-api-timeout={{ .Values.global.consulAPITimeout }} \
               -init-type="client"
         volumeMounts:
           - name: aclconfig

--- a/control-plane/helper/test/test_util.go
+++ b/control-plane/helper/test/test_util.go
@@ -151,7 +151,10 @@ func SetupK8sComponentAuthMethod(t *testing.T, consulClient *api.Client, service
 	_, _, err := consulClient.ACL().AuthMethodCreate(&authMethodTmpl, nil)
 	require.NoError(t, err)
 
-	rules := `acl = "write"`
+	rules := `acl = "write"
+service_prefix "" {
+  policy = "write"
+}`
 	policyName := fmt.Sprintf("%s-token", serviceAccountName)
 	policy := api.ACLPolicy{
 		Name:        policyName,

--- a/control-plane/subcommand/acl-init/command.go
+++ b/control-plane/subcommand/acl-init/command.go
@@ -17,8 +17,8 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand"
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/flags"
+	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/go-discover"
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
 	corev1 "k8s.io/api/core/v1"
@@ -34,39 +34,27 @@ const (
 type Command struct {
 	UI cli.Ui
 
-	flags *flag.FlagSet
-	k8s   *flags.K8SFlags
-	http  *flags.HTTPFlags
+	flags  *flag.FlagSet
+	k8s    *flags.K8SFlags
+	consul *flags.ConsulFlags
 
-	flagSecretName        string
-	flagInitType          string
-	flagNamespace         string
-	flagPrimaryDatacenter string
-	flagACLDir            string
-	flagTokenSinkFile     string
+	flagSecretName    string
+	flagInitType      string
+	flagACLDir        string
+	flagTokenSinkFile string
 
-	flagACLAuthMethod string // Auth Method to use for ACLs.
-	flagLogLevel      string
-	flagLogJSON       bool
-
-	bearerTokenFile   string // Location of the bearer token. Default is defaultBearerTokenFile.
-	flagComponentName string // Name of the component to be used as metadata to ACL Login.
-
-	// Flags to configure Consul connection
-	flagServerAddresses []string
-	flagServerPort      uint
-	flagConsulCACert    string
-	flagUseHTTPS        bool
+	flagLogLevel string
+	flagLogJSON  bool
 
 	k8sClient kubernetes.Interface
 
-	once      sync.Once
-	help      string
-	logger    hclog.Logger
-	providers map[string]discover.Provider
+	once   sync.Once
+	help   string
+	logger hclog.Logger
 
 	ctx          context.Context
 	consulClient *api.Client
+	watcher      consul.ServerConnectionManager
 }
 
 func (c *Command) init() {
@@ -82,19 +70,6 @@ func (c *Command) init() {
 		"Optional filepath to write acl token")
 
 	// Flags related to using consul login to fetch the ACL token.
-	c.flags.StringVar(&c.flagNamespace, "k8s-namespace", "", "Name of Kubernetes namespace where the token Kubernetes secret is stored.")
-	c.flags.StringVar(&c.flagPrimaryDatacenter, "primary-datacenter", "", "Name of the primary datacenter when federation is enabled and the command is run in a secondary datacenter.")
-	c.flags.StringVar(&c.flagACLAuthMethod, "acl-auth-method", "", "Name of the auth method to login with.")
-	c.flags.StringVar(&c.flagComponentName, "component-name", "",
-		"Name of the component to pass to ACL Login as metadata.")
-	c.flags.Var((*flags.AppendSliceValue)(&c.flagServerAddresses), "server-address",
-		"The IP, DNS name or the cloud auto-join string of the Consul server(s). If providing IPs or DNS names, may be specified multiple times. "+
-			"At least one value is required.")
-	c.flags.UintVar(&c.flagServerPort, "server-port", 8500, "The HTTP or HTTPS port of the Consul server. Defaults to 8500.")
-	c.flags.StringVar(&c.flagConsulCACert, "consul-ca-cert", "",
-		"Path to the PEM-encoded CA certificate of the Consul cluster.")
-	c.flags.BoolVar(&c.flagUseHTTPS, "use-https", false,
-		"Toggle for using HTTPS for all API calls to Consul.")
 	c.flags.StringVar(&c.flagLogLevel, "log-level", "info",
 		"Log verbosity level. Supported values (in order of detail) are \"trace\", "+
 			"\"debug\", \"info\", \"warn\", and \"error\".")
@@ -102,9 +77,9 @@ func (c *Command) init() {
 		"Enable or disable JSON output format for logging.")
 
 	c.k8s = &flags.K8SFlags{}
-	c.http = &flags.HTTPFlags{}
+	c.consul = &flags.ConsulFlags{}
 	flags.Merge(c.flags, c.k8s.Flags())
-	flags.Merge(c.flags, c.http.Flags())
+	flags.Merge(c.flags, c.consul.Flags())
 	c.help = flags.Usage(help, c.flags)
 }
 
@@ -120,18 +95,18 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	if c.bearerTokenFile == "" {
-		c.bearerTokenFile = defaultBearerTokenFile
+	if c.consul.ConsulLogin.BearerTokenFile == "" {
+		c.consul.ConsulLogin.BearerTokenFile = defaultBearerTokenFile
 	}
 	// This allows us to utilize the default path of `/consul/login/acl-token` for the ACL token
 	// but only in the case of when we're using ACL.Login. If flagACLAuthMethod is not set and
 	// the tokenSinkFile is also unset it means we do not want to write an ACL token in the case
 	// of the client token.
-	if c.flagTokenSinkFile == "" && c.flagACLAuthMethod != "" {
+	if c.flagTokenSinkFile == "" {
 		c.flagTokenSinkFile = defaultTokenSinkFile
 	}
-	if c.flagNamespace == "" {
-		c.flagNamespace = corev1.NamespaceDefault
+	if c.consul.Namespace == "" {
+		c.consul.Namespace = corev1.NamespaceDefault
 	}
 
 	if c.ctx == nil {
@@ -162,47 +137,31 @@ func (c *Command) Run(args []string) int {
 	}
 
 	var secret string
-	if c.flagACLAuthMethod != "" {
-		cfg := api.DefaultConfig()
-		c.http.MergeOntoConfig(cfg)
+	if c.consul.ConsulLogin.AuthMethod != "" {
+		serverConnMgrConfig, err := c.consul.ConsulServerConnMgrConfig()
+		if err != nil {
+			c.logger.Error("Failed to construct consul server connection manager", "error", err)
+		}
 
-		if len(c.flagServerAddresses) > 0 {
-			serverAddresses, err := common.GetResolvedServerAddresses(c.flagServerAddresses, c.providers, c.logger)
+		if c.watcher == nil {
+			c.watcher, err = discovery.NewWatcher(c.ctx, serverConnMgrConfig, c.logger.Named("consul-server-connection-manager"))
 			if err != nil {
-				c.UI.Error(fmt.Sprintf("Unable to discover any Consul addresses from %q: %s", c.flagServerAddresses[0], err))
-				return 1
+				c.logger.Error("Failed to construct Consul server watcher", "error", err)
 			}
-
-			scheme := "http"
-			if c.flagUseHTTPS {
-				scheme = "https"
-			}
-
-			serverAddr := fmt.Sprintf("%s:%d", serverAddresses[0], c.flagServerPort)
-			cfg.Address = serverAddr
-			cfg.Scheme = scheme
 		}
 
-		c.consulClient, err = consul.NewClient(cfg, c.http.ConsulAPITimeout())
+		go c.watcher.Run()
+		defer c.watcher.Stop()
+
+		c.consulClient, err = consul.NewClientFromConnMgr(c.consul.ConsulClientConfig(), c.watcher)
 		if err != nil {
-			c.logger.Error("Unable to get client connection", "error", err)
-			return 1
+			c.logger.Error("Failed to create Consul client", "error", err)
 		}
-
-		loginParams := common.LoginParams{
-			AuthMethod:      c.flagACLAuthMethod,
-			Datacenter:      c.flagPrimaryDatacenter,
-			BearerTokenFile: c.bearerTokenFile,
-			TokenSinkFile:   c.flagTokenSinkFile,
-			Meta: map[string]string{
-				"component": c.flagComponentName,
-			},
-		}
-		secret, err = common.ConsulLogin(c.consulClient, loginParams, c.logger)
+		state, err := c.watcher.State()
 		if err != nil {
-			c.logger.Error("Consul login failed", "error", err)
-			return 1
+			c.logger.Error("Failed to get Consul watcher state", "error", err)
 		}
+		secret = state.Token
 		c.logger.Info("Successfully read ACL token from the server")
 	} else {
 		// Use k8s secret to obtain token.
@@ -258,7 +217,7 @@ func (c *Command) Run(args []string) int {
 }
 
 func (c *Command) getSecret(secretName string) (string, error) {
-	secret, err := c.k8sClient.CoreV1().Secrets(c.flagNamespace).Get(c.ctx, secretName, metav1.GetOptions{})
+	secret, err := c.k8sClient.CoreV1().Secrets(c.consul.Namespace).Get(c.ctx, secretName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -271,7 +230,7 @@ func (c *Command) validateFlags() error {
 	if len(c.flags.Args()) > 0 {
 		return errors.New("Should have no non-flag arguments.")
 	}
-	if c.http.ConsulAPITimeout() <= 0 {
+	if c.consul.APITimeout <= 0 {
 		return errors.New("-consul-api-timeout must be set to a value greater than 0")
 	}
 

--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -90,7 +90,7 @@ partition "{{ .PartitionName }}" {
   namespace_prefix "" {
 {{- end }}
     service_prefix "" {
-      policy = "read"
+      policy = "write"
     }
 {{- if .EnableNamespaces }}
   }

--- a/control-plane/subcommand/server-acl-init/rules_test.go
+++ b/control-plane/subcommand/server-acl-init/rules_test.go
@@ -24,7 +24,7 @@ func TestAgentRules(t *testing.T) {
     policy = "write"
   }
     service_prefix "" {
-      policy = "read"
+      policy = "write"
     }`,
 		},
 		{
@@ -36,7 +36,7 @@ func TestAgentRules(t *testing.T) {
   }
   namespace_prefix "" {
     service_prefix "" {
-      policy = "read"
+      policy = "write"
     }
   }`,
 		},
@@ -52,7 +52,7 @@ partition "part-1" {
   }
   namespace_prefix "" {
     service_prefix "" {
-      policy = "read"
+      policy = "write"
     }
   }
 }`,


### PR DESCRIPTION
Changes proposed in this PR:
- Update ACL init to use Consul Server Connection Manager

How I've tested this PR:
- Unit tests
- Acceptance test (basic)

How I expect reviewers to test this PR:
- 👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

