### PR TITLE
remove clients from basic installation acceptance test

### DIFF
--- a/acceptance/tests/basic/basic_test.go
+++ b/acceptance/tests/basic/basic_test.go
@@ -50,7 +50,6 @@ func TestBasicInstallation(t *testing.T) {
 				"global.tls.enabled":                   strconv.FormatBool(c.secure),
 				"global.gossipEncryption.autoGenerate": strconv.FormatBool(c.secure),
 				"global.tls.enableAutoEncrypt":         strconv.FormatBool(c.autoEncrypt),
-				"client.enabled":                       "true",
 			}
 			consulCluster := consul.NewHelmCluster(t, helmValues, suite.Environment().DefaultContext(t), suite.Config(), releaseName)
 


### PR DESCRIPTION
Changes proposed in this PR:
-  TestBasicInstallation is failing due to an error in client pod that says 
```
==> the `ports.grpc` listener no longer supports TLS. Use `ports.grpc_tls` instead. This message is appearing because GRPC is configured to use TLS, but `ports.grpc_tls` is not defined
```

- I don't think clients should be enabled.  Please confirm

How I've tested this PR:
- acceptance

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

