### PR TITLE
Fix Sync Catalog ACL Token Environment Var Name

### DIFF
--- a/charts/consul/templates/sync-catalog-deployment.yaml
+++ b/charts/consul/templates/sync-catalog-deployment.yaml
@@ -100,7 +100,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             {{- if (and .Values.syncCatalog.aclSyncToken.secretName .Values.syncCatalog.aclSyncToken.secretKey) }}
-            - name: CONSUL_HTTP_TOKEN
+            - name: CONSUL_ACL_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.syncCatalog.aclSyncToken.secretName }}

--- a/charts/consul/test/unit/sync-catalog-deployment.bats
+++ b/charts/consul/test/unit/sync-catalog-deployment.bats
@@ -338,7 +338,7 @@ load _helpers
       --set 'syncCatalog.enabled=true' \
       --set 'syncCatalog.aclSyncToken.secretKey=bar' \
       . | tee /dev/stderr |
-      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_ACL_TOKEN"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
@@ -349,7 +349,7 @@ load _helpers
       --set 'syncCatalog.enabled=true' \
       --set 'syncCatalog.aclSyncToken.secretName=foo' \
       . | tee /dev/stderr |
-      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_ACL_TOKEN"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
@@ -361,7 +361,7 @@ load _helpers
       --set 'syncCatalog.aclSyncToken.secretName=foo' \
       --set 'syncCatalog.aclSyncToken.secretKey=bar' \
       . | tee /dev/stderr |
-      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_HTTP_TOKEN"))' | tee /dev/stderr)
+      yq '[.spec.template.spec.containers[0].env[].name] | any(contains("CONSUL_ACL_TOKEN"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 


### PR DESCRIPTION
Changes proposed in this PR:

- Change the environment variable name for the ACL token secret to match what is expected by the control plane. (Fixes #1891)
  - Currently, the chart is setting the `CONSUL_HTTP_TOKEN` environment variable which is not used by the Consul client within the control plane.
  - The control plane is instead reading `CONSUL_ACL_TOKEN`: https://github.com/hashicorp/consul-k8s/blob/11f842cbe94b5df544c03e2441a1820397f92b9b/control-plane/subcommand/flags/consul.go#L153-L155 

How I've tested this PR:

- Deployed the chart with the included changes and observed the control plane properly loaded the provided Consul token and used it to register services. 

How I expect reviewers to test this PR:

- Deploy an external Consul server that has ACLs enabled.
- Create a policy and token with the proper permissions to run the catalog sync agent.
- Populate the token secret into a K8S secret and provide that secret name and key to the chart.
- Verify that the sync catalog agent loads the token and is able to register services.

Checklist:
- [X] Tests updated
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

