### PR TITLE
Fix changelog for 2194

### DIFF
--- a/.changelog/2194.txt
+++ b/.changelog/2194.txt
@@ -1,3 +1,3 @@
-```release-note:
+```release-note:bug
 crd: fix bug on service intentions CRD causing some updates to be ignored.
 ```


### PR DESCRIPTION
Changes proposed in this PR:
- I found this during release/1.1.2
- go-changelog doesn't work correctly if the changelog is missing a category.

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

