### PR TITLE
Allow API Gateways to bind to privileged ports

### DIFF
--- a/acceptance/tests/api-gateway/api_gateway_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_test.go
@@ -175,7 +175,7 @@ func TestAPIGateway_Basic(t *testing.T) {
 
 			// finally we check that we can actually route to the service via the gateway
 			k8sOptions := ctx.KubectlOptions(t)
-			targetAddress := fmt.Sprintf("http://%s:8080/", gatewayAddress)
+			targetAddress := fmt.Sprintf("http://%s/", gatewayAddress)
 
 			if c.secure {
 				// check that intentions keep our connection from happening

--- a/acceptance/tests/fixtures/bases/api-gateway/apigateway.yaml
+++ b/acceptance/tests/fixtures/bases/api-gateway/apigateway.yaml
@@ -9,19 +9,19 @@ spec:
   gatewayClassName: gateway-class
   listeners:
   - protocol: HTTP
-    port: 8080
+    port: 80
     name: http
     allowedRoutes:
       namespaces:
         from: "All"
   - protocol: TCP
-    port: 8081
+    port: 81
     name: tcp
     allowedRoutes:
       namespaces:
         from: "All"
   - protocol: HTTPS
-    port: 8082
+    port: 443
     name: https
     tls:
       certificateRefs:


### PR DESCRIPTION
Changes proposed in this PR:
Previously we weren't able to bind API gateways to privileged ports due to running as non-root users without proper linux capabilities in the context of the running container.

I attempted to just set the `NET_BIND_SERVICE` capability directly on the container while running as non-root, unfortunately this isn't supported due to how Docker passes off the ambient capability set to the underlying container when you're running non-root. So, the only real option is explicitly running as root and then dropping all privileges other than what we need, which is `NET_BIND_SERVICE`.

The only other alternative if we want to keep this to non-root users is for someone to configure every single one of their Kubernetes nodes (as in the host machines) with the unprivileged port range starting at 0 (i.e. running `sysctl net.ipv4.ip_unprivileged_port_start=0` on each host node) -- which doesn't seem realistic.

How I've tested this PR:
Modified our acceptance tests to use port 80 to test that the privileged port targeting/binding actually works.

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

