### PR TITLE
Adjust API gateway controller deployment appropriately when Vault configured as secrets backend

### DIFF
--- a/.changelog/2083.txt
+++ b/.changelog/2083.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api-gateway: fix issue where when Vault is configured as the secrets backend, the API Gateway controller is unable to start up successfully
+```

--- a/.changelog/2083.txt
+++ b/.changelog/2083.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-api-gateway: fix issue where when Vault is configured as the secrets backend, the API Gateway controller is unable to start up successfully
+api-gateway: fix issue where the API Gateway controller is unable to start up successfully when Vault is configured as the secrets backend
 ```

--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -62,7 +62,7 @@ spec:
           name: sds
           protocol: TCP
         env:
-        {{- if or (not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots)) .Values.client.enabled }}
+        {{- if or (not (or (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) .Values.global.secretsBackend.vault.enabled)) .Values.client.enabled }}
         {{- if .Values.global.tls.enabled }}
         - name: CONSUL_CACERT
           value: /consul/tls/ca/tls.crt
@@ -156,7 +156,7 @@ spec:
         - name: consul-bin
           mountPath: /consul-bin
         {{- end }}
-        {{- if or (not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots)) .Values.client.enabled }}
+        {{- if or (not (or (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) .Values.global.secretsBackend.vault.enabled)) .Values.client.enabled }}
         {{- if .Values.global.tls.enabled }}
         {{- if and .Values.client.enabled .Values.global.tls.enableAutoEncrypt }}
         - name: consul-auto-encrypt-ca-cert
@@ -186,7 +186,7 @@ spec:
         emptyDir: { }
       {{- end }}
       {{- if .Values.global.tls.enabled }}
-      {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
+      {{- if not (or (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) .Values.global.secretsBackend.vault.enabled) }}
       - name: consul-ca-cert
         secret:
           {{- if .Values.global.tls.caCert.secretName }}
@@ -253,7 +253,7 @@ spec:
         - mountPath: /consul/login
           name: consul-data
           readOnly: false
-        {{- if not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) }}
+        {{- if not (or (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) .Values.global.secretsBackend.vault.enabled) }}
         {{- if .Values.global.tls.enabled }}
         - name: consul-ca-cert
           mountPath: /consul/tls/ca

--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -62,10 +62,14 @@ spec:
           name: sds
           protocol: TCP
         env:
-        {{- if or (not (or (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) .Values.global.secretsBackend.vault.enabled)) .Values.client.enabled }}
+        {{- if or (not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots)) .Values.client.enabled }}
         {{- if .Values.global.tls.enabled }}
         - name: CONSUL_CACERT
+          {{- if and (not .Values.client.enabled) .Values.global.secretsBackend.vault.enabled }}
+          value: /vault/secrets/serverca.crt
+          {{- else }}
           value: /consul/tls/ca/tls.crt
+          {{- end }}
         {{- end }}
         {{- end }}
         - name: HOST_IP

--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -65,6 +65,9 @@ spec:
         {{- if or (not (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots)) .Values.client.enabled }}
         {{- if .Values.global.tls.enabled }}
         - name: CONSUL_CACERT
+          {{- /* When Vault is being used as a secrets backend, auto-encrypt must be enabled. Since clients use a separate
+          root CA from servers when auto-encrypt is enabled, and our controller communicates with the agent when clients are
+          enabled, we only use the Vault server CA if clients are disabled and our controller will be communicating w/ the server. */}}
           {{- if and (not .Values.client.enabled) .Values.global.secretsBackend.vault.enabled }}
           value: /vault/secrets/serverca.crt
           {{- else }}

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -1572,6 +1572,21 @@ load _helpers
   [ "${actual}" = "" ]
 }
 
+@test "apiGateway/Deployment: consul-ca-cert volume mount is not set when using Vault as a secrets backend" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-controller-deployment.yaml  \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=bar' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'server.enabled=true' \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+}
+
 @test "apiGateway/Deployment: consul-ca-cert volume mount is not set on acl-init when using externalServers and useSystemRoots" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -1584,6 +1599,21 @@ load _helpers
       --set 'externalServers.hosts[0]=external-consul.host' \
       --set 'externalServers.enabled=true' \
       --set 'externalServers.useSystemRoots=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers[1].volumeMounts[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+}
+
+@test "apiGateway/Deployment: consul-ca-cert volume mount is not set on acl-init when using Vault as secrets backend" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-controller-deployment.yaml  \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=bar' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'server.enabled=true' \
+      --set 'global.secretsBackend.vault.enabled=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.initContainers[1].volumeMounts[] | select(.name == "consul-ca-cert")' | tee /dev/stderr)
   [ "${actual}" = "" ]

--- a/charts/consul/test/unit/api-gateway-controller-deployment.bats
+++ b/charts/consul/test/unit/api-gateway-controller-deployment.bats
@@ -1522,6 +1522,23 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "apiGateway/Deployment: CONSUL_CACERT has correct path with Vault as secrets backend and client disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/api-gateway-controller-deployment.yaml \
+      --set 'apiGateway.enabled=true' \
+      --set 'apiGateway.image=bar' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.caCert.secretName=foo' \
+      --set 'server.enabled=true' \
+      --set 'client.enabled=false' \
+      --set 'global.secretsBackend.vault.enabled=true' \
+      --set 'global.secretsBackend.vault.consulServerRole=foo' \
+      . | tee /dev/stderr|
+      yq '.spec.template.spec.containers[0].env[0].value == "/vault/secrets/serverca.crt"' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 @test "apiGateway/Deployment: CONSUL_CACERT is not set when using tls and useSystemRoots" {
   cd `chart_dir`
   local actual=$(helm template \


### PR DESCRIPTION
**Changes proposed in this PR:**
Consider whether Vault is being used as a secrets backend when determining whether to mount a TLS cert into the API gateway controller deployment.

Largely, this change is based off of how other deployments already handle Vault as a secrets backend. For example:

https://github.com/hashicorp/consul-k8s/blob/112ad18e12683559413c058d8e52f28d66597b07/charts/consul/templates/connect-inject-deployment.yaml#L293-L297

The only unique aspect here is that the api-gateway-controller communicates directly with agents when `client.enabled=true`, so we require some additional gating to make sure that we're using the correct cert in this case.

**How I've tested this PR:**
Install Consul w/ API gateway enabled in configurations both with and without Vault used as a secrets backend. In each case, verify that the API gateway controller is able to start up successfully and that deployed API gateways function correctly.

Install Consul w/ external server configuration (HCP, for example). Test with and without clients enabled.

**How I expect reviewers to test this PR:**


**Checklist:**
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

