### PR TITLE
api-gateway: nightly conformance test action

### DIFF
--- a/.github/workflows/nightly-api-gateway-conformance.yml
+++ b/.github/workflows/nightly-api-gateway-conformance.yml
@@ -1,0 +1,30 @@
+# Dispatch to the consul-k8s-workflows with a nightly cron
+name: nightly-api-gateway-conformance
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run nightly at 12AM UTC/8PM EST/5PM PST.
+    - cron:  '0 0 * * *'
+
+  push:
+    #TODO remove this trigger before merge just for testing
+
+# these should be the only settings that you will ever need to change
+env:
+  CONSUL_IMAGE: hashicorppreview/consul-enterprise:1.16-dev # Consul's enterprise version to use in tests
+  BRANCH: ${{ github.ref_name }}
+  CONTEXT: "nightly"
+
+jobs:
+  api-gateway-conformance:
+    name: api-gateway-conformance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1.2.2
+        name: conformance
+        with:
+          workflow: api-gateway-conformance.yml
+          repo: hashicorp/consul-k8s-workflows
+          ref: api-gateway-conformance-tests
+          token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          inputs: '{ "context":"${{ env.CONTEXT }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ github.sha }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'

--- a/.github/workflows/nightly-api-gateway-conformance.yml
+++ b/.github/workflows/nightly-api-gateway-conformance.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           workflow: api-gateway-conformance.yml
           repo: hashicorp/consul-k8s-workflows
-          ref: api-gateway-conformance-tests
+          ref: main
           token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
           inputs: '{ "context":"${{ env.CONTEXT }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ github.sha }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'

--- a/.github/workflows/nightly-api-gateway-conformance.yml
+++ b/.github/workflows/nightly-api-gateway-conformance.yml
@@ -6,8 +6,6 @@ on:
     # Run nightly at 12AM UTC/8PM EST/5PM PST.
     - cron:  '0 0 * * *'
 
-  push:
-    #TODO remove this trigger before merge just for testing
 
 # these should be the only settings that you will ever need to change
 env:


### PR DESCRIPTION
Changes proposed in this PR:
- Every night trigger API Gateway conformance test github action from consul-k8s-workflows
- Conformance tests will likely not pass in this current iteration, need to update conformance test target to latest


How I've tested this PR:
- CI action runs

How I expect reviewers to test this PR:
- CI Action runs

Checklist:
- [ X ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

