### PR TITLE
Pre-release 0.49.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## UNRELEASED
+## 0.49.3 (January 30, 2023)
 
 IMPROVEMENTS:
 * Helm:

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: consul
-version: 0.49.3-dev
-appVersion: 1.13.4
+version: 0.49.3
+appVersion: 1.13.6
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
@@ -10,12 +10,12 @@ sources:
   - https://github.com/hashicorp/consul
   - https://github.com/hashicorp/consul-k8s
 annotations:
-  artifacthub.io/prerelease: true
+  artifacthub.io/prerelease: false
   artifacthub.io/images: |
     - name: consul
-      image: hashicorp/consul:1.13.4
+      image: hashicorp/consul:1.13.6
     - name: consul-k8s-control-plane
-      image: hashicorp/consul-k8s-control-plane:0.49.3-dev
+      image: hashicorp/consul-k8s-control-plane:0.49.3
     - name: envoy
       image: envoyproxy/envoy:v1.23.1
   artifacthub.io/license: MPL-2.0

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -109,7 +109,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.10.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: "hashicorp/consul:1.13.4"
+  image: "hashicorp/consul:1.13.6"
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.
@@ -129,7 +129,7 @@ global:
   # image that is used for functionality such as catalog sync.
   # This can be overridden per component.
   # @default: hashicorp/consul-k8s-control-plane:<latest version>
-  imageK8S: hashicorp/consul-k8s-control-plane:0.49.3-dev
+  imageK8S: hashicorp/consul-k8s-control-plane:0.49.3
 
   # The name of the datacenter that the agents should
   # register as. This can't be changed once the Consul cluster is up and running

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -19,7 +19,7 @@ var (
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable

--- a/control-plane/version/version.go
+++ b/control-plane/version/version.go
@@ -19,7 +19,7 @@ var (
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
Changes proposed in this PR:
- I checked the backports to make sure they line up with the CHANGELOG entries and they do 👍 
- Update version to 0.49.3 in go and and chart.
- Set the consul version to 1.13.6 (released Jan 27th)
- Update CHANGELOG to tomorrows date as the release.
- Note: no update to envoy version in this one.

How I've tested this PR:

:eyes:

How I expect reviewers to test this PR:

:eyes:

Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

