### PR TITLE
1.0.3 dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## UNRELEASED
+
 ## 1.0.2 (December 1, 2022)
 
 IMPROVEMENTS:

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: consul
-version: 1.0.2
+version: 1.0.3-dev
 appVersion: 1.14.2
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Consul Chart
@@ -10,12 +10,12 @@ sources:
   - https://github.com/hashicorp/consul
   - https://github.com/hashicorp/consul-k8s
 annotations:
-  artifacthub.io/prerelease: false
+  artifacthub.io/prerelease: true
   artifacthub.io/images: |
     - name: consul
       image: hashicorp/consul:1.14.2
     - name: consul-k8s-control-plane
-      image: hashicorp/consul-k8s-control-plane:1.0.2
+      image: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.0.3-dev
     - name: consul-dataplane
       image: hashicorp/consul-dataplane:1.0.0
     - name: envoy

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -83,7 +83,7 @@ global:
   # image that is used for functionality such as catalog sync.
   # This can be overridden per component.
   # @default: hashicorp/consul-k8s-control-plane:<latest version>
-  imageK8S: hashicorp/consul-k8s-control-plane:1.0.2
+  imageK8S: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.0.3-dev
 
   # The name of the datacenter that the agents should
   # register as. This can't be changed once the Consul cluster is up and running

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -14,12 +14,12 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
-	Version = "1.0.2"
+	Version = "1.0.3"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = ""
+	VersionPrerelease = "dev"
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable

--- a/control-plane/version/version.go
+++ b/control-plane/version/version.go
@@ -14,12 +14,12 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
-	Version = "1.0.2"
+	Version = "1.0.3"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = ""
+	VersionPrerelease = "dev"
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
Changes proposed in this PR:
- 1.0.3 is the next release
- Sets things to dev mode

How I've tested this PR:

👀 

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [X] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

