### PR TITLE
Disable DNS redirection when tproxy is disabled

### DIFF
--- a/.changelog/2176.txt
+++ b/.changelog/2176.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+control-plane: fix issue with multiport pods crashlooping due to dataplane port conflicts by ensuring dns redirection is disabled for non-tproxy pods
+```

--- a/acceptance/tests/connect/connect_inject_test.go
+++ b/acceptance/tests/connect/connect_inject_test.go
@@ -136,13 +136,10 @@ func TestConnectInject_MultiportServices(t *testing.T) {
 			cfg := suite.Config()
 			ctx := suite.Environment().DefaultContext(t)
 
-			// Multi port apps don't work with transparent proxy.
-			if cfg.EnableTransparentProxy {
-				t.Skipf("skipping this test because transparent proxy is enabled")
-			}
-
 			helmValues := map[string]string{
 				"connectInject.enabled": "true",
+				// Enable DNS so we can test that DNS redirection _isn't_ set in the pod.
+				"dns.enabled": "true",
 
 				"global.tls.enabled":           strconv.FormatBool(secure),
 				"global.acls.manageSystemACLs": strconv.FormatBool(secure),

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
@@ -314,7 +314,11 @@ func (w *MeshWebhook) getContainerSidecarArgs(namespace corev1.Namespace, mpi mu
 
 	// If Consul DNS is enabled, we want to configure consul-dataplane to be the DNS proxy
 	// for Consul DNS in the pod.
-	if w.EnableConsulDNS {
+	dnsEnabled, err := consulDNSEnabled(namespace, pod, w.EnableConsulDNS, w.EnableTransparentProxy)
+	if err != nil {
+		return nil, err
+	}
+	if dnsEnabled {
 		args = append(args, "-consul-dns-bind-port="+strconv.Itoa(consulDataplaneDNSBindPort))
 	}
 

--- a/control-plane/connect-inject/webhook/container_init_test.go
+++ b/control-plane/connect-inject/webhook/container_init_test.go
@@ -937,7 +937,8 @@ func TestHandlerContainerInit_Resources(t *testing.T) {
 
 var testNS = corev1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
-		Name: k8sNamespace,
+		Name:   k8sNamespace,
+		Labels: map[string]string{},
 	},
 }
 

--- a/control-plane/connect-inject/webhook/redirect_traffic.go
+++ b/control-plane/connect-inject/webhook/redirect_traffic.go
@@ -98,7 +98,7 @@ func (w *MeshWebhook) iptablesConfigJSON(pod corev1.Pod, ns corev1.Namespace) (s
 	// Add init container user ID to exclude from traffic redirection.
 	cfg.ExcludeUIDs = append(cfg.ExcludeUIDs, strconv.Itoa(initContainersUserAndGroupID))
 
-	dnsEnabled, err := consulDNSEnabled(ns, pod, w.EnableConsulDNS)
+	dnsEnabled, err := consulDNSEnabled(ns, pod, w.EnableConsulDNS, w.EnableTransparentProxy)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Changes proposed in this PR:
- DNS redirection and the various settings that make that possible (like
the dataplane binding to a port for DNS) is only useful if tproxy is
enabled. Most of the code checked if tproxy was enabled but there
was one location where we didn't check. This resulted in a bug
with our multiport support where even though tproxy is disabled,
we tried to setup the dataplane to proxy DNS. This meant each dataplane
tried to bind to 8600 but because there are >1 dataplanes with
multiport, there was a port conflict.

  This PR fixes the location where we didn't check if tproxy was enabled
and as a result fixes the multiport issue.
- the reason this wasn't caught in our acceptance tests is because we don't run the multiport test when global tproxy is enabled and this bug only occurs when global tproxy is enabled but pod-level tproxy is disabled
- Fixes https://github.com/hashicorp/consul-k8s/issues/2144

How I've tested this PR:
- built out a dataplane and manually deployed it with multiport: `go test ./... -p 1 -timeout 20m -run TestConnectInject_MultiportServices -no-cleanup-on-failure -v -consul-image hashicorppreview/consul:1.16-dev -enable-transparent-proxy -consul-k8s-image ghcr.io/lkysow/consul-k8s-dev:mar25-23@sha256:fba790b616687308a2b1159da087eb52109d8acda239b1b69a1775bf12db9570`

How I expect reviewers to test this PR:
- code

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

