### PR TITLE
Exclude openebs namespace from injection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## UNRELEASED
 
+BREAKING CHANGES:
+* Helm:
+  * Change defaults to exclude the `openebs` namespace from sidecar injection. If you previously had pods in that namespace
+    that you wanted to be injected, you must now set `namespaceSelector` as follows:
+  
+    ```yaml
+    connectInject:
+      namespaceSelector: |
+        matchExpressions:
+        - key: "kubernetes.io/metadata.name"
+          operator: "NotIn"
+          values: ["kube-system","local-path-storage"]
+    ```
+    [[GH-1869](https://github.com/hashicorp/consul-k8s/pull/1869)]
+
 IMPROVEMENTS:
 * Helm:
   * Kubernetes v1.26 is now supported. Minimum tested version of Kubernetes is now v1.23. [[GH-1852](https://github.com/hashicorp/consul-k8s/pull/1852)]

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2140,9 +2140,9 @@ connectInject:
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
   # for more details.
   #
-  # By default, we exclude the kube-system namespace since usually users won't
-  # want those pods injected and also the local-path-storage namespace so that
-  # Kind (Kubernetes In Docker) can provision Pods used to create PVCs.
+  # By default, we exclude kube-system since usually users won't
+  # want those pods injected and local-path-storage and openebs so that
+  # Kind (Kubernetes In Docker) and OpenEBS (https://openebs.io/) respectively can provision Pods used to create PVCs.
   # Note that this exclusion is only supported in Kubernetes v1.21.1+.
   #
   # Example:
@@ -2157,7 +2157,7 @@ connectInject:
     matchExpressions:
       - key: "kubernetes.io/metadata.name"
         operator: "NotIn"
-        values: ["kube-system","local-path-storage"]
+        values: ["kube-system","local-path-storage","openebs"]
 
   # List of k8s namespaces to allow Connect sidecar
   # injection in. If a k8s namespace is not included or is listed in `k8sDenyNamespaces`,


### PR DESCRIPTION
OpenEBS is a Kubernetes storage solution. When you spin up a PVC, under the hood OpenEBS creates a pod to handle the necessary storage operations. If the openebs namespace is not excluded from injection, that pod can't start because our mutatingwebhook config requires all pod scheduling requests make it to our webhook and our webhook isn't running yet because the consul servers aren't running.

This is a breaking change but I think it's worth it because it's very unlikely anyone is using the openebs namespace for anything other than openebs.

Fixes https://github.com/hashicorp/consul-k8s/issues/1867

Checklist:
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

