### PR TITLE
Revert "added imagePullPolicy for images in values.yaml (#2310)"

### DIFF
--- a/.changelog/2310.txt
+++ b/.changelog/2310.txt
@@ -1,3 +1,0 @@
-```release-note:feature
-helm: Added imagePullPolicy global field which can be configured to override the default behaviour.
-```

--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -57,7 +57,6 @@ spec:
       containers:
       - name: api-gateway-controller
         image: {{ .Values.apiGateway.image }}
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         ports:
         - containerPort: 9090
           name: sds
@@ -220,7 +219,6 @@ spec:
       {{- if .Values.global.acls.manageSystemACLs }}
       - name: copy-consul-bin
         image: {{ .Values.global.image | quote }}
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         command:
         - cp
         - /bin/consul
@@ -258,7 +256,6 @@ spec:
         {{- end}}
         {{- include "consul.consulK8sConsulServerEnvVars" . | nindent 8 }}
         image: {{ .Values.global.imageK8S }}
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         volumeMounts:
         - mountPath: /consul/login
           name: consul-data

--- a/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
+++ b/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
@@ -65,7 +65,6 @@ spec:
   image:
     consulAPIGateway: {{ .Values.apiGateway.image }}
     envoy: {{ .Values.apiGateway.imageEnvoy }}
-  imagePullPolicy: {{ .Values.global.imagePullPolicy }}
   {{- if .Values.apiGateway.managedGatewayClass.nodeSelector }}
   nodeSelector:
     {{ tpl .Values.apiGateway.managedGatewayClass.nodeSelector . | indent 4 | trim }}

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -493,7 +493,6 @@ spec:
       {{- if .Values.global.acls.manageSystemACLs }}
       - name: client-acl-init
         image: {{ .Values.global.imageK8S }}
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         env:
         - name: NAMESPACE
           valueFrom:

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -61,7 +61,6 @@ spec:
         # This container installs the consul CNI binaries and CNI network config file on each node
         - name: install-cni
           image: {{ .Values.global.imageK8S }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           securityContext:
             privileged: true
           command:

--- a/charts/consul/templates/enterprise-license-job.yaml
+++ b/charts/consul/templates/enterprise-license-job.yaml
@@ -124,7 +124,6 @@ spec:
       initContainers:
       - name: ent-license-acl-init
         image: {{ .Values.global.imageK8S }}
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         command:
           - "/bin/sh"
           - "-ec"

--- a/charts/consul/templates/gateway-cleanup-job.yaml
+++ b/charts/consul/templates/gateway-cleanup-job.yaml
@@ -37,7 +37,6 @@ spec:
       containers:
         - name: gateway-cleanup
           image: {{ .Values.global.imageK8S }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           command:
             - consul-k8s-control-plane
           args:

--- a/charts/consul/templates/gateway-resources-job.yaml
+++ b/charts/consul/templates/gateway-resources-job.yaml
@@ -37,7 +37,6 @@ spec:
       containers:
         - name: gateway-resources
           image: {{ .Values.global.imageK8S }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           command:
             - consul-k8s-control-plane
           args:

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -121,7 +121,6 @@ spec:
       initContainers:
       - name: mesh-gateway-init
         image: {{ .Values.global.imageK8S }}
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         env:
         - name: NAMESPACE
           valueFrom:
@@ -180,7 +179,6 @@ spec:
       containers:
       - name: mesh-gateway
         image: {{ .Values.global.imageConsulDataplane | quote }}
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         {{- if .Values.meshGateway.resources }}
         resources:
             {{- if eq (typeOf .Values.meshGateway.resources) "string" }}

--- a/charts/consul/templates/partition-init-job.yaml
+++ b/charts/consul/templates/partition-init-job.yaml
@@ -81,7 +81,6 @@ spec:
       containers:
         - name: partition-init-job
           image: {{ .Values.global.imageK8S }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
           {{- include "consul.consulK8sConsulServerEnvVars" . | nindent 10 }}
           {{- if (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey) }}

--- a/charts/consul/templates/server-acl-init-cleanup-job.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-job.yaml
@@ -53,7 +53,6 @@ spec:
       containers:
         - name: server-acl-init-cleanup
           image: {{ .Values.global.imageK8S }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           command:
             - consul-k8s-control-plane
           args:

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -122,7 +122,6 @@ spec:
       containers:
       - name: server-acl-init-job
         image: {{ .Values.global.imageK8S }}
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         env:
         - name: NAMESPACE
           valueFrom:

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -225,7 +225,6 @@ spec:
       initContainers:
       - name: locality-init
         image: {{ .Values.global.imageK8S }}
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         env:
         - name: NODE_NAME
           valueFrom:

--- a/charts/consul/templates/webhook-cert-manager-deployment.yaml
+++ b/charts/consul/templates/webhook-cert-manager-deployment.yaml
@@ -50,7 +50,6 @@ spec:
             -deployment-name={{ template "consul.fullname" . }}-webhook-cert-manager \
             -deployment-namespace={{ .Release.Namespace }}
         image: {{ .Values.global.imageK8S }}
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         name: webhook-cert-manager
         resources:
           limits:

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -52,12 +52,6 @@ global:
     # Changing the partition name would require an un-install and a re-install with the updated name.
     # Must be "default" in the server cluster ie the Kubernetes cluster that the Consul server pods are deployed onto.
     name: "default"
-  
-  # Set imagePullPolicy for all images used. This is applies to all the images being used.
-  # One of "IfNotPresent", "Always", "Never"
-  # Refer to https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
-  # @type: string
-  imagePullPolicy: ""
 
   # The name (and tag) of the Consul Docker image for clients and servers.
   # This can be overridden per component. This should be pinned to a specific


### PR DESCRIPTION
This reverts commit 285096241e0d5c5b6d53dd8a37889ab3ea5a8af2.

Changes proposed in this PR:
- The above PR missed some places to add support for the imagePullPolicy leading to inconsistent behavior across the helm chart. This change will be reintroduced in a future PR once we have implemented it completely.

