### PR TITLE
add sameness group to exported services

### DIFF
--- a/charts/consul/templates/crd-exportedservices.yaml
+++ b/charts/consul/templates/crd-exportedservices.yaml
@@ -79,6 +79,9 @@ spec:
                             description: '[Experimental] Peer is the name of the peer
                               to export the service to.'
                             type: string
+                          samenessGroup:
+                            description: SamenessGroup is the name of the sameness group to export the service to.
+                            type: string
                         type: object
                       type: array
                     name:

--- a/control-plane/api/v1alpha1/exportedservices_types.go
+++ b/control-plane/api/v1alpha1/exportedservices_types.go
@@ -19,6 +19,7 @@ import (
 )
 
 const ExportedServicesKubeKind = "exportedservices"
+const WildcardSpecifier = "*"
 
 func init() {
 	SchemeBuilder.Register(&ExportedServices{}, &ExportedServicesList{})
@@ -73,6 +74,8 @@ type ServiceConsumer struct {
 	Partition string `json:"partition,omitempty"`
 	// [Experimental] Peer is the name of the peer to export the service to.
 	Peer string `json:"peer,omitempty"`
+	// SamenessGroup is the name of the sameness group to export the service to.
+	SamenessGroup string `json:"samenessGroup,omitempty"`
 }
 
 func (in *ExportedServices) GetObjectMeta() metav1.ObjectMeta {
@@ -169,8 +172,9 @@ func (in *ExportedService) toConsul() capi.ExportedService {
 	var consumers []capi.ServiceConsumer
 	for _, consumer := range in.Consumers {
 		consumers = append(consumers, capi.ServiceConsumer{
-			Partition: consumer.Partition,
-			Peer:      consumer.Peer,
+			Partition:     consumer.Partition,
+			Peer:          consumer.Peer,
+			SamenessGroup: consumer.SamenessGroup,
 		})
 	}
 	return capi.ExportedService{
@@ -230,14 +234,31 @@ func (in *ExportedService) validate(path *field.Path, consulMeta common.ConsulMe
 }
 
 func (in *ServiceConsumer) validate(path *field.Path, consulMeta common.ConsulMeta) *field.Error {
-	if in.Partition != "" && in.Peer != "" {
-		return field.Invalid(path, *in, "both partition and peer cannot be specified.")
+	count := 0
+
+	if in.Partition != "" {
+		count++
 	}
-	if in.Partition == "" && in.Peer == "" {
-		return field.Invalid(path, *in, "either partition or peer must be specified.")
+	if in.Peer != "" {
+		count++
+	}
+	if in.SamenessGroup != "" {
+		count++
+	}
+	if count > 1 {
+		return field.Invalid(path, *in, "Service consumer must define at most one of Peer, Partition, or SamenessGroup")
+	}
+	if count == 0 {
+		return field.Invalid(path, *in, "Service consumer must define at least one of Peer, Partition, or SamenessGroup")
 	}
 	if !consulMeta.PartitionsEnabled && in.Partition != "" {
-		return field.Invalid(path.Child("partitions"), in.Partition, "Consul Admin Partitions need to be enabled to specify partition.")
+		return field.Invalid(path.Child("partition"), in.Partition, "Consul Admin Partitions need to be enabled to specify partition.")
+	}
+	if in.Partition == WildcardSpecifier {
+		return field.Invalid(path.Child("partition"), "", "exporting to all partitions (wildcard) is not supported")
+	}
+	if in.Peer == WildcardSpecifier {
+		return field.Invalid(path.Child("peer"), "", "exporting to all peers (wildcard) is not supported")
 	}
 	return nil
 }

--- a/control-plane/api/v1alpha1/exportedservices_types_test.go
+++ b/control-plane/api/v1alpha1/exportedservices_types_test.go
@@ -59,6 +59,9 @@ func TestExportedServices_MatchesConsul(t *testing.T) {
 								{
 									Peer: "second-peer",
 								},
+								{
+									SamenessGroup: "sg1",
+								},
 							},
 						},
 						{
@@ -73,6 +76,9 @@ func TestExportedServices_MatchesConsul(t *testing.T) {
 								},
 								{
 									Peer: "third-peer",
+								},
+								{
+									SamenessGroup: "sg2",
 								},
 							},
 						},
@@ -95,6 +101,9 @@ func TestExportedServices_MatchesConsul(t *testing.T) {
 							{
 								Peer: "second-peer",
 							},
+							{
+								SamenessGroup: "sg1",
+							},
 						},
 					},
 					{
@@ -109,6 +118,9 @@ func TestExportedServices_MatchesConsul(t *testing.T) {
 							},
 							{
 								Peer: "third-peer",
+							},
+							{
+								SamenessGroup: "sg2",
 							},
 						},
 					},
@@ -183,6 +195,9 @@ func TestExportedServices_ToConsul(t *testing.T) {
 								{
 									Peer: "second-peer",
 								},
+								{
+									SamenessGroup: "sg2",
+								},
 							},
 						},
 						{
@@ -197,6 +212,9 @@ func TestExportedServices_ToConsul(t *testing.T) {
 								},
 								{
 									Peer: "third-peer",
+								},
+								{
+									SamenessGroup: "sg3",
 								},
 							},
 						},
@@ -219,6 +237,9 @@ func TestExportedServices_ToConsul(t *testing.T) {
 							{
 								Peer: "second-peer",
 							},
+							{
+								SamenessGroup: "sg2",
+							},
 						},
 					},
 					{
@@ -233,6 +254,9 @@ func TestExportedServices_ToConsul(t *testing.T) {
 							},
 							{
 								Peer: "third-peer",
+							},
+							{
+								SamenessGroup: "sg3",
 							},
 						},
 					},
@@ -277,6 +301,9 @@ func TestExportedServices_Validate(t *testing.T) {
 								},
 								{
 									Peer: "second-peer",
+								},
+								{
+									SamenessGroup: "sg2",
 								},
 							},
 						},
@@ -331,10 +358,10 @@ func TestExportedServices_Validate(t *testing.T) {
 			namespaceEnabled:  true,
 			partitionsEnabled: true,
 			expectedErrMsgs: []string{
-				`spec.services[0].consumers[0]: Invalid value: v1alpha1.ServiceConsumer{Partition:"second", Peer:"second-peer"}: both partition and peer cannot be specified.`,
+				`Service consumer must define at most one of Peer, Partition, or SamenessGroup`,
 			},
 		},
-		"neither partition nor peer name specified": {
+		"none of peer, partition, or sameness group defined": {
 			input: &ExportedServices{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: common.DefaultConsulPartition,
@@ -354,7 +381,7 @@ func TestExportedServices_Validate(t *testing.T) {
 			namespaceEnabled:  true,
 			partitionsEnabled: true,
 			expectedErrMsgs: []string{
-				`spec.services[0].consumers[0]: Invalid value: v1alpha1.ServiceConsumer{Partition:"", Peer:""}: either partition or peer must be specified.`,
+				`Service consumer must define at least one of Peer, Partition, or SamenessGroup`,
 			},
 		},
 		"partition provided when partitions are disabled": {
@@ -379,7 +406,7 @@ func TestExportedServices_Validate(t *testing.T) {
 			namespaceEnabled:  true,
 			partitionsEnabled: false,
 			expectedErrMsgs: []string{
-				`spec.services[0].consumers[0].partitions: Invalid value: "test-partition": Consul Admin Partitions need to be enabled to specify partition.`,
+				`spec.services[0].consumers[0].partition: Invalid value: "test-partition": Consul Admin Partitions need to be enabled to specify partition.`,
 			},
 		},
 		"namespace provided when namespaces are disabled": {
@@ -407,6 +434,56 @@ func TestExportedServices_Validate(t *testing.T) {
 				`spec.services[0]: Invalid value: "frontend": Consul Namespaces must be enabled to specify service namespace.`,
 			},
 		},
+		"exporting to all partitions is not supported": {
+			input: &ExportedServices{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: common.DefaultConsulPartition,
+				},
+				Spec: ExportedServicesSpec{
+					Services: []ExportedService{
+						{
+							Name:      "service-frontend",
+							Namespace: "frontend",
+							Consumers: []ServiceConsumer{
+								{
+									Partition: "*",
+								},
+							},
+						},
+					},
+				},
+			},
+			namespaceEnabled:  true,
+			partitionsEnabled: true,
+			expectedErrMsgs: []string{
+				`exporting to all partitions (wildcard) is not supported`,
+			},
+		},
+		"exporting to all peers (wildcard) is not supported": {
+			input: &ExportedServices{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: common.DefaultConsulPartition,
+				},
+				Spec: ExportedServicesSpec{
+					Services: []ExportedService{
+						{
+							Name:      "service-frontend",
+							Namespace: "frontend",
+							Consumers: []ServiceConsumer{
+								{
+									Peer: "*",
+								},
+							},
+						},
+					},
+				},
+			},
+			namespaceEnabled:  true,
+			partitionsEnabled: true,
+			expectedErrMsgs: []string{
+				`exporting to all peers (wildcard) is not supported`,
+			},
+		},
 		"multiple errors": {
 			input: &ExportedServices{
 				ObjectMeta: metav1.ObjectMeta{
@@ -423,6 +500,10 @@ func TestExportedServices_Validate(t *testing.T) {
 									Peer:      "second-peer",
 								},
 								{},
+								{
+									SamenessGroup: "sg2",
+									Partition:     "partition2",
+								},
 							},
 						},
 					},
@@ -431,8 +512,9 @@ func TestExportedServices_Validate(t *testing.T) {
 			namespaceEnabled:  true,
 			partitionsEnabled: true,
 			expectedErrMsgs: []string{
-				`spec.services[0].consumers[0]: Invalid value: v1alpha1.ServiceConsumer{Partition:"second", Peer:"second-peer"}: both partition and peer cannot be specified.`,
-				`spec.services[0].consumers[1]: Invalid value: v1alpha1.ServiceConsumer{Partition:"", Peer:""}: either partition or peer must be specified.`,
+				`spec.services[0].consumers[0]: Invalid value: v1alpha1.ServiceConsumer{Partition:"second", Peer:"second-peer", SamenessGroup:""}: Service consumer must define at most one of Peer, Partition, or SamenessGroup`,
+				`spec.services[0].consumers[1]: Invalid value: v1alpha1.ServiceConsumer{Partition:"", Peer:"", SamenessGroup:""}: Service consumer must define at least one of Peer, Partition, or SamenessGroup`,
+				`spec.services[0].consumers[2]: Invalid value: v1alpha1.ServiceConsumer{Partition:"partition2", Peer:"", SamenessGroup:"sg2"}: Service consumer must define at most one of Peer, Partition, or SamenessGroup`,
 			},
 		},
 	}

--- a/control-plane/config/crd/bases/consul.hashicorp.com_exportedservices.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_exportedservices.yaml
@@ -75,6 +75,9 @@ spec:
                             description: '[Experimental] Peer is the name of the peer
                               to export the service to.'
                             type: string
+                          samenessGroup:
+                            description: SamenessGroup is the name of the sameness group to export the service to.
+                            type: string
                         type: object
                       type: array
                     name:

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20220831174802-b8af65262de8
 	github.com/hashicorp/consul-server-connection-manager v0.1.0
-	github.com/hashicorp/consul/api v1.10.1-0.20230331190547-fc64a702f43c
+	github.com/hashicorp/consul/api v1.10.1-0.20230418163148-eb9f671eafae
 	github.com/hashicorp/consul/sdk v0.13.1
 	github.com/hashicorp/go-discover v0.0.0-20200812215701-c4b85f6ed31f
 	github.com/hashicorp/go-hclog v1.2.2

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -355,6 +355,8 @@ github.com/hashicorp/consul-server-connection-manager v0.1.0/go.mod h1:XVVlO+Yk7
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.10.1-0.20230331190547-fc64a702f43c h1:MfDuWW38RozPodXT2aGc5jakoYo9EjgYpZl+vR3//Wg=
 github.com/hashicorp/consul/api v1.10.1-0.20230331190547-fc64a702f43c/go.mod h1:f8zVJwBcLdr1IQnfdfszjUM0xzp31Zl3bpws3pL9uFM=
+github.com/hashicorp/consul/api v1.10.1-0.20230418163148-eb9f671eafae h1:lYnO52QxlfATRZ1Vo8tQV+lFns7rZ4iAbbi3JN4ZAQw=
+github.com/hashicorp/consul/api v1.10.1-0.20230418163148-eb9f671eafae/go.mod h1:f8zVJwBcLdr1IQnfdfszjUM0xzp31Zl3bpws3pL9uFM=
 github.com/hashicorp/consul/proto-public v0.1.0 h1:O0LSmCqydZi363hsqc6n2v5sMz3usQMXZF6ziK3SzXU=
 github.com/hashicorp/consul/proto-public v0.1.0/go.mod h1:vs2KkuWwtjkIgA5ezp4YKPzQp4GitV+q/+PvksrA92k=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=


### PR DESCRIPTION
Changes proposed in this PR:
add sameness group to exported services

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

