### PR TITLE
[API Gateway] Add partition test

### DIFF
--- a/acceptance/tests/fixtures/bases/api-gateway/kustomization.yaml
+++ b/acceptance/tests/fixtures/bases/api-gateway/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - gatewayclass.yaml
   - apigateway.yaml
   - httproute.yaml
+  - meshservice.yaml

--- a/acceptance/tests/fixtures/bases/api-gateway/meshservice.yaml
+++ b/acceptance/tests/fixtures/bases/api-gateway/meshservice.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: MeshService
+metadata:
+  name: mesh-service
+spec:
+  name: static-server

--- a/acceptance/tests/fixtures/cases/api-gateways/mesh/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/api-gateways/mesh/kustomization.yaml
@@ -1,0 +1,5 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - proxydefaults.yaml

--- a/acceptance/tests/fixtures/cases/api-gateways/mesh/proxydefaults.yaml
+++ b/acceptance/tests/fixtures/cases/api-gateways/mesh/proxydefaults.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ProxyDefaults
+metadata:
+  name: global
+spec:
+  config:
+    protocol: http
+  meshGateway:
+    mode: local

--- a/acceptance/tests/fixtures/cases/api-gateways/resolver/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/api-gateways/resolver/kustomization.yaml
@@ -1,0 +1,5 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - serviceresolver.yaml

--- a/acceptance/tests/fixtures/cases/api-gateways/resolver/serviceresolver.yaml
+++ b/acceptance/tests/fixtures/cases/api-gateways/resolver/serviceresolver.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceResolver
+metadata:
+  name: static-server
+spec:
+  redirect:
+    partition: default
+    namespace: ns1
+    service: static-server

--- a/acceptance/tests/partitions/partitions_gateway_test.go
+++ b/acceptance/tests/partitions/partitions_gateway_test.go
@@ -35,7 +35,6 @@ func TestPartitions_Gateway(t *testing.T) {
 
 	const defaultPartition = "default"
 	const secondaryPartition = "secondary"
-	const defaultNamespace = "default"
 
 	defaultPartitionClusterContext := env.DefaultContext(t)
 	secondaryPartitionClusterContext := env.Context(t, environment.SecondaryContextName)

--- a/acceptance/tests/partitions/partitions_gateway_test.go
+++ b/acceptance/tests/partitions/partitions_gateway_test.go
@@ -1,0 +1,341 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package partitions
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	terratestk8s "github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// Test that Gateway works in a default and ACLsEnabled installations for X-Partition and in-partition networking.
+func TestPartitions_Gateway(t *testing.T) {
+	env := suite.Environment()
+	cfg := suite.Config()
+
+	if !cfg.EnableEnterprise {
+		t.Skipf("skipping this test because -enable-enterprise is not set")
+	}
+
+	const defaultPartition = "default"
+	const secondaryPartition = "secondary"
+	const defaultNamespace = "default"
+
+	defaultPartitionClusterContext := env.DefaultContext(t)
+	secondaryPartitionClusterContext := env.Context(t, environment.SecondaryContextName)
+
+	commonHelmValues := map[string]string{
+		"global.adminPartitions.enabled": "true",
+		"global.enableConsulNamespaces":  "true",
+		"global.logLevel":                "debug",
+
+		"global.tls.enabled":   "true",
+		"global.tls.httpsOnly": "true",
+
+		"global.acls.manageSystemACLs": "true",
+
+		"connectInject.enabled": "true",
+		// When mirroringK8S is set, this setting is ignored.
+		"connectInject.consulNamespaces.consulDestinationNamespace": staticServerNamespace,
+		"connectInject.consulNamespaces.mirroringK8S":               "true",
+
+		"meshGateway.enabled":  "true",
+		"meshGateway.replicas": "1",
+
+		"dns.enabled":           "true",
+		"dns.enableRedirection": strconv.FormatBool(cfg.EnableTransparentProxy),
+	}
+
+	defaultPartitionHelmValues := make(map[string]string)
+
+	// On Kind, there are no load balancers but since all clusters
+	// share the same node network (docker bridge), we can use
+	// a NodePort service so that we can access node(s) in a different Kind cluster.
+	if cfg.UseKind {
+		defaultPartitionHelmValues["meshGateway.service.type"] = "NodePort"
+		defaultPartitionHelmValues["meshGateway.service.nodePort"] = "30200" // todo: do we need to set this port?
+		defaultPartitionHelmValues["server.exposeService.type"] = "NodePort"
+		defaultPartitionHelmValues["server.exposeService.nodePort.https"] = "30000"
+		defaultPartitionHelmValues["server.exposeService.nodePort.grpc"] = "30100"
+	}
+
+	releaseName := helpers.RandomName()
+
+	helpers.MergeMaps(defaultPartitionHelmValues, commonHelmValues)
+
+	// Install the consul cluster with servers in the default kubernetes context.
+	serverConsulCluster := consul.NewHelmCluster(t, defaultPartitionHelmValues, defaultPartitionClusterContext, cfg, releaseName)
+	serverConsulCluster.Create(t)
+
+	// Get the TLS CA certificate and key secret from the server cluster and apply it to the client cluster.
+	caCertSecretName := fmt.Sprintf("%s-consul-ca-cert", releaseName)
+
+	logger.Logf(t, "retrieving ca cert secret %s from the server cluster and applying to the client cluster", caCertSecretName)
+	k8s.CopySecret(t, defaultPartitionClusterContext, secondaryPartitionClusterContext, caCertSecretName)
+
+	partitionToken := fmt.Sprintf("%s-consul-partitions-acl-token", releaseName)
+	logger.Logf(t, "retrieving partition token secret %s from the server cluster and applying to the client cluster", partitionToken)
+	k8s.CopySecret(t, defaultPartitionClusterContext, secondaryPartitionClusterContext, partitionToken)
+
+	partitionServiceName := fmt.Sprintf("%s-consul-expose-servers", releaseName)
+	partitionSvcAddress := k8s.ServiceHost(t, cfg, defaultPartitionClusterContext, partitionServiceName)
+
+	k8sAuthMethodHost := k8s.KubernetesAPIServerHost(t, cfg, secondaryPartitionClusterContext)
+
+	// Create client cluster.
+	secondaryPartitionHelmValues := map[string]string{
+		"global.enabled": "false",
+
+		"global.adminPartitions.name": secondaryPartition,
+
+		"global.tls.caCert.secretName": caCertSecretName,
+		"global.tls.caCert.secretKey":  "tls.crt",
+
+		"externalServers.enabled":       "true",
+		"externalServers.hosts[0]":      partitionSvcAddress,
+		"externalServers.tlsServerName": "server.dc1.consul",
+	}
+
+	// Setup partition token and auth method host since ACLs enabled.
+	secondaryPartitionHelmValues["global.acls.bootstrapToken.secretName"] = partitionToken
+	secondaryPartitionHelmValues["global.acls.bootstrapToken.secretKey"] = "token"
+	secondaryPartitionHelmValues["externalServers.k8sAuthMethodHost"] = k8sAuthMethodHost
+
+	if cfg.UseKind {
+		secondaryPartitionHelmValues["externalServers.httpsPort"] = "30000"
+		secondaryPartitionHelmValues["externalServers.grpcPort"] = "30100"
+		secondaryPartitionHelmValues["meshGateway.service.type"] = "NodePort"
+		secondaryPartitionHelmValues["meshGateway.service.nodePort"] = "30200"
+	}
+
+	helpers.MergeMaps(secondaryPartitionHelmValues, commonHelmValues)
+
+	// Install the consul cluster without servers in the client cluster kubernetes context.
+	clientConsulCluster := consul.NewHelmCluster(t, secondaryPartitionHelmValues, secondaryPartitionClusterContext, cfg, releaseName)
+	clientConsulCluster.Create(t)
+
+	defaultPartitionClusterStaticServerOpts := &terratestk8s.KubectlOptions{
+		ContextName: defaultPartitionClusterContext.KubectlOptions(t).ContextName,
+		ConfigPath:  defaultPartitionClusterContext.KubectlOptions(t).ConfigPath,
+		Namespace:   staticServerNamespace,
+	}
+	secondaryPartitionClusterStaticServerOpts := &terratestk8s.KubectlOptions{
+		ContextName: secondaryPartitionClusterContext.KubectlOptions(t).ContextName,
+		ConfigPath:  secondaryPartitionClusterContext.KubectlOptions(t).ConfigPath,
+		Namespace:   staticServerNamespace,
+	}
+	secondaryPartitionClusterStaticClientOpts := &terratestk8s.KubectlOptions{
+		ContextName: secondaryPartitionClusterContext.KubectlOptions(t).ContextName,
+		ConfigPath:  secondaryPartitionClusterContext.KubectlOptions(t).ConfigPath,
+		Namespace:   StaticClientNamespace,
+	}
+
+	logger.Logf(t, "creating namespaces %s and %s in servers cluster", staticServerNamespace, StaticClientNamespace)
+	k8s.RunKubectl(t, defaultPartitionClusterContext.KubectlOptions(t), "create", "ns", staticServerNamespace)
+	k8s.RunKubectl(t, defaultPartitionClusterContext.KubectlOptions(t), "create", "ns", StaticClientNamespace)
+	helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+		k8s.RunKubectl(t, defaultPartitionClusterContext.KubectlOptions(t), "delete", "ns", staticServerNamespace, StaticClientNamespace)
+	})
+
+	logger.Logf(t, "creating namespaces %s and %s in clients cluster", staticServerNamespace, StaticClientNamespace)
+	k8s.RunKubectl(t, secondaryPartitionClusterContext.KubectlOptions(t), "create", "ns", staticServerNamespace)
+	k8s.RunKubectl(t, secondaryPartitionClusterContext.KubectlOptions(t), "create", "ns", StaticClientNamespace)
+	helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+		k8s.RunKubectl(t, secondaryPartitionClusterContext.KubectlOptions(t), "delete", "ns", staticServerNamespace, StaticClientNamespace)
+	})
+
+	consulClient, _ := serverConsulCluster.SetupConsulClient(t, true)
+
+	serverQueryServerOpts := &api.QueryOptions{Namespace: staticServerNamespace, Partition: defaultPartition}
+	clientQueryServerOpts := &api.QueryOptions{Namespace: StaticClientNamespace, Partition: defaultPartition}
+
+	serverQueryClientOpts := &api.QueryOptions{Namespace: staticServerNamespace, Partition: secondaryPartition}
+	clientQueryClientOpts := &api.QueryOptions{Namespace: StaticClientNamespace, Partition: secondaryPartition}
+
+	// We need to register the cleanup function before we create the deployments
+	// because golang will execute them in reverse order i.e. the last registered
+	// cleanup function will be executed first.
+	t.Cleanup(func() {
+		retry.Run(t, func(r *retry.R) {
+			tokens, _, err := consulClient.ACL().TokenList(serverQueryServerOpts)
+			require.NoError(r, err)
+			for _, token := range tokens {
+				require.NotContains(r, token.Description, staticServerName)
+			}
+
+			tokens, _, err = consulClient.ACL().TokenList(clientQueryServerOpts)
+			require.NoError(r, err)
+			for _, token := range tokens {
+				require.NotContains(r, token.Description, StaticClientName)
+			}
+			tokens, _, err = consulClient.ACL().TokenList(serverQueryClientOpts)
+			require.NoError(r, err)
+			for _, token := range tokens {
+				require.NotContains(r, token.Description, staticServerName)
+			}
+
+			tokens, _, err = consulClient.ACL().TokenList(clientQueryClientOpts)
+			require.NoError(r, err)
+			for _, token := range tokens {
+				require.NotContains(r, token.Description, StaticClientName)
+			}
+		})
+	})
+
+	// Create a ProxyDefaults resource to configure services to use the mesh
+	// gateways.
+	logger.Log(t, "creating proxy-defaults config")
+	kustomizeDir := "../fixtures/cases/api-gateways/mesh"
+
+	k8s.KubectlApplyK(t, defaultPartitionClusterContext.KubectlOptions(t), kustomizeDir)
+	helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+		k8s.KubectlDeleteK(t, defaultPartitionClusterContext.KubectlOptions(t), kustomizeDir)
+	})
+
+	k8s.KubectlApplyK(t, secondaryPartitionClusterContext.KubectlOptions(t), kustomizeDir)
+	helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+		k8s.KubectlDeleteK(t, secondaryPartitionClusterContext.KubectlOptions(t), kustomizeDir)
+	})
+
+	// We use the static-client pod so that we can make calls to the api gateway
+	// via kubectl exec without needing a route into the cluster from the test machine.
+	// Since we're deploying the gateway in the secondary cluster, we create the static client
+	// in the secondary as well.
+	logger.Log(t, "creating static-client pod in secondary partition cluster")
+	k8s.DeployKustomize(t, secondaryPartitionClusterStaticClientOpts, cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/bases/static-client")
+
+	logger.Log(t, "creating api-gateway resources")
+	out, err := k8s.RunKubectlAndGetOutputE(t, secondaryPartitionClusterStaticServerOpts, "apply", "-k", "../fixtures/bases/api-gateway")
+	require.NoError(t, err, out)
+	helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+		// Ignore errors here because if the test ran as expected
+		// the custom resources will have been deleted.
+		k8s.RunKubectlAndGetOutputE(t, secondaryPartitionClusterStaticServerOpts, "delete", "-k", "../fixtures/bases/api-gateway")
+	})
+
+	// Grab a kubernetes client so that we can verify binding
+	// behavior prior to issuing requests through the gateway.
+	k8sClient := secondaryPartitionClusterContext.ControllerRuntimeClient(t)
+
+	// On startup, the controller can take upwards of 1m to perform
+	// leader election so we may need to wait a long time for
+	// the reconcile loop to run (hence the 1m timeout here).
+	var gatewayAddress string
+	counter := &retry.Counter{Count: 600, Wait: 2 * time.Second}
+	retry.RunWith(counter, t, func(r *retry.R) {
+		var gateway gwv1beta1.Gateway
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "gateway", Namespace: staticServerNamespace}, &gateway)
+		require.NoError(r, err)
+
+		// check that we have an address to use
+		require.Len(r, gateway.Status.Addresses, 1)
+		// now we know we have an address, set it so we can use it
+		gatewayAddress = gateway.Status.Addresses[0].Value
+	})
+
+	targetAddress := fmt.Sprintf("http://%s/", gatewayAddress)
+
+	// This section of the tests runs the in-partition networking tests.
+	t.Run("in-partition", func(t *testing.T) {
+		logger.Log(t, "test in-partition networking")
+		logger.Log(t, "creating target server in secondary partition cluster")
+		k8s.DeployKustomize(t, secondaryPartitionClusterStaticServerOpts, cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
+
+		logger.Log(t, "patching route to target server")
+		k8s.RunKubectl(t, secondaryPartitionClusterStaticServerOpts, "patch", "httproute", "http-route", "-p", `{"spec":{"rules":[{"backendRefs":[{"group":"consul.hashicorp.com","kind":"MeshService","name":"mesh-service","port":80}]}]}}`, "--type=merge")
+
+		logger.Log(t, "checking that the connection is not successful because there's no intention")
+		k8s.CheckStaticServerHTTPConnectionFailing(t, secondaryPartitionClusterStaticClientOpts, StaticClientName, targetAddress)
+
+		intention := &api.ServiceIntentionsConfigEntry{
+			Kind:      api.ServiceIntentions,
+			Name:      staticServerName,
+			Namespace: staticServerNamespace,
+			Sources: []*api.SourceIntention{
+				{
+					Name:      "gateway",
+					Namespace: staticServerNamespace,
+					Action:    api.IntentionActionAllow,
+				},
+			},
+		}
+
+		logger.Log(t, "creating intention")
+		_, _, err = consulClient.ConfigEntries().Set(intention, &api.WriteOptions{Partition: secondaryPartition})
+		require.NoError(t, err)
+		helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+			_, err = consulClient.ConfigEntries().Delete(api.ServiceIntentions, staticServerName, &api.WriteOptions{Partition: secondaryPartition})
+			require.NoError(t, err)
+		})
+
+		logger.Log(t, "checking that connection is successful")
+		k8s.CheckStaticServerConnectionSuccessful(t, secondaryPartitionClusterStaticClientOpts, StaticClientName, targetAddress)
+	})
+
+	// This section of the tests runs the cross-partition networking tests.
+	t.Run("cross-partition", func(t *testing.T) {
+		logger.Log(t, "test cross-partition networking")
+
+		logger.Log(t, "creating target server in default partition cluster")
+		k8s.DeployKustomize(t, defaultPartitionClusterStaticServerOpts, cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
+
+		logger.Log(t, "creating exported services")
+		k8s.KubectlApplyK(t, defaultPartitionClusterContext.KubectlOptions(t), "../fixtures/cases/crd-partitions/default-partition-ns1")
+		helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+			k8s.KubectlDeleteK(t, defaultPartitionClusterContext.KubectlOptions(t), "../fixtures/cases/crd-partitions/default-partition-ns1")
+		})
+
+		logger.Log(t, "creating local service resolver")
+		k8s.KubectlApplyK(t, secondaryPartitionClusterStaticServerOpts, "../fixtures/cases/api-gateways/resolver")
+		helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+			k8s.KubectlDeleteK(t, secondaryPartitionClusterStaticServerOpts, "../fixtures/cases/api-gateways/resolver")
+		})
+
+		logger.Log(t, "patching route to target server")
+		k8s.RunKubectl(t, secondaryPartitionClusterStaticServerOpts, "patch", "httproute", "http-route", "-p", `{"spec":{"rules":[{"backendRefs":[{"group":"consul.hashicorp.com","kind":"MeshService","name":"mesh-service","port":80}]}]}}`, "--type=merge")
+
+		logger.Log(t, "checking that the connection is not successful because there's no intention")
+		k8s.CheckStaticServerHTTPConnectionFailing(t, secondaryPartitionClusterStaticClientOpts, StaticClientName, targetAddress)
+
+		intention := &api.ServiceIntentionsConfigEntry{
+			Kind:      api.ServiceIntentions,
+			Name:      staticServerName,
+			Namespace: staticServerNamespace,
+			Sources: []*api.SourceIntention{
+				{
+					Name:      "gateway",
+					Namespace: staticServerNamespace,
+					Action:    api.IntentionActionAllow,
+					Partition: secondaryPartition,
+				},
+			},
+		}
+
+		logger.Log(t, "creating intention")
+		_, _, err = consulClient.ConfigEntries().Set(intention, &api.WriteOptions{Partition: defaultPartition})
+		require.NoError(t, err)
+		helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+			_, err = consulClient.ConfigEntries().Delete(api.ServiceIntentions, staticServerName, &api.WriteOptions{Partition: defaultPartition})
+			require.NoError(t, err)
+		})
+
+		logger.Log(t, "checking that connection is successful")
+		k8s.CheckStaticServerConnectionSuccessful(t, secondaryPartitionClusterStaticClientOpts, StaticClientName, targetAddress)
+	})
+}

--- a/control-plane/api-gateway/cache/consul.go
+++ b/control-plane/api-gateway/cache/consul.go
@@ -342,7 +342,7 @@ func (c *Cache) ensureRole(client *api.Client) (string, error) {
 
 	role := &api.ACLRole{
 		Name:        aclRoleName,
-		Description: fmt.Sprintf("ACL Role for Managed API Gateways"),
+		Description: "ACL Role for Managed API Gateways",
 		Policies:    []*api.ACLLink{{ID: policyID}},
 	}
 

--- a/control-plane/api-gateway/cache/consul.go
+++ b/control-plane/api-gateway/cache/consul.go
@@ -4,10 +4,12 @@
 package cache
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -18,6 +20,33 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/consul"
 	"github.com/hashicorp/consul-k8s/control-plane/namespaces"
 	"github.com/hashicorp/consul/api"
+)
+
+func init() {
+	gatewayTpl = template.Must(template.New("root").Parse(strings.TrimSpace(gatewayRulesTpl)))
+}
+
+type templateArgs struct {
+	EnableNamespaces bool
+}
+
+var (
+	gatewayTpl      *template.Template
+	gatewayRulesTpl = `
+mesh = "read"
+{{- if .EnableNamespaces }}
+  namespace_prefix "" {
+{{- end }}
+		node_prefix "" {
+			policy = "read"
+		}
+    service_prefix "" {
+      policy = "write"
+    }
+{{- if .EnableNamespaces }}
+	}
+{{- end }}
+`
 )
 
 const (
@@ -278,6 +307,66 @@ func (c *Cache) Write(ctx context.Context, entry api.ConfigEntry) error {
 	return nil
 }
 
+func (c *Cache) ensurePolicy(client *api.Client) (string, error) {
+	policy := c.gatewayPolicy()
+
+	created, _, err := client.ACL().PolicyCreate(&policy, &api.WriteOptions{})
+
+	if isPolicyExistsErr(err, policy.Name) {
+		existing, _, err := client.ACL().PolicyReadByName(policy.Name, &api.QueryOptions{})
+		if err != nil {
+			return "", err
+		}
+		return existing.ID, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return created.ID, nil
+}
+
+func (c *Cache) ensureRole(client *api.Client) (string, error) {
+	policyID, err := c.ensurePolicy(client)
+	if err != nil {
+		return "", err
+	}
+
+	aclRoleName := "managed-gateway-acl-role"
+	aclRole, _, err := client.ACL().RoleReadByName(aclRoleName, &api.QueryOptions{})
+	if err != nil {
+		return "", err
+	}
+	if aclRole != nil {
+		return aclRoleName, nil
+	}
+
+	role := &api.ACLRole{
+		Name:        aclRoleName,
+		Description: fmt.Sprintf("ACL Role for Managed API Gateways"),
+		Policies:    []*api.ACLLink{{ID: policyID}},
+	}
+
+	_, _, err = client.ACL().RoleCreate(role, &api.WriteOptions{})
+	return aclRoleName, err
+}
+
+func (c *Cache) gatewayPolicy() api.ACLPolicy {
+	var data bytes.Buffer
+	if err := gatewayTpl.Execute(&data, templateArgs{
+		EnableNamespaces: c.namespacesEnabled,
+	}); err != nil {
+		// just panic if we can't compile the simple template
+		// as it means something else is going severly wrong.
+		panic(err)
+	}
+
+	return api.ACLPolicy{
+		Name:        "api-gateway-token-policy",
+		Description: "API Gateway token Policy",
+		Rules:       data.String(),
+	}
+}
+
 // Get returns a config entry from the cache that corresponds to the given resource reference.
 func (c *Cache) Get(ref api.ResourceReference) api.ConfigEntry {
 	c.cacheMutex.Lock()
@@ -331,56 +420,42 @@ func (c *Cache) List(kind string) []api.ConfigEntry {
 	return refMap.Entries()
 }
 
-// LinkPolicy links a mesh write policy to a token associated with the service.
-func (c *Cache) LinkPolicy(ctx context.Context, name, namespace string) error {
+func (c *Cache) EnsureRoleBinding(authMethod, service, namespace string) error {
 	client, err := consul.NewClientFromConnMgr(c.config, c.serverMgr)
 	if err != nil {
 		return err
 	}
 
-	options := &api.QueryOptions{}
-
-	if c.namespacesEnabled {
-		options.Namespace = namespace
-	}
-
-	policies, _, err := client.ACL().PolicyList(options.WithContext(ctx))
+	role, err := c.ensureRole(client)
 	if err != nil {
 		return ignoreACLsDisabled(err)
 	}
 
-	links := []*api.ACLLink{}
-	for _, policy := range policies {
-		if strings.HasPrefix(policy.Name, "connect-inject-policy") {
-			links = append(links, &api.ACLLink{
-				Name: policy.Name,
-			})
-		}
+	bindingRule := &api.ACLBindingRule{
+		Description: fmt.Sprintf("Binding Rule for %s/%s", namespace, service),
+		AuthMethod:  authMethod,
+		Selector:    fmt.Sprintf("serviceaccount.name==%q and serviceaccount.namespace==%q", service, namespace),
+		BindType:    api.BindingRuleBindTypeRole,
+		BindName:    role,
 	}
 
-	tokens, _, err := client.ACL().TokenList(options.WithContext(ctx))
+	existingRules, _, err := client.ACL().BindingRuleList(authMethod, &api.QueryOptions{})
 	if err != nil {
-		return ignoreACLsDisabled(err)
+		return err
 	}
 
-	for _, token := range tokens {
-		for _, identity := range token.ServiceIdentities {
-			if identity.ServiceName == name {
-				token, _, err := client.ACL().TokenRead(token.AccessorID, options.WithContext(ctx))
-				if err != nil {
-					return ignoreACLsDisabled(err)
-				}
-				token.Policies = links
-
-				_, _, err = client.ACL().TokenUpdate(token, &api.WriteOptions{})
-				if err != nil {
-					return ignoreACLsDisabled(err)
-				}
-			}
+	for _, existingRule := range existingRules {
+		if existingRule.BindName == bindingRule.BindName && existingRule.Description == bindingRule.Description {
+			bindingRule.ID = existingRule.ID
 		}
 	}
 
-	return nil
+	if bindingRule.ID == "" {
+		_, _, err := client.ACL().BindingRuleCreate(bindingRule, &api.WriteOptions{})
+		return err
+	}
+	_, _, err = client.ACL().BindingRuleUpdate(bindingRule, &api.WriteOptions{})
+	return err
 }
 
 // Register registers a service in Consul.
@@ -410,8 +485,19 @@ func (c *Cache) Deregister(ctx context.Context, deregistration api.CatalogDeregi
 }
 
 func ignoreACLsDisabled(err error) error {
+	if err == nil {
+		return nil
+	}
 	if err.Error() == "Unexpected response code: 401 (ACL support disabled)" {
 		return nil
 	}
 	return err
+}
+
+// isPolicyExistsErr returns true if err is due to trying to call the
+// policy create API when the policy already exists.
+func isPolicyExistsErr(err error, policyName string) bool {
+	return err != nil &&
+		strings.Contains(err.Error(), "Unexpected response code: 500") &&
+		strings.Contains(err.Error(), fmt.Sprintf("Invalid Policy: A Policy with Name %q already exists", policyName))
 }

--- a/control-plane/api-gateway/common/labels.go
+++ b/control-plane/api-gateway/common/labels.go
@@ -6,6 +6,8 @@ package common
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -13,7 +15,7 @@ const (
 	nameLabel      = "gateway.consul.hashicorp.com/name"
 	namespaceLabel = "gateway.consul.hashicorp.com/namespace"
 	createdAtLabel = "gateway.consul.hashicorp.com/created"
-	managedLabel   = "gateway.consul.hashicorp.com/managed"
+	ManagedLabel   = "gateway.consul.hashicorp.com/managed"
 )
 
 // LabelsForGateway formats the default labels that appear on objects managed by the controllers.
@@ -22,6 +24,16 @@ func LabelsForGateway(gateway *gwv1beta1.Gateway) map[string]string {
 		nameLabel:      gateway.Name,
 		namespaceLabel: gateway.Namespace,
 		createdAtLabel: fmt.Sprintf("%d", gateway.CreationTimestamp.Unix()),
-		managedLabel:   "true",
+		ManagedLabel:   "true",
 	}
+}
+
+func GatewayFromPod(pod *corev1.Pod) (types.NamespacedName, bool) {
+	if pod.Labels[ManagedLabel] == "true" {
+		return types.NamespacedName{
+			Name:      pod.Labels[nameLabel],
+			Namespace: pod.Labels[namespaceLabel],
+		}, true
+	}
+	return types.NamespacedName{}, false
 }

--- a/control-plane/api-gateway/gatekeeper/dataplane.go
+++ b/control-plane/api-gateway/gatekeeper/dataplane.go
@@ -142,9 +142,6 @@ func getDataplaneArgs(namespace string, config common.HelmConfig, bearerTokenFil
 			"-login-bearer-token-path="+bearerTokenFile,
 			"-login-meta="+fmt.Sprintf("gateway=%s/%s", namespace, name),
 		)
-		if config.EnableNamespaces {
-			args = append(args, "-login-namespace="+consulNamespace)
-		}
 		if config.ConsulPartition != "" {
 			args = append(args, "-login-partition="+config.ConsulPartition)
 		}

--- a/control-plane/api-gateway/gatekeeper/init.go
+++ b/control-plane/api-gateway/gatekeeper/init.go
@@ -147,11 +147,6 @@ func initContainer(config common.HelmConfig, name, namespace string) (corev1.Con
 				Value: "pod=$(POD_NAMESPACE)/$(POD_NAME)",
 			})
 
-		container.Env = append(container.Env, corev1.EnvVar{
-			Name:  "CONSUL_LOGIN_NAMESPACE",
-			Value: consulNamespace,
-		})
-
 		if config.ConsulPartition != "" {
 			container.Env = append(container.Env, corev1.EnvVar{
 				Name:  "CONSUL_LOGIN_PARTITION",

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -500,7 +500,7 @@ func (c *Command) Run(args []string) int {
 			PeeringEnabled:             c.flagEnablePeering,
 			EnableOpenShift:            c.flagEnableOpenShift,
 			EnableNamespaceMirroring:   c.flagEnableK8SNSMirroring,
-			AuthMethod:                 c.flagACLAuthMethod,
+			AuthMethod:                 c.consul.ConsulLogin.AuthMethod,
 			LogLevel:                   c.flagLogLevel,
 			LogJSON:                    c.flagLogJSON,
 			TLSEnabled:                 c.consul.UseTLS,


### PR DESCRIPTION
Changes proposed in this PR:
This adds a test where a gateway targets a service in a separate partition using a combination of a MeshService CRD, a ServiceResolver, and an ExportedServices entry. It depends on https://github.com/hashicorp/consul/pull/17581 landing, as we had a bug in our core partition handling.

Additionally, I had to revamp the way that authentication was getting handled in deployed services with ACLs enabled.

How I've tested this PR:
Acceptance test passes.

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

