### PR TITLE
Fix tests

### DIFF
--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar_test.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar_test.go
@@ -379,7 +379,12 @@ func TestHandlerConsulDataplaneSidecar_DNSProxy(t *testing.T) {
 					pod.Annotations[constants.KeyTransparentProxy] = strconv.FormatBool(*tproxyCase.PodTProxy)
 				}
 
-				ns := testNS
+				ns := corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   k8sNamespace,
+						Labels: map[string]string{},
+					},
+				}
 				if dnsCase.NamespaceDNS != nil {
 					ns.Labels[constants.KeyConsulDNS] = strconv.FormatBool(*dnsCase.NamespaceDNS)
 				}


### PR DESCRIPTION
Fix deepcopy bug in tests (testNS.Labels is shared even when the struct is copied to ns)