### PR TITLE
fix unit tests with consul 1.13.3

### DIFF
--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -435,7 +435,7 @@ func TestProcessUpstreams(t *testing.T) {
 			},
 			expErr: "upstream \"upstream1:1234:dc1\" is invalid: ProxyDefaults mesh gateway mode is neither \"local\" nor \"remote\"",
 			configEntry: func() api.ConfigEntry {
-				ce, _ := api.MakeConfigEntry(api.ProxyDefaults, "pd")
+				ce, _ := api.MakeConfigEntry(api.ProxyDefaults, "global")
 				pd := ce.(*api.ProxyConfigEntry)
 				pd.MeshGateway.Mode = "bad-mode"
 				return pd
@@ -492,7 +492,7 @@ func TestProcessUpstreams(t *testing.T) {
 				},
 			},
 			configEntry: func() api.ConfigEntry {
-				ce, _ := api.MakeConfigEntry(api.ProxyDefaults, "pd")
+				ce, _ := api.MakeConfigEntry(api.ProxyDefaults, "global")
 				pd := ce.(*api.ProxyConfigEntry)
 				pd.MeshGateway.Mode = api.MeshGatewayModeLocal
 				return pd
@@ -516,7 +516,7 @@ func TestProcessUpstreams(t *testing.T) {
 				},
 			},
 			configEntry: func() api.ConfigEntry {
-				ce, _ := api.MakeConfigEntry(api.ProxyDefaults, "pd")
+				ce, _ := api.MakeConfigEntry(api.ProxyDefaults, "global")
 				pd := ce.(*api.ProxyConfigEntry)
 				pd.MeshGateway.Mode = api.MeshGatewayModeRemote
 				return pd
@@ -533,7 +533,7 @@ func TestProcessUpstreams(t *testing.T) {
 			},
 			expErr: "",
 			configEntry: func() api.ConfigEntry {
-				ce, _ := api.MakeConfigEntry(api.ProxyDefaults, "pd")
+				ce, _ := api.MakeConfigEntry(api.ProxyDefaults, "global")
 				pd := ce.(*api.ProxyConfigEntry)
 				pd.MeshGateway.Mode = "remote"
 				return pd
@@ -634,7 +634,7 @@ func TestProcessUpstreams(t *testing.T) {
 				return pod1
 			},
 			configEntry: func() api.ConfigEntry {
-				ce, _ := api.MakeConfigEntry(api.ProxyDefaults, "pd")
+				ce, _ := api.MakeConfigEntry(api.ProxyDefaults, "global")
 				pd := ce.(*api.ProxyConfigEntry)
 				pd.MeshGateway.Mode = "remote"
 				return pd
@@ -670,7 +670,7 @@ func TestProcessUpstreams(t *testing.T) {
 				return pod1
 			},
 			configEntry: func() api.ConfigEntry {
-				ce, _ := api.MakeConfigEntry(api.ProxyDefaults, "pd")
+				ce, _ := api.MakeConfigEntry(api.ProxyDefaults, "global")
 				pd := ce.(*api.ProxyConfigEntry)
 				pd.MeshGateway.Mode = "remote"
 				return pd

--- a/control-plane/connect-inject/peering_dialer_controller_test.go
+++ b/control-plane/connect-inject/peering_dialer_controller_test.go
@@ -255,6 +255,7 @@ func TestReconcile_CreateUpdatePeeringDialer(t *testing.T) {
 				// must be unique on the acceptor and dialer peers. Otherwise the following consul error will be thrown:
 				// https://github.com/hashicorp/consul/blob/74b87d49d33069a048aead7a86d85d4b4b6461b5/agent/rpc/peering/service.go#L491.
 				c.Datacenter = "acceptor-dc"
+				c.Ports.HTTPS = 0
 			})
 			require.NoError(t, err)
 			defer acceptorPeerServer.Stop()
@@ -438,6 +439,7 @@ func TestReconcile_VersionAnnotationPeeringDialer(t *testing.T) {
 				// We set the datacenter because the server name, typically formatted as "server.<datacenter>.<domain>"
 				// must be unique on the acceptor and dialer peers.
 				c.Datacenter = "acceptor-dc"
+				c.Ports.HTTPS = 0
 			})
 			require.NoError(t, err)
 			defer acceptorPeerServer.Stop()


### PR DESCRIPTION
- use "global" for proxydefaults name to fix tests not finding the proxydefaults
- disable https for peering establishment because the connection was failing due to the acceptor expecting it when using consul 1.13.3

We'll need to make sure unit tests pass here before merging.

