### PR TITLE
Set up 1.1.3 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 1.1.3 (June 28, 2023)
+BREAKING CHANGES:
+
+* control-plane: All policies managed by consul-k8s will now be updated on upgrade. If you previously edited the policies after install, your changes will be overwritten. [[GH-2392](https://github.com/hashicorp/consul-k8s/issues/2392)]
+
+SECURITY:
+
+* Bump Dockerfile base image to `alpine:3.18`. Resolves [CVE-2023-2650](https://github.com/advisories/GHSA-gqxg-9vfr-p9cg) vulnerability in openssl@3.0.8-r4 [[GH-2284](https://github.com/hashicorp/consul-k8s/issues/2284)]
+* Update [Go-Discover](https://github.com/hashicorp/go-discover) in the container has been updated to address [CVE-2020-14040](https://github.com/advisories/GHSA-5rcv-m4m3-hfh7) [[GH-2390](https://github.com/hashicorp/consul-k8s/issues/2390)]
+
+FEATURES:
+
+* Add support for configuring graceful shutdown proxy lifecycle management settings. [[GH-2233](https://github.com/hashicorp/consul-k8s/issues/2233)]
+* helm: Adds `acls.resources` field which can be configured to override the `resource` settings for the `server-acl-init` and `server-acl-init-cleanup` Jobs. [[GH-2416](https://github.com/hashicorp/consul-k8s/issues/2416)]
+* sync-catalog: add ability to support weighted loadbalancing by service annotation `consul.hashicorp.com/service-weight: <number>` [[GH-2293](https://github.com/hashicorp/consul-k8s/issues/2293)]
+
+IMPROVEMENTS:
+
+* (Consul Enterprise) Add support to provide inputs via helm for audit log related configuration [[GH-2369](https://github.com/hashicorp/consul-k8s/issues/2369)]
+* helm: Update the default amount of memory used by the connect-inject controller so that its less likely to get OOM killed. [[GH-2249](https://github.com/hashicorp/consul-k8s/issues/2249)]
+
+BUG FIXES:
+
+* control-plane: Always update ACL policies upon upgrade. [[GH-2392](https://github.com/hashicorp/consul-k8s/issues/2392)]
+* control-plane: Fix casing of the Enforce Consecutive 5xx field on Service Defaults and acceptance test fixtures. [[GH-2266](https://github.com/hashicorp/consul-k8s/issues/2266)]
+
 ## 1.1.2 (June 5, 2023)
 
 SECURITY:

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: consul
-version: 1.1.3-dev
-appVersion: 1.15-dev
+version: 1.1.3
+appVersion: 1.15.4
 kubeVersion: ">=1.22.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
@@ -10,14 +10,14 @@ sources:
   - https://github.com/hashicorp/consul
   - https://github.com/hashicorp/consul-k8s
 annotations:
-  artifacthub.io/prerelease: true
+  artifacthub.io/prerelease: false
   artifacthub.io/images: |
     - name: consul
-      image: docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.15-dev
+      image: hashicorp/consul:1.15.4
     - name: consul-k8s-control-plane
-      image: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.1.3-dev
+      image: hashicorp/consul-k8s-control-plane:1.1.3
     - name: consul-dataplane
-      image: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.1-dev
+      image: hashicorp/consul-dataplane:1.1.3
     - name: envoy
       image: envoyproxy/envoy:v1.25.6
   artifacthub.io/license: MPL-2.0

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -63,7 +63,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.10.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.15-dev
+  image: hashicorp/consul:1.15.4
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.
@@ -83,7 +83,7 @@ global:
   # image that is used for functionality such as catalog sync.
   # This can be overridden per component.
   # @default: hashicorp/consul-k8s-control-plane:<latest version>
-  imageK8S: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.1.3-dev
+  imageK8S: hashicorp/consul-k8s-control-plane:1.1.3
 
   # The name of the datacenter that the agents should
   # register as. This can't be changed once the Consul cluster is up and running
@@ -581,7 +581,7 @@ global:
   # The name (and tag) of the consul-dataplane Docker image used for the
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
   # @default: hashicorp/consul-dataplane:<latest supported version>
-  imageConsulDataplane: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.1-dev
+  imageConsulDataplane: hashicorp/consul-dataplane:1.1.3
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -19,7 +19,7 @@ var (
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable

--- a/control-plane/build-support/scripts/consul-enterprise-version.sh
+++ b/control-plane/build-support/scripts/consul-enterprise-version.sh
@@ -4,8 +4,11 @@
 FILE=$1
 VERSION=$(yq .global.image $FILE)
 
-if [[ !"${VERSION}" == *"consul:"* ]]; then
+if [[ !"${VERSION}" == *"hashicorppreview/consul:"* ]]; then
 	VERSION=$(echo ${VERSION} | sed "s/consul:/consul-enterprise:/g")
+elif [[ !"${VERSION}" == *"hashicorp/consul:"* ]]; then
+	VERSION=$(echo ${VERSION} | sed "s/consul:/consul-enterprise:/g" | sed "s/$/-ent/g")
 fi
+
 
 echo "${VERSION}"

--- a/control-plane/version/version.go
+++ b/control-plane/version/version.go
@@ -19,7 +19,7 @@ var (
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
- Have consul-enterprise-version work for both preview and prod images
- Prepare Consul K8s 1.1.3 release

Changes proposed in this PR:
-
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

