### PR TITLE
JIRA: Add default work stream when syncing JIRA issues

### DIFF
--- a/.github/workflows/jira-issues.yaml
+++ b/.github/workflows/jira-issues.yaml
@@ -5,12 +5,12 @@ on:
     types: [created]
   workflow_dispatch:
 
-name: Jira Sync
+name: Jira Issue Sync
 
 jobs:
   sync:
     runs-on: ubuntu-latest
-    name: Jira sync
+    name: Jira Issue sync
     steps:    
       - name: Login
         uses: atlassian/gajira-login@v3.0.0
@@ -18,6 +18,11 @@ jobs:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          
+      - name: Set ticket type
+        id: set-ticket-type
+        run: |
+          echo "TYPE=GH Issue" >> $GITHUB_OUTPUT
           
       - name: Set ticket labels
         if: github.event.action == 'opened'

--- a/.github/workflows/jira-issues.yaml
+++ b/.github/workflows/jira-issues.yaml
@@ -5,7 +5,7 @@ on:
     types: [created]
   workflow_dispatch:
 
-name: Jira Issue Sync
+name: Jira Community Issue Sync
 
 jobs:
   sync:

--- a/.github/workflows/jira-issues.yaml
+++ b/.github/workflows/jira-issues.yaml
@@ -1,8 +1,6 @@
 on:
   issues:
     types: [opened, closed, deleted, reopened]
-  pull_request_target:
-    types: [opened, closed, reopened]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -20,15 +18,6 @@ jobs:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-
-      - name: Set ticket type
-        id: set-ticket-type
-        run: |
-          if [[ "${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}" == "true" ]]; then
-            echo "TYPE=PR" >> $GITHUB_OUTPUT
-          else
-            echo "TYPE=GH Issue" >> $GITHUB_OUTPUT
-          fi
           
       - name: Set ticket labels
         if: github.event.action == 'opened'
@@ -39,30 +28,14 @@ jobs:
           if [[ "${{ contains(github.event.issue.labels.*.name, 'type/enhancement') }}" == "true" ]]; then LABELS+="\"type/enhancement\", "; fi
           if [[ ${#LABELS} != 1 ]]; then LABELS=${LABELS::-2}"]"; else LABELS+="]"; fi
           echo "LABELS=${LABELS}" >> $GITHUB_OUTPUT
-          
-      - name: Check if team member
-        if: github.event.action == 'opened' && steps.set-ticket-type.outputs.TYPE == 'PR'
-        id: is-team-member
-        run: |
-          TEAM=consul
-          ROLE="$(hub api orgs/hashicorp/teams/${TEAM}/memberships/${{ github.actor }} | jq -r '.role | select(.!=null)')"
-          if [[ -n ${ROLE} ]]; then
-            echo "Actor ${{ github.actor }} is a ${TEAM} team member"
-            echo "MESSAGE=true" >> $GITHUB_OUTPUT
-          else
-            echo "Actor ${{ github.actor }} is NOT a ${TEAM} team member"
-            echo "MESSAGE=false" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.JIRA_SYNC_GITHUB_TOKEN }}
 
       - name: Create ticket if an issue is filed, or if PR not by a team member is opened
-        if: ( github.event.action == 'opened' && steps.set-ticket-type.outputs.TYPE == 'GH Issue' ) || ( github.event.action == 'opened' && steps.is-team-member.outputs.MESSAGE == 'false' )
+        if: github.event.action == 'opened'
         uses: tomhjp/gh-action-jira-create@v0.2.0
         with:
           project: NET
           issuetype: "${{ steps.set-ticket-type.outputs.TYPE }}"
-          summary: "${{ github.event.repository.name }} [${{ steps.set-ticket-type.outputs.TYPE }} #${{ github.event.issue.number || github.event.pull_request.number }}]: ${{ github.event.issue.title || github.event.pull_request.title }}"
+          summary: "${{ github.event.repository.name }} [${{ steps.set-ticket-type.outputs.TYPE }} #${{ github.event.issue.number }}]: ${{ github.event.issue.title }}"
           description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created in GitHub by ${{ github.actor }}._"
           # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve)
           extraFields: '{ "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}",

--- a/.github/workflows/jira-issues.yaml
+++ b/.github/workflows/jira-issues.yaml
@@ -10,7 +10,7 @@ name: Jira Issue Sync
 jobs:
   sync:
     runs-on: ubuntu-latest
-    name: Jira Issue sync
+    name: Jira Community Issue sync
     steps:    
       - name: Login
         uses: atlassian/gajira-login@v3.0.0

--- a/.github/workflows/jira-pr.yaml
+++ b/.github/workflows/jira-pr.yaml
@@ -1,0 +1,96 @@
+on:
+  pull_request_target:
+    types: [opened, closed, reopened]
+  workflow_dispatch:
+
+name: Jira Community PR Sync
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    name: Jira sync
+    steps:    
+      - name: Login
+        uses: atlassian/gajira-login@v3.0.0
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Set ticket type
+        id: set-ticket-type
+        run: |
+          echo "TYPE=Github Issue" >> $GITHUB_OUTPUT
+          
+      - name: Set ticket labels
+        if: github.event.action == 'opened'
+        id: set-ticket-labels
+        run: |
+          LABELS="["
+          if [[ "${{ contains(github.event.issue.labels.*.name, 'type/bug') }}" == "true" ]]; then LABELS+="\"type/bug\", "; fi
+          if [[ "${{ contains(github.event.issue.labels.*.name, 'type/enhancement') }}" == "true" ]]; then LABELS+="\"type/enhancement\", "; fi
+          if [[ ${#LABELS} != 1 ]]; then LABELS=${LABELS::-2}"]"; else LABELS+="]"; fi
+          echo "LABELS=${LABELS}" >> $GITHUB_OUTPUT
+          
+      - name: Check if team member
+        if: github.event.action == 'opened' 
+        id: is-team-member
+        run: |
+          TEAM=consul
+          ROLE="$(hub api orgs/hashicorp/teams/${TEAM}/memberships/${{ github.actor }} | jq -r '.role | select(.!=null)')"
+          if [[ -n ${ROLE} ]]; then
+            echo "Actor ${{ github.actor }} is a ${TEAM} team member"
+            echo "MESSAGE=true" >> $GITHUB_OUTPUT
+          else
+            echo "Actor ${{ github.actor }} is NOT a ${TEAM} team member"
+            echo "MESSAGE=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.JIRA_SYNC_GITHUB_TOKEN }}
+
+      - name: Create ticket if an issue is filed, or if PR not by a team member is opened
+        if: ( github.event.action == 'opened' && steps.is-team-member.outputs.MESSAGE == 'false' )
+        uses: tomhjp/gh-action-jira-create@v0.2.0
+        with:
+          project: NET
+          issuetype: "${{ steps.set-ticket-type.outputs.TYPE }}"
+          summary: "${{ github.event.repository.name }} [${{ steps.set-ticket-type.outputs.TYPE }} #${{ github.event.pull_request.number }}]: ${{ github.event.pull_request.title }}"
+          description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created in GitHub by ${{ github.actor }}._"
+          # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve)
+          extraFields: '{ "customfield_10089": "${{ github.event.pull_request.html_url }}",
+                          "customfield_10371": { "value": "GitHub" },            
+                          "components": [{ "name": "${{ github.event.repository.name }}" }],
+                          "labels": ${{ steps.set-ticket-labels.outputs.LABELS }} }'
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Search
+        if: github.event.action != 'opened'
+        id: search
+        uses: tomhjp/gh-action-jira-search@v0.2.1
+        with:
+          # cf[10089] is Issue Link (use JIRA API to retrieve)
+          jql: 'issuetype = "${{ steps.set-ticket-type.outputs.TYPE }}" and cf[10089] = "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"'
+
+      - name: Sync comment
+        if: github.event.action == 'created' && steps.search.outputs.issue
+        uses: tomhjp/gh-action-jira-comment@v0.1.0
+        with:
+          issue: ${{ steps.search.outputs.issue }}
+          comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"
+
+      - name: Close ticket
+        if: ( github.event.action == 'closed' || github.event.action == 'deleted' ) && steps.search.outputs.issue
+        uses: atlassian/gajira-transition@v2.0.1
+        with:
+          issue: ${{ steps.search.outputs.issue }}
+          transition: "Closed"
+
+      - name: Reopen ticket
+        if: github.event.action == 'reopened' && steps.search.outputs.issue
+        uses: atlassian/gajira-transition@v2.0.1
+        with:
+          issue: ${{ steps.search.outputs.issue }}
+          transition: "To Do"

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -66,7 +66,8 @@ jobs:
           description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created in GitHub by ${{ github.actor }}._"
           # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve)
           extraFields: '{ "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}",
-                          "customfield_10371": { "value": "GitHub" },            
+                          "customfield_10371": { "value": "GitHub" },
+                          "customfield_10535": [{ "value": "Service Mesh" }],
                           "components": [{ "name": "${{ github.event.repository.name }}" }],
                           "labels": ${{ steps.set-ticket-labels.outputs.LABELS }} }'
         env:


### PR DESCRIPTION
Changes proposed in this PR:
- Add work stream
  ```
  2022/12/13 23:27:56 API call POST /rest/api/2/issue failed (400): {"errorMessages":[],"errors":{"customfield_10535":"Consul WS is required."}}
  ```

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

