### PR TITLE
[API Gateway] WAN Federation test and fixes

### DIFF
--- a/acceptance/tests/fixtures/cases/api-gateways/dc1-to-dc2-resolver/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/api-gateways/dc1-to-dc2-resolver/kustomization.yaml
@@ -1,0 +1,5 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - serviceresolver.yaml

--- a/acceptance/tests/fixtures/cases/api-gateways/dc1-to-dc2-resolver/serviceresolver.yaml
+++ b/acceptance/tests/fixtures/cases/api-gateways/dc1-to-dc2-resolver/serviceresolver.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceResolver
+metadata:
+  name: static-server
+spec:
+  redirect:
+    service: static-server
+    datacenter: dc2

--- a/acceptance/tests/fixtures/cases/api-gateways/dc2-to-dc1-resolver/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/api-gateways/dc2-to-dc1-resolver/kustomization.yaml
@@ -1,0 +1,5 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - serviceresolver.yaml

--- a/acceptance/tests/fixtures/cases/api-gateways/dc2-to-dc1-resolver/serviceresolver.yaml
+++ b/acceptance/tests/fixtures/cases/api-gateways/dc2-to-dc1-resolver/serviceresolver.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceResolver
+metadata:
+  name: static-server
+spec:
+  redirect:
+    service: static-server
+    datacenter: dc1

--- a/acceptance/tests/wan-federation/wan_federation_gateway_test.go
+++ b/acceptance/tests/wan-federation/wan_federation_gateway_test.go
@@ -1,0 +1,241 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package wanfederation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/serf/testutil/retry"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+func TestWANFederation_Gateway(t *testing.T) {
+	env := suite.Environment()
+	cfg := suite.Config()
+
+	if cfg.UseKind {
+		// the only way this test can currently run on kind, at least on a Mac, is via leveraging MetalLB, which
+		// isn't in CI, so we just skip for now.
+		t.Skipf("skipping wan federation tests as they currently fail on Kind even though they work on other clouds.")
+	}
+
+	primaryContext := env.DefaultContext(t)
+	secondaryContext := env.Context(t, environment.SecondaryContextName)
+
+	primaryHelmValues := map[string]string{
+		"global.datacenter": "dc1",
+
+		"global.tls.enabled":   "true",
+		"global.tls.httpsOnly": "true",
+
+		"global.federation.enabled":                "true",
+		"global.federation.createFederationSecret": "true",
+
+		"global.acls.manageSystemACLs":       "true",
+		"global.acls.createReplicationToken": "true",
+
+		"connectInject.enabled":  "true",
+		"connectInject.replicas": "1",
+
+		"meshGateway.enabled":  "true",
+		"meshGateway.replicas": "1",
+	}
+
+	releaseName := helpers.RandomName()
+
+	// Install the primary consul cluster in the default kubernetes context
+	primaryConsulCluster := consul.NewHelmCluster(t, primaryHelmValues, primaryContext, cfg, releaseName)
+	primaryConsulCluster.Create(t)
+
+	// Get the federation secret from the primary cluster and apply it to secondary cluster
+	federationSecretName := fmt.Sprintf("%s-consul-federation", releaseName)
+	logger.Logf(t, "retrieving federation secret %s from the primary cluster and applying to the secondary", federationSecretName)
+	federationSecret, err := primaryContext.KubernetesClient(t).CoreV1().Secrets(primaryContext.KubectlOptions(t).Namespace).Get(context.Background(), federationSecretName, metav1.GetOptions{})
+	require.NoError(t, err)
+	federationSecret.ResourceVersion = ""
+	_, err = secondaryContext.KubernetesClient(t).CoreV1().Secrets(secondaryContext.KubectlOptions(t).Namespace).Create(context.Background(), federationSecret, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	var k8sAuthMethodHost string
+	// When running on kind, the kube API address in kubeconfig will have a localhost address
+	// which will not work from inside the container. That's why we need to use the endpoints address instead
+	// which will point the node IP.
+	if cfg.UseKind {
+		// The Kubernetes AuthMethod host is read from the endpoints for the Kubernetes service.
+		kubernetesEndpoint, err := secondaryContext.KubernetesClient(t).CoreV1().Endpoints("default").Get(context.Background(), "kubernetes", metav1.GetOptions{})
+		require.NoError(t, err)
+		k8sAuthMethodHost = fmt.Sprintf("%s:%d", kubernetesEndpoint.Subsets[0].Addresses[0].IP, kubernetesEndpoint.Subsets[0].Ports[0].Port)
+	} else {
+		k8sAuthMethodHost = k8s.KubernetesAPIServerHostFromOptions(t, secondaryContext.KubectlOptions(t))
+	}
+
+	// Create secondary cluster
+	secondaryHelmValues := map[string]string{
+		"global.datacenter": "dc2",
+
+		"global.tls.enabled":           "true",
+		"global.tls.httpsOnly":         "false",
+		"global.acls.manageSystemACLs": "true",
+		"global.tls.caCert.secretName": federationSecretName,
+		"global.tls.caCert.secretKey":  "caCert",
+		"global.tls.caKey.secretName":  federationSecretName,
+		"global.tls.caKey.secretKey":   "caKey",
+
+		"global.federation.enabled": "true",
+
+		"server.extraVolumes[0].type":          "secret",
+		"server.extraVolumes[0].name":          federationSecretName,
+		"server.extraVolumes[0].load":          "true",
+		"server.extraVolumes[0].items[0].key":  "serverConfigJSON",
+		"server.extraVolumes[0].items[0].path": "config.json",
+
+		"connectInject.enabled":  "true",
+		"connectInject.replicas": "1",
+
+		"meshGateway.enabled":  "true",
+		"meshGateway.replicas": "1",
+
+		"global.acls.replicationToken.secretName": federationSecretName,
+		"global.acls.replicationToken.secretKey":  "replicationToken",
+		"global.federation.k8sAuthMethodHost":     k8sAuthMethodHost,
+		"global.federation.primaryDatacenter":     "dc1",
+	}
+
+	// Install the secondary consul cluster in the secondary kubernetes context
+	secondaryConsulCluster := consul.NewHelmCluster(t, secondaryHelmValues, secondaryContext, cfg, releaseName)
+	secondaryConsulCluster.Create(t)
+
+	primaryClient, _ := primaryConsulCluster.SetupConsulClient(t, true)
+	secondaryClient, _ := secondaryConsulCluster.SetupConsulClient(t, true)
+
+	// Verify federation between servers
+	logger.Log(t, "verifying federation was successful")
+	helpers.VerifyFederation(t, primaryClient, secondaryClient, releaseName, true)
+
+	// Create a ProxyDefaults resource to configure services to use the mesh
+	// gateways.
+	logger.Log(t, "creating proxy-defaults config in dc1")
+	kustomizeDir := "../fixtures/cases/api-gateways/mesh"
+	k8s.KubectlApplyK(t, primaryContext.KubectlOptions(t), kustomizeDir)
+	helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+		k8s.KubectlDeleteK(t, primaryContext.KubectlOptions(t), kustomizeDir)
+	})
+
+	// these clients are just there so we can exec in and curl on them.
+	logger.Log(t, "creating static-client in dc1")
+	k8s.DeployKustomize(t, primaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-multi-dc")
+
+	logger.Log(t, "creating static-client in dc2")
+	k8s.DeployKustomize(t, secondaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-multi-dc")
+
+	t.Run("from primary to secondary", func(t *testing.T) {
+		logger.Log(t, "creating static-server in dc2")
+		k8s.DeployKustomize(t, secondaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
+
+		logger.Log(t, "creating api-gateway resources in dc1")
+		out, err := k8s.RunKubectlAndGetOutputE(t, primaryContext.KubectlOptions(t), "apply", "-k", "../fixtures/bases/api-gateway")
+		require.NoError(t, err, out)
+		helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+			// Ignore errors here because if the test ran as expected
+			// the custom resources will have been deleted.
+			k8s.RunKubectlAndGetOutputE(t, primaryContext.KubectlOptions(t), "delete", "-k", "../fixtures/bases/api-gateway")
+		})
+
+		// create a service resolver for doing cross-dc redirects.
+		k8s.KubectlApplyK(t, secondaryContext.KubectlOptions(t), "../fixtures/cases/api-gateways/dc1-to-dc2-resolver")
+		helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+			k8s.KubectlDeleteK(t, secondaryContext.KubectlOptions(t), "../fixtures/cases/api-gateways/dc1-to-dc2-resolver")
+		})
+
+		// patching the route to target a MeshService since we don't have the corresponding Kubernetes service in this
+		// cluster.
+		k8s.RunKubectl(t, primaryContext.KubectlOptions(t), "patch", "httproute", "http-route", "-p", `{"spec":{"rules":[{"backendRefs":[{"group":"consul.hashicorp.com","kind":"MeshService","name":"mesh-service","port":80}]}]}}`, "--type=merge")
+
+		checkConnectivity(t, primaryContext, primaryClient)
+	})
+
+	t.Run("from secondary to primary", func(t *testing.T) {
+		// Check that we can connect services over the mesh gateways
+		logger.Log(t, "creating static-server in dc1")
+		k8s.DeployKustomize(t, primaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
+
+		logger.Log(t, "creating api-gateway resources in dc2")
+		out, err := k8s.RunKubectlAndGetOutputE(t, secondaryContext.KubectlOptions(t), "apply", "-k", "../fixtures/bases/api-gateway")
+		require.NoError(t, err, out)
+		helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+			// Ignore errors here because if the test ran as expected
+			// the custom resources will have been deleted.
+			k8s.RunKubectlAndGetOutputE(t, secondaryContext.KubectlOptions(t), "delete", "-k", "../fixtures/bases/api-gateway")
+		})
+
+		// create a service resolver for doing cross-dc redirects.
+		k8s.KubectlApplyK(t, secondaryContext.KubectlOptions(t), "../fixtures/cases/api-gateways/dc2-to-dc1-resolver")
+		helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
+			k8s.KubectlDeleteK(t, secondaryContext.KubectlOptions(t), "../fixtures/cases/api-gateways/dc2-to-dc1-resolver")
+		})
+
+		// patching the route to target a MeshService since we don't have the corresponding Kubernetes service in this
+		// cluster.
+		k8s.RunKubectl(t, secondaryContext.KubectlOptions(t), "patch", "httproute", "http-route", "-p", `{"spec":{"rules":[{"backendRefs":[{"group":"consul.hashicorp.com","kind":"MeshService","name":"mesh-service","port":80}]}]}}`, "--type=merge")
+
+		checkConnectivity(t, secondaryContext, primaryClient)
+	})
+}
+
+func checkConnectivity(t *testing.T, ctx environment.TestContext, client *api.Client) {
+	k8sClient := ctx.ControllerRuntimeClient(t)
+
+	// On startup, the controller can take upwards of 1m to perform
+	// leader election so we may need to wait a long time for
+	// the reconcile loop to run (hence the 1m timeout here).
+	var gatewayAddress string
+	counter := &retry.Counter{Count: 600, Wait: 2 * time.Second}
+	retry.RunWith(counter, t, func(r *retry.R) {
+		var gateway gwv1beta1.Gateway
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "gateway", Namespace: "default"}, &gateway)
+		require.NoError(r, err)
+
+		// check that we have an address to use
+		require.Len(r, gateway.Status.Addresses, 1)
+		// now we know we have an address, set it so we can use it
+		gatewayAddress = gateway.Status.Addresses[0].Value
+	})
+
+	targetAddress := fmt.Sprintf("http://%s/", gatewayAddress)
+
+	logger.Log(t, "checking that the connection is not successful because there's no intention")
+	k8s.CheckStaticServerHTTPConnectionFailing(t, ctx.KubectlOptions(t), StaticClientName, targetAddress)
+
+	logger.Log(t, "creating intention")
+	_, _, err := client.ConfigEntries().Set(&api.ServiceIntentionsConfigEntry{
+		Kind: api.ServiceIntentions,
+		Name: "static-server",
+		Sources: []*api.SourceIntention{
+			{
+				Name:   "gateway",
+				Action: api.IntentionActionAllow,
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	defer func() {
+		_, err := client.ConfigEntries().Delete(api.ServiceIntentions, "static-server", &api.WriteOptions{})
+		require.NoError(t, err)
+	}()
+
+	logger.Log(t, "checking that connection is successful")
+	k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), StaticClientName, targetAddress)
+}

--- a/control-plane/api-gateway/cache/consul_test.go
+++ b/control-plane/api-gateway/cache/consul_test.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 	"github.com/hashicorp/consul-k8s/control-plane/consul"
 	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 	"github.com/hashicorp/consul/api"
@@ -119,8 +120,10 @@ func Test_resourceCache_diff(t *testing.T) {
 						},
 					},
 					Hostnames: []string{"hostname.com"},
-					Meta:      map[string]string{},
-					Status:    api.ConfigEntryStatus{},
+					Meta: map[string]string{
+						constants.MetaKeyKubeName: "name",
+					},
+					Status: api.ConfigEntryStatus{},
 				},
 			})[api.HTTPRoute],
 			args: args{
@@ -203,8 +206,10 @@ func Test_resourceCache_diff(t *testing.T) {
 							},
 						},
 						Hostnames: []string{"hostname.com"},
-						Meta:      map[string]string{},
-						Status:    api.ConfigEntryStatus{},
+						Meta: map[string]string{
+							constants.MetaKeyKubeName: "name",
+						},
+						Status: api.ConfigEntryStatus{},
 					},
 				})[api.HTTPRoute],
 			},
@@ -291,8 +296,10 @@ func Test_resourceCache_diff(t *testing.T) {
 						},
 					},
 					Hostnames: []string{"hostname.com"},
-					Meta:      map[string]string{},
-					Status:    api.ConfigEntryStatus{},
+					Meta: map[string]string{
+						constants.MetaKeyKubeName: "name",
+					},
+					Status: api.ConfigEntryStatus{},
 				},
 				&api.HTTPRouteConfigEntry{
 					Kind: api.HTTPRoute,
@@ -372,8 +379,10 @@ func Test_resourceCache_diff(t *testing.T) {
 						},
 					},
 					Hostnames: []string{"hostname.com"},
-					Meta:      map[string]string{},
-					Status:    api.ConfigEntryStatus{},
+					Meta: map[string]string{
+						constants.MetaKeyKubeName: "name",
+					},
+					Status: api.ConfigEntryStatus{},
 				},
 			})[api.HTTPRoute],
 			args: args{
@@ -456,8 +465,10 @@ func Test_resourceCache_diff(t *testing.T) {
 							},
 						},
 						Hostnames: []string{"hostname.com"},
-						Meta:      map[string]string{},
-						Status:    api.ConfigEntryStatus{},
+						Meta: map[string]string{
+							constants.MetaKeyKubeName: "name",
+						},
+						Status: api.ConfigEntryStatus{},
 					},
 				})[api.HTTPRoute],
 			},
@@ -540,8 +551,10 @@ func Test_resourceCache_diff(t *testing.T) {
 						},
 					},
 					Hostnames: []string{"hostname.com"},
-					Meta:      map[string]string{},
-					Status:    api.ConfigEntryStatus{},
+					Meta: map[string]string{
+						constants.MetaKeyKubeName: "name",
+					},
+					Status: api.ConfigEntryStatus{},
 				},
 			},
 		},
@@ -626,8 +639,10 @@ func Test_resourceCache_diff(t *testing.T) {
 						},
 					},
 					Hostnames: []string{"hostname.com"},
-					Meta:      map[string]string{},
-					Status:    api.ConfigEntryStatus{},
+					Meta: map[string]string{
+						constants.MetaKeyKubeName: "name",
+					},
+					Status: api.ConfigEntryStatus{},
 				},
 			})[api.HTTPRoute],
 			args: args{
@@ -710,8 +725,10 @@ func Test_resourceCache_diff(t *testing.T) {
 							},
 						},
 						Hostnames: []string{"hostname.com"},
-						Meta:      map[string]string{},
-						Status:    api.ConfigEntryStatus{},
+						Meta: map[string]string{
+							constants.MetaKeyKubeName: "name",
+						},
+						Status: api.ConfigEntryStatus{},
 					},
 					&api.HTTPRouteConfigEntry{
 						Kind: api.HTTPRoute,
@@ -791,8 +808,10 @@ func Test_resourceCache_diff(t *testing.T) {
 							},
 						},
 						Hostnames: []string{"hostname.com"},
-						Meta:      map[string]string{},
-						Status:    api.ConfigEntryStatus{},
+						Meta: map[string]string{
+							constants.MetaKeyKubeName: "name",
+						},
+						Status: api.ConfigEntryStatus{},
 					},
 				})[api.HTTPRoute],
 			},
@@ -875,8 +894,10 @@ func Test_resourceCache_diff(t *testing.T) {
 						},
 					},
 					Hostnames: []string{"hostname.com"},
-					Meta:      map[string]string{},
-					Status:    api.ConfigEntryStatus{},
+					Meta: map[string]string{
+						constants.MetaKeyKubeName: "name",
+					},
+					Status: api.ConfigEntryStatus{},
 				},
 			},
 		},
@@ -962,8 +983,10 @@ func Test_resourceCache_diff(t *testing.T) {
 						},
 					},
 					Hostnames: []string{"hostname.com"},
-					Meta:      map[string]string{},
-					Status:    api.ConfigEntryStatus{},
+					Meta: map[string]string{
+						constants.MetaKeyKubeName: "name",
+					},
+					Status: api.ConfigEntryStatus{},
 				},
 			})[api.HTTPRoute],
 			args: args{
@@ -1047,8 +1070,10 @@ func Test_resourceCache_diff(t *testing.T) {
 							},
 						},
 						Hostnames: []string{"hostname.com"},
-						Meta:      map[string]string{},
-						Status:    api.ConfigEntryStatus{},
+						Meta: map[string]string{
+							constants.MetaKeyKubeName: "name",
+						},
+						Status: api.ConfigEntryStatus{},
 					},
 				})[api.HTTPRoute],
 			},
@@ -1132,8 +1157,10 @@ func Test_resourceCache_diff(t *testing.T) {
 						},
 					},
 					Hostnames: []string{"hostname.com"},
-					Meta:      map[string]string{},
-					Status:    api.ConfigEntryStatus{},
+					Meta: map[string]string{
+						constants.MetaKeyKubeName: "name",
+					},
+					Status: api.ConfigEntryStatus{},
 				},
 			},
 		},
@@ -1378,8 +1405,10 @@ func TestCache_Write(t *testing.T) {
 					},
 				},
 				Hostnames: []string{"hostname.com"},
-				Meta:      map[string]string{},
-				Status:    api.ConfigEntryStatus{},
+				Meta: map[string]string{
+					constants.MetaKeyKubeName: "name",
+				},
+				Status: api.ConfigEntryStatus{},
 			}
 
 			err = c.Write(context.Background(), entry)
@@ -1410,18 +1439,24 @@ func TestCache_Get(t *testing.T) {
 			want: &api.APIGatewayConfigEntry{
 				Kind: api.APIGateway,
 				Name: "api-gw",
-				Meta: map[string]string{},
+				Meta: map[string]string{
+					constants.MetaKeyKubeName: "name",
+				},
 			},
 			cache: loadedReferenceMaps([]api.ConfigEntry{
 				&api.APIGatewayConfigEntry{
 					Kind: api.APIGateway,
 					Name: "api-gw",
-					Meta: map[string]string{},
+					Meta: map[string]string{
+						constants.MetaKeyKubeName: "name",
+					},
 				},
 				&api.APIGatewayConfigEntry{
 					Kind: api.APIGateway,
 					Name: "api-gw-2",
-					Meta: map[string]string{},
+					Meta: map[string]string{
+						constants.MetaKeyKubeName: "name",
+					},
 				},
 			}),
 		},
@@ -1438,12 +1473,16 @@ func TestCache_Get(t *testing.T) {
 				&api.APIGatewayConfigEntry{
 					Kind: api.APIGateway,
 					Name: "api-gw",
-					Meta: map[string]string{},
+					Meta: map[string]string{
+						constants.MetaKeyKubeName: "name",
+					},
 				},
 				&api.APIGatewayConfigEntry{
 					Kind: api.APIGateway,
 					Name: "api-gw-2",
-					Meta: map[string]string{},
+					Meta: map[string]string{
+						constants.MetaKeyKubeName: "name",
+					},
 				},
 			}),
 		},
@@ -1460,7 +1499,9 @@ func TestCache_Get(t *testing.T) {
 				&api.HTTPRouteConfigEntry{
 					Kind: api.HTTPRoute,
 					Name: "route",
-					Meta: map[string]string{},
+					Meta: map[string]string{
+						constants.MetaKeyKubeName: "name",
+					},
 				},
 			}),
 		},
@@ -1766,7 +1807,8 @@ func setupHTTPRoutes() (*api.HTTPRouteConfigEntry, *api.HTTPRouteConfigEntry) {
 		},
 		Hostnames: []string{"hostname.com"},
 		Meta: map[string]string{
-			"metaKey": "metaVal",
+			"metaKey":                 "metaVal",
+			constants.MetaKeyKubeName: "name",
 		},
 		Status: api.ConfigEntryStatus{},
 	}
@@ -1849,7 +1891,8 @@ func setupHTTPRoutes() (*api.HTTPRouteConfigEntry, *api.HTTPRouteConfigEntry) {
 		},
 		Hostnames: []string{"hostname.com"},
 		Meta: map[string]string{
-			"metakey": "meta val",
+			"metakey":                 "meta val",
+			constants.MetaKeyKubeName: "name",
 		},
 	}
 	return routeOne, routeTwo
@@ -1860,7 +1903,8 @@ func setupGateway() *api.APIGatewayConfigEntry {
 		Kind: api.APIGateway,
 		Name: "api-gw",
 		Meta: map[string]string{
-			"metakey": "meta val",
+			"metakey":                 "meta val",
+			constants.MetaKeyKubeName: "name",
 		},
 		Listeners: []api.APIGatewayListener{
 			{
@@ -1891,7 +1935,8 @@ func setupTCPRoute() *api.TCPRouteConfigEntry {
 			},
 		},
 		Meta: map[string]string{
-			"metakey": "meta val",
+			"metakey":                 "meta val",
+			constants.MetaKeyKubeName: "name",
 		},
 		Status: api.ConfigEntryStatus{},
 	}
@@ -1904,7 +1949,8 @@ func setupInlineCertificate() *api.InlineCertificateConfigEntry {
 		Certificate: "cert",
 		PrivateKey:  "super secret",
 		Meta: map[string]string{
-			"metaKey": "meta val",
+			"metaKey":                 "meta val",
+			constants.MetaKeyKubeName: "name",
 		},
 	}
 }

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -46,6 +46,7 @@ type GatewayControllerConfig struct {
 	NamespacesEnabled       bool
 	CrossNamespaceACLPolicy string
 	Partition               string
+	Datacenter              string
 	AllowK8sNamespacesSet   mapset.Set
 	DenyK8sNamespacesSet    mapset.Set
 }
@@ -317,6 +318,7 @@ func SetupGatewayControllerWithManager(ctx context.Context, mgr ctrl.Manager, co
 		ConsulClientConfig:      config.ConsulClientConfig,
 		ConsulServerConnMgr:     config.ConsulServerConnMgr,
 		NamespacesEnabled:       config.NamespacesEnabled,
+		Datacenter:              config.Datacenter,
 		CrossNamespaceACLPolicy: config.CrossNamespaceACLPolicy,
 		Logger:                  mgr.GetLogger(),
 	}
@@ -332,13 +334,14 @@ func SetupGatewayControllerWithManager(ctx context.Context, mgr ctrl.Manager, co
 	r := &GatewayController{
 		Client:     mgr.GetClient(),
 		Log:        mgr.GetLogger(),
-		HelmConfig: config.HelmConfig,
+		HelmConfig: config.HelmConfig.Normalize(),
 		Translator: common.ResourceTranslator{
 			EnableConsulNamespaces: config.HelmConfig.EnableNamespaces,
 			ConsulDestNamespace:    config.HelmConfig.ConsulDestinationNamespace,
 			EnableK8sMirroring:     config.HelmConfig.EnableNamespaceMirroring,
 			MirroringPrefix:        config.HelmConfig.NamespaceMirroringPrefix,
 			ConsulPartition:        config.HelmConfig.ConsulPartition,
+			Datacenter:             config.Datacenter,
 		},
 		denyK8sNamespacesSet:  config.DenyK8sNamespacesSet,
 		allowK8sNamespacesSet: config.AllowK8sNamespacesSet,

--- a/control-plane/api/v1alpha1/serviceresolver_types.go
+++ b/control-plane/api/v1alpha1/serviceresolver_types.go
@@ -425,7 +425,7 @@ func (in *ServiceResolverRedirect) validate(path *field.Path, consulMeta common.
 			"service resolver redirect cannot be empty"))
 	}
 
-	if consulMeta.Partition != "default" && in.Datacenter != "" {
+	if consulMeta.Partition != "default" && consulMeta.Partition != "" && in.Datacenter != "" {
 		errs = append(errs, field.Invalid(path.Child("datacenter"), in.Datacenter,
 			"cross-datacenter redirect is only supported in the default partition"))
 	}

--- a/control-plane/connect-inject/constants/constants.go
+++ b/control-plane/connect-inject/constants/constants.go
@@ -19,6 +19,9 @@ const (
 	// MetaKeyKubeName is the meta key name for Kubernetes object name used for a Consul object.
 	MetaKeyKubeName = "k8s-name"
 
+	// MetaKeyDatacenter is the datacenter that this object was registered from.
+	MetaKeyDatacenter = "datacenter"
+
 	// MetaKeyKubeServiceName is the meta key name for Kubernetes service name used for the Consul services.
 	MetaKeyKubeServiceName = "k8s-service-name"
 

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -515,7 +515,9 @@ func (c *Command) Run(args []string) int {
 		NamespacesEnabled:       c.flagEnableNamespaces,
 		CrossNamespaceACLPolicy: c.flagCrossNamespaceACLPolicy,
 		Partition:               c.consul.Partition,
+		Datacenter:              c.consul.Datacenter,
 	})
+
 	if err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Gateway")
 		return 1


### PR DESCRIPTION
Changes proposed in this PR:
This adds a WAN federation acceptance test for API Gateways. A few fixes went into it:
1. We were disallowing ServiceResolver cross-DC redirects unless someone was explicitly in the default partition, but were only checking for "default" when an empty string means the same thing
2. We needed to normalize the auth method name that we use for our deployments so that we use the DC-local one that we attach our binding rules to.
3. Due to the way we watch and GC config entries, we needed to pass some additional metadata to ignore anything coming from a sync to a federated DC -- basically we were removing config entries if we didn't have the corresponding Kubernetes object backing them in our DC, when we shouldn't touch them because a corresponding Kubernetes object exists for them in another DC.

How I've tested this PR:
I tested this by running this locally on Kind with MetalLB installed so that the mesh gateways could find each other over WAN, but this doesn't typically work in a Kind setup, as the other acceptance test [mentions](https://github.com/hashicorp/consul-k8s/blob/644e02ea206fa4d28dcba34712fce00246ef655c/acceptance/tests/wan-federation/wan_federation_test.go#L47-L49), so it will be disabled for typical CI runs.

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

