### PR TITLE
Replace httpPort with httpsPort to avoid confusion.

### DIFF
--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -87,11 +87,7 @@ spec:
             "externalServers" specified and running in "agentless" mode, this will only work with
             Consul API Gateway v0.5 or newer
           */}}
-          {{- if .Values.global.tls.enabled }}
           value: {{ first .Values.externalServers.hosts }}:{{ .Values.externalServers.httpsPort }}
-          {{- else }}
-          value: {{ first .Values.externalServers.hosts }}:{{ .Values.externalServers.httpPort }}
-          {{- end }}
           {{- else }}
           {{/*
             We have local network connectivity between deployments and the internal cluster, this

--- a/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
+++ b/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
@@ -49,11 +49,7 @@ spec:
     ports:
       {{- if .Values.externalServers.enabled }}
       grpc: {{ .Values.externalServers.grpcPort }} 
-      {{- if .Values.global.tls.enabled }}
       http: {{ .Values.externalServers.httpsPort }}
-      {{- else }}
-      http: {{ .Values.externalServers.httpPort }}
-      {{- end }}
       {{- else }}
       grpc: 8502
       {{- if .Values.global.tls.enabled }}

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -1188,7 +1188,7 @@ load _helpers
       --set 'global.tls.enabled=false' \
       --set 'externalServers.enabled=true' \
       --set 'externalServers.hosts[0]=external-consul.host' \
-      --set 'externalServers.httpPort=8500' \
+      --set 'externalServers.httpsPort=8500' \
       --set 'server.enabled=false' \
       --set 'client.enabled=false' \
       . | tee /dev/stderr |

--- a/charts/consul/test/unit/api-gateway-gatewayclassconfig.bats
+++ b/charts/consul/test/unit/api-gateway-gatewayclassconfig.bats
@@ -149,7 +149,7 @@ load _helpers
       --set 'externalServers.enabled=true' \
       --set 'externalServers.hosts[0]=external-consul.host' \
       --set 'externalServers.grpcPort=1234' \
-      --set 'externalServers.httpPort=5678' \
+      --set 'externalServers.httpsPort=5678' \
       --set 'server.enabled=false' \
       . | tee /dev/stderr |
       yq '.spec.consul.ports' | tee /dev/stderr)

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1143,9 +1143,6 @@ externalServers:
   # @type: array<string>
   hosts: [ ]
 
-  # The HTTP port of the Consul servers.
-  httpPort: 8500
-
   # The HTTPS port of the Consul servers.
   httpsPort: 8501
 


### PR DESCRIPTION
Changes proposed in this PR:
- Unify usage of httpsPort across the project to avoid confusion as `httpPort` is used solely for the API gateway and setting this value would lead to confusion amongst end users who would expect all consul-k8s components to use that value and they wouldn't.

How I've tested this PR:
- BATS

How I expect reviewers to test this PR:
- 👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

