### PR TITLE
Update ACLs, add namespace.write permission

### DIFF
--- a/.changelog/2029.txt
+++ b/.changelog/2029.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-api-gateway: fix issue where when adminPartitions and ACLs are enabled, API Gateway Controller is unable to create a new namespace in Consul
+api-gateway: fix ACL issue where when adminPartitions and ACLs are enabled, API Gateway Controller is unable to create a new namespace in Consul
 ```

--- a/.changelog/2029.txt
+++ b/.changelog/2029.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api-gateway: fix issue where when adminPartitions and ACLs are enabled, API Gateway Controller is unable to create a new namespace in Consul
+```

--- a/charts/consul/templates/api-gateway-controller-clusterrole.yaml
+++ b/charts/consul/templates/api-gateway-controller-clusterrole.yaml
@@ -85,6 +85,7 @@ rules:
   resources:
   - namespaces
   verbs:
+  - create
   - get
   - list
   - watch

--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -146,6 +146,7 @@ func (c *Command) apiGatewayControllerRules() (string, error) {
 	apiGatewayRulesTpl := `{{- if .EnablePartitions }}
 partition "{{ .PartitionName }}" {
   mesh = "write"
+  operator = "write"
   acl = "write"
 {{- else }}
 operator = "write"

--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -146,14 +146,16 @@ func (c *Command) apiGatewayControllerRules() (string, error) {
 	apiGatewayRulesTpl := `{{- if .EnablePartitions }}
 partition "{{ .PartitionName }}" {
   mesh = "write"
-  operator = "write"
   acl = "write"
+  operator = "write"
 {{- else }}
 operator = "write"
 acl = "write"
 {{- end }}
+
 {{- if .EnableNamespaces }}
 namespace_prefix "" {
+  policy = "write"
 {{- end }}
   service_prefix "" {
     policy = "write"
@@ -168,7 +170,7 @@ namespace_prefix "" {
 {{- if .EnablePartitions }}
 }
 {{- end }}
-  `
+`
 
 	return c.renderRules(apiGatewayRulesTpl)
 }

--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -147,7 +147,6 @@ func (c *Command) apiGatewayControllerRules() (string, error) {
 partition "{{ .PartitionName }}" {
   mesh = "write"
   acl = "write"
-  operator = "write"
 {{- else }}
 operator = "write"
 acl = "write"

--- a/control-plane/subcommand/server-acl-init/rules_test.go
+++ b/control-plane/subcommand/server-acl-init/rules_test.go
@@ -184,7 +184,6 @@ namespace_prefix "" {
 partition "Default" {
   mesh = "write"
   acl = "write"
-  operator = "write"
 namespace_prefix "" {
   policy = "write"
   service_prefix "" {

--- a/control-plane/subcommand/server-acl-init/rules_test.go
+++ b/control-plane/subcommand/server-acl-init/rules_test.go
@@ -143,6 +143,7 @@ func TestAPIGatewayControllerRules(t *testing.T) {
 	cases := []struct {
 		Name             string
 		EnableNamespaces bool
+		Partition        string
 		Expected         string
 	}{
 		{
@@ -165,6 +166,7 @@ acl = "write"
 operator = "write"
 acl = "write"
 namespace_prefix "" {
+  policy = "write"
   service_prefix "" {
     policy = "write"
     intentions = "write"
@@ -174,13 +176,36 @@ namespace_prefix "" {
   }
 }`,
 		},
+		{
+			Name:             "Namespaces are enabled, partitions enabled",
+			EnableNamespaces: true,
+			Partition:        "Default",
+			Expected: `
+partition "Default" {
+  mesh = "write"
+  acl = "write"
+  operator = "write"
+namespace_prefix "" {
+  policy = "write"
+  service_prefix "" {
+    policy = "write"
+    intentions = "write"
+  }
+  node_prefix "" {
+    policy = "read"
+  }
+}
+}`,
+		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			cmd := Command{
 				flagEnableNamespaces: tt.EnableNamespaces,
-				consulFlags:          &flags.ConsulFlags{},
+				consulFlags: &flags.ConsulFlags{
+					Partition: tt.Partition,
+				},
 			}
 
 			meshGatewayRules, err := cmd.apiGatewayControllerRules()


### PR DESCRIPTION
Changes proposed in this PR:
- Resolve bug described in https://github.com/hashicorp/consul-k8s/issues/1911 where api-gateway controller is unable to create new namespaces

How I've tested this PR:
- Installed API gateway using a local version of this repository using the reproduction steps described in https://github.com/hashicorp/consul-k8s/issues/1911 and consul API image set to 1.5.2. (ACL permission is missing, but this change is also reliant on a bux fix with how partitions are handled in 1.5.2)

How I expect reviewers to test this PR:
- CI passes


Checklist:
- [ X ] Tests added
- [ X ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

