### PR TITLE
NET-4638: when multiple listeners have the same port, only add to K8s Service once

### DIFF
--- a/.changelog/2413.txt
+++ b/.changelog/2413.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api-gateway: Fix creation of invalid Kubernetes Service when multiple Gateway listeners have the same port.
+```

--- a/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
@@ -40,11 +40,18 @@ var (
 			Name:     "Listener 1",
 			Port:     8080,
 			Protocol: "TCP",
+			Hostname: common.PointerTo(gwv1beta1.Hostname("example.com")),
 		},
 		{
 			Name:     "Listener 2",
 			Port:     8081,
 			Protocol: "TCP",
+		},
+		{
+			Name:     "Listener 3",
+			Port:     8080,
+			Protocol: "TCP",
+			Hostname: common.PointerTo(gwv1beta1.Hostname("example.net")),
 		},
 	}
 )


### PR DESCRIPTION
**Changes proposed in this PR:**
A valid `Gateway` can have multiple listeners with the same port. When this happens, we loop through the listeners and add each listener's port to the list of ports for the corresponding Kubernetes `Service`, resulting in an invalid resource that can't be created.

This change just tracks which ports have already been added so that we only add each port once.

**How I've tested this PR:**
🤖 tests pass

**How I expect reviewers to test this PR:**
🤖 tests pass

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

