### PR TITLE
updated golangci-lint-action to latest

### DIFF
--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -22,13 +22,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ inputs.go-version }}
      
       - name: golangci-lint-${{inputs.directory}}
-        uses: golangci/golangci-lint-action@v3.2.0
+        uses: golangci/golangci-lint-action@v3.4.0
         with:
-          version: v1.46.2
+          version: v1.51
           working-directory: ${{inputs.directory}}
           args: ${{inputs.args}}


### PR DESCRIPTION
Changes proposed in this PR:
- updates golangci-lint-action to latest to support go 1.20+

How I've tested this PR:
👀
How I expect reviewers to test this PR:
👀
Checklist:
- [N/A] Tests added
- [N/A] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

