### PR TITLE
Set imageConsul to non-ent image

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -63,7 +63,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.10.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.14-dev"
+  image: "hashicorp/consul:1.14.8"
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.


### PR DESCRIPTION
Changes proposed in this PR:
- Fixes #2502 in the 1.0.8 Helm chart where `image` was set to the enterprise version.

