### PR TITLE
acceptance: add connect proxy lifecycle shutdown test

### DIFF
--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -46,12 +46,14 @@ type TestConfig struct {
 
 	DisablePeering bool
 
-	HelmChartVersion     string
-	ConsulImage          string
-	ConsulK8SImage       string
-	ConsulVersion        *version.Version
-	EnvoyImage           string
-	ConsulCollectorImage string
+	HelmChartVersion       string
+	ConsulImage            string
+	ConsulK8SImage         string
+	ConsulDataplaneImage   string
+	ConsulVersion          *version.Version
+	ConsulDataplaneVersion *version.Version
+	EnvoyImage             string
+	ConsulCollectorImage   string
 
 	HCPResourceID string
 
@@ -109,6 +111,7 @@ func (t *TestConfig) HelmValuesFromConfig() (map[string]string, error) {
 	setIfNotEmpty(helmValues, "global.image", t.ConsulImage)
 	setIfNotEmpty(helmValues, "global.imageK8S", t.ConsulK8SImage)
 	setIfNotEmpty(helmValues, "global.imageEnvoy", t.EnvoyImage)
+	setIfNotEmpty(helmValues, "global.imageConsulDataplane", t.ConsulDataplaneImage)
 
 	return helmValues, nil
 }

--- a/acceptance/framework/connhelper/connect_helper.go
+++ b/acceptance/framework/connhelper/connect_helper.go
@@ -50,8 +50,8 @@ type ConnectHelper struct {
 	// consulCluster is the cluster to use for the test.
 	consulCluster consul.Cluster
 
-	// consulClient is the client used to test service mesh connectivity.
-	consulClient *api.Client
+	// ConsulClient is the client used to test service mesh connectivity.
+	ConsulClient *api.Client
 }
 
 // Setup creates a new cluster using the New*Cluster function and assigns it
@@ -69,14 +69,14 @@ func (c *ConnectHelper) Setup(t *testing.T) {
 func (c *ConnectHelper) Install(t *testing.T) {
 	logger.Log(t, "Installing Consul cluster")
 	c.consulCluster.Create(t)
-	c.consulClient, _ = c.consulCluster.SetupConsulClient(t, c.Secure)
+	c.ConsulClient, _ = c.consulCluster.SetupConsulClient(t, c.Secure)
 }
 
 // Upgrade uses the existing Consul cluster and upgrades it using Helm values
 // set by the Secure, AutoEncrypt, and HelmValues fields.
 func (c *ConnectHelper) Upgrade(t *testing.T) {
 	require.NotNil(t, c.consulCluster, "consulCluster must be set before calling Upgrade (Call Install first).")
-	require.NotNil(t, c.consulClient, "consulClient must be set before calling Upgrade (Call Install first).")
+	require.NotNil(t, c.ConsulClient, "ConsulClient must be set before calling Upgrade (Call Install first).")
 
 	logger.Log(t, "upgrading Consul cluster")
 	c.consulCluster.Upgrade(t, c.helmValues())
@@ -96,7 +96,7 @@ func (c *ConnectHelper) DeployClientAndServer(t *testing.T) {
 		t.Cleanup(func() {
 			retrier := &retry.Timer{Timeout: 30 * time.Second, Wait: 100 * time.Millisecond}
 			retry.RunWith(retrier, t, func(r *retry.R) {
-				tokens, _, err := c.consulClient.ACL().TokenList(nil)
+				tokens, _, err := c.ConsulClient.ACL().TokenList(nil)
 				require.NoError(r, err)
 				for _, token := range tokens {
 					require.NotContains(r, token.Description, StaticServerName)
@@ -142,7 +142,7 @@ func (c *ConnectHelper) TestConnectionFailureWithoutIntention(t *testing.T) {
 // the static-client pod.
 func (c *ConnectHelper) CreateIntention(t *testing.T) {
 	logger.Log(t, "creating intention")
-	_, _, err := c.consulClient.ConfigEntries().Set(&api.ServiceIntentionsConfigEntry{
+	_, _, err := c.ConsulClient.ConfigEntries().Set(&api.ServiceIntentionsConfigEntry{
 		Kind: api.ServiceIntentions,
 		Name: StaticServerName,
 		Sources: []*api.SourceIntention{

--- a/acceptance/framework/flags/flags.go
+++ b/acceptance/framework/flags/flags.go
@@ -34,14 +34,16 @@ type TestFlags struct {
 
 	flagEnableTransparentProxy bool
 
-	flagHelmChartVersion      string
-	flagConsulImage           string
-	flagConsulK8sImage        string
-	flagConsulVersion         string
-	flagEnvoyImage            string
-	flagConsulCollectorImage  string
-	flagVaultHelmChartVersion string
-	flagVaultServerVersion    string
+	flagHelmChartVersion       string
+	flagConsulImage            string
+	flagConsulK8sImage         string
+	flagConsulDataplaneImage   string
+	flagConsulVersion          string
+	flagConsulDataplaneVersion string
+	flagEnvoyImage             string
+	flagConsulCollectorImage   string
+	flagVaultHelmChartVersion  string
+	flagVaultServerVersion     string
 
 	flagHCPResourceID string
 
@@ -74,7 +76,9 @@ func (t *TestFlags) init() {
 
 	flag.StringVar(&t.flagConsulImage, "consul-image", "", "The Consul image to use for all tests.")
 	flag.StringVar(&t.flagConsulK8sImage, "consul-k8s-image", "", "The consul-k8s image to use for all tests.")
+	flag.StringVar(&t.flagConsulDataplaneImage, "consul-dataplane-image", "", "The consul-dataplane image to use for all tests.")
 	flag.StringVar(&t.flagConsulVersion, "consul-version", "", "The consul version used for all tests.")
+	flag.StringVar(&t.flagConsulDataplaneVersion, "consul-dataplane-version", "", "The consul-dataplane version used for all tests.")
 	flag.StringVar(&t.flagHelmChartVersion, "helm-chart-version", config.HelmChartPath, "The helm chart used for all tests.")
 	flag.StringVar(&t.flagEnvoyImage, "envoy-image", "", "The Envoy image to use for all tests.")
 	flag.StringVar(&t.flagConsulCollectorImage, "consul-collector-image", "", "The consul collector image to use for all tests.")
@@ -152,6 +156,7 @@ func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 
 	// if the Version is empty consulVersion will be nil
 	consulVersion, _ := version.NewVersion(t.flagConsulVersion)
+	consulDataplaneVersion, _ := version.NewVersion(t.flagConsulDataplaneVersion)
 	//vaultserverVersion, _ := version.NewVersion(t.flagVaultServerVersion)
 
 	return &config.TestConfig{
@@ -177,14 +182,16 @@ func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 
 		DisablePeering: t.flagDisablePeering,
 
-		HelmChartVersion:      t.flagHelmChartVersion,
-		ConsulImage:           t.flagConsulImage,
-		ConsulK8SImage:        t.flagConsulK8sImage,
-		ConsulVersion:         consulVersion,
-		EnvoyImage:            t.flagEnvoyImage,
-		ConsulCollectorImage:  t.flagConsulCollectorImage,
-		VaultHelmChartVersion: t.flagVaultHelmChartVersion,
-		VaultServerVersion:    t.flagVaultServerVersion,
+		HelmChartVersion:       t.flagHelmChartVersion,
+		ConsulImage:            t.flagConsulImage,
+		ConsulK8SImage:         t.flagConsulK8sImage,
+		ConsulDataplaneImage:   t.flagConsulDataplaneImage,
+		ConsulVersion:          consulVersion,
+		ConsulDataplaneVersion: consulDataplaneVersion,
+		EnvoyImage:             t.flagEnvoyImage,
+		ConsulCollectorImage:   t.flagConsulCollectorImage,
+		VaultHelmChartVersion:  t.flagVaultHelmChartVersion,
+		VaultServerVersion:     t.flagVaultServerVersion,
 
 		HCPResourceID: t.flagHCPResourceID,
 

--- a/acceptance/tests/connect/proxy_lifecycle_test.go
+++ b/acceptance/tests/connect/proxy_lifecycle_test.go
@@ -52,7 +52,7 @@ func TestConnectInject_ProxyLifecycleShutdown(t *testing.T) {
 					"static-server-sidecar-proxy",
 				} {
 					logger.Logf(t, "checking for %s service in Consul catalog", name)
-					instances, _, err := connHelper.consulClient.Catalog().Service(name, "", nil)
+					instances, _, err := connHelper.ConsulClient.Catalog().Service(name, "", nil)
 					r.Check(err)
 
 					if len(instances) != 1 {
@@ -126,7 +126,7 @@ func TestConnectInject_ProxyLifecycleShutdown(t *testing.T) {
 					"static-client-sidecar-proxy",
 				} {
 					logger.Logf(t, "checking for %s service in Consul catalog", name)
-					instances, _, err := connHelper.consulClient.Catalog().Service(name, "", nil)
+					instances, _, err := connHelper.ConsulClient.Catalog().Service(name, "", nil)
 					r.Check(err)
 
 					for _, instance := range instances {

--- a/acceptance/tests/connect/proxy_lifecycle_test.go
+++ b/acceptance/tests/connect/proxy_lifecycle_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package connect
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul-k8s/acceptance/framework/connhelper"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Test the endpoints controller cleans up force-killed pods.
+func TestConnectInject_ProxyLifecycleShutdown(t *testing.T) {
+	for _, secure := range []bool{false, true} {
+		name := fmt.Sprintf("secure: %t", secure)
+		t.Run(name, func(t *testing.T) {
+			cfg := suite.Config()
+			ctx := suite.Environment().DefaultContext(t)
+			releaseName := helpers.RandomName()
+
+			connHelper := connhelper.ConnectHelper{
+				ClusterKind: consul.Helm,
+				Secure:      secure,
+				ReleaseName: releaseName,
+				Ctx:         ctx,
+				Cfg:         cfg,
+				HelmValues:  map[string]string{},
+			}
+
+			connHelper.Setup(t)
+			connHelper.Install(t)
+			connHelper.DeployClientAndServer(t)
+
+			// TODO: should this move into connhelper.DeployClientAndServer?
+			logger.Log(t, "waiting for static-client and static-server to be registered with Consul")
+			retry.Run(t, func(r *retry.R) {
+				for _, name := range []string{
+					"static-client",
+					"static-client-sidecar-proxy",
+					"static-server",
+					"static-server-sidecar-proxy",
+				} {
+					logger.Logf(t, "checking for %s service in Consul catalog", name)
+					instances, _, err := connHelper.consulClient.Catalog().Service(name, "", nil)
+					r.Check(err)
+
+					if len(instances) != 1 {
+						r.Errorf("expected 1 instance of %s", name)
+					}
+				}
+			})
+
+			if secure {
+				connHelper.TestConnectionFailureWithoutIntention(t)
+				connHelper.CreateIntention(t)
+			}
+
+			connHelper.TestConnectionSuccess(t)
+
+			// Get static-client pod name
+			// TODO: is this necessary?
+			ns := ctx.KubectlOptions(t).Namespace
+			pods, err := ctx.KubernetesClient(t).CoreV1().Pods(ns).List(
+				context.Background(),
+				metav1.ListOptions{
+					LabelSelector: "app=static-client",
+				},
+			)
+			require.NoError(t, err)
+			require.Len(t, pods.Items, 1)
+			clientPodName := pods.Items[0].Name
+
+			var gracePeriod int64 = 30
+			logger.Logf(t, "killing the %q pod with %dseconds termination grace period", clientPodName, gracePeriod)
+			err = ctx.KubernetesClient(t).CoreV1().Pods(ns).Delete(context.Background(), clientPodName, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod})
+			require.NoError(t, err)
+
+			// Exec into terminating pod, not just any static-client pod
+			args := []string{"exec", clientPodName, "-c", connhelper.StaticClientName, "--", "curl", "-vvvsSf"}
+
+			if cfg.EnableTransparentProxy {
+				args = append(args, "http://static-server")
+			} else {
+				args = append(args, "http://localhost:1234")
+			}
+
+			failureMessages := []string{
+				"curl: (7) Failed to connect",
+			}
+
+			// CheckStaticServerConnectionMultipleFailureMessages will retry until the Envoy sidecar container
+			// shuts down, causing the connection to fail. We are expecting a "connection reset by peer" error
+			// because during pod shutdown, there will be no healthy proxy host to connect to. We can't assert
+			// that we receive an empty reply from server, because that is the case when a connection is
+			// unsuccessful due to intentions in other tests.
+			retrier := &retry.Timer{Timeout: 30 * time.Second, Wait: 2 * time.Second}
+			retry.RunWith(retrier, t, func(r *retry.R) {
+				output, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), args...)
+				require.Error(r, err)
+				require.Condition(r, func() bool {
+					exists := false
+					for _, msg := range failureMessages {
+						if strings.Contains(output, msg) {
+							exists = true
+						}
+					}
+					return exists
+				})
+			})
+
+			logger.Log(t, "ensuring pod is deregistered after termination")
+			retry.Run(t, func(r *retry.R) {
+				for _, name := range []string{
+					"static-client",
+					"static-client-sidecar-proxy",
+				} {
+					logger.Logf(t, "checking for %s service in Consul catalog", name)
+					instances, _, err := connHelper.consulClient.Catalog().Service(name, "", nil)
+					r.Check(err)
+
+					for _, instance := range instances {
+						if strings.Contains(instance.ServiceID, clientPodName) {
+							r.Errorf("%s is still registered", instance.ServiceID)
+						}
+					}
+				}
+			})
+		})
+	}
+}

--- a/acceptance/tests/connect/proxy_lifecycle_test.go
+++ b/acceptance/tests/connect/proxy_lifecycle_test.go
@@ -16,16 +16,24 @@ import (
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Test the endpoints controller cleans up force-killed pods.
 func TestConnectInject_ProxyLifecycleShutdown(t *testing.T) {
+	cfg := suite.Config()
+
+	ver, err := version.NewVersion("1.2.0")
+	require.NoError(t, err)
+	if cfg.ConsulDataplaneVersion != nil && cfg.ConsulDataplaneVersion.LessThan(ver) {
+		t.Skipf("skipping this test because proxy lifecycle management is not supported in consul-dataplane version %v", cfg.ConsulDataplaneVersion.String())
+	}
+
 	for _, secure := range []bool{false, true} {
 		name := fmt.Sprintf("secure: %t", secure)
 		t.Run(name, func(t *testing.T) {
-			cfg := suite.Config()
 			ctx := suite.Environment().DefaultContext(t)
 			releaseName := helpers.RandomName()
 


### PR DESCRIPTION
<!-- Fixes NET-1776 -->

### Changes proposed in this PR:
- Add an acceptance test checking current proxy lifecycle behavior during pod shutdown.

### How I've tested this PR:
```
kind create cluster
```
```
go test ./... -p 1 -run TestConnectInject_ProxyLifecycle -consul-image=hashicorppreview/consul:1.16-dev
```
```
go test ./... -p 1 -run TestConnectInject_ProxyLifecycle -consul-image=hashicorppreview/consul:1.16-dev -enable-transparent-proxy
```

### How I expect reviewers to test this PR:
- [ ] Verify that test asserts expected current behavior and reproduces the issue described in https://github.com/hashicorp/consul-k8s/issues/536, https://github.com/hashicorp/consul-k8s/issues/650
- [x] ~~Check if this test could be written more concisely by using other helper functions~~
- [ ] Check if any logic should move into `connhelper`, or existing helpers should be refactored to use lower-level abstractions for easier reuse
- [ ] Check if I'm either missing anything or doing anything strange that would've started causing significant acceptance test failures from hitting various timeouts installing Consul on the cluster - I got this test passing locally both with and without transparent proxy enabled.

### Checklist:
- [x] Tests added
- [ ] ~~CHANGELOG entry added~~
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

