### PR TITLE
Dockerfile: Remove gnupg from Consul k8s container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ IMPROVEMENTS:
 * Control-Plane
   * Add support for the annotation `consul.hashicorp.com/use-proxy-health-check`. When this annotation is used by a service, it configures a readiness endpoint on Consul Dataplane and queries it instead of the proxy's inbound port which forwards requests to the application. [[GH-1824](https://github.com/hashicorp/consul-k8s/pull/1824)], [[GH-1841](https://github.com/hashicorp/consul-k8s/pull/1841)]
   * Add health check for synced services based on the status of the Kubernetes readiness probe on synced pod. [[GH-1821](https://github.com/hashicorp/consul-k8s/pull/1821)]
-  * Remove extraneous `gnupg` depdency from `consul-k8s-control-plane` as is no longer needed for validating binary artifacts prior to release. [[GH-1882](https://github.com/hashicorp/consul-k8s/pull/1882)]
+  * Remove extraneous `gnupg` depdency from `consul-k8s-control-plane` since it is no longer needed for validating binary artifacts prior to release. [[GH-1882](https://github.com/hashicorp/consul-k8s/pull/1882)]
 
 BUG FIXES:
 * Control Plane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ IMPROVEMENTS:
 * Control-Plane
   * Add support for the annotation `consul.hashicorp.com/use-proxy-health-check`. When this annotation is used by a service, it configures a readiness endpoint on Consul Dataplane and queries it instead of the proxy's inbound port which forwards requests to the application. [[GH-1824](https://github.com/hashicorp/consul-k8s/pull/1824)], [[GH-1841](https://github.com/hashicorp/consul-k8s/pull/1841)]
   * Add health check for synced services based on the status of the Kubernetes readiness probe on synced pod. [[GH-1821](https://github.com/hashicorp/consul-k8s/pull/1821)]
+  * Remove extraneous `gnupg` depdency from `consul-k8s-control-plane` as is no longer needed for validating binary artifacts prior to release. [[GH-1882](https://github.com/hashicorp/consul-k8s/pull/1882)]
 
 BUG FIXES:
 * Control Plane

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -89,7 +89,7 @@ LABEL name=${BIN_NAME} \
 ENV BIN_NAME=${BIN_NAME}
 ENV VERSION=${PRODUCT_VERSION}
 
-RUN apk add --no-cache ca-certificates gnupg libcap openssl su-exec iputils libc6-compat iptables
+RUN apk add --no-cache ca-certificates libcap openssl su-exec iputils libc6-compat iptables
 
 # TARGETOS and TARGETARCH are set automatically when --platform is provided.
 ARG TARGETOS
@@ -152,7 +152,7 @@ ARG TARGETARCH
 # Copy license for Red Hat certification.
 COPY LICENSE /licenses/mozilla.txt
 
-RUN microdnf install -y ca-certificates gnupg libcap openssl shadow-utils iptables
+RUN microdnf install -y ca-certificates libcap openssl shadow-utils iptables
 
 # Create a non-root user to run the software. On OpenShift, this
 # will not matter since the container is run as a random user and group


### PR DESCRIPTION
Changes proposed in this PR:
- `gnupg` is likely an artifact from pre-CRT days when we used to validate Consul K8s releases ourselves for publishing with Docker. This is is likely not needed so will attempt removing it. 

How I've tested this PR:
- Acceptance tests

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

