### PR TITLE
HCP bootstrap preset to always downcase datacenter

### DIFF
--- a/cli/preset/cloud_preset.go
+++ b/cli/preset/cloud_preset.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/hashicorp/consul-k8s/cli/common"
 	"github.com/hashicorp/consul-k8s/cli/common/terminal"
@@ -235,7 +236,7 @@ connectInject:
   enabled: true
 controller:
   enabled: true
-`, cfg.BootstrapResponse.Cluster.ID, secretNameServerCA, corev1.TLSCertKey,
+`, strings.ToLower(cfg.BootstrapResponse.Cluster.ID), secretNameServerCA, corev1.TLSCertKey,
 		secretNameGossipKey, secretKeyGossipKey, secretNameBootstrapToken,
 		secretKeyBootstrapToken,
 		secretNameHCPResourceID, secretKeyHCPResourceID,

--- a/cli/preset/cloud_preset_test.go
+++ b/cli/preset/cloud_preset_test.go
@@ -43,7 +43,7 @@ const (
 {
 	"cluster": 
 	{
-		"id": "dc1",
+		"id": "Dc1",
 		"bootstrap_expect" : 3
 	},
 	"bootstrap": 
@@ -63,7 +63,7 @@ const (
 
 var validBootstrapReponse *models.HashicorpCloudGlobalNetworkManager20220215AgentBootstrapResponse = &models.HashicorpCloudGlobalNetworkManager20220215AgentBootstrapResponse{
 	Bootstrap: &models.HashicorpCloudGlobalNetworkManager20220215ClusterBootstrap{
-		ID:              "dc1",
+		ID:              "Dc1",
 		GossipKey:       "Wa6/XFAnYy0f9iqVH2iiG+yore3CqHSemUy4AIVTa/w=",
 		BootstrapExpect: 3,
 		ServerTLS: &models.HashicorpCloudGlobalNetworkManager20220215ServerTLS{
@@ -558,12 +558,30 @@ telemetryCollector:
 
 	cloudPreset := &CloudPreset{}
 
-	testCases := []struct {
-		description  string
+	testCases := map[string]struct {
 		config       *CloudBootstrapConfig
 		expectedYaml string
 	}{
-		{"Config including optional parameters",
+		"Config_including_optional_parameters_with_mixedcase_DC": {
+			&CloudBootstrapConfig{
+				BootstrapResponse: &models.HashicorpCloudGlobalNetworkManager20220215AgentBootstrapResponse{
+					Cluster: &models.HashicorpCloudGlobalNetworkManager20220215Cluster{
+						BootstrapExpect: 3,
+						ID:              "Dc1",
+					},
+				},
+				HCPConfig: HCPConfig{
+					ResourceID:   "consul-hcp-resource-id",
+					ClientID:     "consul-hcp-client-id",
+					ClientSecret: "consul-hcp-client-secret",
+					AuthURL:      "consul-hcp-auth-url",
+					APIHostname:  "consul-hcp-api-host",
+					ScadaAddress: "consul-hcp-scada-address",
+				},
+			},
+			expectedFull,
+		},
+		"Config_including_optional_parameters": {
 			&CloudBootstrapConfig{
 				BootstrapResponse: &models.HashicorpCloudGlobalNetworkManager20220215AgentBootstrapResponse{
 					Cluster: &models.HashicorpCloudGlobalNetworkManager20220215Cluster{
@@ -582,7 +600,7 @@ telemetryCollector:
 			},
 			expectedFull,
 		},
-		{"Config without optional parameters",
+		"Config_without_optional_parameters": {
 			&CloudBootstrapConfig{
 				BootstrapResponse: &models.HashicorpCloudGlobalNetworkManager20220215AgentBootstrapResponse{
 					Cluster: &models.HashicorpCloudGlobalNetworkManager20220215Cluster{
@@ -599,8 +617,8 @@ telemetryCollector:
 			expectedWithoutOptional,
 		},
 	}
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			cloudHelmValues := cloudPreset.getHelmConfigWithMapSecretNames(tc.config)
 			require.NotNil(t, cloudHelmValues)
 			valuesYaml, err := yaml.Marshal(cloudHelmValues)


### PR DESCRIPTION
Changes proposed in this PR:
- downcase the HCP bootstrap response to be lowercase
- added tests cases to validate.


How I've tested this PR:
Manually tested with a e2e test of the cluster bootstrapping.



Checklist:
- [X] Tests added



