### PR TITLE
feat: update dataplane and consul images for 1.0.7 release

### DIFF
--- a/.changelog/2140.txt
+++ b/.changelog/2140.txt
@@ -1,3 +1,4 @@
 ```release-note:improvement
-helm: update `imageConsulDataplane` value to `hashicorp/consul-dataplane:1.0.2` and `image` value to `hashicorp/consul:1.14.7`.
+helm: update `imageConsulDataplane` value to `hashicorp/consul-dataplane:1.0.2`, `image` value to `hashicorp/consul:1.14.7`, 
+and `imageEnvoy` to `envoyproxy/envoy:v1.24.7`.
 ```

--- a/.changelog/2140.txt
+++ b/.changelog/2140.txt
@@ -1,5 +1,3 @@
 ```release-note:improvement
 helm: update `imageConsulDataplane` value to `hashicorp/consul-dataplane:1.0.2` and `image` value to `hashicorp/consul:1.14.7`.
 ```
-
-

--- a/.changelog/2140.txt
+++ b/.changelog/2140.txt
@@ -1,0 +1,5 @@
+```release-note:improvement
+helm: update `imageConsulDataplane` value to `hashicorp/consul-dataplane:1.0.2` and `image` value to `hashicorp/consul:1.14.7`.
+```
+
+

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: consul
-version: 1.0.6
-appVersion: 1.14.5
+version: 1.0.7
+appVersion: 1.14.7
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
@@ -13,13 +13,13 @@ annotations:
   artifacthub.io/prerelease: false
   artifacthub.io/images: |
     - name: consul
-      image: hashicorp/consul:1.14.5
+      image: hashicorp/consul:1.14.7
     - name: consul-k8s-control-plane
-      image: hashicorp/consul-k8s-control-plane:1.0.6
+      image: hashicorp/consul-k8s-control-plane:1.0.7
     - name: consul-dataplane
-      image: hashicorp/consul-dataplane:1.0.1
+      image: hashicorp/consul-dataplane:1.0.2
     - name: envoy
-      image: envoyproxy/envoy:v1.23.1
+      image: envoyproxy/envoy:v1.24.7
   artifacthub.io/license: MPL-2.0
   artifacthub.io/links: |
     - name: Documentation

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -63,7 +63,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.10.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: "hashicorp/consul:1.14.5"
+  image: "hashicorp/consul:1.14.7"
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.
@@ -569,7 +569,7 @@ global:
   # The name (and tag) of the consul-dataplane Docker image used for the
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
   # @default: hashicorp/consul-dataplane:<latest supported version>
-  imageConsulDataplane: "hashicorp/consul-dataplane:1.1.0"
+  imageConsulDataplane: "hashicorp/consul-dataplane:1.0.2"
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2912,7 +2912,7 @@ apiGateway:
   # The name (and tag) of the Envoy Docker image used for the
   # apiGateway. For other Consul compoenents, imageEnvoy has been replaced with Consul Dataplane.
   # @default: envoyproxy/envoy:<latest supported version>
-  imageEnvoy: "envoyproxy/envoy:v1.23.1"
+  imageEnvoy: "envoyproxy/envoy:v1.24.7"
 
   # Override global log verbosity level for api-gateway-controller pods. One of "debug", "info", "warn", or "error".
   # @type: string


### PR DESCRIPTION
Changes proposed in this PR:
- Staging updates for the 1.0.7 release this week.
  - consul-dataplane 1.0.2 was released with security fixes
  - consul 1.14.7 is currently in the release pipeline

How I've tested this PR: CI

How I expect reviewers to test this PR: 👁️ 👁️ 👁️ 


Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

