### PR TITLE
fix: use correct flag when translating namespaces

### DIFF
--- a/control-plane/api-gateway/cache/gateway.go
+++ b/control-plane/api-gateway/cache/gateway.go
@@ -18,7 +18,7 @@ import (
 )
 
 type GatewayCache struct {
-	config    *consul.Config
+	config    Config
 	serverMgr consul.ServerConnectionManager
 	logger    logr.Logger
 
@@ -35,7 +35,7 @@ type GatewayCache struct {
 
 func NewGatewayCache(ctx context.Context, config Config) *GatewayCache {
 	return &GatewayCache{
-		config:             config.ConsulClientConfig,
+		config:             config,
 		serverMgr:          config.ConsulServerConnMgr,
 		logger:             config.Logger,
 		events:             make(chan event.GenericEvent),
@@ -53,13 +53,13 @@ func (r *GatewayCache) ServicesFor(ref api.ResourceReference) []api.CatalogServi
 }
 
 func (r *GatewayCache) FetchServicesFor(ctx context.Context, ref api.ResourceReference) ([]api.CatalogService, error) {
-	client, err := consul.NewClientFromConnMgr(r.config, r.serverMgr)
+	client, err := consul.NewClientFromConnMgr(r.config.ConsulClientConfig, r.serverMgr)
 	if err != nil {
 		return nil, err
 	}
 
 	opts := &api.QueryOptions{}
-	if ref.Namespace != "" {
+	if r.config.NamespacesEnabled && ref.Namespace != "" {
 		opts.Namespace = ref.Namespace
 	}
 
@@ -95,7 +95,7 @@ func (r *GatewayCache) RemoveSubscription(ref api.ResourceReference) {
 
 func (r *GatewayCache) subscribeToGateway(ctx context.Context, ref api.ResourceReference, resource types.NamespacedName) {
 	opts := &api.QueryOptions{}
-	if ref.Namespace != "" {
+	if r.config.NamespacesEnabled && ref.Namespace != "" {
 		opts.Namespace = ref.Namespace
 	}
 
@@ -117,7 +117,7 @@ func (r *GatewayCache) subscribeToGateway(ctx context.Context, ref api.ResourceR
 		retryBackoff := backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 10)
 
 		if err := backoff.Retry(func() error {
-			client, err := consul.NewClientFromConnMgr(r.config, r.serverMgr)
+			client, err := consul.NewClientFromConnMgr(r.config.ConsulClientConfig, r.serverMgr)
 			if err != nil {
 				return err
 			}

--- a/control-plane/api-gateway/common/translation.go
+++ b/control-plane/api-gateway/common/translation.go
@@ -50,7 +50,7 @@ func (t ResourceTranslator) NormalizedResourceReference(kind, namespace string, 
 }
 
 func (t ResourceTranslator) Namespace(namespace string) string {
-	return namespaces.ConsulNamespace(namespace, t.EnableK8sMirroring, t.ConsulDestNamespace, t.EnableK8sMirroring, t.MirroringPrefix)
+	return namespaces.ConsulNamespace(namespace, t.EnableConsulNamespaces, t.ConsulDestNamespace, t.EnableK8sMirroring, t.MirroringPrefix)
 }
 
 // ToAPIGateway translates a kuberenetes API gateway into a Consul APIGateway Config Entry.

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -212,7 +212,7 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		r.gatewayCache.RemoveSubscription(nonNormalizedConsulKey)
 		// make sure we have deregister all services even if they haven't
 		// hit cache yet
-		if err := r.deregisterAllServices(ctx, consulKey); err != nil {
+		if err := r.deregisterAllServices(ctx, nonNormalizedConsulKey); err != nil {
 			log.Error(err, "error deregistering services")
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
**Changes proposed in this PR:**
Fix use of incorrect config flag when translating namespaces

**How I've tested this PR:**
Run conformance tests defined in kubernetes-sigs/gateway-api. These were previously failing because every test involves deleting a Gateway - now they're passing.

<img width="1844" alt="CleanShot 2023-06-13 at 09 25 25@2x" src="https://github.com/hashicorp/consul-k8s/assets/3476400/472018ed-13e4-4efe-8f9e-2b3a94dd2e6d">


**How I expect reviewers to test this PR:**
See above

**Checklist:**
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

