### PR TITLE
Remove second printing of info that the Consul demo is not found when uninstalling

### DIFF
--- a/cli/cmd/uninstall/uninstall.go
+++ b/cli/cmd/uninstall/uninstall.go
@@ -220,8 +220,6 @@ func (c *Command) Run(args []string) int {
 			c.UI.Output(err.Error(), terminal.WithErrorStyle())
 			return 1
 		}
-	} else {
-		c.UI.Output(fmt.Sprintf("No existing %s installation found.", common.ReleaseTypeConsulDemo), terminal.WithInfoStyle())
 	}
 
 	c.UI.Output("Checking if Consul can be uninstalled", terminal.WithHeaderStyle())

--- a/cli/cmd/uninstall/uninstall_test.go
+++ b/cli/cmd/uninstall/uninstall_test.go
@@ -474,7 +474,7 @@ func TestUninstall(t *testing.T) {
 				"-wipe-data",
 			},
 			messages: []string{
-				"\n==> Checking if Consul demo application can be uninstalled\n    No existing Consul demo application installation found.\n    No existing Consul demo application installation found.\n",
+				"\n==> Checking if Consul demo application can be uninstalled\n    No existing Consul demo application installation found.\n",
 				"\n==> Checking if Consul can be uninstalled\n ✓ Existing Consul installation found.\n",
 				"\n==> Consul Uninstall Summary\n    Name: consul\n    Namespace: consul\n ✓ Successfully uninstalled Consul Helm release.\n",
 				"\n==> Other Consul Resources\n    Deleting data for installation: \n    Name: consul\n    Namespace consul\n ✓ No PVCs found.\n ✓ No Consul secrets found.\n ✓ No Consul service accounts found.\n ✓ No Consul roles found.\n ✓ No Consul rolebindings found.\n ✓ No Consul jobs found.\n ✓ No Consul cluster roles found.\n ✓ No Consul cluster role bindings found.\n",


### PR DESCRIPTION
Changes proposed in this PR:
- When uninstalling, the CLI was informing the user that there was no consul demo cluster twice. I changed it so it only tells the user about it once.

How I've tested this PR:
- Manually
- By updating the unit tests

How I expect reviewers to test this PR:
- :eyes:

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

