### PR TITLE
fix acls when peering and partitions are both enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1273,9 +1273,6 @@ workflows:
           context: consul-ci
           requires:
           - dev-upload-docker
-      - acceptance-gke-1-23:
-          requires:
-            - dev-upload-docker
 
   nightly-cleanup:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1273,6 +1273,9 @@ workflows:
           context: consul-ci
           requires:
           - dev-upload-docker
+      - acceptance-gke-1-23:
+          requires:
+            - dev-upload-docker
 
   nightly-cleanup:
     triggers:

--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -183,9 +183,11 @@ func (c *Command) meshGatewayRules() (string, error) {
 	meshGatewayRulesTpl := `mesh = "write"
 {{- if .EnablePeering }}
 peering = "read"
+{{- if eq .PartitionName "default" }}
 partition_prefix "" {
   peering = "read"
 }
+{{- end }}
 {{- end }}
 {{- if .EnableNamespaces }}
 namespace "default" {


### PR DESCRIPTION
Changes proposed in this PR:
- On a non-default partition, this rule errors with this log on server-acl-init
```
Failure: creating mesh-gateway-policy policy: err="Unexpected response code: 500 (rpc error making call: Invalid policy rules: partitioned policy cannot use partition_prefix rules)"
```

This only happens on a non-default partition when peering and partitions are both enabled, so I found this when testing non-default partitions with ACLs. So this adds a condition to the partition_prefix rule

How I've tested this PR:
manually, on non-default partitions, acceptance tests for other cases

How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

