### PR TITLE
Net 4616/windows volume medium fix

### DIFF
--- a/control-plane/connect-inject/webhook/container_volume.go
+++ b/control-plane/connect-inject/webhook/container_volume.go
@@ -10,11 +10,15 @@ const volumeName = "consul-connect-inject-data"
 
 // containerVolume returns the volume data to add to the pod. This volume
 // is used for shared data between containers.
-func (w *MeshWebhook) containerVolume() corev1.Volume {
+func (w *MeshWebhook) containerVolume(isWindowsPod bool) corev1.Volume {
+	storageMedium := corev1.StorageMediumMemory
+	if isWindowsPod {
+		storageMedium = corev1.StorageMediumDefault
+	}
 	return corev1.Volume{
 		Name: volumeName,
 		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory},
+			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: storageMedium},
 		},
 	}
 }

--- a/control-plane/connect-inject/webhook/container_volume_test.go
+++ b/control-plane/connect-inject/webhook/container_volume_test.go
@@ -1,0 +1,46 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_containerVolume(t *testing.T) {
+	cases := []struct {
+		Name      string
+		IsWindows bool
+		ExpVolume corev1.Volume
+	}{
+		{
+			Name:      "windows",
+			IsWindows: true,
+			ExpVolume: corev1.Volume{
+				Name: volumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumDefault},
+				},
+			},
+		},
+		{
+			Name:      "linux",
+			IsWindows: false,
+			ExpVolume: corev1.Volume{
+				Name: volumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory},
+				},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			var w MeshWebhook
+			vol := w.containerVolume(tt.IsWindows)
+			assert.Equal(t, tt.ExpVolume, vol)
+		})
+	}
+
+}

--- a/control-plane/connect-inject/webhook/mesh_webhook.go
+++ b/control-plane/connect-inject/webhook/mesh_webhook.go
@@ -258,7 +258,7 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 
 	// Add our volume that will be shared by the init container and
 	// the sidecar for passing data in the pod.
-	pod.Spec.Volumes = append(pod.Spec.Volumes, w.containerVolume())
+	pod.Spec.Volumes = append(pod.Spec.Volumes, w.containerVolume(isWindows(pod)))
 
 	// Optionally mount data volume to other containers
 	w.injectVolumeMount(pod)


### PR DESCRIPTION
Changes proposed in this PR:
- using defaultStorageMedium("") for consul-connect-inject-data volume incase of windows os.
-

How I've tested this PR:
built a new control plane image and installed consul in gke windows using helm  
How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

