### PR TITLE
Fix default Ent image tag in acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,13 @@ kind: kind-delete
 	kind create cluster --name dc3 --image $(KIND_NODE_IMAGE)
 	kind create cluster --name dc4 --image $(KIND_NODE_IMAGE)
 
+# Helper target for loading local dev images (run with `DEV_IMAGE=...` to load non-k8s images)
+kind-load:
+	kind load docker-image --name dc1 $(DEV_IMAGE)
+	kind load docker-image --name dc2 $(DEV_IMAGE)
+	kind load docker-image --name dc3 $(DEV_IMAGE)
+	kind load docker-image --name dc4 $(DEV_IMAGE)
+
 # ===========> Shared Targets
 
 help: ## Show targets and their descriptions.

--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -217,21 +217,16 @@ func (t *TestConfig) entImage() (string, error) {
 	}
 
 	// Otherwise, assume that we have an image tag with a version in it.
-	consulImageSplits := strings.Split(v.Global.Image, ":")
-	if len(consulImageSplits) != 2 {
-		return "", fmt.Errorf("could not determine consul version from global.image: %s", v.Global.Image)
-	}
-	consulImageVersion := consulImageSplits[1]
+	// Use the same Docker repository and tagging scheme, but replace 'consul' with 'consul-enterprise'.
+	imageTag := strings.Replace(v.Global.Image, "/consul:", "/consul-enterprise:", 1)
 
-	var preRelease string
-	// Handle versions like 1.9.0-rc1.
-	if strings.Contains(consulImageVersion, "-") {
-		split := strings.Split(consulImageVersion, "-")
-		consulImageVersion = split[0]
-		preRelease = fmt.Sprintf("-%s", split[1])
+	// We currently add an '-ent' suffix to release versions of enterprise images (nightly previews
+	// do not include this suffix).
+	if strings.HasPrefix(imageTag, "hashicorp/consul-enterprise:") {
+		imageTag = fmt.Sprintf("%s-ent", imageTag)
 	}
 
-	return fmt.Sprintf("hashicorp/consul-enterprise:%s%s-ent", consulImageVersion, preRelease), nil
+	return imageTag, nil
 }
 
 func (c *TestConfig) SkipWhenOpenshiftAndCNI(t *testing.T) {

--- a/acceptance/framework/config/config_test.go
+++ b/acceptance/framework/config/config_test.go
@@ -137,24 +137,33 @@ func TestConfig_HelmValuesFromConfig_EntImage(t *testing.T) {
 		expErr      string
 	}{
 		{
-			consulImage: "hashicorp/consul:1.9.0",
-			expImage:    "hashicorp/consul-enterprise:1.9.0-ent",
+			consulImage: "hashicorp/consul:1.15.3",
+			expImage:    "hashicorp/consul-enterprise:1.15.3-ent",
 		},
 		{
-			consulImage: "hashicorp/consul:1.8.5-rc1",
-			expImage:    "hashicorp/consul-enterprise:1.8.5-rc1-ent",
+			consulImage: "hashicorp/consul:1.16.0-rc1",
+			expImage:    "hashicorp/consul-enterprise:1.16.0-rc1-ent",
 		},
 		{
-			consulImage: "hashicorp/consul:1.7.0-beta3",
-			expImage:    "hashicorp/consul-enterprise:1.7.0-beta3-ent",
-		},
-		{
-			consulImage: "invalid",
-			expErr:      "could not determine consul version from global.image: invalid",
+			consulImage: "hashicorp/consul:1.14.0-beta1",
+			expImage:    "hashicorp/consul-enterprise:1.14.0-beta1-ent",
 		},
 		{
 			consulImage: "hashicorp/consul@sha256:oioi2452345kjhlkh",
 			expImage:    "hashicorp/consul@sha256:oioi2452345kjhlkh",
+		},
+		// Nightly tags differ from release tags ('-ent' suffix is omitted)
+		{
+			consulImage: "docker.mirror.hashicorp.services/hashicorppreview/consul:1.17-dev",
+			expImage:    "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.17-dev",
+		},
+		{
+			consulImage: "docker.mirror.hashicorp.services/hashicorppreview/consul:1.17-dev-ubi",
+			expImage:    "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.17-dev-ubi",
+		},
+		{
+			consulImage: "docker.mirror.hashicorp.services/hashicorppreview/consul@sha256:oioi2452345kjhlkh",
+			expImage:    "docker.mirror.hashicorp.services/hashicorppreview/consul@sha256:oioi2452345kjhlkh",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Rather than hard-coding the Docker repository and parsing the non-Ent image tag for a version, simply replace the image name and retain other coordinates. This is consistent with our tagging scheme introduced in https://github.com/hashicorp/consul/pull/13541 and will allow for using `hashicorppreview` images seamlessly regardless of whether OSS or Ent is being tested.

Also add a `make` target to help with testing local images in multi-cluster scenarios.

Changes proposed in this PR:
- Align `consul-enterprise` image tag derivation with our OSS + Ent tagging scheme
- Add a `make` target for loading dev images across `kind` clusters

How I've tested this PR: 
- Updated unit tests
- Tested manually:
```shell
❯ go test ./sameness/... -v -timeout 2h -failfast -use-kind -no-cleanup-on-failure -kube-contexts="kind-dc1,kind-dc2,kind-dc3,kind-dc4" -enable-enterprise -enable-multi-cluster -debug-directory=/tmp/debug -consul-k8s-image=consul-k8s-control-plane-dev
...
    command.go:... Running command helm with args... --set global.image=docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.17-dev...
```
```shell
❯ make kind-load
kind load docker-image --name dc1 consul-k8s-control-plane-dev
Image: "consul-k8s-control-plane-dev" with ID "sha256:609bbc07ce629667028157d8c14113123a87ef49592cc2aa94e89bc5707da313" not yet present on node "dc1-control-plane", loading...
kind load docker-image --name dc2 consul-k8s-control-plane-dev
Image: "consul-k8s-control-plane-dev" with ID "sha256:609bbc07ce629667028157d8c14113123a87ef49592cc2aa94e89bc5707da313" not yet present on node "dc2-control-plane", loading...
kind load docker-image --name dc3 consul-k8s-control-plane-dev
Image: "consul-k8s-control-plane-dev" with ID "sha256:609bbc07ce629667028157d8c14113123a87ef49592cc2aa94e89bc5707da313" not yet present on node "dc3-control-plane", loading...
kind load docker-image --name dc4 consul-k8s-control-plane-dev
Image: "consul-k8s-control-plane-dev" with ID "sha256:609bbc07ce629667028157d8c14113123a87ef49592cc2aa94e89bc5707da313" not yet present on node "dc4-control-plane", loading...

❯ DEV_IMAGE=zalimeni-local/consul:recent make kind-load
kind load docker-image --name dc1 zalimeni-local/consul:recent
Image: "zalimeni-local/consul:recent" with ID "sha256:4850dee3c23a007cd30f9814194de884c1336ea6b16c8bfd34a13f6c45651d5a" not yet present on node "dc1-control-plane", loading...
kind load docker-image --name dc2 zalimeni-local/consul:recent
Image: "zalimeni-local/consul:recent" with ID "sha256:4850dee3c23a007cd30f9814194de884c1336ea6b16c8bfd34a13f6c45651d5a" not yet present on node "dc2-control-plane", loading...
kind load docker-image --name dc3 zalimeni-local/consul:recent
Image: "zalimeni-local/consul:recent" with ID "sha256:4850dee3c23a007cd30f9814194de884c1336ea6b16c8bfd34a13f6c45651d5a" not yet present on node "dc3-control-plane", loading...
kind load docker-image --name dc4 zalimeni-local/consul:recent
Image: "zalimeni-local/consul:recent" with ID "sha256:4850dee3c23a007cd30f9814194de884c1336ea6b16c8bfd34a13f6c45651d5a" not yet present on node "dc4-control-plane", loading...
```

How I expect reviewers to test this PR: 👀 


Checklist:
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


