### PR TITLE
helm chart: fix ingress template

### DIFF
--- a/.changelog/2596.txt
+++ b/.changelog/2596.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+helm: fix ui ingress manifest formatting, and exclude `ingressClass` when not defined.
+```

--- a/charts/consul/templates/ui-ingress.yaml
+++ b/charts/consul/templates/ui-ingress.yaml
@@ -25,9 +25,11 @@ metadata:
     {{ tpl .Values.ui.ingress.annotations . | nindent 4 | trim }}
   {{- end }}
 spec:
+  {{- if ne .Values.ui.ingress.ingressClassName "" }}
   ingressClassName: {{ .Values.ui.ingress.ingressClassName }}
+  {{- end }}
   rules:
-  {{ $global := .Values.global }}
+  {{- $global := .Values.global }}
   {{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "19" ) }}
   {{- range .Values.ui.ingress.hosts }}
   - host: {{ .host | quote }}


### PR DESCRIPTION
- blank line between `rules:` and `- host:`
- `ingressClass` was present when no value was specified

Changes proposed in this PR:
-
Fix malformed ingress when using the helm chart. 

Given this values.yaml snippet:
```yaml
ui:
  enabled: true
  ingress:
    enabled: true
    hosts:
    - host: consul.localhost
```

Output before changes:
```yaml
---
# Source: consul/templates/ui-ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: vault-consul-ui
  namespace: consul
  labels:
    app: consul
    chart: consul-helm
    heritage: Helm
    release: vault
    component: ui
spec:
  ingressClassName: 
  rules:
  
  - host: "consul.localhost"
    http:
      paths:
      - backend:
          service:
            name: vault-consul-ui
            port:
              number: 80
        path: /
        pathType: Prefix
```

Output after changes:
```yaml
---
# Source: consul/templates/ui-ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: consul-consul-ui
  namespace: consul
  labels:
    app: consul
    chart: consul-helm
    heritage: Helm
    release: consul
    component: ui
spec:
  rules:
  - host: "consul.localhost"
    http:
      paths:
      - backend:
          service:
            name: consul-consul-ui
            port:
              number: 80
        path: /
        pathType: Prefix
```

How I've tested this PR:

Used bats as shown at: https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#testing-the-helm-chart

I am seeing a failure for this file, but it would fail before any changes I've made due to the default values file not including a host: https://github.com/hashicorp/consul-k8s/blob/b3769b1cb19004112f83badd5028a3fce1030bb4/charts/consul/values.yaml#L1750-L1761 

```
bats consul/test/unit/ui-ingress.bats
ui-ingress.bats
 ✓ ui/Ingress: disabled by default
 ✓ ui/Ingress: enable with ui.ingress.enabled
 ✓ ui/Ingress: disable with ui.ingress.enabled
 ✓ ui/Ingress: disable with ui.ingress.enabled dash string
 ✗ ui/Ingress: no hosts by default
   (in test file consul/test/unit/ui-ingress.bats, line 48)
     `[ "${actual}" = "null" ]' failed
   ---
   # Source: consul/templates/ui-ingress.yaml
   apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     name: release-name-consul-ui
     namespace: consul
     labels:
       app: consul
       chart: consul-helm
       heritage: Helm
       release: release-name
       component: ui
   spec:
     rules:

 ✓ ui/Ingress: hosts can be set
 ✓ ui/Ingress: exposes single port 80 when global.tls.enabled=false
 ✓ ui/Ingress: exposes single port 443 when global.tls.enabled=true and global.tls.httpsOnly=true
 ✓ ui/Ingress: exposes the port 80 when global.tls.enabled=true and global.tls.httpsOnly=false
 ✓ ui/Ingress: exposes the port 443 when global.tls.enabled=true and global.tls.httpsOnly=false
 ✓ ui/Ingress: no tls by default
 ✓ ui/Ingress: tls can be set
 ✓ ui/Ingress: tls with secret name can be set
 ✓ ui/Ingress: no annotations by default
 ✓ ui/Ingress: annotations can be set
 ✓ ui/Ingress: default PathType Prefix
 ✓ ui/Ingress: set PathType ImplementationSpecific
 ✓ ui/Ingress: no ingressClassName by default
 ✓ ui/Ingress: can set ingressClassName

19 tests, 1 failure
```

How I expect reviewers to test this PR:

Using the existing tests.

Checklist:
- [ ] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


