### PR TITLE
Use netaddrs instead of go-discover in acl-init

### DIFF
--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -353,6 +353,9 @@ Consul server environment variables for consul-k8s commands.
 {{- if and .Values.externalServers.enabled .Values.externalServers.tlsServerName }}
 - name: CONSUL_TLS_SERVER_NAME
   value: {{ .Values.externalServers.tlsServerName }}
+{{- else if .Values.global.cloud.enabled }}
+- name: CONSUL_TLS_SERVER_NAME
+  value: server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -353,9 +353,6 @@ Consul server environment variables for consul-k8s commands.
 {{- if and .Values.externalServers.enabled .Values.externalServers.tlsServerName }}
 - name: CONSUL_TLS_SERVER_NAME
   value: {{ .Values.externalServers.tlsServerName }}
-{{- else if .Values.global.cloud.enabled }}
-- name: CONSUL_TLS_SERVER_NAME
-  value: server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -484,47 +484,28 @@ spec:
       - name: client-acl-init
         image: {{ .Values.global.imageK8S }}
         env:
-        - name: CONSUL_HTTP_ADDR
-          {{- if .Values.global.tls.enabled }}
-          value: https://{{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc:8501
-          {{- else }}
-          value: http://{{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc:8500
-          {{- end }}
-        {{- if (and .Values.global.tls.enabled (not .Values.externalServers.useSystemRoots)) }}
-        - name: CONSUL_CACERT
-          {{- if .Values.global.secretsBackend.vault.enabled }}
-          value: "/vault/secrets/serverca.crt" 
-          {{- else }}
-          value: "/consul/tls/ca/tls.crt"
-          {{- end }}
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        {{- include "consul.consulK8sConsulServerEnvVars" . | nindent 8 }}
+        {{- if .Values.global.acls.manageSystemACLs }}
+        - name: CONSUL_LOGIN_AUTH_METHOD
+          value: {{ template "consul.fullname" . }}-k8s-component-auth-method
+        - name: CONSUL_LOGIN_META
+          value: "component=client,pod=$(NAMESPACE)/$(POD_NAME)"
         {{- end }}
         command:
           - "/bin/sh"
           - "-ec"
           - |
             consul-k8s-control-plane acl-init \
-              -component-name=client \
-              -acl-auth-method="{{ template "consul.fullname" . }}-k8s-component-auth-method" \
-              {{- if .Values.global.adminPartitions.enabled }}
-              -partition={{ .Values.global.adminPartitions.name }} \
-              {{- end }}
               -log-level={{ default .Values.global.logLevel .Values.client.logLevel }} \
               -log-json={{ .Values.global.logJSON }} \
-              {{- if .Values.externalServers.enabled }}
-              {{- if .Values.global.tls.enabled }}
-              -use-https \
-              {{- end }}
-              {{- range .Values.externalServers.hosts }}
-              -server-address={{ quote . }} \
-              {{- end }}
-              -server-port={{ .Values.externalServers.httpsPort }} \
-              {{- if .Values.externalServers.tlsServerName }}
-              -tls-server-name={{ .Values.externalServers.tlsServerName }} \
-              {{- end }}
-              {{- else if .Values.global.cloud.enabled }}
-              -tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
-              {{- end }}
-              -consul-api-timeout={{ .Values.global.consulAPITimeout }} \
               -init-type="client"
         volumeMounts:
           - name: aclconfig


### PR DESCRIPTION
Changes proposed in this PR:
- Migrate `acl-init` job to use the `netaddrs` library to resolve the address passed in instead of go-discover in order to align it with changes being made in the project.
- This migrates acl-init to use the new consul flags but uses a traditional Consul login instead of the watcher as the watcher cleans up the token when the process stops. Using the Consul login allows the client to use the correct token when they come up and their `preStop` hook logouts and cleans up the token.

How I've tested this PR:
- Unit tests are still 🟢 
- Acceptance tests for the basic case as that running clients with ACLs enabled.

How I expect reviewers to test this PR:
- 👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

