### PR TITLE
Adding support for retryOn in Service Router spec

### DIFF
--- a/charts/consul/templates/crd-servicerouters.yaml
+++ b/charts/consul/templates/crd-servicerouters.yaml
@@ -152,6 +152,13 @@ spec:
                           description: RetryOnConnectFailure allows for connection
                             failure errors to trigger a retry.
                           type: boolean
+                        retryOn:
+                          description: RetryOn is a flat list of conditions for Consul
+                            to retry requests based on the response from an upstream
+                            service.
+                          items:
+                            type: string
+                          type: array
                         retryOnStatusCodes:
                           description: RetryOnStatusCodes is a flat list of http response
                             status codes that are eligible for retry.

--- a/control-plane/api/v1alpha1/servicerouter_types.go
+++ b/control-plane/api/v1alpha1/servicerouter_types.go
@@ -150,6 +150,8 @@ type ServiceRouteDestination struct {
 	NumRetries uint32 `json:"numRetries,omitempty"`
 	// RetryOnConnectFailure allows for connection failure errors to trigger a retry.
 	RetryOnConnectFailure bool `json:"retryOnConnectFailure,omitempty"`
+	// RetryOn is a flat list of conditions for Consul to retry requests based on the response from an upstream service.
+	RetryOn []string `json:"retryOn,omitempty"`
 	// RetryOnStatusCodes is a flat list of http response status codes that are eligible for retry.
 	RetryOnStatusCodes []uint32 `json:"retryOnStatusCodes,omitempty"`
 	// Allow HTTP header manipulation to be configured.
@@ -344,6 +346,7 @@ func (in *ServiceRouteDestination) toConsul() *capi.ServiceRouteDestination {
 		RequestTimeout:        in.RequestTimeout.Duration,
 		NumRetries:            in.NumRetries,
 		RetryOnConnectFailure: in.RetryOnConnectFailure,
+		RetryOn:               in.RetryOn,
 		RetryOnStatusCodes:    in.RetryOnStatusCodes,
 		RequestHeaders:        in.RequestHeaders.toConsul(),
 		ResponseHeaders:       in.ResponseHeaders.toConsul(),

--- a/control-plane/api/v1alpha1/servicerouter_types_test.go
+++ b/control-plane/api/v1alpha1/servicerouter_types_test.go
@@ -86,6 +86,7 @@ func TestServiceRouter_MatchesConsul(t *testing.T) {
 								RequestTimeout:        metav1.Duration{Duration: 1 * time.Second},
 								NumRetries:            1,
 								RetryOnConnectFailure: true,
+								RetryOn:               []string{"gateway-error"},
 								RetryOnStatusCodes:    []uint32{500, 400},
 								RequestHeaders: &HTTPHeaderModifiers{
 									Add: map[string]string{
@@ -163,6 +164,7 @@ func TestServiceRouter_MatchesConsul(t *testing.T) {
 							RequestTimeout:        1 * time.Second,
 							NumRetries:            1,
 							RetryOnConnectFailure: true,
+							RetryOn:               []string{"gateway-error"},
 							RetryOnStatusCodes:    []uint32{500, 400},
 							RequestHeaders: &capi.HTTPHeaderModifiers{
 								Add: map[string]string{
@@ -289,6 +291,7 @@ func TestServiceRouter_ToConsul(t *testing.T) {
 								RequestTimeout:        metav1.Duration{Duration: 1 * time.Second},
 								NumRetries:            1,
 								RetryOnConnectFailure: true,
+								RetryOn:               []string{"gateway-error"},
 								RetryOnStatusCodes:    []uint32{500, 400},
 								RequestHeaders: &HTTPHeaderModifiers{
 									Add: map[string]string{

--- a/control-plane/api/v1alpha1/zz_generated.deepcopy.go
+++ b/control-plane/api/v1alpha1/zz_generated.deepcopy.go
@@ -3411,6 +3411,11 @@ func (in *ServiceRouteDestination) DeepCopyInto(out *ServiceRouteDestination) {
 	*out = *in
 	out.IdleTimeout = in.IdleTimeout
 	out.RequestTimeout = in.RequestTimeout
+	if in.RetryOn != nil {
+		in, out := &in.RetryOn, &out.RetryOn
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.RetryOnStatusCodes != nil {
 		in, out := &in.RetryOnStatusCodes, &out.RetryOnStatusCodes
 		*out = make([]uint32, len(*in))

--- a/control-plane/config/crd/bases/consul.hashicorp.com_servicerouters.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_servicerouters.yaml
@@ -148,6 +148,13 @@ spec:
                           description: RetryOnConnectFailure allows for connection
                             failure errors to trigger a retry.
                           type: boolean
+                        retryOn:
+                          description: RetryOn is a flat list of conditions for Consul
+                            to retry requests based on the response from an upstream
+                            service.
+                          items:
+                            type: string
+                          type: array
                         retryOnStatusCodes:
                           description: RetryOnStatusCodes is a flat list of http response
                             status codes that are eligible for retry.


### PR DESCRIPTION
Changes proposed in this PR:
- Adding support for [retryOn](https://developer.hashicorp.com/consul/docs/connect/config-entries/service-router#routes-destination-retryon) in Service Router spec

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

