### PR TITLE
always update acl policy if it exists

### DIFF
--- a/.changelog/2392.txt
+++ b/.changelog/2392.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+control-plane: Always update ACL policies upon upgrade
+```

--- a/control-plane/subcommand/server-acl-init/create_or_update_test.go
+++ b/control-plane/subcommand/server-acl-init/create_or_update_test.go
@@ -71,7 +71,7 @@ func TestCreateOrUpdateACLPolicy_ErrorsIfDescriptionDoesNotMatch(t *testing.T) {
 	require.Equal(policyDescription, rereadPolicy.Description)
 }
 
-func TestCreateOrUpdateACLPolicy_Update(t *testing.T) {
+func TestCreateOrUpdateACLPolicy(t *testing.T) {
 	require := require.New(t)
 	ui := cli.NewMockUi()
 	k8s := fake.NewSimpleClientset()

--- a/control-plane/subcommand/server-acl-init/create_or_update_test.go
+++ b/control-plane/subcommand/server-acl-init/create_or_update_test.go
@@ -70,3 +70,93 @@ func TestCreateOrUpdateACLPolicy_ErrorsIfDescriptionDoesNotMatch(t *testing.T) {
 	require.NoError(err)
 	require.Equal(policyDescription, rereadPolicy.Description)
 }
+
+func TestCreateOrUpdateACLPolicy_Update(t *testing.T) {
+	require := require.New(t)
+	ui := cli.NewMockUi()
+	k8s := fake.NewSimpleClientset()
+	cmd := Command{
+		UI:        ui,
+		clientset: k8s,
+		log:       hclog.NewNullLogger(),
+	}
+	cmd.init()
+	// Start Consul.
+	bootToken := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	svr, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
+		c.ACL.Enabled = true
+		c.ACL.Tokens.InitialManagement = bootToken
+	})
+	require.NoError(err)
+	defer svr.Stop()
+	svr.WaitForLeader(t)
+
+	// Get a Consul client.
+	consul, err := api.NewClient(&api.Config{
+		Address: svr.HTTPAddr,
+		Token:   bootToken,
+	})
+	require.NoError(err)
+	connectInjectRule, err := cmd.injectRules()
+	require.NoError(err)
+	aclReplRule, err := cmd.aclReplicationRules()
+	require.NoError(err)
+	policyDescription := "policy-description"
+	policyName := "policy-name"
+	policy, _, err := consul.ACL().PolicyCreate(&api.ACLPolicy{
+		Name:        "new-policy-name",
+		Description: "new-policy-desc",
+	}, nil)
+	require.NoError(err)
+	cases := []struct {
+		Name              string
+		ID                string
+		PolicyDescription string
+		PolicyName        string
+		Rules             string
+		Err               error
+		ExpPolicy         *api.ACLPolicy
+	}{
+		{
+			Name:              "create",
+			ID:                "",
+			PolicyDescription: policyDescription,
+			PolicyName:        policyName,
+			Rules:             connectInjectRule,
+			Err:               nil,
+			ExpPolicy: &api.ACLPolicy{
+				Name:        policyName,
+				Description: policyDescription,
+				Rules:       connectInjectRule,
+			},
+		},
+		{
+			Name:              "update",
+			ID:                policy.ID,
+			PolicyDescription: policy.Description,
+			PolicyName:        policy.Name,
+			Rules:             aclReplRule,
+			Err:               nil,
+			ExpPolicy: &api.ACLPolicy{
+				Name:        policyName,
+				Description: policyDescription,
+				Rules:       aclReplRule,
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			err = cmd.createOrUpdateACLPolicy(api.ACLPolicy{
+				Name:        tt.PolicyName,
+				Description: tt.PolicyDescription,
+				Rules:       tt.Rules,
+			}, consul)
+			require.Equal(tt.Err, err)
+			if tt.ID != "" {
+				readPolicy, _, err := consul.ACL().PolicyRead(tt.ID, nil)
+				require.NoError(err)
+				require.Equal(tt.Rules, readPolicy.Rules)
+			}
+		})
+	}
+}

--- a/control-plane/subcommand/server-acl-init/create_or_update_test.go
+++ b/control-plane/subcommand/server-acl-init/create_or_update_test.go
@@ -156,6 +156,8 @@ func TestCreateOrUpdateACLPolicy(t *testing.T) {
 				readPolicy, _, err := consul.ACL().PolicyRead(tt.ID, nil)
 				require.NoError(err)
 				require.Equal(tt.Rules, readPolicy.Rules)
+				require.Equal(tt.PolicyName, readPolicy.Name)
+				require.Equal(tt.PolicyDescription, readPolicy.Description)
 			}
 		})
 	}

--- a/control-plane/subcommand/server-acl-init/create_or_update_test.go
+++ b/control-plane/subcommand/server-acl-init/create_or_update_test.go
@@ -103,45 +103,23 @@ func TestCreateOrUpdateACLPolicy(t *testing.T) {
 	require.NoError(err)
 	policyDescription := "policy-description"
 	policyName := "policy-name"
-	policy, _, err := consul.ACL().PolicyCreate(&api.ACLPolicy{
-		Name:        "new-policy-name",
-		Description: "new-policy-desc",
-	}, nil)
-	require.NoError(err)
 	cases := []struct {
 		Name              string
-		ID                string
 		PolicyDescription string
 		PolicyName        string
 		Rules             string
-		Err               error
-		ExpPolicy         *api.ACLPolicy
 	}{
 		{
 			Name:              "create",
-			ID:                "",
 			PolicyDescription: policyDescription,
 			PolicyName:        policyName,
 			Rules:             connectInjectRule,
-			Err:               nil,
-			ExpPolicy: &api.ACLPolicy{
-				Name:        policyName,
-				Description: policyDescription,
-				Rules:       connectInjectRule,
-			},
 		},
 		{
 			Name:              "update",
-			ID:                policy.ID,
-			PolicyDescription: policy.Description,
-			PolicyName:        policy.Name,
+			PolicyDescription: policyDescription,
+			PolicyName:        policyName,
 			Rules:             aclReplRule,
-			Err:               nil,
-			ExpPolicy: &api.ACLPolicy{
-				Name:        policyName,
-				Description: policyDescription,
-				Rules:       aclReplRule,
-			},
 		},
 	}
 	for _, tt := range cases {
@@ -151,14 +129,12 @@ func TestCreateOrUpdateACLPolicy(t *testing.T) {
 				Description: tt.PolicyDescription,
 				Rules:       tt.Rules,
 			}, consul)
-			require.Equal(tt.Err, err)
-			if tt.ID != "" {
-				readPolicy, _, err := consul.ACL().PolicyRead(tt.ID, nil)
-				require.NoError(err)
-				require.Equal(tt.Rules, readPolicy.Rules)
-				require.Equal(tt.PolicyName, readPolicy.Name)
-				require.Equal(tt.PolicyDescription, readPolicy.Description)
-			}
+			require.Nil(err)
+			policy, _, err := consul.ACL().PolicyReadByName(tt.PolicyName, nil)
+			require.Nil(err)
+			require.Equal(tt.Rules, policy.Rules)
+			require.Equal(tt.PolicyName, policy.Name)
+			require.Equal(tt.PolicyDescription, policy.Description)
 		})
 	}
 }


### PR DESCRIPTION
Changes proposed in this PR:
- removed c.flagEnableNamespaces || c.flagSyncCatalog check to always allow  acl update

Context :- 
Between 0.49.0 and 1.0.x: we don't update ACL policies unless namespaces or sync catalog is enabled but between those versions, we merged controller and connect-inject. This meant we added required ACL rules to connect inject but those don't actually get updated and so now the controller can't do things like create intention CRDs.

How I've tested this PR:
  - deploy 0.49.x with connect inject enabled and acls enabled
  - Get the acl policy for connect injector and save it locally
  - build a control plane image and set imageK8s  with it.
  - upgrade to 1.0.x with your changes
  - Check the acl policy again and check that it has updated rules as opposed to the one from step 2
  


Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

