### PR TITLE
Add support for syncing Ingress hostname to the Consul Catalog

### DIFF
--- a/.changelog/2098.txt
+++ b/.changelog/2098.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+sync-catalog: add ability to sync hostname from a Kubernetes Ingress resource to the Consul Catalog during service registration.
+```

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -36,7 +36,7 @@ jobs:
             changelog_file_path=".changelog/[_0-9]*.txt"
           fi
 
-          changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/${{ github.event.pull_request.base.ref }}")" | egrep -e "${changelog_file_path}"))
+          changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/${{ github.event.pull_request.base.ref }}")" | egrep -e "${changelog_file_path}")
 
           # If we do not find a file in .changelog/, we fail the check
           if [ -z "$changelog_files" ]; then

--- a/charts/consul/templates/sync-catalog-clusterrole.yaml
+++ b/charts/consul/templates/sync-catalog-clusterrole.yaml
@@ -11,31 +11,38 @@ metadata:
     release: {{ .Release.Name }}
     component: sync-catalog
 rules:
-  - apiGroups: [""]
-    resources:
-      - services
-      - endpoints
-    verbs:
-      - get
-      - list
-      - watch
+- apiGroups: [ "" ]
+  resources:
+  - services
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
 {{- if .Values.syncCatalog.toK8S }}
-      - update
-      - patch
-      - delete
-      - create
+  - update
+  - patch
+  - delete
+  - create
 {{- end }}
-  - apiGroups: [""]
-    resources:
-      - nodes
-    verbs:
-      - get
+- apiGroups: [ "" ]
+  resources:
+  - nodes
+  verbs:
+  - get
 {{- if .Values.global.enablePodSecurityPolicies }}
-  - apiGroups: ["policy"]
-    resources: ["podsecuritypolicies"]
-    verbs:
-      - use
-    resourceNames:
-      - {{ template "consul.fullname" . }}-sync-catalog
+- apiGroups: [ "policy" ]
+  resources: [ "podsecuritypolicies" ]
+  verbs:
+  - use
+  resourceNames:
+  - {{ template "consul.fullname" . }}-sync-catalog
 {{- end }}
+- apiGroups: [ "networking.k8s.io" ]
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}

--- a/charts/consul/templates/sync-catalog-deployment.yaml
+++ b/charts/consul/templates/sync-catalog-deployment.yaml
@@ -75,136 +75,142 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-        - name: sync-catalog
-          image: "{{ default .Values.global.imageK8S .Values.syncCatalog.image }}"
-          env:
-            {{- include "consul.consulK8sConsulServerEnvVars" . | nindent 12 }}
-            {{- if .Values.global.acls.manageSystemACLs }}
-            - name: CONSUL_LOGIN_AUTH_METHOD
-              {{- if and .Values.global.federation.enabled .Values.global.federation.primaryDatacenter .Values.global.enableConsulNamespaces }}
-              value: {{ template "consul.fullname" . }}-k8s-component-auth-method-{{ .Values.global.datacenter }}
-              {{- else }}
-              value: {{ template "consul.fullname" . }}-k8s-component-auth-method
-              {{- end }}
-            - name: CONSUL_LOGIN_DATACENTER
-              {{- if and .Values.global.federation.enabled .Values.global.federation.primaryDatacenter .Values.global.enableConsulNamespaces }}
-              value: {{ .Values.global.federation.primaryDatacenter }}
-              {{- else }}
-              value: {{ .Values.global.datacenter }}
-              {{- end }}
-            - name: CONSUL_LOGIN_META
-              value: "component=sync-catalog,pod=$(NAMESPACE)/$(POD_NAME)"
-            {{- end }}
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            {{- if (and .Values.syncCatalog.aclSyncToken.secretName .Values.syncCatalog.aclSyncToken.secretKey) }}
-            - name: CONSUL_ACL_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.syncCatalog.aclSyncToken.secretName }}
-                  key: {{ .Values.syncCatalog.aclSyncToken.secretKey }}
-            {{- end }}
-          volumeMounts:
-            {{- if .Values.global.tls.enabled }}
-            {{- if not (or (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) .Values.global.secretsBackend.vault.enabled) }}
-            - name: consul-ca-cert
-              mountPath: /consul/tls/ca
-              readOnly: true
-            {{- end }}
-            {{- end }}
-          command:
-            - "/bin/sh"
-            - "-ec"
-            - |
-              consul-k8s-control-plane sync-catalog \
-                -log-level={{ default .Values.global.logLevel .Values.syncCatalog.logLevel }} \
-                -log-json={{ .Values.global.logJSON }} \
-                -k8s-default-sync={{ .Values.syncCatalog.default }} \
-                {{- if (not .Values.syncCatalog.toConsul) }}
-                -to-consul=false \
-                {{- end }}
-                {{- if (not .Values.syncCatalog.toK8S) }}
-                -to-k8s=false \
-                {{- end }}
-                -consul-domain={{ .Values.global.domain }} \
-                {{- if .Values.syncCatalog.k8sPrefix }}
-                -k8s-service-prefix="{{ .Values.syncCatalog.k8sPrefix}}" \
-                {{- end }}
-                {{- if .Values.syncCatalog.k8sSourceNamespace }}
-                -k8s-source-namespace="{{ .Values.syncCatalog.k8sSourceNamespace}}" \
-                {{- end }}
-                {{- range $value := .Values.syncCatalog.k8sAllowNamespaces }}
-                -allow-k8s-namespace="{{ $value }}" \
-                {{- end }}
-                {{- range $value := .Values.syncCatalog.k8sDenyNamespaces }}
-                -deny-k8s-namespace="{{ $value }}" \
-                {{- end }}
-                -k8s-write-namespace=${NAMESPACE} \
-                {{- if (not .Values.syncCatalog.syncClusterIPServices) }}
-                -sync-clusterip-services=false \
-                {{- end }}
-                {{- if .Values.syncCatalog.nodePortSyncType }}
-                -node-port-sync-type={{ .Values.syncCatalog.nodePortSyncType }} \
-                {{- end }}
-                {{- if .Values.syncCatalog.consulWriteInterval }}
-                -consul-write-interval={{ .Values.syncCatalog.consulWriteInterval }} \
-                {{- end }}
-                {{- if .Values.syncCatalog.k8sTag }}
-                -consul-k8s-tag={{ .Values.syncCatalog.k8sTag }} \
-                {{- end }}
-                {{- if .Values.syncCatalog.consulNodeName }}
-                -consul-node-name={{ .Values.syncCatalog.consulNodeName }} \
-                {{- end }}
-                {{- if .Values.global.adminPartitions.enabled }}
-                -partition={{ .Values.global.adminPartitions.name }} \
-                {{- end }}
-                {{- if .Values.syncCatalog.consulPrefix}}
-                -consul-service-prefix="{{ .Values.syncCatalog.consulPrefix}}" \
-                {{- end}}
-                {{- if .Values.syncCatalog.addK8SNamespaceSuffix}}
-                -add-k8s-namespace-suffix \
-                {{- end}}
-                {{- if .Values.global.enableConsulNamespaces }}
-                -enable-namespaces=true \
-                {{- if .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }}
-                -consul-destination-namespace={{ .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }} \
-                {{- end }}
-                {{- if .Values.syncCatalog.consulNamespaces.mirroringK8S }}
-                -enable-k8s-namespace-mirroring=true \
-                {{- if .Values.syncCatalog.consulNamespaces.mirroringK8SPrefix }}
-                -k8s-namespace-mirroring-prefix={{ .Values.syncCatalog.consulNamespaces.mirroringK8SPrefix }} \
-                {{- end }}
-                {{- end }}
-                {{- if .Values.global.acls.manageSystemACLs }}
-                -consul-cross-namespace-acl-policy=cross-namespace-policy \
-                {{- end }}
-                {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /health/ready
-              port: 8080
-              scheme: HTTP
-            failureThreshold: 3
-            initialDelaySeconds: 30
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /health/ready
-              port: 8080
-              scheme: HTTP
-            failureThreshold: 5
-            initialDelaySeconds: 10
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 5
-          {{- with .Values.syncCatalog.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
+      - name: sync-catalog
+        image: "{{ default .Values.global.imageK8S .Values.syncCatalog.image }}"
+        env:
+        {{- include "consul.consulK8sConsulServerEnvVars" . | nindent 8 }}
+        {{- if .Values.global.acls.manageSystemACLs }}
+        - name: CONSUL_LOGIN_AUTH_METHOD
+          {{- if and .Values.global.federation.enabled .Values.global.federation.primaryDatacenter .Values.global.enableConsulNamespaces }}
+          value: {{ template "consul.fullname" . }}-k8s-component-auth-method-{{ .Values.global.datacenter }}
+          {{- else }}
+          value: {{ template "consul.fullname" . }}-k8s-component-auth-method
           {{- end }}
+        - name: CONSUL_LOGIN_DATACENTER
+          {{- if and .Values.global.federation.enabled .Values.global.federation.primaryDatacenter .Values.global.enableConsulNamespaces }}
+          value: {{ .Values.global.federation.primaryDatacenter }}
+          {{- else }}
+          value: {{ .Values.global.datacenter }}
+          {{- end }}
+        - name: CONSUL_LOGIN_META
+          value: "component=sync-catalog,pod=$(NAMESPACE)/$(POD_NAME)"
+        {{- end }}
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- if (and .Values.syncCatalog.aclSyncToken.secretName .Values.syncCatalog.aclSyncToken.secretKey) }}
+        - name: CONSUL_ACL_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.syncCatalog.aclSyncToken.secretName }}
+              key: {{ .Values.syncCatalog.aclSyncToken.secretKey }}
+        {{- end }}
+        volumeMounts:
+        {{- if .Values.global.tls.enabled }}
+        {{- if not (or (and .Values.externalServers.enabled .Values.externalServers.useSystemRoots) .Values.global.secretsBackend.vault.enabled) }}
+        - name: consul-ca-cert
+          mountPath: /consul/tls/ca
+          readOnly: true
+        {{- end }}
+        {{- end }}
+        command:
+        - "/bin/sh"
+        - "-ec"
+        - |
+          consul-k8s-control-plane sync-catalog \
+            -log-level={{ default .Values.global.logLevel .Values.syncCatalog.logLevel }} \
+            -log-json={{ .Values.global.logJSON }} \
+            -k8s-default-sync={{ .Values.syncCatalog.default }} \
+            {{- if (not .Values.syncCatalog.toConsul) }}
+            -to-consul=false \
+            {{- end }}
+            {{- if (not .Values.syncCatalog.toK8S) }}
+            -to-k8s=false \
+            {{- end }}
+            -consul-domain={{ .Values.global.domain }} \
+            {{- if .Values.syncCatalog.k8sPrefix }}
+            -k8s-service-prefix="{{ .Values.syncCatalog.k8sPrefix}}" \
+            {{- end }}
+            {{- if .Values.syncCatalog.k8sSourceNamespace }}
+            -k8s-source-namespace="{{ .Values.syncCatalog.k8sSourceNamespace}}" \
+            {{- end }}
+            {{- range $value := .Values.syncCatalog.k8sAllowNamespaces }}
+            -allow-k8s-namespace="{{ $value }}" \
+            {{- end }}
+            {{- range $value := .Values.syncCatalog.k8sDenyNamespaces }}
+            -deny-k8s-namespace="{{ $value }}" \
+            {{- end }}
+            -k8s-write-namespace=${NAMESPACE} \
+            {{- if (not .Values.syncCatalog.syncClusterIPServices) }}
+            -sync-clusterip-services=false \
+            {{- end }}
+            {{- if .Values.syncCatalog.nodePortSyncType }}
+            -node-port-sync-type={{ .Values.syncCatalog.nodePortSyncType }} \
+            {{- end }}
+            {{- if .Values.syncCatalog.consulWriteInterval }}
+            -consul-write-interval={{ .Values.syncCatalog.consulWriteInterval }} \
+            {{- end }}
+            {{- if .Values.syncCatalog.k8sTag }}
+            -consul-k8s-tag={{ .Values.syncCatalog.k8sTag }} \
+            {{- end }}
+            {{- if .Values.syncCatalog.consulNodeName }}
+            -consul-node-name={{ .Values.syncCatalog.consulNodeName }} \
+            {{- end }}
+            {{- if .Values.global.adminPartitions.enabled }}
+            -partition={{ .Values.global.adminPartitions.name }} \
+            {{- end }}
+            {{- if .Values.syncCatalog.consulPrefix}}
+            -consul-service-prefix="{{ .Values.syncCatalog.consulPrefix}}" \
+            {{- end}}
+            {{- if .Values.syncCatalog.addK8SNamespaceSuffix}}
+            -add-k8s-namespace-suffix \
+            {{- end}}
+            {{- if .Values.global.enableConsulNamespaces }}
+            -enable-namespaces=true \
+            {{- if .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }}
+            -consul-destination-namespace={{ .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }} \
+            {{- end }}
+            {{- if .Values.syncCatalog.consulNamespaces.mirroringK8S }}
+            -enable-k8s-namespace-mirroring=true \
+            {{- if .Values.syncCatalog.consulNamespaces.mirroringK8SPrefix }}
+            -k8s-namespace-mirroring-prefix={{ .Values.syncCatalog.consulNamespaces.mirroringK8SPrefix }} \
+            {{- end }}
+            {{- end }}
+            {{- if .Values.global.acls.manageSystemACLs }}
+            -consul-cross-namespace-acl-policy=cross-namespace-policy \
+            {{- end }}
+            {{- end }}
+            {{- if .Values.syncCatalog.ingress.enabled }}
+            -enable-ingress=true \
+            {{- if .Values.syncCatalog.ingress.loadBalancerIPs }}
+            -loadBalancer-ips=true \
+            {{- end }}
+            {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health/ready
+            port: 8080
+            scheme: HTTP
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 8080
+            scheme: HTTP
+          failureThreshold: 5
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+        {{- with .Values.syncCatalog.resources }}
+        resources:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- if .Values.syncCatalog.priorityClassName }}
       priorityClassName: {{ .Values.syncCatalog.priorityClassName | quote }}
       {{- end }}

--- a/charts/consul/test/unit/sync-catalog-deployment.bats
+++ b/charts/consul/test/unit/sync-catalog-deployment.bats
@@ -366,6 +366,54 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# sync ingress
+
+@test "syncCatalog/Deployment: enable ingress sync flag not passed when disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.ingress.enabled=false' \
+      --set 'syncCatalog.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-ingress=true"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+@test "syncCatalog/Deployment: enable ingress sync flag passed when enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'syncCatalog.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-ingress=true"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "syncCatalog/Deployment: enable loadbalancer IP sync flag not passed when  syncIngress disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'syncCatalog.ingress.enabled=false' \
+      --set 'syncCatalog.ingress.loadBalancerIPs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-loadBalancer-ips=true"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "syncCatalog/Deployment: enable loadbalancer IP sync flag passed when enabled with ingress sync" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'syncCatalog.ingress.enabled=true' \
+      --set 'syncCatalog.ingress.loadBalancerIPs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-loadBalancer-ips=true"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # affinity
 
 @test "syncCatalog/Deployment: affinity not set by default" {

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1780,6 +1780,19 @@ syncCatalog:
   # Set this to false to skip syncing ClusterIP services.
   syncClusterIPServices: true
 
+  ingress:
+    # Syncs the hostname from a Kubernetes Ingress resource to service registrations
+    # when a rule matched a service. Currently only supports host based routing and
+    # not path based routing. The only supported path on an ingress rule is "/".
+    # Set this to false to skip syncing Ingress services.
+    #
+    # Currently, port 80 is synced if there is not TLS entry for the hostname. Syncs the port
+    # 443 if there is a TLS entry that matches the hostname.
+    enabled: false
+    # Requires syncIngress to be `true`. syncs the LoadBalancer IP from a Kubernetes Ingress
+    # resource instead of the hostname to service registrations when a rule matched a service.
+    loadBalancerIPs: false
+
   # Configures the type of syncing that happens for NodePort
   # services. The valid options are: ExternalOnly, InternalOnly, ExternalFirst.
   #

--- a/control-plane/catalog/to-consul/resource_test.go
+++ b/control-plane/catalog/to-consul/resource_test.go
@@ -13,7 +13,8 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
@@ -445,7 +446,7 @@ func TestServiceResource_lbMultiEndpoint(t *testing.T) {
 	svc := lbService("foo", metav1.NamespaceDefault, "1.2.3.4")
 	svc.Status.LoadBalancer.Ingress = append(
 		svc.Status.LoadBalancer.Ingress,
-		apiv1.LoadBalancerIngress{IP: "2.3.4.5"},
+		corev1.LoadBalancerIngress{IP: "2.3.4.5"},
 	)
 	_, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(context.Background(), svc, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -504,7 +505,7 @@ func TestServiceResource_lbPort(t *testing.T) {
 
 	// Insert an LB service
 	svc := lbService("foo", metav1.NamespaceDefault, "1.2.3.4")
-	svc.Spec.Ports = []apiv1.ServicePort{
+	svc.Spec.Ports = []corev1.ServicePort{
 		{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)},
 		{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000)},
 	}
@@ -537,7 +538,7 @@ func TestServiceResource_lbAnnotatedPort(t *testing.T) {
 	// Insert an LB service
 	svc := lbService("foo", metav1.NamespaceDefault, "1.2.3.4")
 	svc.Annotations[annotationServicePort] = "rpc"
-	svc.Spec.Ports = []apiv1.ServicePort{
+	svc.Spec.Ports = []corev1.ServicePort{
 		{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)},
 		{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000)},
 	}
@@ -628,17 +629,17 @@ func TestServiceResource_lbRegisterEndpoints(t *testing.T) {
 	// Insert the endpoints
 	_, err := client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(
 		context.Background(),
-		&apiv1.Endpoints{
+		&corev1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
 
-			Subsets: []apiv1.EndpointSubset{
+			Subsets: []corev1.EndpointSubset{
 				{
-					Addresses: []apiv1.EndpointAddress{
+					Addresses: []corev1.EndpointAddress{
 						{NodeName: &node1.Name, IP: "8.8.8.8"},
 					},
-					Ports: []apiv1.EndpointPort{
+					Ports: []corev1.EndpointPort{
 						{Name: "http", Port: 8080},
 						{Name: "rpc", Port: 2000},
 					},
@@ -763,17 +764,17 @@ func TestServiceResource_nodePort_singleEndpoint(t *testing.T) {
 	// Insert the endpoints
 	_, err := client.CoreV1().Endpoints(metav1.NamespaceDefault).Create(
 		context.Background(),
-		&apiv1.Endpoints{
+		&corev1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
 
-			Subsets: []apiv1.EndpointSubset{
+			Subsets: []corev1.EndpointSubset{
 				{
-					Addresses: []apiv1.EndpointAddress{
+					Addresses: []corev1.EndpointAddress{
 						{NodeName: &node1.Name, IP: "1.2.3.4"},
 					},
-					Ports: []apiv1.EndpointPort{
+					Ports: []corev1.EndpointPort{
 						{Name: "http", Port: 8080},
 						{Name: "rpc", Port: 2000},
 					},
@@ -860,7 +861,7 @@ func TestServiceResource_nodePortUnnamedPort(t *testing.T) {
 	// Insert the service
 	svc := nodePortService("foo", metav1.NamespaceDefault)
 	// Override service ports
-	svc.Spec.Ports = []apiv1.ServicePort{
+	svc.Spec.Ports = []corev1.ServicePort{
 		{Port: 80, TargetPort: intstr.FromInt(8080), NodePort: 30000},
 		{Port: 8500, TargetPort: intstr.FromInt(2000), NodePort: 30001},
 	}
@@ -940,9 +941,9 @@ func TestServiceResource_nodePort_externalFirstSync(t *testing.T) {
 
 	node1, _ := createNodes(t, client)
 
-	node1.Status = apiv1.NodeStatus{
-		Addresses: []apiv1.NodeAddress{
-			{Type: apiv1.NodeInternalIP, Address: "4.5.6.7"},
+	node1.Status = corev1.NodeStatus{
+		Addresses: []corev1.NodeAddress{
+			{Type: corev1.NodeInternalIP, Address: "4.5.6.7"},
 		},
 	}
 	_, err := client.CoreV1().Nodes().UpdateStatus(context.Background(), node1, metav1.UpdateOptions{})
@@ -1173,7 +1174,7 @@ func TestServiceResource_clusterIPUnnamedPorts(t *testing.T) {
 
 	// Insert the service
 	svc := clusterIPService("foo", metav1.NamespaceDefault)
-	svc.Spec.Ports = []apiv1.ServicePort{
+	svc.Spec.Ports = []corev1.ServicePort{
 		{Port: 80, TargetPort: intstr.FromInt(8080)},
 		{Port: 8500, TargetPort: intstr.FromInt(2000)},
 	}
@@ -1281,7 +1282,7 @@ func TestServiceResource_clusterIPTargetPortNamed(t *testing.T) {
 	// Insert the service
 	svc := clusterIPService("foo", metav1.NamespaceDefault)
 	svc.Annotations[annotationServicePort] = "rpc"
-	svc.Spec.Ports = []apiv1.ServicePort{
+	svc.Spec.Ports = []corev1.ServicePort{
 		{Port: 80, TargetPort: intstr.FromString("httpPort"), Name: "http"},
 		{Port: 8500, TargetPort: intstr.FromString("rpcPort"), Name: "rpc"},
 	}
@@ -1531,22 +1532,323 @@ func TestServiceResource_MirroredPrefixNamespace(t *testing.T) {
 	})
 }
 
+// Test k8s namespace suffix is not appended
+// when the service name annotation is provided.
+func TestServiceResource_addIngress(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		enableIngress     bool
+		syncIngressIP     bool
+		ingress           *networkingv1.Ingress
+		expectIngressSync bool
+		expectedAddress   string
+		expectedPort      int
+	}{
+		"enable ingress on port 80": {
+			enableIngress: true,
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ingress",
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"test.other.consul"},
+							SecretName: "test-other-tls-secret",
+						},
+					},
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "test.host.consul",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path: "/",
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "test-service",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 8080,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectIngressSync: true,
+			expectedAddress:   "test.host.consul",
+			expectedPort:      80,
+		},
+		"enable ingress on port 443": {
+			enableIngress: true,
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ingress",
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"test.host.consul"},
+							SecretName: "test-tls-secret",
+						},
+					},
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "test.host.consul",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path: "/",
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "test-service",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 8080,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectIngressSync: true,
+			expectedAddress:   "test.host.consul",
+			expectedPort:      443,
+		},
+		"enable ingress on port 80 with loadbalancer IP": {
+			enableIngress: true,
+			syncIngressIP: true,
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ingress",
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"test.other.consul"},
+							SecretName: "test-other-tls-secret",
+						},
+					},
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "test.host.consul",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path: "/",
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "test-service",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 8080,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: networkingv1.IngressStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+					},
+				},
+			},
+			expectIngressSync: true,
+			expectedAddress:   "1.2.3.4",
+			expectedPort:      80,
+		},
+		"enable ingress on port 443 with loadbalancer IP": {
+			enableIngress: true,
+			syncIngressIP: true,
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ingress",
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"test.host.consul"},
+							SecretName: "test-tls-secret",
+						},
+					},
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "test.host.consul",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path: "/",
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "test-service",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 8080,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: networkingv1.IngressStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+					},
+				},
+			},
+			expectIngressSync: true,
+			expectedAddress:   "1.2.3.4",
+			expectedPort:      443,
+		},
+		"ingress disabled": {
+			enableIngress: false,
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ingress",
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "test.host.consul",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path: "/",
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "test-service",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 8080,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectIngressSync: false,
+			expectedAddress:   "1.1.1.1",
+			expectedPort:      8080,
+		},
+		"ignores ingress if host != /": {
+			enableIngress: true,
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ingress",
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "test.host.consul",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path: "/foo",
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "test-service",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 8080,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectIngressSync: false,
+			expectedAddress:   "1.1.1.1",
+			expectedPort:      8080,
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+			syncer := newTestSyncer()
+			serviceResource := defaultServiceResource(client, syncer)
+			serviceResource.ClusterIPSync = true
+			serviceResource.EnableIngress = test.enableIngress
+			serviceResource.SyncLoadBalancerIPs = test.syncIngressIP
+
+			// Start the controller
+			closer := controller.TestControllerRun(&serviceResource)
+			defer closer()
+
+			// Create the service
+			_, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(context.Background(), clusterIPService("test-service", metav1.NamespaceDefault), metav1.CreateOptions{})
+			require.NoError(t, err)
+			// Create the ingress
+			_, err = client.NetworkingV1().Ingresses(metav1.NamespaceDefault).Create(context.Background(), test.ingress, metav1.CreateOptions{})
+			require.NoError(t, err)
+			createEndpoints(t, client, "test-service", metav1.NamespaceDefault)
+			// Verify that the service name annotation is preferred
+			retry.Run(t, func(r *retry.R) {
+				syncer.Lock()
+				defer syncer.Unlock()
+				actual := syncer.Registrations
+				if test.expectIngressSync {
+					require.Len(r, actual, 1)
+					require.Equal(r, test.expectedAddress, actual[0].Service.Address)
+					require.Equal(r, test.expectedPort, actual[0].Service.Port)
+				} else {
+					require.Len(r, actual, 2)
+					require.Equal(r, test.expectedAddress, actual[0].Service.Address)
+					require.Equal(r, test.expectedPort, actual[0].Service.Port)
+				}
+
+			})
+		})
+	}
+}
+
 // lbService returns a Kubernetes service of type LoadBalancer.
-func lbService(name, namespace, lbIP string) *apiv1.Service {
-	return &apiv1.Service{
+func lbService(name, namespace, lbIP string) *corev1.Service {
+	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
 			Annotations: map[string]string{},
 		},
 
-		Spec: apiv1.ServiceSpec{
-			Type: apiv1.ServiceTypeLoadBalancer,
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
 		},
 
-		Status: apiv1.ServiceStatus{
-			LoadBalancer: apiv1.LoadBalancerStatus{
-				Ingress: []apiv1.LoadBalancerIngress{
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
 					{
 						IP: lbIP,
 					},
@@ -1557,16 +1859,16 @@ func lbService(name, namespace, lbIP string) *apiv1.Service {
 }
 
 // nodePortService returns a Kubernetes service of type NodePort.
-func nodePortService(name, namespace string) *apiv1.Service {
-	return &apiv1.Service{
+func nodePortService(name, namespace string) *corev1.Service {
+	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
 
-		Spec: apiv1.ServiceSpec{
-			Type: apiv1.ServiceTypeNodePort,
-			Ports: []apiv1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeNodePort,
+			Ports: []corev1.ServicePort{
 				{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), NodePort: 30000},
 				{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000), NodePort: 30001},
 			},
@@ -1575,17 +1877,17 @@ func nodePortService(name, namespace string) *apiv1.Service {
 }
 
 // clusterIPService returns a Kubernetes service of type ClusterIP.
-func clusterIPService(name, namespace string) *apiv1.Service {
-	return &apiv1.Service{
+func clusterIPService(name, namespace string) *corev1.Service {
+	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
 			Annotations: map[string]string{},
 		},
 
-		Spec: apiv1.ServiceSpec{
-			Type: apiv1.ServiceTypeClusterIP,
-			Ports: []apiv1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
 				{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)},
 				{Name: "rpc", Port: 8500, TargetPort: intstr.FromInt(2000)},
 			},
@@ -1594,34 +1896,34 @@ func clusterIPService(name, namespace string) *apiv1.Service {
 }
 
 // createNodes calls the fake k8s client to create two Kubernetes nodes and returns them.
-func createNodes(t *testing.T, client *fake.Clientset) (*apiv1.Node, *apiv1.Node) {
+func createNodes(t *testing.T, client *fake.Clientset) (*corev1.Node, *corev1.Node) {
 	// Insert the nodes
-	node1 := &apiv1.Node{
+	node1 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName1,
 		},
 
-		Status: apiv1.NodeStatus{
-			Addresses: []apiv1.NodeAddress{
-				{Type: apiv1.NodeExternalIP, Address: "1.2.3.4"},
-				{Type: apiv1.NodeInternalIP, Address: "4.5.6.7"},
-				{Type: apiv1.NodeInternalIP, Address: "7.8.9.10"},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeExternalIP, Address: "1.2.3.4"},
+				{Type: corev1.NodeInternalIP, Address: "4.5.6.7"},
+				{Type: corev1.NodeInternalIP, Address: "7.8.9.10"},
 			},
 		},
 	}
 	_, err := client.CoreV1().Nodes().Create(context.Background(), node1, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	node2 := &apiv1.Node{
+	node2 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName2,
 		},
 
-		Status: apiv1.NodeStatus{
-			Addresses: []apiv1.NodeAddress{
-				{Type: apiv1.NodeExternalIP, Address: "2.3.4.5"},
-				{Type: apiv1.NodeInternalIP, Address: "3.4.5.6"},
-				{Type: apiv1.NodeInternalIP, Address: "6.7.8.9"},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeExternalIP, Address: "2.3.4.5"},
+				{Type: corev1.NodeInternalIP, Address: "3.4.5.6"},
+				{Type: corev1.NodeInternalIP, Address: "6.7.8.9"},
 			},
 		},
 	}
@@ -1635,31 +1937,31 @@ func createNodes(t *testing.T, client *fake.Clientset) (*apiv1.Node, *apiv1.Node
 func createEndpoints(t *testing.T, client *fake.Clientset, serviceName string, namespace string) {
 	node1 := nodeName1
 	node2 := nodeName2
-	targetRef := apiv1.ObjectReference{Kind: "pod", Name: "foobar"}
+	targetRef := corev1.ObjectReference{Kind: "pod", Name: "foobar"}
 	_, err := client.CoreV1().Endpoints(namespace).Create(
 		context.Background(),
-		&apiv1.Endpoints{
+		&corev1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      serviceName,
 				Namespace: namespace,
 			},
 
-			Subsets: []apiv1.EndpointSubset{
+			Subsets: []corev1.EndpointSubset{
 				{
-					Addresses: []apiv1.EndpointAddress{
+					Addresses: []corev1.EndpointAddress{
 						{NodeName: &node1, IP: "1.1.1.1", TargetRef: &targetRef},
 					},
-					Ports: []apiv1.EndpointPort{
+					Ports: []corev1.EndpointPort{
 						{Name: "http", Port: 8080},
 						{Name: "rpc", Port: 2000},
 					},
 				},
 
 				{
-					Addresses: []apiv1.EndpointAddress{
+					Addresses: []corev1.EndpointAddress{
 						{NodeName: &node2, IP: "2.2.2.2"},
 					},
-					Ports: []apiv1.EndpointPort{
+					Ports: []corev1.EndpointPort{
 						{Name: "http", Port: 8080},
 						{Name: "rpc", Port: 2000},
 					},

--- a/control-plane/subcommand/sync-catalog/command.go
+++ b/control-plane/subcommand/sync-catalog/command.go
@@ -67,6 +67,10 @@ type Command struct {
 	flagK8SNSMirroringPrefix       string   // Prefix added to Consul namespaces created when mirroring
 	flagCrossNamespaceACLPolicy    string   // The name of the ACL policy to add to every created namespace if ACLs are enabled
 
+	// Flags to support Kubernetes Ingress resources
+	flagEnableIngress   bool // Register services using the hostname from an ingress resource
+	flagLoadBalancerIPs bool // Use the load balancer IP of an ingress resource instead of the hostname
+
 	clientset kubernetes.Interface
 
 	// ready indicates whether this controller is ready to sync services. This will be changed to true once the
@@ -150,6 +154,11 @@ func (c *Command) init() {
 	c.flags.StringVar(&c.flagCrossNamespaceACLPolicy, "consul-cross-namespace-acl-policy", "",
 		"[Enterprise Only] Name of the ACL policy to attach to all created Consul namespaces to allow service "+
 			"discovery across Consul namespaces. Only necessary if ACLs are enabled.")
+
+	c.flags.BoolVar(&c.flagEnableIngress, "enable-ingress", false,
+		"[Enterprise Only] Enables namespaces, in either a single Consul namespace or mirrored.")
+	c.flags.BoolVar(&c.flagLoadBalancerIPs, "loadBalancer-ips", false,
+		"[Enterprise Only] Enables namespaces, in either a single Consul namespace or mirrored.")
 
 	c.consul = &flags.ConsulFlags{}
 	c.k8s = &flags.K8SFlags{}
@@ -294,6 +303,8 @@ func (c *Command) Run(args []string) int {
 				EnableK8SNSMirroring:       c.flagEnableK8SNSMirroring,
 				K8SNSMirroringPrefix:       c.flagK8SNSMirroringPrefix,
 				ConsulNodeName:             c.flagConsulNodeName,
+				EnableIngress:              c.flagEnableIngress,
+				SyncLoadBalancerIPs:        c.flagLoadBalancerIPs,
 			},
 		}
 


### PR DESCRIPTION
Changes proposed in this PR:
- Add support for Kubernetes Ingress resources where the hostname or the LoadBalancer IP of the ingress LB are synced as the address of the services that the ingress is in front of. Flags are used to determine whether to sync the hostname or the loadbalancer IP. The only supported path is `/` since Consul does not currently support path-based routing only valid DNS entries are supported as service addresses.
- The hostname of a service is compared against the list of hosts in the TLS section of the Ingress resource to determine if TLS is enabled/disabled. The 443 port is registered as the service port if TLS is enabled, otherwise it is port 80.

Usage:
```yaml
syncCatalog:
  ingress:
    syncIngress: true         # Enables syncing the hostname from the Ingress resource.
    syncLoadBalancerIPs: false   # Set this to true as well if you want to sync the LB IP instead of the hostname.
```

How I've tested this PR:
- Deployed an ingress resource into a cluster and compared the details of the service registered to check that either the correct hostname or IP was configured on the service. Did this in multiple configurations.
- Unit tests.
- User testing.

How I expect reviewers to test this PR:
- Code Review
- Test changes locally if you'd like to. Happy to pair.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

