### PR TITLE
Add CRDs for `ProritizeByLocality` Routing

### DIFF
--- a/.changelog/2357.txt
+++ b/.changelog/2357.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Add the `PrioritizeByLocality` field to the `ServiceResolver` CRD.
+```

--- a/charts/consul/templates/crd-serviceresolvers.yaml
+++ b/charts/consul/templates/crd-serviceresolvers.yaml
@@ -227,6 +227,15 @@ spec:
                         type: integer
                     type: object
                 type: object
+              prioritizeByLocality:
+                description: PrioritizeByLocality contains the configuration for
+                  locality aware routing.
+                properties:
+                  mode:
+                    description: Mode specifies the behavior of PrioritizeByLocality
+                      routing. Valid values are "", "none", and "failover".
+                    type: string
+                type: object
               redirect:
                 description: Redirect when configured, all attempts to resolve the
                   service this resolver defines will be substituted for the supplied

--- a/control-plane/api/v1alpha1/serviceresolver_types_test.go
+++ b/control-plane/api/v1alpha1/serviceresolver_types_test.go
@@ -66,6 +66,9 @@ func TestServiceResolver_MatchesConsul(t *testing.T) {
 						Datacenter:    "redirect_datacenter",
 						Peer:          "redirect_peer",
 					},
+					PrioritizeByLocality: &ServiceResolverPrioritizeByLocality{
+						Mode: "failover",
+					},
 					Failover: map[string]ServiceResolverFailover{
 						"failover1": {
 							Service:       "failover1",
@@ -146,6 +149,9 @@ func TestServiceResolver_MatchesConsul(t *testing.T) {
 					Namespace:     "redirect_namespace",
 					Datacenter:    "redirect_datacenter",
 					Peer:          "redirect_peer",
+				},
+				PrioritizeByLocality: &capi.ServiceResolverPrioritizeByLocality{
+					Mode: "failover",
 				},
 				Failover: map[string]capi.ServiceResolverFailover{
 					"failover1": {
@@ -277,6 +283,9 @@ func TestServiceResolver_ToConsul(t *testing.T) {
 						Datacenter:    "redirect_datacenter",
 						Partition:     "redirect_partition",
 					},
+					PrioritizeByLocality: &ServiceResolverPrioritizeByLocality{
+						Mode: "none",
+					},
 					Failover: map[string]ServiceResolverFailover{
 						"failover1": {
 							Service:       "failover1",
@@ -357,6 +366,9 @@ func TestServiceResolver_ToConsul(t *testing.T) {
 					Namespace:     "redirect_namespace",
 					Datacenter:    "redirect_datacenter",
 					Partition:     "redirect_partition",
+				},
+				PrioritizeByLocality: &capi.ServiceResolverPrioritizeByLocality{
+					Mode: "none",
 				},
 				Failover: map[string]capi.ServiceResolverFailover{
 					"failover1": {
@@ -880,6 +892,22 @@ func TestServiceResolver_Validate(t *testing.T) {
 			expectedErrMsgs: []string{
 				"spec.failover[failA].namespace: Invalid value: \"namespace-a\": Consul Enterprise namespaces must be enabled to set failover.namespace",
 				"spec.failover[failB].namespace: Invalid value: \"namespace-b\": Consul Enterprise namespaces must be enabled to set failover.namespace",
+			},
+		},
+		"prioritize by locality none": {
+			input: &ServiceResolver{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: ServiceResolverSpec{
+					PrioritizeByLocality: &ServiceResolverPrioritizeByLocality{
+						Mode: "bad",
+					},
+				},
+			},
+			namespacesEnabled: false,
+			expectedErrMsgs: []string{
+				"mode must be one of '', 'none', or 'failover'",
 			},
 		},
 	}

--- a/control-plane/config/crd/bases/consul.hashicorp.com_serviceresolvers.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_serviceresolvers.yaml
@@ -223,6 +223,15 @@ spec:
                         type: integer
                     type: object
                 type: object
+              prioritizeByLocality:
+                description: PrioritizeByLocality contains the configuration for
+                  locality aware routing.
+                properties:
+                  mode:
+                    description: Mode specifies the behavior of PrioritizeByLocality
+                      routing. Valid values are "", "none", and "failover".
+                    type: string
+                type: object
               redirect:
                 description: Redirect when configured, all attempts to resolve the
                   service this resolver defines will be substituted for the supplied


### PR DESCRIPTION
Changes proposed in this PR:
- Add `prioritizeByLocality` to `ServiceResolver` CRD

How I've tested this PR:
I spun up a consul-k8s cluster and tried setting this field to different values.

How I expect reviewers to test this PR:
👁️ 

Checklist:
- [X] Tests added
- [X] CHANGELOG entry added 