### PR TITLE
values.yaml - set default connect inject init cpu resource limits to `null` to increase service registration times

### DIFF
--- a/.changelog/2008.txt
+++ b/.changelog/2008.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-helm: Increase cpu limits from `50m` to `500m` cores for `consul-connect-inject-init` container to speed up registration times when onboarding services onto the mesh.
+helm: Set default `limits.cpu` resource setting to `null` for `consul-connect-inject-init` container to speed up registration times when onboarding services onto the mesh during the init container lifecycle. 
 ```

--- a/.changelog/2008.txt
+++ b/.changelog/2008.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+helm: Increase cpu limits from `50m` to `500m` cores for `consul-connect-inject-init` container to speed up registration times when onboarding services onto the mesh.
+```

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -988,7 +988,7 @@ load _helpers
   [ "${actual}" = "true" ]
 
   local actual=$(echo "$cmd" |
-    yq 'any(contains("-init-container-cpu-limit=50m"))' | tee /dev/stderr)
+    yq 'any(contains("-init-container-cpu-limit=500m"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -986,10 +986,7 @@ load _helpers
   local actual=$(echo "$cmd" |
     yq 'any(contains("-init-container-memory-limit=150Mi"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
-
-  local actual=$(echo "$cmd" |
-    yq 'any(contains("-init-container-cpu-limit=500m"))' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
+  
 }
 
 @test "connectInject/Deployment: can set init container resources" {

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2134,17 +2134,17 @@ connectInject:
   # @type: map
   resources:
     requests:
-      # Recommended default: 500Mi
+      # Recommended production default: 500Mi
       # @type: string
       memory: "50Mi"
-      # Recommended default: 250m
+      # Recommended production default: 250m
       # @type: string
       cpu: "50m"
     limits:
-      # Recommended default: 500Mi
+      # Recommended production default: 500Mi
       # @type: string
       memory: "50Mi"
-      # Recommended default: 250m
+      # Recommended production default: 250m
       # @type: string
       cpu: "50m"
 
@@ -2313,17 +2313,17 @@ connectInject:
     # @type: map
     resources:
       requests:
-        # Recommended default: 100Mi
+        # Recommended production default: 100Mi
         # @type: string
         memory: null
-        # Recommended default: 100m
+        # Recommended production default: 100m
         # @type: string
         cpu: null
       limits:
-        # Recommended default: 100Mi
+        # Recommended production default: 100Mi
         # @type: string
         memory: null
-        # Recommended default: 100m
+        # Recommended production default: 100m
         # @type: string
         cpu: null
 
@@ -2334,17 +2334,17 @@ connectInject:
   initContainer:
     resources:
       requests:
-        # Recommended default: 150Mi
+        # Recommended production default: 150Mi
         # @type: string
         memory: "25Mi"
-        # Recommended default: 250m
+        # Recommended production default: 250m
         # @type: string
         cpu: "50m"
       limits:
-        # Recommended default: 150Mi
+        # Recommended production default: 150Mi
         # @type: string
         memory: "150Mi"
-        # Recommended default: 500m
+        # Recommended production default: 500m
         # @type: string
         cpu: null
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2330,7 +2330,7 @@ connectInject:
         cpu: "50m"
       limits:
         memory: "150Mi"
-        cpu: "250m"
+        cpu: "500m"
 
 # [Mesh Gateways](https://developer.hashicorp.com/consul/docs/connect/gateways/mesh-gateway) enable Consul Connect to work across Consul datacenters.
 meshGateway:

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2330,7 +2330,7 @@ connectInject:
         cpu: "50m"
       limits:
         memory: "150Mi"
-        cpu: "50m"
+        cpu: "250m"
 
 # [Mesh Gateways](https://developer.hashicorp.com/consul/docs/connect/gateways/mesh-gateway) enable Consul Connect to work across Consul datacenters.
 meshGateway:

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2130,15 +2130,22 @@ connectInject:
     # @type: string
     annotations: null
 
-  # The resource settings for connect inject pods.
-  # @recurse: false
+  # The resource settings for connect inject pods. The defaults, are optimized for getting started worklows on developer deployments. The settings should be tweaked for production deployments. 
   # @type: map
   resources:
     requests:
+      # Recommended default: 500Mi
+      # @type: string
       memory: "50Mi"
+      # Recommended default: 250m
+      # @type: string
       cpu: "50m"
     limits:
+      # Recommended default: 500Mi
+      # @type: string
       memory: "50Mi"
+      # Recommended default: 250m
+      # @type: string
       cpu: "50m"
 
   # Sets the failurePolicy for the mutating webhook. By default this will cause pods not part of the consul installation to fail scheduling while the webhook
@@ -2320,17 +2327,26 @@ connectInject:
         # @type: string
         cpu: null
 
-  # The resource settings for the Connect injected init container.
-  # @recurse: false
+  # The resource settings for the Connect injected init container. If null, the resources
+  # won't be set for the initContainer. The defaults are optimized for developer instances of 
+  # Kubernetes, however they should be tweaked with the recommended defaults as shown below to speed up service registration times. 
   # @type: map
   initContainer:
     resources:
       requests:
+        # Recommended default: 150Mi
+        # @type: string
         memory: "25Mi"
+        # Recommended default: 250m
+        # @type: string
         cpu: "50m"
       limits:
+        # Recommended default: 150Mi
+        # @type: string
         memory: "150Mi"
-        cpu: "500m"
+        # Recommended default: 500m
+        # @type: string
+        cpu: null
 
 # [Mesh Gateways](https://developer.hashicorp.com/consul/docs/connect/gateways/mesh-gateway) enable Consul Connect to work across Consul datacenters.
 meshGateway:


### PR DESCRIPTION
Changes proposed in this PR:
- Based on internal investigations allowing the connect-inject-init container to utilize more cpu will allow registration times to Consul to improve registration times from 3.5 seconds to 0.25 seconds. This PR removes the default cpu limits of 50 millicores to allow the the init container to temporarily eat up more CPU to speed up registration times during the init container lifecycle.

How I've tested this PR:

Tested manually on kind as shown below following the kind Consul k8s learn guide: https://developer.hashicorp.com/consul/tutorials/kubernetes/kubernetes-kind 

```
dyu@dyu-JRXHVGG467 kind-consulk8s % kind create cluster --name dc1
Creating cluster "dc1" ...
 ✓ Ensuring node image (kindest/node:v1.25.3) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-dc1"
You can now use your cluster with:

kubectl cluster-info --context kind-dc1

Have a nice day! 👋
dyu@dyu-JRXHVGG467 kind-consulk8s % kind create cluster --name dc1
dyu@dyu-JRXHVGG467 kind-consulk8s % helm install --values values.yaml consul hashicorp/consul --create-namespace --namespace consul --version "1.1.0"
NAME: consul
LAST DEPLOYED: Fri Mar 10 10:45:34 2023
NAMESPACE: consul
STATUS: deployed
REVISION: 1
NOTES:
Thank you for installing HashiCorp Consul!

Your release is named consul.

To learn more about the release, run:

  $ helm status consul --namespace consul
  $ helm get all consul --namespace consul

Consul on Kubernetes Documentation:
https://www.consul.io/docs/platform/k8s

Consul on Kubernetes CLI Reference:
https://www.consul.io/docs/k8s/k8s-cli
dyu@dyu-JRXHVGG467 kind-consulk8s % k get pods -n consul
NAME                                          READY   STATUS    RESTARTS   AGE
consul-connect-injector-54c5c75775-k2rr5      1/1     Running   0          89s
consul-server-0                               1/1     Running   0          89s
consul-webhook-cert-manager-57fd9b6db-drzvw   1/1     Running   0          89s
dyu@dyu-JRXHVGG467 kind-consulk8s % kubectl apply -f counting.yaml && kubectl apply -f dashboard.yaml
serviceaccount/counting created
service/counting created
deployment.apps/counting created
serviceaccount/dashboard created
service/dashboard created
deployment.apps/dashboard created
dyu@dyu-JRXHVGG467 kind-consulk8s % k get pods
NAME                         READY   STATUS    RESTARTS   AGE
counting-7547ff85f7-bxfp6    2/2     Running   0          17s
dashboard-6b957f4b9b-thdjr   2/2     Running   0          16s
```

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

