### PR TITLE
add sameness group to source intention

### DIFF
--- a/charts/consul/templates/crd-exportedservices.yaml
+++ b/charts/consul/templates/crd-exportedservices.yaml
@@ -76,7 +76,8 @@ spec:
                               the service to.
                             type: string
                           peer:
-                            description: Peer is the name of the peer to export the service to.
+                            description: Peer is the name of the peer to export the
+                              service to.
                             type: string
                           samenessGroup:
                             description: SamenessGroup is the name of the sameness

--- a/charts/consul/templates/crd-serviceintentions.yaml
+++ b/charts/consul/templates/crd-serviceintentions.yaml
@@ -185,6 +185,10 @@ spec:
                             type: object
                         type: object
                       type: array
+                    samenessGroup:
+                      description: SamenessGroup is the name of the sameness group,
+                        if applicable.
+                      type: string
                   type: object
                 type: array
             type: object

--- a/control-plane/api/v1alpha1/serviceintentions_types_test.go
+++ b/control-plane/api/v1alpha1/serviceintentions_types_test.go
@@ -4,6 +4,7 @@
 package v1alpha1
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -616,6 +617,8 @@ func TestServiceIntentions_DefaultNamespaceFields(t *testing.T) {
 }
 
 func TestServiceIntentions_Validate(t *testing.T) {
+	longDescription := strings.Repeat("x", metaValueMaxLength+1)
+
 	cases := map[string]struct {
 		input             *ServiceIntentions
 		namespacesEnabled bool
@@ -1138,6 +1141,54 @@ func TestServiceIntentions_Validate(t *testing.T) {
 				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0]: Invalid value: "{\"name\":\"svc-2\",\"namespace\":\"bar\",\"action\":\"deny\",\"permissions\":[{\"action\":\"allow\",\"http\":{\"pathExact\":\"/bar\"}}]}": action and permissions are mutually exclusive and only one of them can be specified`,
 			},
 		},
+		"name not specified": {
+			input: &ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: IntentionDestination{
+						Name:      "dest-service",
+						Namespace: "namespace",
+					},
+					Sources: SourceIntentions{
+						{
+							Namespace: "bar",
+							Action:    "deny",
+						},
+					},
+				},
+			},
+			namespacesEnabled: true,
+			expectedErrMsgs: []string{
+				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0].name: Required value: name is required.`,
+			},
+		},
+		"description is too long": {
+			input: &ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: IntentionDestination{
+						Name:      "dest-service",
+						Namespace: "namespace",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:        "foo",
+							Namespace:   "bar",
+							Action:      "deny",
+							Description: longDescription,
+						},
+					},
+				},
+			},
+			namespacesEnabled: true,
+			expectedErrMsgs: []string{
+				`serviceintentions.consul.hashicorp.com "does-not-matter" is invalid: spec.sources[0]: Invalid value: "": description exceeds maximum length 512`,
+			},
+		},
 		"namespaces disabled: destination namespace specified": {
 			input: &ServiceIntentions{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1457,6 +1508,46 @@ func TestServiceIntentions_Validate(t *testing.T) {
 			expectedErrMsgs: []string{
 				`spec.sources[0]: Invalid value: v1alpha1.SourceIntention{Name:"web", Namespace:"namespace-b", Peer:"peer-other", Partition:"partition-other", SamenessGroup:"", Action:"allow", Permissions:v1alpha1.IntentionPermissions(nil), Description:""}: cannot set peer and partition at the same time.`,
 				`spec.sources[1]: Invalid value: v1alpha1.SourceIntention{Name:"db", Namespace:"namespace-c", Peer:"peer-2", Partition:"partition-2", SamenessGroup:"", Action:"deny", Permissions:v1alpha1.IntentionPermissions(nil), Description:""}: cannot set peer and partition at the same time.`,
+			},
+		},
+		"multiple errors: wildcard peer and partition and samenessgroup specified": {
+			input: &ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: IntentionDestination{
+						Name:      "dest-service",
+						Namespace: "namespace-a",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:      "web",
+							Action:    "allow",
+							Namespace: "namespace-b",
+							Partition: "*",
+						},
+						{
+							Name:      "db",
+							Action:    "deny",
+							Namespace: "namespace-c",
+							Peer:      "*",
+						},
+						{
+							Name:          "db2",
+							Action:        "deny",
+							Namespace:     "namespace-d",
+							SamenessGroup: "*",
+						},
+					},
+				},
+			},
+			namespacesEnabled: true,
+			partitionsEnabled: true,
+			expectedErrMsgs: []string{
+				`partition cannot use or contain wildcard '*'`,
+				`peer cannot use or contain wildcard '*'`,
+				`samenessgroup cannot use or contain wildcard '*'`,
 			},
 		},
 	}

--- a/control-plane/api/v1alpha1/shared_types.go
+++ b/control-plane/api/v1alpha1/shared_types.go
@@ -16,6 +16,7 @@ import (
 
 // This file contains structs that are shared between multiple config entries.
 
+// metaValueMaxLength is the maximum allowed string length of a metadata value
 const metaValueMaxLength = 512
 
 type MeshGatewayMode string

--- a/control-plane/api/v1alpha1/shared_types.go
+++ b/control-plane/api/v1alpha1/shared_types.go
@@ -16,6 +16,8 @@ import (
 
 // This file contains structs that are shared between multiple config entries.
 
+const metaValueMaxLength = 512
+
 type MeshGatewayMode string
 
 // Expose describes HTTP paths to expose through Envoy outside of Connect.

--- a/control-plane/api/v1alpha1/shared_types.go
+++ b/control-plane/api/v1alpha1/shared_types.go
@@ -16,7 +16,7 @@ import (
 
 // This file contains structs that are shared between multiple config entries.
 
-// metaValueMaxLength is the maximum allowed string length of a metadata value
+// metaValueMaxLength is the maximum allowed string length of a metadata value.
 const metaValueMaxLength = 512
 
 type MeshGatewayMode string

--- a/control-plane/config/crd/bases/consul.hashicorp.com_exportedservices.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_exportedservices.yaml
@@ -72,7 +72,8 @@ spec:
                               the service to.
                             type: string
                           peer:
-                            description: Peer is the name of the peer to export the service to.
+                            description: Peer is the name of the peer to export the
+                              service to.
                             type: string
                           samenessGroup:
                             description: SamenessGroup is the name of the sameness

--- a/control-plane/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
@@ -181,6 +181,10 @@ spec:
                             type: object
                         type: object
                       type: array
+                    samenessGroup:
+                      description: SamenessGroup is the name of the sameness group,
+                        if applicable.
+                      type: string
                   type: object
                 type: array
             type: object

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -353,8 +353,6 @@ github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20220831174802-b8af6526
 github.com/hashicorp/consul-server-connection-manager v0.1.0 h1:XCweGvMHzra88rYv2zxwwuUOjBUdcQmNKVrnQmt/muo=
 github.com/hashicorp/consul-server-connection-manager v0.1.0/go.mod h1:XVVlO+Yk7aiRpspiHZkrrFVn9BJIiOPnQIzqytPxGaU=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
-github.com/hashicorp/consul/api v1.10.1-0.20230424202255-e47f3216e51b h1:6JQAVFzqHzB51SP55BOLoDsw6sVD2WGkNSOoxI1hVZ4=
-github.com/hashicorp/consul/api v1.10.1-0.20230424202255-e47f3216e51b/go.mod h1:tXfrC6o0yFTgAW46xd5Ic8STHc9oIBcRVBcwhX5KNCQ=
 github.com/hashicorp/consul/api v1.10.1-0.20230427155444-391ed069c461 h1:cbsTR88ShbvcRMqLU8K0atm4GmRr8UH4x4jX4e12RYE=
 github.com/hashicorp/consul/api v1.10.1-0.20230427155444-391ed069c461/go.mod h1:tXfrC6o0yFTgAW46xd5Ic8STHc9oIBcRVBcwhX5KNCQ=
 github.com/hashicorp/consul/proto-public v0.1.0 h1:O0LSmCqydZi363hsqc6n2v5sMz3usQMXZF6ziK3SzXU=


### PR DESCRIPTION
Changes proposed in this PR:
- added samenessgroup to source intention
- updated source intention validation 
- updated tests on validation 

How I tested it:
Followed instructions on testing a new CRD: tested docker image and added an intention with samenessgroup. 

Checklist:
- [x] Tests added
- NA CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

