### PR TITLE
fix: translate consul namespace when attempting to deregister service

### DIFF
--- a/control-plane/api-gateway/binding/binder.go
+++ b/control-plane/api-gateway/binding/binder.go
@@ -204,7 +204,7 @@ func (b *Binder) Snapshot() *Snapshot {
 				snapshot.Consul.Deregistrations = append(snapshot.Consul.Deregistrations, api.CatalogDeregistration{
 					Node:      service.Node,
 					ServiceID: service.ServiceID,
-					Namespace: service.Namespace,
+					Namespace: b.config.Translator.Namespace(service.Namespace),
 				})
 			}
 		}

--- a/control-plane/api-gateway/binding/binder_test.go
+++ b/control-plane/api-gateway/binding/binder_test.go
@@ -15,6 +15,7 @@ import (
 
 	logrtest "github.com/go-logr/logr/testing"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -849,7 +850,7 @@ func TestBinder_Registrations(t *testing.T) {
 			}),
 			expectedRegistrations: []string{"pod1", "pod3", "pod4"},
 			expectedDeregistrations: []api.CatalogDeregistration{
-				{Node: "test", ServiceID: "pod2", Namespace: "namespace1"},
+				{Node: "test", ServiceID: "pod2", Namespace: ""},
 			},
 		},
 	} {
@@ -872,11 +873,11 @@ func TestBinder_Registrations(t *testing.T) {
 				registration := actual.Consul.Registrations[i]
 				expected := tt.expectedRegistrations[i]
 
-				require.EqualValues(t, expected, registration.Service.ID)
-				require.EqualValues(t, "gateway", registration.Service.Service)
+				assert.EqualValues(t, expected, registration.Service.ID)
+				assert.EqualValues(t, "gateway", registration.Service.Service)
 			}
 
-			require.EqualValues(t, tt.expectedDeregistrations, actual.Consul.Deregistrations)
+			assert.EqualValues(t, tt.expectedDeregistrations, actual.Consul.Deregistrations)
 		})
 	}
 }

--- a/control-plane/api-gateway/common/translation.go
+++ b/control-plane/api-gateway/common/translation.go
@@ -50,7 +50,7 @@ func (t ResourceTranslator) NormalizedResourceReference(kind, namespace string, 
 }
 
 func (t ResourceTranslator) Namespace(namespace string) string {
-	return namespaces.ConsulNamespace(namespace, t.EnableK8sMirroring, t.ConsulDestNamespace, t.EnableK8sMirroring, t.MirroringPrefix)
+	return namespaces.ConsulNamespace(namespace, t.EnableConsulNamespaces, t.ConsulDestNamespace, t.EnableK8sMirroring, t.MirroringPrefix)
 }
 
 // ToAPIGateway translates a kuberenetes API gateway into a Consul APIGateway Config Entry.

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -212,7 +212,7 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		r.gatewayCache.RemoveSubscription(nonNormalizedConsulKey)
 		// make sure we have deregister all services even if they haven't
 		// hit cache yet
-		if err := r.deregisterAllServices(ctx, consulKey); err != nil {
+		if err := r.deregisterAllServices(ctx, nonNormalizedConsulKey); err != nil {
 			log.Error(err, "error deregistering services")
 			return ctrl.Result{}, err
 		}

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -288,13 +288,11 @@ func (r *GatewayController) deregisterAllServices(ctx context.Context, consulKey
 		return err
 	}
 	for _, service := range services {
-		deregistration := api.CatalogDeregistration{
+		if err := r.cache.Deregister(ctx, api.CatalogDeregistration{
 			Node:      service.Node,
 			ServiceID: service.ServiceID,
 			Namespace: r.Translator.Namespace(service.Namespace),
-		}
-
-		if err := r.cache.Deregister(ctx, deregistration); err != nil {
+		}); err != nil {
 			return err
 		}
 	}

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -288,11 +288,15 @@ func (r *GatewayController) deregisterAllServices(ctx context.Context, consulKey
 		return err
 	}
 	for _, service := range services {
-		if err := r.cache.Deregister(ctx, api.CatalogDeregistration{
+		deregistration := api.CatalogDeregistration{
 			Node:      service.Node,
 			ServiceID: service.ServiceID,
-			Namespace: service.Namespace,
-		}); err != nil {
+		}
+		if r.HelmConfig.EnableNamespaces {
+			deregistration.Namespace = service.Namespace
+		}
+
+		if err := r.cache.Deregister(ctx, deregistration); err != nil {
 			return err
 		}
 	}

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -291,9 +291,7 @@ func (r *GatewayController) deregisterAllServices(ctx context.Context, consulKey
 		deregistration := api.CatalogDeregistration{
 			Node:      service.Node,
 			ServiceID: service.ServiceID,
-		}
-		if r.HelmConfig.EnableNamespaces {
-			deregistration.Namespace = service.Namespace
+			Namespace: r.Translator.Namespace(service.Namespace),
 		}
 
 		if err := r.cache.Deregister(ctx, deregistration); err != nil {


### PR DESCRIPTION
**Changes proposed in this PR:**
When deregistering service, we always include the namespace, even if running OSS. This causes the controller to be unable to deregister services when running OSS due to the following error:
```bash
error deregistering services	{"gateway": "gateway-conformance-infra/same-namespace-with-http-listener-on-8080", "error": "Unexpected response code: 400 (Invalid query parameter: \"ns\" - Namespaces are a Consul Enterprise feature)"}
github.com/hashicorp/consul-k8s/control-plane/api-gateway/controllers.(*GatewayController).Reconcile
	/home/runner/work/consul-k8s/consul-k8s/control-plane/api-gateway/controllers/gateway_controller.go:216
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:122
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:323
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:274
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:235
```

This was introduced in #2321 

**How I've tested this PR:**

1. Run consul-k8s using consul OSS instead of enterprise.
2. Create a `Gateway` and then delete it.

The above naturally occurs as part of the conformance testing suite defined by kubernetes-sigs/gateway-api.

**How I expect reviewers to test this PR:**
See above

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

