### PR TITLE
chore(ci): fix backport assistant not finding new branches

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,7 +13,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.3.0
+    container: hashicorpdev/backport-assistant:0.3.3
     steps:
       - name: Run Backport Assistant
         run: backport-assistant backport -merge-method=squash -gh-automerge


### PR DESCRIPTION
Changes proposed in this PR:
- Backport-assistant is erroring out because it tries to check out a branch immediately after it creates it. [Example](https://github.com/hashicorp/consul-k8s/actions/runs/4916113298). This is fixed in 0.3.3.

I will manually backport to the other branches considering the nature of the changes.

