### PR TITLE
Mw/add backport checker

### DIFF
--- a/.github/workflows/backport-checker.yml
+++ b/.github/workflows/backport-checker.yml
@@ -1,0 +1,32 @@
+# This workflow checks that there is either a 'pr/no-backport' label applied to a PR
+# or there is a backport/<pr number>.txt file associated with a PR for a backport label
+
+name: Backport Checker
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+    # Runs on PRs to main and all release branches
+    branches:
+      - main
+      - release/*
+
+jobs:
+  # checks that a backport label is present for a PR
+  backport-check:
+    # If there's a `pr/no-backport` label we ignore this check. Also, we ignore PRs created by the bot assigned to `backport-assistant`
+    if: "! ( contains(github.event.pull_request.labels.*.name, 'pr/no-backport') || github.event.pull_request.user.login == 'hc-github-team-consul-core' )"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check for Backport Label
+        run: |
+          labels="${{join(github.event.pull_request.labels.*.name, ', ') }}"
+          if [[ "$labels" =~ .*"backport/".* ]]; then
+            echo "Found backport label!"
+            exit 0
+          fi
+          # Fail status check when no backport label was found on the PR
+          echo "Did not find a backport label matching the pattern 'backport/*' and the 'pr/no-backport' label was not applied. Reference - https://github.com/hashicorp/consul-k8s/pull/1982"
+          exit 1
+

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   # checks that a .changelog entry is present for a PR
   changelog-check:
-    # If there  a `pr/no-changelog` label we ignore this check. Also, we ignore PRs created by the bot assigned to `backport-assistant`
+    # If there's a `pr/no-changelog` label we ignore this check. Also, we ignore PRs created by the bot assigned to `backport-assistant`
     if: "! ( contains(github.event.pull_request.labels.*.name, 'pr/no-changelog') || github.event.pull_request.user.login == 'hc-github-team-consul-core' )" 
     runs-on: ubuntu-latest
 
@@ -39,7 +39,7 @@ jobs:
           # If we do not find a file in .changelog/, we fail the check
           if [ -z "$changelog_files" ]; then
             # Fail status check when no .changelog entry was found on the PR
-            echo "Did not find a .changelog entry ${enforce_matching_pull_request_number}and the 'pr/no-changelog' label was not applied. Reference - https://github.com/hashicorp/consul/pull/8387"
+            echo "Did not find a .changelog entry ${enforce_matching_pull_request_number}and the 'pr/no-changelog' label was not applied. Reference - https://github.com/hashicorp/consul-k8s/pull/1947"
             exit 1
           else
             echo "Found .changelog entry in PR!"


### PR DESCRIPTION
Changes proposed in this PR:
- Add a pipeline check for backport labels. This will ensure that developers must either add a backport label or deliberately specify that this pr does not require backporting with the `pr/no-backport` label.
- This check simply checks for the presence of a label matching `backport/*`. It is up to the developer to add the right backport labels as appropriate for a given PR.

How I've tested this PR:

No Backport label and no `pr/no-backport`
<img width="1091" alt="image" src="https://user-images.githubusercontent.com/62034708/222814907-712bcdbf-fd57-4b3d-b998-130196a76ab8.png">

With backport label
<img width="1103" alt="image" src="https://user-images.githubusercontent.com/62034708/222821175-152d3636-6516-4f8c-a836-750fe9959774.png">

With `pr/no-backport` label
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/62034708/222821286-b0c82682-6c18-4884-bb18-db7d0eb32673.png">


How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

