### PR TITLE
Mw/fix pipeline 1 1 6

### DIFF
--- a/charts/consul/test/terraform/aks/main.tf
+++ b/charts/consul/test/terraform/aks/main.tf
@@ -1,8 +1,15 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+terraform {
+  required_providers {
+    azurerm = {
+      version = "3.40.0"
+    }
+  }
+}
+
 provider "azurerm" {
-  version = "3.40.0"
   features {}
 }
 

--- a/charts/consul/test/terraform/aks/main.tf
+++ b/charts/consul/test/terraform/aks/main.tf
@@ -48,7 +48,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   location                          = azurerm_resource_group.default[count.index].location
   resource_group_name               = azurerm_resource_group.default[count.index].name
   dns_prefix                        = "consul-k8s-${random_id.suffix[count.index].dec}"
-  kubernetes_version                = "1.24.6"
+  kubernetes_version                = "1.26"
   role_based_access_control_enabled = true
 
   // We're setting the network plugin and other network properties explicitly

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -61,7 +61,7 @@ module "eks" {
   kubeconfig_api_version = "client.authentication.k8s.io/v1beta1"
 
   cluster_name    = "consul-k8s-${random_id.suffix[count.index].dec}"
-  cluster_version = "1.23"
+  cluster_version = "1.26"
   subnets         = module.vpc[count.index].private_subnets
   enable_irsa     = true
 

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -1,9 +1,16 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 4.0.0"
+    }
+  }
+}
+
 provider "aws" {
-  version = ">= 2.28.1"
-  region  = var.region
+  region = var.region
 
   assume_role {
     role_arn = var.role_arn
@@ -28,7 +35,7 @@ resource "random_string" "suffix" {
 module "vpc" {
   count   = var.cluster_count
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.11.0"
+  version = "4.0.0"
 
   name = "consul-k8s-${random_id.suffix[count.index].dec}"
   # The cidr range needs to be unique in each VPC to allow setting up a peering connection.

--- a/charts/consul/test/terraform/gke/main.tf
+++ b/charts/consul/test/terraform/gke/main.tf
@@ -1,9 +1,16 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+terraform {
+  required_providers {
+    google = {
+      version = "~> 4.58.0"
+    }
+  }
+}
+
 provider "google" {
   project = var.project
-  version = "~> 4.58.0"
   zone    = var.zone
 }
 


### PR DESCRIPTION
Changes proposed in this PR:
- Updated cloud acceptance test terraform files to fix issues with nightly tests
- updated `main.tf` for gke, eks and aks to use the following block as the old way of setting provider version was deprecated:
```hcl
terraform {
  required_providers {
    aws = {
      version = ">= 4.0.0"
    }
  }
}
```
- Updated aks to latest supported K8s version
- Updated eks cluster to latest supported K8s version
- gke is still using 1.25, which I think is fine for now

How I've tested this PR:
- Manually trigger nightly test: https://github.com/hashicorp/consul-k8s-workflows/actions/runs/5193186962/jobs/9378714025

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

