### PR TITLE
Backport of Add SNI skip for client node configuration into release/1.1.x

### DIFF
--- a/.changelog/2013.txt
+++ b/.changelog/2013.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api-gateway: fix issue where specifying an external server SNI name while using client nodes resulted in a TLS verification error.
+```

--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -112,7 +112,7 @@ spec:
           {{- end }}
         - name: CONSUL_HTTP_SSL
           value: "{{ .Values.global.tls.enabled }}"
-        {{- if and .Values.externalServers.enabled .Values.externalServers.tlsServerName }}
+        {{- if and (not .Values.client.enabled) .Values.externalServers.enabled .Values.externalServers.tlsServerName }}
         - name: CONSUL_TLS_SERVER_NAME
           value: {{ .Values.externalServers.tlsServerName }}
         {{- end }}

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -2,6 +2,16 @@
 
 load _helpers
 
+testOnly() {
+  if [ "$BATS_TEST_DESCRIPTION" != "$1" ]; then
+    skip
+  fi
+}
+
+setup() {
+  testOnly "apiGateway/Deployment: CONSUL_TLS_SERVER_NAME will not be set for when clients are used"
+}
+
 @test "apiGateway/Deployment: disabled by default" {
   cd `chart_dir`
   assert_empty helm template \
@@ -1416,6 +1426,24 @@ load _helpers
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].env[4].value == "hashi"' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "apiGateway/Deployment: CONSUL_TLS_SERVER_NAME will not be set for when clients are used" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-controller-deployment.yaml  \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=bar' \
+      --set 'global.tls.enabled=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=external-consul.host' \
+      --set 'externalServers.httpsPort=8501' \
+      --set 'externalServers.tlsServerName=hashi' \
+      --set 'client.enabled=true' \
+      --set 'server.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[] | select (.name == "api-gateway-controller") | .env[] | select(.name == "CONSUL_TLS_SERVER_NAME")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -2,16 +2,6 @@
 
 load _helpers
 
-testOnly() {
-  if [ "$BATS_TEST_DESCRIPTION" != "$1" ]; then
-    skip
-  fi
-}
-
-setup() {
-  testOnly "apiGateway/Deployment: CONSUL_TLS_SERVER_NAME will not be set for when clients are used"
-}
-
 @test "apiGateway/Deployment: disabled by default" {
   cd `chart_dir`
   assert_empty helm template \


### PR DESCRIPTION
## Backport

This PR is a manual backport from #2013 to release/1.1.x since the backport bot failed to generate a backport PR for it.



The below text is copied from the body of the original PR.

---

Changes proposed in this PR:

This adds a fix for where we were injecting an server name env variable to the gateway controller in the case of trying to connect to client agent nodes when we had an external server with an SNI override.

What that results in is a TLS certificate verification error because the controller, when attempting to talk to the client node, then winds up expecting the client certificate to match the external server's name.

How I've tested this PR:

Unit tested.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 


---

<details>
<summary> Overview of commits </summary>

  - e23dbb65afe8226d756de4510016ac4a7a6f469f  - 730ab263c8d791011901208c36b8d467ce382135 

</details>


