### PR TITLE
Disable PodSecurityPolicy when global.enablePodSecurityPolicies set to false

### DIFF
--- a/charts/consul/templates/gossip-encryption-autogenerate-podsecuritypolicy.yaml
+++ b/charts/consul/templates/gossip-encryption-autogenerate-podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.gossipEncryption.autoGenerate }}
+{{- if and .Values.global.gossipEncryption.autoGenerate .Values.global.enablePodSecurityPolicies }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/charts/consul/templates/partition-init-podsecuritypolicy.yaml
+++ b/charts/consul/templates/partition-init-podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
-{{- if (and .Values.global.adminPartitions.enabled (not $serverEnabled)) }}
+{{- if (and .Values.global.adminPartitions.enabled .Values.global.enablePodSecurityPolicies (not $serverEnabled)) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/consul/test/unit/gossip-encryption-autogenerate-podsecuritypolicy.bats
+++ b/charts/consul/test/unit/gossip-encryption-autogenerate-podsecuritypolicy.bats
@@ -17,11 +17,30 @@ load _helpers
       .
 }
 
-@test "gossipEncryptionAutogenerate/PodSecurityPolicy: enabled with global.gossipEncryption.autoGenerate=true" {
+@test "gossipEncryptionAutogenerate/PodSecurityPolicy: disabled with global.gossipEncryption.autoGenerate=true and global.enablePodSecurityPolicies=false" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/gossip-encryption-autogenerate-podsecuritypolicy.yaml  \
+      --set 'global.gossipEncryption.autoGenerate=true' \
+      --set 'global.enablePodSecurityPolicies=false' \
+      .
+}
+
+@test "gossipEncryptionAutogenerate/PodSecurityPolicy: disabled with global.gossipEncryption.autoGenerate=false and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/gossip-encryption-autogenerate-podsecuritypolicy.yaml  \
+      --set 'global.gossipEncryption.autoGenerate=false' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      .
+}
+
+@test "gossipEncryptionAutogenerate/PodSecurityPolicy: enabled with global.gossipEncryption.autoGenerate=true and global.enablePodSecurityPolicies=true" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/gossip-encryption-autogenerate-podsecuritypolicy.yaml  \
       --set 'global.gossipEncryption.autoGenerate=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/charts/consul/test/unit/partition-init-podsecuritypolicy.bats
+++ b/charts/consul/test/unit/partition-init-podsecuritypolicy.bats
@@ -9,44 +9,92 @@ load _helpers
       .
 }
 
-@test "partitionInit/PodSecurityPolicy: enabled with global.adminPartitions.enabled=true and server.enabled=false" {
+@test "partitionInit/PodSecurityPolicy: enabled with global.adminPartitions.enabled=true and global.enablePodSecurityPolicies=true and server.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/partition-init-podsecuritypolicy.yaml  \
       --set 'global.adminPartitions.enabled=true' \
       --set 'global.enableConsulNamespaces=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 
-@test "partitionInit/PodSecurityPolicy: disabled with global.adminPartitions.enabled=true and servers = true" {
+@test "partitionInit/PodSecurityPolicy: disabled with global.adminPartitions.enabled=true and global.enablePodSecurityPolicies=false and server.enabled=false" {
   cd `chart_dir`
   assert_empty helm template \
       -s templates/partition-init-podsecuritypolicy.yaml  \
       --set 'global.adminPartitions.enabled=true' \
       --set 'global.enableConsulNamespaces=true' \
+      --set 'global.enablePodSecurityPolicies=false' \
+      --set 'server.enabled=false' \
+      .
+}
+
+@test "partitionInit/PodSecurityPolicy: disabled with global.adminPartitions.enabled=true and global.enablePodSecurityPolicies=true and servers = true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/partition-init-podsecuritypolicy.yaml  \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
       --set 'server.enabled=true' \
       .
 }
 
-@test "partitionInit/PodSecurityPolicy: disabled with global.adminPartitions.enabled=true and global.enabled = true" {
+@test "partitionInit/PodSecurityPolicy: disabled with global.adminPartitions.enabled=true and global.enablePodSecurityPolicies=false and servers = true" {
   cd `chart_dir`
   assert_empty helm template \
       -s templates/partition-init-podsecuritypolicy.yaml  \
       --set 'global.adminPartitions.enabled=true' \
       --set 'global.enableConsulNamespaces=true' \
+      --set 'global.enablePodSecurityPolicies=false' \
+      --set 'server.enabled=true' \
+      .
+}
+
+@test "partitionInit/PodSecurityPolicy: disabled with global.adminPartitions.enabled=true and global.enablePodSecurityPolicies=true and global.enabled = true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/partition-init-podsecuritypolicy.yaml  \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
       --set 'global.enabled=true' \
       .
 }
 
-@test "partitionInit/PodSecurityPolicy: disabled with global.adminPartitions.enabled=false" {
+@test "partitionInit/PodSecurityPolicy: disabled with global.adminPartitions.enabled=true and global.enablePodSecurityPolicies=false and global.enabled = true" {
   cd `chart_dir`
   assert_empty helm template \
       -s templates/partition-init-podsecuritypolicy.yaml  \
       --set 'global.adminPartitions.enabled=true' \
       --set 'global.enableConsulNamespaces=true' \
+      --set 'global.enablePodSecurityPolicies=false' \
+      --set 'global.enabled=true' \
+      .
+}
+
+@test "partitionInit/PodSecurityPolicy: disabled with global.adminPartitions.enabled=false and global.enablePodSecurityPolicies=true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/partition-init-podsecuritypolicy.yaml  \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'server.enabled=true' \
+      .
+}
+
+@test "partitionInit/PodSecurityPolicy: disabled with global.adminPartitions.enabled=false and global.enablePodSecurityPolicies=false" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/partition-init-podsecuritypolicy.yaml  \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'global.enablePodSecurityPolicies=false' \
       --set 'server.enabled=true' \
       .
 }


### PR DESCRIPTION
Changes proposed in this PR:
- Check for `global.enablePodSecurityPolicies` exists in other PodSecurityPolicy manifest, but missing in `gossip-encryption-autogenerate-podsecuritypolicy.yaml` and `partition-init-podsecuritypolicy.yaml` files.
- Update unit tests in `gossip-encryption-autogenerate-podsecuritypolicy.bats` and `partition-init-podsecuritypolicy.bats` to cover the variable `global.enablePodSecurityPolicies`.

How I've tested this PR:
- Via Unit-test

How I expect reviewers to test this PR:
- Via Unit-test

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

