### PR TITLE
default to dataplane being supported when checking version annotation

### DIFF
--- a/control-plane/connect-inject/controllers/endpoints/consul_client_health_checks.go
+++ b/control-plane/connect-inject/controllers/endpoints/consul_client_health_checks.go
@@ -19,7 +19,9 @@ func isConsulDataplaneSupported(pod corev1.Pod) bool {
 	if anno, ok := pod.Annotations[constants.AnnotationConsulK8sVersion]; ok {
 		consulK8sVersion, err := version.NewVersion(anno)
 		if err != nil {
-			return false
+			// Only consul-k8s v1.0.0+ (including pre-release versions) have the version annotation. So it would be
+			// reasonable to default to supporting dataplane even if the version is malformed or invalid.
+			return true
 		}
 		consulDPSupportedVersion, err := version.NewVersion(minSupportedConsulDataplaneVersion)
 		if err != nil {

--- a/control-plane/connect-inject/controllers/endpoints/consul_client_health_checks_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/consul_client_health_checks_test.go
@@ -18,18 +18,19 @@ func TestIsConsulDataplaneSupported(t *testing.T) {
 	versions := map[string]struct {
 		expIsConsulDataplaneSupported bool
 	}{
-		"":                  {false},
-		"v1.0.0":            {true},
-		"1.0.0":             {true},
-		"v0.49.0":           {false},
-		"0.49.0-beta2":      {false},
-		"0.49.2":            {false},
-		"v1.0.0-beta1":      {true},
-		"v1.0.0-beta3":      {true},
-		"v1.1.0-beta1":      {true},
-		"v1.0.0-dev":        {true},
-		"v1.0.0-dev+abcdef": {true},
-		"invalid":           {false},
+		"":                    {false},
+		"v1.0.0":              {true},
+		"1.0.0":               {true},
+		"v0.49.0":             {false},
+		"0.49.0-beta2":        {false},
+		"0.49.2":              {false},
+		"v1.0.0-beta1":        {true},
+		"v1.0.0-beta3":        {true},
+		"v1.1.0-beta1":        {true},
+		"v1.0.0-dev":          {true},
+		"v1.0.0-dev (abcdef)": {true},
+		"v1.0.0-dev+abcdef":   {true},
+		"invalid":             {true},
 	}
 
 	for version, c := range versions {


### PR DESCRIPTION
Changes proposed in this PR:
- Default to consul-dataplane being supported even when the version annotation is malformed. If the version annotation exists, it already means we're running consul-k8s 1.0.0+.

Eric ran into this when using an image built from our pipeline that builds images from main. It has a version formatted like "v1.0.0-dev (<GITSHA>)" which is not a recognized version by the client health checks code and causes endpoints controller to think that consul-dataplane is not supported and attempt to register client health checks which won't work. 

We would have run into this with our released image as well since they are built the same way as the images from main. We did NOT run into this in acceptance tests because the images built for acceptance tests are built differently and do not have the (<GITSHA>) part.

In the future we will fix our pipelines to include versions that can be parsed by the go-version library, but talking to @ishustava, we don't want to do that so close to the release. 


Checklist:
- [x] Tests added
~- [ ] CHANGELOG entry added~
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

