### PR TITLE
chore(ci): fix changelog action for non-main base branches

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -36,7 +36,7 @@ jobs:
             changelog_file_path=".changelog/[_0-9]*.txt"
           fi
 
-          changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/main")" | egrep ${changelog_file_path})
+          changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/${{ github.event.pull_request.base.ref }}")" | egrep -e "${changelog_file_path}"))
 
           # If we do not find a file in .changelog/, we fail the check
           if [ -z "$changelog_files" ]; then


### PR DESCRIPTION
Changes proposed in this PR:
- Fix the changelog checker action for when the base branch is not `main`. In this case the regex gets split because of the lack of quotes, causing an error. Also, the diff should be performed against the desired base branch in this case.

How I've tested this PR:
* This one is failing: https://github.com/hashicorp/consul-k8s/actions/runs/4887457091
* This one is passing with the changes: https://github.com/hashicorp/consul-k8s/actions/runs/4887398414

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

