### PR TITLE
peering: fix acl issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ IMPROVEMENTS:
   * API Gateway: Create PodSecurityPolicy and allow controller to bind it to ServiceAccounts that it creates for Gateway Deployments when `global.enablePodSecurityPolicies=true`. [[GH-1672](https://github.com/hashicorp/consul-k8s/pull/1672)]
   * Deploy `expose-servers` service only when Admin Partitions(ENT) is enabled. [[GH-1683](https://github.com/hashicorp/consul-k8s/pull/1683)]
 
+BUG FIXES:
+* Peering
+  * Add `peering:read` permissions to mesh gateway token to fix peering connections through the mesh gateways. [[GH-1685](https://github.com/hashicorp/consul-k8s/pull/1685)]
+
 ## 1.0.0-beta4 (October 28, 2022)
 
 IMPROVEMENTS:

--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -175,10 +175,18 @@ namespace_prefix "" {
 // This assumes users are using the default name for the service, i.e.
 // "mesh-gateway".
 func (c *Command) meshGatewayRules() (string, error) {
-	// Mesh gateways can only act as a proxy for services
-	// that its ACL token has access to. So, in the case of
-	// Consul namespaces, it needs access to all namespaces.
+	// Mesh gateways can only act as a proxy for services that its ACL token has access to. So, in the case of Consul
+	// namespaces, it needs access to all namespaces. For peering, it requires the ability to list all peers which in
+	// enterprise requires peering:read on all partitions or in OSS requires a top level peering:read. Since we cannot
+	// determine whether we are using an enterprise or OSS consul image based on whether peering is enabled, we include
+	// both permissions here.
 	meshGatewayRulesTpl := `mesh = "write"
+{{- if .EnablePeering }}
+peering = "read"
+partition_prefix "" {
+  peering = "read"
+}
+{{- end }}
 {{- if .EnableNamespaces }}
 namespace "default" {
 {{- end }}

--- a/control-plane/subcommand/server-acl-init/rules_test.go
+++ b/control-plane/subcommand/server-acl-init/rules_test.go
@@ -195,10 +195,11 @@ func TestMeshGatewayRules(t *testing.T) {
 	cases := []struct {
 		Name             string
 		EnableNamespaces bool
+		EnablePeering    bool
 		Expected         string
 	}{
 		{
-			Name: "Namespaces are disabled",
+			Name: "Namespaces and peering are disabled",
 			Expected: `mesh = "write"
   service "mesh-gateway" {
      policy = "write"
@@ -228,12 +229,54 @@ namespace_prefix "" {
   }
 }`,
 		},
+		{
+			Name:          "Peering is enabled",
+			EnablePeering: true,
+			Expected: `mesh = "write"
+peering = "read"
+partition_prefix "" {
+  peering = "read"
+}
+  service "mesh-gateway" {
+     policy = "write"
+  }
+  node_prefix "" {
+  	policy = "read"
+  }
+  service_prefix "" {
+     policy = "read"
+  }`,
+		},
+		{
+			Name:             "Peering and namespaces are enabled",
+			EnablePeering:    true,
+			EnableNamespaces: true,
+			Expected: `mesh = "write"
+peering = "read"
+partition_prefix "" {
+  peering = "read"
+}
+namespace "default" {
+  service "mesh-gateway" {
+     policy = "write"
+  }
+}
+namespace_prefix "" {
+  node_prefix "" {
+  	policy = "read"
+  }
+  service_prefix "" {
+     policy = "read"
+  }
+}`,
+		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			cmd := Command{
 				flagEnableNamespaces: tt.EnableNamespaces,
+				flagEnablePeering:    tt.EnablePeering,
 				consulFlags:          &flags.ConsulFlags{},
 			}
 


### PR DESCRIPTION
Changes proposed in this PR:
- Add peering:read permissions that are compatible with OSS and ENT Consul images. The comment next to the rule explains this further. 
- Fix this log line that shows up in acceptance tests by adding peering permissions to the mesh gateway token. This makes the peering connection actually go through both mesh gateways (as opposed to just the remote mesh gateway)`agent.proxycfg: Failed to handle update from watch: kind=mesh-gateway proxy=test-dyqcwc-consul-mesh-gateway-556fd7855b-fzjq7 service_id=test-dyqcwc-consul-mesh-gateway-556fd7855b-fzjq7 id=peer-servers error="error filling agent cache: Permission denied: token with AccessorID 'c2c7bd05-0e5d-45b2-f2c1-36455c4977e5' lacks permission 'peering:read'"`

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

