### PR TITLE
remove controller webhook cert roles from vault test and the values.yaml

### DIFF
--- a/acceptance/tests/vault/vault_test.go
+++ b/acceptance/tests/vault/vault_test.go
@@ -84,20 +84,6 @@ func TestVault(t *testing.T) {
 	}
 	serverPKIConfig.ConfigurePKIAndAuthRole(t, vaultClient)
 
-	// Configure controller webhook PKI
-	controllerWebhookPKIConfig := &vault.PKIAndAuthRoleConfiguration{
-		BaseURL:             "controller",
-		PolicyName:          "controller-ca-policy",
-		RoleName:            "controller-ca-role",
-		KubernetesNamespace: ns,
-		DataCenter:          "dc1",
-		ServiceAccountName:  fmt.Sprintf("%s-consul-%s", consulReleaseName, "controller"),
-		AllowedSubdomain:    fmt.Sprintf("%s-consul-%s", consulReleaseName, "controller-webhook"),
-		MaxTTL:              fmt.Sprintf("%ds", expirationInSeconds),
-		AuthMethodPath:      KubernetesAuthMethodPath,
-	}
-	controllerWebhookPKIConfig.ConfigurePKIAndAuthRole(t, vaultClient)
-
 	// Configure connect injector webhook PKI
 	connectInjectorWebhookPKIConfig := &vault.PKIAndAuthRoleConfiguration{
 		BaseURL:             "connect",
@@ -212,15 +198,12 @@ func TestVault(t *testing.T) {
 		"connectInject.replicas": "1",
 		"global.secretsBackend.vault.connectInject.tlsCert.secretName": connectInjectorWebhookPKIConfig.CertPath,
 		"global.secretsBackend.vault.connectInject.caCert.secretName":  connectInjectorWebhookPKIConfig.CAPath,
-		"global.secretsBackend.vault.controller.tlsCert.secretName":    controllerWebhookPKIConfig.CertPath,
-		"global.secretsBackend.vault.controller.caCert.secretName":     controllerWebhookPKIConfig.CAPath,
 
 		"global.secretsBackend.vault.enabled":              "true",
 		"global.secretsBackend.vault.consulServerRole":     consulServerRole,
 		"global.secretsBackend.vault.consulClientRole":     consulClientRole,
 		"global.secretsBackend.vault.consulCARole":         serverPKIConfig.RoleName,
 		"global.secretsBackend.vault.connectInjectRole":    connectInjectorWebhookPKIConfig.RoleName,
-		"global.secretsBackend.vault.controllerRole":       controllerWebhookPKIConfig.RoleName,
 		"global.secretsBackend.vault.manageSystemACLsRole": manageSystemACLsRole,
 
 		"global.secretsBackend.vault.ca.secretName": vaultCASecret,

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -73,22 +73,6 @@ as well as the global.name setting.
             {{ "{{" }}- end -{{ "}}" }}
 {{- end -}}
 
-{{- define "consul.controllerWebhookTLSCertTemplate" -}}
- |
-            {{ "{{" }}- with secret "{{ .Values.global.secretsBackend.vault.controller.tlsCert.secretName }}" "{{- $name := include "consul.fullname" . -}}{{ printf "common_name=%s-controller-webhook" $name }}"
-            "alt_names={{ include "consul.controllerWebhookTLSAltNames" . }}" -{{ "}}" }}
-            {{ "{{" }}- .Data.certificate -{{ "}}" }}
-            {{ "{{" }}- end -{{ "}}" }}
-{{- end -}}
-
-{{- define "consul.controllerWebhookTLSKeyTemplate" -}}
- |
-            {{ "{{" }}- with secret "{{ .Values.global.secretsBackend.vault.controller.tlsCert.secretName }}" "{{- $name := include "consul.fullname" . -}}{{ printf "common_name=%s-controller-webhook" $name }}"
-            "alt_names={{ include "consul.controllerWebhookTLSAltNames" . }}" -{{ "}}" }}
-            {{ "{{" }}- .Data.private_key -{{ "}}" }}
-            {{ "{{" }}- end -{{ "}}" }}
-{{- end -}}
-
 {{- define "consul.serverTLSAltNames" -}}
 {{- $name := include "consul.fullname" . -}}
 {{- $ns := .Release.Namespace -}}
@@ -107,12 +91,6 @@ as well as the global.name setting.
 {{- $name := include "consul.fullname" . -}}
 {{- $ns := .Release.Namespace -}}
 {{ printf "%s-connect-injector,%s-connect-injector.%s,%s-connect-injector.%s.svc,%s-connect-injector.%s.svc.cluster.local" $name $name $ns $name $ns $name $ns}}
-{{- end -}}
-
-{{- define "consul.controllerWebhookTLSAltNames" -}}
-{{- $name := include "consul.fullname" . -}}
-{{- $ns := .Release.Namespace -}}
-{{ printf "%s-controller-webhook,%s-controller-webhook.%s,%s-controller-webhook.%s.svc,%s-controller-webhook.%s.svc.cluster.local" $name $name $ns $name $ns $name $ns}}
 {{- end -}}
 
 {{- define "consul.vaultReplicationTokenTemplate" -}}
@@ -285,20 +263,17 @@ Fails when at least one but not all of the following have been set:
 - global.secretsBackend.vault.connectInjectRole
 - global.secretsBackend.vault.connectInject.tlsCert.secretName
 - global.secretsBackend.vault.connectInject.caCert.secretName
-- global.secretsBackend.vault.controllerRole
-- global.secretsBackend.vault.controller.tlsCert.secretName
-- global.secretsBackend.vault.controller.caCert.secretName
 
 The above values are needed in full to turn off web cert manager and allow
-connect inject and controller to manage its own webhook certs.
+connect inject to manage its own webhook certs.
 
 Usage: {{ template "consul.validateVaultWebhookCertConfiguration" . }}
 
 */}}
 {{- define "consul.validateVaultWebhookCertConfiguration" -}}
-{{- if or .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName .Values.global.secretsBackend.vault.controllerRole .Values.global.secretsBackend.vault.controller.tlsCert.secretName .Values.global.secretsBackend.vault.controller.caCert.secretName}}
-{{- if or (not .Values.global.secretsBackend.vault.connectInjectRole) (not .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName) (not .Values.global.secretsBackend.vault.connectInject.caCert.secretName) (not .Values.global.secretsBackend.vault.controllerRole) (not .Values.global.secretsBackend.vault.controller.tlsCert.secretName) (not .Values.global.secretsBackend.vault.controller.caCert.secretName) }}
-{{fail "When one of the following has been set, all must be set:  global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, global.secretsBackend.vault.connectInject.caCert.secretName, global.secretsBackend.vault.controllerRole, global.secretsBackend.vault.controller.tlsCert.secretName, and global.secretsBackend.vault.controller.caCert.secretName."}}
+{{- if or .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName}}
+{{- if or (not .Values.global.secretsBackend.vault.connectInjectRole) (not .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName) (not .Values.global.secretsBackend.vault.connectInject.caCert.secretName) }}
+{{fail "When one of the following has been set, all must be set:  global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, global.secretsBackend.vault.connectInject.caCert.secretName"}}
 {{ end }}
 {{ end }}
 {{- end -}}

--- a/charts/consul/templates/webhook-cert-manager-clusterrole.yaml
+++ b/charts/consul/templates/webhook-cert-manager-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{ $hasConfiguredWebhookCertsUsingVault := (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName .Values.global.secretsBackend.vault.controllerRole .Values.global.secretsBackend.vault.controller.tlsCert.secretName  .Values.global.secretsBackend.vault.controller.caCert.secretName) -}}
+{{ $hasConfiguredWebhookCertsUsingVault := (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName) -}}
 {{- if (and .Values.connectInject.enabled (not $hasConfiguredWebhookCertsUsingVault)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/consul/templates/webhook-cert-manager-clusterrolebinding.yaml
+++ b/charts/consul/templates/webhook-cert-manager-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{ $hasConfiguredWebhookCertsUsingVault := (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName .Values.global.secretsBackend.vault.controllerRole .Values.global.secretsBackend.vault.controller.tlsCert.secretName  .Values.global.secretsBackend.vault.controller.caCert.secretName) -}}
+{{ $hasConfiguredWebhookCertsUsingVault := (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName) -}}
 {{- if (and .Values.connectInject.enabled (not $hasConfiguredWebhookCertsUsingVault)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/consul/templates/webhook-cert-manager-configmap.yaml
+++ b/charts/consul/templates/webhook-cert-manager-configmap.yaml
@@ -1,4 +1,4 @@
-{{ $hasConfiguredWebhookCertsUsingVault := (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName .Values.global.secretsBackend.vault.controllerRole .Values.global.secretsBackend.vault.controller.tlsCert.secretName  .Values.global.secretsBackend.vault.controller.caCert.secretName) -}}
+{{ $hasConfiguredWebhookCertsUsingVault := (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName) -}}
 {{- if (and .Values.connectInject.enabled (not $hasConfiguredWebhookCertsUsingVault)) }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/consul/templates/webhook-cert-manager-deployment.yaml
+++ b/charts/consul/templates/webhook-cert-manager-deployment.yaml
@@ -1,4 +1,4 @@
-{{ $hasConfiguredWebhookCertsUsingVault := (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName .Values.global.secretsBackend.vault.controllerRole .Values.global.secretsBackend.vault.controller.tlsCert.secretName  .Values.global.secretsBackend.vault.controller.caCert.secretName) -}}
+{{ $hasConfiguredWebhookCertsUsingVault := (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName) -}}
 {{- if (and .Values.connectInject.enabled (not $hasConfiguredWebhookCertsUsingVault)) }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/consul/templates/webhook-cert-manager-podsecuritypolicy.yaml
+++ b/charts/consul/templates/webhook-cert-manager-podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{ $hasConfiguredWebhookCertsUsingVault := (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName .Values.global.secretsBackend.vault.controllerRole .Values.global.secretsBackend.vault.controller.tlsCert.secretName  .Values.global.secretsBackend.vault.controller.caCert.secretName) -}}
+{{ $hasConfiguredWebhookCertsUsingVault := (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName) -}}
 {{- if (and .Values.global.enablePodSecurityPolicies (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled))) }}
 {{- if (and .Values.connectInject.enabled (not $hasConfiguredWebhookCertsUsingVault)) }}
 apiVersion: policy/v1beta1

--- a/charts/consul/templates/webhook-cert-manager-serviceaccount.yaml
+++ b/charts/consul/templates/webhook-cert-manager-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{ $hasConfiguredWebhookCertsUsingVault := (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName .Values.global.secretsBackend.vault.controllerRole .Values.global.secretsBackend.vault.controller.tlsCert.secretName  .Values.global.secretsBackend.vault.controller.caCert.secretName) -}}
+{{ $hasConfiguredWebhookCertsUsingVault := (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName) -}}
 {{- if (and .Values.connectInject.enabled (not $hasConfiguredWebhookCertsUsingVault)) }}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/consul/test/unit/connect-inject-clusterrole.bats
+++ b/charts/consul/test/unit/connect-inject-clusterrole.bats
@@ -193,9 +193,6 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInjectRole=inject-ca-role' \
       --set 'global.secretsBackend.vault.connectInject.tlsCert.secretName=pki/issue/connect-webhook-cert-dc1' \
       --set 'global.secretsBackend.vault.connectInject.caCert.secretName=pki/issue/connect-webhook-cert-dc1' \
-      --set 'global.secretsBackend.vault.controllerRole=test' \
-      --set 'global.secretsBackend.vault.controller.caCert.secretName=foo/ca' \
-      --set 'global.secretsBackend.vault.controller.tlsCert.secretName=foo/tls' \
       --set 'global.secretsBackend.vault.consulClientRole=foo' \
       --set 'global.secretsBackend.vault.consulServerRole=bar' \
       --set 'global.secretsBackend.vault.consulCARole=test2' \

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -1633,9 +1633,6 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInjectRole=test' \
       --set 'global.secretsBackend.vault.connectInject.caCert.secretName=foo/ca' \
       --set 'global.secretsBackend.vault.connectInject.tlsCert.secretName=foo/tls' \
-      --set 'global.secretsBackend.vault.controllerRole=test' \
-      --set 'global.secretsBackend.vault.controller.caCert.secretName=foo/ca' \
-      --set 'global.secretsBackend.vault.controller.tlsCert.secretName=foo/tls' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command | any(contains("-enable-webhook-ca-update"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -1742,7 +1739,7 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInjectRole=connectinjectcarole' \
       --set 'global.secretsBackend.vault.agentAnnotations=foo: bar' .
   [ "$status" -eq 1 ]
-  [[ "$output" =~ "When one of the following has been set, all must be set:  global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, global.secretsBackend.vault.connectInject.caCert.secretName, global.secretsBackend.vault.controllerRole, global.secretsBackend.vault.controller.tlsCert.secretName, and global.secretsBackend.vault.controller.caCert.secretName." ]]
+  [[ "$output" =~ "When one of the following has been set, all must be set:  global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, global.secretsBackend.vault.connectInject.caCert.secretName" ]]
 }
 
 @test "connectInject/Deployment: fails if vault is enabled and global.secretsBackend.vault.connectInject.tlsCert.secretName is set but global.secretsBackend.vault.connectInjectRole and global.secretsBackend.vault.connectInject.caCert.secretName are not" {
@@ -1759,7 +1756,7 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInject.tlsCert.secretName=foo/tls' \
       --set 'global.secretsBackend.vault.agentAnnotations=foo: bar' .
   [ "$status" -eq 1 ]
-  [[ "$output" =~ "When one of the following has been set, all must be set:  global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, global.secretsBackend.vault.connectInject.caCert.secretName, global.secretsBackend.vault.controllerRole, global.secretsBackend.vault.controller.tlsCert.secretName, and global.secretsBackend.vault.controller.caCert.secretName." ]]
+  [[ "$output" =~ "When one of the following has been set, all must be set:  global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, global.secretsBackend.vault.connectInject.caCert.secretName" ]]
 }
 
 @test "connectInject/Deployment: fails if vault is enabled and global.secretsBackend.vault.connectInject.caCert.secretName is set but global.secretsBackend.vault.connectInjectRole and global.secretsBackend.vault.connectInject.tlsCert.secretName are not" {
@@ -1776,7 +1773,7 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInject.caCert.secretName=foo/ca' \
       --set 'global.secretsBackend.vault.agentAnnotations=foo: bar' .
   [ "$status" -eq 1 ]
-  [[ "$output" =~ "When one of the following has been set, all must be set:  global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, global.secretsBackend.vault.connectInject.caCert.secretName, global.secretsBackend.vault.controllerRole, global.secretsBackend.vault.controller.tlsCert.secretName, and global.secretsBackend.vault.controller.caCert.secretName." ]]
+  [[ "$output" =~ "When one of the following has been set, all must be set:  global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, global.secretsBackend.vault.connectInject.caCert.secretName" ]]
 }
 
 @test "connectInject/Deployment: vault tls annotations are set when tls is enabled" {
@@ -1794,9 +1791,6 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInjectRole=test' \
       --set 'global.secretsBackend.vault.connectInject.caCert.secretName=foo/ca' \
       --set 'global.secretsBackend.vault.connectInject.tlsCert.secretName=pki/issue/connect-webhook-cert-dc1' \
-      --set 'global.secretsBackend.vault.controllerRole=test' \
-      --set 'global.secretsBackend.vault.controller.caCert.secretName=foo/ca' \
-      --set 'global.secretsBackend.vault.controller.tlsCert.secretName=foo/tls' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata' | tee /dev/stderr)
 
@@ -1870,9 +1864,6 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInjectRole=inject-ca-role' \
       --set 'global.secretsBackend.vault.connectInject.tlsCert.secretName=pki/issue/connect-webhook-cert-dc1' \
       --set 'global.secretsBackend.vault.connectInject.caCert.secretName=pki/issue/connect-webhook-cert-dc1' \
-      --set 'global.secretsBackend.vault.controllerRole=test' \
-      --set 'global.secretsBackend.vault.controller.caCert.secretName=foo/ca' \
-      --set 'global.secretsBackend.vault.controller.tlsCert.secretName=foo/tls' \
       --set 'global.secretsBackend.vault.consulClientRole=foo' \
       --set 'global.secretsBackend.vault.consulServerRole=bar' \
       --set 'global.secretsBackend.vault.consulCARole=test2' \
@@ -1895,9 +1886,6 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInjectRole=inject-ca-role' \
       --set 'global.secretsBackend.vault.connectInject.tlsCert.secretName=pki/issue/connect-webhook-cert-dc1' \
       --set 'global.secretsBackend.vault.connectInject.caCert.secretName=pki/issue/connect-webhook-cert-dc1' \
-      --set 'global.secretsBackend.vault.controllerRole=test' \
-      --set 'global.secretsBackend.vault.controller.caCert.secretName=foo/ca' \
-      --set 'global.secretsBackend.vault.controller.tlsCert.secretName=foo/tls' \
       --set 'server.serverCert.secretName=pki_int/issue/test' \
       --set 'global.tls.caCert.secretName=pki_int/cert/ca' \
       . | tee /dev/stderr |
@@ -1927,9 +1915,6 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInjectRole=inject-ca-role' \
       --set 'global.secretsBackend.vault.connectInject.tlsCert.secretName=pki/issue/connect-webhook-cert-dc1' \
       --set 'global.secretsBackend.vault.connectInject.caCert.secretName=pki/issue/connect-webhook-cert-dc1' \
-      --set 'global.secretsBackend.vault.controllerRole=test' \
-      --set 'global.secretsBackend.vault.controller.caCert.secretName=foo/ca' \
-      --set 'global.secretsBackend.vault.controller.tlsCert.secretName=foo/tls' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.volumes[] | select(.name == "certs")' | tee /dev/stderr)
   [ "${actual}" == "" ]
@@ -1949,9 +1934,6 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInjectRole=inject-ca-role' \
       --set 'global.secretsBackend.vault.connectInject.tlsCert.secretName=pki/issue/connect-webhook-cert-dc1' \
       --set 'global.secretsBackend.vault.connectInject.caCert.secretName=pki/issue/connect-webhook-cert-dc1' \
-      --set 'global.secretsBackend.vault.controllerRole=test' \
-      --set 'global.secretsBackend.vault.controller.caCert.secretName=foo/ca' \
-      --set 'global.secretsBackend.vault.controller.tlsCert.secretName=foo/tls' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "certs")' | tee /dev/stderr)
   [ "${actual}" == "" ]

--- a/charts/consul/test/unit/webhook-cert-manager-clusterrole.bats
+++ b/charts/consul/test/unit/webhook-cert-manager-clusterrole.bats
@@ -130,7 +130,7 @@ load _helpers
 #--------------------------------------------------------------------
 # Vault
 
-@test "webhookCertManager/ClusterRole: disabled when the following are configured - global.secretsBackend.vault.enabled, global.secretsBackend.vault.enabled, global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, global.secretsBackend.vault.connectInject.caCert.secretName, global.secretsBackend.vault.controllerRole, global.secretsBackend.vault.controller.tlsCert.secretName, and .global.secretsBackend.vault.controller.caCert.secretName" {
+@test "webhookCertManager/ClusterRole: disabled when the following are configured - global.secretsBackend.vault.enabled, global.secretsBackend.vault.enabled, global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, and global.secretsBackend.vault.connectInject.caCert.secretName" {
   cd `chart_dir`
   assert_empty helm template \
       -s templates/webhook-cert-manager-clusterrole.yaml  \
@@ -142,9 +142,6 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInjectRole=inject-ca-role' \
       --set 'global.secretsBackend.vault.connectInject.tlsCert.secretName=pki/issue/connect-webhook-cert-dc1' \
       --set 'global.secretsBackend.vault.connectInject.caCert.secretName=pki/issue/connect-webhook-cert-dc1' \
-      --set 'global.secretsBackend.vault.controllerRole=test' \
-      --set 'global.secretsBackend.vault.controller.caCert.secretName=foo/ca' \
-      --set 'global.secretsBackend.vault.controller.tlsCert.secretName=foo/tls' \
       --set 'global.secretsBackend.vault.consulClientRole=foo' \
       --set 'global.secretsBackend.vault.consulServerRole=bar' \
       --set 'global.secretsBackend.vault.consulCARole=test2' \

--- a/charts/consul/test/unit/webhook-cert-manager-clusterrolebinding.bats
+++ b/charts/consul/test/unit/webhook-cert-manager-clusterrolebinding.bats
@@ -24,7 +24,7 @@ load _helpers
 #--------------------------------------------------------------------
 # Vault
 
-@test "webhookCertManager/ClusterRoleBinding: disabled when the following are configured - global.secretsBackend.vault.enabled, global.secretsBackend.vault.enabled, global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, global.secretsBackend.vault.connectInject.caCert.secretName, global.secretsBackend.vault.controllerRole, global.secretsBackend.vault.controller.tlsCert.secretName, and .global.secretsBackend.vault.controller.caCert.secretName" {
+@test "webhookCertManager/ClusterRoleBinding: disabled when the following are configured - global.secretsBackend.vault.enabled, global.secretsBackend.vault.enabled, global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, and global.secretsBackend.vault.connectInject.caCert.secretName" {
   cd `chart_dir`
   assert_empty helm template \
       -s templates/webhook-cert-manager-clusterrolebinding.yaml  \
@@ -36,9 +36,6 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInjectRole=inject-ca-role' \
       --set 'global.secretsBackend.vault.connectInject.tlsCert.secretName=pki/issue/connect-webhook-cert-dc1' \
       --set 'global.secretsBackend.vault.connectInject.caCert.secretName=pki/issue/connect-webhook-cert-dc1' \
-      --set 'global.secretsBackend.vault.controllerRole=test' \
-      --set 'global.secretsBackend.vault.controller.caCert.secretName=foo/ca' \
-      --set 'global.secretsBackend.vault.controller.tlsCert.secretName=foo/tls' \
       --set 'global.secretsBackend.vault.consulClientRole=foo' \
       --set 'global.secretsBackend.vault.consulServerRole=bar' \
       --set 'global.secretsBackend.vault.consulCARole=test2' \

--- a/charts/consul/test/unit/webhook-cert-manager-configmap.bats
+++ b/charts/consul/test/unit/webhook-cert-manager-configmap.bats
@@ -24,7 +24,7 @@ load _helpers
 #--------------------------------------------------------------------
 # Vault
 
-@test "webhookCertManager/Configmap: disabled when the following are configured - global.secretsBackend.vault.enabled, global.secretsBackend.vault.enabled, global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, global.secretsBackend.vault.connectInject.caCert.secretName, global.secretsBackend.vault.controllerRole, global.secretsBackend.vault.controller.tlsCert.secretName, and .global.secretsBackend.vault.controller.caCert.secretName" {
+@test "webhookCertManager/Configmap: disabled when the following are configured - global.secretsBackend.vault.enabled, global.secretsBackend.vault.enabled, global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, and global.secretsBackend.vault.connectInject.caCert.secretName" {
   cd `chart_dir`
   assert_empty helm template \
       -s templates/webhook-cert-manager-configmap.yaml  \
@@ -36,9 +36,6 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInjectRole=inject-ca-role' \
       --set 'global.secretsBackend.vault.connectInject.tlsCert.secretName=pki/issue/connect-webhook-cert-dc1' \
       --set 'global.secretsBackend.vault.connectInject.caCert.secretName=pki/issue/connect-webhook-cert-dc1' \
-      --set 'global.secretsBackend.vault.controllerRole=test' \
-      --set 'global.secretsBackend.vault.controller.caCert.secretName=foo/ca' \
-      --set 'global.secretsBackend.vault.controller.tlsCert.secretName=foo/tls' \
       --set 'global.secretsBackend.vault.consulClientRole=foo' \
       --set 'global.secretsBackend.vault.consulServerRole=bar' \
       --set 'global.secretsBackend.vault.consulCARole=test2' \

--- a/charts/consul/test/unit/webhook-cert-manager-deployment.bats
+++ b/charts/consul/test/unit/webhook-cert-manager-deployment.bats
@@ -66,7 +66,7 @@ load _helpers
 #--------------------------------------------------------------------
 # Vault
 
-@test "webhookCertManager/Deployment: disabled when the following are configured - global.secretsBackend.vault.enabled, global.secretsBackend.vault.enabled, global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, global.secretsBackend.vault.connectInject.caCert.secretName, global.secretsBackend.vault.controllerRole, global.secretsBackend.vault.controller.tlsCert.secretName, and .global.secretsBackend.vault.controller.caCert.secretName" {
+@test "webhookCertManager/Deployment: disabled when the following are configured - global.secretsBackend.vault.enabled, global.secretsBackend.vault.enabled, global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, and global.secretsBackend.vault.connectInject.caCert.secretName" {
   cd `chart_dir`
   assert_empty helm template \
       -s templates/webhook-cert-manager-deployment.yaml  \
@@ -78,9 +78,6 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInjectRole=inject-ca-role' \
       --set 'global.secretsBackend.vault.connectInject.tlsCert.secretName=pki/issue/connect-webhook-cert-dc1' \
       --set 'global.secretsBackend.vault.connectInject.caCert.secretName=pki/issue/connect-webhook-cert-dc1' \
-      --set 'global.secretsBackend.vault.controllerRole=test' \
-      --set 'global.secretsBackend.vault.controller.caCert.secretName=foo/ca' \
-      --set 'global.secretsBackend.vault.controller.tlsCert.secretName=foo/tls' \
       --set 'global.secretsBackend.vault.consulClientRole=foo' \
       --set 'global.secretsBackend.vault.consulServerRole=bar' \
       --set 'global.secretsBackend.vault.consulCARole=test2' \

--- a/charts/consul/test/unit/webhook-cert-manager-podsecuritypolicy.bats
+++ b/charts/consul/test/unit/webhook-cert-manager-podsecuritypolicy.bats
@@ -35,7 +35,7 @@ load _helpers
 #--------------------------------------------------------------------
 # Vault
 
-@test "webhookCertManager/PodSecurityPolicy: disabled when the following are configured - global.secretsBackend.vault.enabled, global.secretsBackend.vault.enabled, global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, global.secretsBackend.vault.connectInject.caCert.secretName, global.secretsBackend.vault.controllerRole, global.secretsBackend.vault.controller.tlsCert.secretName, and .global.secretsBackend.vault.controller.caCert.secretName" {
+@test "webhookCertManager/PodSecurityPolicy: disabled when the following are configured - global.secretsBackend.vault.enabled, global.secretsBackend.vault.enabled, global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, and global.secretsBackend.vault.connectInject.caCert.secretName" {
   cd `chart_dir`
   assert_empty helm template \
       -s templates/webhook-cert-manager-podsecuritypolicy.yaml  \
@@ -48,9 +48,6 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInjectRole=inject-ca-role' \
       --set 'global.secretsBackend.vault.connectInject.tlsCert.secretName=pki/issue/connect-webhook-cert-dc1' \
       --set 'global.secretsBackend.vault.connectInject.caCert.secretName=pki/issue/connect-webhook-cert-dc1' \
-      --set 'global.secretsBackend.vault.controllerRole=test' \
-      --set 'global.secretsBackend.vault.controller.caCert.secretName=foo/ca' \
-      --set 'global.secretsBackend.vault.controller.tlsCert.secretName=foo/tls' \
       --set 'global.secretsBackend.vault.consulClientRole=foo' \
       --set 'global.secretsBackend.vault.consulServerRole=bar' \
       --set 'global.secretsBackend.vault.consulCARole=test2' \

--- a/charts/consul/test/unit/webhook-cert-manager-serviceaccount.bats
+++ b/charts/consul/test/unit/webhook-cert-manager-serviceaccount.bats
@@ -45,7 +45,7 @@ load _helpers
 #--------------------------------------------------------------------
 # Vault
 
-@test "webhookCertManager/ServiceAccount: disabled when the following are configured - global.secretsBackend.vault.enabled, global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, global.secretsBackend.vault.connectInject.caCert.secretName, global.secretsBackend.vault.controllerRole, global.secretsBackend.vault.controller.tlsCert.secretName, and .global.secretsBackend.vault.controller.caCert.secretName" {
+@test "webhookCertManager/ServiceAccount: disabled when the following are configured - global.secretsBackend.vault.enabled, global.secretsBackend.vault.connectInjectRole, global.secretsBackend.vault.connectInject.tlsCert.secretName, and global.secretsBackend.vault.connectInject.caCert.secretName" {
   cd `chart_dir`
   assert_empty helm template \
       -s templates/webhook-cert-manager-serviceaccount.yaml  \
@@ -57,9 +57,6 @@ load _helpers
       --set 'global.secretsBackend.vault.connectInjectRole=inject-ca-role' \
       --set 'global.secretsBackend.vault.connectInject.tlsCert.secretName=pki/issue/connect-webhook-cert-dc1' \
       --set 'global.secretsBackend.vault.connectInject.caCert.secretName=pki/issue/connect-webhook-cert-dc1' \
-      --set 'global.secretsBackend.vault.controllerRole=test' \
-      --set 'global.secretsBackend.vault.controller.caCert.secretName=foo/ca' \
-      --set 'global.secretsBackend.vault.controller.tlsCert.secretName=foo/tls' \
       --set 'global.secretsBackend.vault.consulClientRole=foo' \
       --set 'global.secretsBackend.vault.consulServerRole=bar' \
       --set 'global.secretsBackend.vault.consulCARole=test2' \

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -160,12 +160,6 @@ global:
       # and check the name of `metadata.name`.
       adminPartitionsRole: ""
 
-      # The Vault role to read Consul controller's webhook's
-      # CA and issue a certificate and private key.
-      # A Vault policy must be created which grants issue capabilities to
-      # `global.secretsBackend.vault.controller.tlsCert.secretName`.
-      controllerRole: ""
-
       # The Vault role to read Consul connect-injector webhook's CA
       # and issue a certificate and private key.
       # A Vault policy must be created which grants issue capabilities to
@@ -240,25 +234,6 @@ global:
         # ```
         additionalConfig: |
           {}
-
-      controller:
-        # Configuration to the Vault Secret that Kubernetes will use on
-        # Kubernetes CRD creation, deletion, and update, to get TLS certificates
-        # used issued from vault to send webhooks to the controller.
-        tlsCert:
-          # The Vault secret path that issues TLS certificates for controller
-          # webhooks.
-          # @type: string
-          secretName: null
-
-        # Configuration to the Vault Secret that Kubernetes will use on 
-        # Kubernetes CRD creation, deletion, and update, to get CA certificates
-        # used issued from vault to send webhooks to the controller.
-        caCert:
-          # The Vault secret path that contains the CA certificate for controller
-          # webhooks.
-          # @type: string
-          secretName: null
 
       connectInject:
         # Configuration to the Vault Secret that Kubernetes will use on


### PR DESCRIPTION
The CRD controller deployment no longer exists as it was merged into connect-inject.

Changes proposed in this PR:
- Removes the webhook cert roles for the controller from the vault test
- updates values.yaml to not reference this field

How I've tested this PR:
👀 

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

