### PR TITLE
Refactor test framework to allow for more than two kube contexts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -666,7 +666,7 @@ Below is the list of available flags:
     This applies only to tests that enable connectInject.
 -enterprise-license
     The enterprise license for Consul.
--kube-configs string
+-kubeconfigs string
     The comma separated list of Kubernetes configs to use (eg. "~/.kube/config,~/.kube/config2"). The first in the list will be treated as the primary config, followed by the secondary, etc. If the list is empty, or items are blank, then the default kubeconfig path (~/.kube/config) will be used.
 -kube-contexts string
     The comma separated list of Kubernetes contexts to use (eg. "kind-dc1,kind-dc2"). The first in the list will be treated as the primary context, followed by the secondary, etc. If the list is empty, or items are blank, then the current context will be used.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -642,7 +642,7 @@ you may use the following command:
 
     go test ./... -p 1 -timeout 20m \
         -enable-multi-cluster \
-        -kubecontexts="<name of the primary Kubernetes context>,<name of the secondary Kubernetes context>, etc.>"
+        -kube-contexts="<name of the primary Kubernetes context>,<name of the secondary Kubernetes context>, etc.>"
 
 Below is the list of available flags:
 
@@ -666,15 +666,14 @@ Below is the list of available flags:
     This applies only to tests that enable connectInject.
 -enterprise-license
     The enterprise license for Consul.
--kubeconfigs string
-    The comma separate list of Kubernetes configs to use (eg. "~/.kube/config,~/.kube/config2"). The first in the list will be treated as the primary config, followed by the secondary, etc. If this is empty, or fields are blank, then the context set as the current context will be used by default.
--kubecontexts string
-    The comma separate list of Kubernetes contexts to use (eg. "kind-dc1,kind-dc2"). The first in the list will be treated as the primary context, followed by the secondary, etc. If this is empty, or fields are blank then the default kubeconfig path (~/.kube/config) will be used.
--kubenamespaces string
-    The comma separate list of Kubernetes namespaces to use (eg. "consul,consul-secondary"). The first in the list will be treated as the primary namespace, followed by the secondary, etc. If the list is empty, or fields are blank, then the "default" namespace will be used.
+-kube-configs string
+    The comma separated list of Kubernetes configs to use (eg. "~/.kube/config,~/.kube/config2"). The first in the list will be treated as the primary config, followed by the secondary, etc. If the list is empty, or items are blank, then the default kubeconfig path (~/.kube/config) will be used.
+-kube-contexts string
+    The comma separated list of Kubernetes contexts to use (eg. "kind-dc1,kind-dc2"). The first in the list will be treated as the primary context, followed by the secondary, etc. If the list is empty, or items are blank, then the current context will be used.
+-kube-namespaces string
+    The comma separated list of Kubernetes namespaces to use (eg. "consul,consul-secondary"). The first in the list will be treated as the primary namespace, followed by the secondary, etc. If the list is empty, or fields are blank, then the current namespace will be used.
 -no-cleanup-on-failure
     If true, the tests will not cleanup Kubernetes resources they create when they finish running.Note this flag must be run with -failfast flag, otherwise subsequent tests will fail.
-
 ```
 
 **Note:** There is a Terraform configuration in the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -642,8 +642,7 @@ you may use the following command:
 
     go test ./... -p 1 -timeout 20m \
         -enable-multi-cluster \
-        -kubecontext=<name of the primary Kubernetes context> \
-        -secondary-kubecontext=<name of the secondary Kubernetes context>
+        -kubecontexts="<name of the primary Kubernetes context>,<name of the secondary Kubernetes context>, etc.>"
 
 Below is the list of available flags:
 
@@ -667,20 +666,15 @@ Below is the list of available flags:
     This applies only to tests that enable connectInject.
 -enterprise-license
     The enterprise license for Consul.
--kubeconfig string
-    The path to a kubeconfig file. If this is blank, the default kubeconfig path (~/.kube/config) will be used.
--kubecontext string
-    The name of the Kubernetes context to use. If this is blank, the context set as the current context will be used by default.
--namespace string
-    The Kubernetes namespace to use for tests. (default "default")
+-kubeconfigs string
+    The comma separate list of Kubernetes configs to use (eg. "~/.kube/config,~/.kube/config2"). The first in the list will be treated as the primary config, followed by the secondary, etc. If this is empty, or fields are blank, then the context set as the current context will be used by default.
+-kubecontexts string
+    The comma separate list of Kubernetes contexts to use (eg. "kind-dc1,kind-dc2"). The first in the list will be treated as the primary context, followed by the secondary, etc. If this is empty, or fields are blank then the default kubeconfig path (~/.kube/config) will be used.
+-kubenamespaces string
+    The comma separate list of Kubernetes namespaces to use (eg. "consul,consul-secondary"). The first in the list will be treated as the primary namespace, followed by the secondary, etc. If the list is empty, or fields are blank, then the "default" namespace will be used.
 -no-cleanup-on-failure
     If true, the tests will not cleanup Kubernetes resources they create when they finish running.Note this flag must be run with -failfast flag, otherwise subsequent tests will fail.
--secondary-kubeconfig string
-    The path to a kubeconfig file of the secondary k8s cluster. If this is blank, the default kubeconfig path (~/.kube/config) will be used.
--secondary-kubecontext string
-    The name of the Kubernetes context for the secondary cluster to use. If this is blank, the context set as the current context will be used by default.
--secondary-namespace string
-    The Kubernetes namespace to use in the secondary k8s cluster. (default "default")
+
 ```
 
 **Note:** There is a Terraform configuration in the

--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -31,7 +31,7 @@ type KubeTestConfig struct {
 
 // NewKubeTestConfigList takes lists of kubernetes configs, contexts and namespaces and constructs KubeTestConfig
 // We validate ahead of time that the lists are either 0 or the same length as we expect that if the length of a list
-// is greater than 0, then the indexes should match. For example: []kubeContexts{"ctx1", "ctx2"} indexes 0, 1 match with []kubeNamespaces{"ns1", "ns2"}
+// is greater than 0, then the indexes should match. For example: []kubeContexts{"ctx1", "ctx2"} indexes 0, 1 match with []kubeNamespaces{"ns1", "ns2"}.
 func NewKubeTestConfigList(kubeConfigs, kubeContexts, kubeNamespaces []string) []KubeTestConfig {
 	// Grab the longest length.
 	l := math.Max(float64(len(kubeConfigs)),

--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -22,66 +23,47 @@ const (
 	LicenseSecretKey  = "key"
 )
 
-type KubeEnv struct {
+type KubeTestConfig struct {
 	KubeConfig    string
 	KubeContext   string
 	KubeNamespace string
 }
 
-func KubeEnvListFromStringList(kubeConfigs, kubeContexts, kubeNamespaces []string) []KubeEnv {
-	// Determine the longest list length
-	maxLen := 0
-	lenConf := len(kubeConfigs)
-	if maxLen < lenConf {
-		maxLen = lenConf
-	}
-
-	lenCtx := len(kubeContexts)
-	if maxLen < lenCtx {
-		maxLen = lenCtx
-	}
-
-	lenNs := len(kubeNamespaces)
-	if maxLen < lenNs {
-		maxLen = lenNs
-	}
+// NewKubeTestConfigList takes lists of kubernetes configs, contexts and namespaces and constructs KubeTestConfig
+// We validate ahead of time that the lists are either 0 or the same length as we expect that if the length of a list
+// is greater than 0, then the indexes should match. For example: []kubeContexts{"ctx1", "ctx2"} indexes 0, 1 match with []kubeNamespaces{"ns1", "ns2"}
+func NewKubeTestConfigList(kubeConfigs, kubeContexts, kubeNamespaces []string) []KubeTestConfig {
+	// Grab the longest length.
+	l := math.Max(float64(len(kubeConfigs)),
+		math.Max(float64(len(kubeContexts)), float64(len(kubeNamespaces))))
 
 	// If all are empty, then return a single empty entry
-	out := make([]KubeEnv, 0)
-	if maxLen == 0 {
-		out = append(out, KubeEnv{})
-		return out
+	if l == 0 {
+		return []KubeTestConfig{{}}
 	}
 
-	// Pad lists if required, all list should be made the same length
-	for i := lenConf; i < maxLen; i++ {
-		kubeConfigs = append(kubeConfigs, "")
-	}
-
-	for i := lenCtx; i < maxLen; i++ {
-		kubeContexts = append(kubeContexts, "")
-	}
-
-	for i := lenNs; i < maxLen; i++ {
-		kubeNamespaces = append(kubeNamespaces, "")
-	}
-
-	// Construct the kubeEnv
-	for k, v := range kubeConfigs {
-		kenv := KubeEnv{
-			KubeConfig:    v,
-			KubeContext:   kubeContexts[k],
-			KubeNamespace: kubeNamespaces[k],
+	// Add each non-zero length list to the new structs, we should have
+	// n structs where n == l.
+	out := make([]KubeTestConfig, int(l))
+	for i := range out {
+		kenv := KubeTestConfig{}
+		if len(kubeConfigs) != 0 {
+			kenv.KubeConfig = kubeConfigs[i]
 		}
-		out = append(out, kenv)
+		if len(kubeContexts) != 0 {
+			kenv.KubeContext = kubeContexts[i]
+		}
+		if len(kubeNamespaces) != 0 {
+			kenv.KubeNamespace = kubeNamespaces[i]
+		}
+		out[i] = kenv
 	}
-
 	return out
 }
 
 // TestConfig holds configuration for the test suite.
 type TestConfig struct {
-	KubeEnvs           []KubeEnv
+	KubeEnvs           []KubeTestConfig
 	EnableMultiCluster bool
 
 	EnableEnterprise  bool
@@ -175,11 +157,11 @@ func (t *TestConfig) IsExpectedClusterCount(count int) bool {
 }
 
 // GetPrimaryKubeEnv returns the primary Kubernetes environment.
-func (t *TestConfig) GetPrimaryKubeEnv() KubeEnv {
+func (t *TestConfig) GetPrimaryKubeEnv() KubeTestConfig {
 	// Return the first in the list as this is always the primary
 	// kube environment. If empty return an empty kubeEnv
 	if len(t.KubeEnvs) < 1 {
-		return KubeEnv{}
+		return KubeTestConfig{}
 	} else {
 		return t.KubeEnvs[0]
 	}

--- a/acceptance/framework/config/config_test.go
+++ b/acceptance/framework/config/config_test.go
@@ -188,69 +188,69 @@ func Test_KubeEnvListFromStringList(t *testing.T) {
 		kubeContexts   []string
 		KubeConfigs    []string
 		kubeNamespaces []string
-		expKubeEnvList []KubeEnv
+		expKubeEnvList []KubeTestConfig
 	}{
 		{
 			name:           "empty-lists",
 			kubeContexts:   []string{},
 			KubeConfigs:    []string{},
 			kubeNamespaces: []string{},
-			expKubeEnvList: []KubeEnv{{}},
+			expKubeEnvList: []KubeTestConfig{{}},
 		},
 		{
 			name:           "kubeContext set",
 			kubeContexts:   []string{"ctx1", "ctx2"},
 			KubeConfigs:    []string{},
 			kubeNamespaces: []string{},
-			expKubeEnvList: []KubeEnv{{KubeContext: "ctx1"}, {KubeContext: "ctx2"}},
+			expKubeEnvList: []KubeTestConfig{{KubeContext: "ctx1"}, {KubeContext: "ctx2"}},
 		},
 		{
 			name:           "kubeNamespace set",
 			kubeContexts:   []string{},
 			KubeConfigs:    []string{"/path/config1", "/path/config2"},
 			kubeNamespaces: []string{},
-			expKubeEnvList: []KubeEnv{{KubeConfig: "/path/config1"}, {KubeConfig: "/path/config2"}},
+			expKubeEnvList: []KubeTestConfig{{KubeConfig: "/path/config1"}, {KubeConfig: "/path/config2"}},
 		},
 		{
 			name:           "kubeConfigs set",
 			kubeContexts:   []string{},
 			KubeConfigs:    []string{},
 			kubeNamespaces: []string{"ns1", "ns2"},
-			expKubeEnvList: []KubeEnv{{KubeNamespace: "ns1"}, {KubeNamespace: "ns2"}},
+			expKubeEnvList: []KubeTestConfig{{KubeNamespace: "ns1"}, {KubeNamespace: "ns2"}},
 		},
 		{
-			name:           "first of everything set multiple contexts",
-			kubeContexts:   []string{"ctx1", "ctx2"},
-			KubeConfigs:    []string{"/path/config1"},
-			kubeNamespaces: []string{"ns1"},
-			expKubeEnvList: []KubeEnv{{KubeContext: "ctx1", KubeNamespace: "ns1", KubeConfig: "/path/config1"}, {KubeContext: "ctx2"}},
-		},
-		{
-			name:           "context config multiple namespace single",
+			name:           "multiple everything",
 			kubeContexts:   []string{"ctx1", "ctx2"},
 			KubeConfigs:    []string{"/path/config1", "/path/config2"},
-			kubeNamespaces: []string{"ns1"},
-			expKubeEnvList: []KubeEnv{{KubeContext: "ctx1", KubeNamespace: "ns1", KubeConfig: "/path/config1"}, {KubeContext: "ctx2", KubeConfig: "/path/config2"}},
-		},
-		{
-			name:           "context namespace multiple config single",
-			kubeContexts:   []string{"ctx1", "ctx2"},
-			KubeConfigs:    []string{"/path/config1"},
 			kubeNamespaces: []string{"ns1", "ns2"},
-			expKubeEnvList: []KubeEnv{{KubeContext: "ctx1", KubeNamespace: "ns1", KubeConfig: "/path/config1"}, {KubeContext: "ctx2", KubeNamespace: "ns2"}},
+			expKubeEnvList: []KubeTestConfig{{KubeContext: "ctx1", KubeNamespace: "ns1", KubeConfig: "/path/config1"}, {KubeContext: "ctx2", KubeNamespace: "ns2", KubeConfig: "/path/config2"}},
 		},
 		{
-			name:           "namespace config multiple namespace single",
-			kubeContexts:   []string{"ctx1"},
+			name:           "multiple context and configs",
+			kubeContexts:   []string{"ctx1", "ctx2"},
+			KubeConfigs:    []string{"/path/config1", "/path/config2"},
+			kubeNamespaces: []string{},
+			expKubeEnvList: []KubeTestConfig{{KubeContext: "ctx1", KubeConfig: "/path/config1"}, {KubeContext: "ctx2", KubeConfig: "/path/config2"}},
+		},
+		{
+			name:           "multiple namespace and configs",
+			kubeContexts:   []string{},
 			KubeConfigs:    []string{"/path/config1", "/path/config2"},
 			kubeNamespaces: []string{"ns1", "ns2"},
-			expKubeEnvList: []KubeEnv{{KubeContext: "ctx1", KubeNamespace: "ns1", KubeConfig: "/path/config1"}, {KubeConfig: "/path/config2", KubeNamespace: "ns2"}},
+			expKubeEnvList: []KubeTestConfig{{KubeNamespace: "ns1", KubeConfig: "/path/config1"}, {KubeNamespace: "ns2", KubeConfig: "/path/config2"}},
+		},
+		{
+			name:           "multiple context and namespace",
+			kubeContexts:   []string{"ctx1", "ctx2"},
+			KubeConfigs:    []string{},
+			kubeNamespaces: []string{"ns1", "ns2"},
+			expKubeEnvList: []KubeTestConfig{{KubeContext: "ctx1", KubeNamespace: "ns1"}, {KubeContext: "ctx2", KubeNamespace: "ns2"}},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := KubeEnvListFromStringList(tt.KubeConfigs, tt.kubeContexts, tt.kubeNamespaces)
+			actual := NewKubeTestConfigList(tt.KubeConfigs, tt.kubeContexts, tt.kubeNamespaces)
 			require.Equal(t, tt.expKubeEnvList, actual)
 		})
 	}
@@ -259,18 +259,18 @@ func Test_KubeEnvListFromStringList(t *testing.T) {
 func Test_GetPrimaryKubeEnv(t *testing.T) {
 	tests := []struct {
 		name              string
-		kubeEnvList       []KubeEnv
-		expPrimaryKubeEnv KubeEnv
+		kubeEnvList       []KubeTestConfig
+		expPrimaryKubeEnv KubeTestConfig
 	}{
 		{
 			name:              "context config multiple namespace single",
-			kubeEnvList:       []KubeEnv{{KubeContext: "ctx1", KubeNamespace: "ns1", KubeConfig: "/path/config1"}, {KubeContext: "ctx2", KubeConfig: "/path/config2"}},
-			expPrimaryKubeEnv: KubeEnv{KubeContext: "ctx1", KubeNamespace: "ns1", KubeConfig: "/path/config1"},
+			kubeEnvList:       []KubeTestConfig{{KubeContext: "ctx1", KubeNamespace: "ns1", KubeConfig: "/path/config1"}, {KubeContext: "ctx2", KubeConfig: "/path/config2"}},
+			expPrimaryKubeEnv: KubeTestConfig{KubeContext: "ctx1", KubeNamespace: "ns1", KubeConfig: "/path/config1"},
 		},
 		{
 			name:              "context config multiple namespace single",
-			kubeEnvList:       []KubeEnv{},
-			expPrimaryKubeEnv: KubeEnv{},
+			kubeEnvList:       []KubeTestConfig{},
+			expPrimaryKubeEnv: KubeTestConfig{},
 		},
 	}
 

--- a/acceptance/framework/consul/cli_cluster.go
+++ b/acceptance/framework/consul/cli_cluster.go
@@ -97,16 +97,17 @@ func NewCLICluster(
 	cli, err := cli.NewCLI()
 	require.NoError(t, err)
 
+	require.Greater(t, len(cfg.KubeEnvs), 0)
 	return &CLICluster{
 		ctx:                ctx,
 		helmOptions:        hopts,
 		kubectlOptions:     kopts,
-		namespace:          cfg.KubeNamespace,
+		namespace:          cfg.GetPrimaryKubeEnv().KubeNamespace,
 		values:             values,
 		releaseName:        releaseName,
 		kubernetesClient:   ctx.KubernetesClient(t),
-		kubeConfig:         cfg.Kubeconfig,
-		kubeContext:        cfg.KubeContext,
+		kubeConfig:         cfg.GetPrimaryKubeEnv().KubeConfig,
+		kubeContext:        cfg.GetPrimaryKubeEnv().KubeContext,
 		noCleanupOnFailure: cfg.NoCleanupOnFailure,
 		debugDirectory:     cfg.DebugDirectory,
 		logger:             logger,

--- a/acceptance/framework/environment/environment.go
+++ b/acceptance/framework/environment/environment.go
@@ -21,17 +21,14 @@ import (
 )
 
 const (
-	DefaultContextName         = "default"
-	SecondaryContextNamePrefix = "secondary"
+	DefaultContextIndex = 0
 )
 
 // TestEnvironment represents the infrastructure environment of the test,
 // such as the kubernetes cluster(s) the test is running against.
 type TestEnvironment interface {
 	DefaultContext(t *testing.T) TestContext
-	Context(t *testing.T, name string) TestContext
-	GetSecondaryContextKey(t *testing.T) string
-	GetContextKeys(t *testing.T) []string
+	Context(t *testing.T, index int) TestContext
 }
 
 // TestContext represents a specific context a test needs,
@@ -43,8 +40,7 @@ type TestContext interface {
 }
 
 type KubernetesEnvironment struct {
-	contexts    map[string]*kubernetesContext
-	contextKeys []string
+	contexts []*kubernetesContext
 }
 
 func NewKubernetesEnvironmentFromConfig(config *config.TestConfig) *KubernetesEnvironment {
@@ -53,58 +49,31 @@ func NewKubernetesEnvironmentFromConfig(config *config.TestConfig) *KubernetesEn
 
 	// Create a kubernetes environment with default context.
 	kenv := &KubernetesEnvironment{
-		contexts: map[string]*kubernetesContext{
-			DefaultContextName: defaultContext,
+		contexts: []*kubernetesContext{
+			defaultContext,
 		},
-		contextKeys: []string{DefaultContextName},
 	}
 
 	// Add additional contexts if multi cluster tests are enabled.
 	if config.EnableMultiCluster {
-		for i, v := range config.KubeEnvs[1:] {
-			ctxName := fmt.Sprintf("%s-%d", SecondaryContextNamePrefix, i)
-			kenv.contexts[ctxName] = NewContext(v.KubeNamespace, v.KubeConfig, v.KubeContext)
-			kenv.contextKeys = append(kenv.contextKeys, ctxName)
+		for _, v := range config.KubeEnvs[1:] {
+			kenv.contexts = append(kenv.contexts, NewContext(v.KubeNamespace, v.KubeConfig, v.KubeContext))
 		}
 	}
 
 	return kenv
 }
 
-func NewKubernetesEnvironmentFromContext(context *kubernetesContext) *KubernetesEnvironment {
-	// Create a kubernetes environment with default context.
-	kenv := &KubernetesEnvironment{
-		contexts: map[string]*kubernetesContext{
-			DefaultContextName: context,
-		},
-	}
-
-	return kenv
-}
-
-func (k *KubernetesEnvironment) GetSecondaryContextKey(t *testing.T) string {
-	require.Equal(t, 2, len(k.contextKeys), "a secondary context does not exist")
-	ctxKeys := k.GetContextKeys(t)
-	return ctxKeys[1]
-}
-
-func (k *KubernetesEnvironment) GetContextKeys(t *testing.T) []string {
-	require.GreaterOrEqual(t, len(k.contextKeys), 1)
-	return k.contextKeys
-}
-
-func (k *KubernetesEnvironment) Context(t *testing.T, name string) TestContext {
-	ctx, ok := k.contexts[name]
-	require.Truef(t, ok, fmt.Sprintf("requested context %s not found", name))
-
-	return ctx
+func (k *KubernetesEnvironment) Context(t *testing.T, index int) TestContext {
+	lenContexts := len(k.contexts)
+	require.Greater(t, lenContexts, index, fmt.Sprintf("context list does not contain an index %d, length is %d", index, lenContexts))
+	return k.contexts[index]
 }
 
 func (k *KubernetesEnvironment) DefaultContext(t *testing.T) TestContext {
-	ctx, ok := k.contexts[DefaultContextName]
-	require.Truef(t, ok, "default context not found")
-
-	return ctx
+	lenContexts := len(k.contexts)
+	require.Greater(t, lenContexts, DefaultContextIndex, fmt.Sprintf("context list does not contain an index %d, length is %d", DefaultContextIndex, lenContexts))
+	return k.contexts[DefaultContextIndex]
 }
 
 type kubernetesContext struct {

--- a/acceptance/framework/flags/flags.go
+++ b/acceptance/framework/flags/flags.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/consul-k8s/acceptance/framework/config"
@@ -14,14 +15,10 @@ import (
 )
 
 type TestFlags struct {
-	flagKubeconfig  string
-	flagKubecontext string
-	flagNamespace   string
-
-	flagEnableMultiCluster   bool
-	flagSecondaryKubeconfig  string
-	flagSecondaryKubecontext string
-	flagSecondaryNamespace   string
+	flagKubeconfigs        listFlag
+	flagKubecontexts       listFlag
+	flagNamespaces         listFlag
+	flagEnableMultiCluster bool
 
 	flagEnableEnterprise  bool
 	flagEnterpriseLicense string
@@ -68,13 +65,19 @@ func NewTestFlags() *TestFlags {
 	return t
 }
 
-func (t *TestFlags) init() {
-	flag.StringVar(&t.flagKubeconfig, "kubeconfig", "", "The path to a kubeconfig file. If this is blank, "+
-		"the default kubeconfig path (~/.kube/config) will be used.")
-	flag.StringVar(&t.flagKubecontext, "kubecontext", "", "The name of the Kubernetes context to use. If this is blank, "+
-		"the context set as the current context will be used by default.")
-	flag.StringVar(&t.flagNamespace, "namespace", "", "The Kubernetes namespace to use for tests.")
+type listFlag []string
 
+// String() returns a comma separated list in the form "var1,var2,var3".
+func (f *listFlag) String() string {
+	return strings.Join(*f, ",")
+}
+
+func (f *listFlag) Set(value string) error {
+	*f = strings.Split(value, ",")
+	return nil
+}
+
+func (t *TestFlags) init() {
 	flag.StringVar(&t.flagConsulImage, "consul-image", "", "The Consul image to use for all tests.")
 	flag.StringVar(&t.flagConsulK8sImage, "consul-k8s-image", "", "The consul-k8s image to use for all tests.")
 	flag.StringVar(&t.flagConsulDataplaneImage, "consul-dataplane-image", "", "The consul-dataplane image to use for all tests.")
@@ -86,16 +89,16 @@ func (t *TestFlags) init() {
 	flag.StringVar(&t.flagVaultServerVersion, "vault-server-version", "", "The vault serverversion used for all tests.")
 	flag.StringVar(&t.flagVaultHelmChartVersion, "vault-helm-chart-version", "", "The Vault helm chart used for all tests.")
 
+	flag.Var(&t.flagKubeconfigs, "kubeconfigs", "The list of paths to a kubeconfig files. If this is blank, "+
+		"the default kubeconfig path (~/.kube/config) will be used.")
+	flag.Var(&t.flagKubecontexts, "kubecontexts", "The list of names of the Kubernetes contexts to use. If this is blank, "+
+		"the context set as the current context will be used by default.")
+	flag.Var(&t.flagNamespaces, "namespaces", "The list Kubernetes namespace to use for tests.")
 	flag.StringVar(&t.flagHCPResourceID, "hcp-resource-id", "", "The hcp resource id to use for all tests.")
 
 	flag.BoolVar(&t.flagEnableMultiCluster, "enable-multi-cluster", false,
 		"If true, the tests that require multiple Kubernetes clusters will be run. "+
 			"At least one of -secondary-kubeconfig or -secondary-kubecontext is required when this flag is used.")
-	flag.StringVar(&t.flagSecondaryKubeconfig, "secondary-kubeconfig", "", "The path to a kubeconfig file of the secondary k8s cluster. "+
-		"If this is blank, the default kubeconfig path (~/.kube/config) will be used.")
-	flag.StringVar(&t.flagSecondaryKubecontext, "secondary-kubecontext", "", "The name of the Kubernetes context for the secondary cluster to use. "+
-		"If this is blank, the context set as the current context will be used by default.")
-	flag.StringVar(&t.flagSecondaryNamespace, "secondary-namespace", "", "The Kubernetes namespace to use in the secondary k8s cluster.")
 
 	flag.BoolVar(&t.flagEnableEnterprise, "enable-enterprise", false,
 		"If true, the test suite will run tests for enterprise features. "+
@@ -143,8 +146,8 @@ func (t *TestFlags) init() {
 
 func (t *TestFlags) Validate() error {
 	if t.flagEnableMultiCluster {
-		if t.flagSecondaryKubecontext == "" && t.flagSecondaryKubeconfig == "" {
-			return errors.New("at least one of -secondary-kubecontext or -secondary-kubeconfig flags must be provided if -enable-multi-cluster is set")
+		if len(t.flagKubecontexts) <= 1 && len(t.flagKubeconfigs) <= 1 {
+			return errors.New("at least two contexts must be included in -kubecontexts or -kubeconfigs if -enable-multi-cluster is set")
 		}
 	}
 
@@ -161,19 +164,14 @@ func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 	consulVersion, _ := version.NewVersion(t.flagConsulVersion)
 	consulDataplaneVersion, _ := version.NewVersion(t.flagConsulDataplaneVersion)
 	//vaultserverVersion, _ := version.NewVersion(t.flagVaultServerVersion)
+	kubeEnvs := config.KubeEnvListFromStringList(t.flagKubeconfigs, t.flagKubecontexts, t.flagNamespaces)
 
-	return &config.TestConfig{
-		Kubeconfig:    t.flagKubeconfig,
-		KubeContext:   t.flagKubecontext,
-		KubeNamespace: t.flagNamespace,
-
-		EnableMultiCluster:     t.flagEnableMultiCluster,
-		SecondaryKubeconfig:    t.flagSecondaryKubeconfig,
-		SecondaryKubeContext:   t.flagSecondaryKubecontext,
-		SecondaryKubeNamespace: t.flagSecondaryNamespace,
-
+	c := &config.TestConfig{
 		EnableEnterprise:  t.flagEnableEnterprise,
 		EnterpriseLicense: t.flagEnterpriseLicense,
+
+		KubeEnvs:           kubeEnvs,
+		EnableMultiCluster: t.flagEnableMultiCluster,
 
 		EnableOpenshift: t.flagEnableOpenshift,
 
@@ -205,4 +203,6 @@ func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 		UseGKE:             t.flagUseGKE,
 		UseKind:            t.flagUseKind,
 	}
+
+	return c
 }

--- a/acceptance/framework/flags/flags_test.go
+++ b/acceptance/framework/flags/flags_test.go
@@ -14,6 +14,7 @@ func TestFlags_validate(t *testing.T) {
 		flagEnableMultiCluster bool
 		flagKubeConfigs        listFlag
 		flagKubeContexts       listFlag
+		flagNamespaces         listFlag
 
 		flagEnableEnt  bool
 		flagEntLicense string
@@ -48,7 +49,7 @@ func TestFlags_validate(t *testing.T) {
 				flagKubeContexts:       listFlag{},
 			},
 			true,
-			"at least two contexts must be included in -kubecontexts or -kubeconfigs if -enable-multi-cluster is set",
+			"at least two contexts must be included in -kube-contexts or -kubeconfigs if -enable-multi-cluster is set",
 		},
 		{
 			"enable multi cluster: no error when secondary kubeconfig but not kubecontext is provided",
@@ -81,6 +82,47 @@ func TestFlags_validate(t *testing.T) {
 			"",
 		},
 		{
+			"enable multi cluster: no error when all of secondary kubecontext, kubeconfigs and namespaces are provided",
+			fields{
+				flagEnableMultiCluster: true,
+				flagKubeConfigs:        listFlag{"foo", "bar"},
+				flagKubeContexts:       listFlag{"foo", "bar"},
+				flagNamespaces:         listFlag{"foo", "bar"},
+			},
+			false,
+			"",
+		},
+		{
+			"enable multi cluster: error when the list of kubeconfigs and kubecontexts do not match",
+			fields{
+				flagEnableMultiCluster: true,
+				flagKubeConfigs:        listFlag{"foo", "bar"},
+				flagKubeContexts:       listFlag{"foo"},
+			},
+			true,
+			"-kube-contexts and -kubeconfigs are both set but are not of equal length",
+		},
+		{
+			"enable multi cluster: error when the list of kubeconfigs and namespaces do not match",
+			fields{
+				flagEnableMultiCluster: true,
+				flagKubeConfigs:        listFlag{"foo", "bar"},
+				flagNamespaces:         listFlag{"foo"},
+			},
+			true,
+			"-kube-namespaces and -kubeconfigs are both set but are not of equal length",
+		},
+		{
+			"enable multi cluster: error when the list of kubecontexts and namespaces do not match",
+			fields{
+				flagEnableMultiCluster: true,
+				flagKubeContexts:       listFlag{"foo", "bar"},
+				flagNamespaces:         listFlag{"foo"},
+			},
+			true,
+			"-kube-contexts and -kube-namespaces are both set but are not of equal length",
+		},
+		{
 			"enterprise license: error when only -enable-enterprise is true but env CONSUL_ENT_LICENSE is not provided",
 			fields{
 				flagEnableEnt: true,
@@ -104,6 +146,7 @@ func TestFlags_validate(t *testing.T) {
 				flagEnableMultiCluster: tt.fields.flagEnableMultiCluster,
 				flagKubeconfigs:        tt.fields.flagKubeConfigs,
 				flagKubecontexts:       tt.fields.flagKubeContexts,
+				flagKubeNamespaces:     tt.fields.flagNamespaces,
 				flagEnableEnterprise:   tt.fields.flagEnableEnt,
 				flagEnterpriseLicense:  tt.fields.flagEntLicense,
 			}

--- a/acceptance/framework/flags/flags_test.go
+++ b/acceptance/framework/flags/flags_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestFlags_validate(t *testing.T) {
 	type fields struct {
-		flagEnableMultiCluster   bool
-		flagSecondaryKubeconfig  string
-		flagSecondaryKubecontext string
+		flagEnableMultiCluster bool
+		flagKubeConfigs        listFlag
+		flagKubeContexts       listFlag
 
 		flagEnableEnt  bool
 		flagEntLicense string
@@ -26,20 +26,16 @@ func TestFlags_validate(t *testing.T) {
 	}{
 		{
 			"no error by default",
-			fields{
-				flagEnableMultiCluster:   false,
-				flagSecondaryKubeconfig:  "",
-				flagSecondaryKubecontext: "",
-			},
+			fields{},
 			false,
 			"",
 		},
 		{
 			"enable multi cluster: no error when multi cluster is disabled",
 			fields{
-				flagEnableMultiCluster:   false,
-				flagSecondaryKubeconfig:  "",
-				flagSecondaryKubecontext: "",
+				flagEnableMultiCluster: false,
+				flagKubeConfigs:        listFlag{},
+				flagKubeContexts:       listFlag{},
 			},
 			false,
 			"",
@@ -47,19 +43,19 @@ func TestFlags_validate(t *testing.T) {
 		{
 			"enable multi cluster: errors when both secondary kubeconfig and kubecontext are empty",
 			fields{
-				flagEnableMultiCluster:   true,
-				flagSecondaryKubeconfig:  "",
-				flagSecondaryKubecontext: "",
+				flagEnableMultiCluster: true,
+				flagKubeConfigs:        listFlag{},
+				flagKubeContexts:       listFlag{},
 			},
 			true,
-			"at least one of -secondary-kubecontext or -secondary-kubeconfig flags must be provided if -enable-multi-cluster is set",
+			"at least two contexts must be included in -kubecontexts or -kubeconfigs if -enable-multi-cluster is set",
 		},
 		{
 			"enable multi cluster: no error when secondary kubeconfig but not kubecontext is provided",
 			fields{
-				flagEnableMultiCluster:   true,
-				flagSecondaryKubeconfig:  "foo",
-				flagSecondaryKubecontext: "",
+				flagEnableMultiCluster: true,
+				flagKubeConfigs:        listFlag{"foo", "bar"},
+				flagKubeContexts:       listFlag{},
 			},
 			false,
 			"",
@@ -67,9 +63,9 @@ func TestFlags_validate(t *testing.T) {
 		{
 			"enable multi cluster: no error when secondary kubecontext but not kubeconfig is provided",
 			fields{
-				flagEnableMultiCluster:   true,
-				flagSecondaryKubeconfig:  "",
-				flagSecondaryKubecontext: "foo",
+				flagEnableMultiCluster: true,
+				flagKubeConfigs:        listFlag{},
+				flagKubeContexts:       listFlag{"foo", "bar"},
 			},
 			false,
 			"",
@@ -77,9 +73,9 @@ func TestFlags_validate(t *testing.T) {
 		{
 			"enable multi cluster: no error when both secondary kubecontext and kubeconfig are provided",
 			fields{
-				flagEnableMultiCluster:   true,
-				flagSecondaryKubeconfig:  "foo",
-				flagSecondaryKubecontext: "bar",
+				flagEnableMultiCluster: true,
+				flagKubeConfigs:        listFlag{"foo", "bar"},
+				flagKubeContexts:       listFlag{"foo", "bar"},
 			},
 			false,
 			"",
@@ -105,11 +101,11 @@ func TestFlags_validate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tf := &TestFlags{
-				flagEnableMultiCluster:   tt.fields.flagEnableMultiCluster,
-				flagSecondaryKubeconfig:  tt.fields.flagSecondaryKubeconfig,
-				flagSecondaryKubecontext: tt.fields.flagSecondaryKubecontext,
-				flagEnableEnterprise:     tt.fields.flagEnableEnt,
-				flagEnterpriseLicense:    tt.fields.flagEntLicense,
+				flagEnableMultiCluster: tt.fields.flagEnableMultiCluster,
+				flagKubeconfigs:        tt.fields.flagKubeConfigs,
+				flagKubecontexts:       tt.fields.flagKubeContexts,
+				flagEnableEnterprise:   tt.fields.flagEnableEnt,
+				flagEnterpriseLicense:  tt.fields.flagEntLicense,
 			}
 			err := tf.Validate()
 			if tt.wantErr {

--- a/acceptance/tests/partitions/main_test.go
+++ b/acceptance/tests/partitions/main_test.go
@@ -16,10 +16,12 @@ var suite testsuite.Suite
 func TestMain(m *testing.M) {
 	suite = testsuite.NewSuite(m)
 
-	if suite.Config().EnableMultiCluster && suite.Config().IsExpectedClusterCount(2) {
+	expectedNumberOfClusters := 2
+	if suite.Config().EnableMultiCluster && suite.Config().IsExpectedClusterCount(expectedNumberOfClusters) {
 		os.Exit(suite.Run())
 	} else {
-		fmt.Println("Skipping partitions tests because -enable-multi-cluster is not set")
+		fmt.Println(fmt.Sprintf("Skipping partitions tests because either -enable-multi-cluster is "+
+			"not set or the number of clusters did not match the expected count of %d", expectedNumberOfClusters))
 		os.Exit(0)
 	}
 }

--- a/acceptance/tests/partitions/main_test.go
+++ b/acceptance/tests/partitions/main_test.go
@@ -16,7 +16,7 @@ var suite testsuite.Suite
 func TestMain(m *testing.M) {
 	suite = testsuite.NewSuite(m)
 
-	if suite.Config().EnableMultiCluster {
+	if suite.Config().EnableMultiCluster && suite.Config().IsExpectedClusterCount(2) {
 		os.Exit(suite.Run())
 	} else {
 		fmt.Println("Skipping partitions tests because -enable-multi-cluster is not set")

--- a/acceptance/tests/partitions/partitions_connect_test.go
+++ b/acceptance/tests/partitions/partitions_connect_test.go
@@ -11,7 +11,6 @@ import (
 
 	terratestk8s "github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
-	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
@@ -85,7 +84,7 @@ func TestPartitions_Connect(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			defaultPartitionClusterContext := env.DefaultContext(t)
-			secondaryPartitionClusterContext := env.Context(t, environment.SecondaryContextName)
+			secondaryPartitionClusterContext := env.Context(t, env.GetSecondaryContextKey(t))
 
 			commonHelmValues := map[string]string{
 				"global.adminPartitions.enabled": "true",

--- a/acceptance/tests/partitions/partitions_connect_test.go
+++ b/acceptance/tests/partitions/partitions_connect_test.go
@@ -84,7 +84,7 @@ func TestPartitions_Connect(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			defaultPartitionClusterContext := env.DefaultContext(t)
-			secondaryPartitionClusterContext := env.Context(t, env.GetSecondaryContextKey(t))
+			secondaryPartitionClusterContext := env.Context(t, 1)
 
 			commonHelmValues := map[string]string{
 				"global.adminPartitions.enabled": "true",

--- a/acceptance/tests/partitions/partitions_gateway_test.go
+++ b/acceptance/tests/partitions/partitions_gateway_test.go
@@ -36,7 +36,7 @@ func TestPartitions_Gateway(t *testing.T) {
 	const secondaryPartition = "secondary"
 
 	defaultPartitionClusterContext := env.DefaultContext(t)
-	secondaryPartitionClusterContext := env.Context(t, env.GetSecondaryContextKey(t))
+	secondaryPartitionClusterContext := env.Context(t, 1)
 
 	commonHelmValues := map[string]string{
 		"global.adminPartitions.enabled": "true",

--- a/acceptance/tests/partitions/partitions_gateway_test.go
+++ b/acceptance/tests/partitions/partitions_gateway_test.go
@@ -12,7 +12,6 @@ import (
 
 	terratestk8s "github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
-	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
@@ -37,7 +36,7 @@ func TestPartitions_Gateway(t *testing.T) {
 	const secondaryPartition = "secondary"
 
 	defaultPartitionClusterContext := env.DefaultContext(t)
-	secondaryPartitionClusterContext := env.Context(t, environment.SecondaryContextName)
+	secondaryPartitionClusterContext := env.Context(t, env.GetSecondaryContextKey(t))
 
 	commonHelmValues := map[string]string{
 		"global.adminPartitions.enabled": "true",

--- a/acceptance/tests/partitions/partitions_sync_test.go
+++ b/acceptance/tests/partitions/partitions_sync_test.go
@@ -11,7 +11,6 @@ import (
 
 	terratestk8s "github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
-	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
@@ -82,7 +81,7 @@ func TestPartitions_Sync(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			primaryClusterContext := env.DefaultContext(t)
-			secondaryClusterContext := env.Context(t, environment.SecondaryContextName)
+			secondaryClusterContext := env.Context(t, env.GetSecondaryContextKey(t))
 
 			commonHelmValues := map[string]string{
 				"global.adminPartitions.enabled": "true",

--- a/acceptance/tests/partitions/partitions_sync_test.go
+++ b/acceptance/tests/partitions/partitions_sync_test.go
@@ -81,7 +81,7 @@ func TestPartitions_Sync(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			primaryClusterContext := env.DefaultContext(t)
-			secondaryClusterContext := env.Context(t, env.GetSecondaryContextKey(t))
+			secondaryClusterContext := env.Context(t, 1)
 
 			commonHelmValues := map[string]string{
 				"global.adminPartitions.enabled": "true",

--- a/acceptance/tests/peering/main_test.go
+++ b/acceptance/tests/peering/main_test.go
@@ -16,7 +16,7 @@ var suite testsuite.Suite
 func TestMain(m *testing.M) {
 	suite = testsuite.NewSuite(m)
 
-	if suite.Config().EnableMultiCluster && !suite.Config().DisablePeering {
+	if suite.Config().EnableMultiCluster && suite.Config().IsExpectedClusterCount(2) && !suite.Config().DisablePeering {
 		os.Exit(suite.Run())
 	} else {
 		fmt.Println("Skipping peering tests because either -enable-multi-cluster is not set or -disable-peering is set")

--- a/acceptance/tests/peering/main_test.go
+++ b/acceptance/tests/peering/main_test.go
@@ -16,10 +16,12 @@ var suite testsuite.Suite
 func TestMain(m *testing.M) {
 	suite = testsuite.NewSuite(m)
 
-	if suite.Config().EnableMultiCluster && suite.Config().IsExpectedClusterCount(2) && !suite.Config().DisablePeering {
+	expectedNumberOfClusters := 2
+	if suite.Config().EnableMultiCluster && suite.Config().IsExpectedClusterCount(expectedNumberOfClusters) && !suite.Config().DisablePeering {
 		os.Exit(suite.Run())
 	} else {
-		fmt.Println("Skipping peering tests because either -enable-multi-cluster is not set or -disable-peering is set")
+		fmt.Println(fmt.Sprintf("Skipping peerings tests because either -enable-multi-cluster is "+
+			"not set, -disable-peering is set, or the number of clusters did not match the expected count of %d", expectedNumberOfClusters))
 		os.Exit(0)
 	}
 }

--- a/acceptance/tests/peering/peering_connect_namespaces_test.go
+++ b/acceptance/tests/peering/peering_connect_namespaces_test.go
@@ -12,7 +12,6 @@ import (
 
 	terratestk8s "github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
-	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
@@ -93,7 +92,7 @@ func TestPeering_ConnectNamespaces(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			staticServerPeerClusterContext := env.DefaultContext(t)
-			staticClientPeerClusterContext := env.Context(t, environment.SecondaryContextName)
+			staticClientPeerClusterContext := env.Context(t, env.GetSecondaryContextKey(t))
 
 			commonHelmValues := map[string]string{
 				"global.peering.enabled":        "true",

--- a/acceptance/tests/peering/peering_connect_namespaces_test.go
+++ b/acceptance/tests/peering/peering_connect_namespaces_test.go
@@ -92,7 +92,7 @@ func TestPeering_ConnectNamespaces(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			staticServerPeerClusterContext := env.DefaultContext(t)
-			staticClientPeerClusterContext := env.Context(t, env.GetSecondaryContextKey(t))
+			staticClientPeerClusterContext := env.Context(t, 1)
 
 			commonHelmValues := map[string]string{
 				"global.peering.enabled":        "true",

--- a/acceptance/tests/peering/peering_connect_test.go
+++ b/acceptance/tests/peering/peering_connect_test.go
@@ -12,7 +12,6 @@ import (
 
 	terratestk8s "github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
-	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
@@ -53,7 +52,7 @@ func TestPeering_Connect(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			staticServerPeerClusterContext := env.DefaultContext(t)
-			staticClientPeerClusterContext := env.Context(t, environment.SecondaryContextName)
+			staticClientPeerClusterContext := env.Context(t, env.GetSecondaryContextKey(t))
 
 			commonHelmValues := map[string]string{
 				"global.peering.enabled": "true",

--- a/acceptance/tests/peering/peering_connect_test.go
+++ b/acceptance/tests/peering/peering_connect_test.go
@@ -52,7 +52,7 @@ func TestPeering_Connect(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			staticServerPeerClusterContext := env.DefaultContext(t)
-			staticClientPeerClusterContext := env.Context(t, env.GetSecondaryContextKey(t))
+			staticClientPeerClusterContext := env.Context(t, 1)
 
 			commonHelmValues := map[string]string{
 				"global.peering.enabled": "true",

--- a/acceptance/tests/peering/peering_gateway_test.go
+++ b/acceptance/tests/peering/peering_gateway_test.go
@@ -41,7 +41,7 @@ func TestPeering_Gateway(t *testing.T) {
 	const staticClientPeer = "client"
 
 	staticServerPeerClusterContext := env.DefaultContext(t)
-	staticClientPeerClusterContext := env.Context(t, env.GetSecondaryContextKey(t))
+	staticClientPeerClusterContext := env.Context(t, 1)
 
 	commonHelmValues := map[string]string{
 		"global.peering.enabled":        "true",

--- a/acceptance/tests/peering/peering_gateway_test.go
+++ b/acceptance/tests/peering/peering_gateway_test.go
@@ -11,7 +11,6 @@ import (
 
 	terratestk8s "github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
-	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
@@ -42,7 +41,7 @@ func TestPeering_Gateway(t *testing.T) {
 	const staticClientPeer = "client"
 
 	staticServerPeerClusterContext := env.DefaultContext(t)
-	staticClientPeerClusterContext := env.Context(t, environment.SecondaryContextName)
+	staticClientPeerClusterContext := env.Context(t, env.GetSecondaryContextKey(t))
 
 	commonHelmValues := map[string]string{
 		"global.peering.enabled":        "true",

--- a/acceptance/tests/vault/main_test.go
+++ b/acceptance/tests/vault/main_test.go
@@ -4,6 +4,7 @@
 package vault
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -14,5 +15,11 @@ var suite testsuite.Suite
 
 func TestMain(m *testing.M) {
 	suite = testsuite.NewSuite(m)
-	os.Exit(suite.Run())
+
+	if suite.Config().EnableMultiCluster && suite.Config().IsExpectedClusterCount(2) {
+		os.Exit(suite.Run())
+	} else {
+		fmt.Println("Skipping vault tests because either -enable-multi-cluster is not set or -disable-peering is set")
+		os.Exit(0)
+	}
 }

--- a/acceptance/tests/vault/main_test.go
+++ b/acceptance/tests/vault/main_test.go
@@ -16,10 +16,12 @@ var suite testsuite.Suite
 func TestMain(m *testing.M) {
 	suite = testsuite.NewSuite(m)
 
-	if suite.Config().EnableMultiCluster && suite.Config().IsExpectedClusterCount(2) {
+	expectedNumberOfClusters := 2
+	if suite.Config().EnableMultiCluster && suite.Config().IsExpectedClusterCount(expectedNumberOfClusters) {
 		os.Exit(suite.Run())
 	} else {
-		fmt.Println("Skipping vault tests because either -enable-multi-cluster is not set or -disable-peering is set")
+		fmt.Println(fmt.Sprintf("Skipping vault tests because either -enable-multi-cluster is "+
+			"not set or the number of clusters did not match the expected count of %d", expectedNumberOfClusters))
 		os.Exit(0)
 	}
 }

--- a/acceptance/tests/vault/vault_partitions_test.go
+++ b/acceptance/tests/vault/vault_partitions_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
-	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
@@ -26,7 +25,7 @@ func TestVault_Partitions(t *testing.T) {
 	env := suite.Environment()
 	cfg := suite.Config()
 	serverClusterCtx := env.DefaultContext(t)
-	clientClusterCtx := env.Context(t, environment.SecondaryContextName)
+	clientClusterCtx := env.Context(t, env.GetSecondaryContextKey(t))
 	ns := serverClusterCtx.KubectlOptions(t).Namespace
 
 	const secondaryPartition = "secondary"

--- a/acceptance/tests/vault/vault_partitions_test.go
+++ b/acceptance/tests/vault/vault_partitions_test.go
@@ -25,7 +25,7 @@ func TestVault_Partitions(t *testing.T) {
 	env := suite.Environment()
 	cfg := suite.Config()
 	serverClusterCtx := env.DefaultContext(t)
-	clientClusterCtx := env.Context(t, env.GetSecondaryContextKey(t))
+	clientClusterCtx := env.Context(t, 1)
 	ns := serverClusterCtx.KubectlOptions(t).Namespace
 
 	const secondaryPartition = "secondary"

--- a/acceptance/tests/vault/vault_wan_fed_test.go
+++ b/acceptance/tests/vault/vault_wan_fed_test.go
@@ -44,7 +44,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	}
 
 	primaryCtx := suite.Environment().DefaultContext(t)
-	secondaryCtx := suite.Environment().Context(t, environment.SecondaryContextName)
+	secondaryCtx := suite.Environment().Context(t, suite.Environment().GetSecondaryContextKey(t))
 
 	ns := primaryCtx.KubectlOptions(t).Namespace
 

--- a/acceptance/tests/vault/vault_wan_fed_test.go
+++ b/acceptance/tests/vault/vault_wan_fed_test.go
@@ -44,7 +44,7 @@ func TestVault_WANFederationViaGateways(t *testing.T) {
 	}
 
 	primaryCtx := suite.Environment().DefaultContext(t)
-	secondaryCtx := suite.Environment().Context(t, suite.Environment().GetSecondaryContextKey(t))
+	secondaryCtx := suite.Environment().Context(t, 1)
 
 	ns := primaryCtx.KubectlOptions(t).Namespace
 

--- a/acceptance/tests/wan-federation/main_test.go
+++ b/acceptance/tests/wan-federation/main_test.go
@@ -16,7 +16,7 @@ var suite testsuite.Suite
 func TestMain(m *testing.M) {
 	suite = testsuite.NewSuite(m)
 
-	if suite.Config().EnableMultiCluster {
+	if suite.Config().EnableMultiCluster && suite.Config().IsExpectedClusterCount(2) {
 		os.Exit(suite.Run())
 	} else {
 		fmt.Println("Skipping wan federation tests because -enable-multi-cluster is not set")

--- a/acceptance/tests/wan-federation/main_test.go
+++ b/acceptance/tests/wan-federation/main_test.go
@@ -16,10 +16,12 @@ var suite testsuite.Suite
 func TestMain(m *testing.M) {
 	suite = testsuite.NewSuite(m)
 
-	if suite.Config().EnableMultiCluster && suite.Config().IsExpectedClusterCount(2) {
+	expectedNumberOfClusters := 2
+	if suite.Config().EnableMultiCluster && suite.Config().IsExpectedClusterCount(expectedNumberOfClusters) {
 		os.Exit(suite.Run())
 	} else {
-		fmt.Println("Skipping wan federation tests because -enable-multi-cluster is not set")
+		fmt.Println(fmt.Sprintf("Skipping wan-federation tests because either -enable-multi-cluster is "+
+			"not set or the number of clusters did not match the expected count of %d", expectedNumberOfClusters))
 		os.Exit(0)
 	}
 }

--- a/acceptance/tests/wan-federation/wan_federation_gateway_test.go
+++ b/acceptance/tests/wan-federation/wan_federation_gateway_test.go
@@ -33,7 +33,7 @@ func TestWANFederation_Gateway(t *testing.T) {
 	}
 
 	primaryContext := env.DefaultContext(t)
-	secondaryContext := env.Context(t, env.GetSecondaryContextKey(t))
+	secondaryContext := env.Context(t, 1)
 
 	primaryHelmValues := map[string]string{
 		"global.datacenter": "dc1",

--- a/acceptance/tests/wan-federation/wan_federation_gateway_test.go
+++ b/acceptance/tests/wan-federation/wan_federation_gateway_test.go
@@ -33,7 +33,7 @@ func TestWANFederation_Gateway(t *testing.T) {
 	}
 
 	primaryContext := env.DefaultContext(t)
-	secondaryContext := env.Context(t, environment.SecondaryContextName)
+	secondaryContext := env.Context(t, env.GetSecondaryContextKey(t))
 
 	primaryHelmValues := map[string]string{
 		"global.datacenter": "dc1",

--- a/acceptance/tests/wan-federation/wan_federation_test.go
+++ b/acceptance/tests/wan-federation/wan_federation_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
-	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
@@ -49,7 +48,7 @@ func TestWANFederation(t *testing.T) {
 			}
 
 			primaryContext := env.DefaultContext(t)
-			secondaryContext := env.Context(t, environment.SecondaryContextName)
+			secondaryContext := env.Context(t, env.GetSecondaryContextKey(t))
 
 			primaryHelmValues := map[string]string{
 				"global.datacenter": "dc1",

--- a/acceptance/tests/wan-federation/wan_federation_test.go
+++ b/acceptance/tests/wan-federation/wan_federation_test.go
@@ -48,7 +48,7 @@ func TestWANFederation(t *testing.T) {
 			}
 
 			primaryContext := env.DefaultContext(t)
-			secondaryContext := env.Context(t, env.GetSecondaryContextKey(t))
+			secondaryContext := env.Context(t, 1)
 
 			primaryHelmValues := map[string]string{
 				"global.datacenter": "dc1",


### PR DESCRIPTION
**Note to reviewer** I have been very particular about my commits, for an easier time reviewing I suggest going through commit by commit. I have added extra notes, and it breaks up the context of the changes so that it's easier to review.

Changes proposed in this PR:
- To support sameness tests we need to be able to run 3 Consul clusters during the acceptance tests. Instead of adding an addition flag to accomodate this, this PR instead refactors the original flags to instead be flags that accept comma separated lists:

```
- -kubeconfig string
    The path to a kubeconfig file. If this is blank, the default kubeconfig path (~/.kube/config) will be used.
- -kubecontext string
    The name of the Kubernetes context to use. If this is blank, the context set as the current context will be used by default.
- -namespace string
    The Kubernetes namespace to use for tests. (default "default")
- -secondary-kubeconfig string
    The path to a kubeconfig file of the secondary k8s cluster. If this is blank, the default kubeconfig path (~/.kube/config) will be used.
- -secondary-kubecontext string
    The name of the Kubernetes context for the secondary cluster to use. If this is blank, the context set as the current context will be used by default.
- -secondary-namespace string
    The Kubernetes namespace to use in the secondary k8s cluster. (default "default")
+ -kubeconfigs string
    The comma separate list of Kubernetes configs to use (eg. "~/.kube/config,~/.kube/config2"). The first in the list will be treated as the primary config, followed by the secondary, etc. If this is empty, or fields are blank, then the context set as the current context will be used by default.
+ -kubecontexts string
    The comma separate list of Kubernetes contexts to use (eg. "kind-dc1,kind-dc2"). The first in the list will be treated as the primary context, followed by the secondary, etc. If this is empty, or fields are blank then the default kubeconfig path (~/.kube/config) will be used.
+ -kubenamespaces string
    The comma separate list of Kubernetes namespaces to use (eg. "consul,consul-secondary"). The first in the list will be treated as the primary namespace, followed by the secondary, etc. If the list is empty, or fields are blank, then the "default" namespace will be used.
```

The lists are then combined into lists of the following object for use in tests:
```
type KubeEnv struct {
	KubeConfig    string
	KubeContext   string
	KubeNamespace string
}
```

Example test run command:
```
go test -run "TestPeering/default_installation" -p 1 -timeout 90m -v -failfast -args -use-kind -kubecontexts "kind-dc1,kind-dc2" -enable-enterprise -enable-multi-cluster -consul-image=wilko1989/consul-enterprise@sha256:3cfc9f5cf8a5c49c636bcc26ef0df1a30ac8fd68becdbb1dece192ea20d467a8 -consul-k8s-image=wilko1989/consul-k8s-control-plane-dev@sha256:af2f5035e987b2946ad1c535b37a565e0adce4e01d777681106c5fa7eb012e8b -consul-dataplane-image=wilko1989/consul-dataplane@sha256:b9db7e4c0f96ad110f35104a7b8de0cbc0b94f81f437b83c264d5a1c0f68fca5 -enterprise-license <redacted>
```

How I've tested this PR:

- Ran acceptance tests and verified that they still pass

How I expect reviewers to test this PR:
👀 


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


