### PR TITLE
Fix Gateway trigger for when secret is modified

### DIFF
--- a/acceptance/tests/api-gateway/api_gateway_tenancy_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_tenancy_test.go
@@ -152,7 +152,7 @@ func TestAPIGateway_Tenancy(t *testing.T) {
 			checkConsulNotExists(t, consulClient, api.APIGateway, "gateway", namespaceForConsul(c.namespaceMirroring, gatewayNamespace))
 
 			// route failure
-			retryCheck(t, 10, func(r *retry.R) {
+			retryCheck(t, 30, func(r *retry.R) {
 				var httproute gwv1beta1.HTTPRoute
 				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "route", Namespace: routeNamespace}, &httproute)
 				require.NoError(r, err)
@@ -178,7 +178,7 @@ func TestAPIGateway_Tenancy(t *testing.T) {
 			createReferenceGrant(t, k8sClient, "route-service", routeNamespace, serviceNamespace)
 
 			// gateway updated with references allowed
-			retryCheck(t, 10, func(r *retry.R) {
+			retryCheck(t, 30, func(r *retry.R) {
 				var gateway gwv1beta1.Gateway
 				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "gateway", Namespace: gatewayNamespace}, &gateway)
 				require.NoError(r, err)
@@ -195,7 +195,7 @@ func TestAPIGateway_Tenancy(t *testing.T) {
 			})
 
 			// check the Consul gateway is updated, with the listener.
-			retryCheck(t, 10, func(r *retry.R) {
+			retryCheck(t, 30, func(r *retry.R) {
 				entry, _, err := consulClient.ConfigEntries().Get(api.APIGateway, "gateway", &api.QueryOptions{
 					Namespace: namespaceForConsul(c.namespaceMirroring, gatewayNamespace),
 				})
@@ -210,7 +210,7 @@ func TestAPIGateway_Tenancy(t *testing.T) {
 			})
 
 			// route updated with gateway and services allowed
-			retryCheck(t, 10, func(r *retry.R) {
+			retryCheck(t, 30, func(r *retry.R) {
 				var httproute gwv1beta1.HTTPRoute
 				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "route", Namespace: routeNamespace}, &httproute)
 				require.NoError(r, err)
@@ -225,7 +225,7 @@ func TestAPIGateway_Tenancy(t *testing.T) {
 			})
 
 			// now check to make sure that the route is updated and valid
-			retryCheck(t, 10, func(r *retry.R) {
+			retryCheck(t, 30, func(r *retry.R) {
 				// since we're not bound, check to make sure that the route doesn't target the gateway in Consul.
 				entry, _, err := consulClient.ConfigEntries().Get(api.HTTPRoute, "route", &api.QueryOptions{
 					Namespace: namespaceForConsul(c.namespaceMirroring, routeNamespace),
@@ -239,7 +239,7 @@ func TestAPIGateway_Tenancy(t *testing.T) {
 			})
 
 			// and check to make sure that the certificate exists
-			retryCheck(t, 10, func(r *retry.R) {
+			retryCheck(t, 30, func(r *retry.R) {
 				entry, _, err := consulClient.ConfigEntries().Get(api.InlineCertificate, "certificate", &api.QueryOptions{
 					Namespace: namespaceForConsul(c.namespaceMirroring, certificateNamespace),
 				})

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -452,11 +452,12 @@ func (r *GatewayController) transformSecret(ctx context.Context) func(o client.O
 		secret := o.(*corev1.Secret)
 		gatewayList := &gwv1beta1.GatewayList{}
 		if err := r.Client.List(ctx, gatewayList, &client.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector(Secret_GatewayIndex, secret.Name),
+			FieldSelector: fields.OneTermEqualSelector(Secret_GatewayIndex, client.ObjectKeyFromObject(secret).String()),
 		}); err != nil {
 			return nil
 		}
-		return common.ObjectsToReconcileRequests(pointersOf(gatewayList.Items))
+		requests := common.ObjectsToReconcileRequests(pointersOf(gatewayList.Items))
+		return requests
 	}
 }
 

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -456,8 +456,7 @@ func (r *GatewayController) transformSecret(ctx context.Context) func(o client.O
 		}); err != nil {
 			return nil
 		}
-		requests := common.ObjectsToReconcileRequests(pointersOf(gatewayList.Items))
-		return requests
+		return common.ObjectsToReconcileRequests(pointersOf(gatewayList.Items))
 	}
 }
 


### PR DESCRIPTION
Changes proposed in this PR:
The original lifecycle test looks like it was flaky (and rarely passes) due to a bug with fetching the proper gateways to reconcile when a referenced secret is updated. This fixes the indexing error that was causing that, so the Lifecycle tests should pass regularly now.

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

