### PR TITLE
Include allowed presets in err msg

### DIFF
--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -589,7 +589,7 @@ func (c *Command) validateFlags(args []string) error {
 		return fmt.Errorf("cannot set both -%s and -%s", flagNameConfigFile, flagNamePreset)
 	}
 	if ok := slices.Contains(preset.Presets, c.flagPreset); c.flagPreset != defaultPreset && !ok {
-		return fmt.Errorf("'%s' is not a valid preset", c.flagPreset)
+		return fmt.Errorf("'%s' is not a valid preset (valid presets: %s)", c.flagPreset, strings.Join(preset.Presets, ", "))
 	}
 	if !common.IsValidLabel(c.flagNamespace) {
 		return fmt.Errorf("'%s' is an invalid namespace. Namespaces follow the RFC 1123 label convention and must "+

--- a/cli/cmd/install/install_test.go
+++ b/cli/cmd/install/install_test.go
@@ -162,39 +162,45 @@ func TestValidateFlags(t *testing.T) {
 	testCases := []struct {
 		description string
 		input       []string
+		expErr      string
 	}{
 		{
 			"Should disallow non-flag arguments.",
 			[]string{"foo", "-auto-approve"},
+			"should have no non-flag arguments",
 		},
 		{
 			"Should disallow specifying both values file AND presets.",
 			[]string{"-f='f.txt'", "-preset=demo"},
+			"cannot set both -config-file and -preset",
 		},
 		{
 			"Should error on invalid presets.",
 			[]string{"-preset=foo"},
+			"'foo' is not a valid preset (valid presets: cloud, quickstart, secure)",
 		},
 		{
 			"Should error on invalid timeout.",
 			[]string{"-timeout=invalid-timeout"},
+			"unable to parse -timeout: time: invalid duration \"invalid-timeout\"",
 		},
 		{
 			"Should error on an invalid namespace. If this failed, TestValidLabel() probably did too.",
 			[]string{"-namespace=\" nsWithSpace\""},
+			"'\" nsWithSpace\"' is an invalid namespace. Namespaces follow the RFC 1123 label convention and must consist of a lower case alphanumeric character or '-' and must start/end with an alphanumeric character",
 		},
 		{
-			"Should have errored on a non-existant file.",
+			"Should have errored on a non-existent file.",
 			[]string{"-f=\"does_not_exist.txt\""},
+			"file '\"does_not_exist.txt\"' does not exist",
 		},
 	}
 
 	for _, testCase := range testCases {
 		c := getInitializedCommand(t, nil)
 		t.Run(testCase.description, func(t *testing.T) {
-			if err := c.validateFlags(testCase.input); err == nil {
-				t.Errorf("Test case should have failed.")
-			}
+			err := c.validateFlags(testCase.input)
+			require.EqualError(t, err, testCase.expErr)
 		})
 	}
 }

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/consul-k8s/cli/helm"
 	"github.com/hashicorp/consul-k8s/cli/preset"
 	"github.com/posener/complete"
-
 	helmCLI "helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/getter"
@@ -425,7 +424,7 @@ func (c *Command) validateFlags(args []string) error {
 		return fmt.Errorf("cannot set both -%s and -%s", flagNameConfigFile, flagNamePreset)
 	}
 	if ok := slices.Contains(preset.Presets, c.flagPreset); c.flagPreset != defaultPreset && !ok {
-		return fmt.Errorf("'%s' is not a valid preset", c.flagPreset)
+		return fmt.Errorf("'%s' is not a valid preset (valid presets: %s)", c.flagPreset, strings.Join(preset.Presets, ", "))
 	}
 	if _, err := time.ParseDuration(c.flagTimeout); err != nil {
 		return fmt.Errorf("unable to parse -%s: %s", flagNameTimeout, err)


### PR DESCRIPTION
```
consul-k8s install -preset demo
'demo' is not a valid preset
```
=>

```
consul-k8s install -preset demo                                                                                                                                                                                                                                                                                                                      
'demo' is not a valid preset (valid presets: cloud, quickstart, secure)
```

How I've tested this PR:
- manually and with tests added

How I expect reviewers to test this PR:
- :eyes:

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

