### PR TITLE
make the acceptance test run for stable branches 0.49.x and 1.0.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1287,8 +1287,7 @@ workflows:
       - cleanup-azure-resources
       - cleanup-eks-resources
 
-
-  nightly-acceptance-tests-release:
+  nightly-acceptance-tests-release-0.49.x:
     description: |
       Tests which run on a release branch nightly. These exist separate from the main
       acceptance tests so that they can run at their own cadence, but 
@@ -1316,18 +1315,38 @@ workflows:
       - acceptance-gke-cni-1-23:
           requires:
             - acceptance-gke-1-23
-      - acceptance-eks-1-21:
+      - acceptance-tproxy:
           requires:
             - dev-upload-docker
-      - acceptance-eks-cni-1-21:
+
+  nightly-acceptance-tests-release-1.0.x:
+    description: |
+      Tests which run on a release branch nightly. These exist separate from the main
+      acceptance tests so that they can run at their own cadence, but 
+      contains the same sequence of jobs.
+    triggers:
+      - schedule:
+          cron: "0 0 * * *" # Run at 12 am UTC (5 pm PST)
+          filters:
+            branches:
+              only:
+                - release/1.0.x
+    jobs:
+      - build-distro:
+          OS: "linux"
+          ARCH: "amd64 arm64"
+          name: build-distros-linux
+      - dev-upload-docker:
           requires:
-            - acceptance-eks-1-21
-      - acceptance-aks-1-22:
+            - build-distros-linux
+      # Disable until we can use UBI images.
+      # - acceptance-openshift
+      - acceptance-gke-1-23:
           requires:
             - dev-upload-docker
-      - acceptance-aks-cni-1-22:
+      - acceptance-gke-cni-1-23:
           requires:
-            - acceptance-aks-1-22
+            - acceptance-gke-1-23
       - acceptance-tproxy:
           requires:
             - dev-upload-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1287,7 +1287,7 @@ workflows:
       - cleanup-azure-resources
       - cleanup-eks-resources
 
-  nightly-acceptance-tests-release-0.49.x:
+  nightly-acceptance-tests-release:
     description: |
       Tests which run on a release branch nightly. These exist separate from the main
       acceptance tests so that they can run at their own cadence, but 
@@ -1299,37 +1299,6 @@ workflows:
             branches:
               only:
                 - release/0.49.x
-    jobs:
-      - build-distro:
-          OS: "linux"
-          ARCH: "amd64 arm64"
-          name: build-distros-linux
-      - dev-upload-docker:
-          requires:
-            - build-distros-linux
-      # Disable until we can use UBI images.
-      # - acceptance-openshift
-      - acceptance-gke-1-23:
-          requires:
-            - dev-upload-docker
-      - acceptance-gke-cni-1-23:
-          requires:
-            - acceptance-gke-1-23
-      - acceptance-tproxy:
-          requires:
-            - dev-upload-docker
-
-  nightly-acceptance-tests-release-1.0.x:
-    description: |
-      Tests which run on a release branch nightly. These exist separate from the main
-      acceptance tests so that they can run at their own cadence, but 
-      contains the same sequence of jobs.
-    triggers:
-      - schedule:
-          cron: "0 0 * * *" # Run at 12 am UTC (5 pm PST)
-          filters:
-            branches:
-              only:
                 - release/1.0.x
     jobs:
       - build-distro:


### PR DESCRIPTION
Changes proposed in this PR:
-
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

