### PR TITLE
consul-dataplane: bump consul-dataplane to 1.1.0 for consul k8s 1.0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 IMPROVEMENTS:
 * Control Plane
   * Update alpine to 3.17 in the Docker image. [[GH-1934](https://github.com/hashicorp/consul-k8s/pull/1934)]
-  * Update `consul-dataplane` image to `hashicorp/consul-dataplane:1.1.0`. [[GH-1953](https://github.com/hashicorp/consul-k8s/pull/1953)]
+  * Update `imageConsulDataplane` value to `hashicorp/consul-dataplane:1.1.0`. [[GH-1953](https://github.com/hashicorp/consul-k8s/pull/1953)]
   
 ## 1.0.4 (February 7, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 * Control Plane
   * Update alpine to 3.17 in the Docker image. [[GH-1934](https://github.com/hashicorp/consul-k8s/pull/1934)]
+  * Update `consul-dataplane` image to `hashicorp/consul-dataplane:1.1.0`. [[GH-1953](https://github.com/hashicorp/consul-k8s/pull/1953)]
   
 ## 1.0.4 (February 7, 2023)
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -569,7 +569,7 @@ global:
   # The name (and tag) of the consul-dataplane Docker image used for the
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
   # @default: hashicorp/consul-dataplane:<latest supported version>
-  imageConsulDataplane: "hashicorp/consul-dataplane:1.0.1"
+  imageConsulDataplane: "hashicorp/consul-dataplane:1.1.0"
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.


### PR DESCRIPTION
Changes proposed in this PR:
- Bump Consul Dataplane to 1.1.0 to allow for longer timeline for a supported Consul dataplane proxy. 

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

