### PR TITLE
JIRA: Re-use previous structure from labels 

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -34,8 +34,11 @@ jobs:
         if: github.event.action == 'opened'
         id: set-ticket-labels
         run: |
-          LABELS="[consul-k8s]"
-          echo "LABELS=${LABELS}" >> $GITHUB_OUTPUT
+          LABELS="["
+          if [[ "${{ contains(github.event.issue.labels.*.name, 'type/bug') }}" == "true" ]]; then LABELS+="\"type/bug\", "; fi
+          if [[ "${{ contains(github.event.issue.labels.*.name, 'type/enhancement') }}" == "true" ]]; then LABELS+="\"type/enhancement\", "; fi
+          if [[ ${#LABELS} != 1 ]]; then LABELS=${LABELS::-2}"]"; else LABELS+="]"; fi
+          echo "::set-output name=labels::${LABELS}"
           
       - name: Check if team member
         if: github.event.action == 'opened' && steps.set-ticket-type.outputs.TYPE == 'PR'
@@ -65,7 +68,7 @@ jobs:
           extraFields: '{ "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}",
                           "customfield_10371": { "value": "GitHub" },            
                           "components": [{ "name": "${{ github.event.repository.name }}" }],
-                          "labels": [{ "${{ steps.set-ticket-labels.outputs.LABELS }}" }] }'
+                          "labels": ${{ steps.set-ticket-labels.outputs.labels }} }'
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -38,7 +38,7 @@ jobs:
           if [[ "${{ contains(github.event.issue.labels.*.name, 'type/bug') }}" == "true" ]]; then LABELS+="\"type/bug\", "; fi
           if [[ "${{ contains(github.event.issue.labels.*.name, 'type/enhancement') }}" == "true" ]]; then LABELS+="\"type/enhancement\", "; fi
           if [[ ${#LABELS} != 1 ]]; then LABELS=${LABELS::-2}"]"; else LABELS+="]"; fi
-          echo "::set-output name=labels::${LABELS}"
+          echo "LABELS=${LABELS}" >> $GITHUB_OUTPUT
           
       - name: Check if team member
         if: github.event.action == 'opened' && steps.set-ticket-type.outputs.TYPE == 'PR'
@@ -68,7 +68,7 @@ jobs:
           extraFields: '{ "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}",
                           "customfield_10371": { "value": "GitHub" },            
                           "components": [{ "name": "${{ github.event.repository.name }}" }],
-                          "labels": ${{ steps.set-ticket-labels.outputs.labels }} }'
+                          "labels": ${{ steps.set-ticket-labels.outputs.LABELS }} }'
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}


### PR DESCRIPTION
Changes proposed in this PR:
- Re-using previous structure from labels from hcdiag

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

