### PR TITLE
added make target for checking for hashicorppreview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,10 @@ terraform-fmt:
 	@terraform fmt -recursive
 .PHONY: terraform-fmt
 
+# Check for hashicorppreview containers
+check-preview-containers:
+	@source $(CURDIR)/control-plane/build-support/scripts/check-hashicorppreview.sh
+
 
 # ===========> CLI Targets
 cli-dev:

--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ aks-test-packages:
 check-env:
 	@printenv | grep "CONSUL_K8S"
 
-prepare-release: ## Sets the versions, updates changelog to prepare this repository to release
+prepare-release-script: ## Sets the versions, updates changelog to prepare this repository to release
 ifndef CONSUL_K8S_RELEASE_VERSION
 	$(error CONSUL_K8S_RELEASE_VERSION is required)
 endif
@@ -238,7 +238,9 @@ endif
 ifndef CONSUL_K8S_CONSUL_VERSION
 	$(error CONSUL_K8S_CONSUL_VERSION is required)
 endif
-	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_release $(CURDIR) $(CONSUL_K8S_RELEASE_VERSION) "$(CONSUL_K8S_RELEASE_DATE)" $(CONSUL_K8S_LAST_RELEASE_GIT_TAG) $(CONSUL_K8S_CONSUL_VERSION) $(CONSUL_K8S_CONSUL_DATAPLANE_VERSION) $(CONSUL_K8S_PRERELEASE_VERSION)
+	@source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_release $(CURDIR) $(CONSUL_K8S_RELEASE_VERSION) "$(CONSUL_K8S_RELEASE_DATE)" $(CONSUL_K8S_LAST_RELEASE_GIT_TAG) $(CONSUL_K8S_CONSUL_VERSION) $(CONSUL_K8S_CONSUL_DATAPLANE_VERSION) $(CONSUL_K8S_PRERELEASE_VERSION); \
+
+prepare-release: prepare-release-script check-preview-containers
 
 prepare-dev:
 ifndef CONSUL_K8S_RELEASE_VERSION

--- a/control-plane/build-support/scripts/check-hashicorppreview.sh
+++ b/control-plane/build-support/scripts/check-hashicorppreview.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+if grep -rnw -e 'hashicorppreviewsadfsd'  './charts'; then
+    echo charts contain hashicorppreview images
+else
+    echo charts do not contain hashicorpreview images
+fi

--- a/control-plane/build-support/scripts/check-hashicorppreview.sh
+++ b/control-plane/build-support/scripts/check-hashicorppreview.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
-if grep -rnw -e 'hashicorppreviewsadfsd'  './charts'; then
-    echo charts contain hashicorppreview images
+echo "Checking charts for hashicorpreview images. . ."
+if grep -rnw -e 'hashicorppreview'  './charts'; then
+    echo Charts contain hashicorppreview images. If this is intended for release, please remove the preview images.
 else
-    echo charts do not contain hashicorpreview images
+    echo Charts do not contain hashicorpreview images, ready for release!
 fi


### PR DESCRIPTION
Changes proposed in this PR:
- Adds a make target to check for hashicorppreview images in the charts. This will help verify release steps.

How I've tested this PR:

Example output where hashicorppreview is found
```
$ make check-preview-containers
./charts/consul/Chart.yaml:19:      image: docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.17-dev
./charts/consul/Chart.yaml:21:      image: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.3.0-dev
./charts/consul/Chart.yaml:23:      image: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.3-dev
./charts/consul/values.yaml:69:  image: docker.mirror.hashicorp.services/hashicorppreview/consul:1.17-dev
./charts/consul/values.yaml:89:  imageK8S: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.3.0-dev
./charts/consul/values.yaml:611:  imageConsulDataplane: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.3-dev
charts contain hashicorppreview images
```

Example output where hashicorppreview is not found
```
$ make check-preview-containers
charts do not contain hashicorpreview images
```

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


