### PR TITLE
ISSUE-3411 as the comment from justas147 stated, the memory limit for…

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -807,7 +807,7 @@ server:
   # @type: map
   resources:
     requests:
-      memory: "100Mi"
+      memory: "200Mi"
       cpu: "100m"
     limits:
       memory: "100Mi"

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -810,7 +810,7 @@ server:
       memory: "200Mi"
       cpu: "100m"
     limits:
-      memory: "100Mi"
+      memory: "250Mi"
       cpu: "100m"
 
   # The security context for the server pods. This should be a YAML map corresponding to a


### PR DESCRIPTION
… client agents is pretty low and we quickly faced problems we couldn't explain us. Only a describe at the right time showed us an OOM error. This behaviour exists for more than 5 years and could easily be fixed for standard installations with this quick fix for everyone trying out consul on a medium sized project.

Changes proposed in this PR:
- increased resource limit from 100m to 200m
-

How I've tested this PR:
Redeployed our consul with more than 50 routes and seeing no agent-client ooms

How I expect reviewers to test this PR:
Set up with 50 or more routes without the change, looking at various restarts of the client agent(s) and start again with doubled memory to see no restarts and lost service routes at all


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

