### PR TITLE
docs: self service changelog instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,6 @@ How I expect reviewers to test this PR:
 
 Checklist:
 - [ ] Tests added
-- [ ] CHANGELOG entry added 
-  > HashiCorp engineers only, community PRs should not add a changelog entry.
-  > Entries should use present tense (e.g. Add support for...)
+- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
+
 


### PR DESCRIPTION
Changes proposed in this PR:
- 3rd party contributors should add their own changelog. Link to instructions included.

