### PR TITLE
update redhat registry id

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -359,7 +359,7 @@ jobs:
           pkg_name: consul-k8s-control-plane_${{ env.version }}
           bin_name: consul-k8s-control-plane
           workdir: control-plane
-          redhat_tag: quay.io/redhat-isv-containers/611ca2f89a9b407267837100:${{env.version}}-ubi
+          redhat_tag: quay.io/redhat-isv-containers/6486b1beabfc4e51588c0416:${{env.version}}-ubi # this is different than the non-FIPS one
       - name: Docker FIPS Build (Action)
         if: ${{ matrix.fips }}
         uses: hashicorp/actions-docker-build@v1


### PR DESCRIPTION
Changes proposed in this PR:
- Follow up #2337 
- The redhat repo created in https://github.com/hashicorp/consul-k8s/pull/2333 missed a setting (have the registry be hosted by redhat) that cannot be changed after repo creation, so the repo had to be recreated.

How I've tested this PR:

👀 

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

