### PR TITLE
[CI] Use different consul versions (release/1.2.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 VERSION = $(shell ./control-plane/build-support/scripts/version.sh control-plane/version/version.go)
 CONSUL_IMAGE_VERSION = $(shell ./control-plane/build-support/scripts/consul-version.sh charts/consul/values.yaml)
+CONSUL_ENTERPRISE_IMAGE_VERSION = $(shell ./control-plane/build-support/scripts/consul-enterprise-version.sh charts/consul/values.yaml)
 CONSUL_DATAPLANE_IMAGE_VERSION = $(shell ./control-plane/build-support/scripts/consul-dataplane-version.sh charts/consul/values.yaml)
 
 # ===========> Helm Targets
@@ -179,6 +180,9 @@ version:
 
 consul-version:
 	@echo $(CONSUL_IMAGE_VERSION)
+
+consul-enterprise-version:
+	@echo $(CONSUL_ENTERPRISE_IMAGE_VERSION)
 
 consul-dataplane-version:
 	@echo $(CONSUL_DATAPLANE_IMAGE_VERSION)

--- a/control-plane/build-support/scripts/consul-enterprise-version.sh
+++ b/control-plane/build-support/scripts/consul-enterprise-version.sh
@@ -4,8 +4,8 @@
 FILE=$1
 VERSION=$(yq .global.image $FILE)
 
-if [[ "${VERSION}" == *"consul-enterprise:"* ]]; then
-	VERSION=$(echo ${VERSION} | sed "s/consul-enterprise:/consul:/g")
+if [[ !"${VERSION}" == *"consul:"* ]]; then
+	VERSION=$(echo ${VERSION} | sed "s/consul:/consul-enterprise:/g")
 fi
 
 echo "${VERSION}"


### PR DESCRIPTION
Changes proposed in this PR:

- this is a release branch version of #2342
- add/update make targets to do the following:

> $ make consul-version
> docker.mirror.hashicorp.services/hashicorppreview/consul:1.16-dev
>
> $ make consul-enterprise-version
> docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.16-dev

This way we can use this in the pipelines to make sure that the correct consul version is passed into the tests.


How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

