### PR TITLE
Set 5min timeout on HTTP Client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1272,7 +1272,7 @@ workflows:
       - acceptance-tproxy:
           context: consul-ci
           requires:
-            - dev-upload-docker
+          - dev-upload-docker
 
   nightly-cleanup:
     triggers:


### PR DESCRIPTION
Changes proposed in this PR:

- The call to the bootstrap endpoint of the server can take some time to respond when running on cloud platforms. This commit re-introduces the 5min timeout to the HTTP client from the default 5 seconds.

How I've tested this PR:
- acceptance tests against the clouds

How I expect reviewers to test this PR:
- 👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

