### PR TITLE
Increase golangci-lint timeout to 10m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,4 +34,4 @@ linters-settings:
     simplify: true
 
 run:
-  timeout: 5m
+  timeout: 10m


### PR DESCRIPTION
This is meant to solve for recurrent timeouts in several steps, particularly `golangci-lint-control-plane` and `golang-ci-lint-cli`.

An [accompanying change](https://github.com/hashicorp/consul-k8s-workflows/pull/29) in `consul-k8s-workflows` should disable caching until the (unclear) root of the issue can be resolved, or we can disable or clear cache in a more targeted way that solves for these cases.

Note from @DanStough : we've also done this in `consul`
https://github.com/hashicorp/consul-k8s/pull/2621
https://github.com/hashicorp/consul/pull/17459

Changes proposed in this PR:
- Disable `golangci-lint` caching

How I've tested this PR:
- Example passing workflow after combined fix: https://github.com/hashicorp/consul-k8s-workflows/actions/runs/5624313593/job/15240886287

How I expect reviewers to test this PR: 👀 

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


