### PR TITLE
Update to consul-dataplane:1.0.0-beta4

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -566,7 +566,7 @@ global:
   # The name (and tag) of the consul-dataplane Docker image used for the
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
   # @default: hashicorp/consul-dataplane:<latest supported version>
-  imageConsulDataplane: "hashicorppreview/consul-dataplane:1.0-dev"
+  imageConsulDataplane: "hashicorp/consul-dataplane:1.0.0-beta4"
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.


### PR DESCRIPTION
Changes proposed in this PR:

This switches imageConsulDataplane to the released 1.0.0-beta4 image. This image is identical in functionality to the latest hashicorppreview image, so no other changes should be needed.

How I've tested this PR:

CI tests

How I expect reviewers to test this PR:

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

