### PR TITLE
Net 3490/reference grants

### DIFF
--- a/control-plane/api-gateway/controllers/reference_validator.go
+++ b/control-plane/api-gateway/controllers/reference_validator.go
@@ -25,49 +25,25 @@ func (rv ReferenceValidator) GatewayCanReferenceSecret(ctx context.Context, gate
 		Kind:  gateway.GroupVersionKind().Kind,
 	}
 
-	toName := string(secretRef.Name)
-	toNS := ""
-	if secretRef.Namespace != nil {
-		toNS = string(*secretRef.Namespace)
-	}
-
 	// Kind should default to Secret if not set
 	// https://github.com/kubernetes-sigs/gateway-api/blob/v0.6.2/apis/v1beta1/object_reference_types.go#LL59C21-L59C21
-	toGK := metav1.GroupKind{Kind: "Secret"}
-	if secretRef.Group != nil {
-		toGK.Group = string(*secretRef.Group)
-	}
-	if secretRef.Kind != nil {
-		toGK.Kind = string(*secretRef.Kind)
-	}
+	toNS, toGK := createValuesFromRef(secretRef.Namespace, secretRef.Group, secretRef.Kind, "Secret")
 
-	return referenceAllowed(ctx, fromGK, fromNS, toGK, toNS, toName, rv.Client)
+	return referenceAllowed(ctx, fromGK, fromNS, toGK, toNS, string(secretRef.Name), rv.Client)
 }
 
-func (rv ReferenceValidator) HTTPRouteCanReferenceGateway(ctx context.Context, httproute gwv1beta1.HTTPRoute, gatewayRef gwv1beta1.ParentReference) (bool, error) {
+func (rv ReferenceValidator) HTTPRouteCanReferenceGateway(ctx context.Context, httproute gwv1beta1.HTTPRoute, parentRef gwv1beta1.ParentReference) (bool, error) {
 	fromNS := httproute.GetNamespace()
 	fromGK := metav1.GroupKind{
 		Group: httproute.GroupVersionKind().Group,
 		Kind:  httproute.GroupVersionKind().Kind,
 	}
 
-	toName := string(gatewayRef.Name)
-	toNS := ""
-	if gatewayRef.Namespace != nil {
-		toNS = string(*gatewayRef.Namespace)
-	}
-
 	// Kind should default to Gateway if not set
 	// https://github.com/kubernetes-sigs/gateway-api/blob/v0.6.2/apis/v1beta1/shared_types.go#L48
-	toGK := metav1.GroupKind{Kind: "Gateway"}
-	if gatewayRef.Group != nil {
-		toGK.Group = string(*gatewayRef.Group)
-	}
-	if gatewayRef.Kind != nil {
-		toGK.Kind = string(*gatewayRef.Kind)
-	}
+	toNS, toGK := createValuesFromRef(parentRef.Namespace, parentRef.Group, parentRef.Kind, "Gateway")
 
-	return referenceAllowed(ctx, fromGK, fromNS, toGK, toNS, toName, rv.Client)
+	return referenceAllowed(ctx, fromGK, fromNS, toGK, toNS, string(parentRef.Name), rv.Client)
 }
 
 func (rv ReferenceValidator) HTTPRouteCanReferenceBackend(ctx context.Context, httproute gwv1beta1.HTTPRoute, backendRef gwv1beta1.BackendRef) (bool, error) {
@@ -77,50 +53,26 @@ func (rv ReferenceValidator) HTTPRouteCanReferenceBackend(ctx context.Context, h
 		Kind:  httproute.GroupVersionKind().Kind,
 	}
 
-	toName := string(backendRef.Name)
-	toNS := ""
-	if backendRef.Namespace != nil {
-		toNS = string(*backendRef.Namespace)
-	}
-
 	// Kind should default to Service if not set
 	// https://github.com/kubernetes-sigs/gateway-api/blob/v0.6.2/apis/v1beta1/object_reference_types.go#L106
-	toGK := metav1.GroupKind{Kind: "Service"}
-	if backendRef.Group != nil {
-		toGK.Group = string(*backendRef.Group)
-	}
-	if backendRef.Kind != nil {
-		toGK.Kind = string(*backendRef.Kind)
-	}
+	toNS, toGK := createValuesFromRef(backendRef.Namespace, backendRef.Group, backendRef.Kind, "Service")
 
-	return referenceAllowed(ctx, fromGK, fromNS, toGK, toNS, toName, rv.Client)
+	return referenceAllowed(ctx, fromGK, fromNS, toGK, toNS, string(backendRef.Name), rv.Client)
 
 }
 
-func (rv ReferenceValidator) TCPRouteCanReferenceGateway(ctx context.Context, tcpRoute gwv1alpha2.TCPRoute, gatewayRef gwv1beta1.ParentReference) (bool, error) {
+func (rv ReferenceValidator) TCPRouteCanReferenceGateway(ctx context.Context, tcpRoute gwv1alpha2.TCPRoute, parentRef gwv1beta1.ParentReference) (bool, error) {
 	fromNS := tcpRoute.GetNamespace()
 	fromGK := metav1.GroupKind{
 		Group: tcpRoute.GroupVersionKind().Group,
 		Kind:  tcpRoute.GroupVersionKind().Kind,
 	}
 
-	toName := string(gatewayRef.Name)
-	toNS := ""
-	if gatewayRef.Namespace != nil {
-		toNS = string(*gatewayRef.Namespace)
-	}
-
 	// Kind should default to Gateway if not set
 	// https://github.com/kubernetes-sigs/gateway-api/blob/v0.6.2/apis/v1beta1/shared_types.go#L48
-	toGK := metav1.GroupKind{Kind: "Gateway"}
-	if gatewayRef.Group != nil {
-		toGK.Group = string(*gatewayRef.Group)
-	}
-	if gatewayRef.Kind != nil {
-		toGK.Kind = string(*gatewayRef.Kind)
-	}
+	toNS, toGK := createValuesFromRef(parentRef.Namespace, parentRef.Group, parentRef.Kind, "Gateway")
 
-	return referenceAllowed(ctx, fromGK, fromNS, toGK, toNS, toName, rv.Client)
+	return referenceAllowed(ctx, fromGK, fromNS, toGK, toNS, string(parentRef.Name), rv.Client)
 }
 
 func (rv ReferenceValidator) TCPRouteCanReferenceBackend(ctx context.Context, tcpRoute gwv1alpha2.TCPRoute, backendRef gwv1beta1.BackendRef) (bool, error) {
@@ -130,24 +82,31 @@ func (rv ReferenceValidator) TCPRouteCanReferenceBackend(ctx context.Context, tc
 		Kind:  tcpRoute.GroupVersionKind().Kind,
 	}
 
-	toName := string(backendRef.Name)
-	toNS := ""
-	if backendRef.Namespace != nil {
-		toNS = string(*backendRef.Namespace)
-	}
-
 	// Kind should default to Service if not set
 	// https://github.com/kubernetes-sigs/gateway-api/blob/v0.6.2/apis/v1beta1/object_reference_types.go#L106
-	toGK := metav1.GroupKind{Kind: "Service"}
-	if backendRef.Group != nil {
-		toGK.Group = string(*backendRef.Group)
-	}
-	if backendRef.Kind != nil {
-		toGK.Kind = string(*backendRef.Kind)
+	toNS, toGK := createValuesFromRef(backendRef.Namespace, backendRef.Group, backendRef.Kind, "Service")
+
+	return referenceAllowed(ctx, fromGK, fromNS, toGK, toNS, string(backendRef.Name), rv.Client)
+
+}
+
+func createValuesFromRef(ns *gwv1beta1.Namespace, group *gwv1beta1.Group, kind *gwv1beta1.Kind, defaultKind string) (string, metav1.GroupKind) {
+	toNS := ""
+	if ns != nil {
+		toNS = string(*ns)
 	}
 
-	return referenceAllowed(ctx, fromGK, fromNS, toGK, toNS, toName, rv.Client)
+	gk := metav1.GroupKind{
+		Kind: defaultKind,
+	}
+	if group != nil {
+		gk.Group = string(*group)
+	}
+	if kind != nil {
+		gk.Kind = string(*kind)
+	}
 
+	return toNS, gk
 }
 
 // referenceAllowed checks to see if a reference between resources is allowed.

--- a/control-plane/api-gateway/controllers/reference_validator.go
+++ b/control-plane/api-gateway/controllers/reference_validator.go
@@ -1,0 +1,119 @@
+package controllers
+
+import (
+	"context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+//
+// client. (K8s client)
+
+type ReferenceValidator struct {
+	client.Client
+}
+
+/*
+		bindValidator.CanBind(ctx, gateway, secret) -> true, false, error
+		bindValidator.CanBind(ctx, httproute, gatewayref)
+		bindValidator.CanBind(ctx, tcproute, gatewayref)
+	    bindValidator.CanBind(ctx, httproute, backendref)
+		bindValidator.CanBind(ctx, tcproute, backendref)
+*/
+
+func NewReferenceValidator(client client.Client) *ReferenceValidator {
+	return &ReferenceValidator{
+		client,
+	}
+}
+
+func (rv ReferenceValidator) HTTPRouteCanReferenceGateway(ctx context.Context, httproute gwv1beta1.HTTPRoute, gatewayRef gwv1beta1.ParentReference) (bool, error) {
+	fromNS := httproute.GetNamespace()
+	fromGK := metav1.GroupKind{
+		Group: httproute.GroupVersionKind().Group,
+		Kind:  httproute.GroupVersionKind().Kind,
+	}
+
+	toName := string(gatewayRef.Name)
+	toNS := ""
+	if gatewayRef.Namespace != nil {
+		toNS = string(*gatewayRef.Namespace)
+	}
+
+	// Kind should default to Gateway if not set
+	// https://github.com/kubernetes-sigs/gateway-api/blob/v0.6.2/apis/v1beta1/shared_types.go#L48
+	toGK := metav1.GroupKind{Kind: "Gateway"}
+	if gatewayRef.Group != nil {
+		toGK.Group = string(*gatewayRef.Group)
+	}
+	if gatewayRef.Kind != nil {
+		toGK.Kind = string(*gatewayRef.Kind)
+	}
+
+	return referenceAllowed(ctx, fromGK, fromNS, toGK, toNS, toName, rv.Client)
+
+}
+
+// referenceAllowed checks to see if a reference between resources is allowed.
+// In particular, references from one namespace to a resource in a different namespace
+// require an applicable ReferenceGrant be found in the namespace containing the resource
+// being referred to.
+//
+// For example, a Gateway in namespace "foo" may only reference a Secret in namespace "bar"
+// if a ReferenceGrant in namespace "bar" allows references from namespace "foo".
+func referenceAllowed(ctx context.Context, fromGK metav1.GroupKind, fromNamespace string, toGK metav1.GroupKind, toNamespace, toName string, c client.Client) (bool, error) {
+	// Reference does not cross namespaces
+	if toNamespace == "" || toNamespace == fromNamespace {
+		return true, nil
+	}
+
+	// Fetch all ReferenceGrants in the referenced namespace
+	refGrants, err := GetReferenceGrantsInNamespace(ctx, toNamespace, c)
+	if err != nil || len(refGrants) == 0 {
+		return false, err
+	}
+
+	for _, refGrant := range refGrants {
+		// Check for a From that applies
+		fromMatch := false
+		for _, from := range refGrant.Spec.From {
+			if fromGK.Group == string(from.Group) && fromGK.Kind == string(from.Kind) && fromNamespace == string(from.Namespace) {
+				fromMatch = true
+				break
+			}
+		}
+
+		if !fromMatch {
+			continue
+		}
+
+		// Check for a To that applies
+		for _, to := range refGrant.Spec.To {
+			if toGK.Group == string(to.Group) && toGK.Kind == string(to.Kind) {
+				if to.Name == nil || *to.Name == "" {
+					// No name specified is treated as a wildcard within the namespace
+					return true, nil
+				}
+
+				if gwv1beta1.ObjectName(toName) == *to.Name {
+					// The ReferenceGrant specifically targets this object
+					return true, nil
+				}
+			}
+		}
+	}
+
+	// No ReferenceGrant was found which allows this cross-namespace reference
+	return false, nil
+}
+
+func GetReferenceGrantsInNamespace(ctx context.Context, namespace string, c client.Client) ([]gwv1beta1.ReferenceGrant, error) {
+	refGrantList := &gwv1beta1.ReferenceGrantList{}
+	if err := c.List(ctx, refGrantList, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+	refGrants := refGrantList.Items
+
+	return refGrants, nil
+}

--- a/control-plane/api-gateway/controllers/reference_validator.go
+++ b/control-plane/api-gateway/controllers/reference_validator.go
@@ -203,7 +203,7 @@ func referenceAllowed(ctx context.Context, fromGK metav1.GroupKind, fromNamespac
 	return false, nil
 }
 
-// This function will get all reference grants in the given namespace
+// This function will get all reference grants in the given namespace.
 func getReferenceGrantsInNamespace(ctx context.Context, namespace string, c client.Client) ([]gwv1beta1.ReferenceGrant, error) {
 	refGrantList := &gwv1beta1.ReferenceGrantList{}
 	if err := c.List(ctx, refGrantList, client.InNamespace(namespace)); err != nil {

--- a/control-plane/api-gateway/controllers/reference_validator.go
+++ b/control-plane/api-gateway/controllers/reference_validator.go
@@ -18,7 +18,7 @@ func NewReferenceValidator(client client.Client) *ReferenceValidator {
 	}
 }
 
-func (rv ReferenceValidator) GatewayCanReferenceSecret(ctx context.Context, gateway gwv1beta1.Gateway, secretRef gwv1beta1.SecretObjectReference) (bool, error) {
+func (rv *ReferenceValidator) GatewayCanReferenceSecret(ctx context.Context, gateway gwv1beta1.Gateway, secretRef gwv1beta1.SecretObjectReference) (bool, error) {
 	fromNS := gateway.GetNamespace()
 	fromGK := metav1.GroupKind{
 		Group: gateway.GroupVersionKind().Group,
@@ -32,7 +32,7 @@ func (rv ReferenceValidator) GatewayCanReferenceSecret(ctx context.Context, gate
 	return referenceAllowed(ctx, fromGK, fromNS, toGK, toNS, string(secretRef.Name), rv.Client)
 }
 
-func (rv ReferenceValidator) HTTPRouteCanReferenceGateway(ctx context.Context, httproute gwv1beta1.HTTPRoute, parentRef gwv1beta1.ParentReference) (bool, error) {
+func (rv *ReferenceValidator) HTTPRouteCanReferenceGateway(ctx context.Context, httproute gwv1beta1.HTTPRoute, parentRef gwv1beta1.ParentReference) (bool, error) {
 	fromNS := httproute.GetNamespace()
 	fromGK := metav1.GroupKind{
 		Group: httproute.GroupVersionKind().Group,
@@ -46,7 +46,7 @@ func (rv ReferenceValidator) HTTPRouteCanReferenceGateway(ctx context.Context, h
 	return referenceAllowed(ctx, fromGK, fromNS, toGK, toNS, string(parentRef.Name), rv.Client)
 }
 
-func (rv ReferenceValidator) HTTPRouteCanReferenceBackend(ctx context.Context, httproute gwv1beta1.HTTPRoute, backendRef gwv1beta1.BackendRef) (bool, error) {
+func (rv *ReferenceValidator) HTTPRouteCanReferenceBackend(ctx context.Context, httproute gwv1beta1.HTTPRoute, backendRef gwv1beta1.BackendRef) (bool, error) {
 	fromNS := httproute.GetNamespace()
 	fromGK := metav1.GroupKind{
 		Group: httproute.GroupVersionKind().Group,
@@ -61,7 +61,7 @@ func (rv ReferenceValidator) HTTPRouteCanReferenceBackend(ctx context.Context, h
 
 }
 
-func (rv ReferenceValidator) TCPRouteCanReferenceGateway(ctx context.Context, tcpRoute gwv1alpha2.TCPRoute, parentRef gwv1beta1.ParentReference) (bool, error) {
+func (rv *ReferenceValidator) TCPRouteCanReferenceGateway(ctx context.Context, tcpRoute gwv1alpha2.TCPRoute, parentRef gwv1beta1.ParentReference) (bool, error) {
 	fromNS := tcpRoute.GetNamespace()
 	fromGK := metav1.GroupKind{
 		Group: tcpRoute.GroupVersionKind().Group,
@@ -75,7 +75,7 @@ func (rv ReferenceValidator) TCPRouteCanReferenceGateway(ctx context.Context, tc
 	return referenceAllowed(ctx, fromGK, fromNS, toGK, toNS, string(parentRef.Name), rv.Client)
 }
 
-func (rv ReferenceValidator) TCPRouteCanReferenceBackend(ctx context.Context, tcpRoute gwv1alpha2.TCPRoute, backendRef gwv1beta1.BackendRef) (bool, error) {
+func (rv *ReferenceValidator) TCPRouteCanReferenceBackend(ctx context.Context, tcpRoute gwv1alpha2.TCPRoute, backendRef gwv1beta1.BackendRef) (bool, error) {
 	fromNS := tcpRoute.GetNamespace()
 	fromGK := metav1.GroupKind{
 		Group: tcpRoute.GroupVersionKind().Group,

--- a/control-plane/api-gateway/controllers/reference_validator_test.go
+++ b/control-plane/api-gateway/controllers/reference_validator_test.go
@@ -54,14 +54,9 @@ func TestGatewayCanReferenceSecret(t *testing.T) {
 		},
 	}
 
-	var secretRefGroup gwv1beta1.Group
-	secretRefGroup = Group
-
-	var secretRefKind gwv1beta1.Kind
-	secretRefKind = SecretKind
-
-	var secretRefNamespace gwv1beta1.Namespace
-	secretRefNamespace = toNamespace
+	secretRefGroup := gwv1beta1.Group(Group)
+	secretRefKind := gwv1beta1.Kind(SecretKind)
+	secretRefNamespace := gwv1beta1.Namespace(toNamespace)
 
 	cases := map[string]struct {
 		canReference       bool
@@ -142,14 +137,9 @@ func TestHTTPRouteCanReferenceGateway(t *testing.T) {
 		},
 	}
 
-	var gatewayRefGroup gwv1beta1.Group
-	gatewayRefGroup = Group
-
-	var gatewayRefKind gwv1beta1.Kind
-	gatewayRefKind = GatewayKind
-
-	var gatewayRefNamespace gwv1beta1.Namespace
-	gatewayRefNamespace = toNamespace
+	gatewayRefGroup := gwv1beta1.Group(Group)
+	gatewayRefKind := gwv1beta1.Kind(GatewayKind)
+	gatewayRefNamespace := gwv1beta1.Namespace(toNamespace)
 
 	cases := map[string]struct {
 		canReference       bool
@@ -232,14 +222,9 @@ func TestHTTPRouteCanReferenceBackend(t *testing.T) {
 		},
 	}
 
-	var backendRefGroup gwv1beta1.Group
-	backendRefGroup = Group
-
-	var backendRefKind gwv1beta1.Kind
-	backendRefKind = BackendRefKind
-
-	var backendRefNamespace gwv1beta1.Namespace
-	backendRefNamespace = toNamespace
+	backendRefGroup := gwv1beta1.Group(Group)
+	backendRefKind := gwv1beta1.Kind(BackendRefKind)
+	backendRefNamespace := gwv1beta1.Namespace(toNamespace)
 
 	cases := map[string]struct {
 		canReference       bool
@@ -324,14 +309,9 @@ func TestTCPRouteCanReferenceGateway(t *testing.T) {
 		},
 	}
 
-	var gatewayRefGroup gwv1beta1.Group
-	gatewayRefGroup = Group
-
-	var gatewayRefKind gwv1beta1.Kind
-	gatewayRefKind = GatewayKind
-
-	var gatewayRefNamespace gwv1beta1.Namespace
-	gatewayRefNamespace = toNamespace
+	gatewayRefGroup := gwv1beta1.Group(Group)
+	gatewayRefKind := gwv1beta1.Kind(GatewayKind)
+	gatewayRefNamespace := gwv1beta1.Namespace(toNamespace)
 
 	cases := map[string]struct {
 		canReference       bool
@@ -414,14 +394,9 @@ func TestTCPRouteCanReferenceBackend(t *testing.T) {
 		},
 	}
 
-	var backendRefGroup gwv1beta1.Group
-	backendRefGroup = Group
-
-	var backendRefKind gwv1beta1.Kind
-	backendRefKind = BackendRefKind
-
-	var backendRefNamespace gwv1beta1.Namespace
-	backendRefNamespace = toNamespace
+	backendRefGroup := gwv1beta1.Group(Group)
+	backendRefKind := gwv1beta1.Kind(BackendRefKind)
+	backendRefNamespace := gwv1beta1.Namespace(toNamespace)
 
 	cases := map[string]struct {
 		canReference       bool

--- a/control-plane/api-gateway/controllers/reference_validator_test.go
+++ b/control-plane/api-gateway/controllers/reference_validator_test.go
@@ -1,0 +1,303 @@
+package controllers
+
+import (
+	"context"
+	"k8s.io/apimachinery/pkg/runtime"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	toNamespace      = "toNamespace"
+	fromNamespace    = "fromNamespace"
+	invalidNamespace = "invalidNamespace"
+	v1beta1Group     = "v1beta1"
+	HTTPRouteKind    = "HTTPRoute"
+	GatewayKind      = "Gateway"
+)
+
+func TestHTTPRouteCanReferenceGateway(t *testing.T) {
+	t.Parallel()
+
+	var objName gwv1beta1.ObjectName
+	objName = "barHttpRoute"
+
+	basicValidReferenceGrant := &gwv1beta1.ReferenceGrant{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: toNamespace,
+		},
+		Spec: gwv1beta1.ReferenceGrantSpec{
+			From: []gwv1beta1.ReferenceGrantFrom{
+				{
+					Group:     v1beta1Group,
+					Kind:      HTTPRouteKind,
+					Namespace: fromNamespace,
+				},
+			},
+			To: []gwv1beta1.ReferenceGrantTo{
+				{
+					Group: v1beta1Group,
+					Kind:  GatewayKind,
+					Name:  &objName,
+				},
+			},
+		},
+	}
+
+	var gatewayRefGroup gwv1beta1.Group
+	gatewayRefGroup = v1beta1Group
+
+	var gatewayRefKind gwv1beta1.Kind
+	gatewayRefKind = GatewayKind
+
+	var gatewayRefNamespace gwv1beta1.Namespace
+	gatewayRefNamespace = toNamespace
+
+	cases := map[string]struct {
+		canReference       bool
+		err                error
+		ctx                context.Context
+		httpRoute          gwv1beta1.HTTPRoute
+		gatewayRef         gwv1beta1.ParentReference
+		k8sReferenceGrants []runtime.Object
+	}{
+		"empty namespace on gateway": {
+			canReference: true,
+			err:          nil,
+			ctx:          context.TODO(),
+			httpRoute: gwv1beta1.HTTPRoute{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       HTTPRouteKind,
+					APIVersion: v1beta1Group, // TODO: where tf does the group go
+				},
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       gwv1beta1.HTTPRouteSpec{},
+				Status:     gwv1beta1.HTTPRouteStatus{},
+			},
+			gatewayRef: gwv1beta1.ParentReference{
+				Group:       &gatewayRefGroup,
+				Kind:        &gatewayRefKind,
+				Namespace:   &gatewayRefNamespace,
+				Name:        "toGateway",
+				SectionName: nil,
+				Port:        nil,
+			},
+			k8sReferenceGrants: []runtime.Object{
+				basicValidReferenceGrant,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			s := runtime.NewScheme()
+			require.NoError(t, gwv1beta1.Install(s))
+			require.NoError(t, gwv1beta1.AddToScheme(s))
+
+			client := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(tc.k8sReferenceGrants...).Build()
+			rv := NewReferenceValidator(client)
+			canReference, err := rv.HTTPRouteCanReferenceGateway(tc.ctx, tc.httpRoute, tc.gatewayRef)
+
+			require.Equal(t, tc.err, err)
+			require.Equal(t, tc.canReference, canReference)
+		})
+	}
+}
+
+func TestReferenceAllowed(t *testing.T) {
+	t.Parallel()
+
+	var objName gwv1beta1.ObjectName
+	objName = "barHttpRoute"
+
+	basicValidReferenceGrant := &gwv1beta1.ReferenceGrant{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: toNamespace,
+		},
+		Spec: gwv1beta1.ReferenceGrantSpec{
+			From: []gwv1beta1.ReferenceGrantFrom{
+				{
+					Group:     v1beta1Group,
+					Kind:      HTTPRouteKind,
+					Namespace: fromNamespace,
+				},
+			},
+			To: []gwv1beta1.ReferenceGrantTo{
+				{
+					Group: v1beta1Group,
+					Kind:  "Gateway",
+					Name:  &objName,
+				},
+			},
+		},
+	}
+
+	cases := map[string]struct {
+		refAllowed         bool
+		err                error
+		ctx                context.Context
+		fromGK             metav1.GroupKind
+		fromNamespace      string
+		toGK               metav1.GroupKind
+		toNamespace        string
+		toName             string
+		k8sReferenceGrants []runtime.Object
+	}{
+		"same namespace": {
+			refAllowed: true,
+			err:        nil,
+			ctx:        context.TODO(),
+			fromGK: metav1.GroupKind{
+				Group: v1beta1Group,
+				Kind:  HTTPRouteKind,
+			},
+			fromNamespace: fromNamespace,
+			toGK: metav1.GroupKind{
+				Group: v1beta1Group,
+				Kind:  "Gateway",
+			},
+			toNamespace: fromNamespace,
+			toName:      string(objName),
+			k8sReferenceGrants: []runtime.Object{
+				&gwv1beta1.ReferenceGrant{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: fromNamespace,
+					},
+					Spec: gwv1beta1.ReferenceGrantSpec{
+						From: []gwv1beta1.ReferenceGrantFrom{
+							{
+								Group:     v1beta1Group,
+								Kind:      HTTPRouteKind,
+								Namespace: fromNamespace,
+							},
+						},
+						To: []gwv1beta1.ReferenceGrantTo{
+							{
+								Group: v1beta1Group,
+								Kind:  "Gateway",
+								Name:  &objName,
+							},
+						},
+					},
+				},
+			},
+		},
+		"reference allowed": {
+			refAllowed: true,
+			err:        nil,
+			ctx:        context.TODO(),
+			fromGK: metav1.GroupKind{
+				Group: v1beta1Group,
+				Kind:  HTTPRouteKind,
+			},
+			fromNamespace: fromNamespace,
+			toGK: metav1.GroupKind{
+				Group: v1beta1Group,
+				Kind:  "Gateway",
+			},
+			toNamespace: toNamespace,
+			toName:      string(objName),
+			k8sReferenceGrants: []runtime.Object{
+				basicValidReferenceGrant,
+			},
+		},
+		"reference not allowed": {
+			refAllowed: false,
+			err:        nil,
+			ctx:        context.TODO(),
+			fromGK: metav1.GroupKind{
+				Group: v1beta1Group,
+				Kind:  HTTPRouteKind,
+			},
+			fromNamespace: invalidNamespace,
+			toGK: metav1.GroupKind{
+				Group: v1beta1Group,
+				Kind:  "Gateway",
+			},
+			toNamespace: toNamespace,
+			toName:      string(objName),
+			k8sReferenceGrants: []runtime.Object{
+				basicValidReferenceGrant,
+			},
+		},
+		"no reference grant defined in namespace": {
+			refAllowed: false,
+			err:        nil,
+			ctx:        context.TODO(),
+			fromGK: metav1.GroupKind{
+				Group: v1beta1Group,
+				Kind:  HTTPRouteKind,
+			},
+			fromNamespace: fromNamespace,
+			toGK: metav1.GroupKind{
+				Group: v1beta1Group,
+				Kind:  "Gateway",
+			},
+			toNamespace:        toNamespace,
+			toName:             string(objName),
+			k8sReferenceGrants: nil,
+		},
+		"reference allowed to all objects in namespace": {
+			refAllowed: true,
+			err:        nil,
+			ctx:        context.TODO(),
+			fromGK: metav1.GroupKind{
+				Group: v1beta1Group,
+				Kind:  HTTPRouteKind,
+			},
+			fromNamespace: fromNamespace,
+			toGK: metav1.GroupKind{
+				Group: v1beta1Group,
+				Kind:  "Gateway",
+			},
+			toNamespace: toNamespace,
+			toName:      string(objName),
+			k8sReferenceGrants: []runtime.Object{
+				&gwv1beta1.ReferenceGrant{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: toNamespace,
+					},
+					Spec: gwv1beta1.ReferenceGrantSpec{
+						From: []gwv1beta1.ReferenceGrantFrom{
+							{
+								Group:     v1beta1Group,
+								Kind:      HTTPRouteKind,
+								Namespace: fromNamespace,
+							},
+						},
+						To: []gwv1beta1.ReferenceGrantTo{
+							{
+								Group: v1beta1Group,
+								Kind:  "Gateway",
+								Name:  nil,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			s := runtime.NewScheme()
+			require.NoError(t, gwv1beta1.Install(s))
+			require.NoError(t, gwv1beta1.AddToScheme(s))
+
+			client := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(tc.k8sReferenceGrants...).Build()
+
+			refAllowed, err := referenceAllowed(tc.ctx, tc.fromGK, tc.fromNamespace, tc.toGK, tc.toNamespace, tc.toName, client)
+
+			require.Equal(t, tc.err, err)
+			require.Equal(t, tc.refAllowed, refAllowed)
+		})
+	}
+}

--- a/control-plane/api-gateway/controllers/reference_validator_test.go
+++ b/control-plane/api-gateway/controllers/reference_validator_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	toNamespace      = "toNamespace"
-	fromNamespace    = "fromNamespace"
-	invalidNamespace = "invalidNamespace"
+	ToNamespace      = "toNamespace"
+	FromNamespace    = "fromNamespace"
+	InvalidNamespace = "invalidNamespace"
 	Group            = "gateway.networking.k8s.io"
 	V1Beta1          = "/v1beta1"
 	V1Alpha2         = "/v1alpha2"
@@ -34,14 +34,14 @@ func TestGatewayCanReferenceSecret(t *testing.T) {
 	basicValidReferenceGrant := &gwv1beta1.ReferenceGrant{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: toNamespace,
+			Namespace: ToNamespace,
 		},
 		Spec: gwv1beta1.ReferenceGrantSpec{
 			From: []gwv1beta1.ReferenceGrantFrom{
 				{
 					Group:     Group,
 					Kind:      GatewayKind,
-					Namespace: fromNamespace,
+					Namespace: FromNamespace,
 				},
 			},
 			To: []gwv1beta1.ReferenceGrantTo{
@@ -56,7 +56,7 @@ func TestGatewayCanReferenceSecret(t *testing.T) {
 
 	secretRefGroup := gwv1beta1.Group(Group)
 	secretRefKind := gwv1beta1.Kind(SecretKind)
-	secretRefNamespace := gwv1beta1.Namespace(toNamespace)
+	secretRefNamespace := gwv1beta1.Namespace(ToNamespace)
 
 	cases := map[string]struct {
 		canReference       bool
@@ -76,7 +76,7 @@ func TestGatewayCanReferenceSecret(t *testing.T) {
 					APIVersion: Group + V1Beta1,
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: fromNamespace,
+					Namespace: FromNamespace,
 				},
 				Spec:   gwv1beta1.GatewaySpec{},
 				Status: gwv1beta1.GatewayStatus{},
@@ -117,14 +117,14 @@ func TestHTTPRouteCanReferenceGateway(t *testing.T) {
 	basicValidReferenceGrant := &gwv1beta1.ReferenceGrant{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: toNamespace,
+			Namespace: ToNamespace,
 		},
 		Spec: gwv1beta1.ReferenceGrantSpec{
 			From: []gwv1beta1.ReferenceGrantFrom{
 				{
 					Group:     Group,
 					Kind:      HTTPRouteKind,
-					Namespace: fromNamespace,
+					Namespace: FromNamespace,
 				},
 			},
 			To: []gwv1beta1.ReferenceGrantTo{
@@ -139,7 +139,7 @@ func TestHTTPRouteCanReferenceGateway(t *testing.T) {
 
 	gatewayRefGroup := gwv1beta1.Group(Group)
 	gatewayRefKind := gwv1beta1.Kind(GatewayKind)
-	gatewayRefNamespace := gwv1beta1.Namespace(toNamespace)
+	gatewayRefNamespace := gwv1beta1.Namespace(ToNamespace)
 
 	cases := map[string]struct {
 		canReference       bool
@@ -159,7 +159,7 @@ func TestHTTPRouteCanReferenceGateway(t *testing.T) {
 					APIVersion: Group + V1Beta1,
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: fromNamespace,
+					Namespace: FromNamespace,
 				},
 				Spec:   gwv1beta1.HTTPRouteSpec{},
 				Status: gwv1beta1.HTTPRouteStatus{},
@@ -202,14 +202,14 @@ func TestHTTPRouteCanReferenceBackend(t *testing.T) {
 	basicValidReferenceGrant := &gwv1beta1.ReferenceGrant{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: toNamespace,
+			Namespace: ToNamespace,
 		},
 		Spec: gwv1beta1.ReferenceGrantSpec{
 			From: []gwv1beta1.ReferenceGrantFrom{
 				{
 					Group:     Group,
 					Kind:      HTTPRouteKind,
-					Namespace: fromNamespace,
+					Namespace: FromNamespace,
 				},
 			},
 			To: []gwv1beta1.ReferenceGrantTo{
@@ -224,7 +224,7 @@ func TestHTTPRouteCanReferenceBackend(t *testing.T) {
 
 	backendRefGroup := gwv1beta1.Group(Group)
 	backendRefKind := gwv1beta1.Kind(BackendRefKind)
-	backendRefNamespace := gwv1beta1.Namespace(toNamespace)
+	backendRefNamespace := gwv1beta1.Namespace(ToNamespace)
 
 	cases := map[string]struct {
 		canReference       bool
@@ -244,7 +244,7 @@ func TestHTTPRouteCanReferenceBackend(t *testing.T) {
 					APIVersion: Group + V1Beta1,
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: fromNamespace,
+					Namespace: FromNamespace,
 				},
 				Spec:   gwv1beta1.HTTPRouteSpec{},
 				Status: gwv1beta1.HTTPRouteStatus{},
@@ -289,14 +289,14 @@ func TestTCPRouteCanReferenceGateway(t *testing.T) {
 	basicValidReferenceGrant := &gwv1beta1.ReferenceGrant{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: toNamespace,
+			Namespace: ToNamespace,
 		},
 		Spec: gwv1beta1.ReferenceGrantSpec{
 			From: []gwv1beta1.ReferenceGrantFrom{
 				{
 					Group:     Group,
 					Kind:      TCPRouteKind,
-					Namespace: fromNamespace,
+					Namespace: FromNamespace,
 				},
 			},
 			To: []gwv1beta1.ReferenceGrantTo{
@@ -311,7 +311,7 @@ func TestTCPRouteCanReferenceGateway(t *testing.T) {
 
 	gatewayRefGroup := gwv1beta1.Group(Group)
 	gatewayRefKind := gwv1beta1.Kind(GatewayKind)
-	gatewayRefNamespace := gwv1beta1.Namespace(toNamespace)
+	gatewayRefNamespace := gwv1beta1.Namespace(ToNamespace)
 
 	cases := map[string]struct {
 		canReference       bool
@@ -331,7 +331,7 @@ func TestTCPRouteCanReferenceGateway(t *testing.T) {
 					APIVersion: Group + V1Alpha2,
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: fromNamespace,
+					Namespace: FromNamespace,
 				},
 				Spec:   gwv1alpha2.TCPRouteSpec{},
 				Status: gwv1alpha2.TCPRouteStatus{},
@@ -374,14 +374,14 @@ func TestTCPRouteCanReferenceBackend(t *testing.T) {
 	basicValidReferenceGrant := &gwv1beta1.ReferenceGrant{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: toNamespace,
+			Namespace: ToNamespace,
 		},
 		Spec: gwv1beta1.ReferenceGrantSpec{
 			From: []gwv1beta1.ReferenceGrantFrom{
 				{
 					Group:     Group,
 					Kind:      TCPRouteKind,
-					Namespace: fromNamespace,
+					Namespace: FromNamespace,
 				},
 			},
 			To: []gwv1beta1.ReferenceGrantTo{
@@ -396,7 +396,7 @@ func TestTCPRouteCanReferenceBackend(t *testing.T) {
 
 	backendRefGroup := gwv1beta1.Group(Group)
 	backendRefKind := gwv1beta1.Kind(BackendRefKind)
-	backendRefNamespace := gwv1beta1.Namespace(toNamespace)
+	backendRefNamespace := gwv1beta1.Namespace(ToNamespace)
 
 	cases := map[string]struct {
 		canReference       bool
@@ -416,7 +416,7 @@ func TestTCPRouteCanReferenceBackend(t *testing.T) {
 					APIVersion: Group + V1Alpha2,
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: fromNamespace,
+					Namespace: FromNamespace,
 				},
 				Spec:   gwv1alpha2.TCPRouteSpec{},
 				Status: gwv1alpha2.TCPRouteStatus{},
@@ -461,14 +461,14 @@ func TestReferenceAllowed(t *testing.T) {
 	basicValidReferenceGrant := &gwv1beta1.ReferenceGrant{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: toNamespace,
+			Namespace: ToNamespace,
 		},
 		Spec: gwv1beta1.ReferenceGrantSpec{
 			From: []gwv1beta1.ReferenceGrantFrom{
 				{
 					Group:     Group,
 					Kind:      HTTPRouteKind,
-					Namespace: fromNamespace,
+					Namespace: FromNamespace,
 				},
 			},
 			To: []gwv1beta1.ReferenceGrantTo{
@@ -500,25 +500,25 @@ func TestReferenceAllowed(t *testing.T) {
 				Group: Group,
 				Kind:  HTTPRouteKind,
 			},
-			fromNamespace: fromNamespace,
+			fromNamespace: FromNamespace,
 			toGK: metav1.GroupKind{
 				Group: Group,
 				Kind:  GatewayKind,
 			},
-			toNamespace: fromNamespace,
+			toNamespace: FromNamespace,
 			toName:      string(objName),
 			k8sReferenceGrants: []runtime.Object{
 				&gwv1beta1.ReferenceGrant{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: fromNamespace,
+						Namespace: FromNamespace,
 					},
 					Spec: gwv1beta1.ReferenceGrantSpec{
 						From: []gwv1beta1.ReferenceGrantFrom{
 							{
 								Group:     Group,
 								Kind:      HTTPRouteKind,
-								Namespace: fromNamespace,
+								Namespace: FromNamespace,
 							},
 						},
 						To: []gwv1beta1.ReferenceGrantTo{
@@ -540,12 +540,12 @@ func TestReferenceAllowed(t *testing.T) {
 				Group: Group,
 				Kind:  HTTPRouteKind,
 			},
-			fromNamespace: fromNamespace,
+			fromNamespace: FromNamespace,
 			toGK: metav1.GroupKind{
 				Group: Group,
 				Kind:  GatewayKind,
 			},
-			toNamespace: toNamespace,
+			toNamespace: ToNamespace,
 			toName:      string(objName),
 			k8sReferenceGrants: []runtime.Object{
 				basicValidReferenceGrant,
@@ -559,12 +559,12 @@ func TestReferenceAllowed(t *testing.T) {
 				Group: Group,
 				Kind:  HTTPRouteKind,
 			},
-			fromNamespace: invalidNamespace,
+			fromNamespace: InvalidNamespace,
 			toGK: metav1.GroupKind{
 				Group: Group,
 				Kind:  GatewayKind,
 			},
-			toNamespace: toNamespace,
+			toNamespace: ToNamespace,
 			toName:      string(objName),
 			k8sReferenceGrants: []runtime.Object{
 				basicValidReferenceGrant,
@@ -578,12 +578,12 @@ func TestReferenceAllowed(t *testing.T) {
 				Group: Group,
 				Kind:  HTTPRouteKind,
 			},
-			fromNamespace: fromNamespace,
+			fromNamespace: FromNamespace,
 			toGK: metav1.GroupKind{
 				Group: Group,
 				Kind:  GatewayKind,
 			},
-			toNamespace:        toNamespace,
+			toNamespace:        ToNamespace,
 			toName:             string(objName),
 			k8sReferenceGrants: nil,
 		},
@@ -595,25 +595,25 @@ func TestReferenceAllowed(t *testing.T) {
 				Group: Group,
 				Kind:  HTTPRouteKind,
 			},
-			fromNamespace: fromNamespace,
+			fromNamespace: FromNamespace,
 			toGK: metav1.GroupKind{
 				Group: Group,
 				Kind:  GatewayKind,
 			},
-			toNamespace: toNamespace,
+			toNamespace: ToNamespace,
 			toName:      string(objName),
 			k8sReferenceGrants: []runtime.Object{
 				&gwv1beta1.ReferenceGrant{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: toNamespace,
+						Namespace: ToNamespace,
 					},
 					Spec: gwv1beta1.ReferenceGrantSpec{
 						From: []gwv1beta1.ReferenceGrantFrom{
 							{
 								Group:     Group,
 								Kind:      HTTPRouteKind,
-								Namespace: fromNamespace,
+								Namespace: FromNamespace,
 							},
 						},
 						To: []gwv1beta1.ReferenceGrantTo{

--- a/control-plane/api-gateway/controllers/reference_validator_test.go
+++ b/control-plane/api-gateway/controllers/reference_validator_test.go
@@ -456,8 +456,7 @@ func TestTCPRouteCanReferenceBackend(t *testing.T) {
 func TestReferenceAllowed(t *testing.T) {
 	t.Parallel()
 
-	var objName gwv1beta1.ObjectName
-	objName = "barHttpRoute"
+	objName := gwv1beta1.ObjectName("myObject")
 
 	basicValidReferenceGrant := &gwv1beta1.ReferenceGrant{
 		TypeMeta: metav1.TypeMeta{},

--- a/control-plane/api-gateway/controllers/reference_validator_test.go
+++ b/control-plane/api-gateway/controllers/reference_validator_test.go
@@ -29,8 +29,7 @@ const (
 func TestGatewayCanReferenceSecret(t *testing.T) {
 	t.Parallel()
 
-	var objName gwv1beta1.ObjectName
-	objName = "mysecret"
+	objName := gwv1beta1.ObjectName("mysecret")
 
 	basicValidReferenceGrant := &gwv1beta1.ReferenceGrant{
 		TypeMeta: metav1.TypeMeta{},
@@ -118,8 +117,7 @@ func TestGatewayCanReferenceSecret(t *testing.T) {
 func TestHTTPRouteCanReferenceGateway(t *testing.T) {
 	t.Parallel()
 
-	var objName gwv1beta1.ObjectName
-	objName = "mygateway"
+	objName := gwv1beta1.ObjectName("mygateway")
 
 	basicValidReferenceGrant := &gwv1beta1.ReferenceGrant{
 		TypeMeta: metav1.TypeMeta{},
@@ -209,8 +207,7 @@ func TestHTTPRouteCanReferenceGateway(t *testing.T) {
 func TestHTTPRouteCanReferenceBackend(t *testing.T) {
 	t.Parallel()
 
-	var objName gwv1beta1.ObjectName
-	objName = "myBackendRef"
+	objName := gwv1beta1.ObjectName("myBackendRef")
 
 	basicValidReferenceGrant := &gwv1beta1.ReferenceGrant{
 		TypeMeta: metav1.TypeMeta{},
@@ -302,8 +299,7 @@ func TestHTTPRouteCanReferenceBackend(t *testing.T) {
 func TestTCPRouteCanReferenceGateway(t *testing.T) {
 	t.Parallel()
 
-	var objName gwv1beta1.ObjectName
-	objName = "mygateway"
+	objName := gwv1beta1.ObjectName("mygateway")
 
 	basicValidReferenceGrant := &gwv1beta1.ReferenceGrant{
 		TypeMeta: metav1.TypeMeta{},
@@ -393,8 +389,7 @@ func TestTCPRouteCanReferenceGateway(t *testing.T) {
 func TestTCPRouteCanReferenceBackend(t *testing.T) {
 	t.Parallel()
 
-	var objName gwv1beta1.ObjectName
-	objName = "myBackendRef"
+	objName := gwv1beta1.ObjectName("myBackendRef")
 
 	basicValidReferenceGrant := &gwv1beta1.ReferenceGrant{
 		TypeMeta: metav1.TypeMeta{},

--- a/control-plane/api-gateway/controllers/reference_validator_test.go
+++ b/control-plane/api-gateway/controllers/reference_validator_test.go
@@ -58,7 +58,7 @@ func TestGatewayCanReferenceSecret(t *testing.T) {
 	secretRefGroup = Group
 
 	var secretRefKind gwv1beta1.Kind
-	secretRefKind = GatewayKind
+	secretRefKind = SecretKind
 
 	var secretRefNamespace gwv1beta1.Namespace
 	secretRefNamespace = toNamespace
@@ -77,7 +77,7 @@ func TestGatewayCanReferenceSecret(t *testing.T) {
 			ctx:          context.TODO(),
 			gateway: gwv1beta1.Gateway{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       HTTPRouteKind,
+					Kind:       GatewayKind,
 					APIVersion: Group + V1Beta1,
 				},
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Changes proposed in this PR:
- Adds a validator for reference grants. The following scenarios are included
   - Gateway can reference a secret
   - HTTPRoute can reference a Gateway
   - HTTPRoute can reference a Backend (Services)  
   - TCPRoute can reference a Gateway
   - TCPRoute can reference a Backend (Services)  

How I've tested this PR:
Tests

How I expect reviewers to test this PR:
Tests

Checklist:
- [x] Tests added


