### PR TITLE
Enable envoy bootstrap config logging if global.logLevel == debug

### DIFF
--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -388,6 +388,9 @@ spec:
             {{- if $root.Values.global.adminPartitions.enabled }}
             - -partition={{ $root.Values.global.adminPartitions.name }}
             {{- end }}
+            {{- if (eq $root.Values.global.logLevel "debug")}}
+            - -enable-config-gen-logging
+            {{- end }}
           livenessProbe:
             tcpSocket:
               port: 21000

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -333,6 +333,9 @@ spec:
             {{- if .Values.global.adminPartitions.enabled }}
             - -partition={{ .Values.global.adminPartitions.name }}
             {{- end }}
+            {{- if eq .Values.global.logLevel "debug"}}
+            - -enable-config-gen-logging
+            {{- end }}
           livenessProbe:
             tcpSocket:
               port: {{ .Values.meshGateway.containerPort }}

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -343,6 +343,9 @@ spec:
             {{- if $root.Values.global.adminPartitions.enabled }}
             - -partition={{ $root.Values.global.adminPartitions.name }}
             {{- end }}
+            {{- if (eq $root.Values.global.logLevel "debug")}}
+            - -enable-config-gen-logging
+            {{- end }}
           livenessProbe:
             tcpSocket:
               port: 8443

--- a/charts/consul/test/unit/ingress-gateways-deployment.bats
+++ b/charts/consul/test/unit/ingress-gateways-deployment.bats
@@ -1662,6 +1662,36 @@ EOF
 }
 
 #--------------------------------------------------------------------
+# envoy bootstrap logging
+
+@test "ingressGateways/Deployment: envoy bootstrap logging is not present by default" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.command | any(contains("-enable-config-gen-logging"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "ingressGateways/Deployment: envoy bootstrap logging flag is present if global.logLevel == debug" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.logLevel=debug' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.command | any(contains("-enable-config-gen-logging"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # multiple gateways
 
 @test "ingressGateways/Deployment: multiple gateways" {

--- a/charts/consul/test/unit/mesh-gateway-deployment.bats
+++ b/charts/consul/test/unit/mesh-gateway-deployment.bats
@@ -1789,6 +1789,35 @@ EOF
 }
 
 #--------------------------------------------------------------------
+# envoy bootstrap logging
+
+@test "meshGateway/Deployment: envoy bootstrap logging is not present by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-config-gen-logging"))' | tee /dev/stderr)
+
+  [ "${actual}" = "false" ]
+}
+
+@test "meshGateway/Deployment: envoy bootstrap logging flag is present if global.logLevel == debug" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.logLevel=debug' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-config-gen-logging"))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+
+#--------------------------------------------------------------------
 # get-auto-encrypt-client-ca
 
 @test "meshGateway/Deployment: get-auto-encrypt-client-ca uses server's stateful set address by default and passes ca cert" {

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -1476,6 +1476,36 @@ EOF
 }
 
 #--------------------------------------------------------------------
+# envoy bootstrap logging
+
+@test "terminatingGateways/Deployment: envoy bootstrap logging is not present by default" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.command | any(contains("-enable-config-gen-logging"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "terminatingGateways/Deployment: envoy bootstrap logging flag is present if global.logLevel == debug" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.logLevel=debug' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.spec.containers[0]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.command | any(contains("-enable-config-gen-logging"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # multiple gateways
 
 @test "terminatingGateways/Deployment: multiple gateways" {

--- a/control-plane/connect-inject/container_init_test.go
+++ b/control-plane/connect-inject/container_init_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -160,6 +161,24 @@ consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD
   -prometheus-ca-path="/certs/ca/" \
   -prometheus-cert-file="/certs/server.crt" \
   -prometheus-key-file="/certs/key.pem" \
+  -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`,
+			"",
+			"",
+		},
+		{
+			"When logLevel is debug, enable logging for Envoy bootstrap config generation",
+			func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[annotationService] = "web"
+				return pod
+			},
+			MeshWebhook{
+				ConsulAPITimeout: 5 * time.Second,
+				LogLevel:         zapcore.DebugLevel.String(),
+			},
+			`# Generate the envoy bootstrap code
+/consul/connect-inject/consul connect envoy \
+  -proxy-id="$(cat /consul/connect-inject/proxyid)" \
+  -enable-config-gen-logging \
   -bootstrap > /consul/connect-inject/envoy-bootstrap.yaml`,
 			"",
 			"",


### PR DESCRIPTION
Changes proposed in this PR:
- Enable the Envoy bootstrap config logging flag added in https://github.com/hashicorp/consul/pull/15988 when `global.logLevel` is `debug`.

How I've tested this PR:
Unit tests

How I expect reviewers to test this PR:
CI/Unit tests

Checklist:
- [x] Tests added
- [ ] ~CHANGELOG entry added~
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

