### PR TITLE
Add support for node meta field

### DIFF
--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -139,6 +139,9 @@ spec:
                 -release-namespace="{{ .Release.Namespace }}" \
                 -resource-prefix={{ template "consul.fullname" . }} \
                 -listen=:8080 \
+                {{- range $k, $v := .Values.connectInject.consulNode.meta }}
+                -node-meta={{ $k }}={{ $v }} \
+                {{- end }}
                 {{- if .Values.connectInject.transparentProxy.defaultEnabled }}
                 -default-enable-transparent-proxy=true \
                 {{- else }}

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -1492,6 +1492,40 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+#--------------------------------------------------------------------
+# nodeMeta
+
+@test "connectInject/Deployment: nodeMeta is not set by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-node-meta"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: can set nodeMeta explicitly" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.consulNode.meta.foo=bar' \
+      --set 'connectInject.consulNode.meta.test=value' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-node-meta=foo=bar"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-node-meta=test=value"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
 
 #--------------------------------------------------------------------
 # replicas

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2012,6 +2012,20 @@ connectInject:
     # @type: string
     updateStrategy: null
 
+  consulNode:
+    # meta specifies an arbitrary metadata key/value pair to associate with the node.
+    #
+    # Example:
+    #
+    # ```yaml
+    # meta:
+    #   cluster: test-cluster
+    #   persistent: true
+    # ```
+    #
+    # @type: map
+    meta: null
+
 
   # Configures metrics for Consul Connect services. All values are overridable
   # via annotations on a per-pod basis.

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
@@ -125,6 +125,7 @@ type Controller struct {
 
 	// consulClientHttpPort is only used in tests.
 	consulClientHttpPort int
+	NodeMeta             map[string]string
 }
 
 // Reconcile reads the state of an Endpoints object for a Kubernetes Service and reconciles Consul services which
@@ -443,6 +444,7 @@ func (r *Controller) createServiceRegistrations(pod corev1.Pod, serviceEndpoints
 		},
 		SkipNodeUpdate: true,
 	}
+	r.appendNodeMeta(serviceRegistration)
 
 	proxySvcName := proxyServiceName(pod, serviceEndpoints)
 	proxySvcID := proxyServiceID(pod, serviceEndpoints)
@@ -631,6 +633,7 @@ func (r *Controller) createServiceRegistrations(pod corev1.Pod, serviceEndpoints
 		},
 		SkipNodeUpdate: true,
 	}
+	r.appendNodeMeta(proxyServiceRegistration)
 
 	return serviceRegistration, proxyServiceRegistration, nil
 }
@@ -766,6 +769,7 @@ func (r *Controller) createGatewayRegistrations(pod corev1.Pod, serviceEndpoints
 		},
 		SkipNodeUpdate: true,
 	}
+	r.appendNodeMeta(serviceRegistration)
 
 	return serviceRegistration, nil
 }
@@ -1243,6 +1247,12 @@ func shouldIgnore(namespace string, denySet, allowSet mapset.Set) bool {
 // depending on Consul Namespaces being enabled and the value of namespace mirroring.
 func (r *Controller) consulNamespace(namespace string) string {
 	return namespaces.ConsulNamespace(namespace, r.EnableConsulNamespaces, r.ConsulDestinationNamespace, r.EnableNSMirroring, r.NSMirroringPrefix)
+}
+
+func (r *Controller) appendNodeMeta(registration *api.CatalogRegistration) {
+	for k, v := range r.NodeMeta {
+		registration.NodeMeta[k] = v
+	}
 }
 
 // hasBeenInjected checks the value of the status annotation and returns true if the Pod has been injected.

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -99,6 +99,9 @@ type Command struct {
 	// CNI flag.
 	flagEnableCNI bool
 
+	// Additional metadata to get applied to nodes.
+	flagNodeMeta map[string]string
+
 	// Peering flags.
 	flagEnablePeering bool
 
@@ -137,6 +140,8 @@ func init() {
 func (c *Command) init() {
 	c.flagSet = flag.NewFlagSet("", flag.ContinueOnError)
 	c.flagSet.StringVar(&c.flagListen, "listen", ":8080", "Address to bind listener to.")
+	c.flagSet.Var((*flags.FlagMapValue)(&c.flagNodeMeta), "node-meta",
+		"Metadata to set on the node, formatted as key=value. This flag may be specified multiple times to set multiple meta fields.")
 	c.flagSet.BoolVar(&c.flagDefaultInject, "default-inject", true, "Inject by default.")
 	c.flagSet.StringVar(&c.flagCertDir, "tls-cert-dir", "",
 		"Directory with PEM-encoded TLS certificate and key to serve.")
@@ -428,6 +433,7 @@ func (c *Command) Run(args []string) int {
 		EnableWANFederation:        c.flagEnableFederation,
 		TProxyOverwriteProbes:      c.flagTransparentProxyDefaultOverwriteProbes,
 		AuthMethod:                 c.flagACLAuthMethod,
+		NodeMeta:                   c.flagNodeMeta,
 		Log:                        ctrl.Log.WithName("controller").WithName("endpoints"),
 		Scheme:                     mgr.GetScheme(),
 		ReleaseName:                c.flagReleaseName,


### PR DESCRIPTION
Changes proposed in this PR:
- Add `connectInject.consulNode.meta` to values file to allow users to provide custom metadata to append to the NodeMeta. Pipe those values through into the NodeMeta of the service and proxy registrations for both services and gateways.

How I've tested this PR:
- Unit tests and bats tests.

How I expect reviewers to test this PR:
- 👀 

Does this need a changelog?

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

