### PR TITLE
Remove extra logs for timeout error

### DIFF
--- a/control-plane/api-gateway/cache/consul.go
+++ b/control-plane/api-gateway/cache/consul.go
@@ -160,7 +160,11 @@ func (c *Cache) subscribeToConsul(ctx context.Context, kind string) {
 
 		entries, meta, err := client.ConfigEntries().List(kind, opts.WithContext(ctx))
 		if err != nil {
-			c.logger.Error(err, fmt.Sprintf("error fetching config entries for kind: %s", kind))
+			// if we timeout we don't care about the error message because it's expected to happen on long polls
+			// any other error we want to alert on
+			if !strings.Contains(strings.ToLower(err.Error()), "timeout") {
+				c.logger.Error(err, fmt.Sprintf("error fetching config entries for kind: %s", kind))
+			}
 			continue
 		}
 


### PR DESCRIPTION
Changes proposed in this PR:
- Swallow timeout errors on long polling for consul resources as they aren't actionable
-

How I've tested this PR:
Ran the code

How I expect reviewers to test this PR:
Read the code


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

