### PR TITLE
Bumping go-discover to the lastest version

### DIFF
--- a/.changelog/2390.txt
+++ b/.changelog/2390.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Update [Go-Discover](https://github.com/hashicorp/go-discover) in the container has been updated to address [CVE-2020-14040](https://github.com/advisories/GHSA-5rcv-m4m3-hfh7)
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## 1.1.? (TODO DATE)
-SECURITY:
-* [Go-Discover](https://github.com/hashicorp/go-discover) in the container has been updated to address [CVE-2020-14040](https://github.com/advisories/GHSA-5rcv-m4m3-hfh7)
-
-
-
 ## 1.1.2 (June 5, 2023)
 
 SECURITY:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.? (TODO DATE)
+SECURITY:
+* [Go-Discover](https://github.com/hashicorp/go-discover) in the container has been updated to address [CVE-2020-14040](https://github.com/advisories/GHSA-5rcv-m4m3-hfh7)
+
+
+
 ## 1.1.2 (June 5, 2023)
 
 SECURITY:

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -17,7 +17,7 @@
 # go-discover builds the discover binary (which we don't currently publish
 # either).
 FROM golang:1.19.2-alpine as go-discover
-RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@49f60c093101c9c5f6b04d5b1c80164251a761a6
+RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@214571b6a5309addf3db7775f4ee8cf4d264fd5f
 
 # dev copies the binary from a local build
 # -----------------------------------


### PR DESCRIPTION
Changes proposed in this PR:
- Updating `go-discover` to the latest head ref. https://github.com/hashicorp/go-discover

How I've tested this PR:
* `make control-plane-dev-docker`

How I expect reviewers to test this PR:
* Just verify the the container is building properly in CI.
* I'm unsure if there are breaking changes in go-discover, since it doesn't use semver.

Checklist:
- [ ] Tests added
- [X] CHANGELOG entry added (_I'm not super sure what to do here, but let me know what changes I need to make_)


