### PR TITLE
NET-4813: Fix issue where virtual IP saving had insufficient ACLs.

### DIFF
--- a/.changelog/2520.txt
+++ b/.changelog/2520.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+transparent-proxy: Fix issue where connect-inject lacked sufficient `mesh:write` privileges in some deployments,
+which prevented virtual IPs from persisting properly.
+```

--- a/acceptance/framework/connhelper/connect_helper.go
+++ b/acceptance/framework/connhelper/connect_helper.go
@@ -6,7 +6,6 @@ package connhelper
 import (
 	"context"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -19,9 +18,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 const (
@@ -137,13 +134,6 @@ func (c *ConnectHelper) CreateResolverRedirect(t *testing.T) {
 	options := c.Ctx.KubectlOptions(t)
 	kustomizeDir := "../fixtures/cases/resolver-redirect-virtualip"
 	k8s.KubectlApplyK(t, options, kustomizeDir)
-
-	output, err := k8s.RunKubectlAndGetOutputE(t, options, "kustomize", kustomizeDir)
-	require.NoError(t, err)
-
-	deployment := v1.Deployment{}
-	err = yaml.NewYAMLOrJSONDecoder(strings.NewReader(output), 1024).Decode(&deployment)
-	require.NoError(t, err)
 
 	helpers.Cleanup(t, c.Cfg.NoCleanupOnFailure, func() {
 		k8s.KubectlDeleteK(t, options, kustomizeDir)

--- a/acceptance/framework/connhelper/connect_helper.go
+++ b/acceptance/framework/connhelper/connect_helper.go
@@ -6,6 +6,7 @@ package connhelper
 import (
 	"context"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,7 +19,9 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 const (
@@ -125,6 +128,26 @@ func (c *ConnectHelper) DeployClientAndServer(t *testing.T) {
 		require.Len(t, podList.Items, 1)
 		require.Len(t, podList.Items[0].Spec.Containers, 2)
 	}
+}
+
+// CreateResolverRedirect creates a resolver that redirects to a static-server, a corresponding k8s service,
+// and intentions. This helper is primarly used to ensure that the virtual-ips are persisted to consul properly.
+func (c *ConnectHelper) CreateResolverRedirect(t *testing.T) {
+	logger.Log(t, "creating resolver redirect")
+	options := c.Ctx.KubectlOptions(t)
+	kustomizeDir := "../fixtures/cases/resolver-redirect-virtualip"
+	k8s.KubectlApplyK(t, options, kustomizeDir)
+
+	output, err := k8s.RunKubectlAndGetOutputE(t, options, "kustomize", kustomizeDir)
+	require.NoError(t, err)
+
+	deployment := v1.Deployment{}
+	err = yaml.NewYAMLOrJSONDecoder(strings.NewReader(output), 1024).Decode(&deployment)
+	require.NoError(t, err)
+
+	helpers.Cleanup(t, c.Cfg.NoCleanupOnFailure, func() {
+		k8s.KubectlDeleteK(t, options, kustomizeDir)
+	})
 }
 
 // TestConnectionFailureWithoutIntention ensures the connection to the static

--- a/acceptance/tests/fixtures/bases/resolver-redirect/intention.yaml
+++ b/acceptance/tests/fixtures/bases/resolver-redirect/intention.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceIntentions
+metadata:
+  name: client-to-server
+spec:
+  destination:
+    name: static-server
+  sources:
+    - name: static-client
+      action: allow
+---
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceIntentions
+metadata:
+  name: client-to-redirect
+spec:
+  destination:
+    name: resolver-redirect
+  sources:
+    - name: static-client
+      action: allow

--- a/acceptance/tests/fixtures/bases/resolver-redirect/kustomization.yaml
+++ b/acceptance/tests/fixtures/bases/resolver-redirect/kustomization.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - intention.yaml
+  - service.yaml
+  - serviceaccount.yaml
+  - resolver.yaml

--- a/acceptance/tests/fixtures/bases/resolver-redirect/resolver.yaml
+++ b/acceptance/tests/fixtures/bases/resolver-redirect/resolver.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceResolver
+metadata:
+  name: resolver-redirect
+spec:
+  redirect:
+    service: static-server

--- a/acceptance/tests/fixtures/bases/resolver-redirect/service.yaml
+++ b/acceptance/tests/fixtures/bases/resolver-redirect/service.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: resolver-redirect
+spec:
+  selector:
+    # Nothing needs to be selected. We only utilize this service so that KubeDNS has a ClusterIP to resolve.
+    app: idonotexist
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080

--- a/acceptance/tests/fixtures/bases/resolver-redirect/serviceaccount.yaml
+++ b/acceptance/tests/fixtures/bases/resolver-redirect/serviceaccount.yaml
@@ -1,0 +1,7 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: resolver-redirect

--- a/acceptance/tests/fixtures/cases/resolver-redirect-virtualip/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/resolver-redirect-virtualip/kustomization.yaml
@@ -1,0 +1,5 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - ../../bases/resolver-redirect

--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -330,6 +330,7 @@ partition "{{ .PartitionName }}" {
   mesh = "write"
   acl = "write"
 {{- else }}
+  mesh = "write"
   operator = "write"
   acl = "write"
 {{- end }}

--- a/control-plane/subcommand/server-acl-init/rules_test.go
+++ b/control-plane/subcommand/server-acl-init/rules_test.go
@@ -953,6 +953,7 @@ func TestInjectRules(t *testing.T) {
 			EnablePartitions: false,
 			EnablePeering:    false,
 			Expected: `
+  mesh = "write"
   operator = "write"
   acl = "write"
   node_prefix "" {
@@ -969,6 +970,7 @@ func TestInjectRules(t *testing.T) {
 			EnablePartitions: false,
 			EnablePeering:    false,
 			Expected: `
+  mesh = "write"
   operator = "write"
   acl = "write"
   node_prefix "" {
@@ -987,6 +989,7 @@ func TestInjectRules(t *testing.T) {
 			EnablePartitions: false,
 			EnablePeering:    true,
 			Expected: `
+  mesh = "write"
   operator = "write"
   acl = "write"
   peering = "write"


### PR DESCRIPTION
When partitions were not enabled, the ACL token for the connect-inject pod would have insufficient privileges to persist virtual IP addresses to Consul. This PR ensures that connect-inject always has `mesh:write` access, so that transparent proxy can correctly utilize KubeDNS names.