### PR TITLE
Update go-discover

### DIFF
--- a/.changelog/2390.txt
+++ b/.changelog/2390.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Update [Go-Discover](https://github.com/hashicorp/go-discover) in the container has been updated to address [CVE-2020-14040](https://github.com/advisories/GHSA-5rcv-m4m3-hfh7)
+```

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -17,7 +17,7 @@
 # go-discover builds the discover binary (which we don't currently publish
 # either).
 FROM golang:1.19.2-alpine as go-discover
-RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@49f60c093101c9c5f6b04d5b1c80164251a761a6
+RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@214571b6a5309addf3db7775f4ee8cf4d264fd5f
 
 # dev copies the binary from a local build
 # -----------------------------------


### PR DESCRIPTION
Changes proposed in this PR:
- Follow on from #2390
- Update go-discover to the latest version '214571b6a5309addf3db7775f4ee8cf4d264fd5f'

How I've tested this PR:

👀 

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

