### PR TITLE
[CI] Get acceptance tests passing on release/0.49.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ consul-enterprise-version:
 	@echo $(CONSUL_ENTERPRISE_IMAGE_VERSION)
 
 consul-dataplane-version:
-	@echo $(CONSUL_DATAPLANE_IMAGE_VERSION)
+	@echo "docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.0-dev"
 
 
 # ===========> Release Targets


### PR DESCRIPTION
Changes proposed in this PR:
- Acceptance tests on release/0.49.x are failing because we don't use consul-dataplane and the workflows are expecting it.
- This just fakes that out so that CI will run.

How I've tested this PR:

:eyes:

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

