### PR TITLE
add changelog for 1.2.0 dataplane and consul 1.16.0

### DIFF
--- a/.changelog/2476.txt
+++ b/.changelog/2476.txt
@@ -1,0 +1,4 @@
+```release-note:feature
+helm: update `imageConsulDataplane` value to `hashicorp/consul-dataplane:1.2.0`
+helm: update `image` value to `hashicorp/consul:1.16.0`
+```

--- a/.changelog/2476.txt
+++ b/.changelog/2476.txt
@@ -1,7 +1,7 @@
-```release-note:feature
+```release-note:improvement
 helm: update `imageConsulDataplane` value to `hashicorp/consul-dataplane:1.2.0`
 ```
 
-```release-note:feature
+```release-note:improvement
 helm: update `image` value to `hashicorp/consul:1.16.0`
 ```

--- a/.changelog/2476.txt
+++ b/.changelog/2476.txt
@@ -1,4 +1,7 @@
 ```release-note:feature
 helm: update `imageConsulDataplane` value to `hashicorp/consul-dataplane:1.2.0`
+```
+
+```release-note:feature
 helm: update `image` value to `hashicorp/consul:1.16.0`
 ```


### PR DESCRIPTION
Changes proposed in this PR:
- Add changelog for dataplane and consul version updates to helm
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

