### PR TITLE
update kind to kubernetes-1.25 and mark Kubernetes-1.25 supported

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
             sudo tar -C /usr/local/bin -xzf gotestsum_1.8.2_linux_amd64.tar.gz
             rm gotestsum_1.8.2_linux_amd64.tar.gz
 
-            curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.15.0/kind-linux-amd64
+            curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.17.0/kind-linux-amd64
             chmod +x ./kind
             sudo mv ./kind /usr/local/bin/kind
 
@@ -573,7 +573,7 @@ jobs:
       - checkout
       - install-prereqs
       - create-kind-clusters:
-          version: "v1.24.4"
+          version: "v1.25.3"
       - restore_cache:
           keys:
             - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
@@ -606,7 +606,7 @@ jobs:
       - checkout
       - install-prereqs
       - create-kind-clusters:
-          version: "v1.24.4"
+          version: "v1.25.3"
       - restore_cache:
           keys:
             - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
@@ -639,7 +639,7 @@ jobs:
       - checkout
       - install-prereqs
       - create-kind-cni-clusters:
-          version: "v1.24.4"
+          version: "v1.25.3"
       - restore_cache:
           keys:
             - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BREAKING CHANGES:
 * Helm:
-  * Kubernetes-1.25 is now supported with the caveat that `global.enablePodSecurityPolicies` is not supported since PodSecurityPolicies have been removed from Kubernetes-1.25. Full support for PodSecurityStandards will be added in a follow-on commit. [[GH-1726](https://github.com/hashicorp/consul-k8s/pull/1726)]
+  * Kubernetes-1.25 is now supported with the caveat that `global.enablePodSecurityPolicies` is not supported since PodSecurityPolicies have been removed in favor of PodSecurityStandards in Kubernetes-1.25. Full support for PodSecurityStandards will be added in a follow-on commit. [[GH-1726](https://github.com/hashicorp/consul-k8s/pull/1726)]
 * CLI:
   * Change default behavior of `consul-k8s install` to perform the installation when no answer is provided to the prompt. [[GH-1673](https://github.com/hashicorp/consul-k8s/pull/1673)]
 * Helm:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## UNRELEASED
 
 BREAKING CHANGES:
+* Helm:
+  * Kubernetes-1.25 is now supported with the caveat that `global.enablePodSecurityPolicies` is not supported since PodSecurityPolicies have been removed from Kubernetes-1.25. Full support for PodSecurityStandards will be added in a follow-on commit. [[GH-1726](https://github.com/hashicorp/consul-k8s/pull/1726)]
 * CLI:
   * Change default behavior of `consul-k8s install` to perform the installation when no answer is provided to the prompt. [[GH-1673](https://github.com/hashicorp/consul-k8s/pull/1673)]
 * Helm:

--- a/charts/consul/templates/webhook-cert-manager-podsecuritypolicy.yaml
+++ b/charts/consul/templates/webhook-cert-manager-podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
 {{ $hasConfiguredWebhookCertsUsingVault := (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName .Values.global.secretsBackend.vault.controllerRole .Values.global.secretsBackend.vault.controller.tlsCert.secretName  .Values.global.secretsBackend.vault.controller.caCert.secretName) -}}
+{{- if (and .Values.global.enablePodSecurityPolicies (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled))) }}
 {{- if (and .Values.connectInject.enabled (not $hasConfiguredWebhookCertsUsingVault)) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -38,4 +39,5 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}

--- a/charts/consul/test/unit/webhook-cert-manager-podsecuritypolicy.bats
+++ b/charts/consul/test/unit/webhook-cert-manager-podsecuritypolicy.bats
@@ -7,6 +7,16 @@ load _helpers
   assert_empty helm template \
       -s templates/webhook-cert-manager-podsecuritypolicy.yaml  \
       --set 'connectInject.enabled=false' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      .
+}
+
+@test "webhookCertManager/PodSecurityPolicy: disabled by default with PSP disabled" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/webhook-cert-manager-podsecuritypolicy.yaml  \
+      --set 'connectInject.enabled=false' \
+      --set 'global.enablePodSecurityPolicies=false' \
       .
 }
 

--- a/charts/consul/test/unit/webhook-cert-manager-podsecuritypolicy.bats
+++ b/charts/consul/test/unit/webhook-cert-manager-podsecuritypolicy.bats
@@ -15,7 +15,7 @@ load _helpers
   cd `chart_dir`
   assert_empty helm template \
       -s templates/webhook-cert-manager-podsecuritypolicy.yaml  \
-      --set 'connectInject.enabled=false' \
+      --set 'connectInject.enabled=true' \
       --set 'global.enablePodSecurityPolicies=false' \
       .
 }


### PR DESCRIPTION
Changes proposed in this PR:
- Update CI to test with Kubernetes-1.25 for acceptance tests.
- Adds a fix to the webhook-cert-manager PSP so that it is not deployed unless PSP are enabled + bats tests.

How I've tested this PR:
acceptance tests still pass: https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/9531/workflows/75acb13f-c9ea-4838-8f38-a994da93f860/jobs/66796


How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

