### PR TITLE
Fix the indentation of the copyAnnotations example

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2927,7 +2927,7 @@ apiGateway:
       # ```yaml
       # service:
       #   annotations: |
-      #   - external-dns.alpha.kubernetes.io/hostname
+      #     - external-dns.alpha.kubernetes.io/hostname
       # ```
       #
       # @type: string


### PR DESCRIPTION
Changes proposed in this PR:
- Fixes the docs example where `copyAnnotations.service.annotation` has the wrong indentation. This caused some confusion for a customer recently. Just needs an extra two spaces. 
