### PR TITLE
api-gateway: create RoleBinding attaching Role to ServiceAccount

### DIFF
--- a/charts/consul/templates/connect-inject-clusterrole.yaml
+++ b/charts/consul/templates/connect-inject-clusterrole.yaml
@@ -72,7 +72,6 @@ rules:
   - watch
   - delete
   - update
-# TODO Can we gate this so that we're only granting when necessary?
 - apiGroups: [ "rbac.authorization.k8s.io" ]
   resources: [ "roles", "rolebindings" ]
   verbs:

--- a/charts/consul/templates/connect-inject-clusterrole.yaml
+++ b/charts/consul/templates/connect-inject-clusterrole.yaml
@@ -72,8 +72,9 @@ rules:
   - watch
   - delete
   - update
+# TODO Can we gate this so that we're only granting when necessary?
 - apiGroups: [ "rbac.authorization.k8s.io" ]
-  resources: [ "roles" ]
+  resources: [ "roles", "rolebindings" ]
   verbs:
   - get
   - list

--- a/control-plane/api-gateway/gatekeeper/deployment.go
+++ b/control-plane/api-gateway/gatekeeper/deployment.go
@@ -75,8 +75,8 @@ func (g *Gatekeeper) upsertDeployment(ctx context.Context, gateway gwv1beta1.Gat
 	return nil
 }
 
-func (g *Gatekeeper) deleteDeployment(ctx context.Context, nsname types.NamespacedName) error {
-	err := g.Client.Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}})
+func (g *Gatekeeper) deleteDeployment(ctx context.Context, gwName types.NamespacedName) error {
+	err := g.Client.Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: gwName.Name, Namespace: gwName.Namespace}})
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}

--- a/control-plane/api-gateway/gatekeeper/gatekeeper.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper.go
@@ -30,6 +30,7 @@ func New(log logr.Logger, client client.Client) *Gatekeeper {
 }
 
 // Upsert creates or updates the resources for handling routing of network traffic.
+// This is done in order based on dependencies between resources.
 func (g *Gatekeeper) Upsert(ctx context.Context, gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config common.HelmConfig) error {
 	g.Log.Info(fmt.Sprintf("Upsert Gateway Deployment %s/%s", gateway.Namespace, gateway.Name))
 

--- a/control-plane/api-gateway/gatekeeper/gatekeeper.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper.go
@@ -87,14 +87,14 @@ func (g *Gatekeeper) Delete(ctx context.Context, gatewayName types.NamespacedNam
 // resourceMutator is passed to create or update functions to mutate Kubernetes resources.
 type resourceMutator = func() error
 
-func (g Gatekeeper) namespacedName(gateway gwv1beta1.Gateway) types.NamespacedName {
+func (g *Gatekeeper) namespacedName(gateway gwv1beta1.Gateway) types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: gateway.Namespace,
 		Name:      gateway.Name,
 	}
 }
 
-func (g Gatekeeper) serviceAccountName(gateway gwv1beta1.Gateway, config common.HelmConfig) string {
+func (g *Gatekeeper) serviceAccountName(gateway gwv1beta1.Gateway, config common.HelmConfig) string {
 	if config.AuthMethod == "" {
 		return ""
 	}

--- a/control-plane/api-gateway/gatekeeper/role.go
+++ b/control-plane/api-gateway/gatekeeper/role.go
@@ -51,9 +51,9 @@ func (g *Gatekeeper) upsertRole(ctx context.Context, gateway gwv1beta1.Gateway, 
 	return nil
 }
 
-func (g *Gatekeeper) deleteRole(ctx context.Context, nsname types.NamespacedName) error {
+func (g *Gatekeeper) deleteRole(ctx context.Context, gwName types.NamespacedName) error {
 	// Delete the Role
-	if err := g.Client.Delete(ctx, &rbac.Role{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}}); err != nil {
+	if err := g.Client.Delete(ctx, &rbac.Role{ObjectMeta: metav1.ObjectMeta{Name: gwName.Name, Namespace: gwName.Namespace}}); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
@@ -61,7 +61,7 @@ func (g *Gatekeeper) deleteRole(ctx context.Context, nsname types.NamespacedName
 	}
 
 	// Delete the RoleBinding
-	if err := g.Client.Delete(ctx, &rbac.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}}); err != nil {
+	if err := g.Client.Delete(ctx, &rbac.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: gwName.Name, Namespace: gwName.Namespace}}); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}

--- a/control-plane/api-gateway/gatekeeper/role.go
+++ b/control-plane/api-gateway/gatekeeper/role.go
@@ -52,16 +52,7 @@ func (g *Gatekeeper) upsertRole(ctx context.Context, gateway gwv1beta1.Gateway, 
 }
 
 func (g *Gatekeeper) deleteRole(ctx context.Context, gwName types.NamespacedName) error {
-	// Delete the Role
 	if err := g.Client.Delete(ctx, &rbac.Role{ObjectMeta: metav1.ObjectMeta{Name: gwName.Name, Namespace: gwName.Namespace}}); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	// Delete the RoleBinding
-	if err := g.Client.Delete(ctx, &rbac.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: gwName.Name, Namespace: gwName.Namespace}}); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}

--- a/control-plane/api-gateway/gatekeeper/rolebinding.go
+++ b/control-plane/api-gateway/gatekeeper/rolebinding.go
@@ -66,7 +66,7 @@ func (g *Gatekeeper) deleteRoleBinding(ctx context.Context, gwName types.Namespa
 func (g *Gatekeeper) roleBinding(gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config common.HelmConfig) *rbac.RoleBinding {
 	// Create resources for reference. This avoids bugs if naming patterns change.
 	serviceAccount := g.serviceAccount(gateway)
-	role := g.role(gateway, gcc, config)
+	role := g.role(gateway, gcc)
 
 	return &rbac.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane/api-gateway/gatekeeper/rolebinding.go
+++ b/control-plane/api-gateway/gatekeeper/rolebinding.go
@@ -52,8 +52,8 @@ func (g *Gatekeeper) upsertRoleBinding(ctx context.Context, gateway gwv1beta1.Ga
 	return nil
 }
 
-func (g *Gatekeeper) deleteRoleBinding(ctx context.Context, nsname types.NamespacedName) error {
-	if err := g.Client.Delete(ctx, &rbac.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}}); err != nil {
+func (g *Gatekeeper) deleteRoleBinding(ctx context.Context, gwName types.NamespacedName) error {
+	if err := g.Client.Delete(ctx, &rbac.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: gwName.Name, Namespace: gwName.Namespace}}); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}

--- a/control-plane/api-gateway/gatekeeper/service.go
+++ b/control-plane/api-gateway/gatekeeper/service.go
@@ -53,8 +53,8 @@ func (g *Gatekeeper) upsertService(ctx context.Context, gateway gwv1beta1.Gatewa
 	return nil
 }
 
-func (g *Gatekeeper) deleteService(ctx context.Context, nsname types.NamespacedName) error {
-	if err := g.Client.Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}}); err != nil {
+func (g *Gatekeeper) deleteService(ctx context.Context, gwName types.NamespacedName) error {
+	if err := g.Client.Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: gwName.Name, Namespace: gwName.Namespace}}); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}

--- a/control-plane/api-gateway/gatekeeper/serviceaccount.go
+++ b/control-plane/api-gateway/gatekeeper/serviceaccount.go
@@ -58,8 +58,8 @@ func (g *Gatekeeper) upsertServiceAccount(ctx context.Context, gateway gwv1beta1
 	return nil
 }
 
-func (g *Gatekeeper) deleteServiceAccount(ctx context.Context, nsname types.NamespacedName) error {
-	if err := g.Client.Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: nsname.Name, Namespace: nsname.Namespace}}); err != nil {
+func (g *Gatekeeper) deleteServiceAccount(ctx context.Context, gwName types.NamespacedName) error {
+	if err := g.Client.Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: gwName.Name, Namespace: gwName.Namespace}}); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}


### PR DESCRIPTION
**Changes proposed in this PR:**
We create a `Role` and `ServiceAccount` for the api-gateway `Deployment` in certain scenarios; however, we do not create a `RoleBinding` to bind them together.

This is causing issues when deploying to OpenShift where the `ServiceAccount` needs a `SecurityContextConstraints` resource attached, and that chain needs to go:
SecurityContextConstraints => Role => RoleBinding => ServiceAccount

**How I've tested this PR:**
Deploy into K8s with system-managed ACLs enabled and verify that the `RoleBinding` is now created alongside the `Role`, `ServiceAccount`, etc.

**How I expect reviewers to test this PR:**
See above

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

