### PR TITLE
GHA: Get the consul version from values.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 VERSION = $(shell ./control-plane/build-support/scripts/version.sh control-plane/version/version.go)
+CONSUL_VERSION = $(shell ./control-plane/build-support/scripts/consul-version.sh charts/consul/values.yaml)
 
 # ===========> Helm Targets
 
@@ -146,6 +147,10 @@ ci.aws-acceptance-test-cleanup: ## Deletes AWS resources left behind after faile
 
 version:
 	@echo $(VERSION)
+
+consul-version:
+	@echo $(CONSUL_VERSION)
+
 
 # ===========> Release Targets
 

--- a/control-plane/build-support/scripts/consul-version.sh
+++ b/control-plane/build-support/scripts/consul-version.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+FILE=$1
+VERSION=$(yq .global.image $FILE)
+
+# echo full string "hashicorp/consul:1.15.1" | remove first and last characters | cut everything before ':'
+echo "${VERSION}" | sed 's/^.//;s/.$//' | cut -d ':' -f2-


### PR DESCRIPTION
Changes proposed in this PR:
- The release branches are running the wrong version of consul in the tests.
-  This let's us run `make consul-version` to pull the consul version out of the values.yaml file so that we can use the correct consul version on the release branches.
- I will do a change on the github actions side once this is merged and backported

How I've tested this PR:

- Ran the make target locally (yq is installed on the runners so it should succeed there too)

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

