### PR TITLE
Update ServiceIntentions CRD for JWT auth

### DIFF
--- a/.changelog/2213.txt
+++ b/.changelog/2213.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+helm: Update the ServiceIntentions CRD to support `JWT` fields.
+```

--- a/charts/consul/templates/crd-serviceintentions.yaml
+++ b/charts/consul/templates/crd-serviceintentions.yaml
@@ -74,6 +74,43 @@ spec:
                       have intentions defined.
                     type: string
                 type: object
+              jwt:
+                description: JWT specifies the configuration to validate a JSON Web
+                  Token for all incoming requests.
+                properties:
+                  providers:
+                    description: Providers is a list of providers to consider when
+                      verifying a JWT.
+                    items:
+                      properties:
+                        name:
+                          description: Name is the name of the JWT provider. There
+                            MUST be a corresponding "jwt-provider" config entry with
+                            this name.
+                          type: string
+                        verifyClaims:
+                          description: VerifyClaims is a list of additional claims
+                            to verify in a JWT's payload.
+                          items:
+                            properties:
+                              path:
+                                description: Path is the path to the claim in the
+                                  token JSON.
+                                items:
+                                  type: string
+                                type: array
+                              value:
+                                description: Value is the expected value at the given
+                                  path. If the type at the path is a list then we
+                                  verify that this value is contained in the list.
+                                  If the type at the path is a string then we verify
+                                  that this value matches.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                type: object
               sources:
                 description: Sources is the list of all intention sources and the
                   authorization granted to those sources. The order of this list does
@@ -182,6 +219,44 @@ spec:
                                 description: PathRegex is the regular expression to
                                   match on the HTTP request path.
                                 type: string
+                            type: object
+                          jwt:
+                            description: JWT specifies configuration to validate a
+                              JSON Web Token for incoming requests.
+                            properties:
+                              providers:
+                                description: Providers is a list of providers to consider
+                                  when verifying a JWT.
+                                items:
+                                  properties:
+                                    name:
+                                      description: Name is the name of the JWT provider.
+                                        There MUST be a corresponding "jwt-provider"
+                                        config entry with this name.
+                                      type: string
+                                    verifyClaims:
+                                      description: VerifyClaims is a list of additional
+                                        claims to verify in a JWT's payload.
+                                      items:
+                                        properties:
+                                          path:
+                                            description: Path is the path to the claim
+                                              in the token JSON.
+                                            items:
+                                              type: string
+                                            type: array
+                                          value:
+                                            description: Value is the expected value
+                                              at the given path. If the type at the
+                                              path is a list then we verify that this
+                                              value is contained in the list. If the
+                                              type at the path is a string then we
+                                              verify that this value matches.
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
                             type: object
                         type: object
                       type: array

--- a/control-plane/api/v1alpha1/serviceintentions_types.go
+++ b/control-plane/api/v1alpha1/serviceintentions_types.go
@@ -59,6 +59,8 @@ type ServiceIntentionsSpec struct {
 	// The order of this list does not matter, but out of convenience Consul will always store this
 	// reverse sorted by intention precedence, as that is the order that they will be evaluated at enforcement time.
 	Sources SourceIntentions `json:"sources,omitempty"`
+	// JWT specifies the configuration to validate a JSON Web Token for all incoming requests.
+	JWT *IntentionJWTRequirement `json:"jwt,omitempty"`
 }
 
 type IntentionDestination struct {
@@ -108,6 +110,8 @@ type IntentionPermission struct {
 	Action IntentionAction `json:"action,omitempty"`
 	// HTTP is a set of HTTP-specific authorization criteria.
 	HTTP *IntentionHTTPPermission `json:"http,omitempty"`
+	// JWT specifies configuration to validate a JSON Web Token for incoming requests.
+	JWT *IntentionJWTRequirement `json:"jwt,omitempty"`
 }
 
 type IntentionHTTPPermission struct {
@@ -140,6 +144,30 @@ type IntentionHTTPHeaderPermission struct {
 	Regex string `json:"regex,omitempty"`
 	// Invert inverts the logic of the match.
 	Invert bool `json:"invert,omitempty"`
+}
+
+type IntentionJWTRequirement struct {
+	// Providers is a list of providers to consider when verifying a JWT.
+	Providers []*IntentionJWTProvider `json:"providers,omitempty"`
+}
+
+type IntentionJWTProvider struct {
+	// Name is the name of the JWT provider. There MUST be a corresponding
+	// "jwt-provider" config entry with this name.
+	Name string `json:"name,omitempty"`
+
+	// VerifyClaims is a list of additional claims to verify in a JWT's payload.
+	VerifyClaims []*IntentionJWTClaimVerification `json:"verifyClaims,omitempty"`
+}
+
+type IntentionJWTClaimVerification struct {
+	// Path is the path to the claim in the token JSON.
+	Path []string `json:"path,omitempty"`
+
+	// Value is the expected value at the given path. If the type at the path
+	// is a list then we verify that this value is contained in the list. If
+	// the type at the path is a string then we verify that this value matches.
+	Value string `json:"value,omitempty"`
 }
 
 // IntentionAction is the action that the intention represents. This
@@ -226,6 +254,7 @@ func (in *ServiceIntentions) ToConsul(datacenter string) api.ConfigEntry {
 		Name:      in.Spec.Destination.Name,
 		Namespace: in.Spec.Destination.Namespace,
 		Sources:   in.Spec.Sources.toConsul(),
+		JWT:       in.Spec.JWT.toConsul(),
 		Meta:      meta(datacenter),
 	}
 }
@@ -296,6 +325,8 @@ func (in *ServiceIntentions) Validate(consulMeta common.ConsulMeta) error {
 	}
 
 	errs = append(errs, in.validateNamespaces(consulMeta.NamespacesEnabled)...)
+
+	errs = append(errs, in.Spec.JWT.validate(path.Child("jwt"))...)
 
 	if len(errs) > 0 {
 		return apierrors.NewInvalid(
@@ -394,6 +425,7 @@ func (in IntentionPermissions) toConsul() []*capi.IntentionPermission {
 		consulIntentionPermissions = append(consulIntentionPermissions, &capi.IntentionPermission{
 			Action: permission.Action.toConsul(),
 			HTTP:   permission.HTTP.toConsul(),
+			JWT:    permission.JWT.toConsul(),
 		})
 	}
 	return consulIntentionPermissions
@@ -429,15 +461,54 @@ func (in IntentionHTTPHeaderPermissions) toConsul() []capi.IntentionHTTPHeaderPe
 	return headerPermissions
 }
 
+func (in *IntentionJWTRequirement) toConsul() *capi.IntentionJWTRequirement {
+	if in == nil {
+		return nil
+	}
+	var providers []*capi.IntentionJWTProvider
+	for _, p := range in.Providers {
+		providers = append(providers, p.toConsul())
+	}
+	return &capi.IntentionJWTRequirement{
+		Providers: providers,
+	}
+}
+
+func (in *IntentionJWTProvider) toConsul() *capi.IntentionJWTProvider {
+	if in == nil {
+		return nil
+	}
+	var claims []*capi.IntentionJWTClaimVerification
+	for _, c := range in.VerifyClaims {
+		claims = append(claims, c.toConsul())
+	}
+	return &capi.IntentionJWTProvider{
+		Name:         in.Name,
+		VerifyClaims: claims,
+	}
+}
+
+func (in *IntentionJWTClaimVerification) toConsul() *capi.IntentionJWTClaimVerification {
+	if in == nil {
+		return nil
+	}
+	return &capi.IntentionJWTClaimVerification{
+		Path:  in.Path,
+		Value: in.Value,
+	}
+}
+
 func (in IntentionPermissions) validate(path *field.Path) field.ErrorList {
 	var errs field.ErrorList
 	for i, permission := range in {
-		if err := permission.Action.validate(path.Child("permissions").Index(i)); err != nil {
+		permPath := path.Child("permissions").Index(i)
+		if err := permission.Action.validate(permPath); err != nil {
 			errs = append(errs, err)
 		}
 		if permission.HTTP != nil {
-			errs = append(errs, permission.HTTP.validate(path.Child("permissions").Index(i))...)
+			errs = append(errs, permission.HTTP.validate(permPath)...)
 		}
+		errs = append(errs, permission.JWT.validate(permPath.Child("jwt"))...)
 	}
 	return errs
 }
@@ -538,6 +609,27 @@ func numNotEmpty(ss ...string) int {
 		}
 	}
 	return count
+}
+
+func (in *IntentionJWTRequirement) validate(path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if in == nil {
+		return errs
+	}
+
+	for i, p := range in.Providers {
+		if err := p.validate(path.Child("providers").Index(i)); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+func (in *IntentionJWTProvider) validate(path *field.Path) *field.Error {
+	if in != nil && in.Name == "" {
+		return field.Invalid(path.Child("name"), in.Name, "JWT provider name is required")
+	}
+	return nil
 }
 
 // sourceIntentionSortKey returns a string that can be used to sort intention

--- a/control-plane/api/v1alpha1/serviceintentions_types_test.go
+++ b/control-plane/api/v1alpha1/serviceintentions_types_test.go
@@ -165,9 +165,35 @@ func TestServiceIntentions_MatchesConsul(t *testing.T) {
 											"PUT",
 										},
 									},
+									JWT: &IntentionJWTRequirement{
+										Providers: []*IntentionJWTProvider{
+											{
+												Name: "okta-nested",
+												VerifyClaims: []*IntentionJWTClaimVerification{
+													{
+														Path:  []string{"perms", "role"},
+														Value: "admin-nested",
+													},
+												},
+											},
+										},
+									},
 								},
 							},
 							Description: "an L7 config",
+						},
+					},
+					JWT: &IntentionJWTRequirement{
+						Providers: []*IntentionJWTProvider{
+							{
+								Name: "okta",
+								VerifyClaims: []*IntentionJWTClaimVerification{
+									{
+										Path:  []string{"perms", "role"},
+										Value: "admin",
+									},
+								},
+							},
 						},
 					},
 				},
@@ -220,9 +246,35 @@ func TestServiceIntentions_MatchesConsul(t *testing.T) {
 										"PUT",
 									},
 								},
+								JWT: &capi.IntentionJWTRequirement{
+									Providers: []*capi.IntentionJWTProvider{
+										{
+											Name: "okta-nested",
+											VerifyClaims: []*capi.IntentionJWTClaimVerification{
+												{
+													Path:  []string{"perms", "role"},
+													Value: "admin-nested",
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 						Description: "an L7 config",
+					},
+				},
+				JWT: &capi.IntentionJWTRequirement{
+					Providers: []*capi.IntentionJWTProvider{
+						{
+							Name: "okta",
+							VerifyClaims: []*capi.IntentionJWTClaimVerification{
+								{
+									Path:  []string{"perms", "role"},
+									Value: "admin",
+								},
+							},
+						},
 					},
 				},
 				Meta: nil,
@@ -376,9 +428,35 @@ func TestServiceIntentions_ToConsul(t *testing.T) {
 											"PUT",
 										},
 									},
+									JWT: &IntentionJWTRequirement{
+										Providers: []*IntentionJWTProvider{
+											{
+												Name: "okta-nested",
+												VerifyClaims: []*IntentionJWTClaimVerification{
+													{
+														Path:  []string{"perms", "role"},
+														Value: "admin-nested",
+													},
+												},
+											},
+										},
+									},
 								},
 							},
 							Description: "an L7 config",
+						},
+					},
+					JWT: &IntentionJWTRequirement{
+						Providers: []*IntentionJWTProvider{
+							{
+								Name: "okta",
+								VerifyClaims: []*IntentionJWTClaimVerification{
+									{
+										Path:  []string{"perms", "role"},
+										Value: "admin",
+									},
+								},
+							},
 						},
 					},
 				},
@@ -436,9 +514,35 @@ func TestServiceIntentions_ToConsul(t *testing.T) {
 										"PUT",
 									},
 								},
+								JWT: &capi.IntentionJWTRequirement{
+									Providers: []*capi.IntentionJWTProvider{
+										{
+											Name: "okta-nested",
+											VerifyClaims: []*capi.IntentionJWTClaimVerification{
+												{
+													Path:  []string{"perms", "role"},
+													Value: "admin-nested",
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 						Description: "an L7 config",
+					},
+				},
+				JWT: &capi.IntentionJWTRequirement{
+					Providers: []*capi.IntentionJWTProvider{
+						{
+							Name: "okta",
+							VerifyClaims: []*capi.IntentionJWTClaimVerification{
+								{
+									Path:  []string{"perms", "role"},
+									Value: "admin",
+								},
+							},
+						},
 					},
 				},
 				Meta: map[string]string{
@@ -741,9 +845,35 @@ func TestServiceIntentions_Validate(t *testing.T) {
 											"PUT",
 										},
 									},
+									JWT: &IntentionJWTRequirement{
+										Providers: []*IntentionJWTProvider{
+											{
+												Name: "okta-nested",
+												VerifyClaims: []*IntentionJWTClaimVerification{
+													{
+														Path:  []string{"perms", "role"},
+														Value: "admin-nested",
+													},
+												},
+											},
+										},
+									},
 								},
 							},
 							Description: "an L7 config",
+						},
+					},
+					JWT: &IntentionJWTRequirement{
+						Providers: []*IntentionJWTProvider{
+							{
+								Name: "okta",
+								VerifyClaims: []*IntentionJWTClaimVerification{
+									{
+										Path:  []string{"perms", "role"},
+										Value: "admin",
+									},
+								},
+							},
 						},
 					},
 				},
@@ -1620,6 +1750,66 @@ func TestServiceIntentions_Validate(t *testing.T) {
 				`partition cannot use or contain wildcard '*'`,
 				`peer cannot use or contain wildcard '*'`,
 				`samenessgroup cannot use or contain wildcard '*'`,
+			},
+		},
+		"invalid empty jwt provider name at top-level": {
+			input: &ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: IntentionDestination{
+						Name: "dest-service",
+					},
+					Sources: SourceIntentions{
+						{
+							Name:   "bar",
+							Action: "allow",
+						},
+					},
+					JWT: &IntentionJWTRequirement{
+						Providers: []*IntentionJWTProvider{
+							{
+								Name: "",
+							},
+						},
+					},
+				},
+			},
+			expectedErrMsgs: []string{
+				`spec.jwt.providers[0].name: Invalid value: "": JWT provider name is required`,
+			},
+		},
+		"invalid empty jwt provider name in permissions": {
+			input: &ServiceIntentions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "does-not-matter",
+				},
+				Spec: ServiceIntentionsSpec{
+					Destination: IntentionDestination{
+						Name: "dest-service",
+					},
+					Sources: SourceIntentions{
+						{
+							Name: "bar",
+							Permissions: IntentionPermissions{
+								{
+									Action: "allow",
+									JWT: &IntentionJWTRequirement{
+										Providers: []*IntentionJWTProvider{
+											{
+												Name: "",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrMsgs: []string{
+				`spec.sources[0].permissions[0].jwt.providers[0].name: Invalid value: "": JWT provider name is required`,
 			},
 		},
 	}

--- a/control-plane/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_serviceintentions.yaml
@@ -70,6 +70,43 @@ spec:
                       have intentions defined.
                     type: string
                 type: object
+              jwt:
+                description: JWT specifies the configuration to validate a JSON Web
+                  Token for all incoming requests.
+                properties:
+                  providers:
+                    description: Providers is a list of providers to consider when
+                      verifying a JWT.
+                    items:
+                      properties:
+                        name:
+                          description: Name is the name of the JWT provider. There
+                            MUST be a corresponding "jwt-provider" config entry with
+                            this name.
+                          type: string
+                        verifyClaims:
+                          description: VerifyClaims is a list of additional claims
+                            to verify in a JWT's payload.
+                          items:
+                            properties:
+                              path:
+                                description: Path is the path to the claim in the
+                                  token JSON.
+                                items:
+                                  type: string
+                                type: array
+                              value:
+                                description: Value is the expected value at the given
+                                  path. If the type at the path is a list then we
+                                  verify that this value is contained in the list.
+                                  If the type at the path is a string then we verify
+                                  that this value matches.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                type: object
               sources:
                 description: Sources is the list of all intention sources and the
                   authorization granted to those sources. The order of this list does
@@ -178,6 +215,44 @@ spec:
                                 description: PathRegex is the regular expression to
                                   match on the HTTP request path.
                                 type: string
+                            type: object
+                          jwt:
+                            description: JWT specifies configuration to validate a
+                              JSON Web Token for incoming requests.
+                            properties:
+                              providers:
+                                description: Providers is a list of providers to consider
+                                  when verifying a JWT.
+                                items:
+                                  properties:
+                                    name:
+                                      description: Name is the name of the JWT provider.
+                                        There MUST be a corresponding "jwt-provider"
+                                        config entry with this name.
+                                      type: string
+                                    verifyClaims:
+                                      description: VerifyClaims is a list of additional
+                                        claims to verify in a JWT's payload.
+                                      items:
+                                        properties:
+                                          path:
+                                            description: Path is the path to the claim
+                                              in the token JSON.
+                                            items:
+                                              type: string
+                                            type: array
+                                          value:
+                                            description: Value is the expected value
+                                              at the given path. If the type at the
+                                              path is a list then we verify that this
+                                              value is contained in the list. If the
+                                              type at the path is a string then we
+                                              verify that this value matches.
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
                             type: object
                         type: object
                       type: array


### PR DESCRIPTION
Changes proposed in this PR:

* This updates the ServiceIntentions CRD with the new fields for JWT auth.

How I've tested this PR:

* Unit tests

How I expect reviewers to test this PR:


Checklist:
- [x] Depends on #2209 
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

