### PR TITLE
Net 4124/handle syncing consul lifecycle events

### DIFF
--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -402,12 +402,12 @@ func SetupGatewayControllerWithManager(ctx context.Context, mgr ctrl.Manager, co
 		).
 		Watches(
 			// Subscribe to changes from Consul for HTTPRoutes
-			&source.Channel{Source: c.Subscribe(ctx, api.APIGateway, translator.BuildConsulHTTPRouteTranslator(ctx)).Events()},
+			&source.Channel{Source: c.Subscribe(ctx, api.HTTPRoute, translator.BuildConsulHTTPRouteTranslator(ctx)).Events()},
 			&handler.EnqueueRequestForObject{},
 		).
 		Watches(
 			// Subscribe to changes from Consul for TCPRoutes
-			&source.Channel{Source: c.Subscribe(ctx, api.APIGateway, translator.BuildConsulTCPRouteTranslator(ctx)).Events()},
+			&source.Channel{Source: c.Subscribe(ctx, api.TCPRoute, translator.BuildConsulTCPRouteTranslator(ctx)).Events()},
 			&handler.EnqueueRequestForObject{},
 		).
 		Watches(

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -64,29 +64,13 @@ func buildOpts(ref api.ConfigEntry) cmp.Option {
 	case *api.HTTPRouteConfigEntry:
 		return cmpopts.IgnoreFields(api.HTTPRouteConfigEntry{}, "Status", "ModifyIndex", "CreateIndex")
 	case *api.TCPRouteConfigEntry:
-		return cmpopts.IgnoreFields(api.TCPRouteConfigEntry{}, "Status", "ModifiyIndex", "CreateIndex")
+		return cmpopts.IgnoreFields(api.TCPRouteConfigEntry{}, "Status", "ModifyIndex", "CreateIndex")
 	case *api.InlineCertificateConfigEntry:
-		return cmpopts.IgnoreFields(api.InlineCertificateConfigEntry{}, "Status", "ModifiyIndex", "CreateIndex")
+		return cmpopts.IgnoreFields(api.InlineCertificateConfigEntry{}, "Status", "ModifyIndex", "CreateIndex")
 	default:
 		panic(fmt.Sprintf("type is not known: %+v", v))
 	}
 }
-
-// func buildOpts[T any](_ T) cmp.Option {
-// empty := *(new(T))
-// fmt.Println()
-// fmt.Println()
-// fmt.Println()
-// fmt.Println()
-// fmt.Println()
-// fmt.Println(empty)
-// fmt.Println()
-// fmt.Println()
-// fmt.Println()
-// fmt.Println()
-// fmt.Println()
-// return cmpopts.IgnoreFields(empty, "Status", "ModifiedIndex", "CreateIndex")
-// }
 
 // Reconcile handles the reconciliation loop for Gateway objects.
 func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -231,7 +215,11 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	for _, deletion := range updates.Consul.Deletions {
 		log.Info("deleting from Consul", "kind", deletion.Kind, "namespace", deletion.Namespace, "name", deletion.Name)
-		r.cache.Delete(deletion)
+		err = r.cache.Delete(deletion)
+		if err != nil {
+			log.Error(err, "failed to delete entry from consul", "kind", deletion.Kind, "namespace", deletion.Namespace, "name", deletion.Name)
+		}
+
 	}
 
 	for _, update := range updates.Consul.Updates {

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -236,9 +236,6 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	for _, update := range updates.Consul.Updates {
 		log.Info("updating in Consul", "kind", update.GetKind(), "namespace", update.GetNamespace(), "name", update.GetName())
-		if update.GetKind() == api.HTTPRoute {
-			panic("ROUTE")
-		}
 		ref := translation.EntryToReference(update)
 		old := r.cache.Get(ref)
 		if cmp.Equal(old, update, buildOpts(update)) {

--- a/control-plane/cache/consul.go
+++ b/control-plane/cache/consul.go
@@ -23,7 +23,10 @@ const (
 	apiTimeout        = 5 * time.Minute
 )
 
-var ErrDidNotSet = errors.New("entry failed to be set")
+var (
+	ErrDidNotSet    = errors.New("entry failed to be set")
+	ErrDidNotDelete = errors.New("entry failed to be deleted")
+)
 
 var Kinds = []string{api.APIGateway, api.HTTPRoute, api.TCPRoute, api.InlineCertificate}
 
@@ -564,7 +567,7 @@ func (c *Cache) Delete(ref api.ResourceReference) error {
 
 	_, err = client.ConfigEntries().Delete(ref.Kind, ref.Name, options)
 	if err != nil {
-		return err
+		return errors.Join(ErrDidNotDelete, err)
 	}
 
 	return nil

--- a/control-plane/cache/consul.go
+++ b/control-plane/cache/consul.go
@@ -597,7 +597,7 @@ func (c *Cache) List(kind string) []api.ConfigEntry {
 	if !ok {
 		return nil
 	}
-	entries := make([]api.ConfigEntry, len(entryMap))
+	entries := make([]api.ConfigEntry, 0, len(entryMap))
 	for _, entry := range entryMap {
 		entries = append(entries, entry)
 	}
@@ -610,7 +610,7 @@ func (c *Cache) ListServices() []api.CatalogService {
 	c.cacheMutex.Lock()
 	defer c.cacheMutex.Unlock()
 
-	entries := make([]api.CatalogService, len(c.serviceCache))
+	entries := make([]api.CatalogService, 0, len(c.serviceCache))
 	for _, service := range c.serviceCache {
 		entries = append(entries, *service)
 	}

--- a/control-plane/cache/consul.go
+++ b/control-plane/cache/consul.go
@@ -23,7 +23,7 @@ const (
 	apiTimeout        = 5 * time.Minute
 )
 
-var ErrStaleEntry = errors.New("entry is stale")
+var ErrDidNotSet = errors.New("entry failed to be set")
 
 var Kinds = []string{api.APIGateway, api.HTTPRoute, api.TCPRoute, api.InlineCertificate}
 
@@ -532,13 +532,13 @@ func (c *Cache) Write(entry api.ConfigEntry) error {
 		options.Partition = c.partition
 	}
 
-	updated, _, err := client.ConfigEntries().CAS(entry, entry.GetModifyIndex(), options)
+	updated, _, err := client.ConfigEntries().Set(entry, options)
 	if err != nil {
 		return err
 	}
 
 	if !updated {
-		return ErrStaleEntry
+		return ErrDidNotSet
 	}
 
 	return nil

--- a/control-plane/cache/consul.go
+++ b/control-plane/cache/consul.go
@@ -544,6 +544,32 @@ func (c *Cache) Write(entry api.ConfigEntry) error {
 	return nil
 }
 
+// Delete handles deleting the config entry from consul, if the current reference of the config entry is stale then
+// it returns an error
+func (c *Cache) Delete(ref api.ResourceReference) error {
+	client, err := consul.NewClientFromConnMgr(c.config, c.serverMgr)
+	if err != nil {
+		return err
+	}
+
+	options := &api.WriteOptions{}
+
+	if c.namespacesEnabled {
+		options.Namespace = namespaceWildcard
+	}
+
+	if c.partition != "" {
+		options.Partition = c.partition
+	}
+
+	_, err = client.ConfigEntries().Delete(ref.Kind, ref.Name, options)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Get returns a config entry from the cache that corresponds to the given resource reference.
 func (c *Cache) Get(ref api.ResourceReference) api.ConfigEntry {
 	c.cacheMutex.Lock()

--- a/control-plane/cache/consul.go
+++ b/control-plane/cache/consul.go
@@ -545,7 +545,7 @@ func (c *Cache) Write(entry api.ConfigEntry) error {
 }
 
 // Delete handles deleting the config entry from consul, if the current reference of the config entry is stale then
-// it returns an error
+// it returns an error.
 func (c *Cache) Delete(ref api.ResourceReference) error {
 	client, err := consul.NewClientFromConnMgr(c.config, c.serverMgr)
 	if err != nil {

--- a/control-plane/cache/consul_test.go
+++ b/control-plane/cache/consul_test.go
@@ -1311,7 +1311,7 @@ func TestCache_Write(t *testing.T) {
 				w.WriteHeader(200)
 				fmt.Fprintln(w, `{updated: false}`)
 			},
-			expectedErr: ErrStaleEntry,
+			expectedErr: ErrDidNotSet,
 		},
 	}
 


### PR DESCRIPTION
Changes proposed in this PR:
- Add config entry deletion/upsert for changed consul resources
-

How I've tested this PR:
- Run tests
- Ran https://github.com/jm96441n/consul-experiments/blob/main/k8s/apigw4conk8s/deploy.sh and then modified and deleted the http route and checked that changes showed up in consul


How I expect reviewers to test this PR:
Read code
Potentially run locally

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

