### PR TITLE
Update memory defaults for connect inject controller

### DIFF
--- a/.changelog/2249.txt
+++ b/.changelog/2249.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+helm: Update the default amount of memory used by the connect-inject controller so that its less likely to get OOM killed.
+```

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -960,7 +960,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -rc '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
-  [ "${actual}" = '{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"50m","memory":"50Mi"}}' ]
+  [ "${actual}" = '{"limits":{"cpu":"50m","memory":"200Mi"},"requests":{"cpu":"50m","memory":"200Mi"}}' ]
 }
 
 @test "connectInject/Deployment: can set resources" {

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -99,7 +99,7 @@ load _helpers
       -s templates/server-statefulset.yaml  \
       . | tee /dev/stderr |
       yq -rc '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
-  [ "${actual}" = '{"limits":{"cpu":"100m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}' ]
+  [ "${actual}" = '{"limits":{"cpu":"100m","memory":"200Mi"},"requests":{"cpu":"100m","memory":"200Mi"}}' ]
 }
 
 @test "server/StatefulSet: resources can be overridden" {

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2277,14 +2277,14 @@ connectInject:
     requests:
       # Recommended production default: 500Mi
       # @type: string
-      memory: "50Mi"
+      memory: "200Mi"
       # Recommended production default: 250m
       # @type: string
       cpu: "50m"
     limits:
       # Recommended production default: 500Mi
       # @type: string
-      memory: "50Mi"
+      memory: "200Mi"
       # Recommended production default: 250m
       # @type: string
       cpu: "50m"

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -808,10 +808,10 @@ server:
   # ```yaml
   # resources:
   #   requests:
-  #     memory: '100Mi'
+  #     memory: '200Mi'
   #     cpu: '100m'
   #   limits:
-  #     memory: '100Mi'
+  #     memory: '200Mi'
   #     cpu: '100m'
   # ```
   #
@@ -819,10 +819,10 @@ server:
   # @type: map
   resources:
     requests:
-      memory: "100Mi"
+      memory: "200Mi"
       cpu: "100m"
     limits:
-      memory: "100Mi"
+      memory: "200Mi"
       cpu: "100m"
 
   # The security context for the server pods. This should be a YAML map corresponding to a


### PR DESCRIPTION
Changes proposed in this PR:
We're [subscribing to a lot of resources](https://github.com/hashicorp/consul-k8s/blob/46055a324f8b1fcfb6e6debf95f5d059d7b50fe4/control-plane/api-gateway/controllers/gateway_controller.go#L341-L397) for API Gateways because of the complexity of what can trigger reconciliation due to the nature of distributed references within the spec. Running the controller on OpenShift got the controller OOM killed almost immediately. This gives the pod generally more headroom.

Marking as a draft for now to make sure that we verify that this is plenty of space for the controller.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

