### PR TITLE
Fix telemetry collector issue and fix for bat test

### DIFF
--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -216,7 +216,7 @@ load _helpers
   local cmd=$(helm template \
       -s templates/connect-inject-deployment.yaml \
       --set 'connectInject.enabled=true' \
-      --set 'connectInject.metrics.enableTelemetryCollector=true' \
+      --set 'global.metrics.enableTelemetryCollector=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
@@ -671,6 +671,9 @@ func (r *Controller) createGatewayRegistrations(pod corev1.Pod, serviceEndpoints
 		ID:      pod.Name,
 		Address: pod.Status.PodIP,
 		Meta:    meta,
+		Proxy: &api.AgentServiceConnectProxyConfig{
+			Config: map[string]interface{}{},
+		},
 	}
 
 	gatewayServiceName, ok := pod.Annotations[constants.AnnotationGatewayConsulServiceName]

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
@@ -487,7 +487,7 @@ func (r *Controller) createServiceRegistrations(pod corev1.Pod, serviceEndpoints
 		proxyConfig.Config[envoyPrometheusBindAddr] = prometheusScrapeListener
 	}
 
-	if r.EnableTelemetryCollector {
+	if r.EnableTelemetryCollector && proxyConfig.Config != nil {
 		proxyConfig.Config[envoyTelemetryCollectorBindSocketDir] = "/consul/connect-inject"
 	}
 
@@ -770,7 +770,7 @@ func (r *Controller) createGatewayRegistrations(pod corev1.Pod, serviceEndpoints
 		}
 	}
 
-	if r.EnableTelemetryCollector {
+	if r.EnableTelemetryCollector && service.Proxy != nil && service.Proxy.Config != nil {
 		service.Proxy.Config[envoyTelemetryCollectorBindSocketDir] = "/consul/service"
 	}
 

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
@@ -996,6 +996,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 		expectedProxySvcInstances  []*api.CatalogService
 		expectedHealthChecks       []*api.HealthCheck
 		metricsEnabled             bool
+		telemetryCollectorDisabled bool
 		nodeMeta                   map[string]string
 		expErr                     string
 	}{
@@ -1078,6 +1079,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 						DestinationServiceID:   "pod1-service-created",
 						LocalServiceAddress:    "",
 						LocalServicePort:       0,
+						Config:                 map[string]any{"envoy_telemetry_collector_bind_socket_dir": string("/consul/connect-inject")},
 					},
 					ServiceMeta: map[string]string{constants.MetaKeyPodName: "pod1", metaKeyKubeServiceName: "service-created", constants.MetaKeyKubeNS: "default", metaKeyManagedBy: constants.ManagedByValue, metaKeySyntheticNode: "true"},
 					ServiceTags: []string{},
@@ -1186,6 +1188,80 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 			name:          "Mesh Gateway with Metrics enabled",
 			svcName:       "mesh-gateway",
 			consulSvcName: "mesh-gateway",
+			k8sObjects: func() []runtime.Object {
+				gateway := createGatewayPod("mesh-gateway", "1.2.3.4", map[string]string{
+					constants.AnnotationGatewayConsulServiceName: "mesh-gateway",
+					constants.AnnotationGatewayWANSource:         "Static",
+					constants.AnnotationGatewayWANAddress:        "2.3.4.5",
+					constants.AnnotationGatewayWANPort:           "443",
+					constants.AnnotationMeshGatewayContainerPort: "8443",
+					constants.AnnotationGatewayKind:              meshGateway})
+				endpoint := &corev1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "mesh-gateway",
+						Namespace: "default",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									IP: "1.2.3.4",
+									TargetRef: &corev1.ObjectReference{
+										Kind:      "Pod",
+										Name:      "mesh-gateway",
+										Namespace: "default",
+									},
+								},
+							},
+						},
+					},
+				}
+				return []runtime.Object{gateway, endpoint}
+			},
+			expectedConsulSvcInstances: []*api.CatalogService{
+				{
+					ServiceID:      "mesh-gateway",
+					ServiceName:    "mesh-gateway",
+					ServiceAddress: "1.2.3.4",
+					ServicePort:    8443,
+					ServiceMeta:    map[string]string{constants.MetaKeyPodName: "mesh-gateway", metaKeyKubeServiceName: "mesh-gateway", constants.MetaKeyKubeNS: "default", metaKeyManagedBy: constants.ManagedByValue, metaKeySyntheticNode: "true"},
+					ServiceTags:    []string{},
+					ServiceTaggedAddresses: map[string]api.ServiceAddress{
+						"lan": {
+							Address: "1.2.3.4",
+							Port:    8443,
+						},
+						"wan": {
+							Address: "2.3.4.5",
+							Port:    443,
+						},
+					},
+					ServiceProxy: &api.AgentServiceConnectProxyConfig{
+						Config: map[string]interface{}{
+							"envoy_prometheus_bind_addr":                "1.2.3.4:20200",
+							"envoy_telemetry_collector_bind_socket_dir": "/consul/service",
+						},
+					},
+				},
+			},
+			expectedHealthChecks: []*api.HealthCheck{
+				{
+					CheckID:     "default/mesh-gateway",
+					ServiceName: "mesh-gateway",
+					ServiceID:   "mesh-gateway",
+					Name:        consulKubernetesCheckName,
+					Status:      api.HealthPassing,
+					Output:      kubernetesSuccessReasonMsg,
+					Type:        consulKubernetesCheckType,
+				},
+			},
+			metricsEnabled: true,
+		},
+		{
+			name:                       "Mesh_Gateway_with_Metrics_enabled_and_telemetry_collector_disabled",
+			svcName:                    "mesh-gateway",
+			consulSvcName:              "mesh-gateway",
+			telemetryCollectorDisabled: true,
 			k8sObjects: func() []runtime.Object {
 				gateway := createGatewayPod("mesh-gateway", "1.2.3.4", map[string]string{
 					constants.AnnotationGatewayConsulServiceName: "mesh-gateway",
@@ -1362,7 +1438,8 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 					ServiceTags: []string{},
 					ServiceProxy: &api.AgentServiceConnectProxyConfig{
 						Config: map[string]interface{}{
-							"envoy_prometheus_bind_addr": "1.2.3.4:20200",
+							"envoy_prometheus_bind_addr":                "1.2.3.4:20200",
+							"envoy_telemetry_collector_bind_socket_dir": "/consul/service",
 						},
 					},
 				},
@@ -1462,6 +1539,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 									"address": "0.0.0.0",
 								},
 							},
+							"envoy_telemetry_collector_bind_socket_dir": "/consul/service",
 						},
 					},
 				},
@@ -1562,7 +1640,8 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 									"address": "0.0.0.0",
 								},
 							},
-							"envoy_prometheus_bind_addr": "1.2.3.4:20200",
+							"envoy_prometheus_bind_addr":                "1.2.3.4:20200",
+							"envoy_telemetry_collector_bind_socket_dir": "/consul/service",
 						},
 					},
 				},
@@ -1647,6 +1726,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 						DestinationServiceID:   "pod1-service-created",
 						LocalServiceAddress:    "",
 						LocalServicePort:       0,
+						Config:                 map[string]any{"envoy_telemetry_collector_bind_socket_dir": string("/consul/connect-inject")},
 					},
 					ServiceMeta: map[string]string{constants.MetaKeyPodName: "pod1", metaKeyKubeServiceName: "service-created", constants.MetaKeyKubeNS: "default", metaKeyManagedBy: constants.ManagedByValue, metaKeySyntheticNode: "true"},
 					ServiceTags: []string{},
@@ -1661,6 +1741,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 						DestinationServiceID:   "pod2-service-created",
 						LocalServiceAddress:    "",
 						LocalServicePort:       0,
+						Config:                 map[string]any{"envoy_telemetry_collector_bind_socket_dir": string("/consul/connect-inject")},
 					},
 					ServiceMeta: map[string]string{constants.MetaKeyPodName: "pod2", metaKeyKubeServiceName: "service-created", constants.MetaKeyKubeNS: "default", metaKeyManagedBy: constants.ManagedByValue, metaKeySyntheticNode: "true"},
 					ServiceTags: []string{},
@@ -1786,6 +1867,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 						DestinationServiceID:   "pod1-service-created",
 						LocalServiceAddress:    "",
 						LocalServicePort:       0,
+						Config:                 map[string]any{"envoy_telemetry_collector_bind_socket_dir": string("/consul/connect-inject")},
 					},
 					ServiceMeta: map[string]string{constants.MetaKeyPodName: "pod1", metaKeyKubeServiceName: "service-created", constants.MetaKeyKubeNS: "default", metaKeyManagedBy: constants.ManagedByValue, metaKeySyntheticNode: "true"},
 					ServiceTags: []string{},
@@ -1800,6 +1882,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 						DestinationServiceID:   "pod2-service-created",
 						LocalServiceAddress:    "",
 						LocalServicePort:       0,
+						Config:                 map[string]any{"envoy_telemetry_collector_bind_socket_dir": string("/consul/connect-inject")},
 					},
 					ServiceMeta: map[string]string{constants.MetaKeyPodName: "pod2", metaKeyKubeServiceName: "service-created", constants.MetaKeyKubeNS: "default", metaKeyManagedBy: constants.ManagedByValue, metaKeySyntheticNode: "true"},
 					ServiceTags: []string{},
@@ -1912,7 +1995,8 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 							},
 						},
 						Config: map[string]interface{}{
-							"envoy_prometheus_bind_addr": "0.0.0.0:12345",
+							"envoy_prometheus_bind_addr":                "0.0.0.0:12345",
+							"envoy_telemetry_collector_bind_socket_dir": "/consul/connect-inject",
 						},
 					},
 					ServiceMeta: map[string]string{
@@ -2013,6 +2097,7 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 						DestinationServiceID:   "pod1-service-created",
 						LocalServiceAddress:    "",
 						LocalServicePort:       0,
+						Config:                 map[string]any{"envoy_telemetry_collector_bind_socket_dir": string("/consul/connect-inject")},
 					},
 					ServiceMeta: map[string]string{constants.MetaKeyPodName: "pod1", metaKeyKubeServiceName: "service-created", constants.MetaKeyKubeNS: "default", metaKeyManagedBy: constants.ManagedByValue, metaKeySyntheticNode: "true"},
 					ServiceTags: []string{},
@@ -2072,6 +2157,9 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 					EnableGatewayMetrics: true,
 				}
 			}
+
+			ep.EnableTelemetryCollector = !tt.telemetryCollectorDisabled
+
 			namespacedName := types.NamespacedName{
 				Namespace: "default",
 				Name:      tt.svcName,

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
@@ -1165,7 +1165,9 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 							Port:    443,
 						},
 					},
-					ServiceProxy: &api.AgentServiceConnectProxyConfig{},
+					ServiceProxy: &api.AgentServiceConnectProxyConfig{
+						Config: map[string]any{"envoy_telemetry_collector_bind_socket_dir": string("/consul/service")},
+					},
 					NodeMeta: map[string]string{
 						"synthetic-node": "true",
 						"test-node":      "true",
@@ -1374,8 +1376,10 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 						metaKeyManagedBy:         constants.ManagedByValue,
 						metaKeySyntheticNode:     "true",
 					},
-					ServiceTags:  []string{},
-					ServiceProxy: &api.AgentServiceConnectProxyConfig{},
+					ServiceTags: []string{},
+					ServiceProxy: &api.AgentServiceConnectProxyConfig{
+						Config: map[string]any{"envoy_telemetry_collector_bind_socket_dir": string("/consul/service")},
+					},
 				},
 			},
 			expectedHealthChecks: []*api.HealthCheck{


### PR DESCRIPTION
Changes proposed in this PR:
- Check for nil on proxy config. It appears in Mesh Gateways , Terminating Gateways and Ingress Gateways if we do not enable metrics then we will not have a service proxy enabled

How I've tested this PR:
 - unit tested


How I expect reviewers to test this PR:


Checklist:
- [X] Tests added
- [] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

