### PR TITLE
Pin Kind versions on release branches

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,6 @@ jobs:
       with:
         workflow: test.yml
         repo: hashicorp/consul-k8s-workflows
-        ref: main
+        ref: mw/add-support-pinned-kind
         token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
         inputs: '{ "context":"${{ env.CONTEXT }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,6 @@ jobs:
       with:
         workflow: test.yml
         repo: hashicorp/consul-k8s-workflows
-        ref: mw/add-support-pinned-kind
+        ref: main
         token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
         inputs: '{ "context":"${{ env.CONTEXT }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ VERSION = $(shell ./control-plane/build-support/scripts/version.sh control-plane
 CONSUL_IMAGE_VERSION = $(shell ./control-plane/build-support/scripts/consul-version.sh charts/consul/values.yaml)
 CONSUL_ENTERPRISE_IMAGE_VERSION = $(shell ./control-plane/build-support/scripts/consul-enterprise-version.sh charts/consul/values.yaml)
 CONSUL_DATAPLANE_IMAGE_VERSION = $(shell ./control-plane/build-support/scripts/consul-dataplane-version.sh charts/consul/values.yaml)
+KIND_VERSION= $(shell ./control-plane/build-support/scripts/read-yaml-config.sh acceptance/ci-inputs/kind-inputs.yaml .kindVersion)
+KIND_NODE_IMAGE= $(shell ./control-plane/build-support/scripts/read-yaml-config.sh acceptance/ci-inputs/kind-inputs.yaml .kindNodeImage)
+KUBECTL_VERSION= $(shell ./control-plane/build-support/scripts/read-yaml-config.sh acceptance/ci-inputs/kind-inputs.yaml .kubectlVersion)
 
 # ===========> Helm Targets
 
@@ -105,7 +108,6 @@ terraform-fmt:
 
 
 # ===========> CLI Targets
-
 cli-dev:
 	@echo "==> Installing consul-k8s CLI tool for ${GOOS}/${GOARCH}"
 	@cd cli; go build -o ./bin/consul-k8s; cp ./bin/consul-k8s ${GOPATH}/bin/
@@ -113,7 +115,6 @@ cli-dev:
 cli-fips-dev:
 	@echo "==> Installing consul-k8s CLI tool for ${GOOS}/${GOARCH}"
 	@cd cli; CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go build -o ./bin/consul-k8s -tags "fips"; cp ./bin/consul-k8s ${GOPATH}/bin/
-
 
 cli-lint: ## Run linter in the control-plane directory.
 	cd cli; golangci-lint run -c ../.golangci.yml
@@ -187,8 +188,15 @@ consul-enterprise-version:
 consul-dataplane-version:
 	@echo $(CONSUL_DATAPLANE_IMAGE_VERSION)
 
-kind-config:
-	@./control-plane/build-support/scripts/read-yaml-config.sh acceptance/ci-inputs/kind-inputs.yaml
+kind-version:
+	@echo $(KIND_VERSION)
+
+kind-node-image:
+	@echo $(KIND_NODE_IMAGE)
+
+kubectl-version:
+	@echo $(KUBECTL_VERSION)
+
 
 
 # ===========> Release Targets

--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,9 @@ consul-enterprise-version:
 consul-dataplane-version:
 	@echo $(CONSUL_DATAPLANE_IMAGE_VERSION)
 
+kind-config:
+	@./control-plane/build-support/scripts/read-yaml.sh acceptance/ci-inputs/kind-inputs.yaml
+
 
 # ===========> Release Targets
 

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ consul-dataplane-version:
 	@echo $(CONSUL_DATAPLANE_IMAGE_VERSION)
 
 kind-config:
-	@./control-plane/build-support/scripts/read-yaml.sh acceptance/ci-inputs/kind-inputs.yaml
+	@./control-plane/build-support/scripts/read-yaml-config.sh acceptance/ci-inputs/kind-inputs.yaml
 
 
 # ===========> Release Targets

--- a/acceptance/ci-inputs/kind-inputs.yaml
+++ b/acceptance/ci-inputs/kind-inputs.yaml
@@ -1,0 +1,3 @@
+kind-version: v0.19.0
+kind-node-image: kindest/node:v1.27.1
+kubectl-version: v1.27.1

--- a/acceptance/ci-inputs/kind-inputs.yaml
+++ b/acceptance/ci-inputs/kind-inputs.yaml
@@ -1,3 +1,3 @@
-kind-version: v0.19.0
-kind-node-image: kindest/node:v1.27.1
-kubectl-version: v1.27.1
+kindVersion: v0.19.0
+kindNodeImage: kindest/node:v1.27.1
+kubectlVersion: v1.27.1

--- a/control-plane/build-support/scripts/read-yaml-config.sh
+++ b/control-plane/build-support/scripts/read-yaml-config.sh
@@ -3,8 +3,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 INPUT_FILE=$1
+FIELD=$2
 
-# Convert YAML content to JSON as it is easier to deal with
-JSON_CONTENTS=$(yq eval '. | tojson' "${INPUT_FILE}")
+VALUE=$(yq $FIELD $INPUT_FILE)
 
-echo "${JSON_CONTENTS}"
+echo "${VALUE}"

--- a/control-plane/build-support/scripts/read-yaml-config.sh
+++ b/control-plane/build-support/scripts/read-yaml-config.sh
@@ -2,9 +2,9 @@
 
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
-input_file=$1
+INPUT_FILE=$1
 
 # Convert YAML content to JSON as it is easier to deal with
-JSON_CONTENTS=$(yq eval '. | tojson' "${input_file}")
+JSON_CONTENTS=$(yq eval '. | tojson' "${INPUT_FILE}")
 
 echo "${JSON_CONTENTS}"

--- a/control-plane/build-support/scripts/read-yaml-config.sh
+++ b/control-plane/build-support/scripts/read-yaml-config.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+input_file=$1
+
+# Convert YAML content to JSON as it is easier to deal with
+JSON_CONTENTS=$(yq eval '. | tojson' "${input_file}")
+
+echo "${JSON_CONTENTS}"


### PR DESCRIPTION
Changes proposed in this PR:
This pins the KIND version to the Consul-K8s branch

- created a yaml file with the desired pinned versions
- created a script to read the yaml
- added a make target which can be used in CI to get the desired kind inputs/config

How I've tested this PR:
- ran this against branch in https://github.com/hashicorp/consul-k8s-workflows/pull/17 and verified the pinned kind config was being picked up
- Success Run: https://github.com/hashicorp/consul-k8s-workflows/actions/runs/5293009439

How I expect reviewers to test this PR:
👀 


Checklist:
- [x] Tests added
- [n/a] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

