### PR TITLE
Manual backport of Added logLevel field for components  (#2302)

### DIFF
--- a/.changelog/2302.txt
+++ b/.changelog/2302.txt
@@ -1,0 +1,13 @@
+```release-note:improvement
+Add support to provide the logLevel flag via helm for multiple low level components. Introduces the following fields
+1. `global.acls.logLevel`
+2. `global.tls.logLevel`
+3. `global.federation.logLevel`
+4. `global.gossipEncryption.logLevel`
+5. `server.logLevel`
+6. `client.logLevel`
+7. `meshGateway.logLevel`
+8. `ingressGateways.logLevel`
+9. `terminatingGateways.logLevel`
+10. `telemetryCollector.logLevel`
+```

--- a/.changelog/2302.txt
+++ b/.changelog/2302.txt
@@ -9,5 +9,4 @@ Add support to provide the logLevel flag via helm for multiple low level compone
 7. `meshGateway.logLevel`
 8. `ingressGateways.logLevel`
 9. `terminatingGateways.logLevel`
-10. `telemetryCollector.logLevel`
 ```

--- a/charts/consul/templates/client-config-configmap.yaml
+++ b/charts/consul/templates/client-config-configmap.yaml
@@ -19,6 +19,12 @@ data:
       "auto_reload_config": true
       {{- end }}
     }
+  log-level.json: |-
+    {
+      {{- if .Values.client.logLevel }}
+      "log_level": "{{ .Values.client.logLevel | upper }}"
+      {{- end }}
+    }
   extra-from-values.json: |-
 {{ tpl .Values.client.extraConfig . | trimAll "\"" | indent 4 }}
   central-config.json: |-

--- a/charts/consul/templates/create-federation-secret-job.yaml
+++ b/charts/consul/templates/create-federation-secret-job.yaml
@@ -119,7 +119,7 @@ spec:
             - "-ec"
             - |
                 consul-k8s-control-plane create-federation-secret \
-                  -log-level={{ .Values.global.logLevel }} \
+                  -log-level={{ default .Values.global.logLevel .Values.global.federation.logLevel }} \
                   -log-json={{ .Values.global.logJSON }} \
                   {{- if (or .Values.global.gossipEncryption.autoGenerate (and .Values.global.gossipEncryption.secretName .Values.global.gossipEncryption.secretKey)) }}
                   -gossip-key-file=/consul/gossip/gossip.key \

--- a/charts/consul/templates/gossip-encryption-autogenerate-job.yaml
+++ b/charts/consul/templates/gossip-encryption-autogenerate-job.yaml
@@ -57,7 +57,7 @@ spec:
                 -namespace={{ .Release.Namespace }} \
                 -secret-name={{ template "consul.fullname" . }}-gossip-encryption-key \
                 -secret-key="key" \
-                -log-level={{ .Values.global.logLevel }} \
+                -log-level={{ default .Values.global.logLevel .Values.global.gossipEncryption.logLevel }} \
                 -log-json={{ .Values.global.logJSON }}
           resources:
             requests:

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -211,7 +211,7 @@ spec:
           -gateway-kind="ingress-gateway" \
           -proxy-id-file=/consul/service/proxy-id \
           -service-name={{ template "consul.fullname" $root }}-{{ .name }} \
-          -log-level={{ default $root.Values.global.logLevel }} \
+          -log-level={{ default $root.Values.global.logLevel $root.Values.ingressGateways.logLevel }} \
           -log-json={{ $root.Values.global.logJSON }}
         volumeMounts:
         - name: consul-service
@@ -319,7 +319,7 @@ spec:
         {{- if $root.Values.global.adminPartitions.enabled }}
         - -service-partition={{ $root.Values.global.adminPartitions.name }}
         {{- end }}
-        - -log-level={{ default $root.Values.global.logLevel }}
+        - -log-level={{ default $root.Values.global.logLevel $root.Values.ingressGateways.logLevel }}
         - -log-json={{ $root.Values.global.logJSON }}
         {{- if (and $root.Values.global.metrics.enabled $root.Values.global.metrics.enableGatewayMetrics) }}
         - -telemetry-prom-scrape-path=/metrics

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -161,7 +161,7 @@ spec:
            -gateway-kind="mesh-gateway" \
            -proxy-id-file=/consul/service/proxy-id \
            -service-name={{ .Values.meshGateway.consulServiceName }} \
-           -log-level={{ default .Values.global.logLevel }} \
+           -log-level={{ default .Values.global.logLevel .Values.meshGateway.logLevel }} \
            -log-json={{ .Values.global.logJSON }}
         volumeMounts:
         - name: consul-service
@@ -267,7 +267,7 @@ spec:
         {{- if .Values.global.adminPartitions.enabled }}
         - -service-partition={{ .Values.global.adminPartitions.name }}
         {{- end }}
-        - -log-level={{ default .Values.global.logLevel }}
+        - -log-level={{ default .Values.global.logLevel .Values.meshGateway.logLevel }}
         - -log-json={{ .Values.global.logJSON }}
         {{- if (and .Values.global.metrics.enabled .Values.global.metrics.enableGatewayMetrics) }}
         - -telemetry-prom-scrape-path=/metrics

--- a/charts/consul/templates/server-acl-init-cleanup-job.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-job.yaml
@@ -67,7 +67,7 @@ spec:
             - consul-k8s-control-plane
           args:
             - delete-completed-job
-            - -log-level={{ .Values.global.logLevel }}
+            - -log-level={{ default .Values.global.logLevel .Values.global.acls.logLevel }}
             - -log-json={{ .Values.global.logJSON }}
             - -k8s-namespace={{ .Release.Namespace }}
             - {{ template "consul.fullname" . }}-server-acl-init

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -166,7 +166,7 @@ spec:
           CONSUL_FULLNAME="{{template "consul.fullname" . }}"
 
           consul-k8s-control-plane server-acl-init \
-            -log-level={{ .Values.global.logLevel }} \
+            -log-level={{ default .Values.global.logLevel .Values.global.acls.logLevel}} \
             -log-json={{ .Values.global.logJSON }} \
             -resource-prefix=${CONSUL_FULLNAME} \
             -k8s-namespace={{ .Release.Namespace }} \

--- a/charts/consul/templates/server-config-configmap.yaml
+++ b/charts/consul/templates/server-config-configmap.yaml
@@ -26,6 +26,9 @@ data:
       },
       "datacenter": "{{ .Values.global.datacenter }}",
       "data_dir": "/consul/data",
+      {{- if .Values.server.logLevel }}
+      "log_level": "{{ .Values.server.logLevel | upper }}",
+      {{- end }}
       "domain": "{{ .Values.global.domain }}",
       "ports": {
         {{- if not .Values.global.tls.enabled }}

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -196,7 +196,7 @@ spec:
                   -gateway-kind="terminating-gateway" \
                   -proxy-id-file=/consul/service/proxy-id \
                   -service-name={{ .name }} \
-                  -log-level={{ default $root.Values.global.logLevel }} \
+                  -log-level={{ default $root.Values.global.logLevel $root.Values.terminatingGateways.logLevel }} \
                   -log-json={{ $root.Values.global.logJSON }}
           volumeMounts:
             - name: consul-service
@@ -300,7 +300,7 @@ spec:
           {{- if $root.Values.global.adminPartitions.enabled }}
           - -service-partition={{ $root.Values.global.adminPartitions.name }}
           {{- end }}
-          - -log-level={{ default $root.Values.global.logLevel }}
+          - -log-level={{ default $root.Values.global.logLevel $root.Values.terminatingGateways.logLevel }}
           - -log-json={{ $root.Values.global.logJSON }}
           {{- if (and $root.Values.global.metrics.enabled $root.Values.global.metrics.enableGatewayMetrics) }}
           - -telemetry-prom-scrape-path=/metrics

--- a/charts/consul/templates/tls-init-job.yaml
+++ b/charts/consul/templates/tls-init-job.yaml
@@ -80,7 +80,7 @@ spec:
               # and use * at the start of the dns name when setting -additional-dnsname.
               set -o noglob
               consul-k8s-control-plane tls-init \
-                -log-level={{ .Values.global.logLevel }} \
+                -log-level={{ default .Values.global.logLevel .Values.global.tls.logLevel }} \
                 -log-json={{ .Values.global.logJSON }} \
                 -domain={{ .Values.global.domain }} \
                 -days=730 \

--- a/charts/consul/test/unit/client-config-configmap.bats
+++ b/charts/consul/test/unit/client-config-configmap.bats
@@ -95,3 +95,29 @@ load _helpers
 
   [ "${actual}" = null ]
 }
+
+#--------------------------------------------------------------------
+# logLevel
+
+@test "client/ConfigMap: client.logLevel is empty" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-config-configmap.yaml  \
+      --set 'client.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.data["log-level.json"]' | jq -r .log_level | tee /dev/stderr)
+
+  [ "${actual}" = "null" ]
+}
+
+@test "client/ConfigMap: client.logLevel is non empty" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-config-configmap.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.logLevel=DEBUG' \
+      . | tee /dev/stderr |
+      yq -r '.data["log-level.json"]' | jq -r .log_level | tee /dev/stderr)
+
+  [ "${actual}" = "DEBUG" ]
+}

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -621,7 +621,7 @@ load _helpers
       --set 'client.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = f9be2829fed80a127e3752e10be32f29c2f9ca0ea548abcf3d4fc2c985cb7201 ]
+  [ "${actual}" = 4fa9ddc3abc4c79eafccb19e5beef80006b7c9736b867d8873554ca03f42a6b3 ]
 }
 
 @test "client/DaemonSet: config-checksum annotation changes when extraConfig is provided" {
@@ -632,7 +632,7 @@ load _helpers
       --set 'client.extraConfig="{\"hello\": \"world\"}"' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = e9fb5f0b4ff4e36a89e8ca2dc1aed2072306e0dd6d4cc60b3edf155cf8dbe2e9 ]
+  [ "${actual}" = 42b99932385e7a0580b134fe36a9bda405aab2e375593326677b9838708f0796 ]
 }
 
 @test "client/DaemonSet: config-checksum annotation changes when connectInject.enabled=true" {
@@ -643,7 +643,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.annotations."consul.hashicorp.com/config-checksum"' | tee /dev/stderr)
-  [ "${actual}" = f9be2829fed80a127e3752e10be32f29c2f9ca0ea548abcf3d4fc2c985cb7201 ]
+  [ "${actual}" = 4fa9ddc3abc4c79eafccb19e5beef80006b7c9736b867d8873554ca03f42a6b3 ]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/test/unit/create-federation-secret-job.bats
+++ b/charts/consul/test/unit/create-federation-secret-job.bats
@@ -418,3 +418,41 @@ load _helpers
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# logLevel
+
+@test "createFederationSecret/Job: logLevel is not set by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/create-federation-secret-job.yaml  \
+      --set 'global.federation.enabled=true' \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.federation.createFederationSecret=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "createFederationSecret/Job: override the global.logLevel flag with global.federation.logLevel" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/create-federation-secret-job.yaml  \
+      --set 'global.federation.enabled=true' \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.federation.createFederationSecret=true' \
+      --set 'global.federation.logLevel=debug' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=debug"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/gossip-encryption-autogenerate-job.bats
+++ b/charts/consul/test/unit/gossip-encryption-autogenerate-job.bats
@@ -105,3 +105,33 @@ load _helpers
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# logLevel
+
+@test "gossipEncryptionAutogenerate/Job: uses the global.logLevel flag by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/gossip-encryption-autogenerate-job.yaml  \
+      --set 'global.gossipEncryption.autoGenerate=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "gossipEncryptionAutogenerate/Job: overrides the global.logLevel flag when global.gossipEncryption.logLevel is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/gossip-encryption-autogenerate-job.yaml  \
+      --set 'global.gossipEncryption.autoGenerate=true' \
+      --set 'global.gossipEncryption.logLevel=debug' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=debug"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/ingress-gateways-deployment.bats
+++ b/charts/consul/test/unit/ingress-gateways-deployment.bats
@@ -1504,3 +1504,64 @@ key2: value2' \
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# logLevel
+
+@test "ingressGateways/Deployment: use global.logLevel by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+  
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "ingressGateways/Deployment: override global.logLevel when ingressGateways.logLevel is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'ingressGateways.logLevel=warn' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+  
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=warn"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "ingressGateways/Deployment: use global.logLevel by default for dataplane container" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].args' | tee /dev/stderr)
+  
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "ingressGateways/Deployment: override global.logLevel when ingressGateways.logLevel is set for dataplane container" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'ingressGateways.logLevel=trace' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].args' | tee /dev/stderr)
+  
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=trace"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/mesh-gateway-deployment.bats
+++ b/charts/consul/test/unit/mesh-gateway-deployment.bats
@@ -1644,3 +1644,64 @@ key2: value2' \
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# logLevel
+
+@test "meshGateway/Deployment: use global.logLevel by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "meshGateway/Deployment: override global.logLevel when meshGateway.logLevel is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'meshGateway.logLevel=warn' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=warn"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "meshGateway/Deployment: use global.logLevel by default for dataplane container" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].args' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "meshGateway/Deployment: override global.logLevel when meshGateway.logLevel is set for dataplane container" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'meshGateway.logLevel=warn' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].args' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=warn"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/server-acl-init-cleanup-job.bats
+++ b/charts/consul/test/unit/server-acl-init-cleanup-job.bats
@@ -161,6 +161,34 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# logLevel
+
+@test "serverACLInitCleanup/Job: use global.logLevel by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/server-acl-init-cleanup-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].args' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInitCleanup/Job: override global.logLevel when global.acls.logLevel is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/server-acl-init-cleanup-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.logLevel=debug' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].args' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=debug"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
 # resources
 
 @test "serverACLInitCleanup/Job: resources defined by default" {

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -2228,6 +2228,36 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# logLevel
+
+@test "serverACLInit/Job: use global.logLevel by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/server-acl-init-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "serverACLInit/Job: override global.logLevel when global.acls.logLevel is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/server-acl-init-job.yaml \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'global.acls.logLevel=debug' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=debug"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # resources
 
 @test "serverACLInit/Job: resources defined by default" {

--- a/charts/consul/test/unit/server-config-configmap.bats
+++ b/charts/consul/test/unit/server-config-configmap.bats
@@ -1105,3 +1105,24 @@ load _helpers
   local actual=$(echo $object |  jq -r .audit.sink.MySink3.type | tee /dev/stderr)
   [ "${actual}" = "file" ]
 }
+
+@test "server/ConfigMap: server.logLevel is empty" {
+  cd `chart_dir`
+  local configmap=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.data["server.json"]' | jq -r .log_level | tee /dev/stderr)
+
+  [ "${configmap}" = "null" ]
+}
+
+@test "server/ConfigMap: server.logLevel is non empty" {
+  cd `chart_dir`
+  local configmap=$(helm template \
+      -s templates/server-config-configmap.yaml  \
+      --set 'server.logLevel=debug' \
+      . | tee /dev/stderr |
+      yq -r '.data["server.json"]' | jq -r .log_level | tee /dev/stderr)
+
+  [ "${configmap}" = "DEBUG" ]
+}

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -1504,3 +1504,64 @@ key2: value2' \
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# logLevel
+
+@test "terminatingGateways/Deployment: use global.logLevel by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "terminatingGateways/Deployment: override global.logLevel when terminatingGateways.logLevel is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'terminatingGateways.logLevel=debug' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.initContainers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=debug"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "terminatingGateways/Deployment: use global.logLevel by default for dataplane container" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].args' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "terminatingGateways/Deployment: override global.logLevel when terminatingGateways.logLevel is set for dataplane container" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'terminatingGateways.logLevel=debug' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].args' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=debug"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/tls-init-job.bats
+++ b/charts/consul/test/unit/tls-init-job.bats
@@ -209,6 +209,36 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# logLevel
+
+@test "tlsInit/Job: use global.logLevel by default" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/tls-init-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=info"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "tlsInit/Job: override global.logLevel when global.tls.logLevel is set" {
+  cd `chart_dir`
+  local cmd=$(helm template \
+      -s templates/tls-init-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.logLevel=error' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].command' | tee /dev/stderr)
+
+  local actual=$(echo "$cmd" |
+    yq 'any(contains("-log-level=error"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # server.containerSecurityContext.tlsInit
 
 @test "tlsInit/Job: securityContext is set when server.containerSecurityContext.tlsInit is set" {

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -314,6 +314,9 @@ global:
     # The key within the Kubernetes secret or Vault secret key that holds the gossip
     # encryption key.
     secretKey: ""
+    # Override global log verbosity level for gossip-encryption-autogenerate-job pods. One of "trace", "debug", "info", "warn", or "error".
+    # @type: string
+    logLevel: ""
 
   # A list of addresses of upstream DNS servers that are used to recursively resolve DNS queries.
   # These values are given as `-recursor` flags to Consul servers and clients.
@@ -331,6 +334,10 @@ global:
     # authority (optional) and server and client certificates.
     # This setting is required for [Cluster Peering](https://developer.hashicorp.com/consul/docs/connect/cluster-peering/k8s).
     enabled: false
+
+    # Override global log verbosity level. One of "trace", "debug", "info", "warn", or "error".
+    # @type: string
+    logLevel: ""
 
     # If true, turns on the auto-encrypt feature on clients and servers.
     # It also switches consul-k8s-control-plane components to retrieve the CA from the servers
@@ -431,6 +438,10 @@ global:
     # This requires Consul >= 1.4.
     manageSystemACLs: false
 
+    # Override global log verbosity level. One of "trace", "debug", "info", "warn", or "error".
+    # @type: string
+    logLevel: ""
+    
     # A Kubernetes or Vault secret containing the bootstrap token to use for
     # creating policies and tokens for all Consul and consul-k8s-control-plane components.
     # If set, we will skip ACL bootstrapping of the servers and will only
@@ -597,6 +608,10 @@ global:
     # @type: string
     k8sAuthMethodHost: null
 
+    # Override global log verbosity level for the create-federation-secret-job pods. One of "trace", "debug", "info", "warn", or "error".
+    # @type: string
+    logLevel: ""
+
   # Configures metrics for Consul service mesh
   metrics:
     # Configures the Helm chart’s components
@@ -729,6 +744,10 @@ server:
   # @default: global.enabled
   # @type: boolean
   enabled: "-"
+
+  # Override global log verbosity level. One of "trace", "debug", "info", "warn", or "error".
+  # @type: string
+  logLevel: ""
 
   # The name of the Docker image (including any tag) for the containers running
   # Consul server agents.
@@ -1329,6 +1348,10 @@ client:
   # `server.enabled`, since the agents can be configured to join an external cluster.
   # @type: boolean
   enabled: false
+
+  # Override global log verbosity level. One of "trace", "debug", "info", "warn", or "error".
+  # @type: string
+  logLevel: ""
 
   # The name of the Docker image (including any tag) for the containers
   # running Consul client agents.
@@ -2526,6 +2549,10 @@ meshGateway:
   # Requirements: consul 1.6.0+ if using `global.acls.manageSystemACLs``.
   enabled: false
 
+  # Override global log verbosity level for mesh-gateway-deployment pods. One of "trace", "debug", "info", "warn", or "error".
+  # @type: string
+  logLevel: ""
+
   # Number of replicas for the Deployment.
   replicas: 1
 
@@ -2739,6 +2766,10 @@ ingressGateways:
   # and `client.enabled=true`.
   enabled: false
 
+  # Override global log verbosity level for ingress-gateways-deployment pods. One of "trace", "debug", "info", "warn", or "error".
+  # @type: string
+  logLevel: ""
+
   # Defaults sets default values for all gateway fields. With the exception
   # of annotations, defining any of these values in the `gateways` list
   # will override the default values provided here. Annotations will
@@ -2905,6 +2936,10 @@ terminatingGateways:
   # Enable terminating gateway deployment. Requires `connectInject.enabled=true`
   # and `client.enabled=true`.
   enabled: false
+
+  # Override global log verbosity level. One of "trace", "debug", "info", "warn", or "error".
+  # @type: string
+  logLevel: ""
 
   # Defaults sets default values for all gateway fields. With the exception
   # of annotations, defining any of these values in the `gateways` list


### PR DESCRIPTION
Changes proposed in this PR:
- Manually backporting the changes in #2302 to the `1.0.x` release branch

How I've tested this PR:

Unit tests & CI

How I expect reviewers to test this PR:


Checklist:
- [X] Tests added
- [X] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

