### PR TITLE
feat(helm): add configurable server-acl-init and cleanup resource limits

### DIFF
--- a/.changelog/2416.txt
+++ b/.changelog/2416.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+helm: Adds `acls.resources` field which can be configured to override the `resource` settings for the `server-acl-init` and `server-acl-init-cleanup` Jobs.
+```

--- a/charts/consul/templates/server-acl-init-cleanup-job.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-job.yaml
@@ -64,7 +64,7 @@ spec:
             - {{ template "consul.fullname" . }}-server-acl-init
           {{- if .Values.acls.resources }}
           resources:
-            {{- toYaml .Values.server.resources | nindent 12 }}
+            {{- toYaml .Values.acls.resources | nindent 12 }}
           {{- end }}
       {{- if .Values.global.acls.tolerations }}
       tolerations:

--- a/charts/consul/templates/server-acl-init-cleanup-job.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-job.yaml
@@ -62,13 +62,10 @@ spec:
             - -log-json={{ .Values.global.logJSON }}
             - -k8s-namespace={{ .Release.Namespace }}
             - {{ template "consul.fullname" . }}-server-acl-init
+          {{- if .Values.acls.resources }}
           resources:
-            requests:
-              memory: "50Mi"
-              cpu: "50m"
-            limits:
-              memory: "50Mi"
-              cpu: "50m"
+            {{- toYaml .Values.server.resources | nindent 12 }}
+          {{- end }}
       {{- if .Values.global.acls.tolerations }}
       tolerations:
         {{ tpl .Values.global.acls.tolerations . | indent 8 | trim }}

--- a/charts/consul/templates/server-acl-init-cleanup-job.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-job.yaml
@@ -62,9 +62,9 @@ spec:
             - -log-json={{ .Values.global.logJSON }}
             - -k8s-namespace={{ .Release.Namespace }}
             - {{ template "consul.fullname" . }}-server-acl-init
-          {{- if .Values.acls.resources }}
+          {{- if .Values.global.acls.resources }}
           resources:
-            {{- toYaml .Values.acls.resources | nindent 12 }}
+            {{- toYaml .Values.global.acls.resources | nindent 12 }}
           {{- end }}
       {{- if .Values.global.acls.tolerations }}
       tolerations:

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -308,13 +308,10 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
+        {{- if .Values.acls.resources }}
         resources:
-          requests:
-            memory: "50Mi"
-            cpu: "50m"
-          limits:
-            memory: "50Mi"
-            cpu: "50m"
+          {{- toYaml .Values.server.resources | nindent 10 }}
+        {{- end }}
       {{- if .Values.global.acls.tolerations }}
       tolerations:
         {{ tpl .Values.global.acls.tolerations . | indent 8 | trim }}

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -310,7 +310,7 @@ spec:
             {{- end }}
         {{- if .Values.acls.resources }}
         resources:
-          {{- toYaml .Values.server.resources | nindent 10 }}
+          {{- toYaml .Values.acls.resources | nindent 10 }}
         {{- end }}
       {{- if .Values.global.acls.tolerations }}
       tolerations:

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -308,9 +308,9 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-        {{- if .Values.acls.resources }}
+        {{- if .Values.global.acls.resources }}
         resources:
-          {{- toYaml .Values.acls.resources | nindent 10 }}
+          {{- toYaml .Values.global.acls.resources | nindent 10 }}
         {{- end }}
       {{- if .Values.global.acls.tolerations }}
       tolerations:

--- a/charts/consul/test/unit/server-acl-init-cleanup-job.bats
+++ b/charts/consul/test/unit/server-acl-init-cleanup-job.bats
@@ -159,3 +159,25 @@ load _helpers
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# resources
+
+@test "serverACLInitCleanup/Job: resources defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-cleanup-job.yaml  \
+      . | tee /dev/stderr |
+      yq -rc '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
+  [ "${actual}" = '{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"50m","memory":"50Mi"}}' ]
+}
+
+@test "serverACLInitCleanup/Job: resources can be overridden" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-cleanup-job.yaml  \
+      --set 'acls.resources.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].resources.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/charts/consul/test/unit/server-acl-init-cleanup-job.bats
+++ b/charts/consul/test/unit/server-acl-init-cleanup-job.bats
@@ -176,7 +176,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-acl-init-cleanup-job.yaml  \
-      --set 'acls.resources.foo=bar' \
+      --set 'global.acls.resources.foo=bar' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].resources.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]

--- a/charts/consul/test/unit/server-acl-init-cleanup-job.bats
+++ b/charts/consul/test/unit/server-acl-init-cleanup-job.bats
@@ -166,7 +166,8 @@ load _helpers
 @test "serverACLInitCleanup/Job: resources defined by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/server-acl-init-cleanup-job.yaml  \
+      -s templates/server-acl-init-cleanup-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -rc '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
   [ "${actual}" = '{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"50m","memory":"50Mi"}}' ]
@@ -175,7 +176,8 @@ load _helpers
 @test "serverACLInitCleanup/Job: resources can be overridden" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/server-acl-init-cleanup-job.yaml  \
+      -s templates/server-acl-init-cleanup-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.resources.foo=bar' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].resources.foo' | tee /dev/stderr)

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -2209,7 +2209,8 @@ load _helpers
 @test "serverACLInit/Job: resources defined by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -rc '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
   [ "${actual}" = '{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"50m","memory":"50Mi"}}' ]
@@ -2218,7 +2219,8 @@ load _helpers
 @test "serverACLInit/Job: resources can be overridden" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/server-acl-init-job.yaml  \
+      -s templates/server-acl-init-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.resources.foo=bar' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].resources.foo' | tee /dev/stderr)

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -2219,7 +2219,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
-      --set 'acls.resources.foo=bar' \
+      --set 'global.acls.resources.foo=bar' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].resources.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -2202,3 +2202,25 @@ load _helpers
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# resources
+
+@test "serverACLInit/Job: resources defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      . | tee /dev/stderr |
+      yq -rc '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
+  [ "${actual}" = '{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"50m","memory":"50Mi"}}' ]
+}
+
+@test "serverACLInit/Job: resources can be overridden" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'acls.resources.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].resources.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -436,6 +436,33 @@ global:
       # @type: string
       secretKey: null
 
+    # The resource requests (CPU, memory, etc.) for the server-acl-init and server-acl-init-cleanup pods. 
+    # This should be a YAML map corresponding to a Kubernetes
+    # [`ResourceRequirements``](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core)
+    # object.
+    #
+    # Example:
+    #
+    # ```yaml
+    # resources:
+    #   requests:
+    #     memory: '200Mi'
+    #     cpu: '100m'
+    #   limits:
+    #     memory: '200Mi'
+    #     cpu: '100m'
+    # ```
+    #
+    # @recurse: false
+    # @type: map
+    resources:
+      requests:
+        memory: "50Mi"
+        cpu: "50m"
+      limits:
+        memory: "50Mi"
+        cpu: "50m"
+
     # partitionToken references a Vault secret containing the ACL token to be used in non-default partitions.
     # This value should only be provided in the default partition and only when setting
     # the `global.secretsBackend.vault.enabled` value to true.


### PR DESCRIPTION
Changes proposed in this PR:
- Exposes resource configuration for `server-acl-init` and `sercer-acl-init-cleanup` Jobs as helm values with existing defaults. 

How I've tested this PR: unit tests

How I expect reviewers to test this PR: 👀 


Checklist:
- [X] Tests added
- [X] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

