### PR TITLE
Set to dev mode for 0.49.x

### DIFF
--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: consul
 version: 0.49.7-dev
-appVersion: 1.13.7
+appVersion: 1.13-dev
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
@@ -13,7 +13,7 @@ annotations:
   artifacthub.io/prerelease: true
   artifacthub.io/images: |
     - name: consul
-      image: hashicorp/consul:1.13.7
+      image: docker.mirror.hashicorp.services/hashicorppreview/consul:1.13-dev
     - name: consul-k8s-control-plane
       image: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:0.49.7-dev
     - name: envoy

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -109,7 +109,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.10.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: "hashicorp/consul:1.13.8"
+  image: docker.mirror.hashicorp.services/hashicorppreview/consul:1.13-dev
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.


### PR DESCRIPTION
Changes proposed in this PR:
- Set this release branch to use the dev images of consul
- Also use the HC docker registry so that we do not get throttled.

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

