### PR TITLE
Fix flakey test in troubleshoot/upstreams_test.go

### DIFF
--- a/cli/cmd/troubleshoot/upstreams/upstreams.go
+++ b/cli/cmd/troubleshoot/upstreams/upstreams.go
@@ -3,6 +3,7 @@ package upstreams
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -245,6 +246,7 @@ func formatClusterNames(names map[string]struct{}) string {
 	for k := range names {
 		out = append(out, k)
 	}
+	sort.Strings(out)
 	return strings.Join(out, ", ")
 }
 


### PR DESCRIPTION
When using maps as input, the order is not guaranteed in go, and s our tests are flakey because we're asserting on specific order in the output. This changes the formatClusterNames function to sort the cluster names array first.

How I've tested this PR:
unit tests

How I expect reviewers to test this PR:
👀 

Checklist:
- N/A Tests added
- N/A CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

