### PR TITLE
Fix retry loops that use `t` (release/1.1.x)

### DIFF
--- a/acceptance/tests/cli/cli_install_test.go
+++ b/acceptance/tests/cli/cli_install_test.go
@@ -71,7 +71,7 @@ func TestInstall(t *testing.T) {
 			retry.RunWith(retrier, t, func(r *retry.R) {
 				for podName := range list {
 					out, err := cli.Run(t, ctx.KubectlOptions(t), "proxy", "read", podName)
-					require.NoError(t, err)
+					require.NoError(r, err)
 
 					output := string(out)
 					logger.Log(t, output)

--- a/control-plane/subcommand/create-federation-secret/command_test.go
+++ b/control-plane/subcommand/create-federation-secret/command_test.go
@@ -525,7 +525,7 @@ func TestRun_WaitsForMeshGatewayInstances(t *testing.T) {
 					CAFile: caFile,
 				},
 			})
-			require.NoError(t, err)
+			require.NoError(r, err)
 		})
 
 		err = client.Agent().ServiceRegister(&api.AgentServiceRegistration{
@@ -822,7 +822,7 @@ func TestRun_ReplicationSecretDelay(t *testing.T) {
 					},
 				},
 				metav1.CreateOptions{})
-			require.NoError(t, err)
+			require.NoError(r, err)
 		})
 	}()
 
@@ -1002,7 +1002,7 @@ func TestRun_ConsulClientDelay(t *testing.T) {
 					Server:  randomPorts[5],
 				}
 			})
-			require.NoError(t, err)
+			require.NoError(r, err)
 		})
 
 		// Construct Consul client.


### PR DESCRIPTION
Changes proposed in this PR:
- Use linter to fix usage of `t` in retry loops with the context `r`

How I've tested this PR:
- `go install github.com/hashicorp/lint-consul-retry@master`
- `lint-consul-retry`

How I expect reviewers to test this PR:
- 👀 

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)
