### PR TITLE
[CI] update unit tests to use enterprise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 VERSION = $(shell ./control-plane/build-support/scripts/version.sh control-plane/version/version.go)
 CONSUL_IMAGE_VERSION = $(shell ./control-plane/build-support/scripts/consul-version.sh charts/consul/values.yaml)
+CONSUL_ENTERPRISE_IMAGE_VERSION = $(shell ./control-plane/build-support/scripts/consul-enterprise-version.sh charts/consul/values.yaml)
 CONSUL_DATAPLANE_IMAGE_VERSION = $(shell ./control-plane/build-support/scripts/consul-dataplane-version.sh charts/consul/values.yaml)
 
 # ===========> Helm Targets
@@ -179,6 +180,9 @@ version:
 
 consul-version:
 	@echo $(CONSUL_IMAGE_VERSION)
+
+consul-enterprise-version:
+	@echo $(CONSUL_ENTERPRISE_IMAGE_VERSION)
 
 consul-dataplane-version:
 	@echo $(CONSUL_DATAPLANE_IMAGE_VERSION)

--- a/control-plane/build-support/functions/10-util.sh
+++ b/control-plane/build-support/functions/10-util.sh
@@ -631,13 +631,8 @@ function update_version_helm {
 	sed_i ${SED_EXT} -e "s/(version:[[:space:]]*)[^\"]*/\1${full_version}/g" "${cfile}"
 	sed_i ${SED_EXT} -e "s/(appVersion:[[:space:]]*)[^\"]*/\1${full_consul_version}/g" "${cfile}"
 	sed_i ${SED_EXT} -e "s/(image:.*\/consul-k8s-control-plane:)[^\"]*/image: $4${full_version}/g" "${cfile}"
-	if ! test -z "$3"; then
-		sed_i ${SED_EXT} -e "s/(image:.*\/consul:)[^\"]*/image: $6:${full_consul_version}/g" "${cfile}"
-		sed_i ${SED_EXT} -e "s/(image:.*\/consul:)[^\"]*/image: $6:${full_consul_version}/g" "${vfile}"
-	else
-		sed_i ${SED_EXT} -e "s/(image:.*\/consul-enterprise:)[^\"]*/image: $6:${full_consul_version}/g" "${cfile}"
-		sed_i ${SED_EXT} -e "s/(image:.*\/consul-enterprise:)[^\"]*/image: $6:${full_consul_version}/g" "${vfile}"
-	fi
+	sed_i ${SED_EXT} -e "s/(image:.*\/consul:)[^\"]*/image: $6:${full_consul_version}/g" "${cfile}"
+	sed_i ${SED_EXT} -e "s/(image:.*\/consul:)[^\"]*/image: $6:${full_consul_version}/g" "${vfile}"
 
 	if test -z "$3"; then
 		sed_i ${SED_EXT} -e "s/(artifacthub.io\/prerelease:[[:space:]]*)[^\"]*/\1false/g" "${cfile}"
@@ -774,7 +769,7 @@ function prepare_dev {
 	#   * - error
 
 	echo "prepare_dev: dir:$1 consul-k8s:$5 consul:$6 date:"$3" mode:dev"
-	set_version "$1" "$5" "$3" "dev" "docker.mirror.hashicorp.services\/hashicorppreview\/consul-k8s-control-plane:" "$6" "docker.mirror.hashicorp.services\/hashicorppreview\/consul-enterprise"
+	set_version "$1" "$5" "$3" "dev" "docker.mirror.hashicorp.services\/hashicorppreview\/consul-k8s-control-plane:" "$6" "docker.mirror.hashicorp.services\/hashicorppreview\/consul"
 
 	return 0
 }

--- a/control-plane/build-support/scripts/consul-enterprise-version.sh
+++ b/control-plane/build-support/scripts/consul-enterprise-version.sh
@@ -4,8 +4,8 @@
 FILE=$1
 VERSION=$(yq .global.image $FILE)
 
-if [[ "${VERSION}" == *"consul-enterprise:"* ]]; then
-	VERSION=$(echo ${VERSION} | sed "s/consul-enterprise:/consul:/g")
+if [[ !"${VERSION}" == *"consul:"* ]]; then
+	VERSION=$(echo ${VERSION} | sed "s/consul:/consul-enterprise:/g")
 fi
 
 echo "${VERSION}"


### PR DESCRIPTION
Changes proposed in this PR:
- Update values.yaml to use the consul OSS version
- add/update make targets to do the following:

> $ make consul-version
> docker.mirror.hashicorp.services/hashicorppreview/consul:1.16-dev
>
> $ make consul-enterprise-version
> docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.16-dev

This way we can use this in the pipelines to make sure that the correct consul version is passed into the tests.


How I've tested this PR:

:eyes:

How I expect reviewers to test this PR:

:eyes: 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

