### PR TITLE
Add Peer to serviceDefaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ IMPROVEMENTS:
   * Add the `accessLogs` field to the `ProxyDefaults` CRD. [[GH-1816](https://github.com/hashicorp/consul-k8s/pull/1816)]
   * Add the `envoyExtensions` field to the `ProxyDefaults` and `ServiceDefaults` CRD. [[GH-1823]](https://github.com/hashicorp/consul-k8s/pull/1823)
   * Add the `balanceInboundConnections` field to the `ServiceDefaults` CRD. [[GH-1823]](https://github.com/hashicorp/consul-k8s/pull/1823)
+  * Add the `upstreamConfig.overrides[].peer` field to the `ServiceDefaults` CRD. [[GH-1853]](https://github.com/hashicorp/consul-k8s/pull/1853)
 * Control-Plane
   * Add support for the annotation `consul.hashicorp.com/use-proxy-health-check`. When this annotation is used by a service, it configures a readiness endpoint on Consul Dataplane and queries it instead of the proxy's inbound port which forwards requests to the application. [[GH-1824](https://github.com/hashicorp/consul-k8s/pull/1824)], [[GH-1841](https://github.com/hashicorp/consul-k8s/pull/1841)]
   * Add health check for synced services based on the status of the Kubernetes readiness probe on synced pod. [[GH-1821](https://github.com/hashicorp/consul-k8s/pull/1821)]

--- a/charts/consul/templates/crd-servicedefaults.yaml
+++ b/charts/consul/templates/crd-servicedefaults.yaml
@@ -258,15 +258,15 @@ spec:
                             type: string
                         type: object
                       name:
-                        description: Name is only accepted within a service-defaults
+                        description: Name is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
                           config entry.
                         type: string
                       namespace:
-                        description: Namespace is only accepted within a service-defaults
+                        description: Namespace is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
                           config entry.
                         type: string
                       partition:
-                        description: Partition is only accepted within a service-defaults
+                        description: Partition is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
                           config entry.
                         type: string
                       passiveHealthCheck:
@@ -291,6 +291,10 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      peer:
+                        description: Peer is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
+                          config entry.
+                        type: string
                       protocol:
                         description: Protocol describes the upstream's service protocol.
                           Valid values are "tcp", "http" and "grpc". Anything else
@@ -357,15 +361,15 @@ spec:
                               type: string
                           type: object
                         name:
-                          description: Name is only accepted within a service-defaults
+                          description: Name is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
                             config entry.
                           type: string
                         namespace:
-                          description: Namespace is only accepted within a service-defaults
+                          description: Namespace is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
                             config entry.
                           type: string
                         partition:
-                          description: Partition is only accepted within a service-defaults
+                          description: Partition is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
                             config entry.
                           type: string
                         passiveHealthCheck:
@@ -392,6 +396,10 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        peer:
+                          description: Peer is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
+                            config entry.
+                          type: string
                         protocol:
                           description: Protocol describes the upstream's service protocol.
                             Valid values are "tcp", "http" and "grpc". Anything else

--- a/control-plane/config/crd/bases/consul.hashicorp.com_servicedefaults.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_servicedefaults.yaml
@@ -251,15 +251,15 @@ spec:
                             type: string
                         type: object
                       name:
-                        description: Name is only accepted within a service-defaults
+                        description: Name is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
                           config entry.
                         type: string
                       namespace:
-                        description: Namespace is only accepted within a service-defaults
+                        description: Namespace is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
                           config entry.
                         type: string
                       partition:
-                        description: Partition is only accepted within a service-defaults
+                        description: Partition is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
                           config entry.
                         type: string
                       passiveHealthCheck:
@@ -284,6 +284,10 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      peer:
+                        description: Peer is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
+                          config entry.
+                        type: string
                       protocol:
                         description: Protocol describes the upstream's service protocol.
                           Valid values are "tcp", "http" and "grpc". Anything else
@@ -350,15 +354,15 @@ spec:
                               type: string
                           type: object
                         name:
-                          description: Name is only accepted within a service-defaults
+                          description: Name is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
                             config entry.
                           type: string
                         namespace:
-                          description: Namespace is only accepted within a service-defaults
+                          description: Namespace is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
                             config entry.
                           type: string
                         partition:
-                          description: Partition is only accepted within a service-defaults
+                          description: Partition is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
                             config entry.
                           type: string
                         passiveHealthCheck:
@@ -385,6 +389,10 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        peer:
+                          description: Peer is only accepted within service ServiceDefaultsSpec.UpstreamConfig.Overrides
+                            config entry.
+                          type: string
                         protocol:
                           description: Protocol describes the upstream's service protocol.
                             Valid values are "tcp", "http" and "grpc". Anything else

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20220831174802-b8af65262de8
 	github.com/hashicorp/consul-server-connection-manager v0.1.0
-	github.com/hashicorp/consul/api v1.10.1-0.20230106171340-8d923c178919
+	github.com/hashicorp/consul/api v1.10.1-0.20230203155153-2f149d60ccbf
 	github.com/hashicorp/consul/sdk v0.13.0
 	github.com/hashicorp/go-discover v0.0.0-20200812215701-c4b85f6ed31f
 	github.com/hashicorp/go-hclog v1.2.2

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -348,6 +348,10 @@ github.com/hashicorp/consul-server-connection-manager v0.1.0/go.mod h1:XVVlO+Yk7
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.10.1-0.20230106171340-8d923c178919 h1:8aVegJMSv7PIAAa1zqQQ0CT4TKv+Nf7I4rhE6+uDa1U=
 github.com/hashicorp/consul/api v1.10.1-0.20230106171340-8d923c178919/go.mod h1:c1u8FzGHcavbEtRW/p1YditvfMgn4QsKNgz2rnCDF7c=
+github.com/hashicorp/consul/api v1.10.1-0.20230126204442-a43eadd1225b h1:dNIQYhru10Hg+E1oEL8f9CX6MC+8CW5JuQ4jk3g70LA=
+github.com/hashicorp/consul/api v1.10.1-0.20230126204442-a43eadd1225b/go.mod h1:c1u8FzGHcavbEtRW/p1YditvfMgn4QsKNgz2rnCDF7c=
+github.com/hashicorp/consul/api v1.10.1-0.20230203155153-2f149d60ccbf h1:vvsHghmX3LyNUaDe7onYKHyDiny+ystdHKIEujbNj4Q=
+github.com/hashicorp/consul/api v1.10.1-0.20230203155153-2f149d60ccbf/go.mod h1:c1u8FzGHcavbEtRW/p1YditvfMgn4QsKNgz2rnCDF7c=
 github.com/hashicorp/consul/proto-public v0.1.0 h1:O0LSmCqydZi363hsqc6n2v5sMz3usQMXZF6ziK3SzXU=
 github.com/hashicorp/consul/proto-public v0.1.0/go.mod h1:vs2KkuWwtjkIgA5ezp4YKPzQp4GitV+q/+PvksrA92k=
 github.com/hashicorp/consul/sdk v0.4.1-0.20221021205723-cc843c4be892 h1:jw0NwPmNPr5CxAU04hACdj61JSaJBKZ0FdBo+kwfNp4=

--- a/hack/copy-crds-to-chart/main.go
+++ b/hack/copy-crds-to-chart/main.go
@@ -9,6 +9,14 @@ import (
 	"strings"
 )
 
+var (
+	// HACK IT!
+	requiresPeering = map[string]struct{}{
+		"consul.hashicorp.com_peeringacceptors.yaml": {},
+		"consul.hashicorp.com_peeringdialers.yaml":   {},
+	}
+)
+
 func main() {
 	if len(os.Args) != 1 {
 		fmt.Println("Usage: go run ./...")
@@ -43,8 +51,13 @@ func realMain(helmPath string) error {
 		// Strip leading newline.
 		contents = strings.TrimPrefix(contents, "\n")
 
-		// Add {{- if .Values.connectInject.enabled }} {{- end }} wrapper.
-		contents = fmt.Sprintf("{{- if .Values.connectInject.enabled }}\n%s{{- end }}\n", contents)
+		if _, ok := requiresPeering[info.Name()]; ok {
+			// Add {{- if and .Values.connectInject.enabled .Values.global.peering.enabled  }} {{- end }} wrapper.
+			contents = fmt.Sprintf("{{- if and .Values.connectInject.enabled .Values.global.peering.enabled }}\n%s{{- end }}\n", contents)
+		} else {
+			// Add {{- if .Values.connectInject.enabled }} {{- end }} wrapper.
+			contents = fmt.Sprintf("{{- if .Values.connectInject.enabled }}\n%s{{- end }}\n", contents)
+		}
 
 		// Add labels, this is hacky because we're relying on the line number
 		// but it means we don't need to regex or yaml parse.


### PR DESCRIPTION
Changes proposed in this PR:
- Adds a new `Peer` field to serviceDefaults.upstreamConig.Overrides that disambiguates overrides for local vs. peered services. 
- Fixes CRD generation for peeringDialer and peeringAcceptor

How I've tested this PR:
Unit tests.

How I expect reviewers to test this PR:
👁️ 👄 👁️ 

Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added 


