### PR TITLE
Mw/net 3598 update kind for consul k8s acceptance tests with latest version of kind and k8s 1.27

### DIFF
--- a/.changelog/2304.txt
+++ b/.changelog/2304.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+helm: Kubernetes v1.27 is now supported. Minimum tested version of Kubernetes is now v1.24.
+```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
 
 The following pre-requisites must be met before installing Consul on Kubernetes. 
 
-  * **Kubernetes 1.23.x - 1.26.x** - This represents the earliest versions of Kubernetes tested.
+  * **Kubernetes 1.24.x - 1.27.x** - This represents the earliest versions of Kubernetes tested.
     It is possible that this chart works with earlier versions, but it is
     untested.
   * Helm install

--- a/charts/consul/test/terraform/aks/main.tf
+++ b/charts/consul/test/terraform/aks/main.tf
@@ -55,7 +55,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   location                          = azurerm_resource_group.default[count.index].location
   resource_group_name               = azurerm_resource_group.default[count.index].name
   dns_prefix                        = "consul-k8s-${random_id.suffix[count.index].dec}"
-  kubernetes_version                = "1.26"
+  kubernetes_version                = "1.24.10"
   role_based_access_control_enabled = true
 
   // We're setting the network plugin and other network properties explicitly

--- a/charts/consul/test/terraform/gke/main.tf
+++ b/charts/consul/test/terraform/gke/main.tf
@@ -21,7 +21,7 @@ resource "random_id" "suffix" {
 
 data "google_container_engine_versions" "main" {
   location       = var.zone
-  version_prefix = "1.25."
+  version_prefix = "1.25.9"
 }
 
 # We assume that the subnets are already created to save time.


### PR DESCRIPTION
Changes proposed in this PR:
- I used this branch to test 1.27 support in the workflow, the acceptance tests passing demonstrates that that works correctly
- I also updated the cloud tests to cover 1.24, 1.25 and 1.26. EKS seems to not support setting a patch version for kubernetes? In the past we haven't set it, so I've left it set to `1.26`. GKE and AKS, I have pinned to a patch number in order to help with repro-ability.

How I've tested this PR:
- I temporarily enabled cloud tests on this PR, here are the results (they didn't all pass, but I just wanted to verify that they setup with no issues with the version changes): https://github.com/hashicorp/consul-k8s-workflows/actions/runs/5216611633/jobs/9415586427

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

