### PR TITLE
Set consul api = v1.18.0, sdk = v0.13.0 and imageConsul = 1.14.2

### DIFF
--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: consul
 version: 1.1.0-dev
-appVersion: 1.14.0
+appVersion: 1.14.2
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
@@ -13,7 +13,7 @@ annotations:
   artifacthub.io/prerelease: true
   artifacthub.io/images: |
     - name: consul
-      image: hashicorp/consul:1.14.0
+      image: hashicorp/consul:1.14.2
     - name: consul-k8s-control-plane
       image: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.1.0-dev
     - name: consul-dataplane

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -63,7 +63,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.10.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: "hashicorp/consul:1.14.0"
+  image: "hashicorp/consul:1.14.2"
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.

--- a/control-plane/cni/go.mod
+++ b/control-plane/cni/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/consul-k8s/control-plane/cni
 require (
 	github.com/containernetworking/cni v1.1.1
 	github.com/containernetworking/plugins v1.1.1
-	github.com/hashicorp/consul/sdk v0.12.0
+	github.com/hashicorp/consul/sdk v0.13.0
 	github.com/hashicorp/go-hclog v0.16.1
 	github.com/stretchr/testify v1.7.1
 	k8s.io/api v0.22.2

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20220831174802-b8af65262de8
 	github.com/hashicorp/consul-server-connection-manager v0.1.0
-	github.com/hashicorp/consul/api v1.16.0
-	github.com/hashicorp/consul/sdk v0.12.0
+	github.com/hashicorp/consul/api v1.18.0
+	github.com/hashicorp/consul/sdk v0.13.0
 	github.com/hashicorp/go-discover v0.0.0-20200812215701-c4b85f6ed31f
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-multierror v1.1.1


### PR DESCRIPTION
Changes proposed in this PR:
- Update consul versions to things that were released last week so that the nightlies are using the latest things.
- consul api = v1.18.0
-  sdk = v0.13.0 
- imageConsul = 1.14.2

How I've tested this PR:

👀 

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

