### PR TITLE
Refine server TLS Vault PKI role config in acceptance tests

### DIFF
--- a/acceptance/framework/vault/helpers.go
+++ b/acceptance/framework/vault/helpers.go
@@ -40,7 +40,6 @@ func ConfigurePKICerts(t *testing.T,
 		"allow_bare_domains": "true",
 		"allow_localhost":    "true",
 		"allow_subdomains":   "true",
-		"generate_lease":     "true",
 		"max_ttl":            maxTTL,
 	}
 


### PR DESCRIPTION
The generate_lease=true configuration is unnecessary and generates a note about performance implications in Vault logs. Remove this configuration from the acceptance tests so that the default value of generate_lease=false is used instead.

A follow on PR will update the public Consul docs to reflect this change in recommendation.

How I've tested this PR:
- I'm relying on the existing k8s acceptance tests to ensure the integration still works

Checklist:
- [ ] Tests added: No - relying on existing tests
- [ ] CHANGELOG entry added: Seems unnecessary since this only affects the acceptance tests, not consul k8s itself

