### PR TITLE
Update Release Scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,8 +209,9 @@ eks-test-packages:
 aks-test-packages:
 	@./control-plane/build-support/scripts/set_test_package_matrix.sh "acceptance/ci-inputs/aks_acceptance_test_packages.yaml"
 
-
 # ===========> Release Targets
+check-env:
+	@printenv | grep "CONSUL_K8S"
 
 prepare-release: ## Sets the versions, updates changelog to prepare this repository to release
 ifndef CONSUL_K8S_RELEASE_VERSION
@@ -225,7 +226,7 @@ endif
 ifndef CONSUL_K8S_CONSUL_VERSION
 	$(error CONSUL_K8S_CONSUL_VERSION is required)
 endif
-	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_release $(CURDIR) $(CONSUL_K8S_RELEASE_VERSION) "$(CONSUL_K8S_RELEASE_DATE)" $(CONSUL_K8S_LAST_RELEASE_GIT_TAG) $(CONSUL_K8S_CONSUL_VERSION) $(CONSUL_K8S_PRERELEASE_VERSION)
+	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_release $(CURDIR) $(CONSUL_K8S_RELEASE_VERSION) "$(CONSUL_K8S_RELEASE_DATE)" $(CONSUL_K8S_LAST_RELEASE_GIT_TAG) $(CONSUL_K8S_CONSUL_VERSION) $(CONSUL_K8S_CONSUL_DATAPLANE_VERSION) $(CONSUL_K8S_PRERELEASE_VERSION)
 
 prepare-dev:
 ifndef CONSUL_K8S_RELEASE_VERSION
@@ -234,13 +235,16 @@ endif
 ifndef CONSUL_K8S_RELEASE_DATE
 	$(error CONSUL_K8S_RELEASE_DATE is required, use format <Month> <Day>, <Year> (ex. October 4, 2022))
 endif
-ifndef NEXT_RELEASE_VERSION
-	$(error NEXT_RELEASE_VERSION is required)
+ifndef CONSUL_K8S_NEXT_RELEASE_VERSION
+	$(error CONSUL_K8S_NEXT_RELEASE_VERSION is required)
 endif
-ifndef NEXT_CONSUL_VERSION
-	$(error NEXT_CONSUL_VERSION is required)
+ifndef CONSUL_K8S_NEXT_CONSUL_VERSION
+	$(error CONSUL_K8S_NEXT_CONSUL_VERSION is required)
 endif
-	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_dev $(CURDIR) $(CONSUL_K8S_RELEASE_VERSION) "$(CONSUL_K8S_RELEASE_DATE)" "" $(NEXT_RELEASE_VERSION) $(NEXT_CONSUL_VERSION)
+ifndef CONSUL_K8S_NEXT_CONSUL_DATAPLANE_VERSION
+	$(error CONSUL_K8S_NEXT_CONSUL_DATAPLANE_VERSION is required)
+endif
+	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_dev $(CURDIR) $(CONSUL_K8S_RELEASE_VERSION) "$(CONSUL_K8S_RELEASE_DATE)" "" $(CONSUL_K8S_NEXT_RELEASE_VERSION) $(CONSUL_K8S_NEXT_CONSUL_VERSION) $(CONSUL_K8S_NEXT_CONSUL_DATAPLANE_VERSION)
 
 # ===========> Makefile config
 

--- a/Makefile
+++ b/Makefile
@@ -213,26 +213,26 @@ aks-test-packages:
 # ===========> Release Targets
 
 prepare-release: ## Sets the versions, updates changelog to prepare this repository to release
-ifndef RELEASE_VERSION
-	$(error RELEASE_VERSION is required)
+ifndef CONSUL_K8S_RELEASE_VERSION
+	$(error CONSUL_K8S_RELEASE_VERSION is required)
 endif
-ifndef RELEASE_DATE
-	$(error RELEASE_DATE is required, use format <Month> <Day>, <Year> (ex. October 4, 2022))
+ifndef CONSUL_K8S_RELEASE_DATE
+	$(error CONSUL_K8S_RELEASE_DATE is required, use format <Month> <Day>, <Year> (ex. October 4, 2022))
 endif
-ifndef LAST_RELEASE_GIT_TAG 
-	$(error LAST_RELEASE_GIT_TAG is required)
+ifndef CONSUL_K8S_LAST_RELEASE_GIT_TAG
+	$(error CONSUL_K8S_LAST_RELEASE_GIT_TAG is required)
 endif
-ifndef CONSUL_VERSION
-	$(error CONSUL_VERSION is required)
+ifndef CONSUL_K8S_CONSUL_VERSION
+	$(error CONSUL_K8S_CONSUL_VERSION is required)
 endif
-	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_release $(CURDIR) $(RELEASE_VERSION) "$(RELEASE_DATE)" $(LAST_RELEASE_GIT_TAG) $(CONSUL_VERSION) $(PRERELEASE_VERSION)
+	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_release $(CURDIR) $(CONSUL_K8S_RELEASE_VERSION) "$(CONSUL_K8S_RELEASE_DATE)" $(CONSUL_K8S_LAST_RELEASE_GIT_TAG) $(CONSUL_K8S_CONSUL_VERSION) $(CONSUL_K8S_PRERELEASE_VERSION)
 
 prepare-dev:
-ifndef RELEASE_VERSION
-	$(error RELEASE_VERSION is required)
+ifndef CONSUL_K8S_RELEASE_VERSION
+	$(error CONSUL_K8S_RELEASE_VERSION is required)
 endif
-ifndef RELEASE_DATE
-	$(error RELEASE_DATE is required, use format <Month> <Day>, <Year> (ex. October 4, 2022))
+ifndef CONSUL_K8S_RELEASE_DATE
+	$(error CONSUL_K8S_RELEASE_DATE is required, use format <Month> <Day>, <Year> (ex. October 4, 2022))
 endif
 ifndef NEXT_RELEASE_VERSION
 	$(error NEXT_RELEASE_VERSION is required)
@@ -240,7 +240,7 @@ endif
 ifndef NEXT_CONSUL_VERSION
 	$(error NEXT_CONSUL_VERSION is required)
 endif
-	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_dev $(CURDIR) $(RELEASE_VERSION) "$(RELEASE_DATE)" "" $(NEXT_RELEASE_VERSION) $(NEXT_CONSUL_VERSION)
+	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_dev $(CURDIR) $(CONSUL_K8S_RELEASE_VERSION) "$(CONSUL_K8S_RELEASE_DATE)" "" $(NEXT_RELEASE_VERSION) $(NEXT_CONSUL_VERSION)
 
 # ===========> Makefile config
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -608,7 +608,7 @@ global:
   # The name (and tag) of the consul-dataplane Docker image used for the
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
   # @default: hashicorp/consul-dataplane:<latest supported version>
-  imageConsulDataplane: "docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.3-dev"
+  imageConsulDataplane: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.3-dev
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.

--- a/control-plane/build-support/functions/10-util.sh
+++ b/control-plane/build-support/functions/10-util.sh
@@ -720,14 +720,14 @@ function set_changelog {
 		return 1
 	fi
 
-	if [ -z "$LAST_RELEASE_GIT_TAG" ]; then
-		echo "Error: LAST_RELEASE_GIT_TAG not specified."
+	if [ -z "$CONSUL_K8S_LAST_RELEASE_GIT_TAG" ]; then
+		echo "Error: CONSUL_K8S_LAST_RELEASE_GIT_TAG not specified."
 		exit 1
 	fi
 
 	cat <<EOT | cat - "${curdir}"/CHANGELOG.MD >tmp && mv tmp "${curdir}"/CHANGELOG.MD
 ## ${version} (${rel_date})
-$(changelog-build -last-release ${LAST_RELEASE_GIT_TAG} \
+$(changelog-build -last-release ${CONSUL_K8S_LAST_RELEASE_GIT_TAG} \
 		-entries-dir .changelog/ \
 		-changelog-template .changelog/changelog.tmpl \
 		-note-template .changelog/note.tmpl \
@@ -896,7 +896,7 @@ function ui_version {
 		return 1
 	fi
 
-	local ui_version=$(sed -n ${SED_EXT} -e 's/.*CONSUL_VERSION%22%3A%22([^%]*)%22%2C%22.*/\1/p' <"$1") || return 1
+	local ui_version=$(sed -n ${SED_EXT} -e 's/.*CONSUL_K8S_CONSUL_VERSION%22%3A%22([^%]*)%22%2C%22.*/\1/p' <"$1") || return 1
 	echo "$ui_version"
 	return 0
 }

--- a/control-plane/build-support/functions/10-util.sh
+++ b/control-plane/build-support/functions/10-util.sh
@@ -599,6 +599,8 @@ function update_version_helm {
 	#   $4 - Image base path
 	#   $5 - Consul version string
 	#   $6 - Consul image base path
+	#   $7 - Consul-Dataplane version string
+	#   $8 - Consul-Dataplane base path
 	#
 	# Returns:
 	#   0 - success
@@ -620,19 +622,32 @@ function update_version_helm {
 	local prerelease="$3"
 	local full_version="$2"
 	local full_consul_version="$5"
-	if ! test -z "$3"; then
+	local full_consul_dataplane_version="$7"
+	local consul_dataplane_base_path="$8"
+	if ! test -z "$3" && test "$3" != "dev"; then
 		full_version="$2-$3"
+    full_consul_version="$5-$3"
+    full_consul_dataplane_version="$7-$3"
+	elif test "$3" == "dev"; then
+    full_version="$2-$3"
 		# strip off the last minor patch version so that the consul image can be set to something like 1.16-dev. The image
 		# is produced by Consul every night
 		full_consul_version="${5%.*}-$3"
+		full_consul_dataplane_version="${7%.*}-$3"
 	fi
 
 	sed_i ${SED_EXT} -e "s/(imageK8S:.*\/consul-k8s-control-plane:)[^\"]*/imageK8S: $4${full_version}/g" "${vfile}"
 	sed_i ${SED_EXT} -e "s/(version:[[:space:]]*)[^\"]*/\1${full_version}/g" "${cfile}"
 	sed_i ${SED_EXT} -e "s/(appVersion:[[:space:]]*)[^\"]*/\1${full_consul_version}/g" "${cfile}"
 	sed_i ${SED_EXT} -e "s/(image:.*\/consul-k8s-control-plane:)[^\"]*/image: $4${full_version}/g" "${cfile}"
-	sed_i ${SED_EXT} -e "s/(image:.*\/consul:)[^\"]*/image: $6:${full_consul_version}/g" "${cfile}"
-	sed_i ${SED_EXT} -e "s/(image:.*\/consul:)[^\"]*/image: $6:${full_consul_version}/g" "${vfile}"
+
+  sed_i ${SED_EXT} -e "s,^( *image:)(.*/consul:)[^\"]*\$,\1 $6:${full_consul_version},g" ${cfile}
+  sed_i ${SED_EXT} -e "s,^( *image:)(.*/consul:)[^\"]*\$,\1 $6:${full_consul_version},g" ${vfile}
+  sed_i ${SED_EXT} -e "s,^( *image:)(.*/consul-enterprise:)[^\"]*\$,\1 $6:${full_consul_version},g" ${cfile}
+  sed_i ${SED_EXT} -e "s,^( *image:)(.*/consul-enterprise:)[^\"]*\$,\1 $6:${full_consul_version},g" ${vfile}
+
+  sed_i ${SED_EXT} -e "s/(imageConsulDataplane:.*\/consul-dataplane:)[^\"]*/imageConsulDataplane: ${consul_dataplane_base_path}:${full_consul_dataplane_version}/g" "${vfile}"
+  sed_i ${SED_EXT} -e "s,^( *image:)(.*/consul-dataplane:)[^\"]*\$,\1 ${consul_dataplane_base_path}:${full_consul_dataplane_version},g" ${cfile}
 
 	if test -z "$3"; then
 		sed_i ${SED_EXT} -e "s/(artifacthub.io\/prerelease:[[:space:]]*)[^\"]*/\1false/g" "${cfile}"
@@ -651,6 +666,8 @@ function set_version {
 	#   $5 - The consul-k8s helm docker image base path
 	#   $6 - The consul version
 	#   $7 - The consul helm docker image base path
+	#   $8 - The consul dataplane version
+	#   $9 - The consul-dataplane helm docker image base path
 	#
 	#
 	# Returns:
@@ -670,6 +687,7 @@ function set_version {
 	local sdir="$1"
 	local vers="$2"
 	local consul_vers="$6"
+	local consul_dataplane_vers="$8"
 
 	status_stage "==> Updating control-plane version/version.go with version info: ${vers} "$4""
 	if ! update_version "${sdir}/control-plane/version/version.go" "${vers}" "$4"; then
@@ -681,8 +699,8 @@ function set_version {
 		return 1
 	fi
 
-	status_stage "==> Updating Helm chart version, consul-k8s: ${vers} "$4" consul: ${consul_vers} "$4""
-	if ! update_version_helm "${sdir}/charts/consul" "${vers}" "$4" "$5" "${consul_vers}" "$7"; then
+	status_stage "==> Updating Helm chart version, consul-k8s: ${vers} "$4" consul: ${consul_vers} "$4" consul-dataplane: ${consul_dataplane_vers} "$4""
+	if ! update_version_helm "${sdir}/charts/consul" "${vers}" "$4" "$5" "${consul_vers}" "$7" "${consul_dataplane_vers}" "$9"; then
 		return 1
 	fi
 
@@ -695,6 +713,7 @@ function set_changelog {
 	#   $2 - Version
 	#   $3 - Release Date
 	#   $4 - The last git release tag
+  #   $5 - Pre-release version
 	#
 	#
 	# Returns:
@@ -714,6 +733,7 @@ function set_changelog {
 		rel_date="$3"
 	fi
 	local last_release_date_git_tag=$4
+  local preReleaseVersion="-$5"
 
 	if test -z "${version}"; then
 		err "ERROR: Must specify a version to put into the changelog"
@@ -726,7 +746,7 @@ function set_changelog {
 	fi
 
 	cat <<EOT | cat - "${curdir}"/CHANGELOG.MD >tmp && mv tmp "${curdir}"/CHANGELOG.MD
-## ${version} (${rel_date})
+## ${version}${preReleaseVersion} (${rel_date})
 $(changelog-build -last-release ${CONSUL_K8S_LAST_RELEASE_GIT_TAG} \
 		-entries-dir .changelog/ \
 		-changelog-template .changelog/changelog.tmpl \
@@ -742,17 +762,26 @@ function prepare_release {
 	#   $2 - The version of the release
 	#   $3 - The release date
 	#   $4 - The last release git tag for this branch (eg. v1.1.0)
-	#   $5 - The pre-release version
-	#   $6 - The consul version
+  #   $5 - The consul version
+	#   $6 - The consul-dataplane version
+  #   $7 - The pre-release version
 	#
 	#
 	# Returns:
 	#   0 - success
 	#   * - error
 
-	echo "prepare_release: dir:$1 consul-k8s:$2 consul:$5 date:"$3" git tag:$4"
-	set_version "$1" "$2" "$3" "$6" "hashicorp\/consul-k8s-control-plane:" "$5" "hashicorp\/consul"
-	set_changelog "$1" "$2" "$3" "$4"
+  local curDir=$1
+  local version=$2
+  local releaseDate=$3
+  local lastGitTag=$4
+  local consulVersion=$5
+  local consulDataplaneVersion=$6
+  local prereleaseVersion=$7
+
+	echo "prepare_release: dir:${curDir} consul-k8s:${version} consul:${consulVersion} consul-dataplane:${consulDataplaneVersion} date:"${releaseDate}" git tag:${lastGitTag}"
+	set_version "${curDir}" "${version}" "${releaseDate}" "${prereleaseVersion}" "hashicorp\/consul-k8s-control-plane:" "${consulVersion}" "hashicorp\/consul" "${consulDataplaneVersion}" "hashicorp\/consul-dataplane"
+	set_changelog "${curDir}" "${version}" "${releaseDate}" "${lastGitTag}" "${prereleaseVersion}"
 }
 
 function prepare_dev {
@@ -763,13 +792,21 @@ function prepare_dev {
 	#   $4 - The last release git tag for this branch (eg. v1.1.0) (Unused)
 	#   $5 - The version of the next release
 	#   $6 - The version of the next consul release
+  #   $7 - The next consul-dataplane version
 	#
 	# Returns:
 	#   0 - success
 	#   * - error
 
-	echo "prepare_dev: dir:$1 consul-k8s:$5 consul:$6 date:"$3" mode:dev"
-	set_version "$1" "$5" "$3" "dev" "docker.mirror.hashicorp.services\/hashicorppreview\/consul-k8s-control-plane:" "$6" "docker.mirror.hashicorp.services\/hashicorppreview\/consul"
+  local curDir=$1
+  local version=$2
+  local releaseDate=$3
+  local nextReleaseVersion=$5
+  local nextConsulVersion=$6
+  local nextConsulDataplaneVersion=$7
+
+	echo "prepare_dev: dir:${curDir} consul-k8s:${nextReleaseVersion} consul:${nextConsulVersion} date:"${releaseDate}" mode:dev"
+	set_version "${curDir}" "${nextReleaseVersion}" "${releaseDate}" "dev" "docker.mirror.hashicorp.services\/hashicorppreview\/consul-k8s-control-plane:" "${nextConsulVersion}" "docker.mirror.hashicorp.services\/hashicorppreview\/consul" "${nextConsulDataplaneVersion}" "docker.mirror.hashicorp.services\/hashicorppreview\/consul-dataplane"
 
 	return 0
 }

--- a/control-plane/build-support/functions/10-util.sh
+++ b/control-plane/build-support/functions/10-util.sh
@@ -626,10 +626,10 @@ function update_version_helm {
 	local consul_dataplane_base_path="$8"
 	if ! test -z "$3" && test "$3" != "dev"; then
 		full_version="$2-$3"
-    full_consul_version="$5-$3"
-    full_consul_dataplane_version="$7-$3"
+		full_consul_version="$5-$3"
+		full_consul_dataplane_version="$7-$3"
 	elif test "$3" == "dev"; then
-    full_version="$2-$3"
+		full_version="$2-$3"
 		# strip off the last minor patch version so that the consul image can be set to something like 1.16-dev. The image
 		# is produced by Consul every night
 		full_consul_version="${5%.*}-$3"
@@ -641,13 +641,13 @@ function update_version_helm {
 	sed_i ${SED_EXT} -e "s/(appVersion:[[:space:]]*)[^\"]*/\1${full_consul_version}/g" "${cfile}"
 	sed_i ${SED_EXT} -e "s/(image:.*\/consul-k8s-control-plane:)[^\"]*/image: $4${full_version}/g" "${cfile}"
 
-  sed_i ${SED_EXT} -e "s,^( *image:)(.*/consul:)[^\"]*\$,\1 $6:${full_consul_version},g" ${cfile}
-  sed_i ${SED_EXT} -e "s,^( *image:)(.*/consul:)[^\"]*\$,\1 $6:${full_consul_version},g" ${vfile}
-  sed_i ${SED_EXT} -e "s,^( *image:)(.*/consul-enterprise:)[^\"]*\$,\1 $6:${full_consul_version},g" ${cfile}
-  sed_i ${SED_EXT} -e "s,^( *image:)(.*/consul-enterprise:)[^\"]*\$,\1 $6:${full_consul_version},g" ${vfile}
+	sed_i ${SED_EXT} -e "s,^( *image:)(.*/consul:)[^\"]*\$,\1 $6:${full_consul_version},g" ${cfile}
+	sed_i ${SED_EXT} -e "s,^( *image:)(.*/consul:)[^\"]*\$,\1 $6:${full_consul_version},g" ${vfile}
+	sed_i ${SED_EXT} -e "s,^( *image:)(.*/consul-enterprise:)[^\"]*\$,\1 $6:${full_consul_version},g" ${cfile}
+	sed_i ${SED_EXT} -e "s,^( *image:)(.*/consul-enterprise:)[^\"]*\$,\1 $6:${full_consul_version},g" ${vfile}
 
-  sed_i ${SED_EXT} -e "s/(imageConsulDataplane:.*\/consul-dataplane:)[^\"]*/imageConsulDataplane: ${consul_dataplane_base_path}:${full_consul_dataplane_version}/g" "${vfile}"
-  sed_i ${SED_EXT} -e "s,^( *image:)(.*/consul-dataplane:)[^\"]*\$,\1 ${consul_dataplane_base_path}:${full_consul_dataplane_version},g" ${cfile}
+	sed_i ${SED_EXT} -e "s/(imageConsulDataplane:.*\/consul-dataplane:)[^\"]*/imageConsulDataplane: ${consul_dataplane_base_path}:${full_consul_dataplane_version}/g" "${vfile}"
+	sed_i ${SED_EXT} -e "s,^( *image:)(.*/consul-dataplane:)[^\"]*\$,\1 ${consul_dataplane_base_path}:${full_consul_dataplane_version},g" ${cfile}
 
 	if test -z "$3"; then
 		sed_i ${SED_EXT} -e "s/(artifacthub.io\/prerelease:[[:space:]]*)[^\"]*/\1false/g" "${cfile}"
@@ -713,7 +713,7 @@ function set_changelog {
 	#   $2 - Version
 	#   $3 - Release Date
 	#   $4 - The last git release tag
-  #   $5 - Pre-release version
+	#   $5 - Pre-release version
 	#
 	#
 	# Returns:
@@ -733,7 +733,7 @@ function set_changelog {
 		rel_date="$3"
 	fi
 	local last_release_date_git_tag=$4
-  local preReleaseVersion="-$5"
+        local preReleaseVersion="-$5"
 
 	if test -z "${version}"; then
 		err "ERROR: Must specify a version to put into the changelog"
@@ -792,7 +792,7 @@ function prepare_dev {
 	#   $4 - The last release git tag for this branch (eg. v1.1.0) (Unused)
 	#   $5 - The version of the next release
 	#   $6 - The version of the next consul release
-  #   $7 - The next consul-dataplane version
+        #   $7 - The next consul-dataplane version
 	#
 	# Returns:
 	#   0 - success


### PR DESCRIPTION
NOTE TO REVIEWER: You can go through my PR commit by commit, I've organized changes to be isolated to each commit. You can often get more context from them.

Changes proposed in this PR:
- update environment variables with `CONSUL_K8s` prefix. This will let us check that we have all the environment variables set more easily with `printenv | grep "CONSUL_K8S"`
- also added a make target that just runs printenv | grep "CONSUL_K8S"
- update `imageConsulDataplane` without quotes. This makes it consistent with the other images and allows scripting to work similarly to other images
- updated utils script
    - handle replace case where consul-enterprise is in the values.yaml file and charts.yaml file
    - handle adding pre-release tag in changelog
    - handle updating consul-dataplane

How I've tested this PR:
- Ran three scenarios for prepare release/prepare dev scripts
1. Scenario with a prerelease set (`rc1`)
2. Scenario with switching to dev mode
3. Scenario with release without a prerelease set
- ran `make check-env`
```shell
$ make check-env      
CONSUL_K8S_RELEASE_BRANCH=release/1.1.0
CONSUL_K8S_PRERELEASE_VERSION=
CONSUL_K8S_CONSUL_VERSION=1.16.0
CONSUL_K8S_CONSUL_DATAPLANE_VERSION=1.2.0
CONSUL_K8S_RELEASE_DATE=September 31, 2022
CONSUL_K8S_NEXT_CONSUL_DATAPLANE_VERSION=1.1.3
CONSUL_K8S_PRODUCT_VERSION=1.1.0
CONSUL_K8S_NEXT_CONSUL_VERSION=1.17.3
CONSUL_K8S_NEXT_RELEASE_VERSION=1.1.6
CONSUL_K8S_RELEASE_VERSION=1.1.0
CONSUL_K8S_LAST_RELEASE_GIT_TAG=v0.48.0
```

How I expect reviewers to test this PR:
- I've included the outputs of each scenario in my testing as commits that I'll drop, so check out those commits
- 👀 

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


