### PR TITLE
chore: Update chart to use OSS image

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -66,7 +66,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.10.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.17-dev
+  image: docker.mirror.hashicorp.services/hashicorppreview/consul:1.17-dev
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.


### PR DESCRIPTION
Changes proposed in this PR:
- Our helm chart should be using the consul OSS image by default so that everyone can pull it.
- I had set it to enterprise during the GHA migration but that is no longer required because we have make targets to determine the correct OSS or ENT images.

How I've tested this PR:

CI

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


