### PR TITLE
Use Proxy Healthchecks when configured.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ IMPROVEMENTS:
 * Helm:
   * Add a `global.extraLabels` stanza to allow setting global Kubernetes labels for all components deployed by the `consul-k8s` Helm chart. [[GH-1778](https://github.com/hashicorp/consul-k8s/pull/1778)]
 * Control-Plane
-  * Add support for the annotation `consul.hashicorp.com/use-proxy-health-check`. [[GH-1824](https://github.com/hashicorp/consul-k8s/pull/1824)]
+  * Add support for the annotation `consul.hashicorp.com/use-proxy-health-check`. When this annotation is used by a service, it configures a readiness endpoint on Consul Dataplane and queries it instead of the proxy's inbound port which forwards requests to the application. [[GH-1824](https://github.com/hashicorp/consul-k8s/pull/1824)], [[GH-1843](https://github.com/hashicorp/consul-k8s/pull/1843)]
   * Add health check for synced services based on the status of the Kubernetes readiness probe on synced pod. [[GH-1821](https://github.com/hashicorp/consul-k8s/pull/1821)]
 
 BUG FIXES:

--- a/control-plane/connect-inject/endpoints_controller_test.go
+++ b/control-plane/connect-inject/endpoints_controller_test.go
@@ -1187,6 +1187,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 		expectedProxySvcInstances  []*api.CatalogService
 		expectedAgentHealthChecks  []*api.AgentCheck
 		expErr                     string
+		useProxyHealthChecks       bool
 	}{
 		{
 			name:          "Empty endpoints",
@@ -1216,6 +1217,76 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 			consulSvcName: "service-created",
 			k8sObjects: func() []runtime.Object {
 				pod1 := createPod("pod1", "1.2.3.4", true, true)
+				endpoint := &corev1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "service-created",
+						Namespace: "default",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									IP:       "1.2.3.4",
+									NodeName: &nodeName,
+									TargetRef: &corev1.ObjectReference{
+										Kind:      "Pod",
+										Name:      "pod1",
+										Namespace: "default",
+									},
+								},
+							},
+						},
+					},
+				}
+				return []runtime.Object{pod1, endpoint}
+			},
+			initialConsulSvcs:       []*api.AgentServiceRegistration{},
+			expectedNumSvcInstances: 1,
+			expectedConsulSvcInstances: []*api.CatalogService{
+				{
+					ServiceID:      "pod1-service-created",
+					ServiceName:    "service-created",
+					ServiceAddress: "1.2.3.4",
+					ServicePort:    0,
+					ServiceMeta:    map[string]string{MetaKeyPodName: "pod1", MetaKeyKubeServiceName: "service-created", MetaKeyKubeNS: "default", MetaKeyManagedBy: managedByValue},
+					ServiceTags:    []string{},
+				},
+			},
+			expectedProxySvcInstances: []*api.CatalogService{
+				{
+					ServiceID:      "pod1-service-created-sidecar-proxy",
+					ServiceName:    "service-created-sidecar-proxy",
+					ServiceAddress: "1.2.3.4",
+					ServicePort:    20000,
+					ServiceProxy: &api.AgentServiceConnectProxyConfig{
+						DestinationServiceName: "service-created",
+						DestinationServiceID:   "pod1-service-created",
+						LocalServiceAddress:    "",
+						LocalServicePort:       0,
+					},
+					ServiceMeta: map[string]string{MetaKeyPodName: "pod1", MetaKeyKubeServiceName: "service-created", MetaKeyKubeNS: "default", MetaKeyManagedBy: managedByValue},
+					ServiceTags: []string{},
+				},
+			},
+			expectedAgentHealthChecks: []*api.AgentCheck{
+				{
+					CheckID:     "default/pod1-service-created/kubernetes-health-check",
+					ServiceName: "service-created",
+					ServiceID:   "pod1-service-created",
+					Name:        "Kubernetes Health Check",
+					Status:      api.HealthPassing,
+					Output:      kubernetesSuccessReasonMsg,
+					Type:        ttl,
+				},
+			},
+		},
+		{
+			name:                 "Basic endpoints with proxy healthchecks",
+			useProxyHealthChecks: true,
+			consulSvcName:        "service-created",
+			k8sObjects: func() []runtime.Object {
+				pod1 := createPod("pod1", "1.2.3.4", true, true)
+				pod1.Annotations[annotationUseProxyHealthCheck] = "true"
 				endpoint := &corev1.Endpoints{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-created",
@@ -1810,6 +1881,17 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 				checks := checkInfo.Checks
 				require.Contains(t, expectedChecks, checks[0].Name)
 				require.Contains(t, expectedChecks, checks[1].Name)
+			}
+			agentChecks, err := consulClient.Agent().Checks()
+			require.NoError(t, err)
+			for _, check := range agentChecks {
+				if check.Name == "Proxy Public Listener" {
+					if tt.useProxyHealthChecks {
+						require.Equal(t, "http", check.Type)
+					} else {
+						require.Equal(t, "tcp", check.Type)
+					}
+				}
 			}
 
 			// Check that the Consul health check was created for the k8s pod.

--- a/control-plane/connect-inject/redirect_traffic.go
+++ b/control-plane/connect-inject/redirect_traffic.go
@@ -44,6 +44,12 @@ func (w *MeshWebhook) addRedirectTrafficConfigAnnotation(pod *corev1.Pod, ns cor
 		cfg.ExcludeInboundPorts = append(cfg.ExcludeInboundPorts, prometheusScrapePort)
 	}
 
+	// Exclude the port on which the proxy health check port will be configured if
+	// using the proxy health check for a service.
+	if useProxyHealthCheck(*pod) {
+		cfg.ExcludeInboundPorts = append(cfg.ExcludeInboundPorts, strconv.Itoa(proxyDefaultHealthPort))
+	}
+
 	// Exclude any overwritten liveness/readiness/startup ports from redirection.
 	overwriteProbes, err := shouldOverwriteProbes(*pod, w.TProxyOverwriteProbes)
 	if err != nil {

--- a/control-plane/connect-inject/redirect_traffic_test.go
+++ b/control-plane/connect-inject/redirect_traffic_test.go
@@ -75,6 +75,39 @@ func TestAddRedirectTrafficConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "proxy health checks enabled",
+			webhook: MeshWebhook{
+				Log:                   logrtest.TestLogger{T: t},
+				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
+				DenyK8sNamespacesSet:  mapset.NewSet(),
+				decoder:               decoder,
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: defaultNamespace,
+					Name:      defaultPodName,
+					Annotations: map[string]string{
+						annotationUseProxyHealthCheck: "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test",
+						},
+					},
+				},
+			},
+			expCfg: iptables.Config{
+				ConsulDNSIP:         "",
+				ProxyUserID:         strconv.Itoa(envoyUserAndGroupID),
+				ProxyInboundPort:    proxyDefaultInboundPort,
+				ProxyOutboundPort:   iptables.DefaultTProxyOutboundPort,
+				ExcludeUIDs:         []string{"5996"},
+				ExcludeInboundPorts: []string{"21000"},
+			},
+		},
+		{
 			name: "metrics enabled",
 			webhook: MeshWebhook{
 				Log:                   logrtest.TestLogger{T: t},


### PR DESCRIPTION
This is a semantic backport of #1841 that supports "agentful" consul.

Changes proposed in this PR:
- When a service is configured with the correct annotation, a readiness endpoint with be configured in Consul dataplane, and the readiness probe of the sidecar will be configured to use that endpoint to determine the health of the system. Additionally, when t-proxy is enabled, that port shall be in the ExcludeList for inbound connections.

How I've tested this PR:
- Unit tests
- Zookeeper deployment to test with: https://gist.github.com/thisisnotashwin/e81939e62225e61c37ac5e2e3423a7c8

How I expect reviewers to test this PR:
- Code Review


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

