### PR TITLE
Fix fully namespace-qualified KubeDNS host in GatewayClassConfig

### DIFF
--- a/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
+++ b/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
@@ -31,7 +31,7 @@ spec:
       We have local network connectivity between deployments and the internal cluster, this
       should be supported in all versions of api-gateway
     */}}
-    address: {{ template "consul.fullname" . }}-server
+    address: {{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc
     {{- end }}
     authentication:
       {{- if .Values.global.acls.manageSystemACLs }}

--- a/charts/consul/test/unit/api-gateway-gatewayclassconfig.bats
+++ b/charts/consul/test/unit/api-gateway-gatewayclassconfig.bats
@@ -120,7 +120,7 @@ load _helpers
       --set 'apiGateway.image=foo' \
       --set 'client.enabled=false' \
       . | tee /dev/stderr |
-      yq '.spec.consul.address == "release-name-consul-server"' | tee /dev/stderr)
+      yq '.spec.consul.address == "release-name-consul-server.default.svc"' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 


### PR DESCRIPTION
Changes proposed in this PR:

Namespace-qualifies the KubeDNS address used by default in our managed GatewayClassConfig. Without this gateways deployed in namespaces differing than the Helm installation won't be able to talk to the internal Consul server because they'll try and resolve a service that's in the wrong namespace and won't find it.

How I've tested this PR:

Applied the patch and created a Gateway that was in another namespace. It came up properly, without the patch it errors with:

> 2022-11-17T14:46:34.086Z [ERROR] connection error: error="failed to discover Consul server addresses: failed to resolve DNS name: consul-consul-server: lookup consul-consul-server on 10.96.0.10:53: no such host"

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

