### PR TITLE
Added support for go-changelog automations

### DIFF
--- a/.changelog/changelog.tmpl
+++ b/.changelog/changelog.tmpl
@@ -1,0 +1,57 @@
+{{- if index .NotesByType "breaking-change" -}}
+BREAKING CHANGES:
+
+{{range index .NotesByType "breaking-change" -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}
+
+{{- if .NotesByType.security }}
+SECURITY:
+
+{{range .NotesByType.security -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}
+
+{{- if .NotesByType.feature }}
+FEATURES:
+
+{{range .NotesByType.feature -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}
+
+{{- $improvements := combineTypes .NotesByType.improvement .NotesByType.enhancement -}}
+{{- if $improvements }}
+IMPROVEMENTS:
+
+{{range $improvements | sort -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}
+
+{{- if .NotesByType.deprecation }}
+DEPRECATIONS:
+
+{{range .NotesByType.deprecation -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}
+
+{{- if .NotesByType.bug }}
+BUG FIXES:
+
+{{range .NotesByType.bug -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}
+
+{{- if .NotesByType.note }}
+NOTES:
+
+{{range .NotesByType.note -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}
+

--- a/.changelog/note.tmpl
+++ b/.changelog/note.tmpl
@@ -1,0 +1,3 @@
+{{- define "note" -}}
+{{.Body}}{{if not (stringHasPrefix .Issue "_")}} [[GH-{{- .Issue -}}](https://github.com/hashicorp/consul-k8s/issues/{{- .Issue -}})]{{end}}
+{{- end -}}

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -1,0 +1,46 @@
+# This workflow checks that there is either a 'pr/no-changelog' label applied to a PR
+# or there is a .changelog/<pr number>.txt file associated with a PR for a changelog entry
+
+name: Changelog Checker
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+    # Runs on PRs to main and all release branches
+    branches:
+      - main
+      - release/*
+
+jobs:
+  # checks that a .changelog entry is present for a PR
+  changelog-check:
+    # If there  a `pr/no-changelog` label we ignore this check. Also, we ignore PRs created by the bot assigned to `backport-assistant`
+    if: "! ( contains(github.event.pull_request.labels.*.name, 'pr/no-changelog') || github.event.pull_request.user.login == 'hc-github-team-consul-core' )" 
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 # by default the checkout action doesn't checkout all branches
+      - name: Check for changelog entry in diff
+        run: |
+          # check if there is a diff in the .changelog directory
+          # for PRs against the main branch, the changelog file name should match the PR number
+          if [ "${{ github.event.pull_request.base.ref }}" = "${{ github.event.repository.default_branch }}" ]; then
+            enforce_matching_pull_request_number="matching this PR number "
+            changelog_file_path=".changelog/(_)?${{ github.event.pull_request.number }}.txt"
+          else
+            changelog_file_path=".changelog/[_0-9]*.txt"
+          fi
+
+          changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/main")" | egrep ${changelog_file_path})
+
+          # If we do not find a file in .changelog/, we fail the check
+          if [ -z "$changelog_files" ]; then
+            # Fail status check when no .changelog entry was found on the PR
+            echo "Did not find a .changelog entry ${enforce_matching_pull_request_number}and the 'pr/no-changelog' label was not applied. Reference - https://github.com/hashicorp/consul/pull/8387"
+            exit 1
+          else
+            echo "Found .changelog entry in PR!"
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
     1. [Making changes to consul-k8s](#making-changes-to-consul-k8s)
     1. [Running linters locally](#running-linters-locally)
     1. [Rebasing contributions against main](#rebasing-contributions-against-main)
-1. [Creating a new CRD](#creating-a-new-crd)
+2. [Creating a new CRD](#creating-a-new-crd)
     1. [The Structs](#the-structs) 
     1. [Spec Methods](#spec-methods)
     1. [Spec Tests](#spec-tests)
@@ -17,13 +17,14 @@
     1. [Updating consul-helm](#updating-consul-helm)
     1. [Testing a new CRD](#testing-a-new-crd)
     1. [Update Consul K8s acceptance tests](#update-consul-k8s-acceptance-tests)
-1. [Adding a new ACL Token](#adding-a-new-acl-token)
-1. [Testing the Helm chart](#testing-the-helm-chart)
+3. [Adding a new ACL Token](#adding-a-new-acl-token)
+4. [Testing the Helm chart](#testing-the-helm-chart)
     1. [Running the tests](#running-the-tests)
     1. [Writing Unit tests](#writing-unit-tests)
     1. [Writing Acceptance tests](#writing-acceptance-tests)
-1. [Using the Acceptance Test Framework to Debug](#using-acceptance-test-framework-to-debug)
-1. [Helm Reference Docs](#helm-reference-docs)
+5. [Using the Acceptance Test Framework to Debug](#using-acceptance-test-framework-to-debug)
+6. [Helm Reference Docs](#helm-reference-docs)
+7. [Adding a Changelog Entry](#adding-a-changelog-entry)
 
 ## Contributing 101
 
@@ -1214,3 +1215,43 @@ So that the documentation can look like:
 ```markdown
 - `ports` ((#v-ingressgateways-defaults-service-ports)) (`array<map>: [{port: 8080, port: 8443}]`) - Port docs
 ```
+
+## Adding a Changelog Entry
+
+Any change that a Consul-K8s user might need to know about should have a changelog entry.
+
+What doesn't need a changelog entry?
+- Typos/fixes, unless they are in a public-facing API
+- Code changes we are certain no Consul-K8s users will need to know about
+
+To include a [changelog entry](../.changelog) in a PR, commit a text file
+named `.changelog/<PR#>.txt`, where `<PR#>` is the number associated with the open
+PR in GitHub. The text file should describe the changes in the following format:
+
+````
+```release-note:<change type>
+<code area>: <brief description of the improvement you made here>
+```
+````
+
+Valid values for `<change type>` include:
+- `feature`: for the addition of a new feature
+- `improvement`: for an improvement (not a bug fix) to an existing feature
+- `bug`: for a bug fix
+- `security`: for any Common Vulnerabilities and Exposures (CVE) resolutions
+- `breaking-change`: for any change that is not fully backwards-compatible
+- `deprecation`: for functionality which is now marked for removal in a future release
+
+`<code area>` is meant to categorize the functionality affected by the change.
+Some common values are:
+- `cli`: related to the command-line interface and its commands
+- `control-plane`: related to control-plane functionality
+- `helm`: related to the charts module and any files, yaml, go, etc. therein
+
+There may be cases where a `code area` doesn't make sense (i.e. addressing a Go CVE). In these 
+cases it is okay not to provide a `code area`.
+
+For more examples, look in the [`.changelog/`](../.changelog) folder for existing changelog entries.
+
+If a PR deserves multiple changelog entries, just add multiple entries separated by a newline
+in the format described above to the `.changelog/<PR#>.txt` file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
     1. [Making changes to consul-k8s](#making-changes-to-consul-k8s)
     1. [Running linters locally](#running-linters-locally)
     1. [Rebasing contributions against main](#rebasing-contributions-against-main)
-2. [Creating a new CRD](#creating-a-new-crd)
+1. [Creating a new CRD](#creating-a-new-crd)
     1. [The Structs](#the-structs) 
     1. [Spec Methods](#spec-methods)
     1. [Spec Tests](#spec-tests)
@@ -17,14 +17,14 @@
     1. [Updating consul-helm](#updating-consul-helm)
     1. [Testing a new CRD](#testing-a-new-crd)
     1. [Update Consul K8s acceptance tests](#update-consul-k8s-acceptance-tests)
-3. [Adding a new ACL Token](#adding-a-new-acl-token)
-4. [Testing the Helm chart](#testing-the-helm-chart)
+1. [Adding a new ACL Token](#adding-a-new-acl-token)
+1. [Testing the Helm chart](#testing-the-helm-chart)
     1. [Running the tests](#running-the-tests)
     1. [Writing Unit tests](#writing-unit-tests)
     1. [Writing Acceptance tests](#writing-acceptance-tests)
-5. [Using the Acceptance Test Framework to Debug](#using-acceptance-test-framework-to-debug)
-6. [Helm Reference Docs](#helm-reference-docs)
-7. [Adding a Changelog Entry](#adding-a-changelog-entry)
+1. [Using the Acceptance Test Framework to Debug](#using-acceptance-test-framework-to-debug)
+1. [Helm Reference Docs](#helm-reference-docs)
+1. [Adding a Changelog Entry](#adding-a-changelog-entry)
 
 ## Contributing 101
 

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ endif
 ifndef RELEASE_DATE
 	$(error RELEASE_DATE is required, use format <Month> <Day>, <Year> (ex. October 4, 2022))
 endif
-	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_release $(CURDIR) $(RELEASE_VERSION) "$(RELEASE_DATE)" $(PRERELEASE_VERSION)
+	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_release $(CURDIR) $(RELEASE_VERSION) "$(RELEASE_DATE)" $(LAST_RELEASE_GIT_TAG) $(PRERELEASE_VERSION)
 
 prepare-dev:
 ifndef RELEASE_VERSION
@@ -168,7 +168,7 @@ endif
 ifndef NEXT_RELEASE_VERSION
 	$(error NEXT_RELEASE_VERSION is required)
 endif
-	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_dev $(CURDIR) $(RELEASE_VERSION) "$(RELEASE_DATE)" $(NEXT_RELEASE_VERSION) $(PRERELEASE_VERSION)
+	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_dev $(CURDIR) $(RELEASE_VERSION) "$(RELEASE_DATE)" $(NEXT_RELEASE_VERSION)
 
 # ===========> Makefile config
 


### PR DESCRIPTION
I always add details to my commits and there isn't any crossover, so reviewing commit by commit is usually the best way to review my PRs

# Changes proposed in this PR:
This PR adds go-changelog support to the Consul-K8s repo. This will be a new way of managing changelog items throughout the release cycle.

* added `go-changelog` required templates and directories
* added pipeline checks for unintended missing changelogs
  * added a label `pr/no-changelog` for ignoring missing changelogs if necessary otherwise a changelog is now required
* added contribution instructions for adding changelogs using the `go-changelog` tool
* modified `prepare-release` to automatically run `go-changelog` and add the changes to the `CHANGELOG.MD` file

# How I've tested this PR:

1. Verified that pipeline fails when missing a changelog file
<img width="946" alt="image" src="https://user-images.githubusercontent.com/62034708/220973086-df7b9ca7-356c-4da1-a59b-fdbdde6fe9cb.png">

2. Temporarily commited a changelog file with a combination of feature and bug entries, verified pipeline now passes:
<img width="1079" alt="image" src="https://user-images.githubusercontent.com/62034708/220975606-22a17d60-a808-4f19-b72a-ff23110fe54d.png">

3. Ran  the following with with LAST_RELEASE_GIT_TAG being set to `v1.0.4` and it generated a valid changelog:
```shell
 $ changelog-build -last-release ${LAST_RELEASE_GIT_TAG} -entries-dir .changelog/ -changelog-template .changelog/changelog.tmpl -note-template .changelog/note.tmpl -this-release $(git rev-parse HEAD)

FEATURES:

* cli: Transparent Proxy - Service mesh visualization updates [[GH-1947](https://github.com/hashicorp/consul/issues/1947)]
* control-plane: Transparent Proxy - Service mesh visualization updates [[GH-1947](https://github.com/hashicorp/consul/issues/1947)]
* helm: Transparent Proxy - Service mesh visualization updates [[GH-1947](https://github.com/hashicorp/consul/issues/1947)]

BUG FIXES:

* cli: Transparent Proxy - Service mesh visualization updates [[GH-1947](https://github.com/hashicorp/consul/issues/1947)]
* control-plane: Transparent Proxy - Service mesh visualization updates [[GH-1947](https://github.com/hashicorp/consul/issues/1947)]
* helm: Transparent Proxy - Service mesh visualization updates [[GH-1947](https://github.com/hashicorp/consul/issues/1947)]
```

4. I ran `make prepare-release` and confirmed that it adds the changes with the correct version and date to `CHANGELOG.MD`

# How I expect reviewers to test this PR:
👀 

Checklist:
- [n/a] Tests added
- [n/a] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

