### PR TITLE
test(eks): fix deprecated CSI driver terraform

### DIFF
--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -124,12 +124,13 @@ resource "aws_iam_role_policy_attachment" "csi" {
 }
 
 resource "aws_eks_addon" "csi-driver" {
-  count                    = var.cluster_count
-  cluster_name             = module.eks[count.index].cluster_id
-  addon_name               = "aws-ebs-csi-driver"
-  addon_version            = "v1.15.0-eksbuild.1"
-  service_account_role_arn = aws_iam_role.csi-driver-role[count.index].arn
-  resolve_conflicts        = "OVERWRITE"
+  count                       = var.cluster_count
+  cluster_name                = module.eks[count.index].cluster_id
+  addon_name                  = "aws-ebs-csi-driver"
+  addon_version               = "v1.15.0-eksbuild.1"
+  service_account_role_arn    = aws_iam_role.csi-driver-role[count.index].arn
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
 }
 
 data "aws_eks_cluster" "cluster" {


### PR DESCRIPTION
Changes proposed in this PR:
- Replacing the deprecated [`resolve_conflicts`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon#resolve_conflicts) with the new attributes. I don't know if we really need this setting since it is optional and the addon has no user-defined config, but I'm keeping this to keep the behavior consistent.

How I've tested this PR: I did not.

How I expect reviewers to test this PR: 👀 


Checklist:
- [ ] ~Tests added~
- [ ] ~[CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)~


