### PR TITLE
Update backport assistant to support -gh-automerge

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,10 +13,10 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.2.5
+    container: hashicorpdev/backport-assistant:0.3.0
     steps:
       - name: Run Backport Assistant
-        run: backport-assistant backport -automerge
+        run: backport-assistant backport -merge-method=squash -gh-automerge
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.x)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"


### PR DESCRIPTION
Changes proposed in this PR:
- Add -gh-automerge to backport assistant so that it will automerge GH style

How I've tested this PR:

Compared it against what Consul has.

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

