### PR TITLE
feature: adding security context and annotations to tls and acl init/cleanup jobs

### DIFF
--- a/charts/consul/templates/gateway-cleanup-job.yaml
+++ b/charts/consul/templates/gateway-cleanup-job.yaml
@@ -31,6 +31,9 @@ spec:
         {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
+        {{- if .Values.global.acls.annotations }}
+          {{- tpl .Values.global.acls.annotations . | nindent 8 }}
+        {{- end }}
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-gateway-cleanup

--- a/charts/consul/templates/gateway-resources-job.yaml
+++ b/charts/consul/templates/gateway-resources-job.yaml
@@ -31,6 +31,9 @@ spec:
         {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
+        {{- if .Values.global.acls.annotations }}
+          {{- tpl .Values.global.acls.annotations . | nindent 8 }}
+        {{- end }}
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-gateway-resources

--- a/charts/consul/templates/server-acl-init-cleanup-job.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-job.yaml
@@ -47,9 +47,16 @@ spec:
         {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
+        {{- if .Values.global.acls.annotations }}
+          {{- tpl .Values.global.acls.annotations . | nindent 8 }}
+        {{- end }}
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-server-acl-init-cleanup
+      {{- if .Values.server.containerSecurityContext.aclInit }}
+      securityContext:
+        {{- toYaml .Values.server.containerSecurityContext.aclInit | nindent 8 }}
+      {{- end }}
       containers:
         - name: server-acl-init-cleanup
           image: {{ .Values.global.imageK8S }}

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -46,6 +46,9 @@ spec:
         {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
+        {{- if .Values.global.acls.annotations }}
+          {{- tpl .Values.global.acls.annotations . | nindent 8 }}
+        {{- end }}
         {{- if .Values.global.secretsBackend.vault.enabled }}
 
         {{- /* Run the Vault agent as both an init container and sidecar.
@@ -94,6 +97,10 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-server-acl-init
+      {{- if .Values.server.containerSecurityContext.aclInit }}
+      securityContext:
+        {{- toYaml .Values.server.containerSecurityContext.aclInit | nindent 8 }}
+      {{- end }}
       {{- if (or .Values.global.tls.enabled .Values.global.acls.replicationToken.secretName .Values.global.acls.bootstrapToken.secretName) }}
       volumes:
       {{- if and .Values.global.tls.enabled (not .Values.global.secretsBackend.vault.enabled) }}

--- a/charts/consul/templates/tls-init-cleanup-job.yaml
+++ b/charts/consul/templates/tls-init-cleanup-job.yaml
@@ -35,9 +35,16 @@ spec:
         {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
+        {{- if .Values.global.tls.annotations }}
+          {{- tpl .Values.global.tls.annotations . | nindent 8 }}
+        {{- end }}
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-tls-init-cleanup
+      {{- if .Values.server.containerSecurityContext.tlsInit }}
+      securityContext:
+        {{- toYaml .Values.server.containerSecurityContext.tlsInit | nindent 8 }}
+      {{- end }}
       containers:
         - name: tls-init-cleanup
           image: "{{ .Values.global.image }}"

--- a/charts/consul/templates/tls-init-job.yaml
+++ b/charts/consul/templates/tls-init-job.yaml
@@ -35,9 +35,16 @@ spec:
         {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
+        {{- if .Values.global.tls.annotations }}
+          {{- tpl .Values.global.tls.annotations . | nindent 8 }}
+        {{- end }}
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-tls-init
+      {{- if .Values.server.containerSecurityContext.tlsInit }}
+      securityContext:
+        {{- toYaml .Values.server.containerSecurityContext.tlsInit | nindent 8 }}
+      {{- end }}
       {{- if (and .Values.global.tls.caCert.secretName .Values.global.tls.caKey.secretName) }}
       volumes:
       - name: consul-ca-cert

--- a/charts/consul/test/unit/gateway-cleanup-job.bats
+++ b/charts/consul/test/unit/gateway-cleanup-job.bats
@@ -18,6 +18,28 @@ target=templates/gateway-cleanup-job.yaml
     assert_empty helm template \
         -s $target \
         --set 'connectInject.enabled=false' \
-        . 
+        .
 }
 
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "gatewaycleanup/Job: no annotations defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+        -s $target \
+        . | tee /dev/stderr |
+        yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."consul.hashicorp.com/config-checksum")' | tee /dev/stderr)
+    [ "${actual}" = "{}" ]
+}
+
+@test "gatewaycleanup/Job: annotations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+        -s $target \
+        --set 'global.acls.annotations=foo: bar' \
+        . | tee /dev/stderr |
+        yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
+    [ "${actual}" = "bar" ]
+}

--- a/charts/consul/test/unit/gateway-resources-job.bats
+++ b/charts/consul/test/unit/gateway-resources-job.bats
@@ -18,7 +18,7 @@ target=templates/gateway-resources-job.yaml
     assert_empty helm template \
         -s $target \
         --set 'connectInject.enabled=false' \
-        . 
+        .
 }
 
 @test "gatewayresources/Job: imageK8S set properly" {
@@ -115,4 +115,27 @@ target=templates/gateway-resources-job.yaml
 
   local actual=$(echo "$spec" | jq '.[14]')
   [ "${actual}" = "\"-service-annotations=- bingo\"" ]
+}
+
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "gatewayresources/Job: no annotations defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+        -s $target \
+        . | tee /dev/stderr |
+        yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."consul.hashicorp.com/config-checksum")' | tee /dev/stderr)
+    [ "${actual}" = "{}" ]
+}
+
+@test "gatewayresources/Job: annotations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+        -s $target \
+        --set 'global.acls.annotations=foo: bar' \
+        . | tee /dev/stderr |
+        yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
+    [ "${actual}" = "bar" ]
 }

--- a/charts/consul/test/unit/server-acl-init-cleanup-job.bats
+++ b/charts/consul/test/unit/server-acl-init-cleanup-job.bats
@@ -183,3 +183,42 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].resources.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 }
+
+#--------------------------------------------------------------------
+# server.containerSecurityContext.aclInit
+
+@test "serverACLInitCleanup/Job: securityContext is set when server.containerSecurityContext.aclInit is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-cleanup-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'server.containerSecurityContext.aclInit.runAsUser=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.runAsUser' | tee /dev/stderr)
+
+  [ "${actual}" = "100" ]
+}
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "serverACLInitCleanup/Job: no annotations defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-cleanup-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."consul.hashicorp.com/config-checksum")' | tee /dev/stderr)
+  [ "${actual}" = "{}" ]
+}
+
+@test "serverACLInitCleanup/Job: annotations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-cleanup-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.annotations=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -591,6 +591,22 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# server.containerSecurityContext.aclInit
+
+@test "serverACLInit/Job: securityContext is set when server.containerSecurityContext.aclInit is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-job.yaml  \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'server.containerSecurityContext.aclInit.runAsUser=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.runAsUser' | tee /dev/stderr)
+
+  [ "${actual}" = "100" ]
+
+}
+
+#--------------------------------------------------------------------
 # Vault
 
 @test "serverACLInit/Job: fails when vault is enabled but neither bootstrap nor replication token is provided" {
@@ -2030,7 +2046,7 @@ load _helpers
       --set 'global.cloud.authUrl.secretName=auth-url-name' \
       .
   [ "$status" -eq 1 ]
-  
+
   [[ "$output" =~ "When either global.cloud.authUrl.secretName or global.cloud.authUrl.secretKey is defined, both must be set." ]]
 }
 
@@ -2050,7 +2066,7 @@ load _helpers
       --set 'global.cloud.authUrl.secretKey=auth-url-key' \
       .
   [ "$status" -eq 1 ]
-  
+
   [[ "$output" =~ "When either global.cloud.authUrl.secretName or global.cloud.authUrl.secretKey is defined, both must be set." ]]
 }
 
@@ -2070,7 +2086,7 @@ load _helpers
       --set 'global.cloud.apiHost.secretName=auth-url-name' \
       .
   [ "$status" -eq 1 ]
-  
+
   [[ "$output" =~ "When either global.cloud.apiHost.secretName or global.cloud.apiHost.secretKey is defined, both must be set." ]]
 }
 
@@ -2090,7 +2106,7 @@ load _helpers
       --set 'global.cloud.apiHost.secretKey=auth-url-key' \
       .
   [ "$status" -eq 1 ]
-  
+
   [[ "$output" =~ "When either global.cloud.apiHost.secretName or global.cloud.apiHost.secretKey is defined, both must be set." ]]
 }
 
@@ -2110,7 +2126,7 @@ load _helpers
       --set 'global.cloud.scadaAddress.secretName=scada-address-name' \
       .
   [ "$status" -eq 1 ]
-  
+
   [[ "$output" =~ "When either global.cloud.scadaAddress.secretName or global.cloud.scadaAddress.secretKey is defined, both must be set." ]]
 }
 
@@ -2130,7 +2146,7 @@ load _helpers
       --set 'global.cloud.scadaAddress.secretKey=scada-address-key' \
       .
   [ "$status" -eq 1 ]
-  
+
   [[ "$output" =~ "When either global.cloud.scadaAddress.secretName or global.cloud.scadaAddress.secretKey is defined, both must be set." ]]
 }
 
@@ -2224,5 +2240,29 @@ load _helpers
       --set 'global.acls.resources.foo=bar' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].resources.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "serverACLInit/Job: no annotations defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-cleanup-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."consul.hashicorp.com/config-checksum")' | tee /dev/stderr)
+  [ "${actual}" = "{}" ]
+}
+
+@test "serverACLInit/Job: annotations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-acl-init-cleanup-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.annotations=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 }

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -2249,7 +2249,7 @@ load _helpers
 @test "serverACLInit/Job: no annotations defined by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/server-acl-init-cleanup-job.yaml \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."consul.hashicorp.com/config-checksum")' | tee /dev/stderr)
@@ -2259,7 +2259,7 @@ load _helpers
 @test "serverACLInit/Job: annotations can be set" {
   cd `chart_dir`
   local actual=$(helm template \
-      -s templates/server-acl-init-cleanup-job.yaml \
+      -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
       --set 'global.acls.annotations=foo: bar' \
       . | tee /dev/stderr |

--- a/charts/consul/test/unit/tls-init-cleanup-job.bats
+++ b/charts/consul/test/unit/tls-init-cleanup-job.bats
@@ -119,3 +119,43 @@ load _helpers
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# server.containerSecurityContext.tlsInit
+
+@test "tlsInitCleanup/Job: securityContext is set when server.containerSecurityContext.tlsInit is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tls-init-cleanup-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'server.containerSecurityContext.tlsInit.runAsUser=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.runAsUser' | tee /dev/stderr)
+
+  [ "${actual}" = "100" ]
+}
+
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "tlsInitCleanup/Job: no annotations defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tls-init-cleanup-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."consul.hashicorp.com/config-checksum")' | tee /dev/stderr)
+  [ "${actual}" = "{}" ]
+}
+
+@test "tlsInitCleanup/Job: annotations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tls-init-cleanup-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.annotations=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/charts/consul/test/unit/tls-init-job.bats
+++ b/charts/consul/test/unit/tls-init-job.bats
@@ -207,3 +207,42 @@ load _helpers
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# server.containerSecurityContext.tlsInit
+
+@test "tlsInit/Job: securityContext is set when server.containerSecurityContext.tlsInit is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tls-init-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'server.containerSecurityContext.tlsInit.runAsUser=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.runAsUser' | tee /dev/stderr)
+
+  [ "${actual}" = "100" ]
+}
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "tlsInit/Job: no annotations defined by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tls-init-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."consul.hashicorp.com/config-checksum")' | tee /dev/stderr)
+  [ "${actual}" = "{}" ]
+}
+
+@test "tlsInit/Job: annotations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tls-init-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.annotations=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -379,6 +379,18 @@ global:
       # @type: string
       secretKey: null
 
+    # This value defines additional annotations for
+    # tls init jobs. This should be formatted as a multi-line string.
+    #
+    # ```yaml
+    # annotations: |
+    #   "sample/annotation1": "foo"
+    #   "sample/annotation2": "bar"
+    # ```
+    #
+    # @type: string
+    annotations: null
+
   # [Enterprise Only] `enableConsulNamespaces` indicates that you are running
   # Consul Enterprise v1.7+ with a valid Consul Enterprise license and would
   # like to make use of configuration beyond registering everything into
@@ -488,6 +500,18 @@ global:
     #
     # @type: string
     nodeSelector: null
+
+    # This value defines additional annotations for
+    # acl init jobs. This should be formatted as a multi-line string.
+    #
+    # ```yaml
+    # annotations: |
+    #   "sample/annotation1": "foo"
+    #   "sample/annotation2": "bar"
+    # ```
+    #
+    # @type: string
+    annotations: null
 
   # [Enterprise Only] This value refers to a Kubernetes or Vault secret that you have created
   # that contains your enterprise license. It is required if you are using an
@@ -877,6 +901,14 @@ server:
     # @type: map
     # @recurse: false
     server: null
+    # The acl-init job
+    # @type: map
+    # @recurse: false
+    aclInit: null
+    # The tls-init job
+    # @type: map
+    # @recurse: false
+    tlsInit: null
 
   # This value is used to carefully
   # control a rolling update of Consul server agents. This value specifies the


### PR DESCRIPTION
Changes proposed in this PR:
- Ability to add annotations to acl init and cleanup jobs
- Ability to add annotations to tls init and cleanup jobs
- Ability to add pod security context to acl init and cleanup jobs
- Ability to add pod security context to tls init and cleanup jobs

How I've tested this PR:

Ran unit tests, helm lint, and also used changes to deploy at work where jobs not having the security context set by default run into regulation issues.

How I expect reviewers to test this PR:

helm lint and unit tests

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

