### PR TITLE
use latest 1.2 dataplane

### DIFF
--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -20,7 +20,7 @@ annotations:
     - name: consul-k8s-control-plane
       image: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.2.0-dev
     - name: consul-dataplane
-      image: hashicorp/consul-dataplane:1.1.2
+      image: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.2-dev
     - name: envoy
       image: envoyproxy/envoy:v1.25.1
   artifacthub.io/license: MPL-2.0

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -584,7 +584,7 @@ global:
   # The name (and tag) of the consul-dataplane Docker image used for the
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
   # @default: hashicorp/consul-dataplane:<latest supported version>
-  imageConsulDataplane: "hashicorp/consul-dataplane:1.1.2"
+  imageConsulDataplane: "docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.2-dev"
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.


### PR DESCRIPTION
Changes proposed in this PR:
- The Consul-k8s 1.2 branches point to dataplane 1.1. We should be testing with 1.2, so this bumps it.
-

How I've tested this PR:
👀 acceptance tests passing (except CNI which is a known issue not fixed by this PR)

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

