### PR TITLE
Fix bug on service intention CRDs causing missed updates

### DIFF
--- a/.changelog/2194.txt
+++ b/.changelog/2194.txt
@@ -1,0 +1,3 @@
+```release-note:
+crd: fix bug on service intentions CRD causing some updates to be ignored.
+```

--- a/control-plane/api/v1alpha1/serviceintentions_types_test.go
+++ b/control-plane/api/v1alpha1/serviceintentions_types_test.go
@@ -41,6 +41,78 @@ func TestServiceIntentions_MatchesConsul(t *testing.T) {
 			},
 			Matches: true,
 		},
+		"namespaces and partitions equate `default` and empty strings": {
+			Ours: ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: IntentionDestination{
+						Name:      "svc-name",
+						Namespace: "ns1",
+					},
+					Sources: []*SourceIntention{
+						{
+							Name:      "svc1",
+							Namespace: "",
+							Partition: "default",
+							Action:    "allow",
+						},
+					},
+				},
+			},
+			Theirs: &capi.ServiceIntentionsConfigEntry{
+				Kind:      capi.ServiceIntentions,
+				Name:      "svc-name",
+				Namespace: "ns1",
+				Sources: []*capi.SourceIntention{
+					{
+						Name:       "svc1",
+						Namespace:  "default",
+						Partition:  "",
+						Action:     "allow",
+						Precedence: 0,
+					},
+				},
+			},
+			Matches: true,
+		},
+		"source namespaces and partitions are compared": {
+			Ours: ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: IntentionDestination{
+						Name:      "svc-name",
+						Namespace: "test",
+					},
+					Sources: []*SourceIntention{
+						{
+							Name:      "svc1",
+							Namespace: "test",
+							Partition: "test",
+							Action:    "allow",
+						},
+					},
+				},
+			},
+			Theirs: &capi.ServiceIntentionsConfigEntry{
+				Kind:      capi.ServiceIntentions,
+				Name:      "svc-name",
+				Namespace: "test",
+				Sources: []*capi.SourceIntention{
+					{
+						Name:       "svc1",
+						Namespace:  "not-test",
+						Partition:  "not-test",
+						Action:     "allow",
+						Precedence: 0,
+					},
+				},
+			},
+			Matches: false,
+		},
 		"all fields set matches": {
 			Ours: ServiceIntentions{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Changes proposed in this PR:
- Include partition and namespace in intention source equality checks
- Include namespace in intention destination equality checks.

This code was originally added [here](https://github.com/hashicorp/consul-k8s/pull/1804) to avoid modifying all intentions when upgrading from Consul pre-1.12 to 1.12+. Consul-K8s 1.0.x is compatible with Consul 1.14.x and Consul-K8s 1.1.x is compatible with Consul 1.15.x, so users should be past 1.12 when upgrading to either of the backported versions ([compatibility matrix](https://developer.hashicorp.com/consul/docs/k8s/compatibility#supported-consul-and-kubernetes-versions)).

How I've tested this PR:
- Unit tests
- Manual tests in the sameness group demo environment.

Checklist:
- [X] Tests added
- [x] CHANGELOG entry added 

