### PR TITLE
update redhat registry id

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -377,7 +377,7 @@ jobs:
           pkg_name: consul-k8s-control-plane_${{ env.version }}
           bin_name: consul-k8s-control-plane
           workdir: control-plane
-          redhat_tag: quay.io/redhat-isv-containers/6483ed53b430df51b731406c:${{env.version}}-ubi # this is different than the non-FIPS one
+          redhat_tag: quay.io/redhat-isv-containers/6486b1beabfc4e51588c0416:${{env.version}}-ubi # this is different than the non-FIPS one
 
   build-docker-ubi-dockerhub:
     name: Docker ${{ matrix.arch }} ${{ matrix.fips }} UBI build for DockerHub


### PR DESCRIPTION
Changes proposed in this PR:
- The redhat repo created in https://github.com/hashicorp/consul-k8s/pull/2333 missed a setting (have the registry be hosted by redhat) that cannot be changed after repo creation, so the repo had to be recreated. 

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

