### PR TITLE
Explicitly disable grpc_tls when not using encryption.

### DIFF
--- a/charts/consul/templates/server-config-configmap.yaml
+++ b/charts/consul/templates/server-config-configmap.yaml
@@ -29,8 +29,10 @@ data:
       "ports": {
         {{- if not .Values.global.tls.enabled }}
         "grpc": 8502,
+        "grpc_tls": -1,
         {{- end }}
         {{- if .Values.global.tls.enabled }}
+        "grpc": -1,
         "grpc_tls": 8502,
         {{- end }}
         "serf_lan": {{ .Values.server.ports.serflan.port }}

--- a/charts/consul/test/unit/server-config-configmap.bats
+++ b/charts/consul/test/unit/server-config-configmap.bats
@@ -65,25 +65,31 @@ load _helpers
 #--------------------------------------------------------------------
 # grpc
 
-@test "server/ConfigMap: if tls is disabled, grpc port is set" {
+@test "server/ConfigMap: if tls is disabled, grpc port is set and grpc_tls port is disabled" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local configmap=$(helm template \
       -s templates/server-config-configmap.yaml  \
       . | tee /dev/stderr |
-      yq -r '.data["server.json"]' | jq -r .ports.grpc | tee /dev/stderr)
+      yq -r '.data["server.json"]' | tee /dev/stderr)
 
+  local actual=$(echo $configmap | jq -r .ports.grpc |  tee /dev/stderr)
   [ "${actual}" = "8502" ]
+  local actual=$(echo $configmap | jq -r .ports.grpc_tls |  tee /dev/stderr)
+  [ "${actual}" = "-1" ]
 }
 
-@test "server/ConfigMap: if tls is enabled, grpc_tls port is set" {
+@test "server/ConfigMap: if tls is enabled, grpc_tls port is set and grpc port is disabled" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local configmap=$(helm template \
       --set 'global.tls.enabled=true' \
       -s templates/server-config-configmap.yaml  \
       . | tee /dev/stderr |
-      yq -r '.data["server.json"]' | jq -r .ports.grpc_tls | tee /dev/stderr)
+      yq -r '.data["server.json"]' | tee /dev/stderr)
 
+  local actual=$(echo $configmap | jq -r .ports.grpc_tls |  tee /dev/stderr)
   [ "${actual}" = "8502" ]
+  local actual=$(echo $configmap | jq -r .ports.grpc |  tee /dev/stderr)
+  [ "${actual}" = "-1" ]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -657,7 +657,7 @@ load _helpers
       -s templates/server-statefulset.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = f3b00edc16ec09e90b7a20e379be5ddc1b10121ce60f602809a44130d2dc7aca ]
+  [ "${actual}" = 251dd23c6cc44bf8362acddc24c78440b6a65c4618785d027fae526958af5dde ]
 }
 
 @test "server/StatefulSet: adds config-checksum annotation when extraConfig is provided" {
@@ -667,7 +667,7 @@ load _helpers
       --set 'server.extraConfig="{\"hello\": \"world\"}"' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = b51ac0ef8e40d138e197f4ea86e55f3ceebb91fa07d15998809d8904d5a69606 ]
+  [ "${actual}" = 473d54d05b794be1526d42ef04fdc049f4f979a75d3394c897eef149d399207d ]
 }
 
 @test "server/StatefulSet: adds config-checksum annotation when config is updated" {
@@ -677,7 +677,7 @@ load _helpers
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = a37768452067ddd3a0ab44d1da18e167fe093946b14e43e915f094fa8c86c37f ]
+  [ "${actual}" = 6acd3761c0981d4d6194b3375b0f7a291e3927602ce7857344c26010381d3a61 ]
 }
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
In Consul 1.14, the grpc_tls port will be enabled by default on servers. This explicitly disables the port if encryption is not configured so that the defaults do not affect installations.