### PR TITLE
Get consul-dataplane image from helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 VERSION = $(shell ./control-plane/build-support/scripts/version.sh control-plane/version/version.go)
 CONSUL_IMAGE_VERSION = $(shell ./control-plane/build-support/scripts/consul-version.sh charts/consul/values.yaml)
+CONSUL_DATAPLANE_IMAGE_VERSION = $(shell ./control-plane/build-support/scripts/consul-dataplane-version.sh charts/consul/values.yaml)
 
 # ===========> Helm Targets
 
@@ -163,6 +164,10 @@ version:
 
 consul-version:
 	@echo $(CONSUL_IMAGE_VERSION)
+
+consul-dataplane-version:
+	@echo $(CONSUL_DATAPLANE_IMAGE_VERSION)
+
 
 # ===========> Release Targets
 

--- a/control-plane/build-support/scripts/consul-dataplane-version.sh
+++ b/control-plane/build-support/scripts/consul-dataplane-version.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+FILE=$1
+VERSION=$(yq .global.imageConsulDataplane $FILE)
+
+echo "${VERSION}"


### PR DESCRIPTION
Changes proposed in this PR:
- This is similar to a make target I added last week for the consul-image
- We need this so that we can load the consul-dataplane image onto the Kind clusters and prevent dockerhub from throttling us.
- This will indirectly fix a bunch of Kind acceptance tests when I add the corresponding change to the workflows.

How I've tested this PR:

Ran 'make consul-dataplane-version'

How I expect reviewers to test this PR:

:eyes:

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

