### PR TITLE
add NoSchedule taint toleration for cni daemonset

### DIFF
--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -41,6 +41,8 @@ spec:
           operator: Exists
         - effect: NoExecute
           operator: Exists
+        - operator: Exists
+          effect: NoSchedule
       # Tell kubernetes that this daemonset is critical so that it will be scheduled on a new node before other pods
       priorityClassName: system-node-critical
       serviceAccountName: {{ template "consul.fullname" . }}-cni


### PR DESCRIPTION
Changes proposed in this PR:
I have added a NoSchedule taint toleration for the cni daemonset.

How I expect reviewers to test this PR:
The cni pods should be scheduled on nodes wit a NoSchedule taint.

