### PR TITLE
Added logLevel field for components

### DIFF
--- a/charts/consul/templates/create-federation-secret-job.yaml
+++ b/charts/consul/templates/create-federation-secret-job.yaml
@@ -119,7 +119,7 @@ spec:
             - "-ec"
             - |
                 consul-k8s-control-plane create-federation-secret \
-                  -log-level={{ .Values.global.logLevel }} \
+                  -log-level={{ default .Values.global.logLevel .Values.global.federation.logLevel }} \
                   -log-json={{ .Values.global.logJSON }} \
                   {{- if (or .Values.global.gossipEncryption.autoGenerate (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey)) }}
                   -gossip-key-file=/consul/gossip/gossip.key \

--- a/charts/consul/templates/gossip-encryption-autogenerate-job.yaml
+++ b/charts/consul/templates/gossip-encryption-autogenerate-job.yaml
@@ -56,7 +56,7 @@ spec:
                 -namespace={{ .Release.Namespace }} \
                 -secret-name={{ template "consul.fullname" . }}-gossip-encryption-key \
                 -secret-key="key" \
-                -log-level={{ .Values.global.logLevel }} \
+                -log-level={{ default .Values.global.logLevel .Values.global.gossipEncryption.logLevel }} \
                 -log-json={{ .Values.global.logJSON }}
           resources:
             requests:

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -211,7 +211,7 @@ spec:
           -gateway-kind="ingress-gateway" \
           -proxy-id-file=/consul/service/proxy-id \
           -service-name={{ template "consul.fullname" $root }}-{{ .name }} \
-          -log-level={{ default $root.Values.global.logLevel }} \
+          -log-level={{ default $root.Values.global.logLevel $root.Values.ingressGateways.logLevel }} \
           -log-json={{ $root.Values.global.logJSON }}
         volumeMounts:
         - name: consul-service

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -161,7 +161,7 @@ spec:
            -gateway-kind="mesh-gateway" \
            -proxy-id-file=/consul/service/proxy-id \
            -service-name={{ .Values.meshGateway.consulServiceName }} \
-           -log-level={{ default .Values.global.logLevel }} \
+           -log-level={{ default .Values.global.logLevel .Values.meshGateway.logLevel }} \
            -log-json={{ .Values.global.logJSON }}
         volumeMounts:
         - name: consul-service

--- a/charts/consul/templates/server-acl-init-cleanup-job.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-job.yaml
@@ -57,7 +57,7 @@ spec:
             - consul-k8s-control-plane
           args:
             - delete-completed-job
-            - -log-level={{ .Values.global.logLevel }}
+            - -log-level={{ default .Values.global.logLevel .Values.server.logLevel }}
             - -log-json={{ .Values.global.logJSON }}
             - -k8s-namespace={{ .Release.Namespace }}
             - {{ template "consul.fullname" . }}-server-acl-init

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -161,7 +161,7 @@ spec:
           CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
           consul-k8s-control-plane server-acl-init \
-            -log-level={{ .Values.global.logLevel }} \
+            -log-level={{ default .Values.global.logLevel .Values.server.logLevel}} \
             -log-json={{ .Values.global.logJSON }} \
             -resource-prefix=${CONSUL_FULLNAME} \
             -k8s-namespace={{ .Release.Namespace }} \

--- a/charts/consul/templates/telemetry-collector-deployment.yaml
+++ b/charts/consul/templates/telemetry-collector-deployment.yaml
@@ -115,7 +115,7 @@ spec:
           - -ec
           - |-
             consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-              -log-level={{ default .Values.global.logLevel }} \
+              -log-level={{ default .Values.global.logLevel .Values.telemetryCollector.logLevel }} \
               -log-json={{ .Values.global.logJSON }} \
               -service-account-name="consul-telemetry-collector" \
               -service-name="" \

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -196,7 +196,7 @@ spec:
                   -gateway-kind="terminating-gateway" \
                   -proxy-id-file=/consul/service/proxy-id \
                   -service-name={{ .name }} \
-                  -log-level={{ default $root.Values.global.logLevel }} \
+                  -log-level={{ default $root.Values.global.logLevel $root.Values.terminatingGateways.logLevel }} \
                   -log-json={{ $root.Values.global.logJSON }}
           volumeMounts:
             - name: consul-service

--- a/charts/consul/templates/tls-init-job.yaml
+++ b/charts/consul/templates/tls-init-job.yaml
@@ -70,7 +70,7 @@ spec:
               # and use * at the start of the dns name when setting -additional-dnsname.
               set -o noglob
               consul-k8s-control-plane tls-init \
-                -log-level={{ .Values.global.logLevel }} \
+                -log-level={{ default .Values.global.logLevel .Values.server.logLevel }} \
                 -log-json={{ .Values.global.logJSON }} \
                 -domain={{ .Values.global.domain }} \
                 -days=730 \

--- a/charts/consul/test/unit/create-federation-secret-job.bats
+++ b/charts/consul/test/unit/create-federation-secret-job.bats
@@ -418,3 +418,41 @@ load _helpers
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# logLevel
+
+@test "createFederationSecret/Job: logLevel is not set by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/create-federation-secret-job.yaml  \
+      --set 'global.federation.enabled=true' \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.federation.createFederationSecret=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "createFederationSecret/Job: override the global.logLevel flag with global.federation.logLevel" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/create-federation-secret-job.yaml  \
+      --set 'global.federation.enabled=true' \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.federation.createFederationSecret=true' \
+      --set 'global.federation.logLevel=debug' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=debug"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/gossip-encryption-autogenerate-job.bats
+++ b/charts/consul/test/unit/gossip-encryption-autogenerate-job.bats
@@ -105,3 +105,33 @@ load _helpers
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# logLevel
+
+@test "gossipEncryptionAutogenerate/Job: uses the global.logLevel flag by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/gossip-encryption-autogenerate-job.yaml  \
+      --set 'global.gossipEncryption.autoGenerate=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "gossipEncryptionAutogenerate/Job: overrides the global.logLevel flag when global.gossipEncryption.logLevel is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/gossip-encryption-autogenerate-job.yaml  \
+      --set 'global.gossipEncryption.autoGenerate=true' \
+      --set 'global.gossipEncryption.logLevel=debug' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=debug"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/ingress-gateways-deployment.bats
+++ b/charts/consul/test/unit/ingress-gateways-deployment.bats
@@ -1504,3 +1504,35 @@ key2: value2' \
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# logLevel
+
+@test "ingressGateways/Deployment: use global.logLevel by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+  
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "ingressGateways/Deployment: override global.logLevel when ingressGateways.logLevel is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'ingressGateways.logLevel=warn' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+  
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=warn"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/mesh-gateway-deployment.bats
+++ b/charts/consul/test/unit/mesh-gateway-deployment.bats
@@ -1644,3 +1644,35 @@ key2: value2' \
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# logLevel
+
+@test "meshGateway/Deployment: use global.logLevel by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "meshGateway/Deployment: override global.logLevel when meshGateway.logLevel is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'meshGateway.logLevel=warn' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=warn"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/server-acl-init-cleanup-job.bats
+++ b/charts/consul/test/unit/server-acl-init-cleanup-job.bats
@@ -159,3 +159,33 @@ load _helpers
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# logLevel
+
+@test "serverACLInitCleanup/Job: use global.logLevel by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/server-acl-init-cleanup-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].args' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInitCleanup/Job: override global.logLevel when server.logLevel is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/server-acl-init-cleanup-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'server.logLevel=debug' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].args' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=debug"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -2202,3 +2202,33 @@ load _helpers
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# logLevel
+
+@test "serverACLInit/Job: use global.logLevel by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/server-acl-init-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: override global.logLevel when server.logLevel is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/server-acl-init-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'server.logLevel=debug' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=debug"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/telemetry-collector-deployment.bats
+++ b/charts/consul/test/unit/telemetry-collector-deployment.bats
@@ -1074,3 +1074,33 @@ MIICFjCCAZsCCQCdwLtdjbzlYzAKBggqhkjOPQQDAjB0MQswCQYDVQQGEwJDQTEL' \
       yq -r 'map(select(.name == "foo")) | .[0].value' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 }
+
+#--------------------------------------------------------------------
+# logLevel
+
+@test "telemetryCollector/Deployment: use global.logLevel by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/telemetry-collector-deployment.yaml \
+      --set 'telemetryCollector.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "telemetryCollector/Deployment: override global.logLevel when telemetryCollector.logLevel is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/telemetry-collector-deployment.yaml \
+      --set 'telemetryCollector.enabled=true' \
+      --set 'telemetryCollector.logLevel=warn' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=warn"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -1504,3 +1504,35 @@ key2: value2' \
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# logLevel
+
+@test "terminatingGateways/Deployment: use global.logLevel by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "terminatingGateways/Deployment: override global.logLevel when terminatingGateways.logLevel is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'terminatingGateways.logLevel=debug' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/tls-init-job.bats
+++ b/charts/consul/test/unit/tls-init-job.bats
@@ -207,3 +207,33 @@ load _helpers
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# logLevel
+
+@test "tlsInit/Job: use global.logLevel by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/tls-init-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "tlsInit/Job: override global.logLevel when server.logLevel is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/tls-init-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'server.logLevel=error' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=error"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -289,6 +289,9 @@ global:
     # The key within the Kubernetes secret or Vault secret key that holds the gossip
     # encryption key.
     secretKey: ""
+    # Override global log verbosity level for gossip-encryption-autogenerate-job pods. One of "debug", "info", "warn", or "error".
+    # @type: string
+    logLevel: ""
 
   # A list of addresses of upstream DNS servers that are used to recursively resolve DNS queries.
   # These values are given as `-recursor` flags to Consul servers and clients.
@@ -523,6 +526,10 @@ global:
     # @type: string
     k8sAuthMethodHost: null
 
+    # Override global log verbosity level for the create-federation-secret-job pods. One of "debug", "info", "warn", or "error".
+    # @type: string
+    logLevel: ""
+
   # Configures metrics for Consul service mesh
   metrics:
     # Configures the Helm chart’s components
@@ -675,6 +682,10 @@ server:
   # @default: global.enabled
   # @type: boolean
   enabled: "-"
+
+  # Override global log verbosity level. One of "debug", "info", "warn", or "error".
+  # @type: string
+  logLevel: ""
 
   # The name of the Docker image (including any tag) for the containers running
   # Consul server agents.
@@ -2503,6 +2514,10 @@ meshGateway:
   # Requirements: consul 1.6.0+ if using `global.acls.manageSystemACLs``.
   enabled: false
 
+  # Override global log verbosity level for mesh-gateway-deployment pods. One of "debug", "info", "warn", or "error".
+  # @type: string
+  logLevel: ""
+
   # Number of replicas for the Deployment.
   replicas: 1
 
@@ -2715,6 +2730,10 @@ ingressGateways:
   # Enable ingress gateway deployment. Requires `connectInject.enabled=true`.
   enabled: false
 
+  # Override global log verbosity level for ingress-gateways-deployment pods. One of "debug", "info", "warn", or "error".
+  # @type: string
+  logLevel: ""
+
   # Defaults sets default values for all gateway fields. With the exception
   # of annotations, defining any of these values in the `gateways` list
   # will override the default values provided here. Annotations will
@@ -2880,6 +2899,10 @@ ingressGateways:
 terminatingGateways:
   # Enable terminating gateway deployment. Requires `connectInject.enabled=true`.
   enabled: false
+
+  # Override global log verbosity level. One of "debug", "info", "warn", or "error".
+  # @type: string
+  logLevel: ""
 
   # Defaults sets default values for all gateway fields. With the exception
   # of annotations, defining any of these values in the `gateways` list
@@ -3218,6 +3241,10 @@ telemetryCollector:
   # Enables the consul-telemetry-collector deployment
   # @type: boolean
   enabled: false
+
+  # Override global log verbosity level. One of "debug", "info", "warn", or "error".
+  # @type: string
+  logLevel: ""
 
   # The name of the Docker image (including any tag) for the containers running
   # the consul-telemetry-collector


### PR DESCRIPTION
Changes proposed in this PR:

This PR is aimed at fixing https://github.com/hashicorp/consul-k8s/issues/1256. I've added the `logLevel` attribute to certain low level components which could be used to override the `global.logLevel` flag. This gives users fine grained control over setting logLevels for individual components. For example, `ingressGateways.logLevel` is introduced to override `global.logLevel` within ingress gateway specific kube manifests.

To make it a non breaking change, I have assigned an empty string as the default value for the newly introduced logLevel fields. 

How I've tested this PR:

- Unit tests
- CI

How I expect reviewers to test this PR:


Checklist:
- [X] Tests added
- [X] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

