### PR TITLE
Add fix for api-gateway when using system-wide trusted CAs for external servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+BUG FIXES:
+* Helm:
+  * Don't pass in a CA file to the API Gateway controller when `externalServers.useSystemRoots` is `true`. [[GH-1743](https://github.com/hashicorp/consul-k8s/pull/1743)]
+
 ## 1.0.0 (November 17, 2022)
 
 BREAKING CHANGES:

--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -57,8 +57,10 @@ spec:
           protocol: TCP
         env:
         {{- if .Values.global.tls.enabled }}
+        {{- if or (not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots)) .Values.client.enabled }}
         - name: CONSUL_CACERT
           value: /consul/tls/ca/tls.crt
+        {{- end }}
         {{- end }}
         - name: HOST_IP
           valueFrom:

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -1370,3 +1370,32 @@ load _helpers
       yq '.spec.template.spec.containers[0].env[3]' | tee /dev/stderr)
   [ "${actual}" = "null" ]
 }
+
+@test "apiGateway/Deployment: CONSUL_CACERT is set when using tls and clients even when useSystemRoots is true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-controller-deployment.yaml  \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=bar' \
+      --set 'server.enabled=false' \
+      --set 'externalServers.hosts[0]=external-consul.host' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.useSystemRoots=true' \
+      --set 'client.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].env[0].name == "CONSUL_CACERT"' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "apiGateway/Deployment: CONSUL_CACERT is not set when using tls and useSystemRoots" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-controller-deployment.yaml  \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=bar' \
+      --set 'global.tls.enabled=true' \
+      --set 'server.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].env[0].name == "CONSUL_CACERT"' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -1377,6 +1377,7 @@ load _helpers
       -s templates/api-gateway-controller-deployment.yaml  \
       --set 'apiGateway.enabled=true' \
       --set 'apiGateway.image=bar' \
+      --set 'global.tls.enabled=true' \
       --set 'server.enabled=false' \
       --set 'externalServers.hosts[0]=external-consul.host' \
       --set 'externalServers.enabled=true' \
@@ -1384,7 +1385,20 @@ load _helpers
       --set 'client.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].env[0].name == "CONSUL_CACERT"' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
+}
+
+@test "apiGateway/Deployment: CONSUL_CACERT is set when using tls and internal servers" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-controller-deployment.yaml  \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=bar' \
+      --set 'global.tls.enabled=true' \
+      --set 'server.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].env[0].name == "CONSUL_CACERT"' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
 }
 
 @test "apiGateway/Deployment: CONSUL_CACERT is not set when using tls and useSystemRoots" {
@@ -1395,7 +1409,10 @@ load _helpers
       --set 'apiGateway.image=bar' \
       --set 'global.tls.enabled=true' \
       --set 'server.enabled=false' \
+      --set 'externalServers.hosts[0]=external-consul.host' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.useSystemRoots=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].env[0].name == "CONSUL_CACERT"' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
+  [ "${actual}" = "false" ]
 }


### PR DESCRIPTION
Changes proposed in this PR:

This adds some logic that was forgotten around leveraging `externalServers.useSystemRoots`. Without it, attempting to use something like HCP as an external server without agents causes the gateway controller to fail validating the Consul server connection since it's using the wrong certificate authority.

How I've tested this PR:

Validated against HCP with the api-gateway changes in https://github.com/hashicorp/consul-api-gateway/pull/459

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

