### PR TITLE
Use the non-deprecated logr test

### DIFF
--- a/control-plane/api-gateway/controllers/gateway_class_config_controller_test.go
+++ b/control-plane/api-gateway/controllers/gateway_class_config_controller_test.go
@@ -5,11 +5,10 @@ package controllers
 
 import (
 	"context"
-	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	"testing"
 	"time"
 
-	logrtest "github.com/go-logr/logr/testing"
+	logrtest "github.com/go-logr/logr/testr"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func TestGatewayClassConfigSetup(t *testing.T) {
@@ -102,7 +102,7 @@ func TestGatewayClassConfigReconcile(t *testing.T) {
 			// Create the gateway class config controller.
 			gcc := &GatewayClassConfigController{
 				Client: fakeClient,
-				Log:    logrtest.NewTestLogger(t),
+				Log:    logrtest.New(t),
 			}
 
 			resp, err := gcc.Reconcile(context.Background(), ctrl.Request{

--- a/control-plane/api-gateway/controllers/gateway_controller_test.go
+++ b/control-plane/api-gateway/controllers/gateway_controller_test.go
@@ -2,10 +2,11 @@ package controllers
 
 import (
 	"context"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"testing"
 
-	logrtest "github.com/go-logr/logr/testing"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	logrtest "github.com/go-logr/logr/testr"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,7 +87,7 @@ func TestGatewayReconciler(t *testing.T) {
 
 			r := &GatewayController{
 				Client: fakeClient,
-				Log:    logrtest.NewTestLogger(t),
+				Log:    logrtest.New(t),
 			}
 			result, err := r.Reconcile(context.Background(), req)
 

--- a/control-plane/api-gateway/controllers/gatewayclass_controller_test.go
+++ b/control-plane/api-gateway/controllers/gatewayclass_controller_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	logrtest "github.com/go-logr/logr/testing"
+	logrtest "github.com/go-logr/logr/testr"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -239,7 +239,7 @@ func TestGatewayClassReconciler(t *testing.T) {
 			r := &GatewayClassController{
 				Client:         fakeClient,
 				ControllerName: GatewayClassControllerName,
-				Log:            logrtest.NewTestLogger(t),
+				Log:            logrtest.New(t),
 			}
 			result, err := r.Reconcile(context.Background(), req)
 


### PR DESCRIPTION
Changes proposed in this PR:
- Use the Logr test "constructor" that is _not_ deprecated

