### PR TITLE
Migrate CRT configuration to 'prepare' workflow

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -10,7 +10,7 @@ project "consul-k8s" {
   }
   github {
     organization = "hashicorp"
-    repository = "consul-k8s"
+    repository   = "consul-k8s"
     release_branches = [
       "main",
       "release/**",
@@ -18,167 +18,23 @@ project "consul-k8s" {
   }
 }
 
-event "merge" {
-  // "entrypoint" to use if build is not run automatically
-  // i.e. send "merge" complete signal to orchestrator to trigger build
-}
-
 event "build" {
-  depends = ["merge"]
-  action "build" {
-    organization = "hashicorp"
-    repository = "consul-k8s"
-    workflow = "build"
-  }
+// This event is required by CRT -- do not delete.
 }
 
-event "upload-dev" {
+event "prepare" {
   depends = ["build"]
-  action "upload-dev" {
+  action "prepare" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "upload-dev"
-    depends = ["build"]
+    repository   = "crt-workflows-common"
+    workflow     = "prepare"
+    depends      = ["build"]
   }
 
   notification {
     on = "fail"
   }
 }
-
-event "security-scan-binaries" {
-  depends = ["upload-dev"]
-  action "security-scan-binaries" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "security-scan-binaries"
-    config = "security-scan.hcl"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "security-scan-containers" {
-  depends = ["security-scan-binaries"]
-  action "security-scan-containers" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "security-scan-containers"
-    config = "security-scan.hcl"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-darwin-amd64" {
-  depends = ["security-scan-containers"]
-  action "notarize-darwin-amd64" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-darwin-amd64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-darwin-arm64" {
-  depends = ["notarize-darwin-amd64"]
-  action "notarize-darwin-arm64" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-darwin-arm64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-windows-386" {
-  depends = ["notarize-darwin-arm64"]
-  action "notarize-windows-386" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-windows-386"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-windows-amd64" {
-  depends = ["notarize-windows-386"]
-  action "notarize-windows-amd64" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-windows-amd64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "sign" {
-  depends = ["notarize-windows-amd64"]
-  action "sign" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "sign"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "sign-linux-rpms" {
-  depends = ["sign"]
-  action "sign-linux-rpms" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "sign-linux-rpms"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "verify" {
-  depends = ["sign-linux-rpms"]
-  action "verify" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "verify"
-  }
-
-  notification {
-    on = "always"
-  }
-}
-
-event "promote-dev-docker" {
-  depends = ["verify"]
-  action "promote-dev-docker" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-dev-docker"
-    depends = ["verify"]
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
 
 ## These are promotion and post-publish events
 ## they should be added to the end of the file after the verify event stanza.
@@ -192,9 +48,9 @@ event "promote-staging" {
   depends = ["trigger-staging"]
   action "promote-staging" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-staging"
-    config = "release-metadata.hcl"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-staging"
+    config       = "release-metadata.hcl"
   }
 
   notification {
@@ -206,8 +62,8 @@ event "promote-staging-docker" {
   depends = ["promote-staging"]
   action "promote-staging-docker" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-staging-docker"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-staging-docker"
   }
 
   notification {
@@ -224,8 +80,8 @@ event "promote-production" {
   depends = ["trigger-production"]
   action "promote-production" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-production"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-production"
   }
 
   notification {
@@ -237,8 +93,8 @@ event "promote-production-docker" {
   depends = ["promote-production"]
   action "promote-production-docker" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-production-docker"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-production-docker"
   }
 
   notification {
@@ -250,8 +106,8 @@ event "promote-production-packaging" {
   depends = ["promote-production-docker"]
   action "promote-production-packaging" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-production-packaging"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-production-packaging"
   }
 
   notification {
@@ -263,8 +119,8 @@ event "promote-production-helm" {
   depends = ["promote-production-packaging"]
   action "promote-production-helm" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-production-helm"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-production-helm"
   }
 
   notification {


### PR DESCRIPTION
This replaces the explicit configuration enumerating each step in the common release tooling process with a single step that encapsulates all organizational requirements (signing, notarization, etc.).

