### PR TITLE
Supply chain updates for Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Determine Go version
         id: get-go-version
         # We use .go-version as our source of truth for current Go
@@ -35,7 +35,7 @@ jobs:
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: get product version
         id: get-product-version
         run: |
@@ -49,7 +49,7 @@ jobs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
       - name: "Checkout directory"
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Generate metadata file
         id: generate-metadata-file
         uses: hashicorp/actions-generate-metadata@v1
@@ -57,7 +57,7 @@ jobs:
           version: ${{ needs.get-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
           repositoryOwner: "hashicorp"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
@@ -109,10 +109,10 @@ jobs:
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} ${{ matrix.component }} build    
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: ${{ matrix.go }}
 
@@ -134,7 +134,7 @@ jobs:
           zip -r -j out/${{ matrix.pkg_name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
 
       - name: Upload built binaries 
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: ${{ matrix.pkg_name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
           path: ${{ matrix.component}}/out/${{ matrix.pkg_name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
@@ -162,7 +162,7 @@ jobs:
 
       - name: Test rpm package
         if: ${{ matrix.goos == 'linux' && matrix.component == 'cli' && matrix.goarch == 'amd64'}}
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@v3 # TSCCR: no entry for repository "addnab/docker-run-action"
         with:
           image: registry.access.redhat.com/ubi8/ubi:latest
           options: -v ${{ github.workspace }}:/work
@@ -179,7 +179,7 @@ jobs:
             echo "Test PASSED, expected: ${VERSION}, got: ${CONSUL_K8S_VERSION}"
 
       - name: Upload rpm package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: ${{ matrix.goos == 'linux' && matrix.component == 'cli' && matrix.goarch == 'amd64'}}
         with:
           name: ${{ env.RPM_PACKAGE }}
@@ -187,7 +187,7 @@ jobs:
 
       - name: Test debian package
         if: ${{ matrix.goos == 'linux' && matrix.component == 'cli' && matrix.goarch == 'amd64'}}
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@v3 # TSCCR: no entry for repository "addnab/docker-run-action"
         with:
           image: ubuntu:latest
           options: -v ${{ github.workspace }}:/work
@@ -204,7 +204,7 @@ jobs:
             echo "Test PASSED, expected: ${VERSION}, got: ${CONSUL_K8S_VERSION}"
 
       - name: Upload debian packages 
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: ${{ matrix.goos == 'linux' && matrix.component == 'cli' && matrix.goarch == 'amd64'}}
         with:
           name: ${{ env.DEB_PACKAGE }}
@@ -221,8 +221,8 @@ jobs:
       repo: ${{ github.event.repository.name }}
       version: ${{ needs.get-product-version.outputs.product-version }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: consul-cni_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
           path: control-plane/dist/cni/linux/${{ matrix.arch }}
@@ -265,8 +265,8 @@ jobs:
       repo: ${{ github.event.repository.name }}
       version: ${{ needs.get-product-version.outputs.product-version }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: consul-cni_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
           path: control-plane/dist/cni/linux/${{ matrix.arch }}
@@ -307,8 +307,8 @@ jobs:
       repo: ${{ github.event.repository.name }}
       version: ${{ needs.get-product-version.outputs.product-version }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: consul-cni_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
           path: control-plane/dist/cni/linux/${{ matrix.arch }}

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # by default the checkout action doesn't checkout all branches

--- a/.github/workflows/jira-issues.yaml
+++ b/.github/workflows/jira-issues.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Jira Community Issue sync
     steps:    
       - name: Login
-        uses: atlassian/gajira-login@v3.0.0
+        uses: atlassian/gajira-login@ca13f8850ea309cf44a6e4e0c49d9aa48ac3ca4c # v3
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Create ticket if an issue is filed, or if PR not by a team member is opened
         if: github.event.action == 'opened'
-        uses: tomhjp/gh-action-jira-create@v0.2.0
+        uses: tomhjp/gh-action-jira-create@3ed1789cad3521292e591a7cfa703215ec1348bf # v0.2.1
         with:
           project: NET
           issuetype: "${{ steps.set-ticket-type.outputs.TYPE }}"
@@ -58,28 +58,28 @@ jobs:
       - name: Search
         if: github.event.action != 'opened'
         id: search
-        uses: tomhjp/gh-action-jira-search@v0.2.1
+        uses: tomhjp/gh-action-jira-search@04700b457f317c3e341ce90da5a3ff4ce058f2fa # v0.2.2
         with:
           # cf[10089] is Issue Link (use JIRA API to retrieve)
           jql: 'issuetype = "${{ steps.set-ticket-type.outputs.TYPE }}" and cf[10089] = "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"'
 
       - name: Sync comment
         if: github.event.action == 'created' && steps.search.outputs.issue
-        uses: tomhjp/gh-action-jira-comment@v0.1.0
+        uses: tomhjp/gh-action-jira-comment@6eb6b9ead70221916b6badd118c24535ed220bd9 # v0.2.0
         with:
           issue: ${{ steps.search.outputs.issue }}
           comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"
 
       - name: Close ticket
         if: ( github.event.action == 'closed' || github.event.action == 'deleted' ) && steps.search.outputs.issue
-        uses: atlassian/gajira-transition@v2.0.1
+        uses: atlassian/gajira-transition@4749176faf14633954d72af7a44d7f2af01cc92b # v3
         with:
           issue: ${{ steps.search.outputs.issue }}
           transition: "Closed"
 
       - name: Reopen ticket
         if: github.event.action == 'reopened' && steps.search.outputs.issue
-        uses: atlassian/gajira-transition@v2.0.1
+        uses: atlassian/gajira-transition@4749176faf14633954d72af7a44d7f2af01cc92b # v3
         with:
           issue: ${{ steps.search.outputs.issue }}
           transition: "To Do"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -21,7 +21,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-    - uses: benc-uk/workflow-dispatch@v1.2.2
+    - uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1.2.2
       name: test
       with:
         workflow: test.yml

--- a/.github/workflows/nightly-acceptance.yml
+++ b/.github/workflows/nightly-acceptance.yml
@@ -17,7 +17,7 @@ jobs:
     name: cloud
     runs-on: ubuntu-latest
     steps:
-    - uses: benc-uk/workflow-dispatch@v1.2.2
+    - uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1.2.2
       name: cloud
       with:
         workflow: cloud.yml

--- a/.github/workflows/nightly-cleanup.yml
+++ b/.github/workflows/nightly-cleanup.yml
@@ -17,7 +17,7 @@ jobs:
     name: cleanup
     runs-on: ubuntu-latest
     steps:
-    - uses: benc-uk/workflow-dispatch@v1.2.2
+    - uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1.2.2
       name: cleanup
       with:
         workflow: cleanup.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-    - uses: benc-uk/workflow-dispatch@v1.2.2
+    - uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1.2.2
       name: test
       with:
         workflow: test.yml

--- a/.github/workflows/weekly-acceptance-0-49-x.yml
+++ b/.github/workflows/weekly-acceptance-0-49-x.yml
@@ -19,7 +19,7 @@ jobs:
     name: cloud
     runs-on: ubuntu-latest
     steps:
-    - uses: benc-uk/workflow-dispatch@v1.2.2
+    - uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1.2.2
       name: cloud
       with:
         workflow: cloud.yml

--- a/.github/workflows/weekly-acceptance-1-0-x.yml
+++ b/.github/workflows/weekly-acceptance-1-0-x.yml
@@ -20,7 +20,7 @@ jobs:
     name: cloud
     runs-on: ubuntu-latest
     steps:
-    - uses: benc-uk/workflow-dispatch@v1.2.2
+    - uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1.2.2
       name: cloud
       with:
         workflow: cloud.yml

--- a/.github/workflows/weekly-acceptance-1-1-x.yml
+++ b/.github/workflows/weekly-acceptance-1-1-x.yml
@@ -20,7 +20,7 @@ jobs:
     name: cloud
     runs-on: ubuntu-latest
     steps:
-    - uses: benc-uk/workflow-dispatch@v1.2.2
+    - uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1.2.2
       name: cloud
       with:
         workflow: cloud.yml


### PR DESCRIPTION
Changes proposed in this PR:
- As part of security best practices, we lock down what versions of Github Actions we use.
- This updates our actions to use approved versions.

How I've tested this PR:

:octocat: 

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

