### PR TITLE
Fix GatewayClassConfig Test Timing Issue

### DIFF
--- a/acceptance/tests/api-gateway/api_gateway_gatewayclassconfig_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_gatewayclassconfig_test.go
@@ -5,7 +5,9 @@ package apigateway
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
@@ -29,6 +31,15 @@ import (
 // minInstances,maxInstances and defaultInstances parameters, and that changing the parent gateway does not affect
 // the child gateways.
 func TestAPIGateway_GatewayClassConfig(t *testing.T) {
+	var (
+		defaultInstances = pointer.Int32(2)
+		maxInstances     = pointer.Int32(8)
+		minInstances     = pointer.Int32(1)
+
+		namespace        = "gateway-namespace"
+		gatewayClassName = "gateway-class"
+	)
+
 	ctx := suite.Environment().DefaultContext(t)
 	cfg := suite.Config()
 	helmValues := map[string]string{
@@ -38,6 +49,7 @@ func TestAPIGateway_GatewayClassConfig(t *testing.T) {
 	releaseName := helpers.RandomName()
 	consulCluster := consul.NewHelmCluster(t, helmValues, ctx, cfg, releaseName)
 	consulCluster.Create(t)
+
 	// Override the default proxy config settings for this test.
 	consulClient, _ := consulCluster.SetupConsulClient(t, false)
 	_, _, err := consulClient.ConfigEntries().Set(&api.ProxyConfigEntry{
@@ -50,9 +62,8 @@ func TestAPIGateway_GatewayClassConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	k8sClient := ctx.ControllerRuntimeClient(t)
-	namespace := "gateway-namespace"
 
-	//create clean namespace
+	// Create a clean namespace.
 	err = k8sClient.Create(context.Background(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
@@ -68,10 +79,7 @@ func TestAPIGateway_GatewayClassConfig(t *testing.T) {
 		})
 	})
 
-	defaultInstances := pointer.Int32(2)
-	maxInstances := pointer.Int32(8)
-	minInstances := pointer.Int32(1)
-	// create a GatewayClassConfig with configuration set
+	// Create a GatewayClassConfig.
 	gatewayClassConfigName := "gateway-class-config"
 	gatewayClassConfig := &v1alpha1.GatewayClassConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -99,8 +107,7 @@ func TestAPIGateway_GatewayClassConfig(t *testing.T) {
 		Name:  gatewayClassConfigName,
 	}
 
-	// create gateway class referencing gateway-class-config
-	gatewayClassName := "gateway-class"
+	// Create gateway class referencing gateway-class-config.
 	logger.Log(t, "creating controlled gateway class")
 	createGatewayClass(t, k8sClient, gatewayClassName, gatewayClassControllerName, gatewayParametersRef)
 	helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
@@ -108,7 +115,7 @@ func TestAPIGateway_GatewayClassConfig(t *testing.T) {
 		k8sClient.DeleteAllOf(context.Background(), &gwv1beta1.GatewayClass{})
 	})
 
-	// Create a certificate to reference in listeners
+	// Create a certificate to reference in listeners.
 	certificateInfo := generateCertificate(t, nil, "certificate.consul.local")
 	certificateName := "certificate"
 	certificate := &corev1.Secret{
@@ -132,24 +139,24 @@ func TestAPIGateway_GatewayClassConfig(t *testing.T) {
 		k8sClient.Delete(context.Background(), certificate)
 	})
 
-	// Create gateway referencing gateway class config
+	// Create gateway referencing gateway class.
 	gatewayName := "gateway"
 	logger.Log(t, "creating controlled gateway")
 	gateway := createGateway(t, k8sClient, gatewayName, namespace, gatewayClassName, certificateName)
-	// make sure it exists
-	logger.Log(t, "checking that gateway one is synchronized to Consul")
-	checkConsulExists(t, consulClient, api.APIGateway, gatewayName)
-
 	helpers.Cleanup(t, cfg.NoCleanupOnFailure, func() {
 		logger.Log(t, "deleting all gateways")
 		k8sClient.DeleteAllOf(context.Background(), &gwv1beta1.Gateway{}, client.InNamespace(namespace))
 	})
 
+	// Ensure it exists.
+	logger.Log(t, "checking that gateway is synchronized to Consul")
+	checkConsulExists(t, consulClient, api.APIGateway, gatewayName)
+
 	// Scenario: Gateway deployment should match the default instances defined on the gateway class config
 	logger.Log(t, "checking that gateway instances match defined gateway class config")
 	checkNumberOfInstances(t, k8sClient, consulClient, gateway.Name, gateway.Namespace, defaultInstances, gateway)
 
-	//Scenario: Updating the GatewayClassConfig should not affect gateways that have already been created
+	// Scenario: Updating the GatewayClassConfig should not affect gateways that have already been created
 	logger.Log(t, "updating gatewayclassconfig values")
 	err = k8sClient.Get(context.Background(), types.NamespacedName{Name: gatewayClassConfigName, Namespace: namespace}, gatewayClassConfig)
 	require.NoError(t, err)
@@ -159,7 +166,7 @@ func TestAPIGateway_GatewayClassConfig(t *testing.T) {
 	require.NoError(t, err)
 	checkNumberOfInstances(t, k8sClient, consulClient, gateway.Name, gateway.Namespace, defaultInstances, gateway)
 
-	//Scenario: gateways should be able to scale independently and not get overridden by the controller unless it's above the max
+	// Scenario: gateways should be able to scale independently and not get overridden by the controller unless it's above the max
 	scale(t, k8sClient, gateway.Name, gateway.Namespace, maxInstances)
 	checkNumberOfInstances(t, k8sClient, consulClient, gateway.Name, gateway.Namespace, maxInstances, gateway)
 	scale(t, k8sClient, gateway.Name, gateway.Namespace, pointer.Int32(10))
@@ -186,22 +193,29 @@ func scale(t *testing.T, client client.Client, name, namespace string, scaleTo *
 func checkNumberOfInstances(t *testing.T, k8client client.Client, consulClient *api.Client, name, namespace string, wantNumber *int32, gateway *gwv1beta1.Gateway) {
 	t.Helper()
 
-	retryCheck(t, 30, func(r *retry.R) {
-		//first check to make sure the number of replicas has been set properly
+	retryCheckWithWait(t, 30, 10*time.Second, func(r *retry.R) {
+		logger.Log(t, "checking that gateway instances match defined gateway class config")
+		logger.Log(t, fmt.Sprintf("want: %d", *wantNumber))
+
+		// Ensure the number of replicas has been set properly.
 		var deployment appsv1.Deployment
 		err := k8client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: namespace}, &deployment)
 		require.NoError(r, err)
-		require.EqualValues(r, *wantNumber, *deployment.Spec.Replicas)
+		logger.Log(t, fmt.Sprintf("deployment replicas: %d", *deployment.Spec.Replicas))
+		require.EqualValues(r, *wantNumber, *deployment.Spec.Replicas, "deployment replicas should match the number of instances defined on the gateway class config")
 
-		//then check to make sure the number of gateway pods matches the replicas generated
+		// Ensure the number of gateway pods matches the replicas generated.
 		podList := corev1.PodList{}
 		labels := common.LabelsForGateway(gateway)
 		err = k8client.List(context.Background(), &podList, client.InNamespace(namespace), client.MatchingLabels(labels))
 		require.NoError(r, err)
-		require.EqualValues(r, *wantNumber, len(podList.Items))
+		logger.Log(t, fmt.Sprintf("number of pods: %d", len(podList.Items)))
+		require.EqualValues(r, *wantNumber, len(podList.Items), "number of pods should match the number of instances defined on the gateway class config")
 
+		// Ensure the number of services matches the replicas generated.
 		services, _, err := consulClient.Catalog().Service(name, "", nil)
 		require.NoError(r, err)
-		require.EqualValues(r, *wantNumber, len(services))
+		logger.Log(t, fmt.Sprintf("number of services: %d", len(services)))
+		require.EqualValues(r, *wantNumber, len(services), "number of services should match the number of instances defined on the gateway class config")
 	})
 }

--- a/acceptance/tests/api-gateway/api_gateway_gatewayclassconfig_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_gatewayclassconfig_test.go
@@ -33,7 +33,7 @@ import (
 func TestAPIGateway_GatewayClassConfig(t *testing.T) {
 	var (
 		defaultInstances = pointer.Int32(2)
-		maxInstances     = pointer.Int32(8)
+		maxInstances     = pointer.Int32(4)
 		minInstances     = pointer.Int32(1)
 
 		namespace        = "gateway-namespace"
@@ -167,9 +167,7 @@ func TestAPIGateway_GatewayClassConfig(t *testing.T) {
 	checkNumberOfInstances(t, k8sClient, consulClient, gateway.Name, gateway.Namespace, defaultInstances, gateway)
 
 	// Scenario: gateways should be able to scale independently and not get overridden by the controller unless it's above the max
-	scale(t, k8sClient, gateway.Name, gateway.Namespace, maxInstances)
-	checkNumberOfInstances(t, k8sClient, consulClient, gateway.Name, gateway.Namespace, maxInstances, gateway)
-	scale(t, k8sClient, gateway.Name, gateway.Namespace, pointer.Int32(10))
+	scale(t, k8sClient, gateway.Name, gateway.Namespace, pointer.Int32(*maxInstances+1))
 	checkNumberOfInstances(t, k8sClient, consulClient, gateway.Name, gateway.Namespace, maxInstances, gateway)
 	scale(t, k8sClient, gateway.Name, gateway.Namespace, pointer.Int32(0))
 	checkNumberOfInstances(t, k8sClient, consulClient, gateway.Name, gateway.Namespace, minInstances, gateway)

--- a/acceptance/tests/api-gateway/api_gateway_tenancy_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_tenancy_test.go
@@ -347,9 +347,13 @@ func generateCertificate(t *testing.T, ca *certificateInfo, commonName string) *
 }
 
 func retryCheck(t *testing.T, count int, fn func(r *retry.R)) {
+	retryCheckWithWait(t, count, 2*time.Second, fn)
+}
+
+func retryCheckWithWait(t *testing.T, count int, wait time.Duration, fn func(r *retry.R)) {
 	t.Helper()
 
-	counter := &retry.Counter{Count: count, Wait: 2 * time.Second}
+	counter := &retry.Counter{Count: count, Wait: wait}
 	retry.RunWith(counter, t, fn)
 }
 


### PR DESCRIPTION
Changes proposed in this PR:
- Add retryCheckWithWait func
- Fix retry timing on GatewayClassConfig test

How I've tested this PR:
- Running Acceptance tests locally

How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

