### PR TITLE
Bump Kubernetes versions to existing +2 for clouds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -573,7 +573,7 @@ jobs:
       - checkout
       - install-prereqs
       - create-kind-clusters:
-          version: "v1.25.3"
+          version: "v1.26.0"
       - restore_cache:
           keys:
             - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
@@ -606,7 +606,7 @@ jobs:
       - checkout
       - install-prereqs
       - create-kind-clusters:
-          version: "v1.25.3"
+          version: "v1.26.0"
       - restore_cache:
           keys:
             - consul-helm-modcache-v2-{{ checksum "acceptance/go.mod" }}
@@ -1261,12 +1261,18 @@ workflows:
           context: consul-ci
           requires:
             - build-distros-linux
-      - acceptance-eks-1-23:
+      - acceptance:
+          context: consul-ci
           requires:
           - dev-upload-docker
-      - acceptance-eks-cni-1-23:
+      - acceptance-tproxy-cni:
+          context: consul-ci
           requires:
-          - acceptance-eks-1-23
+          - dev-upload-docker
+      - acceptance-tproxy:
+          context: consul-ci
+          requires:
+          - dev-upload-docker
 
 
   nightly-cleanup:
@@ -1305,24 +1311,15 @@ workflows:
             - build-distros-linux
       # Disable until we can use UBI images.
       # - acceptance-openshift
-      - acceptance:
-          context: consul-ci
+      - acceptance-gke-1-25:
           requires:
           - dev-upload-docker
-      - acceptance-tproxy-cni:
-          context: consul-ci
+      - acceptance-gke-cni-1-25:
           requires:
-          - dev-upload-docker
+          - acceptance-gke-1-25
       - acceptance-tproxy:
-          context: consul-ci
           requires:
           - dev-upload-docker
-      - acceptance-eks-1-23:
-          requires:
-          - dev-upload-docker
-      - acceptance-eks-cni-1-23:
-          requires:
-          - acceptance-eks-1-23
 
   nightly-acceptance-tests-main:
     description: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -723,7 +723,7 @@ jobs:
   #############################
   # CLOUD ACCEPTANCE TEST JOBS
   #############################
-  acceptance-gke-1-23:
+  acceptance-gke-1-25:
     parallelism: 2
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -773,7 +773,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-pod-security-policies -enable-transparent-proxy -consul-image=hashicorppreview/consul-enterprise:1.15-dev-23aaa4f83845d0e2eced9ea69f731d7eedf840d1
+          additional-flags: -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-transparent-proxy -consul-image=hashicorppreview/consul-enterprise:1.15-dev-23aaa4f83845d0e2eced9ea69f731d7eedf840d1
 
       - store_test_results:
           path: /tmp/test-results
@@ -792,7 +792,7 @@ jobs:
           fail_only: true
           failure_message: "GKE acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-gke-cni-1-23:
+  acceptance-gke-cni-1-25:
     parallelism: 2
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -842,7 +842,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
 
       - run-acceptance-tests:
-          additional-flags: -use-gke -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-pod-security-policies -enable-transparent-proxy -enable-cni -consul-image=hashicorppreview/consul-enterprise:1.15-dev-23aaa4f83845d0e2eced9ea69f731d7eedf840d1
+          additional-flags: -use-gke -kubeconfig="$primary_kubeconfig" -secondary-kubeconfig="$secondary_kubeconfig" -enable-transparent-proxy -enable-cni -consul-image=hashicorppreview/consul-enterprise:1.15-dev-23aaa4f83845d0e2eced9ea69f731d7eedf840d1
 
       - store_test_results:
           path: /tmp/test-results
@@ -861,7 +861,7 @@ jobs:
           fail_only: true
           failure_message: "GKE CNI acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-aks-1-22:
+  acceptance-aks-1-24:
     parallelism: 3
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -918,7 +918,7 @@ jobs:
           fail_only: true
           failure_message: "AKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-aks-cni-1-22:
+  acceptance-aks-cni-1-24:
     parallelism: 3
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -974,7 +974,7 @@ jobs:
           fail_only: true
           failure_message: "AKS CNI acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-eks-1-21:
+  acceptance-eks-1-23:
     parallelism: 3
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -1037,7 +1037,7 @@ jobs:
           fail_only: true
           failure_message: "EKS acceptance tests failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
-  acceptance-eks-cni-1-21:
+  acceptance-eks-cni-1-23:
     parallelism: 3
     environment:
       - TEST_RESULTS: /tmp/test-results
@@ -1273,6 +1273,28 @@ workflows:
           context: consul-ci
           requires:
           - dev-upload-docker
+      - acceptance-gke-1-25:
+          requires:
+          - dev-upload-docker
+      - acceptance-gke-cni-1-25:
+          requires:
+          - acceptance-gke-1-25
+      - acceptance-eks-1-23:
+          requires:
+          - dev-upload-docker
+      - acceptance-eks-cni-1-23:
+          requires:
+          - acceptance-eks-1-23
+      - acceptance-aks-1-24:
+          requires:
+          - dev-upload-docker
+      - acceptance-aks-cni-1-24:
+          requires:
+          - acceptance-aks-1-24
+      - acceptance-tproxy:
+          requires:
+          - dev-upload-docker
+
 
   nightly-cleanup:
     triggers:
@@ -1310,12 +1332,12 @@ workflows:
             - build-distros-linux
       # Disable until we can use UBI images.
       # - acceptance-openshift
-      - acceptance-gke-1-23:
+      - acceptance-gke-1-25:
           requires:
             - dev-upload-docker
-      - acceptance-gke-cni-1-23:
+      - acceptance-gke-cni-1-25:
           requires:
-            - acceptance-gke-1-23
+            - acceptance-gke-1-25
       - acceptance-tproxy:
           requires:
             - dev-upload-docker
@@ -1342,24 +1364,24 @@ workflows:
             - build-distros-linux
       # Disable until we can use UBI images.
       # - acceptance-openshift
-      - acceptance-gke-1-23:
+      - acceptance-gke-1-25:
           requires:
             - dev-upload-docker
-      - acceptance-gke-cni-1-23:
+      - acceptance-gke-cni-1-25:
           requires:
-            - acceptance-gke-1-23
-      - acceptance-eks-1-21:
-          requires:
-            - dev-upload-docker
-      - acceptance-eks-cni-1-21:
-          requires:
-            - acceptance-eks-1-21
-      - acceptance-aks-1-22:
+            - acceptance-gke-1-25
+      - acceptance-eks-1-23:
           requires:
             - dev-upload-docker
-      - acceptance-aks-cni-1-22:
+      - acceptance-eks-cni-1-23:
           requires:
-            - acceptance-aks-1-22
+            - acceptance-eks-1-23
+      - acceptance-aks-1-24:
+          requires:
+            - dev-upload-docker
+      - acceptance-aks-cni-1-24:
+          requires:
+            - acceptance-aks-1-24
       - acceptance-tproxy:
           requires:
             - dev-upload-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1193,7 +1193,7 @@ jobs:
       - slack/status:
           channel: *slack-channel
           fail_only: true
-          failure_message: "Acceptance tests against Kind with Kubernetes v1.23 with Consul 1.12 nightly failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+          failure_message: "Acceptance tests against Kind with Kubernetes v1.25 with Consul 1.12 nightly failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
   acceptance-kind-1-23-consul-compat-nightly-1-13:
     environment:
@@ -1234,7 +1234,7 @@ jobs:
       - slack/status:
           channel: *slack-channel
           fail_only: true
-          failure_message: "Acceptance tests against Kind with Kubernetes v1.23 with Consul 1.13 nightly failed. Check the logs at: ${CIRCLE_BUILD_URL}"
+          failure_message: "Acceptance tests against Kind with Kubernetes v1.25 with Consul 1.13 nightly failed. Check the logs at: ${CIRCLE_BUILD_URL}"
 
 ########################
 # WORKFLOWS
@@ -1261,39 +1261,12 @@ workflows:
           context: consul-ci
           requires:
             - build-distros-linux
-      - acceptance:
-          context: consul-ci
-          requires:
-            - dev-upload-docker
-      - acceptance-tproxy-cni:
-          context: consul-ci
-          requires:
-            - dev-upload-docker
-      - acceptance-tproxy:
-          context: consul-ci
-          requires:
-          - dev-upload-docker
-      - acceptance-gke-1-25:
-          requires:
-          - dev-upload-docker
-      - acceptance-gke-cni-1-25:
-          requires:
-          - acceptance-gke-1-25
       - acceptance-eks-1-23:
           requires:
           - dev-upload-docker
       - acceptance-eks-cni-1-23:
           requires:
           - acceptance-eks-1-23
-      - acceptance-aks-1-24:
-          requires:
-          - dev-upload-docker
-      - acceptance-aks-cni-1-24:
-          requires:
-          - acceptance-aks-1-24
-      - acceptance-tproxy:
-          requires:
-          - dev-upload-docker
 
 
   nightly-cleanup:
@@ -1332,15 +1305,24 @@ workflows:
             - build-distros-linux
       # Disable until we can use UBI images.
       # - acceptance-openshift
-      - acceptance-gke-1-25:
+      - acceptance:
+          context: consul-ci
           requires:
-            - dev-upload-docker
-      - acceptance-gke-cni-1-25:
+          - dev-upload-docker
+      - acceptance-tproxy-cni:
+          context: consul-ci
           requires:
-            - acceptance-gke-1-25
+          - dev-upload-docker
       - acceptance-tproxy:
+          context: consul-ci
           requires:
-            - dev-upload-docker
+          - dev-upload-docker
+      - acceptance-eks-1-23:
+          requires:
+          - dev-upload-docker
+      - acceptance-eks-cni-1-23:
+          requires:
+          - acceptance-eks-1-23
 
   nightly-acceptance-tests-main:
     description: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 IMPROVEMENTS:
 * Helm:
+  * Kubernetes v1.26 is now supported. Minimum tested version of Kubernetes is now v1.23. [[GH-1852](https://github.com/hashicorp/consul-k8s/pull/1852)]
   * Add a `global.extraLabels` stanza to allow setting global Kubernetes labels for all components deployed by the `consul-k8s` Helm chart. [[GH-1778](https://github.com/hashicorp/consul-k8s/pull/1778)]
   * Add the `accessLogs` field to the `ProxyDefaults` CRD. [[GH-1816](https://github.com/hashicorp/consul-k8s/pull/1816)]
   * Add the `envoyExtensions` field to the `ProxyDefaults` and `ServiceDefaults` CRD. [[GH-1823]](https://github.com/hashicorp/consul-k8s/pull/1823)
   * Add the `balanceInboundConnections` field to the `ServiceDefaults` CRD. [[GH-1823]](https://github.com/hashicorp/consul-k8s/pull/1823)
 * Control-Plane
-  * Add support for the annotation `consul.hashicorp.com/use-proxy-health-check`. When this annotation is used by a service, it configures a readiness endpoint on Consul Dataplane and queries it instead of the proxy's inbound port which forwards requests to the application. [[GH-1824](https://github.com/hashicorp/consul-k8s/pull/1824)], [[GH-1841](https://github.com/hashicorp/consul-k8s/pull/1824)]
+  * Add support for the annotation `consul.hashicorp.com/use-proxy-health-check`. When this annotation is used by a service, it configures a readiness endpoint on Consul Dataplane and queries it instead of the proxy's inbound port which forwards requests to the application. [[GH-1824](https://github.com/hashicorp/consul-k8s/pull/1824)], [[GH-1841](https://github.com/hashicorp/consul-k8s/pull/1841)]
   * Add health check for synced services based on the status of the Kubernetes readiness probe on synced pod. [[GH-1821](https://github.com/hashicorp/consul-k8s/pull/1821)]
 
 BUG FIXES:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
 
 The following pre-requisites must be met before installing Consul on Kubernetes. 
 
-  * **Kubernetes 1.22.x - 1.25.x** - This represents the earliest versions of Kubernetes tested.
+  * **Kubernetes 1.23.x - 1.26.x** - This represents the earliest versions of Kubernetes tested.
     It is possible that this chart works with earlier versions, but it is
     untested.
   * Helm install

--- a/charts/consul/README.md
+++ b/charts/consul/README.md
@@ -42,7 +42,7 @@ by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
 
 The following pre-requisites must be met before installing Consul on Kubernetes. 
 
-  * **Kubernetes 1.22.x - 1.25.x** - This represents the earliest versions of Kubernetes tested.
+  * **Kubernetes 1.23.x - 1.26.x** - This represents the earliest versions of Kubernetes tested.
     It is possible that this chart works with earlier versions, but it is
     untested.
   * Helm install

--- a/charts/consul/test/terraform/aks/main.tf
+++ b/charts/consul/test/terraform/aks/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "2.90.0"
+  version = "3.40.0"
   features {}
 }
 
@@ -40,12 +40,13 @@ resource "azurerm_virtual_network_peering" "default" {
 }
 
 resource "azurerm_kubernetes_cluster" "default" {
-  count               = var.cluster_count
-  name                = "consul-k8s-${random_id.suffix[count.index].dec}"
-  location            = azurerm_resource_group.default[count.index].location
-  resource_group_name = azurerm_resource_group.default[count.index].name
-  dns_prefix          = "consul-k8s-${random_id.suffix[count.index].dec}"
-  kubernetes_version  = "1.22.11"
+  count                             = var.cluster_count
+  name                              = "consul-k8s-${random_id.suffix[count.index].dec}"
+  location                          = azurerm_resource_group.default[count.index].location
+  resource_group_name               = azurerm_resource_group.default[count.index].name
+  dns_prefix                        = "consul-k8s-${random_id.suffix[count.index].dec}"
+  kubernetes_version                = "1.24.6"
+  role_based_access_control_enabled = true
 
   // We're setting the network plugin and other network properties explicitly
   // here even though they are the same as defaults to ensure that none of these CIDRs
@@ -75,10 +76,6 @@ resource "azurerm_kubernetes_cluster" "default" {
   service_principal {
     client_id     = var.client_id
     client_secret = var.client_secret
-  }
-
-  role_based_access_control {
-    enabled = true
   }
 
   tags = var.tags

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -60,7 +60,7 @@ module "eks" {
   cluster_name    = "consul-k8s-${random_id.suffix[count.index].dec}"
   cluster_version = "1.23"
   subnets         = module.vpc[count.index].private_subnets
-  enable_irsa     = true
+  enable_irsa = true
 
   vpc_id = module.vpc[count.index].vpc_id
 
@@ -83,7 +83,6 @@ module "eks" {
 
 resource "aws_iam_role" "csi-driver-role" {
   count = var.cluster_count
-  name  = "AmazonEKS_EBS_CSI_DriverRole-${count.index}"
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -3,8 +3,8 @@ provider "aws" {
   region  = var.region
 
   assume_role {
-    role_arn         = var.role_arn
-    duration_seconds = 2700
+    role_arn = var.role_arn
+    duration = "2700s"
   }
 }
 
@@ -58,8 +58,9 @@ module "eks" {
   kubeconfig_api_version = "client.authentication.k8s.io/v1beta1"
 
   cluster_name    = "consul-k8s-${random_id.suffix[count.index].dec}"
-  cluster_version = "1.21"
+  cluster_version = "1.23"
   subnets         = module.vpc[count.index].private_subnets
+  enable_irsa     = true
 
   vpc_id = module.vpc[count.index].vpc_id
 
@@ -78,6 +79,48 @@ module "eks" {
   kubeconfig_output_path = pathexpand("~/.kube/consul-k8s-${random_id.suffix[count.index].dec}")
 
   tags = var.tags
+}
+
+resource "aws_iam_role" "csi-driver-role" {
+  count = var.cluster_count
+  name  = "AmazonEKS_EBS_CSI_DriverRole-${count.index}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Principal = {
+          Federated = module.eks[count.index].oidc_provider_arn
+        },
+        Condition = {
+          StringEquals = {
+            join(":", [trimprefix(module.eks[count.index].cluster_oidc_issuer_url, "https://"), "aud"]) = ["sts.amazonaws.com"],
+            join(":", [trimprefix(module.eks[count.index].cluster_oidc_issuer_url, "https://"), "sub"]) = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"],
+          }
+        }
+      }
+    ]
+  })
+}
+
+data "aws_iam_policy" "csi-driver-policy" {
+  name = "AmazonEBSCSIDriverPolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "csi" {
+  count      = var.cluster_count
+  role       = aws_iam_role.csi-driver-role[count.index].name
+  policy_arn = data.aws_iam_policy.csi-driver-policy.arn
+}
+
+resource "aws_eks_addon" "csi-driver" {
+  count                    = var.cluster_count
+  cluster_name             = module.eks[count.index].cluster_id
+  addon_name               = "aws-ebs-csi-driver"
+  addon_version            = "v1.15.0-eksbuild.1"
+  service_account_role_arn = aws_iam_role.csi-driver-role[count.index].arn
+  resolve_conflicts        = "OVERWRITE"
 }
 
 data "aws_eks_cluster" "cluster" {

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -60,7 +60,7 @@ module "eks" {
   cluster_name    = "consul-k8s-${random_id.suffix[count.index].dec}"
   cluster_version = "1.23"
   subnets         = module.vpc[count.index].private_subnets
-  enable_irsa = true
+  enable_irsa     = true
 
   vpc_id = module.vpc[count.index].vpc_id
 

--- a/charts/consul/test/terraform/gke/main.tf
+++ b/charts/consul/test/terraform/gke/main.tf
@@ -1,4 +1,4 @@
-provider "google-beta" {
+provider "google" {
   project = var.project
   version = "~> 3.49.0"
 }
@@ -14,9 +14,8 @@ data "google_container_engine_versions" "main" {
 }
 
 resource "google_container_cluster" "cluster" {
-  provider = "google-beta"
-
-  count = var.cluster_count
+  provider = "google"
+  count    = var.cluster_count
 
   name               = "consul-k8s-${random_id.suffix[count.index].dec}"
   project            = var.project
@@ -28,10 +27,6 @@ resource "google_container_cluster" "cluster" {
     tags         = ["consul-k8s-${random_id.suffix[count.index].dec}"]
     machine_type = "e2-standard-4"
   }
-  pod_security_policy_config {
-    enabled = false
-  }
-
   resource_labels = var.labels
 }
 

--- a/charts/consul/test/terraform/gke/main.tf
+++ b/charts/consul/test/terraform/gke/main.tf
@@ -10,7 +10,7 @@ resource "random_id" "suffix" {
 
 data "google_container_engine_versions" "main" {
   location       = var.zone
-  version_prefix = "1.23."
+  version_prefix = "1.25."
 }
 
 resource "google_container_cluster" "cluster" {
@@ -29,7 +29,7 @@ resource "google_container_cluster" "cluster" {
     machine_type = "e2-standard-4"
   }
   pod_security_policy_config {
-    enabled = true
+    enabled = false
   }
 
   resource_labels = var.labels


### PR DESCRIPTION
Changes proposed in this PR:
- Bump the version of K8s on the pipelines

How I've tested this PR:
- https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/10356/workflows/21b91c9b-2fd4-4a6e-aeef-bc267bb62b3b for AKS and GKE
- https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/10362/workflows/0c656b2b-44aa-4d13-b346-77181663aec3 for EKS
- https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/10367/workflows/905bd862-0255-488b-bca0-f5d1688f884e latest kind

How I expect reviewers to test this PR:
look at them pipelines and how pretty and green they are and then hit approve 😛 

