### PR TITLE
Manual backport gatewayclassconfigtest fix

### DIFF
--- a/acceptance/tests/api-gateway/api_gateway_tenancy_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_tenancy_test.go
@@ -347,9 +347,13 @@ func generateCertificate(t *testing.T, ca *certificateInfo, commonName string) *
 }
 
 func retryCheck(t *testing.T, count int, fn func(r *retry.R)) {
+	retryCheckWithWait(t, count, 2*time.Second, fn)
+}
+
+func retryCheckWithWait(t *testing.T, count int, wait time.Duration, fn func(r *retry.R)) {
 	t.Helper()
 
-	counter := &retry.Counter{Count: count, Wait: 2 * time.Second}
+	counter := &retry.Counter{Count: count, Wait: wait}
 	retry.RunWith(counter, t, fn)
 }
 


### PR DESCRIPTION
Changes proposed in this PR:
- Manual backport of https://github.com/hashicorp/consul-k8s/pull/2458
- Fixed a flaking API Gateway acceptance test. 
- Not a critical bug fix, so it doesn't need to go into release/1.2.0

How I've tested this PR:
-CI tests pass

How I expect reviewers to test this PR:
- CI tests pass


Checklist:
- [ X ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

