### PR TITLE
[API Gateway] fix dangling service registrations

### DIFF
--- a/control-plane/api-gateway/cache/gateway.go
+++ b/control-plane/api-gateway/cache/gateway.go
@@ -52,6 +52,24 @@ func (r *GatewayCache) ServicesFor(ref api.ResourceReference) []api.CatalogServi
 	return r.data[common.NormalizeMeta(ref)]
 }
 
+func (r *GatewayCache) FetchServicesFor(ctx context.Context, ref api.ResourceReference) ([]api.CatalogService, error) {
+	client, err := consul.NewClientFromConnMgr(r.config, r.serverMgr)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := &api.QueryOptions{}
+	if ref.Namespace != "" {
+		opts.Namespace = ref.Namespace
+	}
+
+	services, _, err := client.Catalog().Service(ref.Name, "", opts.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	return common.DerefAll(services), nil
+}
+
 func (r *GatewayCache) EnsureSubscribed(ref api.ResourceReference, resource types.NamespacedName) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -208,6 +208,24 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, err
 		}
 		r.gatewayCache.RemoveSubscription(nonNormalizedConsulKey)
+		// make sure we have deregister all services even if they haven't
+		// hit cache yet
+		services, err := r.gatewayCache.FetchServicesFor(ctx, consulKey)
+		if err != nil {
+			log.Error(err, "unable to fetch latest services for gateways")
+			return ctrl.Result{}, err
+		}
+		for _, service := range services {
+			log.Info("deregistering service in Consul", "id", service.ServiceID)
+			if err := r.cache.Deregister(ctx, api.CatalogDeregistration{
+				Node:      service.Node,
+				ServiceID: service.ServiceID,
+				Namespace: service.Namespace,
+			}); err != nil {
+				log.Error(err, "error deregistering service")
+				return ctrl.Result{}, err
+			}
+		}
 	}
 
 	for _, deletion := range updates.Consul.Deletions {
@@ -234,19 +252,22 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	for _, registration := range updates.Consul.Registrations {
-		log.Info("registering service in Consul", "service", registration.Service.Service, "id", registration.Service.ID)
-		if err := r.cache.Register(ctx, registration); err != nil {
-			log.Error(err, "error registering service")
-			return ctrl.Result{}, err
+	if updates.UpsertGatewayDeployment {
+		// if we don't hit this conditional, we forcibly deregister everything
+		for _, registration := range updates.Consul.Registrations {
+			log.Info("registering service in Consul", "service", registration.Service.Service, "id", registration.Service.ID)
+			if err := r.cache.Register(ctx, registration); err != nil {
+				log.Error(err, "error registering service")
+				return ctrl.Result{}, err
+			}
 		}
-	}
 
-	for _, deregistration := range updates.Consul.Deregistrations {
-		log.Info("deregistering service in Consul", "id", deregistration.ServiceID)
-		if err := r.cache.Deregister(ctx, deregistration); err != nil {
-			log.Error(err, "error deregistering service")
-			return ctrl.Result{}, err
+		for _, deregistration := range updates.Consul.Deregistrations {
+			log.Info("deregistering service in Consul", "id", deregistration.ServiceID)
+			if err := r.cache.Deregister(ctx, deregistration); err != nil {
+				log.Error(err, "error deregistering service")
+				return ctrl.Result{}, err
+			}
 		}
 	}
 

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -210,21 +210,9 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		r.gatewayCache.RemoveSubscription(nonNormalizedConsulKey)
 		// make sure we have deregister all services even if they haven't
 		// hit cache yet
-		services, err := r.gatewayCache.FetchServicesFor(ctx, consulKey)
-		if err != nil {
-			log.Error(err, "unable to fetch latest services for gateways")
+		if err := r.deregisterAllServices(ctx, consulKey); err != nil {
+			log.Error(err, "error deregistering services")
 			return ctrl.Result{}, err
-		}
-		for _, service := range services {
-			log.Info("deregistering service in Consul", "id", service.ServiceID)
-			if err := r.cache.Deregister(ctx, api.CatalogDeregistration{
-				Node:      service.Node,
-				ServiceID: service.ServiceID,
-				Namespace: service.Namespace,
-			}); err != nil {
-				log.Error(err, "error deregistering service")
-				return ctrl.Result{}, err
-			}
 		}
 	}
 
@@ -253,7 +241,9 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if updates.UpsertGatewayDeployment {
-		// if we don't hit this conditional, we forcibly deregister everything
+		// We only do some registration/deregistraion if we still have a valid gateway
+		// otherwise, we've already deregistered everything related to the gateway, so
+		// no need to do any of the following.
 		for _, registration := range updates.Consul.Registrations {
 			log.Info("registering service in Consul", "service", registration.Service.Service, "id", registration.Service.ID)
 			if err := r.cache.Register(ctx, registration); err != nil {
@@ -288,6 +278,23 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *GatewayController) deregisterAllServices(ctx context.Context, consulKey api.ResourceReference) error {
+	services, err := r.gatewayCache.FetchServicesFor(ctx, consulKey)
+	if err != nil {
+		return err
+	}
+	for _, service := range services {
+		if err := r.cache.Deregister(ctx, api.CatalogDeregistration{
+			Node:      service.Node,
+			ServiceID: service.ServiceID,
+			Namespace: service.Namespace,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *GatewayController) updateAndResetStatus(ctx context.Context, o client.Object) error {


### PR DESCRIPTION
Changes proposed in this PR:
This bypasses the cache on gateway deletion to make sure we have dropped any registered services in Consul even if we haven't been informed about them via the cache yet. We had a race condition where if a pod was just registered with Consul we might not know about it if the gateway was deleted right away. I noticed this scenario when running conformance tests when we were leaving around services that were no longer there.

How I've tested this PR:
Ran conformance tests and made sure that quickly deleted gateways are cleaned up in Consul

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

