### PR TITLE
JIRA: Add work stream to PR sync

### DIFF
--- a/.github/workflows/jira-pr.yaml
+++ b/.github/workflows/jira-pr.yaml
@@ -58,7 +58,8 @@ jobs:
           description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created in GitHub by ${{ github.actor }}._"
           # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve)
           extraFields: '{ "customfield_10089": "${{ github.event.pull_request.html_url }}",
-                          "customfield_10371": { "value": "GitHub" },            
+                          "customfield_10371": { "value": "GitHub" },     
+                          "customfield_10535": [{ "value": "Service Mesh" }],
                           "components": [{ "name": "${{ github.event.repository.name }}" }],
                           "labels": ${{ steps.set-ticket-labels.outputs.LABELS }} }'
         env:


### PR DESCRIPTION
Changes proposed in this PR:
- Adding "Service Mesh" value for Workstream custom field that is causing issue on PR sync.

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

