### PR TITLE
Consul client always logs into the local datacenter

### DIFF
--- a/.changelog/2652.txt
+++ b/.changelog/2652.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+helm: fix CONSUL_LOGIN_DATACENTER for consul client-daemonset.
+```

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -510,11 +510,7 @@ spec:
           value: "component=client,pod=$(NAMESPACE)/$(POD_NAME)"
         {{- end }}
         - name: CONSUL_LOGIN_DATACENTER
-        {{- if and .Values.global.federation.enabled .Values.global.federation.primaryDatacenter }}
-          value: {{ .Values.global.federation.primaryDatacenter }}
-        {{- else }}
           value: {{ .Values.global.datacenter }}
-        {{- end}}
         command:
           - "/bin/sh"
           - "-ec"

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -2127,29 +2127,6 @@ rollingUpdate:
   [[ "$output" =~ "If global.federation.enabled is true, global.adminPartitions.enabled must be false because they are mutually exclusive" ]]
 }
 
-@test "client/DaemonSet: consul login datacenter is set to primary when when federation enabled in non-primary datacenter" {
-  cd `chart_dir`
-  local object=$(helm template \
-      -s templates/client-daemonset.yaml  \
-      --set 'client.enabled=true' \
-      --set 'meshGateway.enabled=true' \
-      --set 'global.acls.manageSystemACLs=true' \
-      --set 'global.datacenter=dc1' \
-      --set 'global.federation.enabled=true' \
-      --set 'global.federation.primaryDatacenter=dc2' \
-      --set 'global.tls.enabled=true' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.initContainers[] | select(.name == "client-acl-init")' | tee /dev/stderr)
-
-  local actual=$(echo $object |
-      yq '[.env[11].name] | any(contains("CONSUL_LOGIN_DATACENTER"))' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-
-  local actual=$(echo $object |
-      yq '[.env[11].value] | any(contains("dc2"))' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
 #--------------------------------------------------------------------
 # extraContainers
 


### PR DESCRIPTION
Changes proposed in this PR:
- Update the CONSUL_LOGIN_DATACENTER logic for client daemonset to only login to the local datacenter as it uses a local authmethod and not a global authmethod.
- This led to errors when attempting to deploy clients in a federated cluster.

How I've tested this PR:
- @natemollica-nm was able to replicate the error and this fix fixed it in his federated cluster

How I expect reviewers to test this PR:
- 👀 

Checklist:
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


