### PR TITLE
Add externalServers.skipServerWatch to helm for working with load balancers

### DIFF
--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -355,6 +355,10 @@ Consul server environment variables for consul-k8s commands.
   value: {{ .Values.externalServers.tlsServerName }}
 {{- end }}
 {{- end }}
+{{- if and .Values.externalServers.enabled .Values.externalServers.skipServerWatch }}
+- name: CONSUL_SKIP_SERVER_WATCH
+  value: "true" 
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -8,6 +8,7 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- $serverExposeServiceEnabled := (or (and (ne (.Values.server.exposeService.enabled | toString) "-") .Values.server.exposeService.enabled) (and (eq (.Values.server.exposeService.enabled | toString) "-") .Values.global.adminPartitions.enabled)) -}}
 {{- if and .Values.externalServers.enabled (not .Values.externalServers.hosts) }}{{ fail "externalServers.hosts must be set if externalServers.enabled is true" }}{{ end -}}
+{{- if and .Values.externalServers.skipServerWatch (not .Values.externalServers.enabled) }}{{ fail "externalServers.enabled must be set if externalServers.skipServerWatch is true" }}{{ end -}}
 {{ template "consul.validateRequiredCloudSecretsExist" . }}
 {{ template "consul.validateCloudSecretKeys" . }}
 # The deployment for running the Connect sidecar injector

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -294,6 +294,9 @@ spec:
             {{- if (and $root.Values.global.metrics.enabled $root.Values.global.metrics.enableGatewayMetrics) }}
             -telemetry-prom-scrape-path="/metrics"
             {{- end }}
+            {{- if and $root.Values.externalServers.enabled $root.Values.externalServers.skipServerWatch }}
+            -server-watch-disabled=true
+            {{- end }}
         livenessProbe:
           tcpSocket:
             port: 21000

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -244,6 +244,9 @@ spec:
             {{- if (and .Values.global.metrics.enabled .Values.global.metrics.enableGatewayMetrics) }}
             -telemetry-prom-scrape-path="/metrics"
             {{- end }}
+            {{- if and .Values.externalServers.enabled .Values.externalServers.skipServerWatch }}
+            -server-watch-disabled=true
+            {{- end }}
         livenessProbe:
           tcpSocket:
             port: {{ .Values.meshGateway.containerPort }}

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -285,6 +285,9 @@ spec:
                 {{- if (and $root.Values.global.metrics.enabled $root.Values.global.metrics.enableGatewayMetrics) }}
                 -telemetry-prom-scrape-path="/metrics"
                 {{- end }}
+                {{- if and $root.Values.externalServers.enabled $root.Values.externalServers.skipServerWatch }}
+                -server-watch-disabled=true
+                {{- end }}
           livenessProbe:
             tcpSocket:
               port: 8443

--- a/charts/consul/test/unit/ingress-gateways-deployment.bats
+++ b/charts/consul/test/unit/ingress-gateways-deployment.bats
@@ -313,6 +313,27 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# externalServers.skipServerWatch
+
+@test "ingressGateways/Deployment: sets server-watch-disabled flag when externalServers.enabled and externalServers.skipServerWatch is true" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      --set 'server.enabled=false' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=consul' \
+      --set 'externalServers.skipServerWatch=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '. | contains("-server-watch-disabled")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # replicas
 
 @test "ingressGateways/Deployment: replicas defaults to 2" {

--- a/charts/consul/test/unit/mesh-gateway-deployment.bats
+++ b/charts/consul/test/unit/mesh-gateway-deployment.bats
@@ -141,6 +141,27 @@ key2: value2' \
 }
 
 #--------------------------------------------------------------------
+# externalServers.skipServerWatch
+
+@test "meshGateway/Deployment: sets server-watch-disabled flag when externalServers.enabled and externalServers.skipServerWatch is true" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      --set 'server.enabled=false' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=consul' \
+      --set 'externalServers.skipServerWatch=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '. | contains("-server-watch-disabled")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # replicas
 
 @test "meshGateway/Deployment: replicas defaults to 2" {

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -370,6 +370,27 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# externalServers.skipServerWatch
+
+@test "terminatingGateways/Deployment: sets server-watch-disabled flag when externalServers.enabled and externalServers.skipServerWatch is true" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=false' \
+      --set 'server.enabled=false' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=consul' \
+      --set 'externalServers.skipServerWatch=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0].command[2]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '. | contains("-server-watch-disabled")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # replicas
 
 @test "terminatingGateways/Deployment: replicas defaults to 2" {

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1183,6 +1183,10 @@ externalServers:
   # @type: string
   k8sAuthMethodHost: null
 
+  # If true, setting this prevents the consul-dataplane from watching the consul server upstream for changes. This is
+  # useful for situations where Consul servers are behind a load balancer. 
+  skipServerWatch: false
+
 # Values that configure running a Consul client on Kubernetes nodes.
 client:
   # If true, the chart will install all

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1183,7 +1183,7 @@ externalServers:
   # @type: string
   k8sAuthMethodHost: null
 
-  # If true, setting this prevents the consul-dataplane from watching the consul server upstream for changes. This is
+  # If true, setting this prevents the consul-dataplane and consul-k8s components from watching the Consul servers for changes. This is
   # useful for situations where Consul servers are behind a load balancer. 
   skipServerWatch: false
 

--- a/control-plane/connect-inject/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/consul_dataplane_sidecar.go
@@ -155,6 +155,10 @@ func (w *MeshWebhook) getContainerSidecarCommand(namespace corev1.Namespace, mpi
 		"-envoy-concurrency=" + strconv.Itoa(envoyConcurrency),
 	}
 
+	if w.SkipServerWatch {
+		cmd = append(cmd, "-server-watch-disabled=true")
+	}
+
 	if w.AuthMethod != "" {
 		cmd = append(cmd,
 			"-credential-type=login",

--- a/control-plane/connect-inject/consul_dataplane_sidecar_test.go
+++ b/control-plane/connect-inject/consul_dataplane_sidecar_test.go
@@ -118,6 +118,12 @@ func TestHandlerConsulDataplaneSidecar(t *testing.T) {
 			},
 			additionalExpCmdArgs: " -tls-disabled",
 		},
+		"skip server watch enabled": {
+			webhookSetupFunc: func(w *MeshWebhook) {
+				w.SkipServerWatch = true
+			},
+			additionalExpCmdArgs: " -server-watch-disabled=true -tls-disabled",
+		},
 	}
 
 	for name, c := range cases {

--- a/control-plane/connect-inject/mesh_webhook.go
+++ b/control-plane/connect-inject/mesh_webhook.go
@@ -167,6 +167,10 @@ type MeshWebhook struct {
 	// those containers to be created otherwise.
 	EnableOpenShift bool
 
+	// SkipServerWatch prevents consul-dataplane from consuming the server update stream. This is useful
+	// for situations where Consul servers are behind a load balancer.
+	SkipServerWatch bool
+
 	// ReleaseNamespace is the Kubernetes namespace where this webhook is running.
 	ReleaseNamespace string
 

--- a/control-plane/subcommand/flags/consul_test.go
+++ b/control-plane/subcommand/flags/consul_test.go
@@ -39,6 +39,7 @@ func TestConsulFlags_Flags(t *testing.T) {
 				LoginPartitionEnvVar:       "other-test-partition",
 				LoginNamespaceEnvVar:       "other-test-ns",
 				LoginMetaEnvVar:            "key1=value1,key2=value2",
+				SkipServerWatchEnvVar:      "true",
 			},
 			expFlags: &ConsulFlags{
 				Addresses:  "consul.address",
@@ -66,6 +67,7 @@ func TestConsulFlags_Flags(t *testing.T) {
 						Meta:            map[string]string{"key1": "value1", "key2": "value2"},
 					},
 				},
+				SkipServerWatch: true,
 			},
 		},
 		"defaults": {
@@ -209,6 +211,18 @@ func TestConsulFlags_ConsulServerConnMgrConfig(t *testing.T) {
 						Token: "test-token",
 					},
 				},
+			},
+		},
+		"skip server watch to server watch disabled": {
+			flags: ConsulFlags{
+				Addresses:       "consul.address",
+				GRPCPort:        8502,
+				SkipServerWatch: true,
+			},
+			expConfig: discovery.Config{
+				Addresses:           "consul.address",
+				GRPCPort:            8502,
+				ServerWatchDisabled: true,
 			},
 		},
 	}

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -499,6 +499,7 @@ func (c *Command) Run(args []string) int {
 			ConsulCACert:                 string(caCertPem),
 			TLSEnabled:                   c.consul.UseTLS,
 			ConsulAddress:                c.consul.Addresses,
+			SkipServerWatch:              c.consul.SkipServerWatch,
 			ConsulTLSServerName:          c.consul.TLSServerName,
 			DefaultProxyCPURequest:       sidecarProxyCPURequest,
 			DefaultProxyCPULimit:         sidecarProxyCPULimit,


### PR DESCRIPTION
Changes proposed in this PR:
- Add helm value of `externalServers.skipServerWatch`
- Add the environment variable CONSUL_SKIP_SERVER_WATCH to helm _helpers.tpl so that the environment variable will get automatically picked up by connection manager when talking to consul servers
- Even though not directly needed there, add the check that `externalServers.enabled` is also set when `externalServers.skipServerWatch=true` in connect-inject-deployment.yaml
- Bats tests for connect-inject-deployment to make sure that it fails the condition above and that the CONSUL_SKIP_SERVER_WATCH is set in the environment.
- Read the env variable in flags/consul.go so that it can be passed to connection manager and down into discover.Config (used by partition-init, catalog-sync, server-acl-init, inject-connect, etc)
- Specifically, set the flag in the webhook so that it is passed onto consul-dataplane as a `-server-watch-disabled=true` flag


How I've tested this PR:
- bats tests
- unit tests


How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

