### PR TITLE
JIRA sync: downgrade to tomhjp/gh-action-jira-create@v0.1.3

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Create ticket
         if: ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type != 'Task' ) || ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'Task' && steps.is-team-member.outputs.message == 'false' )
-        uses: tomhjp/gh-action-jira-create@v0.2.0
+        uses: tomhjp/gh-action-jira-create@v0.1.3
         with:
           project: NET
           issuetype: "${{ steps.set-ticket-type.outputs.type }}"

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -31,25 +31,9 @@ jobs:
         run: |
           LABELS="[consul-k8s]"
           echo "::set-output name=labels::${LABELS}"
-          
-      - name: Check if team member
-        if: github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'Task'
-        id: is-team-member
-        run: |
-          TEAM=consul-kubernetes
-          ROLE="$(hub api orgs/hashicorp/teams/${TEAM}/memberships/${{ github.actor }} | jq -r '.role | select(.!=null)')"
-          if [[ -n ${ROLE} ]]; then
-            echo "Actor ${{ github.actor }} is a ${TEAM} team member"
-            echo "::set-output name=message::true"
-          else
-            echo "Actor ${{ github.actor }} is NOT a ${TEAM} team member"
-            echo "::set-output name=message::false"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.JIRA_SYNC_GITHUB_TOKEN }}
 
       - name: Create ticket
-        if: ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type != 'Task' ) || ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'Task')
+        if: ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type != 'Task' ) || ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'Task' )
         uses: tomhjp/gh-action-jira-create@v0.1.3
         with:
           project: NET

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.JIRA_SYNC_GITHUB_TOKEN }}
 
       - name: Create ticket
-        if: ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type != 'Task' ) || ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'Task' && steps.is-team-member.outputs.message == 'false' )
+        if: ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type != 'Task' ) || ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'Task'
         uses: tomhjp/gh-action-jira-create@v0.1.3
         with:
           project: NET

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.JIRA_SYNC_GITHUB_TOKEN }}
 
       - name: Create ticket
-        if: ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type != 'Task' ) || ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'Task'
+        if: ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type != 'Task' ) || ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'Task')
         uses: tomhjp/gh-action-jira-create@v0.1.3
         with:
           project: NET


### PR DESCRIPTION
Changes proposed in this PR:
- Downgrade to tomhjp/gh-action-jira-create@v0.1.3 to get past deserialization error 

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

