### PR TITLE
helm: pass partition and datacenter to consul-api-gateway server command

### DIFF
--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -92,6 +92,10 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
+            {{- if .Values.global.adminPartitions.enabled }}
+            -partition {{ .Values.global.adminPartitions.name }} \
+            {{- end }}
+            -datacenter {{ .Values.global.datacenter }} \
             {{- if and .Values.global.federation.enabled .Values.global.federation.primaryDatacenter }}
             -primary-datacenter={{ .Values.global.federation.primaryDatacenter }} \
             {{- end }}


### PR DESCRIPTION
#### Changes proposed in this PR:
- Plumb configured Consul datacenter and partition values from Helm config through to Consul API Gateway command as CLI args.

#### How I've tested this PR:

#### How I expect reviewers to test this PR:

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

