### PR TITLE
updated security scan to have parity with consul-dataplane

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,14 +1,13 @@
 container {
-	dependencies = false
-	alpine_secdb = false
-	secrets      = false
+	dependencies = true
+	alpine_secdb = true
+	secrets      = true
 }
 
 binary {
-	secrets      = false
-	go_modules   = false
-	osv          = false
+	secrets      = true
+	go_modules   = true
+	osv          = true
 	oss_index    = false
 	nvd          = false
 }
-


### PR DESCRIPTION
Changes proposed in this PR:
- Updated the security scan to have parity with consul-dataplane: https://github.com/hashicorp/consul-dataplane/blob/main/.release/security-scan.hcl

How I've tested this PR:
👀 

How I expect reviewers to test this PR:
👀 

Checklist:
- [n/a] Tests added
- [n/a] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

