### PR TITLE
Fix `make consul-enterprise-version` to work for both dev and prod images

### DIFF
--- a/control-plane/build-support/scripts/consul-enterprise-version.sh
+++ b/control-plane/build-support/scripts/consul-enterprise-version.sh
@@ -4,8 +4,11 @@
 FILE=$1
 VERSION=$(yq .global.image $FILE)
 
-if [[ !"${VERSION}" == *"consul:"* ]]; then
+if [[ !"${VERSION}" == *"hashicorppreview/consul:"* ]]; then
 	VERSION=$(echo ${VERSION} | sed "s/consul:/consul-enterprise:/g")
+elif [[ !"${VERSION}" == *"hashicorp/consul:"* ]]; then
+	VERSION=$(echo ${VERSION} | sed "s/consul:/consul-enterprise:/g" | sed "s/$/-ent/g")
 fi
+
 
 echo "${VERSION}"


### PR DESCRIPTION
Changes proposed in this PR:
- We run a `make` command to set the enterprise Consul image when running unit tests. For development images the delta from non-enterprise images to enterprise images is to just change the image name from `consul` to `consul-enterprise`. In prod, you must also add a `-ent` to the end of the image tag. This change takes that difference into account so that we can use the `make` command when releasing to production.

