### PR TITLE
Add a check to prevent a nil-pointer dereference on Ingress LB

### DIFF
--- a/control-plane/catalog/to-consul/resource.go
+++ b/control-plane/catalog/to-consul/resource.go
@@ -938,7 +938,7 @@ func (t *serviceIngressResource) Upsert(key string, raw interface{}) error {
 			continue
 		}
 		if t.SyncLoadBalancerIPs {
-			if ingress.Status.LoadBalancer.Ingress[0].IP == "" {
+			if len(ingress.Status.LoadBalancer.Ingress) > 0 && ingress.Status.LoadBalancer.Ingress[0].IP == "" {
 				continue
 			}
 			hostName = ingress.Status.LoadBalancer.Ingress[0].IP


### PR DESCRIPTION
Changes proposed in this PR:
- Add a check to prevent a nil-pointer dereference on Ingress LB


How I've tested this PR:
- Deployed an improper Ingress config and validated that it does not crash the sync catalog.

How I expect reviewers to test this PR:
- 👀 

