### PR TITLE
[release/1.2.0] Backport api-gateway: Fix nil pointer exception panic

### DIFF
--- a/control-plane/api-gateway/common/translation.go
+++ b/control-plane/api-gateway/common/translation.go
@@ -254,14 +254,16 @@ func (t ResourceTranslator) translateHTTPFilters(filters []gwv1beta1.HTTPRouteFi
 	}
 
 	for _, filter := range filters {
-		consulFilter.Remove = append(consulFilter.Remove, filter.RequestHeaderModifier.Remove...)
+		if filter.RequestHeaderModifier != nil {
+			consulFilter.Remove = append(consulFilter.Remove, filter.RequestHeaderModifier.Remove...)
 
-		for _, toAdd := range filter.RequestHeaderModifier.Add {
-			consulFilter.Add[string(toAdd.Name)] = toAdd.Value
-		}
+			for _, toAdd := range filter.RequestHeaderModifier.Add {
+				consulFilter.Add[string(toAdd.Name)] = toAdd.Value
+			}
 
-		for _, toSet := range filter.RequestHeaderModifier.Set {
-			consulFilter.Set[string(toSet.Name)] = toSet.Value
+			for _, toSet := range filter.RequestHeaderModifier.Set {
+				consulFilter.Set[string(toSet.Name)] = toSet.Value
+			}
 		}
 
 		// we drop any path rewrites that are not prefix matches as we don't support those

--- a/control-plane/api-gateway/common/translation_test.go
+++ b/control-plane/api-gateway/common/translation_test.go
@@ -1372,3 +1372,57 @@ func generateTestCertificate(t *testing.T, namespace, name string) corev1.Secret
 		},
 	}
 }
+
+func TestResourceTranslator_translateHTTPFilters(t1 *testing.T) {
+	type fields struct {
+		EnableConsulNamespaces bool
+		ConsulDestNamespace    string
+		EnableK8sMirroring     bool
+		MirroringPrefix        string
+		ConsulPartition        string
+		Datacenter             string
+	}
+	type args struct {
+		filters []gwv1beta1.HTTPRouteFilter
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   api.HTTPFilters
+	}{
+		{
+			name:   "no httproutemodifier set",
+			fields: fields{},
+			args: args{
+				filters: []gwv1beta1.HTTPRouteFilter{
+					{
+						URLRewrite: &gwv1beta1.HTTPURLRewriteFilter{},
+					},
+				},
+			},
+			want: api.HTTPFilters{
+				Headers: []api.HTTPHeaderFilter{
+					{
+						Add: map[string]string{},
+						Set: map[string]string{},
+					},
+				},
+				URLRewrite: nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t1.Run(tt.name, func(t1 *testing.T) {
+			t := ResourceTranslator{
+				EnableConsulNamespaces: tt.fields.EnableConsulNamespaces,
+				ConsulDestNamespace:    tt.fields.ConsulDestNamespace,
+				EnableK8sMirroring:     tt.fields.EnableK8sMirroring,
+				MirroringPrefix:        tt.fields.MirroringPrefix,
+				ConsulPartition:        tt.fields.ConsulPartition,
+				Datacenter:             tt.fields.Datacenter,
+			}
+			assert.Equalf(t1, tt.want, t.translateHTTPFilters(tt.args.filters), "translateHTTPFilters(%v)", tt.args.filters)
+		})
+	}
+}


### PR DESCRIPTION
**Changes proposed in this PR:**
This is a backport of https://github.com/hashicorp/consul-k8s/pull/2487 targeting the 1.2.0 release

**How I've tested this PR:**
🤖 tests

**How I expect reviewers to test this PR:**
🤖 tests

**Checklist:**
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

