### PR TITLE
agentless: map k8s nodes to consul nodes instead of using one node

### DIFF
--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -191,13 +191,16 @@ spec:
         - name: CONSUL_LOGIN_META
           value: "component=ingress-gateway,pod=$(NAMESPACE)/$(POD_NAME)"
        {{- end }}
+        - name: CONSUL_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         command:
         - "/bin/sh"
         - "-ec"
         - |
           consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${NAMESPACE} \
           -gateway-kind="ingress-gateway" \
-          -consul-node-name="k8s-service-mesh" \
           -proxy-id-file=/consul/service/proxy-id \
           -service-name={{ template "consul.fullname" $root }}-{{ .name }} \
           -log-level={{ default $root.Values.global.logLevel }} \
@@ -242,6 +245,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: DP_SERVICE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         command:
         - /bin/sh
         - -ec
@@ -260,7 +267,7 @@ spec:
             -grpc-port=8502 \
             {{- end }}
             -proxy-service-id=$POD_NAME \
-            -service-node-name="k8s-service-mesh" \
+            -service-node-name=$DP_SERVICE_NODE_NAME \
             {{- if $root.Values.global.enableConsulNamespaces }}
             -service-namespace={{ (default $defaults.consulNamespace .consulNamespace) }} \
             {{- end }}

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -141,13 +141,16 @@ spec:
         - name: CONSUL_LOGIN_META
           value: "component=mesh-gateway,pod=$(NAMESPACE)/$(POD_NAME)"
         {{- end }}
+        - name: CONSUL_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         command:
         - "/bin/sh"
         - "-ec"
         - |
           consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${NAMESPACE} \
            -gateway-kind="mesh-gateway" \
-           -consul-node-name="k8s-service-mesh" \
            -proxy-id-file=/consul/service/proxy-id \
            -service-name={{ .Values.meshGateway.consulServiceName }} \
            -log-level={{ default .Values.global.logLevel }} \
@@ -192,6 +195,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: DP_SERVICE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         command:
         - /bin/sh
         - -ec
@@ -208,7 +215,7 @@ spec:
             -grpc-port=8502 \
             {{- end }}
             -proxy-service-id=$POD_NAME \
-            -service-node-name="k8s-service-mesh" \
+            -service-node-name=$DP_SERVICE_NODE_NAME \
             {{- if .Values.global.tls.enabled }}
             {{- if (not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots)) }}
             -ca-certs=/consul/tls/ca/tls.crt \

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -176,13 +176,16 @@ spec:
           - name: CONSUL_LOGIN_META
             value: "component=terminating-gateway,pod=$(NAMESPACE)/$(POD_NAME)"
           {{- end }}
+          - name: CONSUL_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           command:  
             - "/bin/sh"
             - "-ec"
             - |
                 consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${NAMESPACE} \
                   -gateway-kind="terminating-gateway" \
-                  -consul-node-name="k8s-service-mesh" \
                   -proxy-id-file=/consul/service/proxy-id \
                   -service-name={{ .name }} \
                   -log-level={{ default $root.Values.global.logLevel }} \
@@ -235,6 +238,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: DP_SERVICE_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           command:
             - /bin/sh
             - -ec
@@ -251,7 +258,7 @@ spec:
                 -grpc-port=8502 \
                 {{- end }}
                 -proxy-service-id=$POD_NAME \
-                -service-node-name="k8s-service-mesh" \
+                -service-node-name=$DP_SERVICE_NODE_NAME \
                 {{- if $root.Values.global.enableConsulNamespaces }}
                 -service-namespace={{ (default $defaults.consulNamespace .consulNamespace) }} \
                 {{- end }}

--- a/control-plane/connect-inject/constants/constants.go
+++ b/control-plane/connect-inject/constants/constants.go
@@ -7,9 +7,6 @@ const (
 	// ProxyDefaultInboundPort is the default inbound port for the proxy.
 	ProxyDefaultInboundPort = 20000
 
-	// ConsulNodeName is the node name that we'll use to register and deregister services.
-	ConsulNodeName = "k8s-service-mesh"
-
 	// MetaKeyKubeNS is the meta key name for Kubernetes namespace used for the Consul services.
 	MetaKeyKubeNS = "k8s-namespace"
 

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
@@ -399,8 +399,8 @@ func (r *Controller) createServiceRegistrations(apiClient *api.Client, pod corev
 		Tags:      tags,
 	}
 	serviceRegistration := &api.CatalogRegistration{
-		Node:    constants.ConsulNodeName,
-		Address: consulNodeAddress,
+		Node:    pod.Spec.NodeName,
+		Address: pod.Status.HostIP,
 		NodeMeta: map[string]string{
 			metaKeySyntheticNode: "true",
 		},
@@ -587,8 +587,8 @@ func (r *Controller) createServiceRegistrations(apiClient *api.Client, pod corev
 	}
 
 	proxyServiceRegistration := &api.CatalogRegistration{
-		Node:    constants.ConsulNodeName,
-		Address: consulNodeAddress,
+		Node:    pod.Spec.NodeName,
+		Address: pod.Status.HostIP,
 		NodeMeta: map[string]string{
 			metaKeySyntheticNode: "true",
 		},
@@ -722,8 +722,8 @@ func (r *Controller) createGatewayRegistrations(pod corev1.Pod, serviceEndpoints
 	}
 
 	serviceRegistration := &api.CatalogRegistration{
-		Node:    constants.ConsulNodeName,
-		Address: consulNodeAddress,
+		Node:    pod.Spec.NodeName,
+		Address: pod.Status.HostIP,
 		NodeMeta: map[string]string{
 			metaKeySyntheticNode: "true",
 		},
@@ -839,52 +839,54 @@ func getHealthCheckStatusReason(healthCheckStatus, podName, podNamespace string)
 // has addresses, it will only deregister instances not in the map.
 func (r *Controller) deregisterService(apiClient *api.Client, k8sSvcName, k8sSvcNamespace string, endpointsAddressesMap map[string]bool) error {
 	// Get services matching metadata.
-	svcs, err := r.serviceInstancesForK8SServiceNameAndNamespace(apiClient, k8sSvcName, k8sSvcNamespace)
+	nodesWithSvcs, err := r.serviceInstancesForK8sNodes(apiClient, k8sSvcName, k8sSvcNamespace)
 	if err != nil {
 		r.Log.Error(err, "failed to get service instances", "name", k8sSvcName)
 		return err
 	}
 
 	// Deregister each service instance that matches the metadata.
-	for _, svc := range svcs.Services {
-		// We need to get services matching "k8s-service-name" and "k8s-namespace" metadata.
-		// If we selectively deregister, only deregister if the address is not in the map. Otherwise, deregister
-		// every service instance.
-		var serviceDeregistered bool
-		if endpointsAddressesMap != nil {
-			if _, ok := endpointsAddressesMap[svc.Address]; !ok {
-				// If the service address is not in the Endpoints addresses, deregister it.
+	for _, nodeSvcs := range nodesWithSvcs {
+		for _, svc := range nodeSvcs.Services {
+			// We need to get services matching "k8s-service-name" and "k8s-namespace" metadata.
+			// If we selectively deregister, only deregister if the address is not in the map. Otherwise, deregister
+			// every service instance.
+			var serviceDeregistered bool
+			if endpointsAddressesMap != nil {
+				if _, ok := endpointsAddressesMap[svc.Address]; !ok {
+					// If the service address is not in the Endpoints addresses, deregister it.
+					r.Log.Info("deregistering service from consul", "svc", svc.ID)
+					_, err = apiClient.Catalog().Deregister(&api.CatalogDeregistration{
+						Node:      nodeSvcs.Node.Node,
+						ServiceID: svc.ID,
+						Namespace: svc.Namespace,
+					}, nil)
+					if err != nil {
+						r.Log.Error(err, "failed to deregister service instance", "id", svc.ID)
+						return err
+					}
+					serviceDeregistered = true
+				}
+			} else {
 				r.Log.Info("deregistering service from consul", "svc", svc.ID)
-				_, err = apiClient.Catalog().Deregister(&api.CatalogDeregistration{
-					Node:      constants.ConsulNodeName,
+				if _, err = apiClient.Catalog().Deregister(&api.CatalogDeregistration{
+					Node:      nodeSvcs.Node.Node,
 					ServiceID: svc.ID,
 					Namespace: svc.Namespace,
-				}, nil)
-				if err != nil {
+				}, nil); err != nil {
 					r.Log.Error(err, "failed to deregister service instance", "id", svc.ID)
 					return err
 				}
 				serviceDeregistered = true
 			}
-		} else {
-			r.Log.Info("deregistering service from consul", "svc", svc.ID)
-			if _, err = apiClient.Catalog().Deregister(&api.CatalogDeregistration{
-				Node:      constants.ConsulNodeName,
-				ServiceID: svc.ID,
-				Namespace: svc.Namespace,
-			}, nil); err != nil {
-				r.Log.Error(err, "failed to deregister service instance", "id", svc.ID)
-				return err
-			}
-			serviceDeregistered = true
-		}
 
-		if r.AuthMethod != "" && serviceDeregistered {
-			r.Log.Info("reconciling ACL tokens for service", "svc", svc.Service)
-			err = r.deleteACLTokensForServiceInstance(apiClient, svc, k8sSvcNamespace, svc.Meta[constants.MetaKeyPodName])
-			if err != nil {
-				r.Log.Error(err, "failed to reconcile ACL tokens for service", "svc", svc.Service)
-				return err
+			if r.AuthMethod != "" && serviceDeregistered {
+				r.Log.Info("reconciling ACL tokens for service", "svc", svc.Service)
+				err = r.deleteACLTokensForServiceInstance(apiClient, svc, k8sSvcNamespace, svc.Meta[constants.MetaKeyPodName])
+				if err != nil {
+					r.Log.Error(err, "failed to reconcile ACL tokens for service", "svc", svc.Service)
+					return err
+				}
 			}
 		}
 	}
@@ -1009,9 +1011,26 @@ func getTokenMetaFromDescription(description string) (map[string]string, error) 
 	return tokenMeta, nil
 }
 
+func (r *Controller) serviceInstancesForK8sNodes(apiClient *api.Client, k8sServiceName, k8sServiceNamespace string) ([]*api.CatalogNodeServiceList, error) {
+	var serviceList []*api.CatalogNodeServiceList
+	// Get a list of k8s nodes.
+	var nodeList corev1.NodeList
+	err := r.Client.List(r.Context, &nodeList)
+	if err != nil {
+		return nil, err
+	}
+	for _, node := range nodeList.Items {
+		var nodeServices *api.CatalogNodeServiceList
+		nodeServices, err = r.serviceInstancesForK8SServiceNameAndNamespace(apiClient, k8sServiceName, k8sServiceNamespace, node.Name)
+		serviceList = append(serviceList, nodeServices)
+	}
+
+	return serviceList, err
+}
+
 // serviceInstancesForK8SServiceNameAndNamespace calls Consul's ServicesWithFilter to get the list
 // of services instances that have the provided k8sServiceName and k8sServiceNamespace in their metadata.
-func (r *Controller) serviceInstancesForK8SServiceNameAndNamespace(apiClient *api.Client, k8sServiceName, k8sServiceNamespace string) (*api.CatalogNodeServiceList, error) {
+func (r *Controller) serviceInstancesForK8SServiceNameAndNamespace(apiClient *api.Client, k8sServiceName, k8sServiceNamespace, nodeName string) (*api.CatalogNodeServiceList, error) {
 	var (
 		serviceList *api.CatalogNodeServiceList
 		err         error
@@ -1019,9 +1038,9 @@ func (r *Controller) serviceInstancesForK8SServiceNameAndNamespace(apiClient *ap
 	filter := fmt.Sprintf(`Meta[%q] == %q and Meta[%q] == %q and Meta[%q] == %q`,
 		metaKeyKubeServiceName, k8sServiceName, constants.MetaKeyKubeNS, k8sServiceNamespace, metaKeyManagedBy, constants.ManagedByValue)
 	if r.EnableConsulNamespaces {
-		serviceList, _, err = apiClient.Catalog().NodeServiceList(constants.ConsulNodeName, &api.QueryOptions{Filter: filter, Namespace: namespaces.WildcardNamespace})
+		serviceList, _, err = apiClient.Catalog().NodeServiceList(nodeName, &api.QueryOptions{Filter: filter, Namespace: namespaces.WildcardNamespace})
 	} else {
-		serviceList, _, err = apiClient.Catalog().NodeServiceList(constants.ConsulNodeName, &api.QueryOptions{Filter: filter})
+		serviceList, _, err = apiClient.Catalog().NodeServiceList(nodeName, &api.QueryOptions{Filter: filter})
 	}
 	return serviceList, err
 }

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_ent_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_ent_test.go
@@ -209,8 +209,9 @@ func TestReconcileCreateEndpointWithNamespaces(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// Add the pods namespace.
 			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testCase.SourceKubeNS}}
+			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
 			// Create fake k8s client.
-			k8sObjects := append(setup.k8sObjects(), &ns)
+			k8sObjects := append(setup.k8sObjects(), &ns, &node)
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
 
 			// Create test consulServer server
@@ -471,7 +472,8 @@ func TestReconcileCreateGatewayWithNamespaces(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			// Create fake k8s client.
-			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(setup.k8sObjects()...).Build()
+			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(append(setup.k8sObjects(), &node)...).Build()
 
 			// Create testCase Consul server.
 			testClient := test.TestServerWithMockConnMgrWatcher(t, nil)
@@ -633,7 +635,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 				},
 				initialConsulSvcs: []*api.CatalogRegistration{
 					{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
@@ -645,8 +647,8 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
-						Address: "127.0.0.1",
+						Node:    nodeName,
+						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -706,7 +708,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 				},
 				initialConsulSvcs: []*api.CatalogRegistration{
 					{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							ID:        "pod1-different-consul-svc-name",
@@ -718,7 +720,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
@@ -787,8 +789,8 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 				},
 				initialConsulSvcs: []*api.CatalogRegistration{
 					{
-						Node:    constants.ConsulNodeName,
-						Address: "127.0.0.1",
+						Node:    nodeName,
+						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
 							Service:   "service-updated",
@@ -799,7 +801,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
@@ -869,8 +871,8 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 				},
 				initialConsulSvcs: []*api.CatalogRegistration{
 					{
-						Node:    constants.ConsulNodeName,
-						Address: "127.0.0.1",
+						Node:    nodeName,
+						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
 							Service:   "service-updated",
@@ -881,7 +883,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
@@ -898,8 +900,8 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
-						Address: "127.0.0.1",
+						Node:    nodeName,
+						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							ID:        "pod2-service-updated",
 							Service:   "service-updated",
@@ -910,7 +912,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
@@ -972,8 +974,8 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 				},
 				initialConsulSvcs: []*api.CatalogRegistration{
 					{
-						Node:    constants.ConsulNodeName,
-						Address: "127.0.0.1",
+						Node:    nodeName,
+						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							ID:        "pod1-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -984,7 +986,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
@@ -1001,8 +1003,8 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
-						Address: "127.0.0.1",
+						Node:    nodeName,
+						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							ID:        "pod2-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -1013,7 +1015,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
@@ -1061,8 +1063,8 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 				},
 				initialConsulSvcs: []*api.CatalogRegistration{
 					{
-						Node:    constants.ConsulNodeName,
-						Address: "127.0.0.1",
+						Node:    nodeName,
+						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
 							Service:   "service-updated",
@@ -1073,7 +1075,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
@@ -1090,8 +1092,8 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
-						Address: "127.0.0.1",
+						Node:    nodeName,
+						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							ID:        "pod2-service-updated",
 							Service:   "service-updated",
@@ -1102,7 +1104,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
@@ -1138,8 +1140,8 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 				},
 				initialConsulSvcs: []*api.CatalogRegistration{
 					{
-						Node:    constants.ConsulNodeName,
-						Address: "127.0.0.1",
+						Node:    nodeName,
+						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							ID:        "pod1-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -1150,7 +1152,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
@@ -1167,8 +1169,8 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
-						Address: "127.0.0.1",
+						Node:    nodeName,
+						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							ID:        "pod2-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -1179,7 +1181,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
@@ -1228,8 +1230,8 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 				},
 				initialConsulSvcs: []*api.CatalogRegistration{
 					{
-						Node:    constants.ConsulNodeName,
-						Address: "127.0.0.1",
+						Node:    nodeName,
+						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							ID:      "pod1-service-updated",
 							Service: "service-updated",
@@ -1246,7 +1248,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
@@ -1314,8 +1316,8 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 				},
 				initialConsulSvcs: []*api.CatalogRegistration{
 					{
-						Node:    constants.ConsulNodeName,
-						Address: "127.0.0.1",
+						Node:    nodeName,
+						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							ID:      "pod1-service-updated",
 							Service: "service-updated",
@@ -1332,7 +1334,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
@@ -1355,8 +1357,8 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
-						Address: "127.0.0.1",
+						Node:    nodeName,
+						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							ID:      "pod2-service-updated",
 							Service: "service-updated",
@@ -1373,7 +1375,7 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						},
 					},
 					{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
@@ -1417,8 +1419,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 			t.Run(fmt.Sprintf("%s: %s", name, tt.name), func(t *testing.T) {
 				// Add the pods namespace.
 				ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ts.SourceKubeNS}}
+				node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
 				// Create fake k8s client.
-				k8sObjects := append(tt.k8sObjects(), &ns)
+				k8sObjects := append(tt.k8sObjects(), &ns, &node)
 				fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
 
 				// Create test consulServer server
@@ -1722,8 +1725,9 @@ func TestReconcileDeleteEndpointWithNamespaces(t *testing.T) {
 		}
 		for _, tt := range cases {
 			t.Run(fmt.Sprintf("%s:%s", name, tt.name), func(t *testing.T) {
+				node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
 				// Create fake k8s client.
-				fakeClient := fake.NewClientBuilder().Build()
+				fakeClient := fake.NewClientBuilder().WithRuntimeObjects(&node).Build()
 
 				// Create test consulServer server
 				adminToken := "123e4567-e89b-12d3-a456-426614174000"
@@ -1742,7 +1746,7 @@ func TestReconcileDeleteEndpointWithNamespaces(t *testing.T) {
 				var token *api.ACLToken
 				for _, svc := range tt.initialConsulSvcs {
 					serviceRegistration := &api.CatalogRegistration{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: svc,
 					}
@@ -2014,7 +2018,8 @@ func TestReconcileDeleteGatewayWithNamespaces(t *testing.T) {
 		for _, tt := range cases {
 			t.Run(fmt.Sprintf("%s:%s", name, tt.name), func(t *testing.T) {
 				// Create fake k8s client.
-				fakeClient := fake.NewClientBuilder().Build()
+				node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+				fakeClient := fake.NewClientBuilder().WithRuntimeObjects(&node).Build()
 
 				// Create test Consul server.
 				adminToken := "123e4567-e89b-12d3-a456-426614174000"
@@ -2033,7 +2038,7 @@ func TestReconcileDeleteGatewayWithNamespaces(t *testing.T) {
 				var token *api.ACLToken
 				for _, svc := range tt.initialConsulSvcs {
 					serviceRegistration := &api.CatalogRegistration{
-						Node:    constants.ConsulNodeName,
+						Node:    nodeName,
 						Address: consulNodeAddress,
 						Service: svc,
 					}
@@ -2116,7 +2121,7 @@ func createPodWithNamespace(name, namespace, ip string, inject bool, managedByEn
 		},
 		Status: corev1.PodStatus{
 			PodIP:  ip,
-			HostIP: "127.0.0.1",
+			HostIP: consulNodeAddress,
 			Phase:  corev1.PodRunning,
 			Conditions: []corev1.PodCondition{
 				{
@@ -2124,6 +2129,9 @@ func createPodWithNamespace(name, namespace, ip string, inject bool, managedByEn
 					Status: corev1.ConditionTrue,
 				},
 			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
 		},
 	}
 	if inject {
@@ -2149,7 +2157,7 @@ func createGatewayWithNamespace(name, namespace, ip string, annotations map[stri
 		},
 		Status: corev1.PodStatus{
 			PodIP:  ip,
-			HostIP: "127.0.0.1",
+			HostIP: consulNodeAddress,
 			Phase:  corev1.PodRunning,
 			Conditions: []corev1.PodCondition{
 				{
@@ -2157,6 +2165,9 @@ func createGatewayWithNamespace(name, namespace, ip string, annotations map[stri
 					Status: corev1.ConditionTrue,
 				},
 			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
 		},
 	}
 	return pod

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
@@ -26,6 +26,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const (
+	nodeName = "test-node"
+)
+
 func TestShouldIgnore(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -778,7 +782,6 @@ func TestReconcileCreateEndpoint_MultiportService(t *testing.T) {
 				},
 			},
 			expectedProxySvcInstances: []*api.CatalogService{
-
 				{
 					ServiceID:      "pod1-web-sidecar-proxy",
 					ServiceName:    "web-sidecar-proxy",
@@ -871,8 +874,9 @@ func TestReconcileCreateEndpoint_MultiportService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Add the default namespace.
 			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
 			// Create fake k8s client
-			k8sObjects := append(tt.k8sObjects(), &ns)
+			k8sObjects := append(tt.k8sObjects(), &ns, &node)
 
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
 
@@ -883,7 +887,7 @@ func TestReconcileCreateEndpoint_MultiportService(t *testing.T) {
 			// Register service and proxy in consul.
 			for _, svc := range tt.initialConsulSvcs {
 				catalogRegistration := &api.CatalogRegistration{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: svc,
 				}
@@ -2017,8 +2021,9 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Add the default namespace.
 			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
 			// Create fake k8s client
-			k8sObjects := append(tt.k8sObjects(), &ns)
+			k8sObjects := append(tt.k8sObjects(), &ns, &node)
 
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
 
@@ -2165,7 +2170,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			},
 			initialConsulSvcs: []*api.CatalogRegistration{
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod1-service-updated",
@@ -2184,8 +2189,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod1-service-updated-sidecar-proxy",
@@ -2270,7 +2275,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			},
 			initialConsulSvcs: []*api.CatalogRegistration{
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod1-service-updated",
@@ -2289,7 +2294,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: "127.0.0.1",
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
@@ -2375,7 +2380,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			},
 			initialConsulSvcs: []*api.CatalogRegistration{
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod1-service-updated",
@@ -2392,8 +2397,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod1-service-updated-sidecar-proxy",
@@ -2457,7 +2462,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			},
 			initialConsulSvcs: []*api.CatalogRegistration{
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod1-different-consul-svc-name",
@@ -2474,8 +2479,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod1-different-consul-svc-name-sidecar-proxy",
@@ -2547,7 +2552,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			},
 			initialConsulSvcs: []*api.CatalogRegistration{
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod1-service-updated",
@@ -2558,8 +2563,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod1-service-updated-sidecar-proxy",
@@ -2661,7 +2666,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			},
 			initialConsulSvcs: []*api.CatalogRegistration{
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod1-service-updated",
@@ -2672,8 +2677,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod1-service-updated-sidecar-proxy",
@@ -2688,7 +2693,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod2-service-updated",
@@ -2699,8 +2704,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod2-service-updated-sidecar-proxy",
@@ -2758,7 +2763,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			},
 			initialConsulSvcs: []*api.CatalogRegistration{
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod1-different-consul-svc-name",
@@ -2769,8 +2774,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod1-different-consul-svc-name-sidecar-proxy",
@@ -2785,7 +2790,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod2-different-consul-svc-name",
@@ -2796,8 +2801,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod2-different-consul-svc-name-sidecar-proxy",
@@ -2841,7 +2846,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			},
 			initialConsulSvcs: []*api.CatalogRegistration{
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod1-service-updated",
@@ -2852,8 +2857,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod1-service-updated-sidecar-proxy",
@@ -2868,7 +2873,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod2-service-updated",
@@ -2879,8 +2884,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod2-service-updated-sidecar-proxy",
@@ -2914,7 +2919,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			},
 			initialConsulSvcs: []*api.CatalogRegistration{
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod1-different-consul-svc-name",
@@ -2925,8 +2930,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod1-different-consul-svc-name-sidecar-proxy",
@@ -2941,7 +2946,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod2-different-consul-svc-name",
@@ -2952,8 +2957,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod2-different-consul-svc-name-sidecar-proxy",
@@ -3000,7 +3005,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			},
 			initialConsulSvcs: []*api.CatalogRegistration{
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod1-service-updated",
@@ -3017,8 +3022,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod1-service-updated-sidecar-proxy",
@@ -3096,7 +3101,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			},
 			initialConsulSvcs: []*api.CatalogRegistration{
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod1-service-updated",
@@ -3113,8 +3118,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod1-service-updated-sidecar-proxy",
@@ -3135,7 +3140,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod2-service-updated",
@@ -3152,8 +3157,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod2-service-updated-sidecar-proxy",
@@ -3235,7 +3240,7 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 			},
 			initialConsulSvcs: []*api.CatalogRegistration{
 				{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod1-service-updated",
@@ -3252,8 +3257,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 					},
 				},
 				{
-					Node:    constants.ConsulNodeName,
-					Address: "127.0.0.1",
+					Node:    nodeName,
+					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						Kind:    api.ServiceKindConnectProxy,
 						ID:      "pod1-service-updated-sidecar-proxy",
@@ -3282,8 +3287,9 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Add the default namespace.
 			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
 			// Create fake k8s client.
-			k8sObjects := append(tt.k8sObjects(), &ns)
+			k8sObjects := append(tt.k8sObjects(), &ns, &node)
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
 
 			// Create test consulServer server
@@ -3720,8 +3726,9 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Add the default namespace.
 			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
 			// Create fake k8s client.
-			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(&ns).Build()
+			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(&ns, &node).Build()
 
 			// Create test consulServer server
 			adminToken := "123e4567-e89b-12d3-a456-426614174000"
@@ -3737,7 +3744,7 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 			var token *api.ACLToken
 			for _, svc := range tt.initialConsulSvcs {
 				serviceRegistration := &api.CatalogRegistration{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: svc,
 				}
@@ -3872,7 +3879,8 @@ func TestReconcileIgnoresServiceIgnoreLabel(t *testing.T) {
 			}
 			pod1 := createServicePod("pod1", "1.2.3.4", true, true)
 			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-			k8sObjects := []runtime.Object{endpoint, pod1, &ns}
+			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+			k8sObjects := []runtime.Object{endpoint, pod1, &ns, &node}
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
 
 			// Create test consulServer server
@@ -3882,7 +3890,7 @@ func TestReconcileIgnoresServiceIgnoreLabel(t *testing.T) {
 			// Set up the initial Consul services.
 			if tt.svcInitiallyRegistered {
 				serviceRegistration := &api.CatalogRegistration{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: consulNodeAddress,
 					Service: &api.AgentService{
 						ID:      "pod1-" + svcName,
@@ -3981,7 +3989,8 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 	pod1 := createServicePod("pod1", "1.2.3.4", true, true)
 	pod1.Annotations[constants.AnnotationKubernetesService] = endpoint.Name
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-	k8sObjects := []runtime.Object{badEndpoint, endpoint, pod1, &ns}
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+	k8sObjects := []runtime.Object{badEndpoint, endpoint, pod1, &ns, &node}
 	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
 
 	// Create test consulServer server
@@ -4004,7 +4013,7 @@ func TestReconcile_podSpecifiesExplicitService(t *testing.T) {
 
 	// Initially register the pod with the bad endpoint
 	_, err := consulClient.Catalog().Register(&api.CatalogRegistration{
-		Node:    constants.ConsulNodeName,
+		Node:    nodeName,
 		Address: consulNodeAddress,
 		Service: &api.AgentService{
 			ID:      "pod1-" + svcName,
@@ -4161,7 +4170,7 @@ func TestServiceInstancesForK8SServiceNameAndNamespace(t *testing.T) {
 
 			for _, svc := range servicesInConsul {
 				catalogRegistration := &api.CatalogRegistration{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: "127.0.0.1",
 					Service: svc,
 				}
@@ -4170,7 +4179,7 @@ func TestServiceInstancesForK8SServiceNameAndNamespace(t *testing.T) {
 			}
 			ep := Controller{}
 
-			svcs, err := ep.serviceInstancesForK8SServiceNameAndNamespace(consulClient, k8sSvc, k8sNS)
+			svcs, err := ep.serviceInstancesForK8SServiceNameAndNamespace(consulClient, k8sSvc, k8sNS, nodeName)
 			require.NoError(t, err)
 			if len(svcs.Services) > 0 {
 				require.Len(t, svcs, 2)
@@ -6125,13 +6134,17 @@ func createServicePod(name, ip string, inject bool, managedByEndpointsController
 			Annotations: map[string]string{},
 		},
 		Status: corev1.PodStatus{
-			PodIP: ip,
+			PodIP:  ip,
+			HostIP: consulNodeAddress,
 			Conditions: []corev1.PodCondition{
 				{
 					Type:   corev1.PodReady,
 					Status: corev1.ConditionTrue,
 				},
 			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
 		},
 	}
 	if inject {
@@ -6160,6 +6173,9 @@ func createGatewayPod(name, ip string, annotations map[string]string) *corev1.Po
 					Status: corev1.ConditionTrue,
 				},
 			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
 		},
 	}
 	return pod

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
@@ -67,6 +67,14 @@ func (w *MeshWebhook) consulDataplaneSidecar(namespace corev1.Namespace, pod cor
 				Name:  "TMPDIR",
 				Value: "/consul/connect-inject",
 			},
+			{
+				Name: "DP_SERVICE_NODE_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "spec.nodeName",
+					},
+				},
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -150,7 +158,7 @@ func (w *MeshWebhook) getContainerSidecarCommand(namespace corev1.Namespace, mpi
 		fmt.Sprintf("-addresses=%q", w.ConsulAddress),
 		"-grpc-port=" + strconv.Itoa(w.ConsulConfig.GRPCPort),
 		"-proxy-service-id=" + fmt.Sprintf("$(cat %s)", proxyIDFileName),
-		"-service-node-name=" + constants.ConsulNodeName,
+		"-service-node-name=${DP_SERVICE_NODE_NAME}",
 		"-log-level=" + w.LogLevel,
 		"-log-json=" + strconv.FormatBool(w.LogJSON),
 		"-envoy-concurrency=" + strconv.Itoa(envoyConcurrency),

--- a/control-plane/connect-inject/webhook/container_init_test.go
+++ b/control-plane/connect-inject/webhook/container_init_test.go
@@ -65,7 +65,6 @@ func TestHandlerContainerInit(t *testing.T) {
 				LogLevel:      "info",
 			},
 			`/bin/sh -ec consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -consul-node-name=k8s-service-mesh \
   -log-level=info \
   -log-json=false \`,
 			[]corev1.EnvVar{
@@ -84,6 +83,14 @@ func TestHandlerContainerInit(t *testing.T) {
 				{
 					Name:  "CONSUL_API_TIMEOUT",
 					Value: "0s",
+				},
+				{
+					Name: "CONSUL_NODE_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "spec.nodeName",
+						},
+					},
 				},
 			},
 		},
@@ -109,7 +116,6 @@ func TestHandlerContainerInit(t *testing.T) {
 				LogJSON:       true,
 			},
 			`/bin/sh -ec consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -consul-node-name=k8s-service-mesh \
   -log-level=debug \
   -log-json=true \
   -service-account-name="a-service-account-name" \
@@ -130,6 +136,14 @@ func TestHandlerContainerInit(t *testing.T) {
 				{
 					Name:  "CONSUL_API_TIMEOUT",
 					Value: "5s",
+				},
+				{
+					Name: "CONSUL_NODE_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "spec.nodeName",
+						},
+					},
 				},
 				{
 					Name:  "CONSUL_LOGIN_AUTH_METHOD",
@@ -344,7 +358,6 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				ConsulConfig:               &consul.Config{HTTPPort: 8500, GRPCPort: 8502, APITimeout: 5 * time.Second},
 			},
 			`/bin/sh -ec consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -consul-node-name=k8s-service-mesh \
   -log-level=info \
   -log-json=false \`,
 			[]corev1.EnvVar{
@@ -363,6 +376,14 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				{
 					Name:  "CONSUL_API_TIMEOUT",
 					Value: "5s",
+				},
+				{
+					Name: "CONSUL_NODE_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "spec.nodeName",
+						},
+					},
 				},
 				{
 					Name:  "CONSUL_NAMESPACE",
@@ -384,7 +405,6 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				ConsulConfig:               &consul.Config{HTTPPort: 8500, GRPCPort: 8502, APITimeout: 5 * time.Second},
 			},
 			`/bin/sh -ec consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -consul-node-name=k8s-service-mesh \
   -log-level=info \
   -log-json=false \`,
 			[]corev1.EnvVar{
@@ -403,6 +423,14 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				{
 					Name:  "CONSUL_API_TIMEOUT",
 					Value: "5s",
+				},
+				{
+					Name: "CONSUL_NODE_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "spec.nodeName",
+						},
+					},
 				},
 				{
 					Name:  "CONSUL_NAMESPACE",
@@ -428,7 +456,6 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				ConsulConfig:               &consul.Config{HTTPPort: 8500, GRPCPort: 8502, APITimeout: 5 * time.Second},
 			},
 			`/bin/sh -ec consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -consul-node-name=k8s-service-mesh \
   -log-level=info \
   -log-json=false \`,
 			[]corev1.EnvVar{
@@ -447,6 +474,14 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				{
 					Name:  "CONSUL_API_TIMEOUT",
 					Value: "5s",
+				},
+				{
+					Name: "CONSUL_NODE_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "spec.nodeName",
+						},
+					},
 				},
 				{
 					Name:  "CONSUL_NAMESPACE",
@@ -468,7 +503,6 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				ConsulConfig:               &consul.Config{HTTPPort: 8500, GRPCPort: 8502, APITimeout: 5 * time.Second},
 			},
 			`/bin/sh -ec consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -consul-node-name=k8s-service-mesh \
   -log-level=info \
   -log-json=false \`,
 			[]corev1.EnvVar{
@@ -487,6 +521,14 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				{
 					Name:  "CONSUL_API_TIMEOUT",
 					Value: "5s",
+				},
+				{
+					Name: "CONSUL_NODE_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "spec.nodeName",
+						},
+					},
 				},
 				{
 					Name:  "CONSUL_NAMESPACE",
@@ -513,7 +555,6 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				ConsulConfig:               &consul.Config{HTTPPort: 8500, GRPCPort: 8502, APITimeout: 5 * time.Second},
 			},
 			`/bin/sh -ec consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -consul-node-name=k8s-service-mesh \
   -log-level=info \
   -log-json=false \
   -service-account-name="web" \
@@ -534,6 +575,14 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				{
 					Name:  "CONSUL_API_TIMEOUT",
 					Value: "5s",
+				},
+				{
+					Name: "CONSUL_NODE_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "spec.nodeName",
+						},
+					},
 				},
 				{
 					Name:  "CONSUL_LOGIN_AUTH_METHOD",
@@ -581,7 +630,6 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				ConsulConfig:               &consul.Config{HTTPPort: 8500, GRPCPort: 8502, APITimeout: 5 * time.Second},
 			},
 			`/bin/sh -ec consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -consul-node-name=k8s-service-mesh \
   -log-level=info \
   -log-json=false \
   -service-account-name="web" \
@@ -602,6 +650,14 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				{
 					Name:  "CONSUL_API_TIMEOUT",
 					Value: "5s",
+				},
+				{
+					Name: "CONSUL_NODE_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "spec.nodeName",
+						},
+					},
 				},
 				{
 					Name:  "CONSUL_LOGIN_AUTH_METHOD",
@@ -724,7 +780,6 @@ func TestHandlerContainerInit_Multiport(t *testing.T) {
 				},
 			},
 			[]string{`/bin/sh -ec consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -consul-node-name=k8s-service-mesh \
   -log-level=info \
   -log-json=false \
   -multiport=true \
@@ -732,7 +787,6 @@ func TestHandlerContainerInit_Multiport(t *testing.T) {
   -service-name="web" \`,
 
 				`/bin/sh -ec consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -consul-node-name=k8s-service-mesh \
   -log-level=info \
   -log-json=false \
   -multiport=true \
@@ -764,7 +818,6 @@ func TestHandlerContainerInit_Multiport(t *testing.T) {
 				},
 			},
 			[]string{`/bin/sh -ec consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -consul-node-name=k8s-service-mesh \
   -log-level=info \
   -log-json=false \
   -service-account-name="web" \
@@ -773,7 +826,6 @@ func TestHandlerContainerInit_Multiport(t *testing.T) {
   -proxy-id-file=/consul/connect-inject/proxyid-web \`,
 
 				`/bin/sh -ec consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-  -consul-node-name=k8s-service-mesh \
   -log-level=info \
   -log-json=false \
   -service-account-name="web-admin" \
@@ -851,11 +903,11 @@ func TestHandlerContainerInit_WithTLSAndCustomPorts(t *testing.T) {
 			require.Equal(t, "CONSUL_HTTP_PORT", container.Env[4].Name)
 			require.Equal(t, fmt.Sprintf("%d", w.ConsulConfig.HTTPPort), container.Env[4].Value)
 			if w.TLSEnabled {
-				require.Equal(t, "CONSUL_USE_TLS", container.Env[6].Name)
-				require.Equal(t, "true", container.Env[6].Value)
+				require.Equal(t, "CONSUL_USE_TLS", container.Env[7].Name)
+				require.Equal(t, "true", container.Env[7].Value)
 				if caProvided {
-					require.Equal(t, "CONSUL_CACERT_PEM", container.Env[7].Name)
-					require.Equal(t, "consul-ca-cert", container.Env[7].Value)
+					require.Equal(t, "CONSUL_CACERT_PEM", container.Env[8].Name)
+					require.Equal(t, "consul-ca-cert", container.Env[8].Value)
 				} else {
 					for _, ev := range container.Env {
 						if ev.Name == "CONSUL_CACERT_PEM" {

--- a/control-plane/subcommand/connect-init/command.go
+++ b/control-plane/subcommand/connect-init/command.go
@@ -71,7 +71,7 @@ type Command struct {
 func (c *Command) init() {
 	c.flagSet = flag.NewFlagSet("", flag.ContinueOnError)
 	c.flagSet.StringVar(&c.flagPodName, "pod-name", "", "Name of the pod.")
-	c.flagSet.StringVar(&c.flagConsulNodeName, "consul-node-name", "", "Name of the Consul node where services are registered.")
+	c.flagSet.StringVar(&c.flagConsulNodeName, "consul-node-name", os.Getenv("CONSUL_NODE_NAME"), "Name of the Consul node where services are registered.")
 	c.flagSet.StringVar(&c.flagPodNamespace, "pod-namespace", "", "Name of the pod namespace.")
 	c.flagSet.StringVar(&c.flagServiceAccountName, "service-account-name", "", "Service account name on the pod.")
 	c.flagSet.StringVar(&c.flagServiceName, "service-name", "", "Service name as specified via the pod annotation.")
@@ -95,7 +95,6 @@ func (c *Command) init() {
 }
 
 func (c *Command) Run(args []string) int {
-	var err error
 	c.once.Do(c.init)
 
 	if err := c.flagSet.Parse(args); err != nil {

--- a/control-plane/subcommand/connect-init/command_ent_test.go
+++ b/control-plane/subcommand/connect-init/command_ent_test.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 	"github.com/hashicorp/consul-k8s/control-plane/namespaces"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -68,7 +67,7 @@ func TestRun_WithNamespaces(t *testing.T) {
 			testConsulServices := []api.AgentService{consulCountingSvc, consulCountingSvcSidecar}
 			for _, svc := range testConsulServices {
 				serviceRegistration := &api.CatalogRegistration{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: "127.0.0.1",
 					Service: &svc,
 				}
@@ -90,7 +89,7 @@ func TestRun_WithNamespaces(t *testing.T) {
 				"-grpc-port", strconv.Itoa(serverCfg.Ports.GRPC),
 				"-namespace", c.consulServiceNamespace,
 				"-proxy-id-file", proxyFile,
-				"-consul-node-name", constants.ConsulNodeName,
+				"-consul-node-name", nodeName,
 			}
 
 			// Run the command.

--- a/control-plane/subcommand/connect-init/command_test.go
+++ b/control-plane/subcommand/connect-init/command_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
 	"github.com/hashicorp/consul/api"
@@ -20,6 +19,8 @@ import (
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
 )
+
+const nodeName = "test-node"
 
 func TestRun_FlagValidation(t *testing.T) {
 	t.Parallel()
@@ -145,7 +146,7 @@ func TestRun_ConnectServices(t *testing.T) {
 			}
 			for _, svc := range testConsulServices {
 				serviceRegistration := &api.CatalogRegistration{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: "127.0.0.1",
 					Service: &svc,
 				}
@@ -169,7 +170,7 @@ func TestRun_ConnectServices(t *testing.T) {
 				"-grpc-port", strconv.Itoa(serverCfg.Ports.GRPC),
 				"-proxy-id-file", proxyFile,
 				"-multiport=" + strconv.FormatBool(tt.multiport),
-				"-consul-node-name", constants.ConsulNodeName,
+				"-consul-node-name", nodeName,
 			}
 			if tt.aclsEnabled {
 				flags = append(flags, "-auth-method-name", test.AuthMethod,
@@ -299,7 +300,7 @@ func TestRun_Gateways(t *testing.T) {
 			testConsulServices := []api.AgentService{tt.agentService}
 			for _, svc := range testConsulServices {
 				serviceRegistration := &api.CatalogRegistration{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: "127.0.0.1",
 					Service: &svc,
 				}
@@ -322,7 +323,7 @@ func TestRun_Gateways(t *testing.T) {
 				"-http-port", strconv.Itoa(serverCfg.Ports.HTTP),
 				"-grpc-port", strconv.Itoa(serverCfg.Ports.GRPC),
 				"-proxy-id-file", proxyFile,
-				"-consul-node-name", constants.ConsulNodeName,
+				"-consul-node-name", nodeName,
 			}
 
 			// Run the command.
@@ -519,7 +520,7 @@ func TestRun_ConnectServices_Errors(t *testing.T) {
 				"-pod-name", testPodName,
 				"-pod-namespace", testPodNamespace,
 				"-proxy-id-file", proxyFile,
-				"-consul-node-name", constants.ConsulNodeName,
+				"-consul-node-name", nodeName,
 			}
 
 			code := cmd.Run(flags)
@@ -612,7 +613,7 @@ func TestRun_Gateways_Errors(t *testing.T) {
 				"-pod-namespace", testPodNamespace,
 				"-proxy-id-file", proxyFile,
 				"-consul-api-timeout", "5s",
-				"-consul-node-name", constants.ConsulNodeName,
+				"-consul-node-name", nodeName,
 			}
 
 			code := cmd.Run(flags)
@@ -648,7 +649,7 @@ func TestRun_RetryServicePolling(t *testing.T) {
 		time.Sleep(time.Second * 2)
 		// Register counting service.
 		serviceRegistration := &api.CatalogRegistration{
-			Node:    constants.ConsulNodeName,
+			Node:    nodeName,
 			Address: "127.0.0.1",
 			Service: &consulCountingSvc,
 		}
@@ -672,7 +673,7 @@ func TestRun_RetryServicePolling(t *testing.T) {
 		"-http-port", strconv.Itoa(serverCfg.Ports.HTTP),
 		"-grpc-port", strconv.Itoa(serverCfg.Ports.GRPC),
 		"-proxy-id-file", proxyFile,
-		"-consul-node-name", constants.ConsulNodeName,
+		"-consul-node-name", nodeName,
 	}
 	code := cmd.Run(flags)
 	wg.Wait()
@@ -706,7 +707,7 @@ func TestRun_InvalidProxyFile(t *testing.T) {
 	testConsulServices := []api.AgentService{consulCountingSvc, consulCountingSvcSidecar}
 	for _, svc := range testConsulServices {
 		serviceRegistration := &api.CatalogRegistration{
-			Node:    constants.ConsulNodeName,
+			Node:    nodeName,
 			Address: "127.0.0.1",
 			Service: &svc,
 		}
@@ -812,7 +813,7 @@ func TestRun_TrafficRedirection(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			proxyFile := fmt.Sprintf("/tmp/%d", rand.Int())
 			t.Cleanup(func() {
-				_ = os.Remove(proxyFile)
+				_ = os.RemoveAll(proxyFile)
 			})
 
 			// Start Consul server.
@@ -845,7 +846,7 @@ func TestRun_TrafficRedirection(t *testing.T) {
 			testConsulServices := []api.AgentService{consulCountingSvc, consulCountingSvcSidecar}
 			for _, svc := range testConsulServices {
 				serviceRegistration := &api.CatalogRegistration{
-					Node:    constants.ConsulNodeName,
+					Node:    nodeName,
 					Address: "127.0.0.1",
 					Service: &svc,
 				}
@@ -869,7 +870,7 @@ func TestRun_TrafficRedirection(t *testing.T) {
 			flags := []string{
 				"-pod-name", testPodName,
 				"-pod-namespace", testPodNamespace,
-				"-consul-node-name", constants.ConsulNodeName,
+				"-consul-node-name", nodeName,
 				"-addresses", "127.0.0.1",
 				"-http-port", strconv.Itoa(serverCfg.Ports.HTTP),
 				"-grpc-port", strconv.Itoa(serverCfg.Ports.GRPC),


### PR DESCRIPTION
Changes proposed in this PR:
- Map k8s nodes to consul nodes for service registration instead of using one node per cluster

How I've tested this PR:
acceptance and unit tests

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

