### PR TITLE
api-gateway: add unit tests verifying scaling parameters on GatewayClassConfig are obeyed

### DIFF
--- a/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
@@ -210,7 +210,7 @@ func TestUpsert(t *testing.T) {
 				},
 			},
 		},
-		"create a new gateway where the GatewayClassConfig has a default number of instances greater than the maximum on the GatewayClassConfig": {
+		"create a new gateway where the GatewayClassConfig has a default number of instances greater than the max on the GatewayClassConfig": {
 			gateway: gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
@@ -245,7 +245,7 @@ func TestUpsert(t *testing.T) {
 				serviceAccounts: []*corev1.ServiceAccount{},
 			},
 		},
-		"create a new gateway where the GatewayClassConfig has a default number of instances lesser than the minimum on the GatewayClassConfig": {
+		"create a new gateway where the GatewayClassConfig has a default number of instances lesser than the min on the GatewayClassConfig": {
 			gateway: gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
@@ -479,7 +479,46 @@ func TestUpsert(t *testing.T) {
 				serviceAccounts: []*corev1.ServiceAccount{},
 			},
 		},
-		"update a gateway deployment by scaling it lower than the minimum number of instances on the GatewayClassConfig": {
+		"update a gateway deployment by scaling it when no min or max number of instances is defined on the GatewayClassConfig": {
+			gateway: gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: gwv1beta1.GatewaySpec{
+					Listeners: listeners,
+				},
+			},
+			gatewayClassConfig: v1alpha1.GatewayClassConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "consul-gatewayclassconfig",
+				},
+				Spec: v1alpha1.GatewayClassConfigSpec{
+					DeploymentSpec: v1alpha1.DeploymentSpec{
+						DefaultInstances: common.PointerTo(int32(3)),
+						MaxInstances:     nil,
+						MinInstances:     nil,
+					},
+					CopyAnnotations: v1alpha1.CopyAnnotationsSpec{},
+					ServiceType:     (*corev1.ServiceType)(common.PointerTo("NodePort")),
+				},
+			},
+			helmConfig: common.HelmConfig{},
+			initialResources: resources{
+				deployments: []*appsv1.Deployment{
+					configureDeployment(name, namespace, labels, 8, nil, nil, "", "1"),
+				},
+			},
+			finalResources: resources{
+				deployments: []*appsv1.Deployment{
+					configureDeployment(name, namespace, labels, 8, nil, nil, "", "1"),
+				},
+				roles:           []*rbac.Role{},
+				services:        []*corev1.Service{},
+				serviceAccounts: []*corev1.ServiceAccount{},
+			},
+		},
+		"update a gateway deployment by scaling it lower than the min number of instances on the GatewayClassConfig": {
 			gateway: gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
@@ -518,7 +557,7 @@ func TestUpsert(t *testing.T) {
 				serviceAccounts: []*corev1.ServiceAccount{},
 			},
 		},
-		"update a gateway deployment by scaling it higher than the maximum number of instances on the GatewayClassConfig": {
+		"update a gateway deployment by scaling it higher than the max number of instances on the GatewayClassConfig": {
 			gateway: gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,

--- a/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
@@ -210,6 +210,76 @@ func TestUpsert(t *testing.T) {
 				},
 			},
 		},
+		"create a new gateway where the GatewayClassConfig has a default number of instances greater than the maximum on the GatewayClassConfig": {
+			gateway: gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: gwv1beta1.GatewaySpec{
+					Listeners: listeners,
+				},
+			},
+			gatewayClassConfig: v1alpha1.GatewayClassConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "consul-gatewayclassconfig",
+				},
+				Spec: v1alpha1.GatewayClassConfigSpec{
+					DeploymentSpec: v1alpha1.DeploymentSpec{
+						DefaultInstances: common.PointerTo(int32(8)),
+						MaxInstances:     common.PointerTo(int32(5)),
+						MinInstances:     common.PointerTo(int32(2)),
+					},
+					CopyAnnotations: v1alpha1.CopyAnnotationsSpec{},
+					ServiceType:     (*corev1.ServiceType)(common.PointerTo("NodePort")),
+				},
+			},
+			helmConfig:       common.HelmConfig{},
+			initialResources: resources{},
+			finalResources: resources{
+				deployments: []*appsv1.Deployment{
+					configureDeployment(name, namespace, labels, 5, nil, nil, "", "1"),
+				},
+				roles:           []*rbac.Role{},
+				services:        []*corev1.Service{},
+				serviceAccounts: []*corev1.ServiceAccount{},
+			},
+		},
+		"create a new gateway where the GatewayClassConfig has a default number of instances lesser than the minimum on the GatewayClassConfig": {
+			gateway: gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: gwv1beta1.GatewaySpec{
+					Listeners: listeners,
+				},
+			},
+			gatewayClassConfig: v1alpha1.GatewayClassConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "consul-gatewayclassconfig",
+				},
+				Spec: v1alpha1.GatewayClassConfigSpec{
+					DeploymentSpec: v1alpha1.DeploymentSpec{
+						DefaultInstances: common.PointerTo(int32(1)),
+						MaxInstances:     common.PointerTo(int32(5)),
+						MinInstances:     common.PointerTo(int32(2)),
+					},
+					CopyAnnotations: v1alpha1.CopyAnnotationsSpec{},
+					ServiceType:     (*corev1.ServiceType)(common.PointerTo("NodePort")),
+				},
+			},
+			helmConfig:       common.HelmConfig{},
+			initialResources: resources{},
+			finalResources: resources{
+				deployments: []*appsv1.Deployment{
+					configureDeployment(name, namespace, labels, 2, nil, nil, "", "1"),
+				},
+				roles:           []*rbac.Role{},
+				services:        []*corev1.Service{},
+				serviceAccounts: []*corev1.ServiceAccount{},
+			},
+		},
 		"update a gateway, adding a listener to a service": {
 			gateway: gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -398,6 +468,84 @@ func TestUpsert(t *testing.T) {
 			initialResources: resources{
 				deployments: []*appsv1.Deployment{
 					configureDeployment(name, namespace, labels, 5, nil, nil, "", "1"),
+				},
+			},
+			finalResources: resources{
+				deployments: []*appsv1.Deployment{
+					configureDeployment(name, namespace, labels, 5, nil, nil, "", "1"),
+				},
+				roles:           []*rbac.Role{},
+				services:        []*corev1.Service{},
+				serviceAccounts: []*corev1.ServiceAccount{},
+			},
+		},
+		"update a gateway deployment by scaling it lower than the minimum number of instances on the GatewayClassConfig": {
+			gateway: gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: gwv1beta1.GatewaySpec{
+					Listeners: listeners,
+				},
+			},
+			gatewayClassConfig: v1alpha1.GatewayClassConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "consul-gatewayclassconfig",
+				},
+				Spec: v1alpha1.GatewayClassConfigSpec{
+					DeploymentSpec: v1alpha1.DeploymentSpec{
+						DefaultInstances: common.PointerTo(int32(3)),
+						MaxInstances:     common.PointerTo(int32(5)),
+						MinInstances:     common.PointerTo(int32(2)),
+					},
+					CopyAnnotations: v1alpha1.CopyAnnotationsSpec{},
+					ServiceType:     (*corev1.ServiceType)(common.PointerTo("NodePort")),
+				},
+			},
+			helmConfig: common.HelmConfig{},
+			initialResources: resources{
+				deployments: []*appsv1.Deployment{
+					configureDeployment(name, namespace, labels, 1, nil, nil, "", "1"),
+				},
+			},
+			finalResources: resources{
+				deployments: []*appsv1.Deployment{
+					configureDeployment(name, namespace, labels, 2, nil, nil, "", "1"),
+				},
+				roles:           []*rbac.Role{},
+				services:        []*corev1.Service{},
+				serviceAccounts: []*corev1.ServiceAccount{},
+			},
+		},
+		"update a gateway deployment by scaling it higher than the maximum number of instances on the GatewayClassConfig": {
+			gateway: gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: gwv1beta1.GatewaySpec{
+					Listeners: listeners,
+				},
+			},
+			gatewayClassConfig: v1alpha1.GatewayClassConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "consul-gatewayclassconfig",
+				},
+				Spec: v1alpha1.GatewayClassConfigSpec{
+					DeploymentSpec: v1alpha1.DeploymentSpec{
+						DefaultInstances: common.PointerTo(int32(3)),
+						MaxInstances:     common.PointerTo(int32(5)),
+						MinInstances:     common.PointerTo(int32(2)),
+					},
+					CopyAnnotations: v1alpha1.CopyAnnotationsSpec{},
+					ServiceType:     (*corev1.ServiceType)(common.PointerTo("NodePort")),
+				},
+			},
+			helmConfig: common.HelmConfig{},
+			initialResources: resources{
+				deployments: []*appsv1.Deployment{
+					configureDeployment(name, namespace, labels, 10, nil, nil, "", "1"),
 				},
 			},
 			finalResources: resources{


### PR DESCRIPTION
**Changes proposed in this PR:**
Add unit test coverage ensuring that `Deployment` for a `Gateway` has its replica count clamped to the min + max specified on the `GatewayClassConfig`.

**How I've tested this PR:**
🤖 tests pass

**How I expect reviewers to test this PR:**
See above

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

