### PR TITLE
Add fake demo/crds to get around that expectation in chart install

### DIFF
--- a/charts/demo/crds/blank
+++ b/charts/demo/crds/blank
@@ -1,0 +1,4 @@
+This is here purely so we can embed it so the HelmDeployment that references does not fail. Otherwise, at the time of writing, we get:
+
+==> Installing Consul demo application
+ ! open demo/crds: file does not exist

--- a/charts/demo/templates/intentions.yaml
+++ b/charts/demo/templates/intentions.yaml
@@ -59,6 +59,17 @@ spec:
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceIntentions
 metadata:
+  name: consul-telemetry-collector
+spec:
+  destination:
+    name: 'consul-telemetry-collector'
+  sources:
+    - name: '*'
+      action: allow
+---
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceIntentions
+metadata:
   name: deny-all
 spec:
   destination:

--- a/charts/embed_chart.go
+++ b/charts/embed_chart.go
@@ -15,9 +15,9 @@ import "embed"
 //
 // The embed directive does not include files with underscores unless explicitly listed, which is why _helpers.tpl is
 // explicitly embedded.
-//
+
 //go:embed consul/Chart.yaml consul/values.yaml consul/crds consul/templates consul/templates/_helpers.tpl
 var ConsulHelmChart embed.FS
 
-//go:embed demo/Chart.yaml demo/values.yaml demo/templates
+//go:embed demo/Chart.yaml demo/values.yaml demo/crds/blank demo/templates
 var DemoHelmChart embed.FS


### PR DESCRIPTION
Changes proposed in this PR:
- this adds a fake `demo/crds` directory for embedding so the install doesn't error out

How I've tested this PR:

```

==> Installing Consul demo application
 ✓ Downloaded charts.
 --> creating 1 resource(s)
 --> creating 32 resource(s)
 --> beginning wait for 32 resources with timeout of 10m0s
 ✓ Consul demo application installed in namespace "consul".

==> Accessing Consul Demo Application UI
    kubectl port-forward service/nginx 8080:80 --namespace consul
    Browse to http://localhost:8080.
```

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

