### PR TITLE
add 365 days instead of 1 year to account for leap years

### DIFF
--- a/control-plane/subcommand/tls-init/command_test.go
+++ b/control-plane/subcommand/tls-init/command_test.go
@@ -395,7 +395,9 @@ func TestRun_CreatesServerCertificatesWithExpiryWithinSpecifiedDays(t *testing.T
 	certBlock, _ := pem.Decode(newServerCert)
 	certificate, err := x509.ParseCertificate(certBlock.Bytes)
 	require.NoError(t, err)
-	require.Equal(t, time.Now().AddDate(1, 0, 0).Unix(), certificate.NotAfter.Unix())
+
+	// Add 365 days instead of 1 year to account for leap years
+	require.Equal(t, time.Now().AddDate(0, 0, 365).Unix(), certificate.NotAfter.Unix())
 }
 
 func TestRun_CreatesServerCertificatesWithProvidedHosts(t *testing.T) {


### PR DESCRIPTION
Changes proposed in this PR:
- There was an issue where adding 1 year to the time check would fail if it was March 1st because the certificate would be expired Feb 29th. Fixed test to use 365 day increment instead of 1 year increment.

How I've tested this PR:
👀 

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [n/a] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

