### PR TITLE
update cloud preset to enable telemetry collector

### DIFF
--- a/.changelog/2205.txt
+++ b/.changelog/2205.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: update cloud preset to enable telemetry collector
+```

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -552,7 +552,7 @@ global:
     # Configures the Helm chart’s components to forward envoy metrics for the Consul service mesh to the
     # consul-telemetry-collector. This includes gateway metrics and sidecar metrics.
     # @type: boolean
-    enableTelemetryCollector: true
+    enableTelemetryCollector: false
 
   # The name (and tag) of the consul-dataplane Docker image used for the
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.

--- a/cli/preset/cloud_preset.go
+++ b/cli/preset/cloud_preset.go
@@ -201,6 +201,8 @@ global:
     bootstrapToken:
       secretName: %s
       secretKey: %s
+  metrics:
+    enableTelemetryCollector: true
   cloud:
     enabled: true
     resourceId:
@@ -215,6 +217,15 @@ global:
     %s
     %s
     %s
+telemetryCollector:
+  enabled: true
+  cloud:
+    clientId:
+      secretName: %s
+      secretKey: %s
+    clientSecret:
+      secretName: %s
+      secretKey: %s
 server:
   replicas: %d
   affinity: null
@@ -231,6 +242,8 @@ controller:
 		secretNameHCPClientID, secretKeyHCPClientID,
 		secretNameHCPClientSecret, secretKeyHCPClientSecret,
 		apiHostCfg, authURLCfg, scadaAddressCfg,
+		secretNameHCPClientID, secretKeyHCPClientID,
+		secretNameHCPClientSecret, secretKeyHCPClientSecret,
 		cfg.BootstrapResponse.Cluster.BootstrapExpect, secretNameServerCert)
 	valuesMap := config.ConvertToMap(values)
 	return valuesMap

--- a/cli/preset/cloud_preset_test.go
+++ b/cli/preset/cloud_preset_test.go
@@ -483,6 +483,8 @@ global:
   gossipEncryption:
     secretKey: key
     secretName: consul-gossip-key
+  metrics:
+    enableTelemetryCollector: true
   tls:
     caCert:
       secretKey: tls.crt
@@ -494,6 +496,15 @@ server:
   replicas: 3
   serverCert:
     secretName: consul-server-cert
+telemetryCollector:
+  cloud:
+    clientId:
+      secretKey: client-id
+      secretName: consul-hcp-client-id
+    clientSecret:
+      secretKey: client-secret
+      secretName: consul-hcp-client-secret
+  enabled: true
 `
 
 	const expectedWithoutOptional = `connectInject:
@@ -521,6 +532,8 @@ global:
   gossipEncryption:
     secretKey: key
     secretName: consul-gossip-key
+  metrics:
+    enableTelemetryCollector: true
   tls:
     caCert:
       secretKey: tls.crt
@@ -532,6 +545,15 @@ server:
   replicas: 3
   serverCert:
     secretName: consul-server-cert
+telemetryCollector:
+  cloud:
+    clientId:
+      secretKey: client-id
+      secretName: consul-hcp-client-id
+    clientSecret:
+      secretKey: client-secret
+      secretName: consul-hcp-client-secret
+  enabled: true
 `
 
 	cloudPreset := &CloudPreset{}


### PR DESCRIPTION
Changes proposed in this PR:
- adds `telemetryCollector` values to cloud preset

How I've tested this PR:
- local dry run testing validating the expected helm values
- updated unit tests to expect updated helm values


Checklist:
- [X] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

