### PR TITLE
When configured, use the health check of the proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ IMPROVEMENTS:
   * Add the `envoyExtensions` field to the `ProxyDefaults` and `ServiceDefaults` CRD. [[GH-1823]](https://github.com/hashicorp/consul-k8s/pull/1823)
   * Add the `balanceInboundConnections` field to the `ServiceDefaults` CRD. [[GH-1823]](https://github.com/hashicorp/consul-k8s/pull/1823)
 * Control-Plane
-  * Add support for the annotation `consul.hashicorp.com/use-proxy-health-check`. [[GH-1824](https://github.com/hashicorp/consul-k8s/pull/1824)]
+  * Add support for the annotation `consul.hashicorp.com/use-proxy-health-check`. When this annotation is used by a service, it configures a readiness endpoint on Consul Dataplane and queries it instead of the application for its readiness. [[GH-1824](https://github.com/hashicorp/consul-k8s/pull/1824)], [[GH-1841](https://github.com/hashicorp/consul-k8s/pull/1824)]
   * Add health check for synced services based on the status of the Kubernetes readiness probe on synced pod. [[GH-1821](https://github.com/hashicorp/consul-k8s/pull/1821)]
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ IMPROVEMENTS:
   * Add the `envoyExtensions` field to the `ProxyDefaults` and `ServiceDefaults` CRD. [[GH-1823]](https://github.com/hashicorp/consul-k8s/pull/1823)
   * Add the `balanceInboundConnections` field to the `ServiceDefaults` CRD. [[GH-1823]](https://github.com/hashicorp/consul-k8s/pull/1823)
 * Control-Plane
-  * Add support for the annotation `consul.hashicorp.com/use-proxy-health-check`. When this annotation is used by a service, it configures a readiness endpoint on Consul Dataplane and queries it instead of the application for its readiness. [[GH-1824](https://github.com/hashicorp/consul-k8s/pull/1824)], [[GH-1841](https://github.com/hashicorp/consul-k8s/pull/1824)]
+  * Add support for the annotation `consul.hashicorp.com/use-proxy-health-check`. When this annotation is used by a service, it configures a readiness endpoint on Consul Dataplane and queries it instead of the proxy's inbound port which forwards requests to the application. [[GH-1824](https://github.com/hashicorp/consul-k8s/pull/1824)], [[GH-1841](https://github.com/hashicorp/consul-k8s/pull/1824)]
   * Add health check for synced services based on the status of the Kubernetes readiness probe on synced pod. [[GH-1821](https://github.com/hashicorp/consul-k8s/pull/1821)]
 
 BUG FIXES:

--- a/control-plane/connect-inject/constants/constants.go
+++ b/control-plane/connect-inject/constants/constants.go
@@ -7,6 +7,9 @@ const (
 	// ProxyDefaultInboundPort is the default inbound port for the proxy.
 	ProxyDefaultInboundPort = 20000
 
+	// ProxyDefaultHealthPort is the default HTTP health check port for the proxy.
+	ProxyDefaultHealthPort = 21000
+
 	// MetaKeyKubeNS is the meta key name for Kubernetes namespace used for the Consul services.
 	MetaKeyKubeNS = "k8s-namespace"
 

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
@@ -47,13 +47,28 @@ func (w *MeshWebhook) consulDataplaneSidecar(namespace corev1.Namespace, pod cor
 		containerName = fmt.Sprintf("%s-%s", sidecarContainer, mpi.serviceName)
 	}
 
-	probe := &corev1.Probe{
-		Handler: corev1.Handler{
-			TCPSocket: &corev1.TCPSocketAction{
-				Port: intstr.FromInt(constants.ProxyDefaultInboundPort + mpi.serviceIndex),
+	var probe *corev1.Probe
+	if useProxyHealthCheck(pod) {
+		// If using the proxy health check for a service, configure an HTTP handler
+		// that queries the '/ready' endpoint of the proxy.
+		probe = &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(constants.ProxyDefaultHealthPort + mpi.serviceIndex),
+					Path: "/ready",
+				},
 			},
-		},
-		InitialDelaySeconds: 1,
+			InitialDelaySeconds: 1,
+		}
+	} else {
+		probe = &corev1.Probe{
+			Handler: corev1.Handler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(constants.ProxyDefaultInboundPort + mpi.serviceIndex),
+				},
+			},
+			InitialDelaySeconds: 1,
+		}
 	}
 
 	container := corev1.Container{
@@ -89,11 +104,25 @@ func (w *MeshWebhook) consulDataplaneSidecar(namespace corev1.Namespace, pod cor
 		},
 		Args:           args,
 		ReadinessProbe: probe,
-		LivenessProbe:  probe,
 	}
 
 	if w.AuthMethod != "" {
 		container.VolumeMounts = append(container.VolumeMounts, saTokenVolumeMount)
+	}
+
+	if useProxyHealthCheck(pod) {
+		// Configure the Readiness Address for the proxy's health check to be the Pod IP.
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name: "DP_ENVOY_READY_BIND_ADDRESS",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+			},
+		})
+		// Configure the port on which the readiness probe will query the proxy for its health.
+		container.Ports = append(container.Ports, corev1.ContainerPort{
+			Name:          fmt.Sprintf("%s-%d", "proxy-health", mpi.serviceIndex),
+			ContainerPort: int32(constants.ProxyDefaultHealthPort + mpi.serviceIndex),
+		})
 	}
 
 	// Add any extra VolumeMounts.
@@ -204,6 +233,11 @@ func (w *MeshWebhook) getContainerSidecarArgs(namespace corev1.Namespace, mpi mu
 		}
 	} else {
 		args = append(args, "-tls-disabled")
+	}
+
+	// Configure the readiness port on the dataplane sidecar if proxy health checks are enabled.
+	if useProxyHealthCheck(pod) {
+		args = append(args, fmt.Sprintf("%s=%d", "-envoy-ready-bind-port", constants.ProxyDefaultHealthPort+mpi.serviceIndex))
 	}
 
 	if mpi.serviceName != "" {
@@ -382,4 +416,13 @@ func (w *MeshWebhook) sidecarResources(pod corev1.Pod) (corev1.ResourceRequireme
 	}
 
 	return resources, nil
+}
+
+// useProxyHealthCheck returns true if the pod has the annotation 'consul.hashicorp.com/use-proxy-health-check'
+// set to "true".
+func useProxyHealthCheck(pod corev1.Pod) bool {
+	if v, ok := pod.Annotations[constants.AnnotationUseProxyHealthCheck]; ok || v == "true" {
+		return true
+	}
+	return false
 }

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
@@ -419,10 +419,14 @@ func (w *MeshWebhook) sidecarResources(pod corev1.Pod) (corev1.ResourceRequireme
 }
 
 // useProxyHealthCheck returns true if the pod has the annotation 'consul.hashicorp.com/use-proxy-health-check'
-// set to "true".
+// set to truthy values.
 func useProxyHealthCheck(pod corev1.Pod) bool {
-	if v, ok := pod.Annotations[constants.AnnotationUseProxyHealthCheck]; ok || v == "true" {
-		return true
+	if v, ok := pod.Annotations[constants.AnnotationUseProxyHealthCheck]; ok {
+		useProxyHealthCheck, err := strconv.ParseBool(v)
+		if err != nil {
+			return false
+		}
+		return useProxyHealthCheck
 	}
 	return false
 }

--- a/control-plane/connect-inject/webhook/redirect_traffic.go
+++ b/control-plane/connect-inject/webhook/redirect_traffic.go
@@ -52,6 +52,12 @@ func (w *MeshWebhook) iptablesConfigJSON(pod corev1.Pod, ns corev1.Namespace) (s
 		return "", err
 	}
 
+	// Exclude the port on which the proxy health check port will be configured if
+	// using the proxy health check for a service.
+	if useProxyHealthCheck(pod) {
+		cfg.ExcludeInboundPorts = append(cfg.ExcludeInboundPorts, strconv.Itoa(constants.ProxyDefaultHealthPort))
+	}
+
 	if overwriteProbes {
 		for i, container := range pod.Spec.Containers {
 			// skip the "envoy-sidecar" container from having its probes overridden

--- a/control-plane/connect-inject/webhook/redirect_traffic_test.go
+++ b/control-plane/connect-inject/webhook/redirect_traffic_test.go
@@ -73,6 +73,39 @@ func TestAddRedirectTrafficConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "proxy health checks enabled",
+			webhook: MeshWebhook{
+				Log:                   logrtest.TestLogger{T: t},
+				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
+				DenyK8sNamespacesSet:  mapset.NewSet(),
+				decoder:               decoder,
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: defaultNamespace,
+					Name:      defaultPodName,
+					Annotations: map[string]string{
+						constants.AnnotationUseProxyHealthCheck: "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test",
+						},
+					},
+				},
+			},
+			expCfg: iptables.Config{
+				ConsulDNSIP:         "",
+				ProxyUserID:         strconv.Itoa(sidecarUserAndGroupID),
+				ProxyInboundPort:    constants.ProxyDefaultInboundPort,
+				ProxyOutboundPort:   iptables.DefaultTProxyOutboundPort,
+				ExcludeUIDs:         []string{"5996"},
+				ExcludeInboundPorts: []string{"21000"},
+			},
+		},
+		{
 			name: "metrics enabled",
 			webhook: MeshWebhook{
 				Log:                   logrtest.TestLogger{T: t},


### PR DESCRIPTION
Changes proposed in this PR:
- When a service is configured with the correct annotation, a readiness endpoint with be configured in Consul dataplane, and the readiness probe of the sidecar will be configured to use that endpoint to determine the health of the system. Additionally, when t-proxy is enabled, that port shall be in the ExcludeList for inbound connections.

How I've tested this PR:
- By deploying zookeeper with and without this annotation and noticing the absence of the lack of the following exception.
```
EndOfStreamException: Unable to read additional data from client sessionid 0x0, likely client has closed socket
	at org.apache.zookeeper.server.NIOServerCnxn.doIO(NIOServerCnxn.java:239)
	at org.apache.zookeeper.server.NIOServerCnxnFactory.run(NIOServerCnxnFactory.java:203)
	at java.lang.Thread.run(Thread.java:748)
```
- Unit tests
- Zookeeper deployment to test with: https://gist.github.com/thisisnotashwin/e81939e62225e61c37ac5e2e3423a7c8
How I expect reviewers to test this PR:
- Code Review
- Does this require an acceptance test?

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

