### PR TITLE
Fix setting args for the telemetry-collector

### DIFF
--- a/charts/consul/templates/telemetry-collector-deployment.yaml
+++ b/charts/consul/templates/telemetry-collector-deployment.yaml
@@ -222,11 +222,10 @@ spec:
           {{- end }}
           {{- end }}
 
-          consul-telemetry-collector agent
-        {{- if .Values.telemetryCollector.customExporterConfig }}
-        args:
-        - -config-file-path /consul/config/config.json
-        {{ end }}
+          consul-telemetry-collector agent \
+          {{- if .Values.telemetryCollector.customExporterConfig }}
+          -config-file-path /consul/config/config.json \
+          {{ end }}
         volumeMounts:
           {{- if .Values.telemetryCollector.customExporterConfig }}
           - name: config

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -216,7 +216,7 @@ load _helpers
   local cmd=$(helm template \
       -s templates/connect-inject-deployment.yaml \
       --set 'connectInject.enabled=true' \
-      --set 'connectInject.metrics.enableTelemetryCollector=true' \
+      --set 'global.metrics.enableTelemetryCollector=true' \
       . | tee /dev/stderr |
       yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
 

--- a/charts/consul/test/unit/telemetry-collector-deployment.bats
+++ b/charts/consul/test/unit/telemetry-collector-deployment.bats
@@ -921,7 +921,7 @@ load _helpers
       --set 'telemetryCollector.image=bar' \
       --set 'telemetryCollector.customExporterConfig="foo"' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].args')
+      yq '.spec.template.spec.containers[0].command')
 
   local actual=$(echo $flags | yq -r '.  | any(contains("-config-file-path /consul/config/config.json"))')
   [ "${actual}" = "true" ]


### PR DESCRIPTION
Either the docker container or the execution method for the telemetry-collector is making the args not get included on the process. Switch to putting it directly in the command so we can ensure this works as expected

Changes proposed in this PR:
- Set the telemetry-collector args in the command field instead of the args field
- Change the unit test

How I've tested this PR:
[x] - manually
[x] - bats
How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

