### PR TITLE
Set Consul Service Instance Localities from K8s Node Labels

### DIFF
--- a/.changelog/2346.txt
+++ b/.changelog/2346.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Set locality on services registered with connect-inject.
+```

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
@@ -318,6 +318,20 @@ func (r *Controller) registerServicesAndHealthCheck(apiClient *api.Client, pod c
 	return nil
 }
 
+func parseLocality(node corev1.Node) *api.Locality {
+	region := node.Labels[corev1.LabelTopologyRegion]
+	zone := node.Labels[corev1.LabelTopologyZone]
+
+	if region == "" {
+		return nil
+	}
+
+	return &api.Locality{
+		Region: region,
+		Zone:   zone,
+	}
+}
+
 // registerGateway creates Consul registrations for the Connect Gateways and registers them with Consul.
 // It also upserts a Kubernetes health check for the service based on whether the endpoint address is ready.
 func (r *Controller) registerGateway(apiClient *api.Client, pod corev1.Pod, serviceEndpoints corev1.Endpoints, healthStatus string, endpointAddressMap map[string]bool) error {
@@ -405,6 +419,11 @@ func (r *Controller) createServiceRegistrations(pod corev1.Pod, serviceEndpoints
 		}
 	}
 
+	var node corev1.Node
+	// Ignore errors because we don't want failures to block running services.
+	_ = r.Client.Get(context.Background(), types.NamespacedName{Name: pod.Spec.NodeName, Namespace: pod.Namespace}, &node)
+	locality := parseLocality(node)
+
 	// We only want that annotation to be present when explicitly overriding the consul svc name
 	// Otherwise, the Consul service name should equal the Kubernetes Service name.
 	// The service name in Consul defaults to the Endpoints object name, and is overridden by the pod
@@ -440,6 +459,7 @@ func (r *Controller) createServiceRegistrations(pod corev1.Pod, serviceEndpoints
 		Meta:      meta,
 		Namespace: consulNS,
 		Tags:      tags,
+		Locality:  locality,
 	}
 	serviceRegistration := &api.CatalogRegistration{
 		Node:    common.ConsulNodeNameFromK8sNode(pod.Spec.NodeName),


### PR DESCRIPTION
Changes proposed in this PR:
- Set localities on service instances similarly to Consul servers https://github.com/hashicorp/consul-k8s/blob/main/control-plane/subcommand/fetch-server-region/command.go
- The connect injector already has permissions to read nodes https://github.com/hashicorp/consul-k8s/blob/main/charts/consul/templates/connect-inject-clusterrole.yaml#L68-L76

How I've tested this PR:

I manually tested that localities are properly set using the sameness demo.

How I expect reviewers to test this PR:

👁️ 


Checklist:
- [X] Tests added
- [x] CHANGELOG entry added 