### PR TITLE
Net 4125/hookup gatekeeper with snapshot

### DIFF
--- a/charts/consul/templates/connect-inject-clusterrole.yaml
+++ b/charts/consul/templates/connect-inject-clusterrole.yaml
@@ -165,6 +165,7 @@ rules:
     - list
     - update
     - watch
+    - delete
 - apiGroups:
     - core
   resources:

--- a/control-plane/api-gateway/binding/binder.go
+++ b/control-plane/api-gateway/binding/binder.go
@@ -214,6 +214,7 @@ func (b *Binder) Snapshot() Snapshot {
 	// if the gateway hasn't been marked for deletion
 	if !isGatewayDeleted {
 		snapshot.GatewayClassConfig = gwcc
+		snapshot.UpsertGatewayDeployment = true
 
 		entry := b.config.Translator.GatewayToAPIGateway(b.config.Gateway, seenCerts)
 		snapshot.Consul.Updates = append(snapshot.Consul.Updates, &entry)

--- a/control-plane/api-gateway/binding/binder_test.go
+++ b/control-plane/api-gateway/binding/binder_test.go
@@ -949,7 +949,7 @@ func TestBinder_Lifecycle(t *testing.T) {
 			actual := binder.Snapshot()
 
 			diff := cmp.Diff(tt.expected, actual, cmp.FilterPath(func(p cmp.Path) bool {
-				return p.String() == "GatewayClassConfig" || strings.HasSuffix(p.String(), "LastTransitionTime") || strings.HasSuffix(p.String(), "Annotations")
+				return p.String() == "GatewayClassConfig" || strings.HasSuffix(p.String(), "LastTransitionTime") || strings.HasSuffix(p.String(), "Annotations") || strings.HasSuffix(p.String(), "UpsertGatewayDeployment")
 			}, cmp.Ignore()))
 			if diff != "" {
 				t.Error("undexpected diff", diff)

--- a/control-plane/api-gateway/binding/snapshot.go
+++ b/control-plane/api-gateway/binding/snapshot.go
@@ -43,4 +43,6 @@ type Snapshot struct {
 	// a Gateway deployment, if it is not set, a deployment should be
 	// deleted instead of updated
 	GatewayClassConfig *v1alpha1.GatewayClassConfig
+	// TODO: melisa describe this
+	UpsertGatewayDeployment bool
 }

--- a/control-plane/api-gateway/binding/snapshot.go
+++ b/control-plane/api-gateway/binding/snapshot.go
@@ -43,6 +43,7 @@ type Snapshot struct {
 	// a Gateway deployment, if it is not set, a deployment should be
 	// deleted instead of updated
 	GatewayClassConfig *v1alpha1.GatewayClassConfig
-	// TODO: melisa describe this
+	// UpsertGatewayDeployment determines whether the gateway deployment
+	// objects should be updated, i.e. deployments, roles, services
 	UpsertGatewayDeployment bool
 }

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -28,6 +28,7 @@ import (
 
 	apigateway "github.com/hashicorp/consul-k8s/control-plane/api-gateway"
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/binding"
+	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/gatekeeper"
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/translation"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	"github.com/hashicorp/consul-k8s/control-plane/cache"
@@ -214,7 +215,16 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// do something with deployments, gwcc and such here, if the following exists on
 	// the snapshot it means we should attempt to enforce the deployment, if it's nil
 	// then we should delete the deployment
-	_ = updates.GatewayClassConfig
+	if updates.GatewayClassConfig == nil {
+		err := r.deleteGatewayK8SResources(ctx, log, &gw)
+		if err != nil {
+			log.Error(err, "unable to delete gateway resources")
+			return ctrl.Result{}, err
+		}
+		//TODO: should we return early here?
+	} else {
+		r.updateGatewayK8SResources(ctx, log, &gw, *updates.GatewayClassConfig)
+	}
 
 	for _, deletion := range updates.Consul.Deletions {
 		log.Info("deleting from Consul", "kind", deletion.Kind, "namespace", deletion.Namespace, "name", deletion.Name)
@@ -240,6 +250,7 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	}
 
+	// currently this runs even after we delete
 	for _, update := range updates.Kubernetes.Updates {
 		log.Info("update in Kubernetes", "kind", update.GetObjectKind().GroupVersionKind().Kind, "namespace", update.GetNamespace(), "name", update.GetName())
 		if err := r.updateAndResetStatus(ctx, update); err != nil {
@@ -295,6 +306,38 @@ func configEntriesTo[T api.ConfigEntry](entries []api.ConfigEntry) []T {
 		es = append(es, e.(T))
 	}
 	return es
+}
+
+func (r *GatewayController) deleteGatewayK8SResources(ctx context.Context, log logr.Logger, gw *gwv1beta1.Gateway) error {
+	// delete k8s resources related to gateway
+	gk := gatekeeper.New(log, r.Client)
+	err := gk.Delete(ctx, types.NamespacedName{
+		Namespace: gw.Namespace,
+		Name:      gw.Name,
+	})
+	if err != nil {
+		log.Error(err, "unable to delete gateway")
+		return err
+	}
+	// TODO: should we still removefinalizer here?
+	_, err = RemoveFinalizer(ctx, r.Client, gw, gatewayFinalizer)
+	if err != nil {
+		log.Error(err, "unable to remove finalizer")
+	}
+
+	return err
+}
+
+func (r *GatewayController) updateGatewayK8SResources(ctx context.Context, log logr.Logger, gw *gwv1beta1.Gateway, gwcc v1alpha1.GatewayClassConfig) error {
+	// delete k8s resources related to gateway
+	gk := gatekeeper.New(log, r.Client)
+	err := gk.Upsert(ctx, *gw, gwcc, r.HelmConfig)
+	if err != nil {
+		log.Error(err, "unable to update gateway")
+		return err
+	}
+
+	return err
 }
 
 // SetupWithGatewayControllerManager registers the controller with the given manager.

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -80,10 +80,14 @@ func buildOpts(ref api.ConfigEntry) cmp.Option {
 func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("gateway", req.NamespacedName)
 <<<<<<< HEAD
+<<<<<<< HEAD
 	log.Info("Reconciling the Gateway: ", "gatewayName", req.Name)
 =======
 	log.Info("Reconciling the Gateway: ")
 >>>>>>> 1cc80777 (still has some print statements, seeing issues with updates)
+=======
+	log.Info("Reconciling Gateway")
+>>>>>>> 6f4db1f5 (cleanup)
 
 	// If gateway does not exist, log an error.
 	var gw gwv1beta1.Gateway
@@ -216,17 +220,13 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	updates := binder.Snapshot()
 
-	fmt.Println("--------------------------------------\n", updates)
-
 	if updates.UpsertGatewayDeployment {
-		log.Info("updating gatekeeper")
 		err := r.updateGatekeeperResources(ctx, log, &gw, gwcc)
 		if err != nil {
 			log.Error(err, "unable to update gateway resources")
 			return ctrl.Result{}, err
 		}
 	} else {
-		log.Info("deleting gatekeeper")
 		err := r.deleteGatekeeperResources(ctx, log, &gw)
 		if err != nil {
 			log.Error(err, "unable to delete gateway resources")

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -79,15 +79,7 @@ func buildOpts(ref api.ConfigEntry) cmp.Option {
 // Reconcile handles the reconciliation loop for Gateway objects.
 func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("gateway", req.NamespacedName)
-<<<<<<< HEAD
-<<<<<<< HEAD
-	log.Info("Reconciling the Gateway: ", "gatewayName", req.Name)
-=======
-	log.Info("Reconciling the Gateway: ")
->>>>>>> 1cc80777 (still has some print statements, seeing issues with updates)
-=======
 	log.Info("Reconciling Gateway")
->>>>>>> 6f4db1f5 (cleanup)
 
 	// If gateway does not exist, log an error.
 	var gw gwv1beta1.Gateway

--- a/control-plane/api-gateway/controllers/gateway_controller_test.go
+++ b/control-plane/api-gateway/controllers/gateway_controller_test.go
@@ -31,17 +31,9 @@ const (
 	TestGatewayClassConfigName = "test-gateway-class-config"
 	TestAnnotationConfigKey    = "api-gateway.consul.hashicorp.com/config"
 	TestGatewayClassName       = "test-gateway-class"
-	TestServiceType            = corev1.ServiceType("NodePort")
 	TestGatewayName            = "test-gateway"
 	TestNamespace              = "test-namespace"
 )
-
-type resources struct {
-	deployments     []*appsv1.Deployment
-	roles           []*rbac.Role
-	services        []*corev1.Service
-	serviceAccounts []*corev1.ServiceAccount
-}
 
 func TestGatewayReconcileUpdates(t *testing.T) {
 	t.Parallel()

--- a/control-plane/api-gateway/controllers/gateway_controller_test.go
+++ b/control-plane/api-gateway/controllers/gateway_controller_test.go
@@ -5,6 +5,8 @@ package controllers
 
 import (
 	"context"
+	appsv1 "k8s.io/api/apps/v1"
+	rbac "k8s.io/api/rbac/v1"
 	"testing"
 
 	logrtest "github.com/go-logr/logr/testr"
@@ -26,12 +28,18 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/consul"
 )
 
+const (
+	TestGatewayClassConfigName = "test-gateway-class-config"
+	TestAnnotationConfigKey    = "api-gateway.consul.hashicorp.com/config"
+	TestGatewayClassName       = "test-gateway-class"
+	TestServiceType            = corev1.ServiceType("NodePort")
+)
+
 func TestGatewayReconciler(t *testing.T) {
 	t.Parallel()
 
 	namespace := "test-namespace"
 	name := "test-gateway"
-	gatewayClassName := gwv1beta1.ObjectName("test-gateway-class")
 
 	req := ctrl.Request{
 		NamespacedName: types.NamespacedName{
@@ -39,6 +47,8 @@ func TestGatewayReconciler(t *testing.T) {
 			Name:      name,
 		},
 	}
+
+	basicGatewayClass, basicGatewayClassConfig := getBasicGatewayClassAndConfig()
 
 	cases := map[string]struct {
 		gateway            *gwv1beta1.Gateway
@@ -55,24 +65,17 @@ func TestGatewayReconciler(t *testing.T) {
 					Namespace:  namespace,
 					Name:       name,
 					Finalizers: []string{gatewayFinalizer},
+					Annotations: map[string]string{
+						TestAnnotationConfigKey: `{"serviceType":"service"}`,
+					},
 				},
 				Spec: gwv1beta1.GatewaySpec{
-					GatewayClassName: gatewayClassName,
+					GatewayClassName: TestGatewayClassName,
 				},
 			},
 			k8sObjects: []runtime.Object{
-				&gwv1beta1.GatewayClass{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "",
-						Name:      string(gatewayClassName),
-						Finalizers: []string{
-							gatewayClassFinalizer,
-						},
-					},
-					Spec: gwv1beta1.GatewayClassSpec{
-						ControllerName: GatewayClassControllerName,
-					},
-				},
+				&basicGatewayClass,
+				&basicGatewayClassConfig,
 			},
 			expectedResult:     ctrl.Result{},
 			expectedError:      nil,
@@ -117,6 +120,202 @@ func TestGatewayReconciler(t *testing.T) {
 			//for i, expectedCondition := range tc.expectedConditions {
 			//	require.True(t, equalConditions(expectedCondition, g.Status.Conditions[i]), "expected %+v, got %+v", expectedCondition, g.Status.Conditions[i])
 			//}
+		})
+	}
+}
+
+func TestGatewayReconcileUpdates(t *testing.T) {
+	t.Parallel()
+
+	namespace := "test-namespace"
+	name := "test-gateway"
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+
+	basicGatewayClass, basicGatewayClassConfig := getBasicGatewayClassAndConfig()
+
+	cases := map[string]struct {
+		gateway       *gwv1beta1.Gateway
+		k8sObjects    []runtime.Object
+		expectedError error
+	}{
+		"successful update of gateway": {
+			gateway: &gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  namespace,
+					Name:       name,
+					Finalizers: []string{gatewayFinalizer},
+					Annotations: map[string]string{
+						TestAnnotationConfigKey: `{"serviceType":"serviceType"}`,
+					},
+				},
+				Spec: gwv1beta1.GatewaySpec{
+					GatewayClassName: TestGatewayClassName,
+				},
+			},
+			k8sObjects: []runtime.Object{
+				&basicGatewayClass,
+				&basicGatewayClassConfig,
+			},
+			expectedError: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			s := runtime.NewScheme()
+			require.NoError(t, gwv1beta1.Install(s))
+			require.NoError(t, v1alpha1.AddToScheme(s))
+			require.NoError(t, gwv1alpha2.AddToScheme(s))
+			require.NoError(t, rbac.AddToScheme(s))
+			require.NoError(t, corev1.AddToScheme(s))
+			require.NoError(t, appsv1.AddToScheme(s))
+
+			objs := tc.k8sObjects
+			if tc.gateway != nil {
+				objs = append(objs, tc.gateway)
+			}
+
+			fakeClient := registerFieldIndexersForTest(fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...)).Build()
+
+			r := &GatewayController{
+				cache:  cache.New(cache.Config{Logger: logrtest.New(t), ConsulClientConfig: &consul.Config{}}),
+				Client: fakeClient,
+				Log:    logrtest.New(t),
+			}
+
+			_, err := r.Reconcile(context.Background(), req)
+
+			require.Equal(t, tc.expectedError, err)
+		})
+	}
+}
+
+func TestGatewayReconcileDeletes(t *testing.T) {
+	t.Parallel()
+
+	namespace := "test-namespace"
+	name := "test-gateway"
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+
+	basicGatewayClass, basicGatewayClassConfig := getBasicGatewayClassAndConfig()
+	serviceType := corev1.ServiceType("NodePort")
+	cases := map[string]struct {
+		gateway       *gwv1beta1.Gateway
+		k8sObjects    []runtime.Object
+		expectedError error
+	}{
+		"successful delete for nonexistent gateway class": {
+			gateway: &gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  namespace,
+					Name:       name,
+					Finalizers: []string{gatewayFinalizer},
+					Annotations: map[string]string{
+						TestAnnotationConfigKey: `{"serviceType":"serviceType"}`,
+					},
+				},
+				Spec: gwv1beta1.GatewaySpec{
+					GatewayClassName: TestGatewayClassName,
+				},
+			},
+			k8sObjects:    []runtime.Object{},
+			expectedError: nil,
+		},
+		"successful change of gatewayclass on gateway": {
+			gateway: &gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  namespace,
+					Name:       name,
+					Finalizers: []string{gatewayFinalizer},
+					Annotations: map[string]string{
+						TestAnnotationConfigKey: `{"serviceType":"serviceType"}`,
+					},
+				},
+				Spec: gwv1beta1.GatewaySpec{
+					GatewayClassName: "DifferentGatewayClassName",
+				},
+			},
+			k8sObjects: []runtime.Object{
+				&gwv1beta1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "",
+						Name:      "DifferentGatewayClassName",
+						Finalizers: []string{
+							gatewayClassFinalizer,
+						},
+					},
+					Spec: gwv1beta1.GatewayClassSpec{
+						ControllerName: "different.controller.name",
+						ParametersRef: &gwv1beta1.ParametersReference{
+							Group:     "different.group",
+							Kind:      "GatewayClassConfig",
+							Name:      "DifferentGatewayClassConfigName",
+							Namespace: nil,
+						},
+					},
+				},
+				&v1alpha1.GatewayClassConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "DifferentGatewayClassConfigName",
+					},
+					Spec: v1alpha1.GatewayClassConfigSpec{
+						ServiceType: &serviceType,
+					},
+				},
+				&basicGatewayClass,
+				&basicGatewayClassConfig,
+			},
+			expectedError: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			s := runtime.NewScheme()
+			require.NoError(t, gwv1beta1.Install(s))
+			require.NoError(t, v1alpha1.AddToScheme(s))
+			require.NoError(t, gwv1alpha2.AddToScheme(s))
+			require.NoError(t, rbac.AddToScheme(s))
+			require.NoError(t, corev1.AddToScheme(s))
+			require.NoError(t, appsv1.AddToScheme(s))
+
+			objs := tc.k8sObjects
+			if tc.gateway != nil {
+				objs = append(objs, tc.gateway)
+			}
+
+			fakeClient := registerFieldIndexersForTest(fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...)).Build()
+
+			r := &GatewayController{
+				cache:  cache.New(cache.Config{Logger: logrtest.New(t), ConsulClientConfig: &consul.Config{}}),
+				Client: fakeClient,
+				Log:    logrtest.New(t),
+			}
+
+			_, err := r.Reconcile(context.TODO(), req)
+
+			require.Equal(t, tc.expectedError, err)
+
+			// Check the finalizer is removed
+			gw := gwv1beta1.Gateway{}
+			err = r.Client.Get(context.TODO(), types.NamespacedName{
+				Namespace: gw.Namespace,
+				Name:      gw.Name,
+			}, &gw)
+			require.NoError(t, err)
+			require.Empty(t, gw.Finalizers)
 		})
 	}
 }
@@ -311,4 +510,40 @@ func TestGatewayController_getAllRefsForGateway(t *testing.T) {
 	expectedEntries := []metav1.Object{httpRouteOnGateway, tcpRoute, secret}
 
 	require.ElementsMatch(t, expectedEntries, actual)
+}
+
+func getBasicGatewayClassAndConfig() (gwv1beta1.GatewayClass, v1alpha1.GatewayClassConfig) {
+	serviceType := corev1.ServiceType("NodePort")
+	basicGatewayClass := gwv1beta1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "",
+			Name:      TestGatewayClassName,
+			Finalizers: []string{
+				gatewayClassFinalizer,
+			},
+		},
+		Spec: gwv1beta1.GatewayClassSpec{
+			ControllerName: GatewayClassControllerName,
+			ParametersRef: &gwv1beta1.ParametersReference{
+				Group:     "consul.hashicorp.com",
+				Kind:      "GatewayClassConfig",
+				Name:      TestGatewayClassConfigName,
+				Namespace: nil,
+			},
+		},
+	}
+
+	basicGatewayClassConfig := v1alpha1.GatewayClassConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: TestGatewayClassConfigName,
+		},
+		Spec: v1alpha1.GatewayClassConfigSpec{
+			ServiceType: &serviceType,
+			CopyAnnotations: v1alpha1.CopyAnnotationsSpec{
+				Service: []string{"serviceType"},
+			},
+		},
+	}
+
+	return basicGatewayClass, basicGatewayClassConfig
 }

--- a/control-plane/api-gateway/gatekeeper/deployment.go
+++ b/control-plane/api-gateway/gatekeeper/deployment.go
@@ -5,6 +5,8 @@ package gatekeeper
 
 import (
 	"context"
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
 
 	apigateway "github.com/hashicorp/consul-k8s/control-plane/api-gateway"
 	appsv1 "k8s.io/api/apps/v1"
@@ -17,12 +19,12 @@ import (
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func (g *Gatekeeper) upsertDeployment(ctx context.Context) error {
+func (g *Gatekeeper) upsertDeployment(ctx context.Context, gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config apigateway.HelmConfig) error {
 	// Get Deployment if it exists.
 	existingDeployment := &appsv1.Deployment{}
 	exists := false
 
-	err := g.Client.Get(ctx, g.namespacedName(), existingDeployment)
+	err := g.Client.Get(ctx, g.namespacedName(gateway), existingDeployment)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return err
 	} else if k8serrors.IsNotFound(err) {
@@ -31,7 +33,7 @@ func (g *Gatekeeper) upsertDeployment(ctx context.Context) error {
 		exists = true
 	}
 
-	deployment := g.deployment()
+	deployment := g.deployment(gateway, gcc, config)
 
 	if exists {
 		g.Log.Info("Existing Gateway Deployment found.")
@@ -41,7 +43,7 @@ func (g *Gatekeeper) upsertDeployment(ctx context.Context) error {
 	}
 
 	mutated := deployment.DeepCopy()
-	mutator := newDeploymentMutator(deployment, mutated, g.Gateway, g.Client.Scheme())
+	mutator := newDeploymentMutator(deployment, mutated, gateway, g.Client.Scheme())
 
 	result, err := controllerutil.CreateOrUpdate(ctx, g.Client, mutated, mutator)
 	if err != nil {
@@ -60,8 +62,8 @@ func (g *Gatekeeper) upsertDeployment(ctx context.Context) error {
 	return nil
 }
 
-func (g *Gatekeeper) deleteDeployment(ctx context.Context) error {
-	err := g.Client.Delete(ctx, g.deployment())
+func (g *Gatekeeper) deleteDeployment(ctx context.Context, nsname types.NamespacedName) error {
+	err := g.Client.Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}})
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}
@@ -69,21 +71,21 @@ func (g *Gatekeeper) deleteDeployment(ctx context.Context) error {
 	return err
 }
 
-func (g *Gatekeeper) deployment() *appsv1.Deployment {
+func (g *Gatekeeper) deployment(gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config apigateway.HelmConfig) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      g.Gateway.Name,
-			Namespace: g.Gateway.Namespace,
-			Labels:    apigateway.LabelsForGateway(&g.Gateway),
+			Name:      gateway.Name,
+			Namespace: gateway.Namespace,
+			Labels:    apigateway.LabelsForGateway(&gateway),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: g.GatewayClassConfig.Spec.DeploymentSpec.DefaultInstances,
+			Replicas: gcc.Spec.DeploymentSpec.DefaultInstances,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: apigateway.LabelsForGateway(&g.Gateway),
+				MatchLabels: apigateway.LabelsForGateway(&gateway),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: apigateway.LabelsForGateway(&g.Gateway),
+					Labels: apigateway.LabelsForGateway(&gateway),
 					Annotations: map[string]string{
 						"consul.hashicorp.com/connect-inject": "false",
 					},
@@ -91,7 +93,7 @@ func (g *Gatekeeper) deployment() *appsv1.Deployment {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Image: g.HelmConfig.Image,
+							Image: config.Image,
 							Name:  "consul-dataplane",
 						},
 					},
@@ -102,7 +104,7 @@ func (g *Gatekeeper) deployment() *appsv1.Deployment {
 									Weight: 1,
 									PodAffinityTerm: corev1.PodAffinityTerm{
 										LabelSelector: &metav1.LabelSelector{
-											MatchLabels: apigateway.LabelsForGateway(&g.Gateway),
+											MatchLabels: apigateway.LabelsForGateway(&gateway),
 										},
 										TopologyKey: "kubernetes.io/hostname",
 									},
@@ -110,8 +112,8 @@ func (g *Gatekeeper) deployment() *appsv1.Deployment {
 							},
 						},
 					},
-					NodeSelector:       g.GatewayClassConfig.Spec.NodeSelector,
-					Tolerations:        g.GatewayClassConfig.Spec.Tolerations,
+					NodeSelector:       gcc.Spec.NodeSelector,
+					Tolerations:        gcc.Spec.Tolerations,
 					ServiceAccountName: g.serviceAccountName(),
 				},
 			},

--- a/control-plane/api-gateway/gatekeeper/deployment.go
+++ b/control-plane/api-gateway/gatekeeper/deployment.go
@@ -153,6 +153,14 @@ func compareDeployments(a, b *appsv1.Deployment) bool {
 		}
 	}
 
+	if b.Spec.Replicas == nil && a.Spec.Replicas == nil {
+		return true
+	} else if b.Spec.Replicas == nil {
+		return false
+	} else if a.Spec.Replicas == nil {
+		return false
+	}
+
 	return *b.Spec.Replicas == *a.Spec.Replicas
 }
 

--- a/control-plane/api-gateway/gatekeeper/gatekeeper.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper.go
@@ -19,40 +19,33 @@ import (
 type Gatekeeper struct {
 	Log    logr.Logger
 	Client client.Client
-
-	Gateway            gwv1beta1.Gateway
-	GatewayClassConfig v1alpha1.GatewayClassConfig
-	HelmConfig         apigateway.HelmConfig
 }
 
 // New creates a new Gatekeeper from the Config.
-func New(log logr.Logger, client client.Client, gateway gwv1beta1.Gateway, gatewayClassConfig v1alpha1.GatewayClassConfig, helmConfig apigateway.HelmConfig) *Gatekeeper {
+func New(log logr.Logger, client client.Client) *Gatekeeper {
 	return &Gatekeeper{
-		Log:                log,
-		Client:             client,
-		Gateway:            gateway,
-		GatewayClassConfig: gatewayClassConfig,
-		HelmConfig:         helmConfig,
+		Log:    log,
+		Client: client,
 	}
 }
 
 // Upsert creates or updates the resources for handling routing of network traffic.
-func (g *Gatekeeper) Upsert(ctx context.Context) error {
-	g.Log.Info(fmt.Sprintf("Upsert Gateway Deployment %s/%s", g.Gateway.Namespace, g.Gateway.Name))
+func (g *Gatekeeper) Upsert(ctx context.Context, gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config apigateway.HelmConfig) error {
+	g.Log.Info(fmt.Sprintf("Upsert Gateway Deployment %s/%s", gateway.Namespace, gateway.Name))
 
-	if err := g.upsertRole(ctx); err != nil {
+	if err := g.upsertRole(ctx, gateway, config); err != nil {
 		return err
 	}
 
-	if err := g.upsertServiceAccount(ctx); err != nil {
+	if err := g.upsertServiceAccount(ctx, gateway, gcc, config); err != nil {
 		return err
 	}
 
-	if err := g.upsertService(ctx); err != nil {
+	if err := g.upsertService(ctx, gateway, gcc, config); err != nil {
 		return err
 	}
 
-	if err := g.upsertDeployment(ctx); err != nil {
+	if err := g.upsertDeployment(ctx, gateway, gcc, config); err != nil {
 		return err
 	}
 
@@ -60,20 +53,20 @@ func (g *Gatekeeper) Upsert(ctx context.Context) error {
 }
 
 // Delete removes the resources for handling routing of network traffic.
-func (g *Gatekeeper) Delete(ctx context.Context) error {
-	if err := g.deleteRole(ctx); err != nil {
+func (g *Gatekeeper) Delete(ctx context.Context, nsname types.NamespacedName) error {
+	if err := g.deleteRole(ctx, nsname); err != nil {
 		return err
 	}
 
-	if err := g.deleteServiceAccount(ctx); err != nil {
+	if err := g.deleteServiceAccount(ctx, nsname); err != nil {
 		return err
 	}
 
-	if err := g.deleteService(ctx); err != nil {
+	if err := g.deleteService(ctx, nsname); err != nil {
 		return err
 	}
 
-	if err := g.deleteDeployment(ctx); err != nil {
+	if err := g.deleteDeployment(ctx, nsname); err != nil {
 		return err
 	}
 
@@ -83,10 +76,10 @@ func (g *Gatekeeper) Delete(ctx context.Context) error {
 // resourceMutator is passed to create or update functions to mutate Kubernetes resources.
 type resourceMutator = func() error
 
-func (g Gatekeeper) namespacedName() types.NamespacedName {
+func (g Gatekeeper) namespacedName(gateway gwv1beta1.Gateway) types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: g.Gateway.Namespace,
-		Name:      g.Gateway.Name,
+		Namespace: gateway.Namespace,
+		Name:      gateway.Name,
 	}
 }
 

--- a/control-plane/api-gateway/gatekeeper/gatekeeper.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper.go
@@ -37,7 +37,7 @@ func (g *Gatekeeper) Upsert(ctx context.Context, gateway gwv1beta1.Gateway, gcc 
 		return err
 	}
 
-	if err := g.upsertServiceAccount(ctx, gateway, gcc, config); err != nil {
+	if err := g.upsertServiceAccount(ctx, gateway, config); err != nil {
 		return err
 	}
 

--- a/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
@@ -419,9 +419,9 @@ func TestUpsert(t *testing.T) {
 			objs := append(joinResources(tc.initialResources), &tc.gateway, &tc.gatewayClassConfig)
 			client := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
 
-			gatekeeper := New(log, client, tc.gateway, tc.gatewayClassConfig, tc.helmConfig)
+			gatekeeper := New(log, client)
 
-			err := gatekeeper.Upsert(context.Background())
+			err := gatekeeper.Upsert(context.Background(), tc.gateway, tc.gatewayClassConfig, tc.helmConfig)
 			require.NoError(t, err)
 			require.NoError(t, validateResourcesExist(t, client, tc.finalResources))
 		})
@@ -602,9 +602,12 @@ func TestDelete(t *testing.T) {
 			objs := append(joinResources(tc.initialResources), &tc.gateway, &tc.gatewayClassConfig)
 			client := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
 
-			gatekeeper := New(log, client, tc.gateway, tc.gatewayClassConfig, tc.helmConfig)
+			gatekeeper := New(log, client)
 
-			err := gatekeeper.Delete(context.Background())
+			err := gatekeeper.Delete(context.Background(), types.NamespacedName{
+				Namespace: tc.gateway.Namespace,
+				Name:      tc.gateway.Name,
+			})
 			require.NoError(t, err)
 			require.NoError(t, validateResourcesExist(t, client, tc.finalResources))
 			require.NoError(t, validateResourcesAreDeleted(t, client, tc.initialResources))

--- a/control-plane/api-gateway/gatekeeper/role.go
+++ b/control-plane/api-gateway/gatekeeper/role.go
@@ -6,7 +6,6 @@ package gatekeeper
 import (
 	"context"
 	"errors"
-	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -58,7 +57,7 @@ func (g *Gatekeeper) upsertRole(ctx context.Context, gateway gwv1beta1.Gateway, 
 }
 
 func (g *Gatekeeper) deleteRole(ctx context.Context, nsname types.NamespacedName) error {
-	if err := g.Client.Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}}); err != nil {
+	if err := g.Client.Delete(ctx, &rbac.Role{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}}); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}

--- a/control-plane/api-gateway/gatekeeper/role.go
+++ b/control-plane/api-gateway/gatekeeper/role.go
@@ -6,6 +6,9 @@ package gatekeeper
 import (
 	"context"
 	"errors"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	apigateway "github.com/hashicorp/consul-k8s/control-plane/api-gateway"
 	rbac "k8s.io/api/rbac/v1"
@@ -14,8 +17,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (g *Gatekeeper) upsertRole(ctx context.Context) error {
-	if !g.HelmConfig.ManageSystemACLs {
+func (g *Gatekeeper) upsertRole(ctx context.Context, gateway gwv1beta1.Gateway, config apigateway.HelmConfig) error {
+	if !config.ManageSystemACLs {
 		return nil
 	}
 
@@ -23,7 +26,7 @@ func (g *Gatekeeper) upsertRole(ctx context.Context) error {
 	exists := false
 
 	// Get ServiceAccount
-	err := g.Client.Get(ctx, g.namespacedName(), role)
+	err := g.Client.Get(ctx, g.namespacedName(gateway), role)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return err
 	} else if k8serrors.IsNotFound(err) {
@@ -35,7 +38,7 @@ func (g *Gatekeeper) upsertRole(ctx context.Context) error {
 	if exists {
 		// Ensure we own the Role.
 		for _, ref := range role.GetOwnerReferences() {
-			if ref.UID == g.Gateway.GetUID() && ref.Name == g.Gateway.GetName() {
+			if ref.UID == gateway.GetUID() && ref.Name == gateway.GetName() {
 				// We found ourselves!
 				return nil
 			}
@@ -43,8 +46,8 @@ func (g *Gatekeeper) upsertRole(ctx context.Context) error {
 		return errors.New("Role not owned by controller")
 	}
 
-	role = g.role()
-	if err := ctrl.SetControllerReference(&g.Gateway, role, g.Client.Scheme()); err != nil {
+	role = g.role(gateway)
+	if err := ctrl.SetControllerReference(&gateway, role, g.Client.Scheme()); err != nil {
 		return err
 	}
 	if err := g.Client.Create(ctx, role); err != nil {
@@ -54,8 +57,8 @@ func (g *Gatekeeper) upsertRole(ctx context.Context) error {
 	return nil
 }
 
-func (g *Gatekeeper) deleteRole(ctx context.Context) error {
-	if err := g.Client.Delete(ctx, g.role()); err != nil {
+func (g *Gatekeeper) deleteRole(ctx context.Context, nsname types.NamespacedName) error {
+	if err := g.Client.Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}}); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
@@ -65,12 +68,12 @@ func (g *Gatekeeper) deleteRole(ctx context.Context) error {
 	return nil
 }
 
-func (g *Gatekeeper) role() *rbac.Role {
+func (g *Gatekeeper) role(gateway gwv1beta1.Gateway) *rbac.Role {
 	return &rbac.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      g.Gateway.Name,
-			Namespace: g.Gateway.Namespace,
-			Labels:    apigateway.LabelsForGateway(&g.Gateway),
+			Name:      gateway.Name,
+			Namespace: gateway.Namespace,
+			Labels:    apigateway.LabelsForGateway(&gateway),
 		},
 		Rules: []rbac.PolicyRule{
 			{

--- a/control-plane/api-gateway/gatekeeper/service.go
+++ b/control-plane/api-gateway/gatekeeper/service.go
@@ -6,7 +6,6 @@ package gatekeeper
 import (
 	"context"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
-	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	apigateway "github.com/hashicorp/consul-k8s/control-plane/api-gateway"
@@ -54,7 +53,7 @@ func (g *Gatekeeper) upsertService(ctx context.Context, gateway gwv1beta1.Gatewa
 }
 
 func (g *Gatekeeper) deleteService(ctx context.Context, nsname types.NamespacedName) error {
-	if err := g.Client.Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}}); err != nil {
+	if err := g.Client.Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}}); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}

--- a/control-plane/api-gateway/gatekeeper/service.go
+++ b/control-plane/api-gateway/gatekeeper/service.go
@@ -5,6 +5,9 @@ package gatekeeper
 
 import (
 	"context"
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	apigateway "github.com/hashicorp/consul-k8s/control-plane/api-gateway"
 	corev1 "k8s.io/api/core/v1"
@@ -23,15 +26,15 @@ var (
 	}
 )
 
-func (g *Gatekeeper) upsertService(ctx context.Context) error {
-	if g.GatewayClassConfig.Spec.ServiceType == nil {
+func (g *Gatekeeper) upsertService(ctx context.Context, gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config apigateway.HelmConfig) error {
+	if gcc.Spec.ServiceType == nil {
 		return nil
 	}
 
-	service := g.service()
+	service := g.service(gateway, gcc)
 
 	mutated := service.DeepCopy()
-	mutator := newServiceMutator(service, mutated, g.Gateway, g.Client.Scheme())
+	mutator := newServiceMutator(service, mutated, gateway, g.Client.Scheme())
 
 	result, err := controllerutil.CreateOrUpdate(ctx, g.Client, mutated, mutator)
 	if err != nil {
@@ -50,8 +53,8 @@ func (g *Gatekeeper) upsertService(ctx context.Context) error {
 	return nil
 }
 
-func (g *Gatekeeper) deleteService(ctx context.Context) error {
-	if err := g.Client.Delete(ctx, g.service()); err != nil {
+func (g *Gatekeeper) deleteService(ctx context.Context, nsname types.NamespacedName) error {
+	if err := g.Client.Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}}); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
@@ -61,9 +64,9 @@ func (g *Gatekeeper) deleteService(ctx context.Context) error {
 	return nil
 }
 
-func (g *Gatekeeper) service() *corev1.Service {
+func (g *Gatekeeper) service(gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig) *corev1.Service {
 	ports := []corev1.ServicePort{}
-	for _, listener := range g.Gateway.Spec.Listeners {
+	for _, listener := range gateway.Spec.Listeners {
 		ports = append(ports, corev1.ServicePort{
 			Name:     string(listener.Name),
 			Protocol: corev1.Protocol(listener.Protocol),
@@ -72,27 +75,27 @@ func (g *Gatekeeper) service() *corev1.Service {
 	}
 
 	// Copy annotations from the Gateway, filtered by those allowed by the GatewayClassConfig.
-	allowedAnnotations := g.GatewayClassConfig.Spec.CopyAnnotations.Service
+	allowedAnnotations := gcc.Spec.CopyAnnotations.Service
 	if allowedAnnotations == nil {
 		allowedAnnotations = defaultServiceAnnotations
 	}
 	annotations := make(map[string]string)
 	for _, allowedAnnotation := range allowedAnnotations {
-		if value, found := g.Gateway.Annotations[allowedAnnotation]; found {
+		if value, found := gateway.Annotations[allowedAnnotation]; found {
 			annotations[allowedAnnotation] = value
 		}
 	}
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        g.Gateway.Name,
-			Namespace:   g.Gateway.Namespace,
-			Labels:      apigateway.LabelsForGateway(&g.Gateway),
+			Name:        gateway.Name,
+			Namespace:   gateway.Namespace,
+			Labels:      apigateway.LabelsForGateway(&gateway),
 			Annotations: annotations,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: apigateway.LabelsForGateway(&g.Gateway),
-			Type:     *g.GatewayClassConfig.Spec.ServiceType,
+			Selector: apigateway.LabelsForGateway(&gateway),
+			Type:     *gcc.Spec.ServiceType,
 			Ports:    ports,
 		},
 	}

--- a/control-plane/api-gateway/gatekeeper/serviceaccount.go
+++ b/control-plane/api-gateway/gatekeeper/serviceaccount.go
@@ -6,7 +6,6 @@ package gatekeeper
 import (
 	"context"
 	"errors"
-	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -60,7 +59,7 @@ func (g *Gatekeeper) upsertServiceAccount(ctx context.Context, gateway gwv1beta1
 }
 
 func (g *Gatekeeper) deleteServiceAccount(ctx context.Context, nsname types.NamespacedName) error {
-	if err := g.Client.Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}}); err != nil {
+	if err := g.Client.Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}}); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}

--- a/control-plane/api-gateway/gatekeeper/serviceaccount.go
+++ b/control-plane/api-gateway/gatekeeper/serviceaccount.go
@@ -6,6 +6,10 @@ package gatekeeper
 import (
 	"context"
 	"errors"
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	apigateway "github.com/hashicorp/consul-k8s/control-plane/api-gateway"
 	corev1 "k8s.io/api/core/v1"
@@ -14,9 +18,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (g *Gatekeeper) upsertServiceAccount(ctx context.Context) error {
+func (g *Gatekeeper) upsertServiceAccount(ctx context.Context, gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config apigateway.HelmConfig) error {
 	// We don't create the ServiceAccount if we are not using ManagedGatewayClass.
-	if !g.HelmConfig.ManageSystemACLs {
+	if !config.ManageSystemACLs {
 		return nil
 	}
 
@@ -24,7 +28,7 @@ func (g *Gatekeeper) upsertServiceAccount(ctx context.Context) error {
 	exists := false
 
 	// Get ServiceAccount if it exists.
-	err := g.Client.Get(ctx, g.namespacedName(), serviceAccount)
+	err := g.Client.Get(ctx, g.namespacedName(gateway), serviceAccount)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return err
 	} else if k8serrors.IsNotFound(err) {
@@ -36,7 +40,7 @@ func (g *Gatekeeper) upsertServiceAccount(ctx context.Context) error {
 	if exists {
 		// Ensure we own the ServiceAccount.
 		for _, ref := range serviceAccount.GetOwnerReferences() {
-			if ref.UID == g.Gateway.GetUID() && ref.Name == g.Gateway.GetName() {
+			if ref.UID == gateway.GetUID() && ref.Name == gateway.GetName() {
 				// We found ourselves!
 				return nil
 			}
@@ -45,8 +49,8 @@ func (g *Gatekeeper) upsertServiceAccount(ctx context.Context) error {
 	}
 
 	// Create the ServiceAccount.
-	serviceAccount = g.serviceAccount()
-	if err := ctrl.SetControllerReference(&g.Gateway, serviceAccount, g.Client.Scheme()); err != nil {
+	serviceAccount = g.serviceAccount(gateway)
+	if err := ctrl.SetControllerReference(&gateway, serviceAccount, g.Client.Scheme()); err != nil {
 		return err
 	}
 	if err := g.Client.Create(ctx, serviceAccount); err != nil {
@@ -56,8 +60,8 @@ func (g *Gatekeeper) upsertServiceAccount(ctx context.Context) error {
 	return nil
 }
 
-func (g *Gatekeeper) deleteServiceAccount(ctx context.Context) error {
-	if err := g.Client.Delete(ctx, g.serviceAccount()); err != nil {
+func (g *Gatekeeper) deleteServiceAccount(ctx context.Context, nsname types.NamespacedName) error {
+	if err := g.Client.Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}}); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
@@ -67,12 +71,12 @@ func (g *Gatekeeper) deleteServiceAccount(ctx context.Context) error {
 	return nil
 }
 
-func (g *Gatekeeper) serviceAccount() *corev1.ServiceAccount {
+func (g *Gatekeeper) serviceAccount(gateway gwv1beta1.Gateway) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      g.Gateway.Name,
-			Namespace: g.Gateway.Namespace,
-			Labels:    apigateway.LabelsForGateway(&g.Gateway),
+			Name:      gateway.Name,
+			Namespace: gateway.Namespace,
+			Labels:    apigateway.LabelsForGateway(&gateway),
 		},
 	}
 }

--- a/control-plane/api-gateway/gatekeeper/serviceaccount.go
+++ b/control-plane/api-gateway/gatekeeper/serviceaccount.go
@@ -6,7 +6,6 @@ package gatekeeper
 import (
 	"context"
 	"errors"
-	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -18,7 +17,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (g *Gatekeeper) upsertServiceAccount(ctx context.Context, gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config apigateway.HelmConfig) error {
+func (g *Gatekeeper) upsertServiceAccount(ctx context.Context, gateway gwv1beta1.Gateway, config apigateway.HelmConfig) error {
 	// We don't create the ServiceAccount if we are not using ManagedGatewayClass.
 	if !config.ManageSystemACLs {
 		return nil


### PR DESCRIPTION
Changes proposed in this PR:
Hooks up gatekeeper with new snapshot.

How I've tested this PR:
Manual testing, added tests.

How I expect reviewers to test this PR:
```
make control-plane-dev-docker
docker tag consul-k8s-control-plane-dev consul-k8s-control-plane-dev:local
kind load docker-image consul-k8s-control-plane-dev:local
kubectl create namespace consul
helm install consul ./charts/consul -n consul --set global.image=hashicorppreview/consul:1.16-dev --set global.imageK8S=consul-k8s-control-plane-dev:local
```
Make a gateway

Checklist:
- [ ] Tests added

