### PR TITLE
Set release 1.1.x to dev mode for 1.1.3

### DIFF
--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: consul
-version: 1.1.2
-appVersion: 1.15.3
+version: 1.1.3-dev
+appVersion: 1.15-dev
 kubeVersion: ">=1.22.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
@@ -10,14 +10,14 @@ sources:
   - https://github.com/hashicorp/consul
   - https://github.com/hashicorp/consul-k8s
 annotations:
-  artifacthub.io/prerelease: false
+  artifacthub.io/prerelease: true
   artifacthub.io/images: |
     - name: consul
-      image: hashicorp/consul:1.15.3
+      image: docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.15-dev
     - name: consul-k8s-control-plane
-      image: hashicorp/consul-k8s-control-plane:1.1.2
+      image: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.1.3-dev
     - name: consul-dataplane
-      image: hashicorp/consul-dataplane:1.1.2
+      image: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.1-dev
     - name: envoy
       image: envoyproxy/envoy:v1.25.6
   artifacthub.io/license: MPL-2.0

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -63,7 +63,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.10.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: hashicorp/consul:1.15.3
+  image: docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.15-dev
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.
@@ -83,7 +83,7 @@ global:
   # image that is used for functionality such as catalog sync.
   # This can be overridden per component.
   # @default: hashicorp/consul-k8s-control-plane:<latest version>
-  imageK8S: hashicorp/consul-k8s-control-plane:1.1.2
+  imageK8S: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.1.3-dev
 
   # The name of the datacenter that the agents should
   # register as. This can't be changed once the Consul cluster is up and running
@@ -555,7 +555,7 @@ global:
   # The name (and tag) of the consul-dataplane Docker image used for the
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
   # @default: hashicorp/consul-dataplane:<latest supported version>
-  imageConsulDataplane: hashicorp/consul-dataplane:1.1.2
+  imageConsulDataplane: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.1-dev
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -14,12 +14,12 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
-	Version = "1.1.2"
+	Version = "1.1.3"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = ""
+	VersionPrerelease = "dev"
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable

--- a/control-plane/version/version.go
+++ b/control-plane/version/version.go
@@ -14,12 +14,12 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
-	Version = "1.1.2"
+	Version = "1.1.3"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = ""
+	VersionPrerelease = "dev"
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
Changes proposed in this PR:
- Set the release/1.1.x branch back to dev mode
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

