### PR TITLE
Do not set securityContext on Openshift < 4.11

### DIFF
--- a/.changelog/2678.txt
+++ b/.changelog/2678.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+helm: do not set container securityContexts by default on OpenShift < 4.11
+```

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -15,8 +15,23 @@ as well as the global.name setting.
 {{- end -}}
 {{- end -}}
 
+
 {{- define "consul.restrictedSecurityContext" -}}
 {{- if not .Values.global.enablePodSecurityPolicies -}}
+{{/*
+To be compatible with the 'restricted' Pod Security Standards profile, we
+should set this securityContext on containers whenever possible.
+
+In OpenShift < 4.11 the restricted SCC disallows setting most of these fields,
+so we do not set any for simplicity (and because that's how it was configured
+prior to adding restricted PSA support here). In OpenShift >= 4.11, the new
+restricted-v2 SCC allows setting these in the securityContext, and by setting
+them we avoid PSA warnings that are enabled by default.
+
+We use the K8s version as a proxy for the OpenShift version because there is a
+1:1 mapping of versions. OpenShift 4.11 corresponds to K8s 1.24.x.
+*/}}
+{{- if (or (not .Values.global.openshift.enabled) (and (ge .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor "24"))) -}}
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
@@ -25,11 +40,12 @@ securityContext:
   runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
+{{- end -}}
 {{- if not .Values.global.openshift.enabled -}}
 {{/*
 We must set runAsUser or else the root user will be used in some cases and
 containers will fail to start due to runAsNonRoot above (e.g.
-tls-init-cleanup). On OpenShift, runAsUser is automatically. We pick user 100
+tls-init-cleanup). On OpenShift, runAsUser is set automatically. We pick user 100
 because it is a non-root user id that exists in the consul, consul-dataplane,
 and consul-k8s-control-plane images.
 */}}


### PR DESCRIPTION
Changes proposed in this PR:

- This is going into `release/1.1.x`, and will be backported into `release/1.0.x` because both of those Consul K8s versions support K8s < 1.23.x and therefore support OpenShift <= 4.10
- Do not set securityContext on OpenShift < 4.11 because the restricted SCC disallows setting some of those settings. I broke this in https://github.com/hashicorp/consul-k8s/pull/2572. In OpenShift >= 4.11, setting the securityContext is okay because the new restricted-v2 SCC is available to all users/accounts and allows setting the fields we want to set, and doing so avoids warnings.
- We determine the OpenShift version in Helm using the Kube version because there is a 1:1 mapping of OpenShift to Kube versions.

How I've tested this PR:

- Ran the connect tests with openshift enabled against 4.10 and 4.11 OpenShift clusters, using instructions similar to those in the description of https://github.com/hashicorp/consul-k8s/pull/2572

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


