### PR TITLE
Manual backport of Improvement- Added helm inputs for managing audit logs into release/1.2.x

### DIFF
--- a/.changelog/2370.txt
+++ b/.changelog/2370.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+(Consul Enterprise) Add support to provide inputs via helm for audit log related configuration
+```

--- a/charts/consul/templates/server-config-configmap.yaml
+++ b/charts/consul/templates/server-config-configmap.yaml
@@ -1,6 +1,6 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if (not (or (eq .Values.server.limits.requestLimits.mode "disabled") (eq .Values.server.limits.requestLimits.mode "permissive") (eq .Values.server.limits.requestLimits.mode "enforce"))) }}{{fail "server.limits.requestLimits.mode must be one of the following values: disabled, permissive, and enforce." }}{{ end -}}
-
+{{- if and .Values.server.auditLogs.enabled (not .Values.global.acls.manageSystemACLs) }}{{fail "ACLs must be enabled inorder to configure audit logs"}}{{ end -}}
 # StatefulSet to run the actual Consul server cluster.
 apiVersion: v1
 kind: ConfigMap
@@ -184,6 +184,29 @@ data:
     {
       "telemetry": {
         "prometheus_retention_time": "{{ .Values.global.metrics.agentMetricsRetentionTime }}"
+      }
+    }
+  {{- end }}
+  {{- if and .Values.server.auditLogs.enabled .Values.global.acls.manageSystemACLs }}
+  audit-logging.json: |-
+    {
+      "audit": {
+        "enabled": "true",
+        "sink": {
+          {{- range $index, $element := .Values.server.auditLogs.sinks }}
+          {{- if ne $index 0 }},{{end}}
+          "{{ $element.name }}": {
+            {{- $firstKeyValuePair := false }}
+            {{- range $k, $v := $element }}
+              {{- if ne $k "name" }}
+              {{- if ne $firstKeyValuePair false }},{{end}}
+              {{- $firstKeyValuePair = true }}
+              "{{ $k }}": "{{ $v }}"
+              {{- end }}
+            {{- end }}
+          }
+          {{- end }}
+        }
       }
     }
   {{- end }}

--- a/charts/consul/test/unit/server-config-configmap.bats
+++ b/charts/consul/test/unit/server-config-configmap.bats
@@ -1057,3 +1057,143 @@ load _helpers
 
   [ "${actual}" = "100" ]
 }
+
+#--------------------------------------------------------------------
+# server.auditLogs
+
+@test "server/ConfigMap: server.auditLogs is disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'server.auditLogs.enabled=false' \
+      . | tee /dev/stderr |
+      yq -r '.data["audit-logging.json"]' | jq -r .audit | tee /dev/stderr)
+
+  [ "${actual}" = "null" ]
+}
+
+@test "server/ConfigMap: server.auditLogs is enabled but ACLs are disabled" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'server.auditLogs.enabled=true' \
+      --set 'server.auditLogs.sinks[0].name=MySink' \
+      --set 'server.auditLogs.sinks[0].type=file' \
+      --set 'server.auditLogs.sinks[0].format=json' \
+      --set 'server.auditLogs.sinks[0].delivery_guarantee=best-effort' \
+      --set 'server.auditLogs.sinks[0].rotate_duration=24h' \
+      --set 'server.auditLogs.sinks[0].path=/tmp/audit.json' \
+      .
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "ACLs must be enabled inorder to configure audit logs" ]]
+}
+
+@test "server/ConfigMap: server.auditLogs is enabled without sink inputs" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'server.auditLogs.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.data["audit-logging.json"]' | jq -r .audit.sink | tee /dev/stderr)
+
+  [ "${actual}" = "{}" ]
+}
+
+@test "server/ConfigMap: server.auditLogs is enabled with 1 sink input object" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'server.auditLogs.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'server.auditLogs.sinks[0].name=MySink' \
+      --set 'server.auditLogs.sinks[0].type=file' \
+      --set 'server.auditLogs.sinks[0].format=json' \
+      --set 'server.auditLogs.sinks[0].delivery_guarantee=best-effort' \
+      --set 'server.auditLogs.sinks[0].rotate_duration=24h' \
+      --set 'server.auditLogs.sinks[0].path=/tmp/audit.json' \
+      . | tee /dev/stderr |
+      yq -r '.data["audit-logging.json"]' | tee /dev/stderr)
+
+  local actual=$(echo $object |  jq -r .audit.sink.MySink.path | tee /dev/stderr)
+  [ "${actual}" = "/tmp/audit.json" ]
+
+  local actual=$(echo $object |  jq -r .audit.sink.MySink.delivery_guarantee | tee /dev/stderr)
+  [ "${actual}" = "best-effort" ]
+
+  local actual=$(echo $object |  jq -r .audit.sink.MySink.rotate_duration | tee /dev/stderr)
+  [ "${actual}" = "24h" ]
+}
+
+@test "server/ConfigMap: server.auditLogs is enabled with 1 sink input object and it does not contain the name attribute" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'server.auditLogs.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'server.auditLogs.sinks[0].name=MySink' \
+      --set 'server.auditLogs.sinks[0].type=file' \
+      --set 'server.auditLogs.sinks[0].format=json' \
+      --set 'server.auditLogs.sinks[0].delivery_guarantee=best-effort' \
+      --set 'server.auditLogs.sinks[0].rotate_duration=24h' \
+      --set 'server.auditLogs.sinks[0].path=/tmp/audit.json' \
+      . | tee /dev/stderr |
+      yq -r '.data["audit-logging.json"]' | jq -r .audit.sink.name | tee /dev/stderr)
+
+  [ "${actual}" = "null" ]
+}
+
+@test "server/ConfigMap: server.auditLogs is enabled with multiple sink input objects" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'server.auditLogs.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'server.auditLogs.sinks[0].name=MySink1' \
+      --set 'server.auditLogs.sinks[0].type=file' \
+      --set 'server.auditLogs.sinks[0].format=json' \
+      --set 'server.auditLogs.sinks[0].delivery_guarantee=best-effort' \
+      --set 'server.auditLogs.sinks[0].rotate_duration=24h' \
+      --set 'server.auditLogs.sinks[0].path=/tmp/audit.json' \
+      --set 'server.auditLogs.sinks[1].name=MySink2' \
+      --set 'server.auditLogs.sinks[1].type=file' \
+      --set 'server.auditLogs.sinks[1].format=json' \
+      --set 'server.auditLogs.sinks[1].delivery_guarantee=best-effort' \
+      --set 'server.auditLogs.sinks[1].rotate_max_files=15' \
+      --set 'server.auditLogs.sinks[1].rotate_duration=24h' \
+      --set 'server.auditLogs.sinks[1].path=/tmp/audit-2.json' \
+      --set 'server.auditLogs.sinks[2].name=MySink3' \
+      --set 'server.auditLogs.sinks[2].type=file' \
+      --set 'server.auditLogs.sinks[2].format=json' \
+      --set 'server.auditLogs.sinks[2].delivery_guarantee=best-effort' \
+      --set 'server.auditLogs.sinks[2].rotate_max_files=20' \
+      --set 'server.auditLogs.sinks[2].rotate_duration=18h' \
+      --set 'server.auditLogs.sinks[2].path=/tmp/audit-3.json' \
+      . | tee /dev/stderr |
+      yq -r '.data["audit-logging.json"]' | tee /dev/stderr)
+
+  local actual=$(echo $object |  jq -r .audit.sink.MySink1.path | tee /dev/stderr)
+  [ "${actual}" = "/tmp/audit.json" ]
+
+  local actual=$(echo $object |  jq -r .audit.sink.MySink3.path | tee /dev/stderr)
+  [ "${actual}" = "/tmp/audit-3.json" ]
+
+  local actual=$(echo $object |  jq -r .audit.sink.MySink2.path | tee /dev/stderr)
+  [ "${actual}" = "/tmp/audit-2.json" ]
+
+  local actual=$(echo $object |  jq -r .audit.sink.MySink1.name | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+
+  local actual=$(echo $object |  jq -r .audit.sink.MySink3.delivery_guarantee | tee /dev/stderr)
+  [ "${actual}" = "best-effort" ]
+
+  local actual=$(echo $object |  jq -r .audit.sink.MySink2.rotate_duration | tee /dev/stderr)
+  [ "${actual}" = "24h" ]
+
+  local actual=$(echo $object |  jq -r .audit.sink.MySink1.format | tee /dev/stderr)
+  [ "${actual}" = "json" ]
+
+  local actual=$(echo $object |  jq -r .audit.sink.MySink3.type | tee /dev/stderr)
+  [ "${actual}" = "file" ]
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1181,6 +1181,60 @@ server:
       # @type: integer
       writeRate: -1
 
+  # [Enterprise Only] Added in Consul 1.8, the audit object allow users to enable auditing 
+  # and configure a sink and filters for their audit logs. Please refer to
+  # [audit logs](https://developer.hashicorp.com/consul/docs/enterprise/audit-logging) documentation
+  # for further information.
+  auditLogs:
+    # Controls whether Consul logs out each time a user performs an operation.
+    # global.acls.manageSystemACLs must be enabled to use this feature.
+    enabled: false
+
+    # A single entry of the sink object provides configuration for the destination to which Consul 
+    # will log auditing events.
+    #
+    # Example:
+    #
+    # ```yaml
+    # sinks:
+    #   - name: My Sink
+    #     type: file
+    #     format: json
+    #     path: /tmp/audit.json
+    #     delivery_guarantee: best-effort
+    #     rotate_duration: 24h
+    #     rotate_max_files: 15
+    #     rotate_bytes: 25165824
+    #     
+    # ```
+    #
+    # The sink object supports the following keys:
+    #
+    # - `name` - Name of the sink.
+    #
+    # - `type` - Type specifies what kind of sink this is. Currently only file sinks are available
+    #
+    # - `format` - Format specifies what format the events will be emitted with. Currently only `json`
+    #   events are emitted.
+    #
+    # - `path` - The directory and filename to write audit events to.
+    #
+    # - `delivery_guarantee` - Specifies the rules governing how audit events are written. Consul
+    #   only supports `best-effort` event delivery.
+    #
+    # - `mode` - The permissions to set on the audit log files.
+    #
+    # - `rotate_duration` - Specifies the interval by which the system rotates to a new log file.
+    #    At least one of `rotate_duration` or `rotate_bytes` must be configured to enable audit logging.
+    #
+    # - `rotate_bytes` -  Specifies how large an individual log file can grow before Consul rotates to a new file.
+    #    At least one of rotate_bytes or rotate_duration must be configured to enable audit logging.
+    #
+    # - `rotate_max_files` - Defines the limit that Consul should follow before it deletes old log files.
+    #
+    # @type: array<map>
+    sinks: []
+
 # Configuration for Consul servers when the servers are running outside of Kubernetes.
 # When running external servers, configuring these values is recommended
 # if setting `global.tls.enableAutoEncrypt` to true


### PR DESCRIPTION
## Backport

This PR is manually created from #2265 to be assessed for backporting targeting the release/1.2.x.

The below text is copied from the body of the original PR.

---

Changes proposed in this PR:
- Adds the relevant inputs in values.yaml to configure audit logging in Consul enterprise.
- Behind the scenes, values get translated to the json configuration present [here](https://developer.hashicorp.com/consul/docs/agent/config/config-files#audit) and the whole configuration is added as a file in the Consul server's config map.

How I've tested this PR:
- Unit tests
- CI

How I expect reviewers to test this PR:
- I've added the `auditLog` field under `server`. Should the same be added to `client`?

Checklist:
- [X] Tests added
- [X] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)



---

