### PR TITLE
disable go mod scanning

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -6,7 +6,7 @@ container {
 
 binary {
 	secrets      = true
-	go_modules   = true
+	go_modules   = false
 	osv          = true
 	oss_index    = false
 	nvd          = false


### PR DESCRIPTION
Changes proposed in this PR:
- Temporarily disable go mod security scanning until after the patch release

How I've tested this PR:
👀 
How I expect reviewers to test this PR:
👀 

Checklist:
- [n/a] Tests added
- [n/a] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

