### PR TITLE
Update consul image on prepare-dev and prepare-release

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,6 @@ on:
 
 # these should be the only settings that you will ever need to change
 env:
-  CONSUL_IMAGE: hashicorppreview/consul-enterprise:1.16-dev # Consul's enterprise version to use in tests. We use this consul image on release branches too
   BRANCH: ${{ github.head_ref || github.ref_name }}
   CONTEXT: "pr"
   SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -20,6 +19,6 @@ jobs:
       with:
         workflow: test.yml
         repo: hashicorp/consul-k8s-workflows
-        ref: main
+        ref: "NET-4185/consul-image"
         token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-        inputs: '{ "context":"${{ env.CONTEXT }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}", "consul-image":"${{ env.CONSUL_IMAGE }}" }'
+        inputs: '{ "context":"${{ env.CONTEXT }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,6 @@ jobs:
       with:
         workflow: test.yml
         repo: hashicorp/consul-k8s-workflows
-        ref: "NET-4185/consul-image"
+        ref: main
         token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
         inputs: '{ "context":"${{ env.CONTEXT }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION = $(shell ./control-plane/build-support/scripts/version.sh control-plane/version/version.go)
-CONSUL_VERSION = $(shell ./control-plane/build-support/scripts/consul-version.sh charts/consul/values.yaml)
+CONSUL_IMAGE_VERSION = $(shell ./control-plane/build-support/scripts/consul-version.sh charts/consul/values.yaml)
 
 # ===========> Helm Targets
 
@@ -149,8 +149,7 @@ version:
 	@echo $(VERSION)
 
 consul-version:
-	@echo $(CONSUL_VERSION)
-
+	@echo $(CONSUL_IMAGE_VERSION)
 
 # ===========> Release Targets
 
@@ -161,7 +160,13 @@ endif
 ifndef RELEASE_DATE
 	$(error RELEASE_DATE is required, use format <Month> <Day>, <Year> (ex. October 4, 2022))
 endif
-	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_release $(CURDIR) $(RELEASE_VERSION) "$(RELEASE_DATE)" $(LAST_RELEASE_GIT_TAG) $(PRERELEASE_VERSION)
+ifndef LAST_RELEASE_GIT_TAG 
+	$(error LAST_RELEASE_GIT_TAG is required)
+endif
+ifndef CONSUL_VERSION
+	$(error CONSUL_VERSION is required)
+endif
+	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_release $(CURDIR) $(RELEASE_VERSION) "$(RELEASE_DATE)" $(LAST_RELEASE_GIT_TAG) $(CONSUL_VERSION) $(PRERELEASE_VERSION)
 
 prepare-dev:
 ifndef RELEASE_VERSION
@@ -173,7 +178,10 @@ endif
 ifndef NEXT_RELEASE_VERSION
 	$(error NEXT_RELEASE_VERSION is required)
 endif
-	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_dev $(CURDIR) $(RELEASE_VERSION) "$(RELEASE_DATE)" $(NEXT_RELEASE_VERSION)
+ifndef NEXT_CONSUL_VERSION
+	$(error NEXT_CONSUL_VERSION is required)
+endif
+	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_dev $(CURDIR) $(RELEASE_VERSION) "$(RELEASE_DATE)" "" $(NEXT_RELEASE_VERSION) $(NEXT_CONSUL_VERSION)
 
 # ===========> Makefile config
 

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: consul
 version: 1.2.0-dev
-appVersion: 1.16-dev
+appVersion: 1.15.1
 kubeVersion: ">=1.22.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
@@ -16,7 +16,7 @@ annotations:
   artifacthub.io/prerelease: true
   artifacthub.io/images: |
     - name: consul
-      image: docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.16-dev
+      image: hashicorp/consul:1.15.1
     - name: consul-k8s-control-plane
       image: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.2.0-dev
     - name: consul-dataplane

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -66,7 +66,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.10.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.16-dev"
+  image: "hashicorp/consul:1.15.1"
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -66,7 +66,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.10.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.16-dev
+  image: docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.16-dev"
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -66,7 +66,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.10.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.16-dev 
+  image: docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.16-dev
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.
@@ -80,7 +80,7 @@ global:
   #   - name: pull-secret-name-2
   # ```
   # @type: array<map>
-  imagePullSecrets: [ ]
+  imagePullSecrets: []
 
   # The name (and tag) of the consul-k8s-control-plane Docker
   # image that is used for functionality such as catalog sync.
@@ -295,7 +295,7 @@ global:
   # Refer to [`-recursor`](https://developer.hashicorp.com/consul/docs/agent/config/cli-flags#_recursor) for more details.
   # If this is an empty array (the default), then Consul DNS will only resolve queries for the Consul top level domain (by default `.consul`).
   # @type: array<string>
-  recursors: [ ]
+  recursors: []
 
   # Enables [TLS](https://developer.hashicorp.com/consul/tutorials/security/tls-encryption-secure)
   # across the cluster to verify authenticity of the Consul servers and clients.
@@ -316,13 +316,13 @@ global:
     # in the server certificate. This is useful when you need to access the
     # Consul server(s) externally, for example, if you're using the UI.
     # @type: array<string>
-    serverAdditionalDNSSANs: [ ]
+    serverAdditionalDNSSANs: []
 
     # A list of additional IP addresses to set as Subject Alternative Names (SANs)
     # in the server certificate. This is useful when you need to access the
     # Consul server(s) externally, for example, if you're using the UI.
     # @type: array<string>
-    serverAdditionalIPSANs: [ ]
+    serverAdditionalIPSANs: []
 
     # If true, `verify_outgoing`, `verify_server_hostname`,
     # and `verify_incoming` for internal RPC communication will be set to `true` for Consul servers and clients.
@@ -389,7 +389,6 @@ global:
 
   # Configure ACLs.
   acls:
-
     # If true, the Helm chart will automatically manage ACL tokens and policies
     # for all Consul and consul-k8s-control-plane components.
     # This requires Consul >= 1.4.
@@ -505,7 +504,7 @@ global:
     # A list of addresses of the primary mesh gateways in the form `<ip>:<port>`.
     # (e.g. ["1.1.1.1:443", "2.3.4.5:443"]
     # @type: array<string>
-    primaryGateways: [ ]
+    primaryGateways: []
 
     # If you are setting `global.federation.enabled` to true and are in a secondary datacenter,
     # set `k8sAuthMethodHost` to the address of the Kubernetes API server of the secondary datacenter.
@@ -655,7 +654,6 @@ global:
 # be disabled if you plan on connecting to a Consul cluster external to
 # the Kube cluster.
 server:
-
   # If true, the chart will install all the resources necessary for a
   # Consul server cluster. If you're running Consul externally and want agents
   # within Kubernetes to join that cluster, this should probably be false.
@@ -910,7 +908,7 @@ server:
   #   with `-config-dir`. This defaults to false.
   #
   # @type: array<map>
-  extraVolumes: [ ]
+  extraVolumes: []
 
   # A list of sidecar containers.
   # Example:
@@ -923,7 +921,7 @@ server:
   #    - ...
   # ```
   # @type: array<map>
-  extraContainers: [ ]
+  extraContainers: []
 
   # This value defines the [affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
   # for server pods. It defaults to allowing only a single server pod on each node, which
@@ -1079,7 +1077,7 @@ server:
   # feature, in case kubernetes cluster is behind egress http proxies. Additionally,
   # it could be used to configure custom consul parameters.
   # @type: map
-  extraEnvironmentVars: { }
+  extraEnvironmentVars: {}
 
   # [Enterprise Only] Values for setting up and running
   # [snapshot agents](https://developer.hashicorp.com/consul/commands/snapshot/agent)
@@ -1135,21 +1133,21 @@ server:
   # as servers, and other settings to limit exposure too many requests, requests
   # waiting for too long, and other runtime considerations.
   limits:
-    # This object specifies configurations that limit the rate of RPC and gRPC 
+    # This object specifies configurations that limit the rate of RPC and gRPC
     # requests on the Consul server. Limiting the rate of gRPC and RPC requests
-    # also limits HTTP requests to the Consul server. 
+    # also limits HTTP requests to the Consul server.
     # https://developer.hashicorp.com/consul/docs/agent/config/config-files#request_limits
-    requestLimits:   
+    requestLimits:
       # Setting for disabling or enabling rate limiting.  If not disabled, it
       # enforces the action that will occur when RequestLimitsReadRate
       # or RequestLimitsWriteRate is exceeded.  The default value of "disabled" will
       # prevent any rate limiting from occuring.  A value of "enforce" will block
       # the request from processings by returning an error.  A value of
-      # "permissive" will not block the request and will allow the request to 
+      # "permissive" will not block the request and will allow the request to
       # continue processing.
       # @type: string
       mode: "disabled"
-      
+
       # Setting that controls how frequently RPC, gRPC, and HTTP
       # queries are allowed to happen. In any large enough time interval, rate
       # limiter limits the rate to RequestLimitsReadRate tokens per second.
@@ -1158,7 +1156,7 @@ server:
       # buckets.
       # @type: integer
       readRate: -1
-      
+
       # Setting that controls how frequently RPC, gRPC, and HTTP
       # writes are allowed to happen. In any large enough time interval, rate
       # limiter limits the rate to RequestLimitsWriteRate tokens per second.
@@ -1187,7 +1185,7 @@ externalServers:
   # should be the same, however, they may be different if you
   # wish to use separate hosts for the HTTPS connections.
   # @type: array<string>
-  hosts: [ ]
+  hosts: []
 
   # The HTTPS port of the Consul servers.
   httpsPort: 8501
@@ -1385,7 +1383,7 @@ client:
   #   with `-config-dir`. This defaults to false.
   #
   # @type: array<map>
-  extraVolumes: [ ]
+  extraVolumes: []
 
   # A list of sidecar containers.
   # Example:
@@ -1398,7 +1396,7 @@ client:
   #    - ...
   # ```
   # @type: array<map>
-  extraContainers: [ ]
+  extraContainers: []
 
   # Toleration Settings for Client pods
   # This should be a multi-line string matching the Toleration array
@@ -1476,7 +1474,7 @@ client:
   # feature, in case kubernetes cluster is behind egress http proxies. Additionally,
   # it could be used to configure custom consul parameters.
   # @type: map
-  extraEnvironmentVars: { }
+  extraEnvironmentVars: {}
 
   # This value defines the [Pod DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)
   # for client pods to use.
@@ -1570,7 +1568,6 @@ ui:
 
     # Set the port value of the UI service.
     port:
-
       # HTTP port.
       http: 80
 
@@ -1581,7 +1578,6 @@ ui:
     # If not set and using a NodePort service, Kubernetes will automatically assign
     # a port.
     nodePort:
-
       # HTTP node port
       # @type: integer
       http: null
@@ -1634,7 +1630,7 @@ ui:
     # ```
     #
     # @type: array<map>
-    hosts: [ ]
+    hosts: []
 
     # tls is a list of hosts and secret name in an Ingress
     # which tells the Ingress controller to secure the channel.
@@ -1646,7 +1642,7 @@ ui:
     #     secretName: testsecret-tls
     # ```
     # @type: array<map>
-    tls: [ ]
+    tls: []
 
     # Annotations to apply to the UI ingress.
     #
@@ -1737,7 +1733,7 @@ syncCatalog:
   #
   # Note: `k8sDenyNamespaces` takes precedence over values defined here.
   # @type: array<string>
-  k8sAllowNamespaces: [ "*" ]
+  k8sAllowNamespaces: ["*"]
 
   # List of k8s namespaces that should not have their
   # services synced. This list takes precedence over `k8sAllowNamespaces`.
@@ -1747,7 +1743,7 @@ syncCatalog:
   # `["namespace1", "namespace2"]`, then all k8s namespaces besides `namespace1`
   # and `namespace2` will be synced.
   # @type: array<string>
-  k8sDenyNamespaces: [ "kube-system", "kube-public" ]
+  k8sDenyNamespaces: ["kube-system", "kube-public"]
 
   # [DEPRECATED] Use k8sAllowNamespaces and k8sDenyNamespaces instead. For
   # backwards compatibility, if both this and the allow/deny lists are set,
@@ -2093,7 +2089,6 @@ connectInject:
     # @type: map
     meta: null
 
-
   # Configures metrics for Consul Connect services. All values are overridable
   # via annotations on a per-pod basis.
   metrics:
@@ -2253,7 +2248,7 @@ connectInject:
   # `namespaceSelector` takes precedence over both since it is applied first.
   # `kube-system` and `kube-public` are never injected, even if included here.
   # @type: array<string>
-  k8sAllowNamespaces: [ "*" ]
+  k8sAllowNamespaces: ["*"]
 
   # List of k8s namespaces that should not allow Connect
   # sidecar injection. This list takes precedence over `k8sAllowNamespaces`.
@@ -2266,7 +2261,7 @@ connectInject:
   # Note: `namespaceSelector` takes precedence over this since it is applied first.
   # `kube-system` and `kube-public` are never injected.
   # @type: array<string>
-  k8sDenyNamespaces: [ ]
+  k8sDenyNamespaces: []
 
   # [Enterprise Only] These settings manage the connect injector's interaction with
   # Consul namespaces (requires consul-ent v1.7+).
@@ -2651,10 +2646,10 @@ ingressGateways:
       # @default: [{port: 8080, port: 8443}]
       # @recurse: false
       ports:
-      - port: 8080
-        nodePort: null
-      - port: 8443
-        nodePort: null
+        - port: 8080
+          nodePort: null
+        - port: 8443
+          nodePort: null
 
       # Annotations to apply to the ingress gateway service. Annotations defined
       # here will be applied to all ingress gateway services in addition to any
@@ -2779,7 +2774,7 @@ ingressGateways:
   # case of annotations where both will be applied.
   # @type: array<map>
   gateways:
-  - name: ingress-gateway
+    - name: ingress-gateway
 
 # Configuration options for terminating gateways. Default values for all
 # terminating gateways are defined in `terminatingGateways.defaults`. Any of
@@ -2814,7 +2809,7 @@ terminatingGateways:
     #         path: path # secret will now mount to /consul/userconfig/my-secret/path
     # ```
     # @type: array<map>
-    extraVolumes: [ ]
+    extraVolumes: []
 
     # Resource limits for all terminating gateway pods
     # @recurse: false
@@ -2920,7 +2915,7 @@ terminatingGateways:
   # case of annotations where both will be applied.
   # @type: array<map>
   gateways:
-  - name: terminating-gateway
+    - name: terminating-gateway
 
 # Configuration settings for the Consul API Gateway integration
 apiGateway:
@@ -3093,7 +3088,6 @@ apiGateway:
 # Configuration settings for the webhook-cert-manager
 # `webhook-cert-manager` ensures that cert bundles are up to date for the mutating webhook.
 webhookCertManager:
-
   # Toleration Settings
   # This should be a multi-line string matching the Toleration array
   # in a PodSpec.

--- a/control-plane/build-support/functions/10-util.sh
+++ b/control-plane/build-support/functions/10-util.sh
@@ -617,7 +617,6 @@ function update_version_helm {
 	local vfile="$1/values.yaml"
 	local cfile="$1/Chart.yaml"
 	local version="$2"
-	local consul_version="$5"
 	local prerelease="$3"
 	local full_version="$2"
 	local full_consul_version="$5"

--- a/control-plane/build-support/functions/10-util.sh
+++ b/control-plane/build-support/functions/10-util.sh
@@ -2,984 +2,932 @@
 # SPDX-License-Identifier: MPL-2.0
 
 function err {
-   if test "${COLORIZE}" -eq 1
-   then
-      tput bold
-      tput setaf 1
-   fi
+	if test "${COLORIZE}" -eq 1; then
+		tput bold
+		tput setaf 1
+	fi
 
-   echo "$@" 1>&2
+	echo "$@" 1>&2
 
-   if test "${COLORIZE}" -eq 1
-   then
-      tput sgr0
-   fi
+	if test "${COLORIZE}" -eq 1; then
+		tput sgr0
+	fi
 }
 
 function status {
-   if test "${COLORIZE}" -eq 1
-   then
-      tput bold
-      tput setaf 4
-   fi
+	if test "${COLORIZE}" -eq 1; then
+		tput bold
+		tput setaf 4
+	fi
 
-   echo "$@"
+	echo "$@"
 
-   if test "${COLORIZE}" -eq 1
-   then
-      tput sgr0
-   fi
+	if test "${COLORIZE}" -eq 1; then
+		tput sgr0
+	fi
 }
 
 function status_stage {
-   if test "${COLORIZE}" -eq 1
-   then
-      tput bold
-      tput setaf 2
-   fi
+	if test "${COLORIZE}" -eq 1; then
+		tput bold
+		tput setaf 2
+	fi
 
-   echo "$@"
+	echo "$@"
 
-   if test "${COLORIZE}" -eq 1
-   then
-      tput sgr0
-   fi
+	if test "${COLORIZE}" -eq 1; then
+		tput sgr0
+	fi
 }
 
 function debug {
-   if is_set "${BUILD_DEBUG}"
-   then
-      if test "${COLORIZE}" -eq 1
-      then
-         tput setaf 6
-      fi
-      echo "$@"
-      if test "${COLORIZE}" -eq 1
-      then
-         tput sgr0
-      fi
-   fi
+	if is_set "${BUILD_DEBUG}"; then
+		if test "${COLORIZE}" -eq 1; then
+			tput setaf 6
+		fi
+		echo "$@"
+		if test "${COLORIZE}" -eq 1; then
+			tput sgr0
+		fi
+	fi
 }
 
 function sed_i {
-   if test "$(uname)" == "Darwin"
-   then
-      sed -i '' "$@"
-      return $?
-   else
-      sed -i "$@"
-      return $?
-   fi
+	if test "$(uname)" == "Darwin"; then
+		sed -i '' "$@"
+		return $?
+	else
+		sed -i "$@"
+		return $?
+	fi
 }
 
 function is_set {
-   # Arguments:
-   #   $1 - string value to check its truthiness
-   #
-   # Return:
-   #   0 - is truthy (backwards I know but allows syntax like `if is_set <var>` to work)
-   #   1 - is not truthy
+	# Arguments:
+	#   $1 - string value to check its truthiness
+	#
+	# Return:
+	#   0 - is truthy (backwards I know but allows syntax like `if is_set <var>` to work)
+	#   1 - is not truthy
 
-   local val=$(tr '[:upper:]' '[:lower:]' <<< "$1")
-   case $val in
-      1 | t | true | y | yes)
-         return 0
-         ;;
-      *)
-         return 1
-         ;;
-   esac
+	local val=$(tr '[:upper:]' '[:lower:]' <<<"$1")
+	case $val in
+	1 | t | true | y | yes)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
 }
 
 function have_gpg_key {
-   # Arguments:
-   #   $1 - GPG Key id to check if we have installed
-   #
-   # Return:
-   #   0 - success (we can use this key for signing)
-   #   * - failure (key cannot be used)
+	# Arguments:
+	#   $1 - GPG Key id to check if we have installed
+	#
+	# Return:
+	#   0 - success (we can use this key for signing)
+	#   * - failure (key cannot be used)
 
-   gpg --list-secret-keys $1 > /dev/null 2>&1
-   return $?
+	gpg --list-secret-keys $1 >/dev/null 2>&1
+	return $?
 }
 
 function parse_version {
-   # Arguments:
-   #   $1 - Path to the top level Consul source
-   #   $2 - boolean value for whether the release version should be parsed from the source
-   #   $3 - boolean whether to use GIT_DESCRIBE and GIT_COMMIT environment variables
-   #   $4 - boolean whether to omit the version part of the version string. (optional)
-   #
-   # Return:
-   #   0 - success (will write the version to stdout)
-   #   * - error   (no version output)
-   #
-   # Notes:
-   #   If the GOTAGS environment variable is present then it is used to determine which
-   #   version file to use for parsing.
+	# Arguments:
+	#   $1 - Path to the top level Consul source
+	#   $2 - boolean value for whether the release version should be parsed from the source
+	#   $3 - boolean whether to use GIT_DESCRIBE and GIT_COMMIT environment variables
+	#   $4 - boolean whether to omit the version part of the version string. (optional)
+	#
+	# Return:
+	#   0 - success (will write the version to stdout)
+	#   * - error   (no version output)
+	#
+	# Notes:
+	#   If the GOTAGS environment variable is present then it is used to determine which
+	#   version file to use for parsing.
 
-   local vfile="${1}/version/version.go"
+	local vfile="${1}/version/version.go"
 
-   # ensure the version file exists
-   if ! test -f "${vfile}"
-   then
-      err "Error - File not found: ${vfile}"
-      return 1
-   fi
+	# ensure the version file exists
+	if ! test -f "${vfile}"; then
+		err "Error - File not found: ${vfile}"
+		return 1
+	fi
 
-   local include_release="$2"
-   local use_git_env="$3"
-   local omit_version="$4"
+	local include_release="$2"
+	local use_git_env="$3"
+	local omit_version="$4"
 
-   local git_version=""
-   local git_commit=""
+	local git_version=""
+	local git_commit=""
 
-   if test -z "${include_release}"
-   then
-      include_release=true
-   fi
+	if test -z "${include_release}"; then
+		include_release=true
+	fi
 
-   if test -z "${use_git_env}"
-   then
-      use_git_env=true
-   fi
+	if test -z "${use_git_env}"; then
+		use_git_env=true
+	fi
 
-   if is_set "${use_git_env}"
-   then
-      git_version="${GIT_DESCRIBE}"
-      git_commit="${GIT_COMMIT}"
-   fi
+	if is_set "${use_git_env}"; then
+		git_version="${GIT_DESCRIBE}"
+		git_commit="${GIT_COMMIT}"
+	fi
 
-   # Get the main version out of the source file
-   version_main=$(awk '$1 == "Version" && $2 == "=" { gsub(/"/, "", $3); print $3 }' < ${vfile})
-   release_main=$(awk '$1 == "VersionPrerelease" && $2 == "=" { gsub(/"/, "", $3); print $3 }' < ${vfile})
+	# Get the main version out of the source file
+	version_main=$(awk '$1 == "Version" && $2 == "=" { gsub(/"/, "", $3); print $3 }' <${vfile})
+	release_main=$(awk '$1 == "VersionPrerelease" && $2 == "=" { gsub(/"/, "", $3); print $3 }' <${vfile})
 
+	# try to determine the version if we have build tags
+	for tag in "$GOTAGS"; do
+		for vfile in $(find "${1}/version" -name "version_*.go" 2>/dev/null | sort); do
+			if grep -q "// +build $tag" "${vfile}"; then
+				version_main=$(awk '$1 == "Version" && $2 == "=" { gsub(/"/, "", $3); print $3 }' <${vfile})
+				release_main=$(awk '$1 == "VersionPrerelease" && $2 == "=" { gsub(/"/, "", $3); print $3 }' <${vfile})
+			fi
+		done
+	done
 
-   # try to determine the version if we have build tags
-   for tag in "$GOTAGS"
-   do
-      for vfile in $(find "${1}/version" -name "version_*.go" 2> /dev/null| sort)
-      do
-         if grep -q "// +build $tag" "${vfile}"
-         then
-            version_main=$(awk '$1 == "Version" && $2 == "=" { gsub(/"/, "", $3); print $3 }' < ${vfile})
-            release_main=$(awk '$1 == "VersionPrerelease" && $2 == "=" { gsub(/"/, "", $3); print $3 }' < ${vfile})
-         fi
-      done
-   done
+	local version="${version_main}"
+	# override the version from source with the value of the GIT_DESCRIBE env var if present
+	if test -n "${git_version}"; then
+		version="${git_version}"
+	fi
 
-   local version="${version_main}"
-   # override the version from source with the value of the GIT_DESCRIBE env var if present
-   if test -n "${git_version}"
-   then
-      version="${git_version}"
-   fi
+	local rel_ver=""
+	if is_set "${include_release}"; then
+		# Default to pre-release from the source
+		rel_ver="${release_main}"
 
-   local rel_ver=""
-   if is_set "${include_release}"
-   then
-      # Default to pre-release from the source
-      rel_ver="${release_main}"
+		# When no GIT_DESCRIBE env var is present and no release is in the source then we
+		# are definitely in dev mode
+		if test -z "${git_version}" -a -z "${rel_ver}" && is_set "${use_git_env}"; then
+			rel_ver="dev"
+		fi
 
-      # When no GIT_DESCRIBE env var is present and no release is in the source then we
-      # are definitely in dev mode
-      if test -z "${git_version}" -a -z "${rel_ver}" && is_set "${use_git_env}"
-      then
-         rel_ver="dev"
-      fi
+		# Add the release to the version
+		if test -n "${rel_ver}" -a -n "${git_commit}"; then
+			rel_ver="${rel_ver} (${git_commit})"
+		fi
+	fi
 
-      # Add the release to the version
-      if test -n "${rel_ver}" -a -n "${git_commit}"
-      then
-         rel_ver="${rel_ver} (${git_commit})"
-      fi
-   fi
-
-   if test -n "${rel_ver}"
-   then
-      if is_set "${omit_version}"
-      then
-         echo "${rel_ver}" | tr -d "'"
-      else
-         echo "${version}-${rel_ver}" | tr -d "'"
-      fi
-      return 0
-   elif ! is_set "${omit_version}"
-   then
-      echo "${version}" | tr -d "'"
-      return 0
-   else
-      return 1
-   fi
+	if test -n "${rel_ver}"; then
+		if is_set "${omit_version}"; then
+			echo "${rel_ver}" | tr -d "'"
+		else
+			echo "${version}-${rel_ver}" | tr -d "'"
+		fi
+		return 0
+	elif ! is_set "${omit_version}"; then
+		echo "${version}" | tr -d "'"
+		return 0
+	else
+		return 1
+	fi
 }
 
 function get_version {
-   # Arguments:
-   #   $1 - Path to the top level Consul source
-   #   $2 - Whether the release version should be parsed from source (optional)
-   #   $3 - Whether to use GIT_DESCRIBE and GIT_COMMIT environment variables
-   #
-   # Returns:
-   #   0 - success (the version is also echoed to stdout)
-   #   1 - error
-   #
-   # Notes:
-   #   If a VERSION environment variable is present it will override any parsing of the version from the source
-   #   In addition to processing the main version.go, version_*.go files will be processed if they have
-   #   a Go build tag that matches the one in the GOTAGS environment variable. This tag processing is
-   #   primitive though and will not match complex build tags in the files with negation etc.
+	# Arguments:
+	#   $1 - Path to the top level Consul source
+	#   $2 - Whether the release version should be parsed from source (optional)
+	#   $3 - Whether to use GIT_DESCRIBE and GIT_COMMIT environment variables
+	#
+	# Returns:
+	#   0 - success (the version is also echoed to stdout)
+	#   1 - error
+	#
+	# Notes:
+	#   If a VERSION environment variable is present it will override any parsing of the version from the source
+	#   In addition to processing the main version.go, version_*.go files will be processed if they have
+	#   a Go build tag that matches the one in the GOTAGS environment variable. This tag processing is
+	#   primitive though and will not match complex build tags in the files with negation etc.
 
-   local vers="$VERSION"
-   if test -z "$vers"
-   then
-      # parse the OSS version from version.go
-      vers="$(parse_version ${1} ${2} ${3})"
-   fi
+	local vers="$VERSION"
+	if test -z "$vers"; then
+		# parse the OSS version from version.go
+		vers="$(parse_version ${1} ${2} ${3})"
+	fi
 
-   if test -z "$vers"
-   then
-      return 1
-   else
-      echo $vers
-      return 0
-   fi
+	if test -z "$vers"; then
+		return 1
+	else
+		echo $vers
+		return 0
+	fi
 }
 
 function git_branch {
-   # Arguments:
-   #   $1 - Path to the git repo (optional - assumes pwd is git repo otherwise)
-   #
-   # Returns:
-   #   0 - success
-   #   * - failure
-   #
-   # Notes:
-   #   Echos the current branch to stdout when successful
+	# Arguments:
+	#   $1 - Path to the git repo (optional - assumes pwd is git repo otherwise)
+	#
+	# Returns:
+	#   0 - success
+	#   * - failure
+	#
+	# Notes:
+	#   Echos the current branch to stdout when successful
 
-   local gdir="$(pwd)"
-   if test -d "$1"
-   then
-      gdir="$1"
-   fi
+	local gdir="$(pwd)"
+	if test -d "$1"; then
+		gdir="$1"
+	fi
 
-   pushd "${gdir}" > /dev/null
+	pushd "${gdir}" >/dev/null
 
-   local ret=0
-   local head="$(git status -b --porcelain=v2 | awk '{if ($1 == "#" && $2 =="branch.head") { print $3 }}')" || ret=1
+	local ret=0
+	local head="$(git status -b --porcelain=v2 | awk '{if ($1 == "#" && $2 =="branch.head") { print $3 }}')" || ret=1
 
-   popd > /dev/null
+	popd >/dev/null
 
-   test ${ret} -eq 0 && echo "$head"
-   return ${ret}
+	test ${ret} -eq 0 && echo "$head"
+	return ${ret}
 }
 
 function git_upstream {
-   # Arguments:
-   #   $1 - Path to the git repo (optional - assumes pwd is git repo otherwise)
-   #
-   # Returns:
-   #   0 - success
-   #   * - failure
-   #
-   # Notes:
-   #   Echos the current upstream branch to stdout when successful
+	# Arguments:
+	#   $1 - Path to the git repo (optional - assumes pwd is git repo otherwise)
+	#
+	# Returns:
+	#   0 - success
+	#   * - failure
+	#
+	# Notes:
+	#   Echos the current upstream branch to stdout when successful
 
-   local gdir="$(pwd)"
-   if test -d "$1"
-   then
-      gdir="$1"
-   fi
+	local gdir="$(pwd)"
+	if test -d "$1"; then
+		gdir="$1"
+	fi
 
-   pushd "${gdir}" > /dev/null
+	pushd "${gdir}" >/dev/null
 
-   local ret=0
-   local head="$(git status -b --porcelain=v2 | awk '{if ($1 == "#" && $2 =="branch.upstream") { print $3 }}')" || ret=1
+	local ret=0
+	local head="$(git status -b --porcelain=v2 | awk '{if ($1 == "#" && $2 =="branch.upstream") { print $3 }}')" || ret=1
 
-   popd > /dev/null
+	popd >/dev/null
 
-   test ${ret} -eq 0 && echo "$head"
-   return ${ret}
+	test ${ret} -eq 0 && echo "$head"
+	return ${ret}
 }
 
 function git_log_summary {
-   # Arguments:
-   #   $1 - Path to the git repo (optional - assumes pwd is git repo otherwise)
-   #
-   # Returns:
-   #   0 - success
-   #   * - failure
-   #
+	# Arguments:
+	#   $1 - Path to the git repo (optional - assumes pwd is git repo otherwise)
+	#
+	# Returns:
+	#   0 - success
+	#   * - failure
+	#
 
-   local gdir="$(pwd)"
-   if test -d "$1"
-   then
-      gdir="$1"
-   fi
+	local gdir="$(pwd)"
+	if test -d "$1"; then
+		gdir="$1"
+	fi
 
-   pushd "${gdir}" > /dev/null
+	pushd "${gdir}" >/dev/null
 
-   local ret=0
+	local ret=0
 
-   local head=$(git_branch) || ret=1
-   local upstream=$(git_upstream) || ret=1
-   local rev_range="${head}...${upstream}"
+	local head=$(git_branch) || ret=1
+	local upstream=$(git_upstream) || ret=1
+	local rev_range="${head}...${upstream}"
 
-   if test ${ret} -eq 0
-   then
-      status "Git Changes:"
-      git log --pretty=oneline ${rev_range} || ret=1
+	if test ${ret} -eq 0; then
+		status "Git Changes:"
+		git log --pretty=oneline ${rev_range} || ret=1
 
-   fi
-   return $ret
+	fi
+	return $ret
 }
 
 function git_diff {
-   # Arguments:
-   #   $1 - Path to the git repo (optional - assumes pwd is git repo otherwise)
-   #   $2 .. $N - Optional path specification
-   #
-   # Returns:
-   #   0 - success
-   #   * - failure
-   #
+	# Arguments:
+	#   $1 - Path to the git repo (optional - assumes pwd is git repo otherwise)
+	#   $2 .. $N - Optional path specification
+	#
+	# Returns:
+	#   0 - success
+	#   * - failure
+	#
 
-   local gdir="$(pwd)"
-   if test -d "$1"
-   then
-      gdir="$1"
-   fi
+	local gdir="$(pwd)"
+	if test -d "$1"; then
+		gdir="$1"
+	fi
 
-   shift
+	shift
 
-   pushd "${gdir}" > /dev/null
+	pushd "${gdir}" >/dev/null
 
-   local ret=0
+	local ret=0
 
-   local head=$(git_branch) || ret=1
-   local upstream=$(git_upstream) || ret=1
+	local head=$(git_branch) || ret=1
+	local upstream=$(git_upstream) || ret=1
 
-   if test ${ret} -eq 0
-   then
-      status "Git Diff - Paths: $@"
-      git diff ${HEAD} ${upstream} -- "$@" || ret=1
-   fi
-   return $ret
+	if test ${ret} -eq 0; then
+		status "Git Diff - Paths: $@"
+		git diff ${HEAD} ${upstream} -- "$@" || ret=1
+	fi
+	return $ret
 }
 
 function normalize_git_url {
-   url="${1#https://}"
-   url="${url#git@}"
-   url="${url%.git}"
-   url="$(sed ${SED_EXT} -e 's/([^\/:]*)[:\/](.*)/\1:\2/' <<< "${url}")"
-   echo "$url"
-   return 0
+	url="${1#https://}"
+	url="${url#git@}"
+	url="${url%.git}"
+	url="$(sed ${SED_EXT} -e 's/([^\/:]*)[:\/](.*)/\1:\2/' <<<"${url}")"
+	echo "$url"
+	return 0
 }
 
 function git_remote_url {
-   # Arguments:
-   #   $1 - Path to the top level Consul source
-   #   $2 - Remote name
-   #
-   # Returns:
-   #   0 - success
-   #   * - error
-   #
-   # Note:
-   #   The push url for the git remote will be echoed to stdout
+	# Arguments:
+	#   $1 - Path to the top level Consul source
+	#   $2 - Remote name
+	#
+	# Returns:
+	#   0 - success
+	#   * - error
+	#
+	# Note:
+	#   The push url for the git remote will be echoed to stdout
 
-   if ! test -d "$1"
-   then
-      err "ERROR: '$1' is not a directory. git_remote_url must be called with the path to the top level source as the first argument'"
-      return 1
-   fi
+	if ! test -d "$1"; then
+		err "ERROR: '$1' is not a directory. git_remote_url must be called with the path to the top level source as the first argument'"
+		return 1
+	fi
 
-   if test -z "$2"
-   then
-      err "ERROR: git_remote_url must be called with a second argument that is the name of the remote"
-      return 1
-   fi
+	if test -z "$2"; then
+		err "ERROR: git_remote_url must be called with a second argument that is the name of the remote"
+		return 1
+	fi
 
-   local ret=0
+	local ret=0
 
-   pushd "$1" > /dev/null
+	pushd "$1" >/dev/null
 
-   local url=$(git remote get-url --push $2 2>&1) || ret=1
+	local url=$(git remote get-url --push $2 2>&1) || ret=1
 
-   popd > /dev/null
+	popd >/dev/null
 
-   if test "${ret}" -eq 0
-   then
-      echo "${url}"
-      return 0
-   fi
+	if test "${ret}" -eq 0; then
+		echo "${url}"
+		return 0
+	fi
 }
 
 function find_git_remote {
-   # Arguments:
-   #   $1 - Path to the top level Consul source
-   #
-   # Returns:
-   #   0 - success
-   #   * - error
-   #
-   # Note:
-   #   The remote name to use for publishing will be echoed to stdout upon success
+	# Arguments:
+	#   $1 - Path to the top level Consul source
+	#
+	# Returns:
+	#   0 - success
+	#   * - error
+	#
+	# Note:
+	#   The remote name to use for publishing will be echoed to stdout upon success
 
-   if ! test -d "$1"
-   then
-      err "ERROR: '$1' is not a directory. find_git_remote must be called with the path to the top level source as the first argument'"
-      return 1
-   fi
+	if ! test -d "$1"; then
+		err "ERROR: '$1' is not a directory. find_git_remote must be called with the path to the top level source as the first argument'"
+		return 1
+	fi
 
-   need_url=$(normalize_git_url "${PUBLISH_GIT_HOST}:${PUBLISH_GIT_REPO}")
-   debug "Required normalized remote: ${need_url}"
+	need_url=$(normalize_git_url "${PUBLISH_GIT_HOST}:${PUBLISH_GIT_REPO}")
+	debug "Required normalized remote: ${need_url}"
 
-   pushd "$1" > /dev/null
+	pushd "$1" >/dev/null
 
-   local ret=1
-   for remote in $(git remote)
-   do
-      url=$(git remote get-url --push ${remote}) || continue
-      url=$(normalize_git_url "${url}")
+	local ret=1
+	for remote in $(git remote); do
+		url=$(git remote get-url --push ${remote}) || continue
+		url=$(normalize_git_url "${url}")
 
-      debug "Testing Remote: ${remote}: ${url}"
-      if test "${url}" == "${need_url}"
-      then
-         echo "${remote}"
-         ret=0
-         break
-      fi
-   done
+		debug "Testing Remote: ${remote}: ${url}"
+		if test "${url}" == "${need_url}"; then
+			echo "${remote}"
+			ret=0
+			break
+		fi
+	done
 
-   popd > /dev/null
-   return ${ret}
+	popd >/dev/null
+	return ${ret}
 }
 
 function git_remote_not_blacklisted {
-   # Arguments:
-   #   $1 - path to the repo
-   #   $2 - the remote name
-   #
-   # Returns:
-   #   0 - not blacklisted
-   #   * - blacklisted
-   return 0
+	# Arguments:
+	#   $1 - path to the repo
+	#   $2 - the remote name
+	#
+	# Returns:
+	#   0 - not blacklisted
+	#   * - blacklisted
+	return 0
 }
 
 function is_git_clean {
-   # Arguments:
-   #   $1 - Path to git repo
-   #   $2 - boolean whether the git status should be output when not clean
-   #
-   # Returns:
-   #   0 - success
-   #   * - error
-   #
+	# Arguments:
+	#   $1 - Path to git repo
+	#   $2 - boolean whether the git status should be output when not clean
+	#
+	# Returns:
+	#   0 - success
+	#   * - error
+	#
 
-   if ! test -d "$1"
-   then
-      err "ERROR: '$1' is not a directory. is_git_clean must be called with the path to a git repo as the first argument'"
-      return 1
-   fi
+	if ! test -d "$1"; then
+		err "ERROR: '$1' is not a directory. is_git_clean must be called with the path to a git repo as the first argument'"
+		return 1
+	fi
 
-   local output_status="$2"
+	local output_status="$2"
 
-   pushd "${1}" > /dev/null
+	pushd "${1}" >/dev/null
 
-   local ret=0
-   test -z "$(git status --porcelain=v2 2> /dev/null)" || ret=1
+	local ret=0
+	test -z "$(git status --porcelain=v2 2>/dev/null)" || ret=1
 
-   if is_set "${output_status}" && test "$ret" -ne 0
-   then
-      err "Git repo is not clean"
-      # --porcelain=v1 is the same as --short except uncolorized
-      git status --porcelain=v1
-   fi
-   popd > /dev/null
-   return ${ret}
+	if is_set "${output_status}" && test "$ret" -ne 0; then
+		err "Git repo is not clean"
+		# --porcelain=v1 is the same as --short except uncolorized
+		git status --porcelain=v1
+	fi
+	popd >/dev/null
+	return ${ret}
 }
 
 function update_git_env {
-   # Arguments:
-   #   $1 - Path to git repo
-   #
-   # Returns:
-   #   0 - success
-   #   * - error
-   #
+	# Arguments:
+	#   $1 - Path to git repo
+	#
+	# Returns:
+	#   0 - success
+	#   * - error
+	#
 
-   if ! test -d "$1"
-   then
-      err "ERROR: '$1' is not a directory. is_git_clean must be called with the path to a git repo as the first argument'"
-      return 1
-   fi
+	if ! test -d "$1"; then
+		err "ERROR: '$1' is not a directory. is_git_clean must be called with the path to a git repo as the first argument'"
+		return 1
+	fi
 
-   export GIT_COMMIT=$(git rev-parse --short HEAD)
-   export GIT_DIRTY=$(test -n "$(git status --porcelain)" && echo "+CHANGES")
-   export GIT_DESCRIBE=$(git describe --tags --always)
-   export GIT_IMPORT=github.com/hashicorp/consul-k8s/version
-   export GOLDFLAGS="-X ${GIT_IMPORT}.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -X ${GIT_IMPORT}.GitDescribe=${GIT_DESCRIBE}"
-   return 0
+	export GIT_COMMIT=$(git rev-parse --short HEAD)
+	export GIT_DIRTY=$(test -n "$(git status --porcelain)" && echo "+CHANGES")
+	export GIT_DESCRIBE=$(git describe --tags --always)
+	export GIT_IMPORT=github.com/hashicorp/consul-k8s/version
+	export GOLDFLAGS="-X ${GIT_IMPORT}.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -X ${GIT_IMPORT}.GitDescribe=${GIT_DESCRIBE}"
+	return 0
 }
 
 function git_push_ref {
-   # Arguments:
-   #   $1 - Path to the top level Consul source
-   #   $2 - Git ref (optional)
-   #   $3 - remote (optional - if not specified we will try to determine it)
-   #
-   # Returns:
-   #   0 - success
-   #   * - error
+	# Arguments:
+	#   $1 - Path to the top level Consul source
+	#   $2 - Git ref (optional)
+	#   $3 - remote (optional - if not specified we will try to determine it)
+	#
+	# Returns:
+	#   0 - success
+	#   * - error
 
-   if ! test -d "$1"
-   then
-      err "ERROR: '$1' is not a directory. push_git_release must be called with the path to the top level source as the first argument'"
-      return 1
-   fi
+	if ! test -d "$1"; then
+		err "ERROR: '$1' is not a directory. push_git_release must be called with the path to the top level source as the first argument'"
+		return 1
+	fi
 
-   local sdir="$1"
-   local ret=0
-   local remote="$3"
+	local sdir="$1"
+	local ret=0
+	local remote="$3"
 
-   # find the correct remote corresponding to the desired repo (basically prevent pushing enterprise to oss or oss to enterprise)
-   if test -z "${remote}"
-   then
-      local remote=$(find_git_remote "${sdir}") || return 1
-      status "Using git remote: ${remote}"
-   fi
+	# find the correct remote corresponding to the desired repo (basically prevent pushing enterprise to oss or oss to enterprise)
+	if test -z "${remote}"; then
+		local remote=$(find_git_remote "${sdir}") || return 1
+		status "Using git remote: ${remote}"
+	fi
 
-   local ref=""
+	local ref=""
 
-   pushd "${sdir}" > /dev/null
+	pushd "${sdir}" >/dev/null
 
-   if test -z "$2"
-   then
-      # If no git ref was provided we lookup the current local branch and its tracking branch
-      # It must have a tracking upstream and it must be tracking the sanctioned git remote
-      local head=$(git_branch "${sdir}") || return 1
-      local upstream=$(git_upstream "${sdir}") || return 1
+	if test -z "$2"; then
+		# If no git ref was provided we lookup the current local branch and its tracking branch
+		# It must have a tracking upstream and it must be tracking the sanctioned git remote
+		local head=$(git_branch "${sdir}") || return 1
+		local upstream=$(git_upstream "${sdir}") || return 1
 
-      # upstream branch for this branch does not track the remote we need to push to
-      # basically this checks that the upstream (could be something like origin/main) references the correct remote
-      # if it doesn't then the string modification wont apply and the var will reamin unchanged and equal to itself.
-      if test "${upstream#${remote}/}" == "${upstream}"
-      then
-         err "ERROR: Upstream branch '${upstream}' does not track the correct remote '${remote}' - cannot push"
-         ret=1
-      fi
-      ref="refs/heads/${head}"
-   else
-      # A git ref was provided - get the full ref and make sure it isn't ambiguous and also to
-      # be able to determine whether its a branch or tag we are pushing
-      ref_out=$(git rev-parse --symbolic-full-name "$2" --)
+		# upstream branch for this branch does not track the remote we need to push to
+		# basically this checks that the upstream (could be something like origin/main) references the correct remote
+		# if it doesn't then the string modification wont apply and the var will reamin unchanged and equal to itself.
+		if test "${upstream#${remote}/}" == "${upstream}"; then
+			err "ERROR: Upstream branch '${upstream}' does not track the correct remote '${remote}' - cannot push"
+			ret=1
+		fi
+		ref="refs/heads/${head}"
+	else
+		# A git ref was provided - get the full ref and make sure it isn't ambiguous and also to
+		# be able to determine whether its a branch or tag we are pushing
+		ref_out=$(git rev-parse --symbolic-full-name "$2" --)
 
-      # -ne 2 because it should have the ref on one line followed by a line with '--'
-      if test "$(wc -l <<< "${ref_out}")" -ne 2
-      then
-         err "ERROR: Git ref '$2' is ambiguous"
-         debug "${ref_out}"
-         ret=1
-      else
-         ref=$(head -n 1 <<< "${ref_out}")
-      fi
-   fi
+		# -ne 2 because it should have the ref on one line followed by a line with '--'
+		if test "$(wc -l <<<"${ref_out}")" -ne 2; then
+			err "ERROR: Git ref '$2' is ambiguous"
+			debug "${ref_out}"
+			ret=1
+		else
+			ref=$(head -n 1 <<<"${ref_out}")
+		fi
+	fi
 
-   if test ${ret} -eq 0
-   then
-      case "${ref}" in
-         refs/tags/*)
-            status "Pushing tag ${ref#refs/tags/} to ${remote}"
-            ;;
-         refs/heads/*)
-            status "Pushing local branch ${ref#refs/tags/} to ${remote}"
-            ;;
-         *)
-            err "ERROR: git_push_ref func is refusing to push ref that isn't a branch or tag"
-            return 1
-      esac
+	if test ${ret} -eq 0; then
+		case "${ref}" in
+		refs/tags/*)
+			status "Pushing tag ${ref#refs/tags/} to ${remote}"
+			;;
+		refs/heads/*)
+			status "Pushing local branch ${ref#refs/tags/} to ${remote}"
+			;;
+		*)
+			err "ERROR: git_push_ref func is refusing to push ref that isn't a branch or tag"
+			return 1
+			;;
+		esac
 
-      if ! git push "${remote}" "${ref}"
-      then
-         err "ERROR: Failed to push ${ref} to remote: ${remote}"
-         ret=1
-      fi
-   fi
+		if ! git push "${remote}" "${ref}"; then
+			err "ERROR: Failed to push ${ref} to remote: ${remote}"
+			ret=1
+		fi
+	fi
 
-   popd > /dev/null
+	popd >/dev/null
 
-   return $ret
+	return $ret
 }
 
 function update_version {
-   # Arguments:
-   #   $1 - Path to the version file
-   #   $2 - Version string
-   #   $3 - PreRelease version (if unset will become an empty string)
-   #
-   # Returns:
-   #   0 - success
-   #   * - error
+	# Arguments:
+	#   $1 - Path to the version file
+	#   $2 - Version string
+	#   $3 - PreRelease version (if unset will become an empty string)
+	#
+	# Returns:
+	#   0 - success
+	#   * - error
 
-   if ! test -f "$1"
-   then
-      err "ERROR: '$1' is not a regular file. update_version must be called with the path to a go version file"
-      return 1
-   fi
+	if ! test -f "$1"; then
+		err "ERROR: '$1' is not a regular file. update_version must be called with the path to a go version file"
+		return 1
+	fi
 
-   if test -z "$2"
-   then
-      err "ERROR: The version specified was empty"
-      return 1
-   fi
+	if test -z "$2"; then
+		err "ERROR: The version specified was empty"
+		return 1
+	fi
 
-   local vfile="$1"
-   local version="$2"
-   local prerelease="$3"
+	local vfile="$1"
+	local version="$2"
+	local prerelease="$3"
 
-   sed_i ${SED_EXT} -e "s/(Version[[:space:]]*=[[:space:]]*)\"[^\"]*\"/\1\"${version}\"/g" -e "s/(VersionPrerelease[[:space:]]*=[[:space:]]*)\"[^\"]*\"/\1\"${prerelease}\"/g" "${vfile}"
-   return $?
+	sed_i ${SED_EXT} -e "s/(Version[[:space:]]*=[[:space:]]*)\"[^\"]*\"/\1\"${version}\"/g" -e "s/(VersionPrerelease[[:space:]]*=[[:space:]]*)\"[^\"]*\"/\1\"${prerelease}\"/g" "${vfile}"
+	return $?
 }
 
 function update_version_helm {
-   # Arguments:
-   #   $1 - Path to the directory where the root of the Helm chart is
-   #   $2 - Version string
-   #   $3 - PreRelease version (if unset will become an empty string)
-   #   $4 - Image base path
-   #
-   # Returns:
-   #   0 - success
-   #   * - error
+	# Arguments:
+	#   $1 - Path to the directory where the root of the Helm chart is
+	#   $2 - Version string
+	#   $3 - Release version (if unset will become an empty string)
+	#   $4 - Image base path
+	#   $5 - Consul version string
+	#   $6 - Consul image base path
+	#
+	# Returns:
+	#   0 - success
+	#   * - error
 
-   if ! test -d "$1"
-   then
-      err "ERROR: '$1' is not a directory. update_version_helm must be called with the path to the Helm chart"
-      return 1
-   fi
+	if ! test -d "$1"; then
+		err "ERROR: '$1' is not a directory. update_version_helm must be called with the path to the Helm chart"
+		return 1
+	fi
 
-   if test -z "$2"
-   then
-      err "ERROR: The version specified was empty"
-      return 1
-   fi
+	if test -z "$2"; then
+		err "ERROR: The version specified was empty"
+		return 1
+	fi
 
-   local vfile="$1/values.yaml"
-   local cfile="$1/Chart.yaml"
-   local version="$2"
-   local prerelease="$3"
-   local full_version="$2"
-   if ! test -z "$3"
-   then
-     full_version="$2-$3"
-   fi
+	local vfile="$1/values.yaml"
+	local cfile="$1/Chart.yaml"
+	local version="$2"
+	local consul_version="$5"
+	local prerelease="$3"
+	local full_version="$2"
+	local full_consul_version="$5"
+	if ! test -z "$3"; then
+		full_version="$2-$3"
+		# strip off the last minor patch version so that the consul image can be set to something like 1.16-dev. The image
+		# is produced by Consul every night
+		full_consul_version="${5%.*}-$3"
+	fi
 
-   sed_i ${SED_EXT} -e "s/(imageK8S:.*\/consul-k8s-control-plane:)[^\"]*/imageK8S: $4${full_version}/g" "${vfile}"
-   sed_i ${SED_EXT} -e "s/(version:[[:space:]]*)[^\"]*/\1${full_version}/g" "${cfile}"
-   sed_i ${SED_EXT} -e "s/(image:.*\/consul-k8s-control-plane:)[^\"]*/image: $4${full_version}/g" "${cfile}"
+	sed_i ${SED_EXT} -e "s/(imageK8S:.*\/consul-k8s-control-plane:)[^\"]*/imageK8S: $4${full_version}/g" "${vfile}"
+	sed_i ${SED_EXT} -e "s/(version:[[:space:]]*)[^\"]*/\1${full_version}/g" "${cfile}"
+	sed_i ${SED_EXT} -e "s/(appVersion:[[:space:]]*)[^\"]*/\1${full_consul_version}/g" "${cfile}"
+	sed_i ${SED_EXT} -e "s/(image:.*\/consul-k8s-control-plane:)[^\"]*/image: $4${full_version}/g" "${cfile}"
+	if ! test -z "$3"; then
+		sed_i ${SED_EXT} -e "s/(image:.*\/consul:)[^\"]*/image: $6:${full_consul_version}/g" "${cfile}"
+		sed_i ${SED_EXT} -e "s/(image:.*\/consul:)[^\"]*/image: $6:${full_consul_version}/g" "${vfile}"
+	else
+		sed_i ${SED_EXT} -e "s/(image:.*\/consul-enterprise:)[^\"]*/image: $6:${full_consul_version}/g" "${cfile}"
+		sed_i ${SED_EXT} -e "s/(image:.*\/consul-enterprise:)[^\"]*/image: $6:${full_consul_version}/g" "${vfile}"
+	fi
 
-   if test -z "$3"
-   then
-     sed_i ${SED_EXT} -e "s/(artifacthub.io\/prerelease:[[:space:]]*)[^\"]*/\1false/g" "${cfile}"
-   else
-     sed_i ${SED_EXT} -e "s/(artifacthub.io\/prerelease:[[:space:]]*)[^\"]*/\1true/g" "${cfile}"
-   fi
-   return $?
+	if test -z "$3"; then
+		sed_i ${SED_EXT} -e "s/(artifacthub.io\/prerelease:[[:space:]]*)[^\"]*/\1false/g" "${cfile}"
+	else
+		sed_i ${SED_EXT} -e "s/(artifacthub.io\/prerelease:[[:space:]]*)[^\"]*/\1true/g" "${cfile}"
+	fi
+	return $?
 }
 
 function set_version {
-     # Arguments:
-     #   $1 - Path to top level Consul source
-     #   $2 - The version of the release
-     #   $3 - The release date
-     #   $4 - The pre-release version
-     #   $5 - The helm docker image base path
-     #
-     #
-     # Returns:
-     #   0 - success
-     #   * - error
+	# Arguments:
+	#   $1 - Path to top level Consul source
+	#   $2 - The version of the release
+	#   $3 - The release date
+	#   $4 - The pre-release version
+	#   $5 - The consul-k8s helm docker image base path
+	#   $6 - The consul version
+	#   $7 - The consul helm docker image base path
+	#
+	#
+	# Returns:
+	#   0 - success
+	#   * - error
 
-     if ! test -d "$1"
-     then
-        err "ERROR: '$1' is not a directory. prepare_release must be called with the path to a git repo as the first argument"
-        return 1
-     fi
+	if ! test -d "$1"; then
+		err "ERROR: '$1' is not a directory. prepare_release must be called with the path to a git repo as the first argument"
+		return 1
+	fi
 
-     if test -z "$2"
-     then
-        err "ERROR: The version specified was empty"
-        return 1
-     fi
+	if test -z "$2"; then
+		err "ERROR: The version specified was empty"
+		return 1
+	fi
 
-     local sdir="$1"
-     local vers="$2"
+	local sdir="$1"
+	local vers="$2"
+	local consul_vers="$6"
 
-     status_stage "==> Updating control-plane version/version.go with version info: ${vers} "$4""
-     if ! update_version "${sdir}/control-plane/version/version.go" "${vers}" "$4"
-     then
-        return 1
-     fi
+	status_stage "==> Updating control-plane version/version.go with version info: ${vers} "$4""
+	if ! update_version "${sdir}/control-plane/version/version.go" "${vers}" "$4"; then
+		return 1
+	fi
 
-     status_stage "==> Updating cli version/version.go with version info: ${vers} "$4""
-     if ! update_version "${sdir}/cli/version/version.go" "${vers}" "$4"
-     then
-        return 1
-     fi
+	status_stage "==> Updating cli version/version.go with version info: ${vers} "$4""
+	if ! update_version "${sdir}/cli/version/version.go" "${vers}" "$4"; then
+		return 1
+	fi
 
-     status_stage "==> Updating Helm chart versions with version info: ${vers} "$4""
-     if ! update_version_helm "${sdir}/charts/consul" "${vers}" "$4" "$5"
-     then
-        return 1
-     fi
+	status_stage "==> Updating Helm chart version, consul-k8s: ${vers} "$4" consul: ${consul_vers} "$4""
+	if ! update_version_helm "${sdir}/charts/consul" "${vers}" "$4" "$5" "${consul_vers}" "$7"; then
+		return 1
+	fi
 
-     return 0
+	return 0
 }
 
 function set_changelog {
-   # Arguments:
-   #   $1 - Path to top level Consul source
-   #   $2 - Version
-   #   $3 - Release Date
-   #   $4 - The last git release tag
-   #
-   #
-   # Returns:
-   #   0 - success
-   #   * - error
+	# Arguments:
+	#   $1 - Path to top level Consul source
+	#   $2 - Version
+	#   $3 - Release Date
+	#   $4 - The last git release tag
+	#
+	#
+	# Returns:
+	#   0 - success
+	#   * - error
 
-  # Check if changelog-build is installed
-  if ! command -v changelog-build &> /dev/null; then
-     echo "Error: changelog-build is not installed. Please install it and try again."
-     exit 1
-  fi
+	# Check if changelog-build is installed
+	if ! command -v changelog-build &>/dev/null; then
+		echo "Error: changelog-build is not installed. Please install it and try again."
+		exit 1
+	fi
 
-  local curdir="$1"
-  local version="$2"
-  local rel_date="$(date +"%B %d, %Y")"
-  if test -n "$3"
-  then
-    rel_date="$3"
-  fi
-  local last_release_date_git_tag=$4
+	local curdir="$1"
+	local version="$2"
+	local rel_date="$(date +"%B %d, %Y")"
+	if test -n "$3"; then
+		rel_date="$3"
+	fi
+	local last_release_date_git_tag=$4
 
-  if test -z "${version}"
-  then
-    err "ERROR: Must specify a version to put into the changelog"
-    return 1
-  fi
+	if test -z "${version}"; then
+		err "ERROR: Must specify a version to put into the changelog"
+		return 1
+	fi
 
-  if [ -z "$LAST_RELEASE_GIT_TAG" ]; then
-    echo "Error: LAST_RELEASE_GIT_TAG not specified."
-    exit 1
-  fi
+	if [ -z "$LAST_RELEASE_GIT_TAG" ]; then
+		echo "Error: LAST_RELEASE_GIT_TAG not specified."
+		exit 1
+	fi
 
-cat <<EOT | cat - "${curdir}"/CHANGELOG.MD > tmp && mv tmp "${curdir}"/CHANGELOG.MD
+	cat <<EOT | cat - "${curdir}"/CHANGELOG.MD >tmp && mv tmp "${curdir}"/CHANGELOG.MD
 ## ${version} (${rel_date})
 $(changelog-build -last-release ${LAST_RELEASE_GIT_TAG} \
-                 -entries-dir .changelog/ \
-                 -changelog-template .changelog/changelog.tmpl \
-                 -note-template .changelog/note.tmpl \
-                 -this-release $(git rev-parse HEAD))
+		-entries-dir .changelog/ \
+		-changelog-template .changelog/changelog.tmpl \
+		-note-template .changelog/note.tmpl \
+		-this-release $(git rev-parse HEAD))
 
 EOT
 }
 
 function prepare_release {
-   # Arguments:
-   #   $1 - Path to top level Consul source
-   #   $2 - The version of the release
-   #   $3 - The release date
-   #   $4 - The last release git tag for this branch (eg. v1.1.0)
-   #   $5 - The pre-release version
-   #
-   #
-   # Returns:
-   #   0 - success
-   #   * - error
+	# Arguments:
+	#   $1 - Path to top level Consul source
+	#   $2 - The version of the release
+	#   $3 - The release date
+	#   $4 - The last release git tag for this branch (eg. v1.1.0)
+	#   $5 - The pre-release version
+	#   $6 - The consul version
+	#
+	#
+	# Returns:
+	#   0 - success
+	#   * - error
 
-  echo "release version: " "$1" "$2" "$3" "$4"
-  set_version "$1" "$2" "$3" "$5" "hashicorp\/consul-k8s-control-plane:"
-  set_changelog "$1" "$2" "$3" "$4"
+	echo "prepare_release: dir:$1 consul-k8s:$2 consul:$5 date:"$3" git tag:$4"
+	set_version "$1" "$2" "$3" "$6" "hashicorp\/consul-k8s-control-plane:" "$5" "hashicorp\/consul"
+	set_changelog "$1" "$2" "$3" "$4"
 }
 
 function prepare_dev {
-   # Arguments:
-   #   $1 - Path to top level Consul source
-   #   $2 - The version of the release
-   #   $3 - The release date
-   #   $4 - The version of the next release
-   #   $5 - The last release git tag for this branch (eg. v1.1.0)
-   #
-   # Returns:
-   #   0 - success
-   #   * - error
+	# Arguments:
+	#   $1 - Path to top level Consul source
+	#   $2 - The version of the release
+	#   $3 - The release date
+	#   $4 - The last release git tag for this branch (eg. v1.1.0) (Unused)
+	#   $5 - The version of the next release
+	#   $6 - The version of the next consul release
+	#
+	# Returns:
+	#   0 - success
+	#   * - error
 
-   echo "dev version: " $1 $4 $3 "dev"
-   set_version "$1" "$4" "$3" "dev" "docker.mirror.hashicorp.services\/hashicorppreview\/consul-k8s-control-plane:"
+	echo "prepare_dev: dir:$1 consul-k8s:$5 consul:$6 date:"$3" mode:dev"
+	set_version "$1" "$5" "$3" "dev" "docker.mirror.hashicorp.services\/hashicorppreview\/consul-k8s-control-plane:" "$6" "docker.mirror.hashicorp.services\/hashicorppreview\/consul-enterprise"
 
-   return 0
+	return 0
 }
 
 function git_staging_empty {
-   # Arguments:
-   #   $1 - Path to git repo
-   #
-   # Returns:
-   #   0 - success (nothing staged)
-   #   * - error (staged files)
+	# Arguments:
+	#   $1 - Path to git repo
+	#
+	# Returns:
+	#   0 - success (nothing staged)
+	#   * - error (staged files)
 
-   if ! test -d "$1"
-   then
-      err "ERROR: '$1' is not a directory. commit_dev_mode must be called with the path to a git repo as the first argument'"
-      return 1
-   fi
+	if ! test -d "$1"; then
+		err "ERROR: '$1' is not a directory. commit_dev_mode must be called with the path to a git repo as the first argument'"
+		return 1
+	fi
 
-   pushd "$1" > /dev/null
+	pushd "$1" >/dev/null
 
-   declare -i ret=0
+	declare -i ret=0
 
-   for status in $(git status --porcelain=v2 | awk '{print $2}' | cut -b 1)
-   do
-      if test "${status}" != "."
-      then
-         ret=1
-         break
-      fi
-   done
+	for status in $(git status --porcelain=v2 | awk '{print $2}' | cut -b 1); do
+		if test "${status}" != "."; then
+			ret=1
+			break
+		fi
+	done
 
-   popd > /dev/null
-   return ${ret}
+	popd >/dev/null
+	return ${ret}
 }
 
 function commit_dev_mode {
-   # Arguments:
-   #   $1 - Path to top level Consul source
-   #
-   # Returns:
-   #   0 - success
-   #   * - error
+	# Arguments:
+	#   $1 - Path to top level Consul source
+	#
+	# Returns:
+	#   0 - success
+	#   * - error
 
-   if ! test -d "$1"
-   then
-      err "ERROR: '$1' is not a directory. commit_dev_mode must be called with the path to a git repo as the first argument'"
-      return 1
-   fi
+	if ! test -d "$1"; then
+		err "ERROR: '$1' is not a directory. commit_dev_mode must be called with the path to a git repo as the first argument'"
+		return 1
+	fi
 
-   status "Checking for previously staged files"
-   git_staging_empty "$1" || return 1
+	status "Checking for previously staged files"
+	git_staging_empty "$1" || return 1
 
-   declare -i ret=0
+	declare -i ret=0
 
-   pushd "$1" > /dev/null
+	pushd "$1" >/dev/null
 
-   status "Staging CHANGELOG.md and version_*.go files"
-   git add CHANGELOG.md && git add */version/version*.go
-   ret=$?
+	status "Staging CHANGELOG.md and version_*.go files"
+	git add CHANGELOG.md && git add */version/version*.go
+	ret=$?
 
-   if test ${ret} -eq 0
-   then
-      status "Adding Commit"
-      git commit -m "Putting source back into Dev Mode"
-      ret=$?
-   fi
+	if test ${ret} -eq 0; then
+		status "Adding Commit"
+		git commit -m "Putting source back into Dev Mode"
+		ret=$?
+	fi
 
-   popd >/dev/null
-   return ${ret}
+	popd >/dev/null
+	return ${ret}
 }
 
 function gpg_detach_sign {
-   # Arguments:
-   #   $1 - File to sign
-   #   $2 - Alternative GPG key to use for signing
-   #
-   # Returns:
-   #   0 - success
-   #   * - failure
+	# Arguments:
+	#   $1 - File to sign
+	#   $2 - Alternative GPG key to use for signing
+	#
+	# Returns:
+	#   0 - success
+	#   * - failure
 
-   # determine whether the gpg key to use is being overridden
-   local gpg_key=${HASHICORP_GPG_KEY}
-   if test -n "$2"
-   then
-      gpg_key=$2
-   fi
+	# determine whether the gpg key to use is being overridden
+	local gpg_key=${HASHICORP_GPG_KEY}
+	if test -n "$2"; then
+		gpg_key=$2
+	fi
 
-   gpg --default-key "${gpg_key}" --detach-sig --yes -v  "$1"
-   return $?
+	gpg --default-key "${gpg_key}" --detach-sig --yes -v "$1"
+	return $?
 }
 
 function shasum_directory {
-   # Arguments:
-   #   $1 - Path to directory containing the files to shasum
-   #   $2 - File to output sha sums to
-   #
-   # Returns:
-   #   0 - success
-   #   * - failure
+	# Arguments:
+	#   $1 - Path to directory containing the files to shasum
+	#   $2 - File to output sha sums to
+	#
+	# Returns:
+	#   0 - success
+	#   * - failure
 
-   if ! test -d "$1"
-   then
-      err "ERROR: '$1' is not a directory and shasum_release requires passing a directory as the first argument"
-      return 1
-   fi
+	if ! test -d "$1"; then
+		err "ERROR: '$1' is not a directory and shasum_release requires passing a directory as the first argument"
+		return 1
+	fi
 
-   if test -z "$2"
-   then
-      err "ERROR: shasum_release requires a second argument to be the filename to output the shasums to but none was given"
-      return 1
-   fi
+	if test -z "$2"; then
+		err "ERROR: shasum_release requires a second argument to be the filename to output the shasums to but none was given"
+		return 1
+	fi
 
-   pushd $1 > /dev/null
-   shasum -a256 * > "$2"
-   ret=$?
-   popd >/dev/null
+	pushd $1 >/dev/null
+	shasum -a256 * >"$2"
+	ret=$?
+	popd >/dev/null
 
-   return $ret
+	return $ret
 }
 
- function ui_version {
-   # Arguments:
-   #   $1 - path to index.html
-   #
-   # Returns:
-   #   0 - success
-   #   * -failure
-   #
-   # Notes: echoes the version to stdout upon success
-   if ! test -f "$1"
-   then
-      err "ERROR: No such file: '$1'"
-      return 1
-   fi
+function ui_version {
+	# Arguments:
+	#   $1 - path to index.html
+	#
+	# Returns:
+	#   0 - success
+	#   * -failure
+	#
+	# Notes: echoes the version to stdout upon success
+	if ! test -f "$1"; then
+		err "ERROR: No such file: '$1'"
+		return 1
+	fi
 
-   local ui_version=$(sed -n ${SED_EXT} -e 's/.*CONSUL_VERSION%22%3A%22([^%]*)%22%2C%22.*/\1/p' < "$1") || return 1
-   echo "$ui_version"
-   return 0
- }
- function ui_logo_type {
-   # Arguments:
-   #   $1 - path to index.html
-   #
-   # Returns:
-   #   0 - success
-   #   * -failure
-   #
-   # Notes: echoes the 'logo type' to stdout upon success
-   # the 'logo' can be one of 'enterprise' or 'oss'
-   # and doesn't necessarily correspond to the binary type of consul
-   # the logo is 'enterprise' if the binary type is anything but 'oss'
-   if ! test -f "$1"
-   then
-      err "ERROR: No such file: '$1'"
-      return 1
-   fi
-   grep -q "data-enterprise-logo" < "$1"
+	local ui_version=$(sed -n ${SED_EXT} -e 's/.*CONSUL_VERSION%22%3A%22([^%]*)%22%2C%22.*/\1/p' <"$1") || return 1
+	echo "$ui_version"
+	return 0
+}
+function ui_logo_type {
+	# Arguments:
+	#   $1 - path to index.html
+	#
+	# Returns:
+	#   0 - success
+	#   * -failure
+	#
+	# Notes: echoes the 'logo type' to stdout upon success
+	# the 'logo' can be one of 'enterprise' or 'oss'
+	# and doesn't necessarily correspond to the binary type of consul
+	# the logo is 'enterprise' if the binary type is anything but 'oss'
+	if ! test -f "$1"; then
+		err "ERROR: No such file: '$1'"
+		return 1
+	fi
+	grep -q "data-enterprise-logo" <"$1"
 
-   if test $? -eq 0
-   then
-     echo "enterprise"
-   else
-     echo "oss"
-   fi
-   return 0
- }
+	if test $? -eq 0; then
+		echo "enterprise"
+	else
+		echo "oss"
+	fi
+	return 0
+}

--- a/control-plane/build-support/scripts/consul-version.sh
+++ b/control-plane/build-support/scripts/consul-version.sh
@@ -4,5 +4,4 @@
 FILE=$1
 VERSION=$(yq .global.image $FILE)
 
-# echo full string "hashicorp/consul:1.15.1" | remove first and last characters | cut everything before ':'
-echo "${VERSION}" | sed 's/^.//;s/.$//' | cut -d ':' -f2-
+echo "${VERSION}"


### PR DESCRIPTION
My apologies on the formatting. I think I might be the only person that uses the bash language server and it 'fixed' everything. See my comments in the 10-utils.sh script for the important changes.

The purpose of this PR is to fix a long standing bug (pre-GHA) so that the correct consul image is set on every release branch. Our automation will use the correct version that matches the consul release that a release branch is paired with. The consul already repo correctly creates `-dev` images when a PR is merged on a release branch.

Changes proposed in this PR:
- Update the consul-version.sh script and make target to get the full image version from the helm chart. This will be used in consul-k8s-workflows to be passed aroudn the tests.
- I will need to put up a consul-k8s-workflows PR before I merge this one so that pipelines do not break
- A release docs PR will also go up soon(tm)
- Change `make prepare-release` and `make prepare-dev` to change the consul image in values.yaml and Chart.yaml.

**_*Note: This will also be tested post merge as I will need to update all of the release branches and main to make sure 'dev mode' is correct.*_**

How I've tested this PR:

- Manual testing of the make targets and they flip the image versions back and forth. 

For example in values.yaml 

`image: "hashicorp/consul:1.15.1"`
flips to:
`image: docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.16-dev`

This also gets changed in Chart.yaml in the correct places.

How I expect reviewers to test this PR:

:eyes:

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

