### PR TITLE
peering: remove unnecessary expose servers service, add error cases, fix flaky test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ BREAKING_CHANGES:
 * Peering:
   * Remove support for customizing the server addresses in peering token generation. Instead, mesh gateways should be used
     to establish peering connections if the server pods are not directly reachable. [[GH-1610](https://github.com/hashicorp/consul-k8s/pull/1610)]
-  * Enabling peering requires `tls.enabled`. [[GH-1610](https://github.com/hashicorp/consul-k8s/pull/1610)]
+  * Require `global.tls.enabled` when peering is enabled. [[GH-1610](https://github.com/hashicorp/consul-k8s/pull/1610)]
+  * Require `meshGateway.enabled` when peering is enabled. [[GH-1683](https://github.com/hashicorp/consul-k8s/pull/1683)]
 
 FEATURES:
 * Consul-dataplane:
@@ -34,6 +35,7 @@ IMPROVEMENTS:
   * API Gateway: Add `tolerations` to `apiGateway.managedGatewayClass` and `apiGateway.controller` [[GH-1650](https://github.com/hashicorp/consul-k8s/pull/1650)]
   * API Gateway: Create PodSecurityPolicy for controller when `global.enablePodSecurityPolicies=true`. [[GH-1656](https://github.com/hashicorp/consul-k8s/pull/1656)]
   * API Gateway: Create PodSecurityPolicy and allow controller to bind it to ServiceAccounts that it creates for Gateway Deployments when `global.enablePodSecurityPolicies=true`. [[GH-1672](https://github.com/hashicorp/consul-k8s/pull/1672)]
+  * Deploy `expose-servers` service only when Admin Partitions(ENT) is enabled. [[GH-1683](https://github.com/hashicorp/consul-k8s/pull/1683)]
 
 ## 1.0.0-beta4 (October 28, 2022)
 

--- a/acceptance/tests/peering/peering_connect_test.go
+++ b/acceptance/tests/peering/peering_connect_test.go
@@ -69,7 +69,6 @@ func TestPeering_Connect(t *testing.T) {
 
 				"dns.enabled":           "true",
 				"dns.enableRedirection": strconv.FormatBool(cfg.EnableTransparentProxy),
-				"peering.tokenGeneration.serverAddresses.source": "consul",
 			}
 
 			staticServerPeerHelmValues := map[string]string{
@@ -131,6 +130,27 @@ func TestPeering_Connect(t *testing.T) {
 				k8s.KubectlDeleteK(t, staticClientPeerClusterContext.KubectlOptions(t), kustomizeMeshDir)
 			})
 
+			staticServerPeerClient, _ := staticServerPeerCluster.SetupConsulClient(t, c.ACLsEnabled)
+			staticClientPeerClient, _ := staticClientPeerCluster.SetupConsulClient(t, c.ACLsEnabled)
+
+			// Ensure mesh config entries are created in Consul.
+			timer := &retry.Timer{Timeout: 1 * time.Minute, Wait: 1 * time.Second}
+			retry.RunWith(timer, t, func(r *retry.R) {
+				ceServer, _, err := staticServerPeerClient.ConfigEntries().Get(api.MeshConfig, "mesh", &api.QueryOptions{})
+				require.NoError(r, err)
+				configEntryServer, ok := ceServer.(*api.MeshConfigEntry)
+				require.True(r, ok)
+				require.Equal(r, configEntryServer.GetName(), "mesh")
+				require.NoError(r, err)
+
+				ceClient, _, err := staticClientPeerClient.ConfigEntries().Get(api.MeshConfig, "mesh", &api.QueryOptions{})
+				require.NoError(r, err)
+				configEntryClient, ok := ceClient.(*api.MeshConfigEntry)
+				require.True(r, ok)
+				require.Equal(r, configEntryClient.GetName(), "mesh")
+				require.NoError(r, err)
+			})
+
 			// Create the peering acceptor on the client peer.
 			k8s.KubectlApply(t, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
 			helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
@@ -138,7 +158,6 @@ func TestPeering_Connect(t *testing.T) {
 			})
 
 			// Ensure the secret is created.
-			timer := &retry.Timer{Timeout: 1 * time.Minute, Wait: 1 * time.Second}
 			retry.RunWith(timer, t, func(r *retry.R) {
 				acceptorSecretName, err := k8s.RunKubectlAndGetOutputE(t, staticClientPeerClusterContext.KubectlOptions(t), "get", "peeringacceptor", "server", "-o", "jsonpath={.status.secret.name}")
 				require.NoError(r, err)
@@ -177,9 +196,6 @@ func TestPeering_Connect(t *testing.T) {
 			helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
 				k8s.RunKubectl(t, staticClientPeerClusterContext.KubectlOptions(t), "delete", "ns", staticClientNamespace)
 			})
-
-			staticServerPeerClient, _ := staticServerPeerCluster.SetupConsulClient(t, c.ACLsEnabled)
-			staticClientPeerClient, _ := staticClientPeerCluster.SetupConsulClient(t, c.ACLsEnabled)
 
 			// Create a ProxyDefaults resource to configure services to use the mesh
 			// gateways.

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.global.peering.enabled (not .Values.connectInject.enabled) }}{{ fail "setting global.peering.enabled to true requires connectInject.enabled to be true" }}{{ end }}
+{{- if and .Values.global.peering.enabled (not .Values.global.tls.enabled) }}{{ fail "setting global.peering.enabled to true requires global.tls.enabled to be true" }}{{ end }}
+{{- if and .Values.global.peering.enabled (not .Values.meshGateway.enabled) }}{{ fail "setting global.peering.enabled to true requires meshGateway.enabled to be true" }}{{ end }}
 {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if and .Values.global.adminPartitions.enabled (not .Values.global.enableConsulNamespaces) }}{{ fail "global.enableConsulNamespaces must be true if global.adminPartitions.enabled=true" }}{{ end }}
 {{ template "consul.validateVaultWebhookCertConfiguration" . }}

--- a/charts/consul/templates/expose-servers-service.yaml
+++ b/charts/consul/templates/expose-servers-service.yaml
@@ -1,5 +1,5 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
-{{- $serverExposeServiceEnabled := (or (and (ne (.Values.server.exposeService.enabled | toString) "-") .Values.server.exposeService.enabled) (and (eq (.Values.server.exposeService.enabled | toString) "-") (or .Values.global.peering.enabled .Values.global.adminPartitions.enabled))) -}}
+{{- $serverExposeServiceEnabled := (or (and (ne (.Values.server.exposeService.enabled | toString) "-") .Values.server.exposeService.enabled) (and (eq (.Values.server.exposeService.enabled | toString) "-") .Values.global.adminPartitions.enabled)) -}}
 {{- if (and $serverEnabled $serverExposeServiceEnabled) }}
 
 # Service with an external IP to reach Consul servers.

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -992,6 +992,7 @@ load _helpers
       --set 'client.enabled=true' \
       --set 'global.tls.enabled=true' \
       --set 'global.peering.enabled=true' \
+      --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | join(" ")' | tee /dev/stderr)
@@ -1014,6 +1015,7 @@ load _helpers
       --set 'client.enabled=true' \
       --set 'global.tls.enabled=true' \
       --set 'global.peering.enabled=true' \
+      --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | join(" ")' | tee /dev/stderr)

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -1370,6 +1370,8 @@ load _helpers
       -s templates/connect-inject-deployment.yaml  \
       --set 'connectInject.enabled=true' \
       --set 'global.peering.enabled=true' \
+      --set 'meshGateway.enabled=true' \
+      --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-enable-peering=true"))' | tee /dev/stderr)
 
@@ -1384,6 +1386,28 @@ load _helpers
       --set 'global.peering.enabled=true' .
   [ "$status" -eq 1 ]
   [[ "$output" =~ "setting global.peering.enabled to true requires connectInject.enabled to be true" ]]
+}
+
+@test "connectInject/Deployment: fails if peering is enabled but tls is not" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'meshGateway.enabled=true' \
+      --set 'global.peering.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "setting global.peering.enabled to true requires global.tls.enabled to be true" ]]
+}
+
+@test "connectInject/Deployment: fails if peering is enabled but mesh gateways are not" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.peering.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "setting global.peering.enabled to true requires meshGateway.enabled to be true" ]]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/test/unit/connect-inject-mutatingwebhookconfiguration.bats
+++ b/charts/consul/test/unit/connect-inject-mutatingwebhookconfiguration.bats
@@ -56,6 +56,8 @@ load _helpers
   local actual=$(helm template \
       -s templates/connect-inject-mutatingwebhookconfiguration.yaml  \
       --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'meshGateway.enabled=true' \
       --set 'global.peering.enabled=true' \
       . | tee /dev/stderr |
       yq '.webhooks[1].name | contains("peeringacceptors.consul.hashicorp.com")' | tee /dev/stderr)
@@ -63,6 +65,8 @@ load _helpers
   local actual=$(helm template \
       -s templates/connect-inject-mutatingwebhookconfiguration.yaml  \
       --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'meshGateway.enabled=true' \
       --set 'global.peering.enabled=true' \
       . | tee /dev/stderr |
       yq '.webhooks[2].name | contains("peeringdialers.consul.hashicorp.com")' | tee /dev/stderr)

--- a/charts/consul/test/unit/expose-servers-service.bats
+++ b/charts/consul/test/unit/expose-servers-service.bats
@@ -9,43 +9,6 @@ load _helpers
       . 
 }
 
-@test "expose-servers/Service: enabled when servers and peering are enabled" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/expose-servers-service.yaml  \
-      --set 'global.enabled=false' \
-      --set 'server.enabled=true' \
-      --set 'client.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-@test "expose-servers/Service: enable with global.enabled true and global.peering.enabled true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/expose-servers-service.yaml  \
-      --set 'global.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-@test "expose-servers/Service: enable with global.peering.enabled true" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/expose-servers-service.yaml  \
-      --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
 @test "expose-servers/Service: enable with global.adminPartitions.enabled true" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -57,14 +20,6 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "expose-servers/Service: disable when peering.enabled is false" {
-  cd `chart_dir`
-  assert_empty helm template \
-      -s templates/expose-servers-service.yaml  \
-      --set 'server.enabled=true' \
-      --set 'global.peering.enabled=false' \
-      .
-}
 
 @test "expose-servers/Service: disable with server.enabled" {
   cd `chart_dir`
@@ -72,7 +27,8 @@ load _helpers
       -s templates/expose-servers-service.yaml  \
       --set 'server.enabled=false' \
       --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
       .
 }
 
@@ -83,7 +39,8 @@ load _helpers
       --set 'global.enabled=false' \
       --set 'client.enabled=true' \
       --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
       .
 }
 
@@ -92,7 +49,8 @@ load _helpers
   local cmd=$(helm template \
       -s templates/expose-servers-service.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.ports[0]' | tee /dev/stderr)
@@ -107,7 +65,8 @@ load _helpers
   local cmd=$(helm template \
       -s templates/expose-servers-service.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
       --set 'global.tls.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.ports[0]' | tee /dev/stderr)
@@ -122,7 +81,8 @@ load _helpers
   local cmd=$(helm template \
       -s templates/expose-servers-service.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.httpsOnly=false' \
       . | tee /dev/stderr |
@@ -135,7 +95,8 @@ load _helpers
   local cmd=$(helm template \
       -s templates/expose-servers-service.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
       --set 'global.tls.enabled=true' \
       --set 'global.tls.httpsOnly=false' \
       . | tee /dev/stderr |
@@ -154,7 +115,8 @@ load _helpers
   local actual=$(helm template \
       -s templates/expose-servers-service.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations | length' | tee /dev/stderr)
   [ "${actual}" = "0" ]
@@ -165,7 +127,8 @@ load _helpers
   local actual=$(helm template \
       -s templates/expose-servers-service.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
       --set 'server.exposeService.annotations=key: value' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations.key' | tee /dev/stderr)
@@ -180,7 +143,8 @@ load _helpers
   local actual=$(helm template \
       -s templates/expose-servers-service.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
       --set 'server.exposeService.type=NodePort' \
       --set 'server.exposeService.nodePort.http=4443' \
       . | tee /dev/stderr |
@@ -193,7 +157,8 @@ load _helpers
   local actual=$(helm template \
       -s templates/expose-servers-service.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
       --set 'global.tls.enabled=true' \
       --set 'server.exposeService.type=NodePort' \
       --set 'server.exposeService.nodePort.https=4443' \
@@ -207,7 +172,8 @@ load _helpers
   local actual=$(helm template \
       -s templates/expose-servers-service.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
       --set 'server.exposeService.type=NodePort' \
       --set 'server.exposeService.nodePort.rpc=4443' \
       . | tee /dev/stderr |
@@ -220,7 +186,8 @@ load _helpers
   local actual=$(helm template \
       -s templates/expose-servers-service.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
       --set 'server.exposeService.type=NodePort' \
       --set 'server.exposeService.nodePort.serf=4444' \
       . | tee /dev/stderr |
@@ -233,7 +200,8 @@ load _helpers
   local actual=$(helm template \
       -s templates/expose-servers-service.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
       --set 'server.exposeService.type=NodePort' \
       --set 'server.exposeService.nodePort.grpc=4444' \
       . | tee /dev/stderr |
@@ -246,7 +214,8 @@ load _helpers
   local ports=$(helm template \
       -s templates/expose-servers-service.yaml  \
       --set 'connectInject.enabled=true' \
-      --set 'global.peering.enabled=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
       --set 'server.exposeService.type=NodePort' \
       --set 'server.exposeService.nodePort.rpc=4443' \
       --set 'server.exposeService.nodePort.grpc=4444' \

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -1392,6 +1392,8 @@ load _helpers
   local object=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'meshGateway.enabled=true' \
       --set 'global.peering.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |

--- a/charts/consul/test/unit/server-config-configmap.bats
+++ b/charts/consul/test/unit/server-config-configmap.bats
@@ -729,6 +729,7 @@ load _helpers
   local config=$(helm template \
       -s templates/server-config-configmap.yaml \
       --set 'global.tls.enabled=true' \
+      --set 'meshGateway.enabled=true' \
       --set 'global.peering.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
@@ -782,6 +783,7 @@ load _helpers
   local config=$(helm template \
       -s templates/server-config-configmap.yaml \
       --set 'global.tls.enabled=true' \
+      --set 'meshGateway.enabled=true' \
       --set 'global.peering.enabled=true' \
       --set 'connectInject.enabled=true' \
       --set 'global.tls.verify=false' \
@@ -855,6 +857,7 @@ load _helpers
   local object=$(helm template \
     -s templates/server-config-configmap.yaml  \
     --set 'global.tls.enabled=true' \
+    --set 'meshGateway.enabled=true' \
     --set 'global.peering.enabled=true' \
     --set 'connectInject.enabled=true' \
     --set 'global.tls.enableAutoEncrypt=true' \
@@ -948,6 +951,8 @@ load _helpers
   local actual=$(helm template \
       -s templates/server-config-configmap.yaml  \
       --set 'global.peering.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'meshGateway.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.data["server.json"]' | jq -r .peering.enabled | tee /dev/stderr)


### PR DESCRIPTION
Changes proposed in this PR:
- Expose servers service is only needed when partitions are enabled, since peering now requires mesh gateways. So this PR makes it so the helm chart doesn't deploy the expose servers service when only peering (and not partitions) is enabled. 
- Fail fast in the helm chart if tls or mesh gateways are not enabled since they are required for peering
- In acceptance tests- fix flakiness due to mesh configuration not being recognized before the applying the acceptor resource (which generates the token), to ensure that the token is generated with mesh gateway addresses rather than server pod ips. 


How I've tested this PR:
acceptance tests, unit tests

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

