### PR TITLE
ci: fix eks terraform quota error by cleaning up oidc providers

### DIFF
--- a/hack/aws-acceptance-test-cleanup/main.go
+++ b/hack/aws-acceptance-test-cleanup/main.go
@@ -78,6 +78,12 @@ func realMain(ctx context.Context) error {
 
 	// Find OIDC providers to delete.
 	oidcProvidersOutput, err := iamClient.ListOpenIDConnectProvidersWithContext(ctx, &iam.ListOpenIDConnectProvidersInput{})
+	if err != nil {
+		return err
+	} else if oidcProvidersOutput == nil {
+		return fmt.Errorf("nil output for OIDC Providers")
+	}
+
 	toDeleteOidcArns := []*oidc{}
 	for _, providerEntry := range oidcProvidersOutput.OpenIDConnectProviderList {
 		arnString := ""


### PR DESCRIPTION
Changes proposed in this PR:
- cleans up oidc providers associated with our pipeline terraform

How I've tested this PR:
- ran it locally and it deleted the oidc providers

How I expect reviewers to test this PR:
- 👀 



