### PR TITLE
Add FIFO sortOrder to api-gateway Kustomization

### DIFF
--- a/acceptance/tests/fixtures/bases/api-gateway/kustomization.yaml
+++ b/acceptance/tests/fixtures/bases/api-gateway/kustomization.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+sortOptions:
+  order: fifo
 resources:
   - gatewayclassconfig.yaml
   - gatewayclass.yaml

--- a/acceptance/tests/fixtures/bases/api-gateway/kustomization.yaml
+++ b/acceptance/tests/fixtures/bases/api-gateway/kustomization.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-sortOptions:
-  order: fifo
 resources:
   - gatewayclassconfig.yaml
   - gatewayclass.yaml


### PR DESCRIPTION
Changes proposed in this PR:
- Added a sortOrder to the Kustomization for `api-gateway`. This solves an issue where randomly ordered deletion events would cause a deadlock.

NOTE: This may fail depending on the version of `kubectl` being used in CI. I'm not sure yet if I need to rev that. This was an easy way to check.

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

