### PR TITLE
DRAFT: Reset log levels per pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ IMPROVEMENTS:
   * Add support for the annotation `consul.hashicorp.com/use-proxy-health-check`. When this annotation is used by a service, it configures a readiness endpoint on Consul Dataplane and queries it instead of the proxy's inbound port which forwards requests to the application. [[GH-1824](https://github.com/hashicorp/consul-k8s/pull/1824)], [[GH-1841](https://github.com/hashicorp/consul-k8s/pull/1841)]
   * Add health check for synced services based on the status of the Kubernetes readiness probe on synced pod. [[GH-1821](https://github.com/hashicorp/consul-k8s/pull/1821)]
   * Remove extraneous `gnupg` dependency from `consul-k8s-control-plane` since it is no longer needed for validating binary artifacts prior to release. [[GH-1882](https://github.com/hashicorp/consul-k8s/pull/1882)]
+* CLI:
+  * Add `consul-k8s proxy log podname` command for displaying and modifying Envoy log levels for a given Pod. [GH-1844](https://github.com/hashicorp/consul-k8s/pull/1844), [GH-1849](https://github.com/hashicorp/consul-k8s/pull/1849), [GH-1864](https://github.com/hashicorp/consul-k8s/pull/1864)
+
 
 BUG FIXES:
 * Control Plane

--- a/cli/common/envoy/http_test.go
+++ b/cli/common/envoy/http_test.go
@@ -527,8 +527,8 @@ func (m *mockPortForwarder) Open(ctx context.Context) (string, error) { return m
 func (m *mockPortForwarder) Close()                                   {}
 
 func testLogConfig() map[string]string {
-	cfg := make(map[string]string, len(envoyLoggers))
-	for k := range envoyLoggers {
+	cfg := make(map[string]string, len(EnvoyLoggers))
+	for k := range EnvoyLoggers {
 		cfg[k] = "debug"
 	}
 	return cfg

--- a/cli/common/envoy/logger_params.go
+++ b/cli/common/envoy/logger_params.go
@@ -56,7 +56,7 @@ func validateLogLevel(level string) error {
 }
 
 func validateLoggerName(name string) error {
-	if _, ok := envoyLoggers[name]; !ok {
+	if _, ok := EnvoyLoggers[name]; !ok {
 		loggers := []string{}
 		for loggerName := range envoyLevels {
 			loggers = append(loggers, loggerName)
@@ -105,7 +105,7 @@ var envoyLevels = map[string]struct{}{
 	"off":      {},
 }
 
-var envoyLoggers = map[string]struct{}{
+var EnvoyLoggers = map[string]struct{}{
 	"admin":                     {},
 	"alternate_protocols_cache": {},
 	"aws":                       {},


### PR DESCRIPTION
Changes proposed in this PR:
- Allow users to reset log levels for envoy in a given pod to the envoy default of "info", (docs on default level: https://www.envoyproxy.io/docs/envoy/latest/start/quick-start/run-envoy#debugging-envoy) 
-

How I've tested this PR:
* Unit tests
* ran consul on k8's locally using kind https://gist.github.com/jm96441n/a56cd2ebd53f4484c3b40e725e305372
     * create a cluster using kind: `kind create cluster`
     * install consul on that cluster using the `consul-values.yml` file in the above gist: `consul-k8s install -config-file=consul-values.yaml -set global.image=hashicorp/consul:1.14.3`
     * once that is up apply the `server.yaml` to your cluster `kubectl apply server.yaml`
     * once that is setup get one of the server pod names using `kubectl get pods`
     * in another terminal window set up port forwarding for that pod `kubectl port-forward <POD_NAME> 19000:19000` (where `19000` is the default admin port for the envoy proxy)
     * in the original terminal run `consul-k8s proxy log <POD_NAME> -l warning` and then `consul-k8s proxy log <POD_NAME> -level grpc:error,kafka:critical,testing:off,admin:debug` to set all loggers to warning, and then modify a few others to different levels
     * then run `consul-k8s proxy log <POD_NAME> -r` to reset the levels and observe that all are set to `info`

How I expect reviewers to test this PR:
* code review
* can run the above steps to recreate


Checklist:
- [X] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

