### PR TITLE
Add opt-in server discovery for API Gateway Controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ IMPROVEMENTS:
   * Allow addition of extra labels to Connect Inject pods. [[GH-1678](https://github.com/hashicorp/consul-k8s/pull/1678)]
   * Add fields `localConnectTimeoutMs` and `localRequestTimeoutMs` to the `ServiceDefaults` CRD. [[GH-1647](https://github.com/hashicorp/consul-k8s/pull/1647)]
   * API Gateway: Enable API Gateways to directly connect to Consul servers when running in the agentless configuration. [[GH-1694](https://github.com/hashicorp/consul-k8s/pull/1694)]
+  * API Gateway: Add support for using dynamic server discovery strings when running without agents. [[GH-1732](https://github.com/hashicorp/consul-k8s/pull/1732)]
 
 BUG FIXES:
 * Peering

--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -119,6 +119,10 @@ spec:
           value: {{ .Values.global.adminPartitions.name }}
         {{- end }}
         {{- end }}
+        {{- if not .Values.client.enabled }}
+        - name: CONSUL_DYNAMIC_SERVER_DISCOVERY
+          value: "true"
+        {{- end }}
         command:
         - "/bin/sh"
         - "-ec"

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -1346,3 +1346,27 @@ load _helpers
       yq '.spec.template.spec.containers[0].env[6].value == "hashi"' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "apiGateway/Deployment: CONSUL_DYNAMIC_SERVER_DISCOVERY is set when not using clients" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-controller-deployment.yaml  \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=bar' \
+      --set 'client.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].env[3].value == "true"' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "apiGateway/Deployment: CONSUL_DYNAMIC_SERVER_DISCOVERY is not set when not using clients" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-controller-deployment.yaml  \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=bar' \
+      --set 'client.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].env[3]' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -1359,7 +1359,7 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "apiGateway/Deployment: CONSUL_DYNAMIC_SERVER_DISCOVERY is not set when not using clients" {
+@test "apiGateway/Deployment: CONSUL_DYNAMIC_SERVER_DISCOVERY is not set when using clients" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/api-gateway-controller-deployment.yaml  \


### PR DESCRIPTION
Changes proposed in this PR:

For backwards compatibility with old helm charts where we only ever talk to the agent nodes which don't have gRPC APIs for Consul dataplane, we need to use our old login/logout flow and the static agent node address rather than leveraging the consul server connection manager. This PR coincides with the changes introduced in https://github.com/hashicorp/consul-api-gateway/pull/454.

How I've tested this PR:

Manually verified in explicitly agent-based and agentless installation modes and added unit tests.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

