### PR TITLE
Add connectInject.prepareDataplanesUpgrade value

### DIFF
--- a/.changelog/2514.txt
+++ b/.changelog/2514.txt
@@ -1,0 +1,1 @@
+improvement: Add `connectInject.prepareDataplanesUpgrade` setting for help upgrading to dataplanes. This setting is required if upgrading from non-dataplanes to dataplanes when ACLs are enabled. See https://developer.hashicorp.com/consul/docs/k8s/upgrade#upgrading-to-consul-dataplane for more information.

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -275,7 +275,7 @@ spec:
                 -default-consul-sidecar-cpu-request={{ $consulSidecarResources.requests.cpu }} \
                 {{- end }}
                 {{- end }}
-          {{- if .Values.global.acls.manageSystemACLs }}
+          {{- if and .Values.global.acls.manageSystemACLs (not .Values.connectInject.prepareDataplanesUpgrade) }}
           lifecycle:
             preStop:
               exec:

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -965,6 +965,19 @@ EOF
   [ "${object}" = "true" ]
 }
 
+@test "connectInject/Deployment: consul-logout preStop hook is disabled added when ACLs are enabled but prepareDataplanesUpgrade=true" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/connect-inject-deployment.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'connectInject.prepareDataplanesUpgrade=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].lifecycle' | tee /dev/stderr)
+
+  [ "${object}" = "null" ]
+}
+
 @test "connectInject/Deployment: CONSUL_HTTP_TOKEN_FILE is not set when acls are disabled" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2436,6 +2436,13 @@ connectInject:
         # @type: string
         cpu: null
 
+  # Set to true when upgrading to Consul dataplanes. This will ensure that the injector ACL tokens won't be deleted
+  # during the upgrade to dataplanes. This is required because after an upgrade, non-dataplane enabled services won't
+  # get re-registered by the new dataplane-capable injector, and so if the ACL token used to register them is deleted,
+  # they won't be able to resolve new upstream services.
+  # See https://developer.hashicorp.com/consul/docs/k8s/upgrade#upgrading-to-consul-dataplane for more information.
+  prepareDataplanesUpgrade: false
+
 # Controller handles config entry custom resources.
 # Requires consul >= 1.8.4.
 # ServiceIntentions require consul 1.9+.


### PR DESCRIPTION
Set to true before performing an upgrade to a consul-dataplanes compatible consul-k8s version. This will ensure that the ACL tokens used to register non-dataplane services won't get deleted during the upgrade to dataplanes. If these ACL tokens are deleted, non-dataplane services won't be able to resolve their upstreams. During a normal non-dataplane upgrade this isn't an issue because the new injector re-registers all services using its new ACL token, but during an upgrade to dataplanes, the injector ignores all non-dataplane services and so doesn't re-register them with its latest token.

How I've tested this PR:
- ran the upgrade and confirmed old non-dataplane services have their upstreams updated

How I expect reviewers to test this PR:
- code

Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

