### PR TITLE
Mw/net 4605 consul k8s pin cloud tests to latest supported kubernetes version for that release 1 0

### DIFF
--- a/charts/consul/test/terraform/aks/main.tf
+++ b/charts/consul/test/terraform/aks/main.tf
@@ -1,5 +1,15 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+terraform {
+  required_providers {
+    azurerm = {
+      version = "3.40.0"
+    }
+  }
+}
+
 provider "azurerm" {
-  version = "3.40.0"
   features {}
 }
 
@@ -45,7 +55,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   location                          = azurerm_resource_group.default[count.index].location
   resource_group_name               = azurerm_resource_group.default[count.index].name
   dns_prefix                        = "consul-k8s-${random_id.suffix[count.index].dec}"
-  kubernetes_version                = "1.24.6"
+  kubernetes_version                = "1.25"
   role_based_access_control_enabled = true
 
   // We're setting the network plugin and other network properties explicitly
@@ -68,7 +78,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   default_node_pool {
     name            = "default"
     node_count      = 3
-    vm_size         = "Standard_D2_v2"
+    vm_size         = "Standard_D3_v2"
     os_disk_size_gb = 30
     vnet_subnet_id  = azurerm_virtual_network.default[count.index].subnet.*.id[0]
   }

--- a/charts/consul/test/terraform/aks/outputs.tf
+++ b/charts/consul/test/terraform/aks/outputs.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 output "kubeconfigs" {
   value = local_file.kubeconfigs.*.filename
 }

--- a/charts/consul/test/terraform/aks/variables.tf
+++ b/charts/consul/test/terraform/aks/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 variable "location" {
   default     = "West US 2"
   description = "The location to launch this AKS cluster in."

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -1,6 +1,16 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 4.0.0"
+    }
+  }
+}
+
 provider "aws" {
-  version = ">= 2.28.1"
-  region  = var.region
+  region = var.region
 
   assume_role {
     role_arn = var.role_arn
@@ -25,7 +35,7 @@ resource "random_string" "suffix" {
 module "vpc" {
   count   = var.cluster_count
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.11.0"
+  version = "4.0.0"
 
   name = "consul-k8s-${random_id.suffix[count.index].dec}"
   # The cidr range needs to be unique in each VPC to allow setting up a peering connection.
@@ -58,7 +68,7 @@ module "eks" {
   kubeconfig_api_version = "client.authentication.k8s.io/v1beta1"
 
   cluster_name    = "consul-k8s-${random_id.suffix[count.index].dec}"
-  cluster_version = "1.23"
+  cluster_version = "1.25"
   subnets         = module.vpc[count.index].private_subnets
   enable_irsa     = true
 
@@ -70,7 +80,7 @@ module "eks" {
       max_capacity     = 3
       min_capacity     = 3
 
-      instance_type = "m5.large"
+      instance_type = "m5.xlarge"
     }
   }
 

--- a/charts/consul/test/terraform/eks/outputs.tf
+++ b/charts/consul/test/terraform/eks/outputs.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 output "kubeconfigs" {
   value = [for cl in module.eks : pathexpand(format("~/.kube/%s", cl.cluster_id))]
 }

--- a/charts/consul/test/terraform/eks/variables.tf
+++ b/charts/consul/test/terraform/eks/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 variable "region" {
   default     = "us-west-2"
   description = "AWS region"

--- a/charts/consul/test/terraform/gke/outputs.tf
+++ b/charts/consul/test/terraform/gke/outputs.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 output "cluster_ids" {
   value = google_container_cluster.cluster.*.id
 }

--- a/charts/consul/test/terraform/gke/variables.tf
+++ b/charts/consul/test/terraform/gke/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 variable "project" {
   description = <<EOF
 Google Cloud Project to launch resources in. This project must have GKE
@@ -33,4 +36,10 @@ variable "labels" {
   type        = map(any)
   default     = {}
   description = "Labels to attach to the created resources."
+}
+
+variable "subnet" {
+  type        = string
+  default     = "default"
+  description = "Subnet to create the cluster in. Currently all clusters use the default subnet and we are running out of IPs"
 }


### PR DESCRIPTION
Changes proposed in this PR:
- This backports https://github.com/hashicorp/consul-k8s/commit/3c565586ffd0c467b14771107d023c9a42854cfe and sets the kubernetes version for cloud tests to the latest supported by Consul-K8s `1.0` which is kubernetes `1.25`
-

How I've tested this PR:
https://github.com/hashicorp/consul-k8s-workflows/actions/runs/5392938127/jobs/9793690720 
- I wanted to just verify that all terraform applies work, but the EKS apply is failing. This seems to be unrelated as it is also affecting the main branch.
- 
How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

