### PR TITLE
ci: update backport assistant to 0.3.4

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,7 +13,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.3.3
+    container: hashicorpdev/backport-assistant:0.3.4
     steps:
       - name: Run Backport Assistant
         run: backport-assistant backport -merge-method=squash -gh-automerge


### PR DESCRIPTION
**Changes proposed in this PR:**
This brings consul-k8s in line with consul.
Most importantly, the backport assistant was updated to automatically assign created PRs to the person who merged the PR that is being backported. This enables us to ask engineers to simply "check for any PRs assigned to you".

**How I've tested this PR:**
This version has been successfully running in consul for a few weeks, since https://github.com/hashicorp/consul/pull/17486

**How I expect reviewers to test this PR:**


**Checklist:**
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

