### PR TITLE
Fix: Set default path for prometheus scrape path to /metrics

### DIFF
--- a/control-plane/connect-inject/metrics/metrics_configuration.go
+++ b/control-plane/connect-inject/metrics/metrics_configuration.go
@@ -111,6 +111,10 @@ func (mc Config) PrometheusScrapePath(pod corev1.Pod) string {
 		return raw
 	}
 
+	if mc.DefaultPrometheusScrapePath == "" {
+		return defaultServiceMetricsPath
+	}
+
 	return mc.DefaultPrometheusScrapePath
 }
 

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
@@ -205,18 +205,20 @@ func (w *MeshWebhook) getContainerSidecarArgs(namespace corev1.Namespace, mpi mu
 		args = append(args, fmt.Sprintf("-envoy-admin-bind-port=%d", 19000+mpi.serviceIndex))
 	}
 
+	// Set a default scrape path that can be overwritten by the annotation.
+	prometheusScrapePath := w.MetricsConfig.PrometheusScrapePath(pod)
+	args = append(args, "-telemetry-prom-scrape-path="+prometheusScrapePath)
+
 	metricsServer, err := w.MetricsConfig.ShouldRunMergedMetricsServer(pod)
 	if err != nil {
 		return nil, fmt.Errorf("unable to determine if merged metrics is enabled: %w", err)
 	}
 	if metricsServer {
-		prometheusScrapePath := w.MetricsConfig.PrometheusScrapePath(pod)
 		mergedMetricsPort, err := w.MetricsConfig.MergedMetricsPort(pod)
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine if merged metrics port: %w", err)
 		}
-		args = append(args, "-telemetry-prom-scrape-path="+prometheusScrapePath,
-			"-telemetry-prom-merge-port="+mergedMetricsPort)
+		args = append(args, "-telemetry-prom-merge-port="+mergedMetricsPort)
 
 		serviceMetricsPath := w.MetricsConfig.ServiceMetricsPath(pod)
 		serviceMetricsPort, err := w.MetricsConfig.ServiceMetricsPort(pod)

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar_test.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar_test.go
@@ -25,20 +25,20 @@ func TestHandlerConsulDataplaneSidecar(t *testing.T) {
 	}{
 		"default": {
 			webhookSetupFunc:     nil,
-			additionalExpCmdArgs: " -tls-disabled",
+			additionalExpCmdArgs: " -tls-disabled -telemetry-prom-scrape-path=/metrics",
 		},
 		"with custom gRPC port": {
 			webhookSetupFunc: func(w *MeshWebhook) {
 				w.ConsulConfig.GRPCPort = 8602
 			},
-			additionalExpCmdArgs: " -tls-disabled",
+			additionalExpCmdArgs: " -tls-disabled -telemetry-prom-scrape-path=/metrics",
 		},
 		"with ACLs": {
 			webhookSetupFunc: func(w *MeshWebhook) {
 				w.AuthMethod = "test-auth-method"
 			},
 			additionalExpCmdArgs: " -credential-type=login -login-auth-method=test-auth-method -login-bearer-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token " +
-				"-login-meta=pod=k8snamespace/test-pod -tls-disabled",
+				"-login-meta=pod=k8snamespace/test-pod -tls-disabled -telemetry-prom-scrape-path=/metrics",
 		},
 		"with ACLs and namespace mirroring": {
 			webhookSetupFunc: func(w *MeshWebhook) {
@@ -47,7 +47,7 @@ func TestHandlerConsulDataplaneSidecar(t *testing.T) {
 				w.EnableK8SNSMirroring = true
 			},
 			additionalExpCmdArgs: " -credential-type=login -login-auth-method=test-auth-method -login-bearer-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token " +
-				"-login-meta=pod=k8snamespace/test-pod -login-namespace=default -service-namespace=k8snamespace -tls-disabled",
+				"-login-meta=pod=k8snamespace/test-pod -login-namespace=default -service-namespace=k8snamespace -tls-disabled -telemetry-prom-scrape-path=/metrics",
 		},
 		"with ACLs and single destination namespace": {
 			webhookSetupFunc: func(w *MeshWebhook) {
@@ -56,7 +56,7 @@ func TestHandlerConsulDataplaneSidecar(t *testing.T) {
 				w.ConsulDestinationNamespace = "test-ns"
 			},
 			additionalExpCmdArgs: " -credential-type=login -login-auth-method=test-auth-method -login-bearer-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token " +
-				"-login-meta=pod=k8snamespace/test-pod -login-namespace=test-ns -service-namespace=test-ns -tls-disabled",
+				"-login-meta=pod=k8snamespace/test-pod -login-namespace=test-ns -service-namespace=test-ns -tls-disabled -telemetry-prom-scrape-path=/metrics",
 		},
 		"with ACLs and partitions": {
 			webhookSetupFunc: func(w *MeshWebhook) {
@@ -64,7 +64,7 @@ func TestHandlerConsulDataplaneSidecar(t *testing.T) {
 				w.ConsulPartition = "test-part"
 			},
 			additionalExpCmdArgs: " -credential-type=login -login-auth-method=test-auth-method -login-bearer-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token " +
-				"-login-meta=pod=k8snamespace/test-pod -login-partition=test-part -service-partition=test-part -tls-disabled",
+				"-login-meta=pod=k8snamespace/test-pod -login-partition=test-part -service-partition=test-part -tls-disabled -telemetry-prom-scrape-path=/metrics",
 		},
 		"with TLS and CA cert provided": {
 			webhookSetupFunc: func(w *MeshWebhook) {
@@ -72,28 +72,28 @@ func TestHandlerConsulDataplaneSidecar(t *testing.T) {
 				w.ConsulTLSServerName = "server.dc1.consul"
 				w.ConsulCACert = "consul-ca-cert"
 			},
-			additionalExpCmdArgs: " -tls-server-name=server.dc1.consul -ca-certs=/consul/connect-inject/consul-ca.pem",
+			additionalExpCmdArgs: " -tls-server-name=server.dc1.consul -ca-certs=/consul/connect-inject/consul-ca.pem -telemetry-prom-scrape-path=/metrics",
 		},
 		"with TLS and no CA cert provided": {
 			webhookSetupFunc: func(w *MeshWebhook) {
 				w.TLSEnabled = true
 				w.ConsulTLSServerName = "server.dc1.consul"
 			},
-			additionalExpCmdArgs: " -tls-server-name=server.dc1.consul",
+			additionalExpCmdArgs: " -tls-server-name=server.dc1.consul -telemetry-prom-scrape-path=/metrics",
 		},
 		"with single destination namespace": {
 			webhookSetupFunc: func(w *MeshWebhook) {
 				w.EnableNamespaces = true
 				w.ConsulDestinationNamespace = "consul-namespace"
 			},
-			additionalExpCmdArgs: " -service-namespace=consul-namespace -tls-disabled",
+			additionalExpCmdArgs: " -service-namespace=consul-namespace -tls-disabled -telemetry-prom-scrape-path=/metrics",
 		},
 		"with namespace mirroring": {
 			webhookSetupFunc: func(w *MeshWebhook) {
 				w.EnableNamespaces = true
 				w.EnableK8SNSMirroring = true
 			},
-			additionalExpCmdArgs: " -service-namespace=k8snamespace -tls-disabled",
+			additionalExpCmdArgs: " -service-namespace=k8snamespace -tls-disabled -telemetry-prom-scrape-path=/metrics",
 		},
 		"with namespace mirroring prefix": {
 			webhookSetupFunc: func(w *MeshWebhook) {
@@ -101,32 +101,38 @@ func TestHandlerConsulDataplaneSidecar(t *testing.T) {
 				w.EnableK8SNSMirroring = true
 				w.K8SNSMirroringPrefix = "foo-"
 			},
-			additionalExpCmdArgs: " -service-namespace=foo-k8snamespace -tls-disabled",
+			additionalExpCmdArgs: " -service-namespace=foo-k8snamespace -tls-disabled -telemetry-prom-scrape-path=/metrics",
 		},
 		"with partitions": {
 			webhookSetupFunc: func(w *MeshWebhook) {
 				w.ConsulPartition = "partition-1"
 			},
-			additionalExpCmdArgs: " -service-partition=partition-1 -tls-disabled",
+			additionalExpCmdArgs: " -service-partition=partition-1 -tls-disabled -telemetry-prom-scrape-path=/metrics",
 		},
 		"with different log level": {
 			webhookSetupFunc: func(w *MeshWebhook) {
 				w.LogLevel = "debug"
 			},
-			additionalExpCmdArgs: " -tls-disabled",
+			additionalExpCmdArgs: " -tls-disabled -telemetry-prom-scrape-path=/metrics",
 		},
 		"with different log level and log json": {
 			webhookSetupFunc: func(w *MeshWebhook) {
 				w.LogLevel = "debug"
 				w.LogJSON = true
 			},
-			additionalExpCmdArgs: " -tls-disabled",
+			additionalExpCmdArgs: " -tls-disabled -telemetry-prom-scrape-path=/metrics",
 		},
 		"skip server watch enabled": {
 			webhookSetupFunc: func(w *MeshWebhook) {
 				w.SkipServerWatch = true
 			},
-			additionalExpCmdArgs: " -server-watch-disabled=true -tls-disabled",
+			additionalExpCmdArgs: " -server-watch-disabled=true -tls-disabled -telemetry-prom-scrape-path=/metrics",
+		},
+		"custom prometheus scrape path": {
+			webhookSetupFunc: func(w *MeshWebhook) {
+				w.MetricsConfig.DefaultPrometheusScrapePath = "/scrape-path" // Simulate what would be passed as a flag
+			},
+			additionalExpCmdArgs: " -tls-disabled -telemetry-prom-scrape-path=/scrape-path",
 		},
 	}
 
@@ -366,18 +372,18 @@ func TestHandlerConsulDataplaneSidecar_Multiport(t *testing.T) {
 			}
 			expArgs := []string{
 				"-addresses 1.1.1.1 -grpc-port=8502 -proxy-service-id-path=/consul/connect-inject/proxyid-web " +
-					"-log-level=info -log-json=false -envoy-concurrency=0 -tls-disabled -envoy-admin-bind-port=19000 -- --base-id 0",
+					"-log-level=info -log-json=false -envoy-concurrency=0 -tls-disabled -envoy-admin-bind-port=19000 -telemetry-prom-scrape-path=/metrics -- --base-id 0",
 				"-addresses 1.1.1.1 -grpc-port=8502 -proxy-service-id-path=/consul/connect-inject/proxyid-web-admin " +
-					"-log-level=info -log-json=false -envoy-concurrency=0 -tls-disabled -envoy-admin-bind-port=19001 -- --base-id 1",
+					"-log-level=info -log-json=false -envoy-concurrency=0 -tls-disabled -envoy-admin-bind-port=19001 -telemetry-prom-scrape-path=/metrics -- --base-id 1",
 			}
 			if aclsEnabled {
 				expArgs = []string{
 					"-addresses 1.1.1.1 -grpc-port=8502 -proxy-service-id-path=/consul/connect-inject/proxyid-web " +
 						"-log-level=info -log-json=false -envoy-concurrency=0 -credential-type=login -login-auth-method=test-auth-method " +
-						"-login-bearer-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token -login-meta=pod=k8snamespace/test-pod -tls-disabled -envoy-admin-bind-port=19000 -- --base-id 0",
+						"-login-bearer-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token -login-meta=pod=k8snamespace/test-pod -tls-disabled -envoy-admin-bind-port=19000 -telemetry-prom-scrape-path=/metrics -- --base-id 0",
 					"-addresses 1.1.1.1 -grpc-port=8502 -proxy-service-id-path=/consul/connect-inject/proxyid-web-admin " +
 						"-log-level=info -log-json=false -envoy-concurrency=0 -credential-type=login -login-auth-method=test-auth-method " +
-						"-login-bearer-token-path=/consul/serviceaccount-web-admin/token -login-meta=pod=k8snamespace/test-pod -tls-disabled -envoy-admin-bind-port=19001 -- --base-id 1",
+						"-login-bearer-token-path=/consul/serviceaccount-web-admin/token -login-meta=pod=k8snamespace/test-pod -tls-disabled -envoy-admin-bind-port=19001 -telemetry-prom-scrape-path=/metrics -- --base-id 1",
 				}
 			}
 			expSAVolumeMounts := []corev1.VolumeMount{


### PR DESCRIPTION
Changes proposed in this PR:
- Pass a default `/metrics` path to the consul-dataplane use the `-telemetry-prom-scrape-path` flag.
- Added a little test case that simulates setting a custom path as a flag.
- No CHANGELOG required as this was the default behaviour in the past.

How I've tested this PR:
- unit & acceptance tests

How I expect reviewers to test this PR:
👀 

Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

