### PR TITLE
Backport of Fix default Ent image tag in acceptance tests into release/1.2.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,13 @@ kind:
 	kind create cluster --name dc2 --image $(KIND_NODE_IMAGE)
 
 
+# Helper target for loading local dev images (run with `DEV_IMAGE=...` to load non-k8s images)
+kind-load:
+	kind load docker-image --name dc1 $(DEV_IMAGE)
+	kind load docker-image --name dc2 $(DEV_IMAGE)
+	kind load docker-image --name dc3 $(DEV_IMAGE)
+	kind load docker-image --name dc4 $(DEV_IMAGE)
+
 # ===========> Shared Targets
 
 help: ## Show targets and their descriptions.

--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -216,21 +216,16 @@ func (t *TestConfig) entImage() (string, error) {
 	}
 
 	// Otherwise, assume that we have an image tag with a version in it.
-	consulImageSplits := strings.Split(v.Global.Image, ":")
-	if len(consulImageSplits) != 2 {
-		return "", fmt.Errorf("could not determine consul version from global.image: %s", v.Global.Image)
-	}
-	consulImageVersion := consulImageSplits[1]
+	// Use the same Docker repository and tagging scheme, but replace 'consul' with 'consul-enterprise'.
+	imageTag := strings.Replace(v.Global.Image, "/consul:", "/consul-enterprise:", 1)
 
-	var preRelease string
-	// Handle versions like 1.9.0-rc1.
-	if strings.Contains(consulImageVersion, "-") {
-		split := strings.Split(consulImageVersion, "-")
-		consulImageVersion = split[0]
-		preRelease = fmt.Sprintf("-%s", split[1])
+	// We currently add an '-ent' suffix to release versions of enterprise images (nightly previews
+	// do not include this suffix).
+	if strings.HasPrefix(imageTag, "hashicorp/consul-enterprise:") {
+		imageTag = fmt.Sprintf("%s-ent", imageTag)
 	}
 
-	return fmt.Sprintf("hashicorp/consul-enterprise:%s%s-ent", consulImageVersion, preRelease), nil
+	return imageTag, nil
 }
 
 func (c *TestConfig) SkipWhenOpenshiftAndCNI(t *testing.T) {

--- a/acceptance/framework/config/config_test.go
+++ b/acceptance/framework/config/config_test.go
@@ -137,24 +137,33 @@ func TestConfig_HelmValuesFromConfig_EntImage(t *testing.T) {
 		expErr      string
 	}{
 		{
-			consulImage: "hashicorp/consul:1.9.0",
-			expImage:    "hashicorp/consul-enterprise:1.9.0-ent",
+			consulImage: "hashicorp/consul:1.15.3",
+			expImage:    "hashicorp/consul-enterprise:1.15.3-ent",
 		},
 		{
-			consulImage: "hashicorp/consul:1.8.5-rc1",
-			expImage:    "hashicorp/consul-enterprise:1.8.5-rc1-ent",
+			consulImage: "hashicorp/consul:1.16.0-rc1",
+			expImage:    "hashicorp/consul-enterprise:1.16.0-rc1-ent",
 		},
 		{
-			consulImage: "hashicorp/consul:1.7.0-beta3",
-			expImage:    "hashicorp/consul-enterprise:1.7.0-beta3-ent",
-		},
-		{
-			consulImage: "invalid",
-			expErr:      "could not determine consul version from global.image: invalid",
+			consulImage: "hashicorp/consul:1.14.0-beta1",
+			expImage:    "hashicorp/consul-enterprise:1.14.0-beta1-ent",
 		},
 		{
 			consulImage: "hashicorp/consul@sha256:oioi2452345kjhlkh",
 			expImage:    "hashicorp/consul@sha256:oioi2452345kjhlkh",
+		},
+		// Nightly tags differ from release tags ('-ent' suffix is omitted)
+		{
+			consulImage: "docker.mirror.hashicorp.services/hashicorppreview/consul:1.17-dev",
+			expImage:    "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.17-dev",
+		},
+		{
+			consulImage: "docker.mirror.hashicorp.services/hashicorppreview/consul:1.17-dev-ubi",
+			expImage:    "docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.17-dev-ubi",
+		},
+		{
+			consulImage: "docker.mirror.hashicorp.services/hashicorppreview/consul@sha256:oioi2452345kjhlkh",
+			expImage:    "docker.mirror.hashicorp.services/hashicorppreview/consul@sha256:oioi2452345kjhlkh",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Manual backport of da99ce404f3f35f87dd51ace4fb11f68097fdfc8 due to partially failed backport assistant run.

Original PR: https://github.com/hashicorp/consul-k8s/pull/2683
