### PR TITLE
Update CRDs for Permissive mTLS

### DIFF
--- a/.changelog/2100.txt
+++ b/.changelog/2100.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+crd: Add `mutualTLSMode` to the ProxyDefaults and ServiceDefaults CRDs and `allowEnablingPermissiveMutualTLS` to the Mesh CRD to support configuring permissive mutual TLS.
+```

--- a/charts/consul/templates/crd-meshes.yaml
+++ b/charts/consul/templates/crd-meshes.yaml
@@ -55,6 +55,11 @@ spec:
           spec:
             description: MeshSpec defines the desired state of Mesh.
             properties:
+              allowEnablingPermissiveMutualTLS:
+                description: AllowEnablingPermissiveMutualTLS must be true in order
+                  to allow setting MutualTLSMode=permissive in either service-defaults
+                  or proxy-defaults.
+                type: boolean
               http:
                 description: HTTP defines the HTTP configuration for the service mesh.
                 properties:

--- a/charts/consul/templates/crd-proxydefaults.yaml
+++ b/charts/consul/templates/crd-proxydefaults.yaml
@@ -180,6 +180,18 @@ spec:
                   CRD and should be set using annotations on the services that are
                   part of the mesh.'
                 type: string
+              mutualTLSMode:
+                description: 'MutualTLSMode controls whether mutual TLS is required
+                  for all incoming connections when transparent proxy is enabled.
+                  This can be set to "permissive" or "strict". "strict" is the default
+                  which requires mutual TLS for incoming connections. In the insecure
+                  "permissive" mode, connections to the sidecar proxy public listener
+                  port require mutual TLS, but connections to the service port do
+                  not require mutual TLS and are proxied to the application unmodified.
+                  Note: Intentions are not enforced for non-mTLS connections. To keep
+                  your services secure, we recommend using "strict" mode whenever
+                  possible and enabling "permissive" mode only when necessary.'
+                type: string
               transparentProxy:
                 description: 'TransparentProxy controls configuration specific to
                   proxies in transparent mode. Note: This cannot be set using the

--- a/charts/consul/templates/crd-servicedefaults.yaml
+++ b/charts/consul/templates/crd-servicedefaults.yaml
@@ -171,6 +171,18 @@ spec:
                   CRD and should be set using annotations on the services that are
                   part of the mesh.'
                 type: string
+              mutualTLSMode:
+                description: 'MutualTLSMode controls whether mutual TLS is required
+                  for all incoming connections when transparent proxy is enabled.
+                  This can be set to "permissive" or "strict". "strict" is the default
+                  which requires mutual TLS for incoming connections. In the insecure
+                  "permissive" mode, connections to the sidecar proxy public listener
+                  port require mutual TLS, but connections to the service port do
+                  not require mutual TLS and are proxied to the application unmodified.
+                  Note: Intentions are not enforced for non-mTLS connections. To keep
+                  your services secure, we recommend using "strict" mode whenever
+                  possible and enabling "permissive" mode only when necessary.'
+                type: string
               protocol:
                 description: Protocol sets the protocol of the service. This is used
                   by Connect proxies for things like observability features and to

--- a/control-plane/api/v1alpha1/mesh_types.go
+++ b/control-plane/api/v1alpha1/mesh_types.go
@@ -51,6 +51,9 @@ type MeshList struct {
 type MeshSpec struct {
 	// TransparentProxy controls the configuration specific to proxies in "transparent" mode. Added in v1.10.0.
 	TransparentProxy TransparentProxyMeshConfig `json:"transparentProxy,omitempty"`
+	// AllowEnablingPermissiveMutualTLS must be true in order to allow setting
+	// MutualTLSMode=permissive in either service-defaults or proxy-defaults.
+	AllowEnablingPermissiveMutualTLS bool `json:"allowEnablingPermissiveMutualTLS,omitempty"`
 	// TLS defines the TLS configuration for the service mesh.
 	TLS *MeshTLSConfig `json:"tls,omitempty"`
 	// HTTP defines the HTTP configuration for the service mesh.
@@ -192,11 +195,12 @@ func (in *Mesh) SetLastSyncedTime(time *metav1.Time) {
 
 func (in *Mesh) ToConsul(datacenter string) capi.ConfigEntry {
 	return &capi.MeshConfigEntry{
-		TransparentProxy: in.Spec.TransparentProxy.toConsul(),
-		TLS:              in.Spec.TLS.toConsul(),
-		HTTP:             in.Spec.HTTP.toConsul(),
-		Peering:          in.Spec.Peering.toConsul(),
-		Meta:             meta(datacenter),
+		TransparentProxy:                 in.Spec.TransparentProxy.toConsul(),
+		AllowEnablingPermissiveMutualTLS: in.Spec.AllowEnablingPermissiveMutualTLS,
+		TLS:                              in.Spec.TLS.toConsul(),
+		HTTP:                             in.Spec.HTTP.toConsul(),
+		Peering:                          in.Spec.Peering.toConsul(),
+		Meta:                             meta(datacenter),
 	}
 }
 

--- a/control-plane/api/v1alpha1/mesh_types_test.go
+++ b/control-plane/api/v1alpha1/mesh_types_test.go
@@ -48,6 +48,7 @@ func TestMesh_MatchesConsul(t *testing.T) {
 					TransparentProxy: TransparentProxyMeshConfig{
 						MeshDestinationsOnly: true,
 					},
+					AllowEnablingPermissiveMutualTLS: true,
 					TLS: &MeshTLSConfig{
 						Incoming: &MeshDirectionalTLSConfig{
 							TLSMinVersion: "TLSv1_0",
@@ -72,6 +73,7 @@ func TestMesh_MatchesConsul(t *testing.T) {
 				TransparentProxy: capi.TransparentProxyMeshConfig{
 					MeshDestinationsOnly: true,
 				},
+				AllowEnablingPermissiveMutualTLS: true,
 				TLS: &capi.MeshTLSConfig{
 					Incoming: &capi.MeshDirectionalTLSConfig{
 						TLSMinVersion: "TLSv1_0",
@@ -148,6 +150,7 @@ func TestMesh_ToConsul(t *testing.T) {
 					TransparentProxy: TransparentProxyMeshConfig{
 						MeshDestinationsOnly: true,
 					},
+					AllowEnablingPermissiveMutualTLS: true,
 					TLS: &MeshTLSConfig{
 						Incoming: &MeshDirectionalTLSConfig{
 							TLSMinVersion: "TLSv1_0",
@@ -172,6 +175,7 @@ func TestMesh_ToConsul(t *testing.T) {
 				TransparentProxy: capi.TransparentProxyMeshConfig{
 					MeshDestinationsOnly: true,
 				},
+				AllowEnablingPermissiveMutualTLS: true,
 				TLS: &capi.MeshTLSConfig{
 					Incoming: &capi.MeshDirectionalTLSConfig{
 						TLSMinVersion: "TLSv1_0",

--- a/control-plane/api/v1alpha1/proxydefaults_types_test.go
+++ b/control-plane/api/v1alpha1/proxydefaults_types_test.go
@@ -74,6 +74,7 @@ func TestProxyDefaults_MatchesConsul(t *testing.T) {
 						OutboundListenerPort: 1000,
 						DialedDirectly:       true,
 					},
+					MutualTLSMode: MutualTLSModePermissive,
 					AccessLogs: &AccessLogs{
 						Enabled:             true,
 						DisableListenerLogs: true,
@@ -129,6 +130,7 @@ func TestProxyDefaults_MatchesConsul(t *testing.T) {
 					OutboundListenerPort: 1000,
 					DialedDirectly:       true,
 				},
+				MutualTLSMode: capi.MutualTLSModePermissive,
 				AccessLogs: &capi.AccessLogsConfig{
 					Enabled:             true,
 					DisableListenerLogs: true,
@@ -292,6 +294,7 @@ func TestProxyDefaults_ToConsul(t *testing.T) {
 						OutboundListenerPort: 1000,
 						DialedDirectly:       true,
 					},
+					MutualTLSMode: MutualTLSModeStrict,
 					AccessLogs: &AccessLogs{
 						Enabled:             true,
 						DisableListenerLogs: true,
@@ -348,6 +351,7 @@ func TestProxyDefaults_ToConsul(t *testing.T) {
 					OutboundListenerPort: 1000,
 					DialedDirectly:       true,
 				},
+				MutualTLSMode: capi.MutualTLSModeStrict,
 				AccessLogs: &capi.AccessLogsConfig{
 					Enabled:             true,
 					DisableListenerLogs: true,
@@ -496,6 +500,17 @@ func TestProxyDefaults_Validate(t *testing.T) {
 				},
 			},
 			expectedErrMsg: "proxydefaults.consul.hashicorp.com \"global\" is invalid: spec.mode: Invalid value: \"transparent\": use the annotation `consul.hashicorp.com/transparent-proxy` to configure the Transparent Proxy Mode",
+		},
+		"mutualTLSMode": {
+			input: &ProxyDefaults{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "global",
+				},
+				Spec: ProxyDefaultsSpec{
+					MutualTLSMode: MutualTLSMode("asdf"),
+				},
+			},
+			expectedErrMsg: `proxydefaults.consul.hashicorp.com "global" is invalid: spec.mutualTLSMode: Invalid value: "asdf": Must be one of "", "strict", or "permissive".`,
 		},
 		"accessLogs.type": {
 			input: &ProxyDefaults{

--- a/control-plane/api/v1alpha1/servicedefaults_types.go
+++ b/control-plane/api/v1alpha1/servicedefaults_types.go
@@ -73,6 +73,17 @@ type ServiceDefaultsSpec struct {
 	// Note: This cannot be set using the CRD and should be set using annotations on the
 	// services that are part of the mesh.
 	TransparentProxy *TransparentProxy `json:"transparentProxy,omitempty"`
+	// MutualTLSMode controls whether mutual TLS is required for all incoming
+	// connections when transparent proxy is enabled. This can be set to
+	// "permissive" or "strict". "strict" is the default which requires mutual
+	// TLS for incoming connections. In the insecure "permissive" mode,
+	// connections to the sidecar proxy public listener port require mutual
+	// TLS, but connections to the service port do not require mutual TLS and
+	// are proxied to the application unmodified. Note: Intentions are not
+	// enforced for non-mTLS connections. To keep your services secure, we
+	// recommend using "strict" mode whenever possible and enabling
+	// "permissive" mode only when necessary.
+	MutualTLSMode MutualTLSMode `json:"mutualTLSMode,omitempty"`
 	// MeshGateway controls the default mesh gateway configuration for this service.
 	MeshGateway MeshGateway `json:"meshGateway,omitempty"`
 	// Expose controls the default expose path configuration for Envoy.
@@ -279,6 +290,7 @@ func (in *ServiceDefaults) ToConsul(datacenter string) capi.ConfigEntry {
 		Expose:                    in.Spec.Expose.toConsul(),
 		ExternalSNI:               in.Spec.ExternalSNI,
 		TransparentProxy:          in.Spec.TransparentProxy.toConsul(),
+		MutualTLSMode:             in.Spec.MutualTLSMode.toConsul(),
 		UpstreamConfig:            in.Spec.UpstreamConfig.toConsul(),
 		Destination:               in.Spec.Destination.toConsul(),
 		Meta:                      meta(datacenter),
@@ -305,6 +317,9 @@ func (in *ServiceDefaults) Validate(consulMeta common.ConsulMeta) error {
 	}
 	if err := in.Spec.TransparentProxy.validate(path.Child("transparentProxy")); err != nil {
 		allErrs = append(allErrs, err)
+	}
+	if err := in.Spec.MutualTLSMode.validate(); err != nil {
+		allErrs = append(allErrs, field.Invalid(path.Child("mutualTLSMode"), in.Spec.MutualTLSMode, err.Error()))
 	}
 	if err := in.Spec.Mode.validate(path.Child("mode")); err != nil {
 		allErrs = append(allErrs, err)

--- a/control-plane/api/v1alpha1/servicedefaults_types_test.go
+++ b/control-plane/api/v1alpha1/servicedefaults_types_test.go
@@ -70,6 +70,7 @@ func TestServiceDefaults_ToConsul(t *testing.T) {
 						OutboundListenerPort: 1000,
 						DialedDirectly:       true,
 					},
+					MutualTLSMode: MutualTLSModePermissive,
 					UpstreamConfig: &Upstreams{
 						Defaults: &Upstream{
 							Name:              "upstream-default",
@@ -197,6 +198,7 @@ func TestServiceDefaults_ToConsul(t *testing.T) {
 					OutboundListenerPort: 1000,
 					DialedDirectly:       true,
 				},
+				MutualTLSMode: capi.MutualTLSModePermissive,
 				UpstreamConfig: &capi.UpstreamConfiguration{
 					Defaults: &capi.UpstreamConfig{
 						Name:              "upstream-default",
@@ -367,6 +369,7 @@ func TestServiceDefaults_MatchesConsul(t *testing.T) {
 						OutboundListenerPort: 1000,
 						DialedDirectly:       true,
 					},
+					MutualTLSMode: MutualTLSModeStrict,
 					UpstreamConfig: &Upstreams{
 						Defaults: &Upstream{
 							Name:              "upstream-default",
@@ -487,6 +490,7 @@ func TestServiceDefaults_MatchesConsul(t *testing.T) {
 					OutboundListenerPort: 1000,
 					DialedDirectly:       true,
 				},
+				MutualTLSMode: capi.MutualTLSModeStrict,
 				UpstreamConfig: &capi.UpstreamConfiguration{
 					Defaults: &capi.UpstreamConfig{
 						Name:              "upstream-default",
@@ -680,6 +684,7 @@ func TestServiceDefaults_Validate(t *testing.T) {
 					MeshGateway: MeshGateway{
 						Mode: "remote",
 					},
+					MutualTLSMode: MutualTLSModePermissive,
 					Expose: Expose{
 						Checks: false,
 						Paths: []ExposePath{
@@ -814,6 +819,17 @@ func TestServiceDefaults_Validate(t *testing.T) {
 				},
 			},
 			expectedErrMsg: "servicedefaults.consul.hashicorp.com \"my-service\" is invalid: spec.transparentProxy.outboundListenerPort: Invalid value: 1000: use the annotation `consul.hashicorp.com/transparent-proxy-outbound-listener-port` to configure the Outbound Listener Port",
+		},
+		"mutualTLSMode": {
+			input: &ServiceDefaults{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-service",
+				},
+				Spec: ServiceDefaultsSpec{
+					MutualTLSMode: MutualTLSMode("asdf"),
+				},
+			},
+			expectedErrMsg: `servicedefaults.consul.hashicorp.com "my-service" is invalid: spec.mutualTLSMode: Invalid value: "asdf": Must be one of "", "strict", or "permissive".`,
 		},
 		"mode": {
 			input: &ServiceDefaults{

--- a/control-plane/api/v1alpha1/shared_types.go
+++ b/control-plane/api/v1alpha1/shared_types.go
@@ -58,6 +58,35 @@ type TransparentProxy struct {
 	DialedDirectly bool `json:"dialedDirectly,omitempty"`
 }
 
+type MutualTLSMode string
+
+const (
+	// MutualTLSModeDefault represents no specific mode and should
+	// be used to indicate that a different layer of the configuration
+	// chain should take precedence.
+	MutualTLSModeDefault MutualTLSMode = ""
+
+	// MutualTLSModeStrict requires mTLS for incoming traffic.
+	MutualTLSModeStrict MutualTLSMode = "strict"
+
+	// MutualTLSModePermissive allows incoming non-mTLS traffic.
+	MutualTLSModePermissive MutualTLSMode = "permissive"
+)
+
+func (m MutualTLSMode) validate() error {
+	switch m {
+	case MutualTLSModeDefault, MutualTLSModeStrict, MutualTLSModePermissive:
+		return nil
+	}
+	return fmt.Errorf("Must be one of %q, %q, or %q.",
+		MutualTLSModeDefault, MutualTLSModeStrict, MutualTLSModePermissive,
+	)
+}
+
+func (m MutualTLSMode) toConsul() capi.MutualTLSMode {
+	return capi.MutualTLSMode(m)
+}
+
 // MeshGateway controls how Mesh Gateways are used for upstream Connect
 // services.
 type MeshGateway struct {

--- a/control-plane/config/crd/bases/consul.hashicorp.com_meshes.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_meshes.yaml
@@ -51,6 +51,11 @@ spec:
           spec:
             description: MeshSpec defines the desired state of Mesh.
             properties:
+              allowEnablingPermissiveMutualTLS:
+                description: AllowEnablingPermissiveMutualTLS must be true in order
+                  to allow setting MutualTLSMode=permissive in either service-defaults
+                  or proxy-defaults.
+                type: boolean
               http:
                 description: HTTP defines the HTTP configuration for the service mesh.
                 properties:

--- a/control-plane/config/crd/bases/consul.hashicorp.com_proxydefaults.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_proxydefaults.yaml
@@ -176,6 +176,18 @@ spec:
                   CRD and should be set using annotations on the services that are
                   part of the mesh.'
                 type: string
+              mutualTLSMode:
+                description: 'MutualTLSMode controls whether mutual TLS is required
+                  for all incoming connections when transparent proxy is enabled.
+                  This can be set to "permissive" or "strict". "strict" is the default
+                  which requires mutual TLS for incoming connections. In the insecure
+                  "permissive" mode, connections to the sidecar proxy public listener
+                  port require mutual TLS, but connections to the service port do
+                  not require mutual TLS and are proxied to the application unmodified.
+                  Note: Intentions are not enforced for non-mTLS connections. To keep
+                  your services secure, we recommend using "strict" mode whenever
+                  possible and enabling "permissive" mode only when necessary.'
+                type: string
               transparentProxy:
                 description: 'TransparentProxy controls configuration specific to
                   proxies in transparent mode. Note: This cannot be set using the

--- a/control-plane/config/crd/bases/consul.hashicorp.com_servicedefaults.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_servicedefaults.yaml
@@ -167,6 +167,18 @@ spec:
                   CRD and should be set using annotations on the services that are
                   part of the mesh.'
                 type: string
+              mutualTLSMode:
+                description: 'MutualTLSMode controls whether mutual TLS is required
+                  for all incoming connections when transparent proxy is enabled.
+                  This can be set to "permissive" or "strict". "strict" is the default
+                  which requires mutual TLS for incoming connections. In the insecure
+                  "permissive" mode, connections to the sidecar proxy public listener
+                  port require mutual TLS, but connections to the service port do
+                  not require mutual TLS and are proxied to the application unmodified.
+                  Note: Intentions are not enforced for non-mTLS connections. To keep
+                  your services secure, we recommend using "strict" mode whenever
+                  possible and enabling "permissive" mode only when necessary.'
+                type: string
               protocol:
                 description: Protocol sets the protocol of the service. This is used
                   by Connect proxies for things like observability features and to


### PR DESCRIPTION
Changes proposed in this PR:

* Add the `mutualTLSMode` field to the ProxyDefaults and ServiceDefaults CRDs
* Add the `allowEnablingPermissiveMutualTLS` field to the Mesh CRD

How I've tested this PR:

* Unit tests
* Local manual testing (see below)

How I expect reviewers to test this PR:

👀 

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

---

Manual testing

  * Setup Kind with a [local docker registry](https://kind.sigs.k8s.io/docs/user/local-registry/)
  * Build dev consul and consul-k8s-control-plane images, and push images to the local registry
    <details>
      <summary>build-images.sh</summary>

    ```shell
    #!/usr/bin/env bash

    set -ex

    (
        cd ~/code/consul-k8s/
        GOPATH=$(go env GOPATH) make cli-dev control-plane-dev-docker
        REMOTE_IMAGE="localhost:5001/consul-k8s-control-plane-dev:latest"
        docker tag consul-k8s-control-plane-dev:latest "$REMOTE_IMAGE"
        docker push "$REMOTE_IMAGE"

    )

    (
        cd ~/code/consul/
        make dev-docker
        REMOTE_IMAGE="localhost:5001/consul:local"
        docker tag consul:local "$REMOTE_IMAGE"
        docker push "$REMOTE_IMAGE"
    )

    REMOTE_IMAGE="localhost:5001/fake-service:latest"
    docker pull nicholasjackson/fake-service:v0.25.1
    docker tag nicholasjackson/fake-service:v0.25.1 "$REMOTE_IMAGE"
    docker push "$REMOTE_IMAGE"
    ```

    </details>
  * Deploy Consul with dev versions images: `consul-k8s install -auto-approve -config-file values.yaml`
     <details>
      <summary>values.yaml</summary>

    ```yaml
    global:
      acls:
        manageSystemACLs: true
      datacenter: dc1
      enabled: true
      name: consul
      tls:
        enabled: true
      metrics:
        enabled: true
        defaultEnabled: true
      image: 'localhost:5001/consul:local'
      imageK8S: 'localhost:5001/consul-k8s-control-plane-dev:latest'
    server:
      enabled: true
      replicas: 1
    ui:
      enabled: true
      service:
        type: NodePort
    connectInject:
      enabled: true
    ```
   </details>

  * Deployed static-client and static-server apps: `kubectl apply -f static-server.yaml -f static-client.yaml`
     <details>
      <summary>static-server.yaml</summary>

    ```yaml
    apiVersion: v1
    kind: Service
    metadata:
      # This name will be the service name in Consul.
      name: static-server
    spec:
      selector:
        app: static-server
      ports:
        - port: 80
          targetPort: 9090
    ---
    apiVersion: v1
    kind: ServiceAccount
    metadata:
      name: static-server
    ---
    apiVersion: apps/v1
    kind: Deployment
    metadata:
      name: static-server
    spec:
      replicas: 1
      selector:
        matchLabels:
          app: static-server
      template:
        metadata:
          name: static-server
          labels:
            app: static-server
          annotations:
            'consul.hashicorp.com/connect-inject': 'true'
        spec:
          containers:
            - name: static-server
              image: 'localhost:5001/fake-service:latest'
              ports:
                - containerPort: 9090
                  name: http
          # If ACLs are enabled, the serviceAccountName must match the Consul service name.
          serviceAccountName: static-server
    ```
    </details>

     <details>
      <summary>static-client.yaml</summary>

    ```yaml
    apiVersion: v1
    kind: Service
    metadata:
      # This name will be the service name in Consul.
      name: static-client
    spec:
      selector:
        app: static-client
      ports:
        - port: 80
          targetPort: 9090
    ---
    apiVersion: v1
    kind: ServiceAccount
    metadata:
      name: static-client
    ---
    apiVersion: apps/v1
    kind: Deployment
    metadata:
      name: static-client
    spec:
      replicas: 1
      selector:
        matchLabels:
          app: static-client
      template:
        metadata:
          name: static-client
          labels:
            app: static-client
          annotations:
            'consul.hashicorp.com/connect-inject': 'true'
        spec:
          containers:
            - name: static-client
              image: 'localhost:5001/fake-service:latest'
              ports:
                - containerPort: 9090
                  name: http
              env:
                - name: UPSTREAM_URIS
                  value: "http://static-server"
          # If ACLs are enabled, the serviceAccountName must match the Consul service name.
          serviceAccountName: static-client
    ```
   </details>

  * Check the static-client to see that requests to static-server are _failing_ (no intentions)
     <details>
      <summary>curl static-client</summary>

     ```shell-session
     $ kubectl port-forward svc/static-client 9090:80
     
     ### Elsewhere
    $ curl localhost:9090
    {
      "name": "Service",
      "uri": "/",
      "type": "HTTP",
      "ip_addresses": [
        "10.244.0.12"
      ],
      "start_time": "2023-05-02T20:56:05.882224",
      "end_time": "2023-05-02T20:56:05.884988",
      "duration": "2.764159ms",
      "body": "Hello World",
      "upstream_calls": {
        "http://static-server": {
          "uri": "http://static-server",
          "code": -1,
          "error": "Error communicating with upstream service: Get \"http://static-server/\": EOF"
        }
      },
      "code": 500
    }     
    ```
    </details>

  * Set `allowEnablingPermissiveMutualTLS: true`: `kubectl apply -f mesh-config-entry.yaml`
     <details>
      <summary>mesh-config-entry.yaml</summary>
  
    ```yaml
    apiVersion: consul.hashicorp.com/v1alpha1
    kind: Mesh
    metadata:
      name: mesh
    spec:
      allowEnablingPermissiveMutualTLS: true
    ```
    </details>

  * Apply service-defaults to static-server with `mutualTLSMode: "permissive"`: `kubectl apply -f service-defaults-static-server.yaml`. Test that requests succeed to the upstream
     <details>
      <summary>service-defaults-static-server.yaml</summary>
  
    ```yaml
    apiVersion: consul.hashicorp.com/v1alpha1
    kind: ServiceDefaults
    metadata:
      name: static-server
    spec:
      protocol: http
      mutualTLSMode: "permissive"
    ```
    </details>

     <details>
      <summary>test succesful curl</summary>
    ```shell-session
    $ kubectl apply -f service-defaults-static-server.yaml
    servicedefaults.consul.hashicorp.com/static-server created
    $ curl localhost:9090
    {
      "name": "Service",
      "uri": "/",
      "type": "HTTP",
      "ip_addresses": [
        "10.244.0.12"
      ],
      "start_time": "2023-05-02T21:04:40.243505",
      "end_time": "2023-05-02T21:04:40.247292",
      "duration": "3.7874ms",
      "body": "Hello World",
      "upstream_calls": {
        "http://static-server": {
          "name": "Service",
          "uri": "http://static-server",
          "type": "HTTP",
          "ip_addresses": [
            "10.244.0.13"
          ],
          "start_time": "2023-05-02T21:04:40.246300",
          "end_time": "2023-05-02T21:04:40.246641",
          "duration": "340.437µs",
          "headers": {
            "Content-Length": "257",
            "Content-Type": "text/plain; charset=utf-8",
            "Date": "Tue, 02 May 2023 21:04:40 GMT"
          },
          "body": "Hello World",
          "code": 200
        }
      },
      "code": 200
    }
    ```
    </details>

  * Delete service-defaults and test for unsuccessful request: `kubectl delete -f service-defaults-static-server.yaml`
  * Set `mutualTLSMode: "permissive"` in ProxyDefaults: `kubectl apply -f proxy-defaults.yaml`. Test that requests succeed to the upstream
     <details>
      <summary>proxy-defaults.yaml</summary>
  
    ```yaml
    apiVersion: consul.hashicorp.com/v1alpha1
    kind: ProxyDefaults
    metadata:
      name: global
    spec:
      mutualTLSMode: "permissive"
    ```
    </details>

     <details>
      <summary>test succesful curl</summary>
    ```shell-session
    $ kubectl apply -f proxy-defaults.yaml
    proxydefaults.consul.hashicorp.com/global created
    $ curl localhost:9090
    {
      "name": "Service",
      "uri": "/",
      "type": "HTTP",
      "ip_addresses": [
        "10.244.0.12"
      ],
      "start_time": "2023-05-02T21:08:21.203786",
      "end_time": "2023-05-02T21:08:21.207303",
      "duration": "3.517716ms",
      "body": "Hello World",
      "upstream_calls": {
        "http://static-server": {
          "name": "Service",
          "uri": "http://static-server",
          "type": "HTTP",
          "ip_addresses": [
            "10.244.0.13"
          ],
          "start_time": "2023-05-02T21:08:21.206645",
          "end_time": "2023-05-02T21:08:21.206751",
          "duration": "106.195µs",
          "headers": {
            "Content-Length": "257",
            "Content-Type": "text/plain; charset=utf-8",
            "Date": "Tue, 02 May 2023 21:08:21 GMT"
          },
          "body": "Hello World",
          "code": 200
        }
      },
      "code": 200
    }
    ```
    </details>