### PR TITLE
Add allow all intention for consul-telemetry-collector for -demo

### DIFF
--- a/.changelog/2262.txt
+++ b/.changelog/2262.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: add consul-telemetry-gateway allow-all intention for -demo
+```

--- a/charts/demo/templates/intentions.yaml
+++ b/charts/demo/templates/intentions.yaml
@@ -56,6 +56,17 @@ spec:
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceIntentions
 metadata:
+  name: consul-telemetry-collector
+spec:
+  destination:
+    name: 'consul-telemetry-collector'
+  sources:
+    - name: '*'
+      action: allow
+---
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceIntentions
+metadata:
   name: deny-all
 spec:
   destination:


### PR DESCRIPTION
Changes proposed in this PR:
- This allowlists all traffic to consul-telemetry-collector for with using `consul-k8s -demo`

How I've tested this PR:
- Used this off main in yesterday's testing: https://github.com/hashicorp/consul-k8s/pull/2245

How I expect reviewers to test this PR:
```
export HCP_API_HOST=https://api.hcp.dev
export HCP_AUTH_URL=https://auth.idp.hcp.dev
export HCP_SCADA_ADDRESS=scada.internal.hcp.dev:7224

HCP_CLIENT_ID=x HCP_CLIENT_SECRET=y consul-k8s install -preset cloud -hcp-resource-id $RESOURCE_ID -demo \
	--set="global.enterpriseLicense.secretName=consul-license" \
	--set="global.enterpriseLicense.secretKey=key" \
	--set="global.image=hashicorp/consul:1.15.3" \
	--set="server.replicas=3" \
	--set="peering.enabled=true" \
	--set="meshGateway.enabled=true" \
	--set="meshGateway.service.type=ClusterIP" \
	--set="global.logLevel=debug" \
	--set="metrics.enableTelemetryCollector=true" \
	--set="global.imageConsulDataplane=hashicorppreview/consul-dataplane:1.1-dev" \
  --set="telemetryCollector.image=hashicorppreview/consul-telemetry-collector:0.0.0-dev"
```



Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

