### PR TITLE
Net 3508/gateway controller

### DIFF
--- a/charts/consul/templates/connect-inject-clusterrole.yaml
+++ b/charts/consul/templates/connect-inject-clusterrole.yaml
@@ -122,6 +122,8 @@ rules:
   resources:
   - gatewayclasses
   - gateways
+  - httproutes
+  - tcproutes
   verbs:
   - create
   - delete
@@ -144,4 +146,27 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+  verbs:
+    - create
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - core
+  resources:
+    - referencegrants
+    - services
+  verbs:
+    - watch
+- apiGroups: [ "" ]
+  resources: [ "secrets", "serviceaccounts" ]
+  verbs:
+    - "get"
+    - "list"
+    - "watch"
 {{- end }}

--- a/charts/consul/templates/connect-inject-clusterrole.yaml
+++ b/charts/consul/templates/connect-inject-clusterrole.yaml
@@ -164,7 +164,7 @@ rules:
   verbs:
     - watch
 - apiGroups: [ "" ]
-  resources: [ "secrets", "serviceaccounts" ]
+  resources: [ "secrets" ]
   verbs:
     - "get"
     - "list"

--- a/charts/consul/templates/connect-inject-clusterrole.yaml
+++ b/charts/consul/templates/connect-inject-clusterrole.yaml
@@ -124,6 +124,7 @@ rules:
   - gateways
   - httproutes
   - tcproutes
+  - referencegrants
   verbs:
   - create
   - delete
@@ -159,10 +160,10 @@ rules:
 - apiGroups:
     - core
   resources:
-    - referencegrants
     - services
   verbs:
     - watch
+    - list
 - apiGroups: [ "" ]
   resources: [ "secrets" ]
   verbs:

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -1,0 +1,145 @@
+package controllers
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+const (
+	gatewayFinalizer = "gateway-finalizer.consul.hashicorp.com"
+)
+
+// GatewayController reconciles a Gateway object.
+// The GatewayClass is responsible for defining the behavior of API gateways.
+type GatewayController struct {
+	Log logr.Logger
+	client.Client
+}
+
+// Reconcile handles the reconciliation loop for Gateway objects.
+func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("gatewayClass", req.NamespacedName)
+	log.Info("------------Reconciling the Gateway GatewayController", "name", req.Name)
+
+	gw := &gwv1beta1.Gateway{}
+	err := r.Client.Get(ctx, req.NamespacedName, gw)
+	if err != nil {
+		log.Error(err, "unable to get Gateway")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// if gw class doesn't exist log an error
+	gwc := &gwv1beta1.GatewayClass{}
+	err = r.Client.Get(ctx, types.NamespacedName{Name: string(gw.Spec.GatewayClassName)}, gwc)
+	if err != nil {
+		log.Error(err, "unable to get GatewayClass")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if string(gwc.Spec.ControllerName) != GatewayClassControllerName || !gw.ObjectMeta.DeletionTimestamp.IsZero() {
+		// This Gateway is not for this controller or the gateway is being deleted
+		// TODO: Cleanup Consul resources
+		log.Info("This Gateway is not for this controller or the gateway is being deleted")
+		_, err := RemoveFinalizer(ctx, r.Client, gw, gatewayFinalizer)
+		if err != nil {
+			log.Error(err, "unable to remove finalizer")
+		}
+
+		return ctrl.Result{}, err
+	}
+
+	//TODO: serialize gatewayClassConfig onto Gateway.
+	didUpdate, err := EnsureFinalizer(ctx, r.Client, gw, gatewayFinalizer)
+	if err != nil {
+		log.Error(err, "unable to add finalizer")
+		return ctrl.Result{}, err
+	}
+	if didUpdate {
+		// We updated the Gateway, requeue to avoid another update.
+		return ctrl.Result{}, nil
+	}
+
+	//TODO: Handle reconcilation.
+	// do the tcp routes
+
+	// do the gateway
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers the controller with the given manager.
+func (r *GatewayController) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&gwv1beta1.Gateway{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&corev1.Secret{}).
+		Watches(
+			source.NewKindWithCache(&gwv1alpha2.TCPRoute{}, mgr.GetCache()), r.tcpRouteFieldIndexEventHandler(ctx),
+		).
+		Watches(
+			source.NewKindWithCache(&gwv1alpha2.HTTPRoute{}, mgr.GetCache()), r.tcpRouteFieldIndexEventHandler(ctx),
+		).
+		//Watches(
+		//	&source.Kind{Type: &corev1.Pod{}},
+		//	handler.EnqueueRequestsFromMapFunc(podToGatewayRequest),
+		//	builder.WithPredicates(predicate),
+		//).
+		//Watches(
+		//	&source.Kind{Type: &gwv1alpha2.ReferenceGrant{}},
+		//	handler.EnqueueRequestsFromMapFunc(r.referenceGrantToGatewayRequests),
+		//).
+		//Watches(
+		//	&source.Kind{Type: &gwv1alpha2.ReferencePolicy{}},
+		//	handler.EnqueueRequestsFromMapFunc(r.referencePolicyToGatewayRequests),
+		//).
+		// TODO: Watches for consul resources.
+		Complete(r)
+}
+
+// gatewayClassConfigFieldIndexEventHandler returns an EventHandler that will enqueue
+// reconcile.Requests for GatewayClass objects that reference the GatewayClassConfig
+// object that triggered the event.
+func (r *GatewayController) tcpRouteFieldIndexEventHandler(ctx context.Context) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
+		// Get all GatewayClass objects from the field index of the GatewayClassConfig which triggered the event.
+		var gList gwv1beta1.GatewayList
+		err := r.Client.List(ctx, &gList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(TCPRoute_GatewayIndex, o.GetName()),
+		})
+		if err != nil {
+			r.Log.Error(err, "unable to list gateway")
+		}
+
+		return makeListOfRequestsToReconcile(gList)
+	})
+}
+
+// TODO: Melisa think about efficiency
+// TODO: Is this where we want this to live
+// makeListOfRequestsToReconcile will take a list of Gateways and return a list of
+// reconcile Requests.
+func makeListOfRequestsToReconcile(gateways gwv1beta1.GatewayList) []reconcile.Request {
+	requests := make([]reconcile.Request, 0, len(gateways.Items))
+	for _, gw := range gateways.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      gw.Name,
+				Namespace: gw.Namespace,
+			},
+		})
+	}
+	return requests
+}

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -40,9 +40,9 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	gw := &gwv1beta1.Gateway{}
 	err := r.Client.Get(ctx, req.NamespacedName, gw)
 	if err != nil {
-	    if k8serror.IsNotFound(err) {
-	        return ctrl.Result{}, nil
-	    }
+		if k8serrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
 		log.Error(err, "unable to get Gateway")
 		return ctrl.Result{}, err
 	}

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -25,7 +25,7 @@ const (
 )
 
 // GatewayController reconciles a Gateway object.
-// The GatewayClass is responsible for defining the behavior of API gateways.
+// The Gateway is responsible for defining the behavior of API gateways.
 type GatewayController struct {
 	Log logr.Logger
 	client.Client
@@ -33,7 +33,7 @@ type GatewayController struct {
 
 // Reconcile handles the reconciliation loop for Gateway objects.
 func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("gatewayClass", req.NamespacedName)
+	log := r.Log.WithValues("gateway", req.NamespacedName)
 	log.Info("Reconciling the Gateway: ", req.Name)
 
 	// If gateway does not exist, log an error.

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -168,7 +168,7 @@ func (r *GatewayController) transformTCPRoute(ctx context.Context) func(o client
 func (r *GatewayController) transformSecret(ctx context.Context) func(o client.Object) []reconcile.Request {
 	return func(o client.Object) []reconcile.Request {
 		secret := o.(*corev1.Secret)
-		gatewayList := &gwv1alpha2.GatewayList{}
+		gatewayList := &gwv1beta1.GatewayList{}
 		if err := r.Client.List(ctx, gatewayList, &client.ListOptions{
 			FieldSelector: fields.OneTermEqualSelector(Secret_GatewayIndex, secret.Name),
 		}); err != nil {
@@ -181,7 +181,7 @@ func (r *GatewayController) transformSecret(ctx context.Context) func(o client.O
 func (r *GatewayController) transformReferenceGrant(ctx context.Context) func(o client.Object) []reconcile.Request {
 	return func(o client.Object) []reconcile.Request {
 		// just reconcile all gateways within the namespace
-		grant := o.(*gwv1alpha2.ReferenceGrant)
+		grant := o.(*gwv1beta1.ReferenceGrant)
 		gatewayList := &gwv1beta1.GatewayList{}
 		if err := r.Client.List(ctx, gatewayList, &client.ListOptions{
 			Namespace: grant.Namespace,

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -124,7 +124,7 @@ func (r *GatewayController) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 }
 
 // transformGatewayClass will check the list of GatewayClass objects for a matching
-// class, then return a list of reconcile Requests for them
+// class, then return a list of reconcile Requests for it.
 func (r *GatewayController) transformGatewayClass(ctx context.Context) func(o client.Object) []reconcile.Request {
 	return func(o client.Object) []reconcile.Request {
 		gatewayClass := o.(*gwv1beta1.GatewayClass)
@@ -230,7 +230,7 @@ func refsToRequests(objects []types.NamespacedName) []reconcile.Request {
 	return requests
 }
 
-// parentRefs takes a list of ParentReference objects and returns a list of NamespacedName objects
+// parentRefs takes a list of ParentReference objects and returns a list of NamespacedName objects.
 func parentRefs(group, kind, namespace string, refs []gwv1beta1.ParentReference) []types.NamespacedName {
 	indexed := make([]types.NamespacedName, 0, len(refs))
 	for _, parent := range refs {

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -40,8 +40,11 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	gw := &gwv1beta1.Gateway{}
 	err := r.Client.Get(ctx, req.NamespacedName, gw)
 	if err != nil {
+	    if k8serror.IsNotFound(err) {
+	        return ctrl.Result{}, nil
+	    }
 		log.Error(err, "unable to get Gateway")
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		return ctrl.Result{}, err
 	}
 
 	// If gateway class on the gateway does not exist, log an error.

--- a/control-plane/api-gateway/controllers/gateway_controller_test.go
+++ b/control-plane/api-gateway/controllers/gateway_controller_test.go
@@ -1,0 +1,160 @@
+package controllers
+
+import (
+	"context"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"testing"
+
+	logrtest "github.com/go-logr/logr/testing"
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+func TestGatewayReconciler(t *testing.T) {
+	t.Parallel()
+
+	namespace := "test-namespace"
+	name := "test-gateway"
+	gatewayClassName := gwv1beta1.ObjectName("test-gateway-class")
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+
+	cases := map[string]struct {
+		gateway            *gwv1beta1.Gateway
+		k8sObjects         []runtime.Object
+		expectedResult     ctrl.Result
+		expectedError      error
+		expectedFinalizers []string
+		expectedIsDeleted  bool
+		expectedConditions []metav1.Condition
+	}{
+		"successful reconcile with no change": {
+			gateway: &gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  namespace,
+					Name:       name,
+					Finalizers: []string{gatewayFinalizer},
+				},
+				Spec: gwv1beta1.GatewaySpec{
+					GatewayClassName: gatewayClassName,
+				},
+			},
+			k8sObjects: []runtime.Object{
+				&gwv1beta1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "",
+						Name:      string(gatewayClassName),
+						Finalizers: []string{
+							gatewayClassFinalizer,
+						},
+					},
+					Spec: gwv1beta1.GatewayClassSpec{
+						ControllerName: GatewayClassControllerName,
+					},
+				},
+			},
+			expectedResult:     ctrl.Result{},
+			expectedError:      nil,
+			expectedFinalizers: []string{gatewayFinalizer},
+			expectedIsDeleted:  false,
+			expectedConditions: []metav1.Condition{
+				{
+					Type:    accepted,
+					Status:  metav1.ConditionTrue,
+					Reason:  configurationAccepted,
+					Message: "Configuration accepted",
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			s := runtime.NewScheme()
+			require.NoError(t, gwv1beta1.Install(s))
+			require.NoError(t, v1alpha1.AddToScheme(s))
+
+			objs := tc.k8sObjects
+			if tc.gateway != nil {
+				objs = append(objs, tc.gateway)
+			}
+
+			fakeClient := registerFieldIndexersForTest(fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...)).Build()
+
+			r := &GatewayController{
+				Client: fakeClient,
+				Log:    logrtest.NewTestLogger(t),
+			}
+			result, err := r.Reconcile(context.Background(), req)
+
+			require.Equal(t, tc.expectedResult, result)
+			require.Equal(t, tc.expectedError, err)
+
+			// TODO: Add back with real implementation of reconcile
+			//// Check the GatewayClass after reconciliation.
+			//g := &gwv1beta1.Gateway{}
+			//err = r.Client.Get(context.Background(), req.NamespacedName, g)
+			//
+			//require.NoError(t, client.IgnoreNotFound(err))
+			//require.Equal(t, tc.expectedFinalizers, g.ObjectMeta.Finalizers)
+			//require.Equal(t, len(tc.expectedConditions), len(g.Status.Conditions), "expected %+v, got %+v", tc.expectedConditions, g.Status.Conditions)
+			//for i, expectedCondition := range tc.expectedConditions {
+			//	require.True(t, equalConditions(expectedCondition, g.Status.Conditions[i]), "expected %+v, got %+v", expectedCondition, g.Status.Conditions[i])
+			//}
+		})
+	}
+}
+func TestObjectsToRequests(t *testing.T) {
+	t.Parallel()
+
+	namespace := "test-namespace"
+	name := "test-gatewayclass"
+
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	cases := map[string]struct {
+		objects        []metav1.Object
+		expectedResult []reconcile.Request
+	}{
+		"successful conversion of gateway to request": {
+			objects: []metav1.Object{
+				&gwv1beta1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      name,
+					},
+					Spec: gwv1beta1.GatewaySpec{
+						GatewayClassName: GatewayClassControllerName,
+					},
+				},
+			},
+			expectedResult: []reconcile.Request{
+				{
+					NamespacedName: namespacedName,
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			requests := objectsToRequests(tc.objects)
+
+			require.Equal(t, tc.expectedResult, requests)
+		})
+	}
+}

--- a/control-plane/api-gateway/controllers/gateway_controller_test.go
+++ b/control-plane/api-gateway/controllers/gateway_controller_test.go
@@ -39,7 +39,7 @@ func TestGatewayReconciler(t *testing.T) {
 		expectedIsDeleted  bool
 		expectedConditions []metav1.Condition
 	}{
-		"successful reconcile with no change": {
+		"successful reconcile with no change simple gateway": {
 			gateway: &gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:  namespace,
@@ -68,14 +68,6 @@ func TestGatewayReconciler(t *testing.T) {
 			expectedError:      nil,
 			expectedFinalizers: []string{gatewayFinalizer},
 			expectedIsDeleted:  false,
-			expectedConditions: []metav1.Condition{
-				{
-					Type:    accepted,
-					Status:  metav1.ConditionTrue,
-					Reason:  configurationAccepted,
-					Message: "Configuration accepted",
-				},
-			},
 		},
 	}
 

--- a/control-plane/api-gateway/controllers/index.go
+++ b/control-plane/api-gateway/controllers/index.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -67,4 +69,17 @@ func gatewayClassConfigForGatewayClass(o client.Object) []string {
 func gatewayClassForGateway(o client.Object) []string {
 	g := o.(*gwv1beta1.Gateway)
 	return []string{string(g.Spec.GatewayClassName)}
+}
+
+// gatewayForTCPRoute creates an index of every Gateway referenced by a TCPRoute.
+func gatewayForTCPRoute(o client.Object) []types.NamespacedName {
+	g := o.(*gwv1alpha2.TCPRoute)
+	parents := make([]types.NamespacedName, 0, len(g.Spec.ParentRefs))
+	for _, p := range g.Spec.ParentRefs {
+		parents = append(parents, types.NamespacedName{
+			Namespace: string(*p.Namespace), // TODO: Melisa handle panic
+			Name:      string(p.Name),
+		})
+	}
+	return parents
 }

--- a/control-plane/api-gateway/controllers/index.go
+++ b/control-plane/api-gateway/controllers/index.go
@@ -5,7 +5,6 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -75,7 +74,7 @@ func gatewayClassForGateway(o client.Object) []string {
 }
 
 func gatewayForSecret(o client.Object) []string {
-	gateway := o.(*gwv1alpha2.Gateway)
+	gateway := o.(*gwv1beta1.Gateway)
 	var secretReferences []string
 	for _, listener := range gateway.Spec.Listeners {
 		if listener.TLS == nil || *listener.TLS.Mode != gwv1beta1.TLSModeTerminate {

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlRuntimeWebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -139,6 +140,7 @@ func init() {
 	// We need v1alpha1 here to add the peering api to the scheme
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	utilruntime.Must(gwv1beta1.AddToScheme(scheme))
+	utilruntime.Must(gwv1alpha2.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -477,7 +477,7 @@ func (c *Command) Run(args []string) int {
 		ControllerName: controllers.GatewayClassControllerName,
 		Client:         mgr.GetClient(),
 		Log:            ctrl.Log.WithName("controllers").WithName("GatewayClass"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GatewayClass")
 		return 1
 	}

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -475,13 +475,11 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	gatewayClassReconciler := &controllers.GatewayClassReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("GatewayClass"),
-	}
-
-	err = gatewayClassReconciler.SetupWithManager(mgr)
-	if err != nil {
+	if err := (&controllers.GatewayClassReconciler{
+		ControllerName: controllers.GatewayClassControllerName,
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("controllers").WithName("GatewayClass"),
+	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GatewayClass")
 		return 1
 	}

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -473,12 +473,11 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	if err := (&controllers.GatewayClassReconciler{
-		ControllerName: controllers.GatewayClassControllerName,
-		Client:         mgr.GetClient(),
-		Log:            ctrl.Log.WithName("controllers").WithName("GatewayClass"),
+	if err := (&controllers.GatewayController{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("Gateway"),
 	}).SetupWithManager(ctx, mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "GatewayClass")
+		setupLog.Error(err, "unable to create controller", "controller", "Gateway")
 		return 1
 	}
 

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -140,6 +140,8 @@ func init() {
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	utilruntime.Must(gwv1beta1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
+
+	utilruntime.Must(gwv1beta1.AddToScheme(scheme))
 }
 
 func (c *Command) init() {
@@ -469,6 +471,17 @@ func (c *Command) Run(args []string) int {
 		Client:         mgr.GetClient(),
 		Log:            ctrl.Log.WithName("controllers").WithName("GatewayClass"),
 	}).SetupWithManager(ctx, mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "GatewayClass")
+		return 1
+	}
+
+	gatewayClassReconciler := &controllers.GatewayClassReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("GatewayClass"),
+	}
+
+	err = gatewayClassReconciler.SetupWithManager(mgr)
+	if err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GatewayClass")
 		return 1
 	}

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -140,8 +140,6 @@ func init() {
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	utilruntime.Must(gwv1beta1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
-
-	utilruntime.Must(gwv1beta1.AddToScheme(scheme))
 }
 
 func (c *Command) init() {


### PR DESCRIPTION
Changes proposed in this PR:
- Adds a stub-out of the Gateway Controller

How I've tested this PR:
With the steps below. Basically wanted to make sure the permissions and schemes were there for the controller to be able to react to changes on the object types.

How I expect reviewers to test this PR:
```
kind create cluster
make control-plane-dev-docker
docker tag consul-k8s-control-plane-dev consul-k8s-control-plane-dev:local
kind load docker-image consul-k8s-control-plane-dev:local
kubectl create namespace consul
helm install consul ./charts/consul -n consul --set global.imageK8S=consul-k8s-control-plane-dev:local
```
Then watch the logs for the connect-inject pod when you apply the following resource types, there shouldn't be any errors about access/nonexistent types.
`kubectl apply -f gateway-stuff.yml`
```
# gateway-stuff.yml
apiVersion: v1
kind: Namespace
metadata:
  name: gateway-namespace
---
apiVersion: consul.hashicorp.com/v1alpha1
kind: GatewayClassConfig
metadata:
  name: example-gateway-class-config
---
apiVersion: gateway.networking.k8s.io/v1beta1
kind: GatewayClass
metadata:
  name: example-gateway-class
spec:
  controllerName: 'hashicorp.com/consul-api-gateway-controller'
  parametersRef:
    group: api-gateway.consul.hashicorp.com
    kind: GatewayClassConfig
    name: example-gateway-class-config
---
apiVersion: gateway.networking.k8s.io/v1beta1
kind: Gateway
metadata:
  name: example-gateway
  namespace: gateway-namespace
spec:
  gatewayClassName: example-gateway-class
  listeners:
    - protocol: HTTPS
      port: 443
      name: https
      allowedRoutes:
        namespaces:
          from: Same
      tls:
        certificateRefs:
          - name: cert
            namespace: secret-namespace
            group: ""
            kind: Secret
    - protocol: tcp
      port: 8888
      name: tcp
---
apiVersion: gateway.networking.k8s.io/v1beta1
kind: HTTPRoute
metadata:
  name: example-route
spec:
  parentRefs:
    - name: example-gateway
      namespace: gateway-namespace
  rules:
    - backendRefs:
        - kind: Service
          name: echo
          port: 8080

---
apiVersion: v1
kind: Namespace
metadata:
  name: secret-namespace
---
apiVersion: gateway.networking.k8s.io/v1beta1
kind: ReferenceGrant
metadata:
  name: reference-grant
  namespace: secret-namespace
spec:
  from:
    - group: gateway.networking.k8s.io
      kind: Gateway
      namespace: gateway-namespace
  to:
    - group: ""
      kind: Secret
      name: cert
---
apiVersion: v1
kind: Secret
metadata:
  name: cert
  namespace: secret-namespace
data:
  password: ZmFrZS1wYXNzd29yZA==/
```
Checklist:
- [x] Tests added (mainly just, does it build tests. More functionality to come)

