### PR TITLE
Add support for setting the namespace that the CNI plugin is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+IMPROVEMENTS:
+* Helm:
+  * CNI: Add `connectInject.cni.namespace` stanza which allows the CNI plugin resources to be deployed in a namespace other than the namespace that Consul is installed. [[GH-1756](https://github.com/hashicorp/consul-k8s/pull/1756)]
+
 ## 1.0.1 (November 21, 2022)
 
 BUG FIXES:

--- a/charts/consul/templates/cni-clusterrole.yaml
+++ b/charts/consul/templates/cni-clusterrole.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "consul.fullname" . }}-cni
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.connectInject.cni.namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/cni-clusterrolebinding.yaml
+++ b/charts/consul/templates/cni-clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-cni
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.connectInject.cni.namespace }}
 {{- end }}

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "consul.fullname" . }}-cni
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.connectInject.cni.namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/cni-networkattachmentdefinition.yaml
+++ b/charts/consul/templates/cni-networkattachmentdefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
   name: {{ template "consul.fullname" . }}-cni
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.connectInject.cni.namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/cni-podsecuritypolicy.yaml
+++ b/charts/consul/templates/cni-podsecuritypolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-cni
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.connectInject.cni.namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/cni-resourcequota.yaml
+++ b/charts/consul/templates/cni-resourcequota.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: {{ template "consul.fullname" . }}-cni
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.connectInject.cni.namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/cni-securitycontextconstraints.yaml
+++ b/charts/consul/templates/cni-securitycontextconstraints.yaml
@@ -3,7 +3,7 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   name: {{ template "consul.fullname" . }}-cni
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.connectInject.cni.namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/cni-serviceaccount.yaml
+++ b/charts/consul/templates/cni-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-cni
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.connectInject.cni.namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/test/unit/cni-clusterrole.bats
+++ b/charts/consul/test/unit/cni-clusterrole.bats
@@ -20,6 +20,29 @@ load _helpers
   [[ "${actual}" == "true" ]]
 }
 
+@test "cni/ClusterRole: cni namespace has a default when not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-clusterrole.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "default" ]]
+}
+
+@test "cni/ClusterRole: able to set cni namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-clusterrole.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.namespace=kube-system' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "kube-system" ]]
+}
+
 @test "cni/ClusterRole: disabled with connectInject.cni.enabled=false and connectInject.enabled=true" {
   cd `chart_dir`
   assert_empty helm template \

--- a/charts/consul/test/unit/cni-clusterrolebinding.bats
+++ b/charts/consul/test/unit/cni-clusterrolebinding.bats
@@ -55,3 +55,25 @@ load _helpers
   [ "${actual}" = "foo" ]
 }
 
+@test "cni/ClusterRoleBinding: subject namespace is correct when not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-clusterrolebinding.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.subjects[0].namespace' | tee /dev/stderr)
+  [[ "${actual}" == "default" ]]
+}
+
+@test "cni/ClusterRoleBinding: subject namespace can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-clusterrolebinding.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.namespace=kube-system' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.subjects[0].namespace' | tee /dev/stderr)
+  [[ "${actual}" == "kube-system" ]]
+}

--- a/charts/consul/test/unit/cni-daemonset.bats
+++ b/charts/consul/test/unit/cni-daemonset.bats
@@ -317,3 +317,26 @@ rollingUpdate:
       yq -r -c '.metadata.namespace' | tee /dev/stderr)
   [[ "${actual}" == "kube-system" ]]
 }
+
+@test "cni/DaemonSet: still uses cni.namespace when helm -n is used" {
+  cd `chart_dir`
+  local actual=$(helm template -n foo \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.cni.namespace=kube-system' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "kube-system" ]]
+}
+
+@test "cni/DaemonSet: default namespace can be overridden by helm -n" {
+  cd `chart_dir`
+  local actual=$(helm template -n foo \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "foo" ]]
+}

--- a/charts/consul/test/unit/cni-daemonset.bats
+++ b/charts/consul/test/unit/cni-daemonset.bats
@@ -295,3 +295,25 @@ rollingUpdate:
       [ "${actual}" = '{"mountPath":"bar","name":"cni-net-dir"}' ]
 }
 
+@test "cni/DaemonSet: cni namespace has a default when not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "default" ]]
+}
+
+@test "cni/DaemonSet: able to set cni namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-daemonset.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.namespace=kube-system' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "kube-system" ]]
+}

--- a/charts/consul/test/unit/cni-networkattachmentdefinition.bats
+++ b/charts/consul/test/unit/cni-networkattachmentdefinition.bats
@@ -59,3 +59,27 @@ load _helpers
 
 }
 
+@test "cni/NetworkAttachmentDefinition: cni namespace has a default when not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-networkattachmentdefinition.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.multus=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "default" ]]
+}
+
+@test "cni/NetworkAttachmentDefinition: able to set cni namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-networkattachmentdefinition.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.cni.multus=true' \
+      --set 'connectInject.cni.namespace=kube-system' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "kube-system" ]]
+}

--- a/charts/consul/test/unit/cni-podsecuritypolicy.bats
+++ b/charts/consul/test/unit/cni-podsecuritypolicy.bats
@@ -30,3 +30,27 @@ load _helpers
   [[ "${actual}" == "true" ]]
 }
 
+@test "cni/PodSecurityPolicy: cni namespace has a default when not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-podsecuritypolicy.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "default" ]]
+}
+
+@test "cni/PodSecurityPolicy: able to set cni namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-podsecuritypolicy.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'connectInject.cni.namespace=kube-system' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "kube-system" ]]
+}

--- a/charts/consul/test/unit/cni-resourcequota.bats
+++ b/charts/consul/test/unit/cni-resourcequota.bats
@@ -29,6 +29,29 @@ load _helpers
       .
 }
 
+@test "cni/ResourceQuota: cni namespace has a default when not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-resourcequota.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "default" ]]
+}
+
+@test "cni/ResourceQuota: able to set cni namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-resourcequota.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.cni.namespace=kube-system' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "kube-system" ]]
+}
+
 #--------------------------------------------------------------------
 # pods 
 

--- a/charts/consul/test/unit/cni-securitycontextcontstraints.bats
+++ b/charts/consul/test/unit/cni-securitycontextcontstraints.bats
@@ -31,3 +31,27 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "cni/SecurityContextConstraints: cni namespace has a default when not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-securitycontextconstraints.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.openshift.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "default" ]]
+}
+
+@test "cni/SecurityContextConstraints: able to set cni namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-securitycontextconstraints.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.openshift.enabled=true' \
+      --set 'connectInject.cni.namespace=kube-system' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "kube-system" ]]
+}

--- a/charts/consul/test/unit/cni-serviceaccount.bats
+++ b/charts/consul/test/unit/cni-serviceaccount.bats
@@ -29,6 +29,29 @@ load _helpers
       .
 }
 
+@test "cni/ServiceAccount: cni namespace has a default when not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-serviceaccount.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "default" ]]
+}
+
+@test "cni/ServiceAccount: able to set cni namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/cni-serviceaccount.yaml  \
+      --set 'connectInject.cni.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.cni.namespace=kube-system' \
+      . | tee /dev/stderr |
+      yq -r -c '.metadata.namespace' | tee /dev/stderr)
+  [[ "${actual}" == "kube-system" ]]
+}
+
 #--------------------------------------------------------------------
 # global.imagePullSecrets
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1920,6 +1920,11 @@ connectInject:
     # @type: string
     logLevel: null
 
+    # Set the namespace to install the CNI plugin into. Overrides global namespace settings for CNI resources.
+    # Ex: "kube-system" 
+    # @type: string
+    namespace: null
+
     # Location on the kubernetes node where the CNI plugin is installed. Shoud be the absolute path and start with a '/'
     # Example on GKE:
     #


### PR DESCRIPTION
Kubernetes 1.25 uses the PSA system which controls pod security standards at the namespace level.
The CNI plugin requires elevated permissions which would otherwise interfere with setting the rest of the consul-k8s resources compliant with `restricted` modes of the PSA.
By allowing the CNI plugin to be installed into another namespace, like `kube-system` or `consul-system` we can still run the rest of Consul in `restricted` mode while the CNI plugin runs in another elevated namespace.
This is a common workflow for other CNI plugins:
```
demo $ k get pods -A
NAMESPACE            NAME                                        READY   STATUS    RESTARTS      AGE
calico-apiserver     calico-apiserver-db5d9d654-hlf62            1/1     Running   0             19h
calico-apiserver     calico-apiserver-db5d9d654-w5ljk            1/1     Running   0             19h
calico-system        calico-kube-controllers-5d95c5d5fb-7vm9h    1/1     Running   0             19h
calico-system        calico-node-9tglm                           1/1     Running   0             19h
calico-system        calico-typha-664b86ccfd-bs65l               1/1     Running   0             19h
calico-system        csi-node-driver-tftld                       2/2     Running   0             19h
```

Changes proposed in this PR:
- Introduces a new field `namespace` into the `connectInject.cni` stanza which controls which namespace CNI related resources are installed in.

How I've tested this PR:
Unit tests + manually test by installing the plugin:
```shell
$ cat x.yaml
connectInject:
  enabled: true
  cni:
    enabled: true
    namespace: kube-system

$ helm install consul /Users/kyle/go/src/github.com/hashicorp/consul-k8s/charts/consul -f x.yaml
<snip>

$ k get pods -A
NAMESPACE            NAME                                        READY   STATUS    RESTARTS      AGE
calico-apiserver     calico-apiserver-db5d9d654-hlf62            1/1     Running   0             20h
calico-apiserver     calico-apiserver-db5d9d654-w5ljk            1/1     Running   0             20h
calico-system        calico-kube-controllers-5d95c5d5fb-7vm9h    1/1     Running   0             20h
calico-system        calico-node-9tglm                           1/1     Running   0             20h
calico-system        calico-typha-664b86ccfd-bs65l               1/1     Running   0             20h
calico-system        csi-node-driver-tftld                       2/2     Running   0             20h
kube-system          consul-consul-cni-94n62                     1/1     Running   0             13s
```

Note to Reviewers:
* Is there anything in the consul-k8s cli that might need to change for this?

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

