### PR TITLE
[API Gateway] Add Consul status to routes and gateways

### DIFF
--- a/acceptance/tests/api-gateway/api_gateway_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_test.go
@@ -110,6 +110,7 @@ func TestAPIGateway_Basic(t *testing.T) {
 
 				// check our statuses
 				checkStatusCondition(r, gateway.Status.Conditions, trueCondition("Accepted", "Accepted"))
+				checkStatusCondition(r, gateway.Status.Conditions, trueCondition("ConsulAccepted", "Accepted"))
 				require.Len(r, gateway.Status.Listeners, 3)
 				require.EqualValues(r, 1, gateway.Status.Listeners[0].AttachedRoutes)
 				checkStatusCondition(r, gateway.Status.Listeners[0].Conditions, trueCondition("Accepted", "Accepted"))
@@ -157,6 +158,7 @@ func TestAPIGateway_Basic(t *testing.T) {
 			require.EqualValues(t, "gateway", httproute.Status.Parents[0].ParentRef.Name)
 			checkStatusCondition(t, httproute.Status.Parents[0].Conditions, trueCondition("Accepted", "Accepted"))
 			checkStatusCondition(t, httproute.Status.Parents[0].Conditions, trueCondition("ResolvedRefs", "ResolvedRefs"))
+			checkStatusCondition(t, httproute.Status.Parents[0].Conditions, trueCondition("ConsulAccepted", "Accepted"))
 
 			// check that the Consul entries were created
 			entry, _, err := consulClient.ConfigEntries().Get(api.APIGateway, "gateway", nil)

--- a/control-plane/api-gateway/common/resources.go
+++ b/control-plane/api-gateway/common/resources.go
@@ -401,7 +401,7 @@ func (s *ResourceMap) gatewaysForRoute(namespace string, refs []gwv1beta1.Parent
 	return gateways
 }
 
-func (s *ResourceMap) TranslateAndMutateHTTPRoute(key types.NamespacedName, onUpdate func(error), mutateFn func(old *api.HTTPRouteConfigEntry, new api.HTTPRouteConfigEntry) api.HTTPRouteConfigEntry) {
+func (s *ResourceMap) TranslateAndMutateHTTPRoute(key types.NamespacedName, onUpdate func(error, api.ConfigEntryStatus), mutateFn func(old *api.HTTPRouteConfigEntry, new api.HTTPRouteConfigEntry) api.HTTPRouteConfigEntry) {
 	consulKey := NormalizeMeta(s.toConsulReference(api.HTTPRoute, key))
 
 	route, ok := s.httpRouteGateways[consulKey]
@@ -419,8 +419,10 @@ func (s *ResourceMap) TranslateAndMutateHTTPRoute(key types.NamespacedName, onUp
 			// to be GC'd.
 			delete(s.consulHTTPRoutes, consulKey)
 			s.consulMutations = append(s.consulMutations, &ConsulUpdateOperation{
-				Entry:    &mutated,
-				OnUpdate: onUpdate,
+				Entry: &mutated,
+				OnUpdate: func(err error) {
+					onUpdate(err, mutated.Status)
+				},
 			})
 		}
 		return
@@ -431,13 +433,15 @@ func (s *ResourceMap) TranslateAndMutateHTTPRoute(key types.NamespacedName, onUp
 		// to be GC'd.
 		delete(s.consulHTTPRoutes, consulKey)
 		s.consulMutations = append(s.consulMutations, &ConsulUpdateOperation{
-			Entry:    &mutated,
-			OnUpdate: onUpdate,
+			Entry: &mutated,
+			OnUpdate: func(err error) {
+				onUpdate(err, mutated.Status)
+			},
 		})
 	}
 }
 
-func (s *ResourceMap) MutateHTTPRoute(key types.NamespacedName, onUpdate func(error), mutateFn func(api.HTTPRouteConfigEntry) api.HTTPRouteConfigEntry) {
+func (s *ResourceMap) MutateHTTPRoute(key types.NamespacedName, onUpdate func(error, api.ConfigEntryStatus), mutateFn func(api.HTTPRouteConfigEntry) api.HTTPRouteConfigEntry) {
 	consulKey := NormalizeMeta(s.toConsulReference(api.HTTPRoute, key))
 
 	consulRoute, ok := s.consulHTTPRoutes[consulKey]
@@ -448,8 +452,10 @@ func (s *ResourceMap) MutateHTTPRoute(key types.NamespacedName, onUpdate func(er
 			// to be GC'd.
 			delete(s.consulHTTPRoutes, consulKey)
 			s.consulMutations = append(s.consulMutations, &ConsulUpdateOperation{
-				Entry:    &mutated,
-				OnUpdate: onUpdate,
+				Entry: &mutated,
+				OnUpdate: func(err error) {
+					onUpdate(err, mutated.Status)
+				},
 			})
 		}
 	}
@@ -462,12 +468,11 @@ func (s *ResourceMap) CanGCHTTPRouteOnUnbind(id api.ResourceReference) bool {
 	return true
 }
 
-func (s *ResourceMap) TranslateAndMutateTCPRoute(key types.NamespacedName, onUpdate func(error), mutateFn func(*api.TCPRouteConfigEntry, api.TCPRouteConfigEntry) api.TCPRouteConfigEntry) {
+func (s *ResourceMap) TranslateAndMutateTCPRoute(key types.NamespacedName, onUpdate func(error, api.ConfigEntryStatus), mutateFn func(*api.TCPRouteConfigEntry, api.TCPRouteConfigEntry) api.TCPRouteConfigEntry) {
 	consulKey := NormalizeMeta(s.toConsulReference(api.TCPRoute, key))
 
 	route, ok := s.tcpRouteGateways[consulKey]
 	if !ok {
-
 		return
 	}
 
@@ -481,8 +486,10 @@ func (s *ResourceMap) TranslateAndMutateTCPRoute(key types.NamespacedName, onUpd
 			// to be GC'd.
 			delete(s.consulTCPRoutes, consulKey)
 			s.consulMutations = append(s.consulMutations, &ConsulUpdateOperation{
-				Entry:    &mutated,
-				OnUpdate: onUpdate,
+				Entry: &mutated,
+				OnUpdate: func(err error) {
+					onUpdate(err, mutated.Status)
+				},
 			})
 		}
 		return
@@ -493,13 +500,15 @@ func (s *ResourceMap) TranslateAndMutateTCPRoute(key types.NamespacedName, onUpd
 		// to be GC'd.
 		delete(s.consulTCPRoutes, consulKey)
 		s.consulMutations = append(s.consulMutations, &ConsulUpdateOperation{
-			Entry:    &mutated,
-			OnUpdate: onUpdate,
+			Entry: &mutated,
+			OnUpdate: func(err error) {
+				onUpdate(err, mutated.Status)
+			},
 		})
 	}
 }
 
-func (s *ResourceMap) MutateTCPRoute(key types.NamespacedName, onUpdate func(error), mutateFn func(api.TCPRouteConfigEntry) api.TCPRouteConfigEntry) {
+func (s *ResourceMap) MutateTCPRoute(key types.NamespacedName, onUpdate func(error, api.ConfigEntryStatus), mutateFn func(api.TCPRouteConfigEntry) api.TCPRouteConfigEntry) {
 	consulKey := NormalizeMeta(s.toConsulReference(api.TCPRoute, key))
 
 	consulRoute, ok := s.consulTCPRoutes[consulKey]
@@ -510,8 +519,10 @@ func (s *ResourceMap) MutateTCPRoute(key types.NamespacedName, onUpdate func(err
 			// to be GC'd.
 			delete(s.consulTCPRoutes, consulKey)
 			s.consulMutations = append(s.consulMutations, &ConsulUpdateOperation{
-				Entry:    &mutated,
-				OnUpdate: onUpdate,
+				Entry: &mutated,
+				OnUpdate: func(err error) {
+					onUpdate(err, mutated.Status)
+				},
 			})
 		}
 	}


### PR DESCRIPTION
Changes proposed in this PR:
This adds the main status from a synchronized Consul ConfigEntry back into the Kubernetes object. This is helpful because there are some things that we just can't fully validate before sending off to Consul, for example, the protocol of the service that a route references that might result in a discovery chain error.

How I've tested this PR:
Added acceptance test criteria to validate the status gets set properly.

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

