### PR TITLE
Add container name to login metadata for init container

### DIFF
--- a/control-plane/connect-inject/webhook/container_init.go
+++ b/control-plane/connect-inject/webhook/container_init.go
@@ -180,7 +180,7 @@ func (w *MeshWebhook) containerInit(namespace corev1.Namespace, pod corev1.Pod, 
 			},
 			corev1.EnvVar{
 				Name:  "CONSUL_LOGIN_META",
-				Value: "pod=$(POD_NAMESPACE)/$(POD_NAME)",
+				Value: fmt.Sprintf("pod=$(POD_NAMESPACE)/$(POD_NAME),container=%s", injectInitContainerName),
 			})
 
 		if w.EnableNamespaces {

--- a/control-plane/connect-inject/webhook/container_init_test.go
+++ b/control-plane/connect-inject/webhook/container_init_test.go
@@ -150,7 +150,7 @@ func TestHandlerContainerInit(t *testing.T) {
 				},
 				{
 					Name:  "CONSUL_LOGIN_META",
-					Value: "pod=$(POD_NAMESPACE)/$(POD_NAME)",
+					Value: "pod=$(POD_NAMESPACE)/$(POD_NAME),container=consul-connect-inject-init",
 				},
 			},
 		},
@@ -569,7 +569,7 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				},
 				{
 					Name:  "CONSUL_LOGIN_META",
-					Value: "pod=$(POD_NAMESPACE)/$(POD_NAME)",
+					Value: "pod=$(POD_NAMESPACE)/$(POD_NAME),container=consul-connect-inject-init",
 				},
 				{
 					Name:  "CONSUL_LOGIN_NAMESPACE",
@@ -640,7 +640,7 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				},
 				{
 					Name:  "CONSUL_LOGIN_META",
-					Value: "pod=$(POD_NAMESPACE)/$(POD_NAME)",
+					Value: "pod=$(POD_NAMESPACE)/$(POD_NAME),container=consul-connect-inject-init",
 				},
 				{
 					Name:  "CONSUL_LOGIN_NAMESPACE",


### PR DESCRIPTION
Services have two ACL tokens (one for init container and one for dataplane) so it's nice to see which container the token is for.

Changes proposed in this PR:
-
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

