### PR TITLE
Allow to apply additional labels to the connect inject pods

### DIFF
--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -35,6 +35,9 @@ spec:
         chart: {{ template "consul.chart" . }}
         release: {{ .Release.Name }}
         component: connect-injector
+        {{- if .Values.connectInject.extraLabels }}
+          {{- toYaml .Values.connectInject.extraLabels | nindent 8 }}
+        {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
         {{- if .Values.connectInject.annotations }}

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -1218,6 +1218,31 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# extraLabels
+
+@test "connectInject/Deployment: no extra labels defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.labels | del(."app") | del(."chart") | del(."release") | del(."component")' | tee /dev/stderr)
+  [ "${actual}" = "{}" ]
+}
+
+@test "connectInject/Deployment: can set extra labels" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.extraLabels.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.labels.foo' | tee /dev/stderr)
+
+  [ "${actual}" = "bar" ]
+}
+
+#--------------------------------------------------------------------
 # annotations
 
 @test "connectInject/Deployment: no annotations defined by default" {

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2062,6 +2062,19 @@ connectInject:
   # Optional priorityClassName.
   priorityClassName: ""
 
+  # Extra labels to attach to the connect inject pods. This should be a YAML map.
+  #
+  # Example:
+  #
+  # ```yaml
+  # extraLabels:
+  #   labelKey: label-value
+  #   anotherLabelKey: another-label-value
+  # ```
+  #
+  # @type: map
+  extraLabels: null
+
   # This value defines additional annotations for
   # connect inject pods. This should be formatted as a multi-line string.
   #


### PR DESCRIPTION
Changes proposed in this PR:
- Allow to apply additional labels to the connect inject pods

How I've tested this PR:
We run this in our production.

How I expect reviewers to test this PR:
I've added a unit tests.

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

