### PR TITLE
server-acl-init to always check for the deployed serviceAccountToken secret (#1770)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ BUG FIXES:
 IMPROVEMENTS:
 * Helm:
   * CNI: Add `connectInject.cni.namespace` stanza which allows the CNI plugin resources to be deployed in a namespace other than the namespace that Consul is installed. [[GH-1756](https://github.com/hashicorp/consul-k8s/pull/1756)]
+* Control Plane:
+  * Server ACL Init always appends both, the secrets from the serviceAccount's secretRefs and the one created by the Helm chart, to support Openshift secret handling. [[GH-1770](https://github.com/hashicorp/consul-k8s/pull/1770)]
 
 BUG FIXES:
 * Helm:

--- a/control-plane/subcommand/server-acl-init/connect_inject.go
+++ b/control-plane/subcommand/server-acl-init/connect_inject.go
@@ -96,16 +96,13 @@ func (c *Command) createAuthMethodTmpl(authMethodName string, useNS bool) (api.A
 
 	var saSecret *apiv1.Secret
 	var secretNames []string
-	if len(authMethodServiceAccount.Secrets) == 0 {
-		// In Kube 1.24+ there is no automatically generated long term JWT token for a ServiceAccount.
-		// Furthermore, there is no reference to a Secret in the ServiceAccount. Instead we have deployed
-		// a Secret in Helm which references the ServiceAccount and contains a permanent JWT token.
-		secretNames = append(secretNames, c.withPrefix("auth-method"))
-	} else {
-		// ServiceAccounts always have a SecretRef in Kubernetes < 1.24. The Secret contains the JWT token.
-		for _, secretRef := range authMethodServiceAccount.Secrets {
-			secretNames = append(secretNames, secretRef.Name)
-		}
+	// In Kube 1.24+ there is no automatically generated long term JWT token for a ServiceAccount.
+	// Furthermore, there is no reference to a Secret in the ServiceAccount. Instead we have deployed
+	// a Secret in Helm which references the ServiceAccount and contains a permanent JWT token.
+	secretNames = append(secretNames, c.withPrefix("auth-method"))
+	// ServiceAccounts always have a SecretRef in Kubernetes < 1.24. The Secret contains the JWT token.
+	for _, secretRef := range authMethodServiceAccount.Secrets {
+		secretNames = append(secretNames, secretRef.Name)
 	}
 	// Because there could be multiple secrets attached to the service account,
 	// we need pick the first one of type corev1.SecretTypeServiceAccountToken.

--- a/control-plane/subcommand/server-acl-init/connect_inject_test.go
+++ b/control-plane/subcommand/server-acl-init/connect_inject_test.go
@@ -30,6 +30,20 @@ func TestCommand_createAuthMethodTmpl_SecretNotFound(t *testing.T) {
 		ctx:                ctx,
 	}
 
+	// create the auth method secret since it is always deployed by helm chart.
+	authMethodSecretName := resourcePrefix + "-auth-method"
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   authMethodSecretName,
+			Labels: map[string]string{common.CLILabelKey: common.CLILabelValue},
+		},
+		Data: map[string][]byte{},
+		// Make it not a service-account-token so the test can pass through to checking the other secrets.
+		Type: v1.SecretTypeOpaque,
+	}
+	_, err := k8s.CoreV1().Secrets(ns).Create(ctx, secret, metav1.CreateOptions{})
+	require.NoError(t, err)
+
 	serviceAccountName := resourcePrefix + "-auth-method"
 	secretName := resourcePrefix + "-connect-injector"
 
@@ -53,7 +67,7 @@ func TestCommand_createAuthMethodTmpl_SecretNotFound(t *testing.T) {
 	}
 
 	// Create a secret of non service-account-token type (we're using the opaque type).
-	secret := &v1.Secret{
+	secret = &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   secretName,
 			Labels: map[string]string{common.CLILabelKey: common.CLILabelValue},
@@ -61,7 +75,7 @@ func TestCommand_createAuthMethodTmpl_SecretNotFound(t *testing.T) {
 		Data: map[string][]byte{},
 		Type: v1.SecretTypeOpaque,
 	}
-	_, err := k8s.CoreV1().Secrets(ns).Create(ctx, secret, metav1.CreateOptions{})
+	_, err = k8s.CoreV1().Secrets(ns).Create(ctx, secret, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	_, err = cmd.createAuthMethodTmpl("test", true)


### PR DESCRIPTION
backport of #1770 
