### PR TITLE
chore(ci): fix typo in changelog checker

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -36,7 +36,7 @@ jobs:
             changelog_file_path=".changelog/[_0-9]*.txt"
           fi
 
-          changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/${{ github.event.pull_request.base.ref }}")" | egrep -e "${changelog_file_path}"))
+          changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/${{ github.event.pull_request.base.ref }}")" | egrep -e "${changelog_file_path}")
 
           # If we do not find a file in .changelog/, we fail the check
           if [ -z "$changelog_files" ]; then


### PR DESCRIPTION
Changes proposed in this PR:
Fixes a typo that causes the changelog checker action to fail. @curtbushko I know you have a fix for this in one of your PRs, but I thought I would PR this separately since it needs to be backported.


