### PR TITLE
Add a cleanup cron job

### DIFF
--- a/.github/workflows/nightly-cleanup.yml
+++ b/.github/workflows/nightly-cleanup.yml
@@ -8,7 +8,7 @@ on:
 
 # these should be the only settings that you will ever need to change
 env:
-  CONSUL_IMAGE: hashicorppreview/consul-enterprise:1.16-dev # Consul's enterprise version to use in tests
+  CONSUL_IMAGE: "not used"
   BRANCH: ${{ github.ref_name }}
   CONTEXT: "nightly"
 

--- a/.github/workflows/nightly-cleanup.yml
+++ b/.github/workflows/nightly-cleanup.yml
@@ -1,0 +1,27 @@
+# Dispatch to the consul-k8s-workflows with a nightly cron
+name: nightly-cleanup
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run nightly at 12PM UTC/8AM EST/5AM PST
+    - cron: '0 12 * * *'
+
+# these should be the only settings that you will ever need to change
+env:
+  CONSUL_IMAGE: hashicorppreview/consul-enterprise:1.16-dev # Consul's enterprise version to use in tests
+  BRANCH: ${{ github.ref_name }}
+  CONTEXT: "nightly"
+
+jobs:
+  cleanup:
+    name: cleanup
+    runs-on: ubuntu-latest
+    steps:
+    - uses: benc-uk/workflow-dispatch@v1.2.2
+      name: cleanup
+      with:
+        workflow: cleanup.yml
+        repo: hashicorp/consul-k8s-workflows
+        ref: main
+        token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+        inputs: '{ "context":"${{ env.CONTEXT }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ github.sha }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}", "consul-image":"${{ env.CONSUL_IMAGE }}" }'


### PR DESCRIPTION
Changes proposed in this PR:
- Adding a nightly cleanup job that will dispatch to consul-k8s-workflows every night
- This is the same schedule that CircleCI had

How I've tested this PR:

👀 

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

