### PR TITLE
Update alpine to 3.18 to fix CVE-2023-2650

### DIFF
--- a/.changelog/2284.txt
+++ b/.changelog/2284.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Resolves [CVE-2023-2650](https://github.com/advisories/GHSA-gqxg-9vfr-p9cg) vulnerability in openssl@3.0.8-r4
+```

--- a/.changelog/2284.txt
+++ b/.changelog/2284.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-Resolves [CVE-2023-2650](https://github.com/advisories/GHSA-gqxg-9vfr-p9cg) vulnerability in openssl@3.0.8-r4
+Bump Dockerfile base image to `alpine:3.18`. Resolves [CVE-2023-2650](https://github.com/advisories/GHSA-gqxg-9vfr-p9cg) vulnerability in openssl@3.0.8-r4
 ```

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@49f60
 # dev copies the binary from a local build
 # -----------------------------------
 # BIN_NAME is a requirement in the hashicorp docker github action 
-FROM alpine:3.17 AS dev
+FROM alpine:3.18 AS dev
 
 # NAME and VERSION are the name of the software in releases.hashicorp.com
 # and the version to download. Example: NAME=consul VERSION=1.2.3.
@@ -74,7 +74,7 @@ CMD /bin/${BIN_NAME}
 # We don't rebuild the software because we want the exact checksums and
 # binary signatures to match the software and our builds aren't fully
 # reproducible currently.
-FROM alpine:3.17 AS release-default
+FROM alpine:3.18 AS release-default
 
 ARG BIN_NAME=consul-k8s-control-plane
 ARG CNI_BIN_NAME=consul-cni


### PR DESCRIPTION
Changes proposed in this PR:
- Our security scanners reported:

>  » Dependency Scanner
    ⚠︎ found reported vulnerability CVE-2023-2650 from Alpine Linux's Security Issue Tracker in openssl@3.0.8-r4
        /lib/apk/db/installed:0:0

- Upgrading to alpine:3:18 fixes the issue.

How I've tested this PR:

Built the release-default image and scanned it:

Before:

> Scanned docker:{owner:"curtbushko"  name:"consul-k8s-control-plane-dev"}  tag:"scan" in 46.7s - found 1 result(s)
  » Dependency Scanner
    ⚠︎ found reported vulnerability CVE-2023-2650 from Alpine Linux's Security Issue Tracker in openssl@3.0.8-r4
        /lib/apk/db/installed:0:0
        
After:

> ✓ Scanned docker:{owner:"curtbushko"  name:"consul-k8s-control-plane-dev"}  tag:"scan" in 45s - no results found

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

