### PR TITLE
Update casing of json tag for ServiceDefault field

### DIFF
--- a/.changelog/2266.txt
+++ b/.changelog/2266.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+control-plane: Fix casing of the Enforce Consecutive 5xx field on Service Defaults and acceptance test fixtures.
+```

--- a/acceptance/tests/fixtures/bases/crds-oss/servicedefaults.yaml
+++ b/acceptance/tests/fixtures/bases/crds-oss/servicedefaults.yaml
@@ -21,7 +21,7 @@ spec:
       passiveHealthCheck:
         interval: 1s
         maxFailures: 10
-        enforcing_consecutive_5xx: 60
+        enforcingConsecutive5xx: 60
         maxEjectionPercent: 100
         baseEjectionTime: 20s
     - name: "bar"

--- a/charts/consul/templates/crd-servicedefaults.yaml
+++ b/charts/consul/templates/crd-servicedefaults.yaml
@@ -292,7 +292,7 @@ spec:
                               capped by max_ejection_time (Default 300s). Defaults
                               to 30000ms or 30s.
                             type: string
-                          enforcing_consecutive_5xx:
+                          enforcingConsecutive5xx:
                             description: EnforcingConsecutive5xx is the % chance that
                               a host will be actually ejected when an outlier status
                               is detected through consecutive 5xx. This setting can
@@ -409,7 +409,7 @@ spec:
                                 is capped by max_ejection_time (Default 300s). Defaults
                                 to 30000ms or 30s.
                               type: string
-                            enforcing_consecutive_5xx:
+                            enforcingConsecutive5xx:
                               description: EnforcingConsecutive5xx is the % chance
                                 that a host will be actually ejected when an outlier
                                 status is detected through consecutive 5xx. This setting

--- a/control-plane/api/v1alpha1/servicedefaults_types.go
+++ b/control-plane/api/v1alpha1/servicedefaults_types.go
@@ -195,7 +195,7 @@ type PassiveHealthCheck struct {
 	// EnforcingConsecutive5xx is the % chance that a host will be actually ejected
 	// when an outlier status is detected through consecutive 5xx.
 	// This setting can be used to disable ejection or to ramp it up slowly.
-	EnforcingConsecutive5xx *uint32 `json:"enforcing_consecutive_5xx,omitempty"`
+	EnforcingConsecutive5xx *uint32 `json:"enforcingConsecutive5xx,omitempty"`
 	// The maximum % of an upstream cluster that can be ejected due to outlier detection.
 	// Defaults to 10% but will eject at least one host regardless of the value.
 	MaxEjectionPercent *uint32 `json:"maxEjectionPercent,omitempty"`

--- a/control-plane/config/crd/bases/consul.hashicorp.com_servicedefaults.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_servicedefaults.yaml
@@ -288,7 +288,7 @@ spec:
                               capped by max_ejection_time (Default 300s). Defaults
                               to 30000ms or 30s.
                             type: string
-                          enforcing_consecutive_5xx:
+                          enforcingConsecutive5xx:
                             description: EnforcingConsecutive5xx is the % chance that
                               a host will be actually ejected when an outlier status
                               is detected through consecutive 5xx. This setting can
@@ -405,7 +405,7 @@ spec:
                                 is capped by max_ejection_time (Default 300s). Defaults
                                 to 30000ms or 30s.
                               type: string
-                            enforcing_consecutive_5xx:
+                            enforcingConsecutive5xx:
                               description: EnforcingConsecutive5xx is the % chance
                                 that a host will be actually ejected when an outlier
                                 status is detected through consecutive 5xx. This setting


### PR DESCRIPTION
Changes proposed in this PR:
- Fix casing of the field `EnforcingConsecutive5xx` from snake case to camel case and fix the acceptance test fixtures as well.

How I've tested this PR:
- Acceptance tests.

How I expect reviewers to test this PR:
- Acceptance tests.

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

