### PR TITLE
[0.49.x] remove livenessProbe from pods with preStop lifecycle hooks that delete ACL tokens

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
   golangci-lint-helm-gen:
    needs:
     - get-go-version
-   uses: ./.github/workflows/golangci-lint
+   uses: ./.github/workflows/reusable-golangci-lint.yml
    with:
       directory: hack/helm-reference-gen
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -64,7 +64,7 @@ jobs:
 
   unit-helm-gen:
     needs: [get-go-version, golangci-lint-helm-gen, validate-helm-gen]
-    uses: ./.github/workflows/reusable-unit
+    uses: ./.github/workflows/reusable-unit.yml
     with:
       directory: hack/helm-reference-gen
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -106,7 +106,7 @@ jobs:
   golangci-lint-control-plane:
     needs:
       - get-go-version
-    uses: ./.github/workflows/golangci-lint
+    uses: ./.github/workflows/reusable-golangci-lint.yml
     with:
       directory: control-plane
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -245,14 +245,14 @@ jobs:
   golangci-lint-acceptance:
     needs:
       - get-go-version
-    uses: ./.github/workflows/golangci-lint
+    uses: ./.github/workflows/reusable-golangci-lint.yml
     with:
       directory:  acceptance 
       go-version: ${{ needs.get-go-version.outputs.go-version }} 
 
   unit-acceptance-framework:
     needs: [get-go-version, golangci-lint-acceptance]
-    uses: ./.github/workflows/reusable-unit
+    uses: ./.github/workflows/reusable-unit.yml
     with:
       directory: acceptance/framework
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -260,14 +260,14 @@ jobs:
   golangci-lint-cli:
     needs:
       - get-go-version
-    uses: ./.github/workflows/golangci-lint
+    uses: ./.github/workflows/reusable-golangci-lint.yml
     with:
       directory: cli 
       go-version: ${{ needs.get-go-version.outputs.go-version }}
 
   unit-cli:
     needs: [get-go-version, golangci-lint-cli]
-    uses: ./.github/workflows/reusable-unit
+    uses: ./.github/workflows/reusable-unit.yml
     with:
       directory: cli 
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -302,7 +302,7 @@ jobs:
 #  acceptance-tproxy:
 #    needs: [get-go-version, unit-cli, dev-upload-docker, unit-acceptance-framework, unit-test-helm-templates]
 #    needs: dev-upload-docker
-#    uses: ./.github/workflows/reusable-acceptance
+#    uses: ./.github/workflows/reusable-acceptance.yml
 #    with:
 #      name: acceptance-tproxy
 #      directory: acceptance/tests
@@ -315,7 +315,7 @@ jobs:
 #  acceptance:
 #    #needs: [get-go-version, unit-cli, dev-upload-docker, unit-acceptance-framework, unit-test-helm-templates]
 #    needs: dev-upload-docker
-#    uses: ./.github/workflows/reusable-acceptance
+#    uses: ./.github/workflows/reusable-acceptance.yml
 #    with:
 #      name: acceptance
 #      directory: acceptance/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
   golangci-lint-helm-gen:
    needs:
     - get-go-version
-   uses: hashicorp/consul-k8s/.github/workflows/reusable-golangci-lint.yml
+   uses: ./reusable-golangci-lint.yml
    with:
       directory: hack/helm-reference-gen
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -64,7 +64,7 @@ jobs:
 
   unit-helm-gen:
     needs: [get-go-version, golangci-lint-helm-gen, validate-helm-gen]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-unit.yml
+    uses: ./reusable-unit.yml
     with:
       directory: hack/helm-reference-gen
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -106,7 +106,7 @@ jobs:
   golangci-lint-control-plane:
     needs:
       - get-go-version
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-golangci-lint.yml
+    uses: ./reusable-golangci-lint.yml
     with:
       directory: control-plane
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -245,14 +245,14 @@ jobs:
   golangci-lint-acceptance:
     needs:
       - get-go-version
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-golangci-lint.yml
+    uses: ./reusable-golangci-lint.yml
     with:
       directory:  acceptance 
       go-version: ${{ needs.get-go-version.outputs.go-version }} 
 
   unit-acceptance-framework:
     needs: [get-go-version, golangci-lint-acceptance]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-unit.yml
+    uses: ./reusable-unit.yml
     with:
       directory: acceptance/framework
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -260,14 +260,14 @@ jobs:
   golangci-lint-cli:
     needs:
       - get-go-version
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-golangci-lint.yml
+    uses: ./reusable-golangci-lint.yml
     with:
       directory: cli 
       go-version: ${{ needs.get-go-version.outputs.go-version }}
 
   unit-cli:
     needs: [get-go-version, golangci-lint-cli]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-unit.yml
+    uses: ./reusable-unit.yml
     with:
       directory: cli 
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -302,7 +302,7 @@ jobs:
 #  acceptance-tproxy:
 #    needs: [get-go-version, unit-cli, dev-upload-docker, unit-acceptance-framework, unit-test-helm-templates]
 #    needs: dev-upload-docker
-#    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml
+#    uses: ./reusable-acceptance.yml
 #    with:
 #      name: acceptance-tproxy
 #      directory: acceptance/tests
@@ -315,7 +315,7 @@ jobs:
 #  acceptance:
 #    #needs: [get-go-version, unit-cli, dev-upload-docker, unit-acceptance-framework, unit-test-helm-templates]
 #    needs: dev-upload-docker
-#    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml
+#    uses: ./reusable-acceptance.yml
 #    with:
 #      name: acceptance
 #      directory: acceptance/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
   golangci-lint-helm-gen:
    needs:
     - get-go-version
-   uses: hashicorp/consul-k8s/.github/workflows/reusable-golangci-lint.yml@main
+   uses: hashicorp/consul-k8s/.github/workflows/reusable-golangci-lint.yml
    with:
       directory: hack/helm-reference-gen
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -64,7 +64,7 @@ jobs:
 
   unit-helm-gen:
     needs: [get-go-version, golangci-lint-helm-gen, validate-helm-gen]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-unit.yml@main
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-unit.yml
     with:
       directory: hack/helm-reference-gen
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -106,7 +106,7 @@ jobs:
   golangci-lint-control-plane:
     needs:
       - get-go-version
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-golangci-lint.yml@main
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-golangci-lint.yml
     with:
       directory: control-plane
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -245,14 +245,14 @@ jobs:
   golangci-lint-acceptance:
     needs:
       - get-go-version
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-golangci-lint.yml@main
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-golangci-lint.yml
     with:
       directory:  acceptance 
       go-version: ${{ needs.get-go-version.outputs.go-version }} 
 
   unit-acceptance-framework:
     needs: [get-go-version, golangci-lint-acceptance]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-unit.yml@main
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-unit.yml
     with:
       directory: acceptance/framework
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -260,14 +260,14 @@ jobs:
   golangci-lint-cli:
     needs:
       - get-go-version
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-golangci-lint.yml@main
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-golangci-lint.yml
     with:
       directory: cli 
       go-version: ${{ needs.get-go-version.outputs.go-version }}
 
   unit-cli:
     needs: [get-go-version, golangci-lint-cli]
-    uses: hashicorp/consul-k8s/.github/workflows/reusable-unit.yml@main
+    uses: hashicorp/consul-k8s/.github/workflows/reusable-unit.yml
     with:
       directory: cli 
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -302,7 +302,7 @@ jobs:
 #  acceptance-tproxy:
 #    needs: [get-go-version, unit-cli, dev-upload-docker, unit-acceptance-framework, unit-test-helm-templates]
 #    needs: dev-upload-docker
-#    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
+#    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml
 #    with:
 #      name: acceptance-tproxy
 #      directory: acceptance/tests
@@ -315,7 +315,7 @@ jobs:
 #  acceptance:
 #    #needs: [get-go-version, unit-cli, dev-upload-docker, unit-acceptance-framework, unit-test-helm-templates]
 #    needs: dev-upload-docker
-#    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml@main
+#    uses: hashicorp/consul-k8s/.github/workflows/reusable-acceptance.yml
 #    with:
 #      name: acceptance
 #      directory: acceptance/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
   golangci-lint-helm-gen:
    needs:
     - get-go-version
-   uses: ./reusable-golangci-lint.yml
+   uses: ./.github/workflows/golangci-lint
    with:
       directory: hack/helm-reference-gen
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -64,7 +64,7 @@ jobs:
 
   unit-helm-gen:
     needs: [get-go-version, golangci-lint-helm-gen, validate-helm-gen]
-    uses: ./reusable-unit.yml
+    uses: ./.github/workflows/reusable-unit
     with:
       directory: hack/helm-reference-gen
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -106,7 +106,7 @@ jobs:
   golangci-lint-control-plane:
     needs:
       - get-go-version
-    uses: ./reusable-golangci-lint.yml
+    uses: ./.github/workflows/golangci-lint
     with:
       directory: control-plane
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -245,14 +245,14 @@ jobs:
   golangci-lint-acceptance:
     needs:
       - get-go-version
-    uses: ./reusable-golangci-lint.yml
+    uses: ./.github/workflows/golangci-lint
     with:
       directory:  acceptance 
       go-version: ${{ needs.get-go-version.outputs.go-version }} 
 
   unit-acceptance-framework:
     needs: [get-go-version, golangci-lint-acceptance]
-    uses: ./reusable-unit.yml
+    uses: ./.github/workflows/reusable-unit
     with:
       directory: acceptance/framework
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -260,14 +260,14 @@ jobs:
   golangci-lint-cli:
     needs:
       - get-go-version
-    uses: ./reusable-golangci-lint.yml
+    uses: ./.github/workflows/golangci-lint
     with:
       directory: cli 
       go-version: ${{ needs.get-go-version.outputs.go-version }}
 
   unit-cli:
     needs: [get-go-version, golangci-lint-cli]
-    uses: ./reusable-unit.yml
+    uses: ./.github/workflows/reusable-unit
     with:
       directory: cli 
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -302,7 +302,7 @@ jobs:
 #  acceptance-tproxy:
 #    needs: [get-go-version, unit-cli, dev-upload-docker, unit-acceptance-framework, unit-test-helm-templates]
 #    needs: dev-upload-docker
-#    uses: ./reusable-acceptance.yml
+#    uses: ./.github/workflows/reusable-acceptance
 #    with:
 #      name: acceptance-tproxy
 #      directory: acceptance/tests
@@ -315,7 +315,7 @@ jobs:
 #  acceptance:
 #    #needs: [get-go-version, unit-cli, dev-upload-docker, unit-acceptance-framework, unit-test-helm-templates]
 #    needs: dev-upload-docker
-#    uses: ./reusable-acceptance.yml
+#    uses: ./.github/workflows/reusable-acceptance
 #    with:
 #      name: acceptance
 #      directory: acceptance/tests

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -293,15 +293,6 @@ spec:
             failureThreshold: 15
             periodSeconds: 2
             timeoutSeconds: 5
-          livenessProbe:
-            httpGet:
-              path: /readyz/ready
-              port: 9445
-              scheme: HTTP
-            failureThreshold: 2
-            initialDelaySeconds: 1
-            successThreshold: 1
-            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /readyz/ready

--- a/charts/consul/templates/sync-catalog-deployment.yaml
+++ b/charts/consul/templates/sync-catalog-deployment.yaml
@@ -214,16 +214,6 @@ spec:
                 - |
                   consul-k8s-control-plane consul-logout -consul-api-timeout={{ .Values.global.consulAPITimeout }}
           {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /health/ready
-              port: 8080
-              scheme: HTTP
-            failureThreshold: 3
-            initialDelaySeconds: 30
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /health/ready


### PR DESCRIPTION
Currently we use an init container to create a consul ACL token via an auth method. We configure a preStop lifecycle hook to delete this token to avoid leaking it but this executes when containers get restarted, not just when the pod is destroyed.

This means that if a container livenessProbe fails and triggers a container to be restarted in place the token it was using will be destroyed but not recreated.
