### PR TITLE
APIGW: Validate length of RSA Keys

### DIFF
--- a/.changelog/2478.txt
+++ b/.changelog/2478.txt
@@ -1,0 +1,5 @@
+```release-note:bug
+api-gateway: fixes bug where envoy will silently reject RSA keys less than 2048 bits in length when not in FIPS mode, and
+will reject keys that are not of length 2048, 3072, or 4096 bits in length in FIPS mode. We now validate
+and reject invalid certs earlier.
+```

--- a/.changelog/2478.txt
+++ b/.changelog/2478.txt
@@ -1,5 +1,5 @@
 ```release-note:bug
 api-gateway: fixes bug where envoy will silently reject RSA keys less than 2048 bits in length when not in FIPS mode, and
-will reject keys that are not of length 2048, 3072, or 4096 bits in length in FIPS mode. We now validate
+will reject keys that are not 2048, 3072, or 4096 bits in length in FIPS mode. We now validate
 and reject invalid certs earlier.
 ```

--- a/control-plane/api-gateway/binding/binder_test.go
+++ b/control-plane/api-gateway/binding/binder_test.go
@@ -15,7 +15,6 @@ import (
 
 	logrtest "github.com/go-logr/logr/testing"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,6 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/hashicorp/consul/api"
 
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
@@ -2330,8 +2331,16 @@ func controlledBinder(config BinderConfig) BinderConfig {
 	return config
 }
 
+func generateInvalidTestCertificate(t *testing.T, namespace, name string, keyLen int) (*api.InlineCertificateConfigEntry, corev1.Secret) {
+	return generateTestCertificateByKeyLen(t, namespace, name, keyLen)
+}
+
 func generateTestCertificate(t *testing.T, namespace, name string) (*api.InlineCertificateConfigEntry, corev1.Secret) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	return generateTestCertificateByKeyLen(t, namespace, name, common.MinKeyLength)
+}
+
+func generateTestCertificateByKeyLen(t *testing.T, namespace, name string, keyLen int) (*api.InlineCertificateConfigEntry, corev1.Secret) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, keyLen)
 	require.NoError(t, err)
 
 	usage := x509.KeyUsageCertSign

--- a/control-plane/api-gateway/binding/binder_test.go
+++ b/control-plane/api-gateway/binding/binder_test.go
@@ -2332,11 +2332,11 @@ func controlledBinder(config BinderConfig) BinderConfig {
 }
 
 func generateInvalidTestCertificate(t *testing.T, namespace, name string) (*api.InlineCertificateConfigEntry, corev1.Secret) {
-	return generateTestCertificateByKeyLen(t, namespace, name, common.MinKeyLength-1)
+	return generateTestCertificateByKeyLen(t, namespace, name, MinKeyLength-1)
 }
 
 func generateTestCertificate(t *testing.T, namespace, name string) (*api.InlineCertificateConfigEntry, corev1.Secret) {
-	return generateTestCertificateByKeyLen(t, namespace, name, common.MinKeyLength)
+	return generateTestCertificateByKeyLen(t, namespace, name, MinKeyLength)
 }
 
 func generateTestCertificateByKeyLen(t *testing.T, namespace, name string, keyLen int) (*api.InlineCertificateConfigEntry, corev1.Secret) {

--- a/control-plane/api-gateway/binding/binder_test.go
+++ b/control-plane/api-gateway/binding/binder_test.go
@@ -2331,8 +2331,8 @@ func controlledBinder(config BinderConfig) BinderConfig {
 	return config
 }
 
-func generateInvalidTestCertificate(t *testing.T, namespace, name string, keyLen int) (*api.InlineCertificateConfigEntry, corev1.Secret) {
-	return generateTestCertificateByKeyLen(t, namespace, name, keyLen)
+func generateInvalidTestCertificate(t *testing.T, namespace, name string) (*api.InlineCertificateConfigEntry, corev1.Secret) {
+	return generateTestCertificateByKeyLen(t, namespace, name, common.MinKeyLength-1)
 }
 
 func generateTestCertificate(t *testing.T, namespace, name string) (*api.InlineCertificateConfigEntry, corev1.Secret) {

--- a/control-plane/api-gateway/binding/binder_test.go
+++ b/control-plane/api-gateway/binding/binder_test.go
@@ -2330,16 +2330,8 @@ func controlledBinder(config BinderConfig) BinderConfig {
 	return config
 }
 
-func generateInvalidTestCertificate(t *testing.T, namespace, name string) (*api.InlineCertificateConfigEntry, corev1.Secret) {
-	return generateTestCertificateByKeyLen(t, namespace, name, common.MinKeyLength-1)
-}
-
 func generateTestCertificate(t *testing.T, namespace, name string) (*api.InlineCertificateConfigEntry, corev1.Secret) {
-	return generateTestCertificateByKeyLen(t, namespace, name, common.MinKeyLength)
-}
-
-func generateTestCertificateByKeyLen(t *testing.T, namespace, name string, keyLen int) (*api.InlineCertificateConfigEntry, corev1.Secret) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, keyLen)
+	privateKey, err := rsa.GenerateKey(rand.Reader, common.MinKeyLength)
 	require.NoError(t, err)
 
 	usage := x509.KeyUsageCertSign

--- a/control-plane/api-gateway/binding/binder_test.go
+++ b/control-plane/api-gateway/binding/binder_test.go
@@ -2331,11 +2331,11 @@ func controlledBinder(config BinderConfig) BinderConfig {
 }
 
 func generateInvalidTestCertificate(t *testing.T, namespace, name string) (*api.InlineCertificateConfigEntry, corev1.Secret) {
-	return generateTestCertificateByKeyLen(t, namespace, name, MinKeyLength-1)
+	return generateTestCertificateByKeyLen(t, namespace, name, common.MinKeyLength-1)
 }
 
 func generateTestCertificate(t *testing.T, namespace, name string) (*api.InlineCertificateConfigEntry, corev1.Secret) {
-	return generateTestCertificateByKeyLen(t, namespace, name, MinKeyLength)
+	return generateTestCertificateByKeyLen(t, namespace, name, common.MinKeyLength)
 }
 
 func generateTestCertificateByKeyLen(t *testing.T, namespace, name string, keyLen int) (*api.InlineCertificateConfigEntry, corev1.Secret) {

--- a/control-plane/api-gateway/binding/binder_test.go
+++ b/control-plane/api-gateway/binding/binder_test.go
@@ -23,10 +23,9 @@ import (
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	"github.com/hashicorp/consul/api"
-
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"github.com/hashicorp/consul/api"
 )
 
 func init() {

--- a/control-plane/api-gateway/binding/result.go
+++ b/control-plane/api-gateway/binding/result.go
@@ -218,15 +218,17 @@ var (
 	// to the ListenerConditionReason given in the spec. If a reason is overloaded and can
 	// be used with two different types of things (i.e. something is not found or it's not supported)
 	// then we distinguish those two usages with errListener*_Usage.
-	errListenerUnsupportedProtocol                = errors.New("listener protocol is unsupported")
-	errListenerPortUnavailable                    = errors.New("listener port is unavailable")
-	errListenerHostnameConflict                   = errors.New("listener hostname conflicts with another listener")
-	errListenerProtocolConflict                   = errors.New("listener protocol conflicts with another listener")
-	errListenerInvalidCertificateRef_NotFound     = errors.New("certificate not found")
-	errListenerInvalidCertificateRef_NotSupported = errors.New("certificate type is not supported")
-	errListenerInvalidCertificateRef_InvalidData  = errors.New("certificate is invalid or does not contain a supported server name")
-	errListenerInvalidRouteKinds                  = errors.New("allowed route kind is invalid")
-	errListenerProgrammed_Invalid                 = errors.New("listener cannot be programmed because it is invalid")
+	errListenerUnsupportedProtocol                    = errors.New("listener protocol is unsupported")
+	errListenerPortUnavailable                        = errors.New("listener port is unavailable")
+	errListenerHostnameConflict                       = errors.New("listener hostname conflicts with another listener")
+	errListenerProtocolConflict                       = errors.New("listener protocol conflicts with another listener")
+	errListenerInvalidCertificateRef_NotFound         = errors.New("certificate not found")
+	errListenerInvalidCertificateRef_NotSupported     = errors.New("certificate type is not supported")
+	errListenerInvalidCertificateRef_InvalidData      = errors.New("certificate is invalid or does not contain a supported server name")
+	errListenerInvalidCertificateRef_NonFIPSRSAKeyLen = errors.New("certificate has an invalid length: RSA Keys must be at least 2048-bit")
+	errListenerInvalidCertificateRef_FIPSRSAKeyLen    = errors.New("certificate has an invalid length: RSA keys must be either 2048-bit, 3072-bit, or 4096-bit in FIPS mode")
+	errListenerInvalidRouteKinds                      = errors.New("allowed route kind is invalid")
+	errListenerProgrammed_Invalid                     = errors.New("listener cannot be programmed because it is invalid")
 
 	// Below is where any custom generic listener validation errors should go.
 	// We map anything under here to a custom ListenerConditionReason of Invalid on
@@ -372,7 +374,7 @@ func (l listenerValidationResult) resolvedRefsCondition(generation int64) metav1
 	}
 
 	switch l.refErr {
-	case errListenerInvalidCertificateRef_NotFound, errListenerInvalidCertificateRef_NotSupported, errListenerInvalidCertificateRef_InvalidData:
+	case errListenerInvalidCertificateRef_NotFound, errListenerInvalidCertificateRef_NotSupported, errListenerInvalidCertificateRef_InvalidData, errListenerInvalidCertificateRef_NonFIPSRSAKeyLen, errListenerInvalidCertificateRef_FIPSRSAKeyLen:
 		return metav1.Condition{
 			Type:               "ResolvedRefs",
 			Status:             metav1.ConditionFalse,

--- a/control-plane/api-gateway/binding/validation.go
+++ b/control-plane/api-gateway/binding/validation.go
@@ -6,7 +6,6 @@ package binding
 import (
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -252,7 +251,7 @@ func validateKeyLength(privateKey string) error {
 func nonFipsLenCheck(keyLen int) error {
 	// ensure private key is of the correct length
 	if keyLen < MinKeyLength {
-		return errors.New("key length must be at least 2048 bits")
+		return errListenerInvalidCertificateRef_NonFIPSRSAKeyLen
 	}
 
 	return nil
@@ -260,7 +259,7 @@ func nonFipsLenCheck(keyLen int) error {
 
 func fipsLenCheck(keyLen int) error {
 	if keyLen != 2048 && keyLen != 3072 && keyLen != 4096 {
-		return errors.New("key length invalid: only RSA lengths of 2048, 3072, and 4096 are allowed in FIPS mode")
+		return errListenerInvalidCertificateRef_FIPSRSAKeyLen
 	}
 	return nil
 }

--- a/control-plane/api-gateway/binding/validation.go
+++ b/control-plane/api-gateway/binding/validation.go
@@ -218,12 +218,7 @@ func validateCertificateData(secret corev1.Secret) error {
 		return errListenerInvalidCertificateRef_InvalidData
 	}
 
-	err = validateKeyLength(privateKey)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return validateKeyLength(privateKey)
 }
 
 func validateKeyLength(privateKey string) error {
@@ -287,7 +282,7 @@ func validateListeners(gateway gwv1beta1.Gateway, listeners []gwv1beta1.Listener
 			_, supported := supportedKindsForProtocol[listener.Protocol]
 			if !supported {
 				result.acceptedErr = errListenerUnsupportedProtocol
-			} else if listener.Port == 20000 { //admin port
+			} else if listener.Port == 20000 { // admin port
 				result.acceptedErr = errListenerPortUnavailable
 			}
 

--- a/control-plane/api-gateway/common/secrets.go
+++ b/control-plane/api-gateway/common/secrets.go
@@ -12,13 +12,7 @@ import (
 
 	"github.com/miekg/dns"
 	corev1 "k8s.io/api/core/v1"
-
-	"github.com/hashicorp/consul-k8s/control-plane/version"
 )
-
-// Envoy will silently reject any keys that are less than 2048 bytes long
-// https://github.com/envoyproxy/envoy/blob/main/source/extensions/transport_sockets/tls/context_impl.cc#L238
-const MinKeyLength = 2048
 
 func ParseCertificateData(secret corev1.Secret) (cert string, privateKey string, err error) {
 	decodedPrivateKey := secret.Data[corev1.TLSPrivateKeyKey]
@@ -27,11 +21,6 @@ func ParseCertificateData(secret corev1.Secret) (cert string, privateKey string,
 	privateKeyBlock, _ := pem.Decode(decodedPrivateKey)
 	if privateKeyBlock == nil {
 		return "", "", errors.New("failed to parse private key PEM")
-	}
-
-	err = validateKeyLength(privateKeyBlock)
-	if err != nil {
-		return "", "", err
 	}
 
 	certificateBlock, _ := pem.Decode(decodedCertificate)
@@ -58,41 +47,6 @@ func ParseCertificateData(secret corev1.Secret) (cert string, privateKey string,
 	}
 
 	return string(decodedCertificate), string(decodedPrivateKey), nil
-}
-
-func validateKeyLength(privateKeyBlock *pem.Block) error {
-	if privateKeyBlock.Type != "RSA PRIVATE KEY" {
-		return nil
-	}
-
-	key, err := x509.ParsePKCS1PrivateKey(privateKeyBlock.Bytes)
-	if err != nil {
-		return err
-	}
-
-	keyBitLen := key.N.BitLen()
-
-	if version.IsFIPS() {
-		return fipsLenCheck(keyBitLen)
-	}
-
-	return nonFipsLenCheck(keyBitLen)
-}
-
-func nonFipsLenCheck(keyLen int) error {
-	// ensure private key is of the correct length
-	if keyLen < MinKeyLength {
-		return errors.New("key length must be at least 2048 bits")
-	}
-
-	return nil
-}
-
-func fipsLenCheck(keyLen int) error {
-	if keyLen != 2048 && keyLen != 3072 && keyLen != 4096 {
-		return errors.New("key length invalid: only RSA lengths of 2048, 3072, and 4096 are allowed in FIPS mode")
-	}
-	return nil
 }
 
 func validateCertificateHosts(certificate *x509.Certificate) error {

--- a/control-plane/api-gateway/common/secrets.go
+++ b/control-plane/api-gateway/common/secrets.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/miekg/dns"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/hashicorp/consul-k8s/control-plane/version"
 )
 
 // Envoy will silently reject any keys that are less than 2048 bytes long
@@ -27,13 +29,9 @@ func ParseCertificateData(secret corev1.Secret) (cert string, privateKey string,
 		return "", "", errors.New("failed to parse private key PEM")
 	}
 
-	key, err := x509.ParsePKCS1PrivateKey(privateKeyBlock.Bytes)
+	err = validateKeyLength(privateKeyBlock)
 	if err != nil {
 		return "", "", err
-	}
-
-	if key.N.BitLen() < MinKeyLength {
-		return "", "", errors.New("key length must be at least 2048 bits")
 	}
 
 	certificateBlock, _ := pem.Decode(decodedCertificate)
@@ -60,6 +58,41 @@ func ParseCertificateData(secret corev1.Secret) (cert string, privateKey string,
 	}
 
 	return string(decodedCertificate), string(decodedPrivateKey), nil
+}
+
+func validateKeyLength(privateKeyBlock *pem.Block) error {
+	if privateKeyBlock.Type != "RSA PRIVATE KEY" {
+		return nil
+	}
+
+	key, err := x509.ParsePKCS1PrivateKey(privateKeyBlock.Bytes)
+	if err != nil {
+		return err
+	}
+
+	keyBitLen := key.N.BitLen()
+
+	if version.IsFIPS() {
+		return fipsLenCheck(keyBitLen)
+	}
+
+	return nonFipsLenCheck(keyBitLen)
+}
+
+func nonFipsLenCheck(keyLen int) error {
+	// ensure private key is of the correct length
+	if keyLen < MinKeyLength {
+		return errors.New("key length must be at least 2048 bits")
+	}
+
+	return nil
+}
+
+func fipsLenCheck(keyLen int) error {
+	if keyLen != 2048 && keyLen != 3072 && keyLen != 4096 {
+		return errors.New("key length invalid: only RSA lengths of 2048, 3072, and 4096 are allowed in FIPS mode")
+	}
+	return nil
 }
 
 func validateCertificateHosts(certificate *x509.Certificate) error {

--- a/control-plane/api-gateway/common/secrets_test.go
+++ b/control-plane/api-gateway/common/secrets_test.go
@@ -1,0 +1,105 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateKeyLength(t *testing.T) {
+	tooShortPrivateKey := `-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQCtmK1VjmXJ7vm4CZkkOSjc+kjGNMlyce5rXxwlDRz9LcGGc3Tg
+kwUJesyBpDtxLLVHXQIPr5mWYbX/W/ezQ9sntxrATbDek8pBgoOlARebwkD2ivVW
+BWfVhlryVihWlXApKiJ2n3i0m+OVtdrceC9Bv2hEMhYVOwzxtb3O0YFkbwIDAQAB
+AoGAIxgnipFUEKPIRiVimUkY8ruCdNd9Fi7kNT6wEOl6v9A9PHIg4bm3Hfh+WYMb
+JUEVkMzDuuoUEavFQE+WXt5L8oE1lEBmN2++FQsvllN+MRBTRg2sfw4mUWDI6S4r
+h8+XNTzTIg2sUd2J3o2qNmQoOheYb+iuYDj76IFoEdwwZ0kCQQDYKKs5HAbnrLj1
+UrOp8TyHdFf0YNw5tGdbNTbffq4rlBD6SW70+Sj624i2UqdnYwRiWzdXv3zN08aI
+Vfoh2cGlAkEAzZe5B6BhiX/PcIYutMtuT3K+mysFNlowrutXWoQOpR7gGAkgEt6e
+oCDgx1QJRjsp6NFQxKc6l034Hzs17gqJgwJAcu9U873aUg9+HTuHOoKB28haCCAE
+mU46cr3d2oKCW7uUN3EaZXmid5iJneBfENMOfrnfuHGiC9NiShXlNWCS3QJAO5Ne
+w83+1ahaxUGs4SkeExmuECrcPM7P0rBRxOIFmGWlDHIAgFdQYhiE6l34vghA8b1O
+CV5oRRYL84jl7M/S3wJBALDfL5YXcc8P6scLJJ1biqhLYppvGN5CUwbsJsluvHCW
+XCTVIbPOaS42A0xUfpoiTcdbNSFRvdCzPR5nsGy8Y7g=
+-----END RSA PRIVATE KEY-----`
+	validPrivateKey := `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAzVKRcYlTHHPjPbCieOFIUT2hCouRYe4N8ZhNrSpZf/BAAn4M
+d/LWn/9OrLagbxrRF6cWdWGNEI2COnBRLgNVxyPXneaHaYFqOBRi9GWhuD3sw1jn
+7gf4/m/AVO8cu2JYjEX+s9RjSRzpjx+4nhit46bGNUyb9qUeQwoBidAzOSmU8nHY
+y3LpuuzkjS3FEyNXHxqgpTJnV4ytx8YGkPnG92GBAlrZnr4Eclv0/Sq6OViTpeuh
+z8noNkbugYWHMXGlTZ4lPnELJW2fx/HIpD2ovOO3X8XYBo5KDzs9qyKzDgIOMZLF
+i/qLCLHgfosb4TMaXCeVu4fA7Y47jtGOO4mbiwIDAQABAoIBAFhicDibIDtRyaLv
+K+l0NPC/4liLPwCUfM0gvmNKJS/VSICqKQzjbK+ANCpWDVb2iMaxRxItdY+IEuS8
+H736cozgaXtP1r+8lXBhmj1RmJ2ajpaC6YgGR5GjonwNWGVzjuGHaf6YcUryVrol
+MhBgWE50psMf4M16Q74hCwt7o+k5Lz55xKasgc9dtSnvyCupPBwrOT+d55C1P2Wn
+2oebWM4WKtCZIgvlvZrt4xQkGWy9qloxL6V1F67ZbizAyFMZUMmJv+4/whF8tmXi
+aydleL64K23ZSK1pM/x0JI+7qo0GpEoA4k+2fdmh5dAOM0TrXhV5Kv01efLIaITT
+s7lYjG0CgYEA4qGIM7qO3e9fHgSK/9UdxnpL/1OvfYATBMhEtR46sAxmKQGC8fTM
+iTBkmLAKn3zBgDghCbygPIQjex+W+Ra7JkQIcGB6KLR8rr5GkOuF6vkqHV93RQRT
+lT/1quqq3fVH6V4ymifKJCDNg0IEPcmo+M8RnXBgpFsCN4b5UyjXNScCgYEA5+4h
+LITPJxGytlWzwtsy44U2PvafJYJCktW+LYqhk3xzz4qWX5ubmPz18LrEyybgcy/W
+Dm4JCu+TOS2gvf2WbJKR/tKdgRN7dkU/dbgMtRL8QW5ir+5qqRITYOhiSZPIOpbP
+5zg+c/ZvmK/t5h35/8l7b0bu/E1FOEF27ADpzP0CgYEArqch2gup0muI+A80N9i7
+q5vQOaL6mVM8VPEp0hLL06Sajnt1uJWZkxhSTkFMzoBMd03KWECflEOZPGep56iW
+7fR8NG6Fdh0yAVDt/P0lJWKEDELoHa4p49l4sBFNQOSoWLaZdKe5ZoJJHyCfOCbT
+K3wY7SYPtFnWqYhBWM8emv0CgYBdrNqNRp78orNR3c+bNjmZl6ZPTAD/f1swP1Bu
+yH12Ol/0RX9y4kC4TANx1Z3Ch9ND8uA8N8lDN3x5Laqs0g29kH2TNLIU/i9xl4qI
+G2xWfnKQYutNL7i4zOoyy+lW2m+W6m7Sbu8am0B7pSMrPJRK8a//Q+Em2nbIv/gu
+XjgQaQKBgHKZUKkMv597vpAjgTNsKIl5RDFONBq3omnAwlK9EDLVeAxIrvrvMHBW
+H/ZMFpSGp1eQgKyu1xkEqGdkYXx7BKtdTHK+Thqif2ZGWczy5rVSAIsBYDo1DGE2
+wbocWxkWNb5o2ZZtis5lTB6nr9EWo0zyaPqIh0pfjqVEES2YDEx6
+-----END RSA PRIVATE KEY-----`
+	nonTraditionalRSAKey := `-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCcrB9oNKLtzA3Q
+02KDgtsnrxns7vJ5aCkjJCm/h0Ju7a2mel5YHSN5iLlU5oTMJVIMpWlW9E8P76/a
+GLGMNfSBRVJdfW71iks/ddp4SjpDe9Bo+aY2snrR2/AP7eQepVNjFbg4YLQqvENh
+05k1FuuP1/AgGVNn0kGEwzKxz35shmhRKBCvaRaHLz/fdkDIeIrVLON4FnmAmpOZ
+AztZCwAZc6HZfj8Nh9Wlaw6Dg2boIgxTU160pwpX+nUxcJ9M5sUP9DBuNL0Mdrqi
+U+R49uqG/5ssSk+xVik3q+WF+XySJ6H21fttWDJS2OTm/Nx/wHlBC73mthbA0emB
+rkiBy9SBAgMBAAECggEAOhybz6aKcmKYE0d8yGPejwMjPh9JH+ATNh4hQBHXAdc1
+7ESCPvOb52XfvE5+nkwPeXJXNrIKq1IPq3kyTdvrc5F3Ygb3A6tGiuTXYnvBzasc
+m/tRfANKjBGkovvte7J90ghJ2tt/qERJR/1Y2/jC6glB314VcjJqK+jNImfgsDa7
+1r47efKG7B5eUGvhQDTpL5ENXKxIdvCghHrLqj19QGUZ5MbXsEYrso0lxKw2Xk39
+uM8p3WTxIy0LQGyCm+FYlJ7r61tm7tUOGuNT0YiptVavIw1QPgIbRWdS2gnJu3+J
+kHS0vu6AW1fJav48TA9hXcIQR70alrJA2VVqsvQouwKBgQDNs96l8BfWD6s/urIw
+yzC3/VZPLFJ3BlxvkdP1UDC0S+7pgQ6qdEmJg0z5IfYzDB1PK2X/DS/70JA1LRSS
+MRmjQGHCYIp9g8EqmABwfKf4YnN53KPRyR8Yq1pwaq7wKowtW+5GH95qQPINZsNO
+J21AENEzq7IoB4gpM3tIaX73YwKBgQDC+yl5JvoV7e6FIpFrwL62aKrWmpidML/G
+stdrg9ylCSM9SIVFINMhmFPicW1+DrkQ5HRV7DG//ZcOZNbbNmSu32PVcQI1MJgQ
+rkMZ3ukUURnlvQYOEmZY4zHzTJ+jcw6kEH/+b47Bv13PpD7ZqA4/28dpU9wi9gt3
++GiSnkKDywKBgHqjr63dPEjapK3lQFHJAu3fM7MWaMAf4cJ+/hD202LbFsDOuhC0
+Lhe3WY/7SI7cvSizZicvFJmcmi2qB+a1MWTcgKxj5I26nNMpNrHaEEcNY22XN3Be
+6ZRKrSvy3wO/Sj3M3n2eiHtu5yFIUE7rQL5+iEu3JQuqmep+kBT3GMSjAoGAP77B
+VlyJ0nWRT3F3vZSsRRJ/F94/GtT/PcTmbL4Vetc78CMvfuQ2YntcoWGX/Ghv1Lf7
+2MN5mF0d75TEMbLcw9dA2l0x7ZXPgVSXl3OrG/tPzi44No2JbHIKuJJKdrN9C+Jh
+Fhv+vhUEZIg8DAjHb9U4opTKGZv7L+PEvHqFIHUCgYBTB2TxTgEMNZSsRwrhQRMh
+tsz5rS2MoTgzk4BlSsv6xVC4GnBJ2HlNAjYEsBEg50zCCTPlZXcsNjrAxFrwWhLJ
+DjN2iMsYFz4WHS94W5UYl6/35ye25KsHuS9vnNeidhFAvYgC1nIkh4mFhLoSeSCG
+GODy2KwC2ssLuUHb6WoJ6A==
+-----END PRIVATE KEY-----`
+
+	testCases := map[string]struct {
+		key           string
+		expectedError error
+	}{
+		"key is RSA and of the correct length": {
+			key:           validPrivateKey,
+			expectedError: nil,
+		},
+		"key is RSA and too short": {
+			key:           tooShortPrivateKey,
+			expectedError: errKeyLengthTooShort,
+		},
+		"key is non-traditional RSA key": {
+			key:           nonTraditionalRSAKey,
+			expectedError: nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateKeyLength(tc.key)
+			require.ErrorIs(t, err, tc.expectedError)
+		})
+	}
+}

--- a/control-plane/api-gateway/common/translation.go
+++ b/control-plane/api-gateway/common/translation.go
@@ -6,14 +6,15 @@ package common
 import (
 	"strings"
 
-	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
-	"github.com/hashicorp/consul-k8s/control-plane/namespaces"
-	"github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
+	"github.com/hashicorp/consul-k8s/control-plane/namespaces"
+	"github.com/hashicorp/consul/api"
 )
 
 // ResourceTranslator handles translating K8s resources into Consul config entries.
@@ -336,6 +337,11 @@ func (t ResourceTranslator) translateTCPRouteRule(route gwv1alpha2.TCPRoute, ref
 
 func (t ResourceTranslator) ToInlineCertificate(secret corev1.Secret) (*api.InlineCertificateConfigEntry, error) {
 	certificate, privateKey, err := ParseCertificateData(secret)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ValidateKeyLength(privateKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Changes proposed in this PR:
- Ensure RSA keys are of the correct length when creating an inline cert

How I've tested this PR:
- unit tests

How I expect reviewers to test this PR:
- read the code

Checklist:
- [X] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

