### PR TITLE
Mw/net 4622 release 0.49.x acceptance tests broken missing packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,17 @@ kind-node-image:
 kubectl-version:
 	@echo $(KUBECTL_VERSION)
 
+kind-test-packages:
+	@./control-plane/build-support/scripts/set_test_package_matrix.sh "acceptance/ci-inputs/kind_acceptance_test_packages.yaml"
+
+gke-test-packages:
+	@./control-plane/build-support/scripts/set_test_package_matrix.sh "acceptance/ci-inputs/gke_acceptance_test_packages.yaml"
+
+eks-test-packages:
+	@./control-plane/build-support/scripts/set_test_package_matrix.sh "acceptance/ci-inputs/eks_acceptance_test_packages.yaml"
+
+aks-test-packages:
+	@./control-plane/build-support/scripts/set_test_package_matrix.sh "acceptance/ci-inputs/aks_acceptance_test_packages.yaml"
 
 
 # ===========> Release Targets

--- a/acceptance/ci-inputs/aks_acceptance_test_packages.yaml
+++ b/acceptance/ci-inputs/aks_acceptance_test_packages.yaml
@@ -1,0 +1,3 @@
+- {runner: 0, test-packages: "connect peering snapshot-agent wan-federation"}
+- {runner: 1, test-packages: "consul-dns example partitions metrics sync"}
+- {runner: 2, test-packages: "basic cli config-entries api-gateway ingress-gateway terminating-gateway vault"}

--- a/acceptance/ci-inputs/eks_acceptance_test_packages.yaml
+++ b/acceptance/ci-inputs/eks_acceptance_test_packages.yaml
@@ -1,0 +1,3 @@
+- {runner: 0, test-packages: "connect peering snapshot-agent wan-federation"}
+- {runner: 1, test-packages: "consul-dns example partitions metrics sync"}
+- {runner: 2, test-packages: "basic cli config-entries api-gateway ingress-gateway terminating-gateway vault"}

--- a/acceptance/ci-inputs/gke_acceptance_test_packages.yaml
+++ b/acceptance/ci-inputs/gke_acceptance_test_packages.yaml
@@ -1,0 +1,3 @@
+- {runner: 0, test-packages: "connect peering snapshot-agent wan-federation"}
+- {runner: 1, test-packages: "consul-dns example partitions metrics sync"}
+- {runner: 2, test-packages: "basic cli config-entries api-gateway ingress-gateway terminating-gateway vault"}

--- a/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
+++ b/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
@@ -1,0 +1,6 @@
+- {runner: 0, test-packages: "partitions"}
+- {runner: 1, test-packages: "peering"}
+- {runner: 2, test-packages: "connect snapshot-agent wan-federation"}
+- {runner: 3, test-packages: "cli vault metrics"}
+- {runner: 4, test-packages: "api-gateway ingress-gateway sync example consul-dns"}
+- {runner: 5, test-packages: "config-entries terminating-gateway basic"}

--- a/control-plane/build-support/scripts/set_test_package_matrix.sh
+++ b/control-plane/build-support/scripts/set_test_package_matrix.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+INPUT_FILE=$1
+
+# convert readable yaml to json for github actions consumption
+# do not include any pretty print, print to single line with -I 0
+VALUE=$(yq eval 'select(fileIndex == 0)' "$INPUT_FILE" -o json -I 0)
+
+echo "$VALUE"


### PR DESCRIPTION
Changes proposed in this PR:
- This PR adds a configurable acceptance test matrix to the repo that can be fetched via the following make targets ( depending on the test):
  - `make kind-test-packages`
  - `make aks-test-packages` 
  -  `make eks-test-packages`
  - `make gke-test-packages`
- Each branch can now have their own defined list of acceptance tests allowing branches to have different packages 

How I've tested this PR:
- Ran against this workflow: https://github.com/hashicorp/consul-k8s-workflows/pull/19
- Will point the pr.yaml file back at main after review
- I wasn't able to test the cloud tests because cloud test security does not allow for point tests to any other branch than main

How I expect reviewers to test this PR:
👀 

Checklist:
- [x] Tests added
- [n/a] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

