### PR TITLE
acceptance: extend api gateway lifecycle test retryCheck timeouts

### DIFF
--- a/acceptance/tests/api-gateway/api_gateway_lifecycle_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_lifecycle_test.go
@@ -196,7 +196,7 @@ func TestAPIGateway_Lifecycle(t *testing.T) {
 
 	// check that the route is unbound and all Consul objects and Kubernetes statuses are cleaned up
 	logger.Log(t, "checking that http route one is not bound to gateway two")
-	retryCheck(t, 10, func(r *retry.R) {
+	retryCheck(t, 30, func(r *retry.R) {
 		var route gwv1beta1.HTTPRoute
 		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: routeOneName, Namespace: defaultNamespace}, &route)
 		require.NoError(r, err)
@@ -246,7 +246,7 @@ func TestAPIGateway_Lifecycle(t *testing.T) {
 
 	// check that the Kubernetes gateway is cleaned up
 	logger.Log(t, "checking that gateway one is cleaned up in Kubernetes")
-	retryCheck(t, 10, func(r *retry.R) {
+	retryCheck(t, 30, func(r *retry.R) {
 		var route gwv1beta1.Gateway
 		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: controlledGatewayOneName, Namespace: defaultNamespace}, &route)
 		require.NoError(r, err)
@@ -299,7 +299,7 @@ func checkConsulNotExists(t *testing.T, client *api.Client, kind, name string, n
 		opts.Namespace = namespace[0]
 	}
 
-	retryCheck(t, 10, func(r *retry.R) {
+	retryCheck(t, 30, func(r *retry.R) {
 		_, _, err := client.ConfigEntries().Get(kind, name, opts)
 		require.Error(r, err)
 		require.EqualError(r, err, fmt.Sprintf("Unexpected response code: 404 (Config entry not found for %q / %q)", kind, name))
@@ -309,7 +309,7 @@ func checkConsulNotExists(t *testing.T, client *api.Client, kind, name string, n
 func checkConsulExists(t *testing.T, client *api.Client, kind, name string) {
 	t.Helper()
 
-	retryCheck(t, 10, func(r *retry.R) {
+	retryCheck(t, 30, func(r *retry.R) {
 		_, _, err := client.ConfigEntries().Get(kind, name, nil)
 		require.NoError(r, err)
 	})
@@ -318,7 +318,7 @@ func checkConsulExists(t *testing.T, client *api.Client, kind, name string) {
 func checkConsulRouteParent(t *testing.T, client *api.Client, name, parent string) {
 	t.Helper()
 
-	retryCheck(t, 10, func(r *retry.R) {
+	retryCheck(t, 30, func(r *retry.R) {
 		entry, _, err := client.ConfigEntries().Get(api.HTTPRoute, name, nil)
 		require.NoError(r, err)
 		route := entry.(*api.HTTPRouteConfigEntry)
@@ -331,7 +331,7 @@ func checkConsulRouteParent(t *testing.T, client *api.Client, name, parent strin
 func checkEmptyRoute(t *testing.T, client client.Client, name, namespace string) {
 	t.Helper()
 
-	retryCheck(t, 10, func(r *retry.R) {
+	retryCheck(t, 30, func(r *retry.R) {
 		var route gwv1beta1.HTTPRoute
 		err := client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: namespace}, &route)
 		require.NoError(r, err)
@@ -344,7 +344,7 @@ func checkEmptyRoute(t *testing.T, client client.Client, name, namespace string)
 func checkRouteBound(t *testing.T, client client.Client, name, namespace, parent string) {
 	t.Helper()
 
-	retryCheck(t, 10, func(r *retry.R) {
+	retryCheck(t, 30, func(r *retry.R) {
 		var route gwv1beta1.HTTPRoute
 		err := client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: namespace}, &route)
 		require.NoError(r, err)


### PR DESCRIPTION
To reduce the likelihood of flakes.

Changes proposed in this PR:
- Extend `retryCheck` timeouts in the API Gateway lifecycle acceptance test from 10s to 30s.

Checklist:
- [ ] ~~Tests added~~
- [ ] ~~CHANGELOG entry added~~
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

