### PR TITLE
Fix Audit Log Config for Consul Enterprise

### DIFF
--- a/charts/consul/templates/server-config-configmap.yaml
+++ b/charts/consul/templates/server-config-configmap.yaml
@@ -191,7 +191,7 @@ data:
   audit-logging.json: |-
     {
       "audit": {
-        "enabled": "true",
+        "enabled": true,
         "sink": {
           {{- range $index, $element := .Values.server.auditLogs.sinks }}
           {{- if ne $index 0 }},{{end}}


### PR DESCRIPTION
Changes proposed in this PR:
- Change the `"true"` value in audit log config to `true`. 

The bug shows up when `server.auditLogs.enable=true`. This creates a JSON config in the `server-config-configmap` that configures audit logs. This JSON used `"true"` to enable the audit logs. Consul Enterprise would try to parse this JSON and fail on startup.

This error would be seen on startup:
```
==> failed to parse /consul/config/..2023_06_23_03_17_33.2371016911/audit-logging.json: 1 error(s) decoding:

* 'audit.enabled' expected type 'bool', got unconvertible type 'string', value: 'true'
```

Now with the value set to `true`, audit logging works just fine :) 

How I've tested this PR:
I installed Consul Enterprise in Kind with the following command.

```sh
helm install consul $HELM_CHART -n consul \
	--set global.image=teckerthashicorp/consul-enterprise:2023-06-22 \
	--set global.imageK8S=hashicorppreview/consul-k8s-control-plane:1.2.0-dev \
	--set global.logLevel=trace \
	--set global.acls.manageSystemACLs=true \
	--set global.enterpriseLicense.secretName=consul-enterprise-license \
	--set global.enterpriseLicense.secretKey=license \
	--set server.auditLogs.enabled=true
```

How I expect reviewers to test this PR:
You can also use that command. Just run Consul Enterprise locally to the K8s cluster with audit logs enabled.

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

