### PR TITLE
Fixing changelog for 2195

### DIFF
--- a/.changelog/2195.txt
+++ b/.changelog/2195.txt
@@ -1,3 +1,3 @@
-```release-note:imrpovement
+```release-note:improvement
 consul-telemetry-collector: add acceptance tests for consul telemetry collector component.
 ```


### PR DESCRIPTION
Changes proposed in this PR:
- Found during the release 1.1.2
- go-changelog didn't categorize this one

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

