### PR TITLE
Remove controller from preset values file

### DIFF
--- a/cli/cmd/install/install_test.go
+++ b/cli/cmd/install/install_test.go
@@ -558,7 +558,7 @@ func TestInstall(t *testing.T) {
 			},
 			messages: []string{
 				"\n==> Checking if Consul can be installed\n ✓ No existing Consul installations found.\n ✓ No existing Consul persistent volume claims found\n ✓ No existing Consul secrets found.\n",
-				"\n==> Consul Installation Summary\n    Name: consul\n    Namespace: consul\n    \n    Helm value overrides\n    --------------------\n    connectInject:\n      enabled: true\n      metrics:\n        defaultEnableMerging: true\n        defaultEnabled: true\n        enableGatewayMetrics: true\n    controller:\n      enabled: true\n    global:\n      metrics:\n        enableAgentMetrics: true\n        enabled: true\n      name: consul\n    prometheus:\n      enabled: true\n    server:\n      replicas: 1\n    ui:\n      enabled: true\n      service:\n        enabled: true\n    \n",
+				"\n==> Consul Installation Summary\n    Name: consul\n    Namespace: consul\n    \n    Helm value overrides\n    --------------------\n    connectInject:\n      enabled: true\n      metrics:\n        defaultEnableMerging: true\n        defaultEnabled: true\n        enableGatewayMetrics: true\n    global:\n      metrics:\n        enableAgentMetrics: true\n        enabled: true\n      name: consul\n    prometheus:\n      enabled: true\n    server:\n      replicas: 1\n    ui:\n      enabled: true\n      service:\n        enabled: true\n    \n",
 				"\n==> Installing Consul\n ✓ Downloaded charts.\n ✓ Consul installed in namespace \"consul\".\n",
 			},
 			helmActionsRunner:                       &helm.MockActionRunner{},
@@ -574,7 +574,7 @@ func TestInstall(t *testing.T) {
 			},
 			messages: []string{
 				"\n==> Checking if Consul can be installed\n ✓ No existing Consul installations found.\n ✓ No existing Consul persistent volume claims found\n ✓ No existing Consul secrets found.\n",
-				"\n==> Consul Installation Summary\n    Name: consul\n    Namespace: consul\n    \n    Helm value overrides\n    --------------------\n    connectInject:\n      enabled: true\n    controller:\n      enabled: true\n    global:\n      acls:\n        manageSystemACLs: true\n      gossipEncryption:\n        autoGenerate: true\n      name: consul\n      tls:\n        enableAutoEncrypt: true\n        enabled: true\n    server:\n      replicas: 1\n    \n",
+				"\n==> Consul Installation Summary\n    Name: consul\n    Namespace: consul\n    \n    Helm value overrides\n    --------------------\n    connectInject:\n      enabled: true\n    global:\n      acls:\n        manageSystemACLs: true\n      gossipEncryption:\n        autoGenerate: true\n      name: consul\n      tls:\n        enableAutoEncrypt: true\n        enabled: true\n    server:\n      replicas: 1\n    \n",
 				"\n==> Installing Consul\n ✓ Downloaded charts.\n ✓ Consul installed in namespace \"consul\".\n",
 			},
 			helmActionsRunner:                       &helm.MockActionRunner{},

--- a/cli/cmd/status/status_test.go
+++ b/cli/cmd/status/status_test.go
@@ -77,7 +77,7 @@ func TestStatus(t *testing.T) {
 		"status with servers returns success": {
 			input: []string{},
 			messages: []string{
-				fmt.Sprintf("\n==> Consul Status Summary\nName\tNamespace\tStatus\tChart Version\tAppVersion\tRevision\tLast Updated            \n    \t         \tREADY \t1.0.0        \t          \t0       \t%s\t\n", notImeStr),
+				fmt.Sprintf("\n==> Consul Status Summary\nName\tNamespace\tStatus\tChart Version\tAppVersion\tRevision\tLast Updated             \n    \t         \tREADY \t1.0.0        \t          \t0       \t%s\t\n", notImeStr),
 				"\n==> Config:\n    {}\n    \nConsul servers healthy 3/3\n",
 			},
 			preProcessingFunc: func(k8s kubernetes.Interface) error {
@@ -102,7 +102,7 @@ func TestStatus(t *testing.T) {
 		"status with pre-install and pre-upgrade hooks returns success and outputs hook status": {
 			input: []string{},
 			messages: []string{
-				fmt.Sprintf("\n==> Consul Status Summary\nName\tNamespace\tStatus\tChart Version\tAppVersion\tRevision\tLast Updated            \n    \t         \tREADY \t1.0.0        \t          \t0       \t%s\t\n", notImeStr),
+				fmt.Sprintf("\n==> Consul Status Summary\nName\tNamespace\tStatus\tChart Version\tAppVersion\tRevision\tLast Updated             \n    \t         \tREADY \t1.0.0        \t          \t0       \t%s\t\n", notImeStr),
 				"\n==> Config:\n    {}\n    \n",
 				"\n==> Status Of Helm Hooks:\npre-install-hook pre-install: Succeeded\npre-upgrade-hook pre-upgrade: Succeeded\nConsul servers healthy 3/3\n",
 			},

--- a/cli/cmd/upgrade/upgrade_test.go
+++ b/cli/cmd/upgrade/upgrade_test.go
@@ -452,7 +452,7 @@ func TestUpgrade(t *testing.T) {
 			messages: []string{
 				"\n==> Checking if Consul can be upgraded\n ✓ Existing Consul installation found to be upgraded.\n    Name: consul\n    Namespace: consul\n",
 				"\n==> Checking if Consul demo application can be upgraded\n    No existing Consul demo application installation found.\n",
-				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  + connectInject:\n  +   enabled: true\n  +   metrics:\n  +     defaultEnableMerging: true\n  +     defaultEnabled: true\n  +     enableGatewayMetrics: true\n  + controller:\n  +   enabled: true\n  + global:\n  +   metrics:\n  +     enableAgentMetrics: true\n  +     enabled: true\n  +   name: consul\n  + prometheus:\n  +   enabled: true\n  + server:\n  +   replicas: 1\n  + ui:\n  +   enabled: true\n  +   service:\n  +     enabled: true\n  \n",
+				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  + connectInject:\n  +   enabled: true\n  +   metrics:\n  +     defaultEnableMerging: true\n  +     defaultEnabled: true\n  +     enableGatewayMetrics: true\n  + global:\n  +   metrics:\n  +     enableAgentMetrics: true\n  +     enabled: true\n  +   name: consul\n  + prometheus:\n  +   enabled: true\n  + server:\n  +   replicas: 1\n  + ui:\n  +   enabled: true\n  +   service:\n  +     enabled: true\n  \n",
 				"\n==> Upgrading Consul\n ✓ Consul upgraded in namespace \"consul\".\n",
 			},
 			helmActionsRunner: &helm.MockActionRunner{
@@ -477,7 +477,7 @@ func TestUpgrade(t *testing.T) {
 			messages: []string{
 				"\n==> Checking if Consul can be upgraded\n ✓ Existing Consul installation found to be upgraded.\n    Name: consul\n    Namespace: consul\n",
 				"\n==> Checking if Consul demo application can be upgraded\n    No existing Consul demo application installation found.\n",
-				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  + connectInject:\n  +   enabled: true\n  + controller:\n  +   enabled: true\n  + global:\n  +   acls:\n  +     manageSystemACLs: true\n  +   gossipEncryption:\n  +     autoGenerate: true\n  +   name: consul\n  +   tls:\n  +     enableAutoEncrypt: true\n  +     enabled: true\n  + server:\n  +   replicas: 1\n  \n",
+				"\n==> Consul Upgrade Summary\n ✓ Downloaded charts.\n    \n    Difference between user overrides for current and upgraded charts\n    -----------------------------------------------------------------\n  + connectInject:\n  +   enabled: true\n  + global:\n  +   acls:\n  +     manageSystemACLs: true\n  +   gossipEncryption:\n  +     autoGenerate: true\n  +   name: consul\n  +   tls:\n  +     enableAutoEncrypt: true\n  +     enabled: true\n  + server:\n  +   replicas: 1\n  \n",
 				"\n==> Upgrading Consul\n ✓ Consul upgraded in namespace \"consul\".\n",
 			},
 			helmActionsRunner: &helm.MockActionRunner{

--- a/cli/preset/demo.go
+++ b/cli/preset/demo.go
@@ -29,8 +29,6 @@ connectInject:
      enableGatewayMetrics: true
 server:
   replicas: 1
-controller:
-  enabled: true
 ui:
   enabled: true
   service:

--- a/cli/preset/quickstart.go
+++ b/cli/preset/quickstart.go
@@ -29,8 +29,6 @@ connectInject:
      enableGatewayMetrics: true
 server:
   replicas: 1
-controller:
-  enabled: true
 ui:
   enabled: true
   service:

--- a/cli/preset/secure.go
+++ b/cli/preset/secure.go
@@ -29,8 +29,6 @@ server:
   replicas: 1
 connectInject:
   enabled: true
-controller:
-  enabled: true
 `
 
 	return config.ConvertToMap(values), nil


### PR DESCRIPTION
Changes proposed in this PR:
- Removed `controller: true` from the preset values file as the controller is now part of connectInject [1697](https://github.com/hashicorp/consul-k8s/pull/1697)


How I've tested this PR:
I built a binary and tried installing using the modified presets.

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

