### PR TITLE
NET-4482: set route condition appropriately when parent ref includes non-existent section

### DIFF
--- a/.changelog/2420.txt
+++ b/.changelog/2420.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api-gateway: set route condition appropriately when parent ref includes non-existent section name
+```

--- a/control-plane/api-gateway/binding/result.go
+++ b/control-plane/api-gateway/binding/result.go
@@ -184,7 +184,7 @@ func (b bindResults) Condition() metav1.Condition {
 				// or if we have a ref not permitted, then use that
 				reason = "RefNotPermitted"
 			case errRouteNoMatchingParent:
-				// or if the route declares a parent with a section name that we can't find
+				// or if the route declares a parent that we can't find
 				reason = "NoMatchingParent"
 			}
 		}

--- a/control-plane/api-gateway/binding/result_test.go
+++ b/control-plane/api-gateway/binding/result_test.go
@@ -1,0 +1,67 @@
+package binding
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBindResults_Condition(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Results  bindResults
+		Expected metav1.Condition
+	}{
+		{
+			Name:     "route successfully bound",
+			Results:  bindResults{{section: "", err: nil}},
+			Expected: metav1.Condition{Type: "Accepted", Status: "True", Reason: "Accepted", Message: "route accepted"},
+		},
+		{
+			Name: "multiple bind results",
+			Results: bindResults{
+				{section: "abc", err: errRouteNoMatchingListenerHostname},
+				{section: "def", err: errRouteNoMatchingParent},
+			},
+			Expected: metav1.Condition{Type: "Accepted", Status: "False", Reason: "NotAllowedByListeners", Message: "abc: listener cannot bind route with a non-aligned hostname; def: no matching parent"},
+		},
+		{
+			Name:     "no matching listener hostname error",
+			Results:  bindResults{{section: "abc", err: errRouteNoMatchingListenerHostname}},
+			Expected: metav1.Condition{Type: "Accepted", Status: "False", Reason: "NoMatchingListenerHostname", Message: "abc: listener cannot bind route with a non-aligned hostname"},
+		},
+		{
+			Name:     "ref not permitted error",
+			Results:  bindResults{{section: "abc", err: errRefNotPermitted}},
+			Expected: metav1.Condition{Type: "Accepted", Status: "False", Reason: "RefNotPermitted", Message: "abc: reference not permitted due to lack of ReferenceGrant"},
+		},
+		{
+			Name:     "no matching parent error",
+			Results:  bindResults{{section: "hello1", err: errRouteNoMatchingParent}},
+			Expected: metav1.Condition{Type: "Accepted", Status: "False", Reason: "NoMatchingParent", Message: "hello1: no matching parent"},
+		},
+		{
+			Name:     "bind result without section name",
+			Results:  bindResults{{section: "", err: errRouteNoMatchingParent}},
+			Expected: metav1.Condition{Type: "Accepted", Status: "False", Reason: "NoMatchingParent", Message: "no matching parent"},
+		},
+		{
+			Name:     "unhandled error type",
+			Results:  bindResults{{section: "abc", err: errors.New("you don't know me")}},
+			Expected: metav1.Condition{Type: "Accepted", Status: "False", Reason: "NotAllowedByListeners", Message: "abc: you don't know me"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s_%s", t.Name(), tc.Name), func(t *testing.T) {
+			actual := tc.Results.Condition()
+			assert.Equalf(t, tc.Expected.Type, actual.Type, "expected condition with type %q but got %q", tc.Expected.Type, actual.Type)
+			assert.Equalf(t, tc.Expected.Status, actual.Status, "expected condition with status %q but got %q", tc.Expected.Status, actual.Status)
+			assert.Equalf(t, tc.Expected.Reason, actual.Reason, "expected condition with reason %q but got %q", tc.Expected.Reason, actual.Reason)
+			assert.Equalf(t, tc.Expected.Message, actual.Message, "expected condition with message %q but got %q", tc.Expected.Message, actual.Message)
+		})
+	}
+}

--- a/control-plane/api-gateway/binding/route_binding.go
+++ b/control-plane/api-gateway/binding/route_binding.go
@@ -106,9 +106,16 @@ func (r *Binder) bindRoute(route client.Object, boundCount map[gwv1beta1.Section
 
 		listeners := listenersFor(&r.config.Gateway, ref.SectionName)
 
+		// If there are no matching listeners, then we failed to find the parent
 		if len(listeners) == 0 {
+			var sectionName gwv1beta1.SectionName
+			if ref.SectionName != nil {
+				sectionName = *ref.SectionName
+			}
+
 			result = append(result, bindResult{
-				err: errRouteNoMatchingListenerName,
+				section: sectionName,
+				err:     errRouteNoMatchingParent,
 			})
 		}
 


### PR DESCRIPTION
**Changes proposed in this PR:**
When a `HTTPRoute` declares a parent `Gateway`, it's allowed to specify a specific listener on that `Gateway` to attach to. If a listener doesn't exist matching that parent reference, then we need to set the `HTTPRoute` acceptance condition appropriately.

**How I've tested this PR:**
- Added unit tests pass
- Previously failing conformance test now passes
<img width="1898" alt="CleanShot 2023-06-21 at 18 07 15@2x" src="https://github.com/hashicorp/consul-k8s/assets/3476400/f4410a19-5bee-4654-8af5-9109e9d260b7">

**How I expect reviewers to test this PR:**
See above

**Checklist:**
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

