### PR TITLE
Increase timeout and backoff for retry on flaky test

### DIFF
--- a/control-plane/subcommand/get-consul-client-ca/command_test.go
+++ b/control-plane/subcommand/get-consul-client-ca/command_test.go
@@ -203,9 +203,10 @@ func TestRun_ConsulServerAvailableLater(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	retrier := &retry.Timer{Timeout: 20 * time.Second, Wait: 1 * time.Second}
 	// get the actual ca cert from consul
 	var expectedCARoot string
-	retry.Run(t, func(r *retry.R) {
+	retry.RunWith(retrier, t, func(r *retry.R) {
 		roots, _, err := client.Agent().ConnectCARoots(nil)
 		require.NoError(r, err)
 		require.NotNil(r, roots)


### PR DESCRIPTION
Changes proposed in this PR:
- reduce flakiness of unit test with more retries with larger backoff.

How I've tested this PR:
Unit test improvement




Checklist:
- [X] Tests added


