### PR TITLE
Added Peering Preset with option to pass DC name

### DIFF
--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -610,6 +610,14 @@ func (c *Command) validateFlags(args []string) error {
 		return fmt.Errorf("The '%s' flag can only be used with the '%s' preset", flagNameHCPResourceID, preset.PresetCloud)
 	}
 
+	if c.flagPreset == preset.PresetPeering {
+		datacenterName := os.Getenv(preset.EnvConsulDatacenter)
+
+		if datacenterName == "" {
+			return fmt.Errorf("When '%s' is specified as the preset, the '%s' environment variable must also be set", preset.PresetPeering, preset.EnvConsulDatacenter)
+		}
+	}
+
 	duration, err := time.ParseDuration(c.flagTimeout)
 	if err != nil {
 		return fmt.Errorf("unable to parse -%s: %s", flagNameTimeout, err)

--- a/cli/preset/peering.go
+++ b/cli/preset/peering.go
@@ -1,0 +1,32 @@
+package preset
+
+import "fmt"
+import "github.com/hashicorp/consul-k8s/cli/config"
+
+// PeeringPreset struct is an implementation of the Preset interface that provides
+// a Helm values map that is used during installation and represents the
+// the peering configuration for Consul on Kubernetes.
+type PeeringPreset struct{}
+
+// GetValueMap returns the Helm value map representing the quickstart
+// configuration for Consul on Kubernetes. It does the following:
+// - enables TLS
+// - enables the Service Mesh.
+// - enables Mesh Gateway
+func (i *PeeringPreset) GetValueMap() (map[string]interface{}, error) {
+	values := fmt.Sprintf(`
+global:
+  name: consul
+  datacenter: %s
+  peering:
+    enabled: true
+  tls:
+    enabled: true
+connectInject:
+  enabled: true
+meshGateway:
+  enabled: true
+`, GetConsulDCFromEnv())
+
+	return config.ConvertToMap(values), nil
+}

--- a/cli/preset/preset.go
+++ b/cli/preset/preset.go
@@ -9,17 +9,20 @@ const (
 	PresetSecure     = "secure"
 	PresetQuickstart = "quickstart"
 	PresetCloud      = "cloud"
+	PresetPeering    = "peering"
 
 	EnvHCPClientID     = "HCP_CLIENT_ID"
 	EnvHCPClientSecret = "HCP_CLIENT_SECRET"
 	EnvHCPAuthURL      = "HCP_AUTH_URL"
 	EnvHCPAPIHost      = "HCP_API_HOST"
 	EnvHCPScadaAddress = "HCP_SCADA_ADDRESS"
+
+	EnvConsulDatacenter = "CONSUL_DATACENTER"
 )
 
 // Presets is a list of all the available presets for use with CLI's install
 // and uninstall commands.
-var Presets = []string{PresetCloud, PresetQuickstart, PresetSecure}
+var Presets = []string{PresetCloud, PresetQuickstart, PresetSecure, PresetPeering}
 
 // Preset is the interface that each instance must implement.  For demo and
 // secure presets, they merely return a pre-configred value map.  For cloud,
@@ -46,6 +49,8 @@ func GetPreset(config *GetPresetConfig) (Preset, error) {
 		return &QuickstartPreset{}, nil
 	case PresetSecure:
 		return &SecurePreset{}, nil
+	case PresetPeering:
+		return &PeeringPreset{}, nil
 	}
 	return nil, fmt.Errorf("'%s' is not a valid preset", config.Name)
 }
@@ -81,4 +86,13 @@ func GetHCPPresetFromEnv(resourceID string) *HCPConfig {
 	}
 
 	return hcpConfig
+}
+
+func GetConsulDCFromEnv() string {
+
+	if consulDC, ok := os.LookupEnv(EnvConsulDatacenter); ok {
+		return consulDC
+	}
+
+	return ""
 }


### PR DESCRIPTION
Changes proposed in this PR:
- Created a new preset to install a cluster with peering enabled
- The preset requires a data center name to be passed as an environment variable 

How I've tested this PR:

```
$ ./cli install --preset peering
When 'peering' is specified as the preset, the 'CONSUL_DATACENTER' environment variable must also be set
```

```
$ CONSUL_DATACENTER=dc1 ./cli install --preset peering

==> Checking if Consul can be installed
 ✓ No existing Consul installations found.
 ✓ No existing Consul persistent volume claims found
 ✓ No existing Consul secrets found.

==> Consul Installation Summary
    Name: consul
    Namespace: consul

    Helm value overrides
    --------------------
    connectInject:
      enabled: true
    global:
      datacenter: dc1
      name: consul
      peering:
        enabled: true
      tls:
        enabled: true
    meshGateway:
      enabled: true

    Proceed with installation? (Y/n)
```

The values file above is taken from the official documentation here: https://developer.hashicorp.com/consul/docs/connect/cluster-peering/k8s#prepare-for-installation.

Tested installation on Minikube (with `minikube tunnel` for LB IP for Mesh Gateway)

```
CONSUL_DATACENTER=dc1 ./cli install --preset peering

==> Checking if Consul can be installed
 ✓ No existing Consul installations found.
 ✓ No existing Consul persistent volume claims found
 ✓ No existing Consul secrets found.

==> Consul Installation Summary
    Name: consul
    Namespace: consul

    Helm value overrides
    --------------------
    connectInject:
      enabled: true
    global:
      datacenter: dc1
      name: consul
      peering:
        enabled: true
      tls:
        enabled: true
    meshGateway:
      enabled: true

    Proceed with installation? (Y/n) y

==> Installing Consul
 ✓ Downloaded charts.
 --> creating 1 resource(s)
 --> Starting delete for "consul-tls-init" ServiceAccount
 --> serviceaccounts "consul-tls-init" not found
 --> creating 1 resource(s)
 --> Starting delete for "consul-tls-init" Role
 --> roles.rbac.authorization.k8s.io "consul-tls-init" not found
 --> creating 1 resource(s)
 --> Starting delete for "consul-tls-init" RoleBinding
 --> rolebindings.rbac.authorization.k8s.io "consul-tls-init" not found
 --> creating 1 resource(s)
 --> Starting delete for "consul-tls-init" Job
 --> jobs.batch "consul-tls-init" not found
 --> creating 1 resource(s)
 --> Watching for changes to Job consul-tls-init with timeout of 10m0s
 --> Add/Modify event for consul-tls-init: ADDED
 --> consul-tls-init: Jobs active: 0, jobs failed: 0, jobs succeeded: 0
 --> Add/Modify event for consul-tls-init: MODIFIED
 --> consul-tls-init: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
 --> Add/Modify event for consul-tls-init: MODIFIED
 --> consul-tls-init: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
 --> Add/Modify event for consul-tls-init: MODIFIED
 --> consul-tls-init: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
 --> Add/Modify event for consul-tls-init: MODIFIED
 --> Starting delete for "consul-tls-init" Job
 --> creating 40 resource(s)
 --> beginning wait for 40 resources with timeout of 10m0s
 --> Service does not have load balancer ingress IP address: consul/consul-mesh-gateway
 --> Service does not have load balancer ingress IP address: consul/consul-mesh-gateway
 --> Service does not have load balancer ingress IP address: consul/consul-mesh-gateway
 --> Service does not have load balancer ingress IP address: consul/consul-mesh-gateway
 --> Service does not have load balancer ingress IP address: consul/consul-mesh-gateway
 --> Service does not have load balancer ingress IP address: consul/consul-mesh-gateway
 --> StatefulSet is ready: consul/consul-server. 1 out of 1 expected pods are ready
 ✓ Consul installed in namespace "consul".
```


How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

