### PR TITLE
Use correct length for certificate RSA key for tests

### DIFF
--- a/control-plane/api-gateway/controllers/gateway_controller_integration_test.go
+++ b/control-plane/api-gateway/controllers/gateway_controller_integration_test.go
@@ -650,7 +650,7 @@ func createCert(t *testing.T, ctx context.Context, k8sClient client.WithWatch, c
 	// listener one tls config
 	certName := "one-cert"
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
 	usage := x509.KeyUsageCertSign


### PR DESCRIPTION
Changes proposed in this PR:
- In halting test use the correct length key for the RSA private key as introduced in this consul PR: https://github.com/hashicorp/consul/pull/17911
-

How I've tested this PR:
Ran the test

How I expect reviewers to test this PR:
read the code/run the test

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

