### PR TITLE
Acceptance test for permissive mTLS

### DIFF
--- a/acceptance/tests/connect/permissive_mtls_test.go
+++ b/acceptance/tests/connect/permissive_mtls_test.go
@@ -1,0 +1,89 @@
+package connect
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/consul-k8s/acceptance/framework/config"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/connhelper"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConnectInject_PermissiveMTLS(t *testing.T) {
+	cfg := suite.Config()
+	if !cfg.EnableTransparentProxy {
+		t.Skipf("skipping this because -enable-transparent-proxy is not set")
+	}
+
+	ctx := suite.Environment().DefaultContext(t)
+
+	releaseName := helpers.RandomName()
+	connHelper := connhelper.ConnectHelper{
+		ClusterKind: consul.Helm,
+		Secure:      true,
+		ReleaseName: releaseName,
+		Ctx:         ctx,
+		Cfg:         cfg,
+	}
+	connHelper.Setup(t)
+	connHelper.Install(t)
+
+	deployNonMeshClient(t, connHelper)
+	deployStaticServer(t, cfg, connHelper)
+
+	kubectlOpts := connHelper.Ctx.KubectlOptions(t)
+	logger.Logf(t, "Check that incoming non-mTLS connection fails in MutualTLSMode = strict")
+	k8s.CheckStaticServerConnectionFailing(t, kubectlOpts, "static-client", "http://static-server")
+
+	t.Logf("Set allowEnablingPermissiveMutualTLS = true")
+	writeCrd(t, connHelper, "../fixtures/cases/permissive-mtls/mesh-config-permissive-allowed.yaml")
+
+	t.Logf("Set mutualTLSMode = permissive for static-server")
+	writeCrd(t, connHelper, "../fixtures/cases/permissive-mtls/service-defaults-static-server-permissive.yaml")
+
+	logger.Log(t, "Check that incoming mTLS connection is successful in MutualTLSMode = permissive")
+	k8s.CheckStaticServerConnectionSuccessful(t, kubectlOpts, "static-client", "http://static-server")
+}
+
+func deployNonMeshClient(t *testing.T, ch connhelper.ConnectHelper) {
+	t.Helper()
+	logger.Log(t, "Creating static-client deployment, with connect-inject=false / unset.")
+	k8s.DeployKustomize(t, ch.Ctx.KubectlOptions(t), ch.Cfg.NoCleanupOnFailure, ch.Cfg.DebugDirectory, "../fixtures/bases/static-client")
+	requirePodContainers(t, ch, "app=static-client", 1)
+}
+
+func deployStaticServer(t *testing.T, cfg *config.TestConfig, ch connhelper.ConnectHelper) {
+	t.Logf("Deploy static-server")
+	k8s.DeployKustomize(t, ch.Ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
+	requirePodContainers(t, ch, "app=static-server", 2)
+}
+
+func writeCrd(t *testing.T, ch connhelper.ConnectHelper, path string) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		_, _ = k8s.RunKubectlAndGetOutputE(t, ch.Ctx.KubectlOptions(t), "delete", "-f", path)
+	})
+
+	_, err := k8s.RunKubectlAndGetOutputE(t, ch.Ctx.KubectlOptions(t), "apply", "-f", path)
+	require.NoError(t, err)
+}
+
+func requirePodContainers(t *testing.T, ch connhelper.ConnectHelper, selector string, nContainers int) {
+	opts := ch.Ctx.KubectlOptions(t)
+	client := ch.Ctx.KubernetesClient(t)
+	retry.Run(t, func(r *retry.R) {
+		podList, err := client.CoreV1().
+			Pods(opts.Namespace).
+			List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+		require.NoError(r, err)
+		require.Len(r, podList.Items, 1)
+		require.Len(r, podList.Items[0].Spec.Containers, nContainers)
+	})
+}

--- a/acceptance/tests/connect/permissive_mtls_test.go
+++ b/acceptance/tests/connect/permissive_mtls_test.go
@@ -53,12 +53,15 @@ func TestConnectInject_PermissiveMTLS(t *testing.T) {
 
 func deployNonMeshClient(t *testing.T, ch connhelper.ConnectHelper) {
 	t.Helper()
+
 	logger.Log(t, "Creating static-client deployment with connect-inject=false")
 	k8s.DeployKustomize(t, ch.Ctx.KubectlOptions(t), ch.Cfg.NoCleanupOnFailure, ch.Cfg.DebugDirectory, "../fixtures/bases/static-client")
 	requirePodContainers(t, ch, "app=static-client", 1)
 }
 
 func deployStaticServer(t *testing.T, cfg *config.TestConfig, ch connhelper.ConnectHelper) {
+	t.Helper()
+
 	logger.Log(t, "Creating static-server deployment with connect-inject=true")
 	k8s.DeployKustomize(t, ch.Ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
 	requirePodContainers(t, ch, "app=static-server", 2)
@@ -76,6 +79,8 @@ func writeCrd(t *testing.T, ch connhelper.ConnectHelper, path string) {
 }
 
 func requirePodContainers(t *testing.T, ch connhelper.ConnectHelper, selector string, nContainers int) {
+	t.Helper()
+
 	opts := ch.Ctx.KubectlOptions(t)
 	client := ch.Ctx.KubernetesClient(t)
 	retry.Run(t, func(r *retry.R) {

--- a/acceptance/tests/connect/permissive_mtls_test.go
+++ b/acceptance/tests/connect/permissive_mtls_test.go
@@ -41,10 +41,10 @@ func TestConnectInject_PermissiveMTLS(t *testing.T) {
 	logger.Logf(t, "Check that incoming non-mTLS connection fails in MutualTLSMode = strict")
 	k8s.CheckStaticServerConnectionFailing(t, kubectlOpts, "static-client", "http://static-server")
 
-	t.Logf("Set allowEnablingPermissiveMutualTLS = true")
+	logger.Log(t, "Set allowEnablingPermissiveMutualTLS = true")
 	writeCrd(t, connHelper, "../fixtures/cases/permissive-mtls/mesh-config-permissive-allowed.yaml")
 
-	t.Logf("Set mutualTLSMode = permissive for static-server")
+	logger.Log(t, "Set mutualTLSMode = permissive for static-server")
 	writeCrd(t, connHelper, "../fixtures/cases/permissive-mtls/service-defaults-static-server-permissive.yaml")
 
 	logger.Log(t, "Check that incoming mTLS connection is successful in MutualTLSMode = permissive")
@@ -53,13 +53,13 @@ func TestConnectInject_PermissiveMTLS(t *testing.T) {
 
 func deployNonMeshClient(t *testing.T, ch connhelper.ConnectHelper) {
 	t.Helper()
-	logger.Log(t, "Creating static-client deployment, with connect-inject=false / unset.")
+	logger.Log(t, "Creating static-client deployment with connect-inject=false")
 	k8s.DeployKustomize(t, ch.Ctx.KubectlOptions(t), ch.Cfg.NoCleanupOnFailure, ch.Cfg.DebugDirectory, "../fixtures/bases/static-client")
 	requirePodContainers(t, ch, "app=static-client", 1)
 }
 
 func deployStaticServer(t *testing.T, cfg *config.TestConfig, ch connhelper.ConnectHelper) {
-	t.Logf("Deploy static-server")
+	logger.Log(t, "Creating static-server deployment with connect-inject=true")
 	k8s.DeployKustomize(t, ch.Ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
 	requirePodContainers(t, ch, "app=static-server", 2)
 }

--- a/acceptance/tests/fixtures/cases/permissive-mtls/mesh-config-permissive-allowed.yaml
+++ b/acceptance/tests/fixtures/cases/permissive-mtls/mesh-config-permissive-allowed.yaml
@@ -1,0 +1,6 @@
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: Mesh
+metadata:
+  name: mesh
+spec:
+  allowEnablingPermissiveMutualTLS: true

--- a/acceptance/tests/fixtures/cases/permissive-mtls/mesh-config-permissive-disallowed.yaml
+++ b/acceptance/tests/fixtures/cases/permissive-mtls/mesh-config-permissive-disallowed.yaml
@@ -1,0 +1,6 @@
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: Mesh
+metadata:
+  name: mesh
+spec:
+  allowEnablingPermissiveMutualTLS: false

--- a/acceptance/tests/fixtures/cases/permissive-mtls/mesh-config-permissive-disallowed.yaml
+++ b/acceptance/tests/fixtures/cases/permissive-mtls/mesh-config-permissive-disallowed.yaml
@@ -1,6 +1,0 @@
-apiVersion: consul.hashicorp.com/v1alpha1
-kind: Mesh
-metadata:
-  name: mesh
-spec:
-  allowEnablingPermissiveMutualTLS: false

--- a/acceptance/tests/fixtures/cases/permissive-mtls/service-defaults-static-server-permissive.yaml
+++ b/acceptance/tests/fixtures/cases/permissive-mtls/service-defaults-static-server-permissive.yaml
@@ -1,0 +1,7 @@
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceDefaults
+metadata:
+  name: static-server
+  namespace: default
+spec:
+  mutualTLSMode: "permissive"

--- a/acceptance/tests/fixtures/cases/permissive-mtls/service-defaults-static-server-strict.yaml
+++ b/acceptance/tests/fixtures/cases/permissive-mtls/service-defaults-static-server-strict.yaml
@@ -1,0 +1,7 @@
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceDefaults
+metadata:
+  name: static-server
+  namespace: default
+spec:
+  mutualTLSMode: "strict"


### PR DESCRIPTION
**Changes proposed in this PR:**

This adds a basic acceptance test for permissive mTLS that tests:

* An inbound non-mTLS connection is rejected in strict mode
* An inbound non-mTLS connection is accepted in permissive mode

**How I've tested this PR:**

* Ran it locally with kind

**How I expect reviewers to test this PR:**

👀 

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

