### PR TITLE
Fix retry loops that use `t`

### DIFF
--- a/acceptance/tests/connect/connect_inject_test.go
+++ b/acceptance/tests/connect/connect_inject_test.go
@@ -102,7 +102,7 @@ func TestConnectInject(t *testing.T) {
 			retry.RunWith(retrier, t, func(r *retry.R) {
 				for podName := range list {
 					out, err := cli.Run(t, ctx.KubectlOptions(t), "proxy", "read", podName)
-					require.NoError(t, err)
+					require.NoError(r, err)
 
 					output := string(out)
 					logger.Log(t, output)


### PR DESCRIPTION
Changes proposed in this PR:
- Use linter to fix usage of `t` in retry loops with the context `r`

How I've tested this PR:
- `go install github.com/hashicorp/lint-consul-retry@master`
- `lint-consul-retry`

How I expect reviewers to test this PR:
- 👀 

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)
