### PR TITLE
JIRA: Use env when creating with custom fields

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -24,16 +24,37 @@ jobs:
       - name: Set ticket type
         id: set-ticket-type
         run: |
-          echo "::set-output name=type::GH Issue"
+          if [[ "${{ github.event_name == 'pull_request' && github.event.action == 'opened' ]]; then
+            echo "::set-output name=type::PR"
+          else
+            echo "::set-output name=type::GH Issue"
+          fi
+          
       - name: Set ticket labels
         if: github.event.action == 'opened'
         id: set-ticket-labels
         run: |
           LABELS="[consul-k8s]"
           echo "::set-output name=labels::${LABELS}"
+          
+      - name: Check if team member PR
+        if: github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'Task'
+        id: is-team-member
+        run: |
+          TEAM=consul
+          ROLE="$(hub api orgs/hashicorp/teams/${TEAM}/memberships/${{ github.actor }} | jq -r '.role | select(.!=null)')"
+          if [[ -n ${ROLE} ]]; then
+            echo "Actor ${{ github.actor }} is a ${TEAM} team member"
+            echo "::set-output name=message::true"
+          else
+            echo "Actor ${{ github.actor }} is NOT a ${TEAM} team member"
+            echo "::set-output name=message::false"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.JIRA_SYNC_GITHUB_TOKEN }}
 
       - name: Create ticket
-        if: ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type != 'Task' ) || ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'Task' )
+        if: ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type != 'PR' && steps.is-team-member.outputs.message == 'false' )
         uses: tomhjp/gh-action-jira-create@v0.2.0
         with:
           project: NET

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Create ticket
         if: ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type != 'Task' ) || ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'Task' )
-        uses: tomhjp/gh-action-jira-create@v0.1.3
+        uses: tomhjp/gh-action-jira-create@v0.2.0
         with:
           project: NET
           issuetype: "${{ steps.set-ticket-type.outputs.type }}"
@@ -45,6 +45,10 @@ jobs:
                           "customfield_10371": { "value": "GitHub" },            
                           "components": [{ "name": "${{ github.event.repository.name }}" }],
                           "labels": ${{ steps.set-ticket-labels.outputs.labels }} }'
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 
       - name: Search
         if: github.event.action != 'opened'

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -53,8 +53,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.JIRA_SYNC_GITHUB_TOKEN }}
 
-      - name: Create ticket
-        if: ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type != 'PR' && steps.is-team-member.outputs.message == 'false' )
+      - name: Create ticket if an issue is filed, or if PR not by a team member is opened
+        if: ( (github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'GH Issue' ) || (github.event.action == 'opened' && steps.set-ticket-type.outputs.type != 'PR' && steps.is-team-member.outputs.message == 'false') )
         uses: tomhjp/gh-action-jira-create@v0.2.0
         with:
           project: NET

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -54,7 +54,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.JIRA_SYNC_GITHUB_TOKEN }}
 
       - name: Create ticket if an issue is filed, or if PR not by a team member is opened
-        if: ( (github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'GH Issue' ) || (github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'PR' && steps.is-team-member.outputs.message == 'false') )
+        if: ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'GH Issue' ) || ( github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'PR' && steps.is-team-member.outputs.message == 'false' )
         uses: tomhjp/gh-action-jira-create@v0.2.0
         with:
           project: NET

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Jira sync
     steps:    
       - name: Login
-        uses: atlassian/gajira-login@v3
+        uses: atlassian/gajira-login@v2.0.0
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -54,7 +54,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.JIRA_SYNC_GITHUB_TOKEN }}
 
       - name: Create ticket if an issue is filed, or if PR not by a team member is opened
-        if: ( (github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'GH Issue' ) || (github.event.action == 'opened' && steps.set-ticket-type.outputs.type != 'PR' && steps.is-team-member.outputs.message == 'false') )
+        if: ( (github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'GH Issue' ) || (github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'PR' && steps.is-team-member.outputs.message == 'false') )
         uses: tomhjp/gh-action-jira-create@v0.2.0
         with:
           project: NET

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -37,7 +37,7 @@ jobs:
           LABELS="[consul-k8s]"
           echo "::set-output name=labels::${LABELS}"
           
-      - name: Check if team member PR
+      - name: Check if team member
         if: github.event.action == 'opened' && steps.set-ticket-type.outputs.type == 'Task'
         id: is-team-member
         run: |


### PR DESCRIPTION
Changes proposed in this PR:

- Adding this in towards end of create JIRA action

  ```
  env:
      JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
  -
  ```

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

