### PR TITLE
docs: Update outdated `consul.io` links

### DIFF
--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -3,5 +3,5 @@
 
 url_docker_registry_dockerhub = "https://hub.docker.com/r/hashicorp/consul-k8s-control-plane"
 url_license = "https://github.com/hashicorp/consul-k8s/blob/main/LICENSE"
-url_project_website = "https://www.consul.io/docs/k8s"
+url_project_website = "https://developer.hashicorp.com/consul/docs/k8s"
 url_source_repository = "https://github.com/hashicorp/consul-k8s"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1134,12 +1134,12 @@ Certificate:
 ---
 
 ## Helm Reference Docs
- 
-The Helm reference docs (https://www.consul.io/docs/k8s/helm) are automatically
+
+The Helm reference docs (https://developer.hashicorp.com/consul/docs/k8s/helm) are automatically
 generated from our `values.yaml` file.
 
 ### Generating Helm Reference Docs
- 
+
 To generate the docs and update the `helm.mdx` file:
 
 1. Fork `hashicorp/consul` (https://github.com/hashicorp/consul) on GitHub.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The `consul-k8s-control-plane` binary includes first-class integrations between 
 Kubernetes. The project encapsulates multiple use cases such as syncing
 services, injecting Consul sidecars, and more.
 The Kubernetes integrations with Consul are
-[documented directly on the Consul website](https://www.consul.io/docs/platform/k8s/index.html).
+[documented directly on the Consul website](https://developer.hashicorp.com/consul/docs/k8s).
 
 This README will present a basic overview of use cases and installing the Helm charts, but for full documentation please reference the Consul website.
 
@@ -26,12 +26,12 @@ you believe you have found a security issue in Consul K8s, _please responsibly d
 by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
 
 ## Features
-    
-  * [**Consul Service Mesh**](https://www.consul.io/docs/k8s/connect):
+
+  * [**Consul Service Mesh**](https://developer.hashicorp.com/consul/docs/k8s/connect):
     Run Consul Service Mesh on Kubernetes. This feature
     injects Envoy sidecars and registers your Pods with Consul.
-    
-  * [**Catalog Sync**](https://www.consul.io/docs/k8s/service-sync):
+
+  * [**Catalog Sync**](https://developer.hashicorp.com/consul/docs/k8s/service-sync):
     Sync Consul services into first-class Kubernetes services and vice versa.
     This enables Kubernetes to easily access external services and for
     non-Kubernetes nodes to easily discover and access Kubernetes services.
@@ -47,11 +47,11 @@ by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
 
   * A [Docker image `hashicorp/consul-k8s-control-plane`](https://hub.docker.com/r/hashicorp/consul-k8s-control-plane) is available. This can be used to manually run `consul-k8s-control-plane` within a scheduled environment.
 
-  * Consul K8s CLI, distributed as `consul-k8s`, can be used to install and uninstall Consul Kubernetes. See the [Consul K8s CLI Reference](https://www.consul.io/docs/k8s/k8s-cli) for more details on usage. 
+  * Consul K8s CLI, distributed as `consul-k8s`, can be used to install and uninstall Consul Kubernetes. See the [Consul K8s CLI Reference](https://developer.hashicorp.com/consul/docs/k8s/k8s-cli) for more details on usage.
 
 ### Prerequisites
 
-The following pre-requisites must be met before installing Consul on Kubernetes. 
+The following pre-requisites must be met before installing Consul on Kubernetes.
 
   * **Kubernetes 1.24.x - 1.27.x** - This represents the earliest versions of Kubernetes tested.
     It is possible that this chart works with earlier versions, but it is
@@ -89,14 +89,14 @@ for each subcommand.
 
 ### Helm
 
-The Helm chart is ideal for those who prefer to use Helm for automation for either the installation or upgrade of Consul on Kubernetes. The chart supports multiple use cases of Consul on Kubernetes, depending on the values provided. Detailed installation instructions for Consul on Kubernetes are found [here](https://www.consul.io/docs/k8s/installation/overview). 
+The Helm chart is ideal for those who prefer to use Helm for automation for either the installation or upgrade of Consul on Kubernetes. The chart supports multiple use cases of Consul on Kubernetes, depending on the values provided. Detailed installation instructions for Consul on Kubernetes are found [here](https://developer.hashicorp.com/consul/docs/k8s/installation/install).
 
 1. Add the HashiCorp Helm repository:
-   
+
     ``` bash
     helm repo add hashicorp https://helm.releases.hashicorp.com
     ```
-    
+
 2. Ensure you have access to the Consul Helm chart and you see the latest chart version listed. If you have previously added the 
    HashiCorp Helm repository, run `helm repo update`. 
 
@@ -112,9 +112,9 @@ The Helm chart is ideal for those who prefer to use Helm for automation for eith
 
 Please see the many options supported in the `values.yaml`
 file. These are also fully documented directly on the
-[Consul website](https://www.consul.io/docs/platform/k8s/helm.html).
+[Consul website](https://developer.hashicorp.com/consul/docs/k8s/helm).
 
 ## Tutorials
 
-You can find examples and complete tutorials on how to deploy Consul on 
+You can find examples and complete tutorials on how to deploy Consul on
 Kubernetes using Helm on the [HashiCorp Learn website](https://learn.hashicorp.com/collections/consul/kubernetes).

--- a/acceptance/framework/vault/helpers.go
+++ b/acceptance/framework/vault/helpers.go
@@ -203,7 +203,7 @@ func (config *KV2Secret) saveSecretAndAddPolicy(t *testing.T, vaultClient *vapi.
 // CreateConnectCARootAndIntermediatePKIPolicy creates the Vault Policy for the connect-ca in a given datacenter.
 func CreateConnectCARootAndIntermediatePKIPolicy(t *testing.T, vaultClient *vapi.Client, policyName, rootPath, intermediatePath string) {
 	// connectCAPolicy allows Consul to bootstrap all certificates for the service mesh in Vault.
-	// Adapted from https://www.consul.io/docs/connect/ca/vault#consul-managed-pki-paths.
+	// Adapted from https://developer.hashicorp.com/consul/docs/connect/ca/vault#consul-managed-pki-paths.
 	err := vaultClient.Sys().PutPolicy(
 		policyName,
 		fmt.Sprintf(`

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -26,7 +26,7 @@ annotations:
   artifacthub.io/license: MPL-2.0
   artifacthub.io/links: |
     - name: Documentation
-      url: https://www.consul.io/docs/k8s
+      url: https://developer.hashicorp.com/consul/docs/k8s
     - name: hashicorp/consul
       url: https://github.com/hashicorp/consul
     - name: hashicorp/consul-k8s

--- a/charts/consul/README.md
+++ b/charts/consul/README.md
@@ -15,12 +15,12 @@ you believe you have found a security issue in Consul K8s, _please responsibly d
 by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
 
 ## Features
-    
-  * [**Consul Service Mesh**](https://www.consul.io/docs/k8s/connect):
+
+  * [**Consul Service Mesh**](https://developer.hashicorp.com/consul/docs/k8s/connect):
     Run Consul Service Mesh on Kubernetes. This feature
     injects Envoy sidecars and registers your Pods with Consul.
-    
-  * [**Catalog Sync**](https://www.consul.io/docs/k8s/service-sync):
+
+  * [**Catalog Sync**](https://developer.hashicorp.com/consul/docs/k8s/service-sync):
     Sync Consul services into first-class Kubernetes services and vice versa.
     This enables Kubernetes to easily access external services and for
     non-Kubernetes nodes to easily discover and access Kubernetes services.
@@ -36,7 +36,7 @@ by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
 
   * A [Docker image `hashicorp/consul-k8s-control-plane`](https://hub.docker.com/r/hashicorp/consul-k8s-control-plane) is available. This can be used to manually run `consul-k8s-control-plane` within a scheduled environment.
 
-  * Consul K8s CLI, distributed as `consul-k8s`, can be used to install and uninstall Consul Kubernetes. See the [Consul K8s CLI Reference](https://www.consul.io/docs/k8s/k8s-cli) for more details on usage. 
+  * Consul K8s CLI, distributed as `consul-k8s`, can be used to install and uninstall Consul Kubernetes. See the [Consul K8s CLI Reference](https://developer.hashicorp.com/consul/docs/k8s/k8s-cli) for more details on usage.
 
 ### Prerequisites
 
@@ -78,7 +78,7 @@ for each subcommand.
 
 ### Helm
 
-The Helm chart is ideal for those who prefer to use Helm for automation for either the installation or upgrade of Consul on Kubernetes. The chart supports multiple use cases of Consul on Kubernetes, depending on the values provided. Detailed installation instructions for Consul on Kubernetes are found [here](https://www.consul.io/docs/k8s/installation/overview). 
+The Helm chart is ideal for those who prefer to use Helm for automation for either the installation or upgrade of Consul on Kubernetes. The chart supports multiple use cases of Consul on Kubernetes, depending on the values provided. Detailed installation instructions for Consul on Kubernetes are found [here](https://developer.hashicorp.com/consul/docs/k8s/installation/install).
 
 1. Add the HashiCorp Helm repository:
    
@@ -101,7 +101,7 @@ The Helm chart is ideal for those who prefer to use Helm for automation for eith
 
 Please see the many options supported in the `values.yaml`
 file. These are also fully documented directly on the
-[Consul website](https://www.consul.io/docs/platform/k8s/helm.html).
+[Consul website](https://developer.hashicorp.com/consul/docs/k8s/helm).
 
 ## Tutorials
 

--- a/charts/consul/templates/NOTES.txt
+++ b/charts/consul/templates/NOTES.txt
@@ -9,10 +9,10 @@ To learn more about the release, run:
   $ helm get all {{ .Release.Name }} {{- if .Release.Namespace }} --namespace {{ .Release.Namespace }}{{ end }}
 
 Consul on Kubernetes Documentation:
-https://www.consul.io/docs/platform/k8s
+https://developer.hashicorp.com/consul/docs/k8s
 
 Consul on Kubernetes CLI Reference:
-https://www.consul.io/docs/k8s/k8s-cli
+https://developer.hashicorp.com/consul/docs/k8s/k8s-cli
 
 {{- if (and .Values.global.acls.manageSystemACLs (gt (len .Values.server.extraConfig) 3)) }}
 Warning: Defining server extraConfig potentially disrupts the automatic ACL

--- a/charts/consul/templates/crd-proxydefaults.yaml
+++ b/charts/consul/templates/crd-proxydefaults.yaml
@@ -92,7 +92,7 @@ spec:
               config:
                 description: Config is an arbitrary map of configuration values used
                   by Connect proxies. Any values that your proxy allows can be configured
-                  globally here. Supports JSON config values. See https://www.consul.io/docs/connect/proxies/envoy#configuration-formatting
+                  globally here. Supports JSON config values. See https://developer.hashicorp.com/consul/docs/connect/proxies/envoy#configuration-formatting
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               envoyExtensions:

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.meshGateway.enabled }}
 {{- if not .Values.connectInject.enabled }}{{ fail "connectInject.enabled must be true" }}{{ end -}}
 {{- if and .Values.global.acls.manageSystemACLs (ne .Values.meshGateway.consulServiceName "") (ne .Values.meshGateway.consulServiceName "mesh-gateway") }}{{ fail "if global.acls.manageSystemACLs is true, meshGateway.consulServiceName cannot be set" }}{{ end -}}
-{{- if .Values.meshGateway.globalMode }}{{ fail "meshGateway.globalMode is no longer supported; instead, you must migrate to CRDs (see www.consul.io/docs/k8s/crds/upgrade-to-crds)" }}{{ end -}}
+{{- if .Values.meshGateway.globalMode }}{{ fail "meshGateway.globalMode is no longer supported; instead, you must migrate to CRDs (see https://developer.hashicorp.com/consul/docs/k8s/crds/upgrade-to-crds)" }}{{ end -}}
 {{- if and .Values.global.adminPartitions.enabled (not .Values.global.enableConsulNamespaces) }}{{ fail "global.enableConsulNamespaces must be true if global.adminPartitions.enabled=true" }}{{ end }}
 {{- if and (eq .Values.meshGateway.wanAddress.source "Static") (eq .Values.meshGateway.wanAddress.static "") }}{{ fail "if meshGateway.wanAddress.source=Static then meshGateway.wanAddress.static cannot be empty" }}{{ end }}
 {{- if and (eq .Values.meshGateway.wanAddress.source "Service") (eq .Values.meshGateway.service.type "NodePort") (not .Values.meshGateway.service.nodePort) }}{{ fail "if meshGateway.wanAddress.source=Service and meshGateway.service.type=NodePort, meshGateway.service.nodePort must be set" }}{{ end }}

--- a/charts/consul/test/unit/mesh-gateway-deployment.bats
+++ b/charts/consul/test/unit/mesh-gateway-deployment.bats
@@ -1133,7 +1133,7 @@ key2: value2' \
       --set 'connectInject.enabled=true' \
       --set 'meshGateway.globalMode=something' .
   [ "$status" -eq 1 ]
-  [[ "$output" =~ "meshGateway.globalMode is no longer supported; instead, you must migrate to CRDs (see www.consul.io/docs/k8s/crds/upgrade-to-crds)" ]]
+  [[ "$output" =~ "meshGateway.globalMode is no longer supported; instead, you must migrate to CRDs (see https://developer.hashicorp.com/consul/docs/k8s/crds/upgrade-to-crds)" ]]
 }
 
 #--------------------------------------------------------------------

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -520,7 +520,7 @@ func (c *Command) checkForPreviousSecrets(release release.Release) (string, erro
 			return fmt.Sprintf("Found secret %s for Consul federation.", fedSecret), nil
 		} else if len(secrets.Items) == 0 {
 			return "", fmt.Errorf("Missing secret %s for Consul federation.\n"+
-				"Please refer to the Consul Secondary Cluster configuration docs:\nhttps://www.consul.io/docs/k8s/installation/multi-cluster/kubernetes#secondary-cluster-s", fedSecret)
+				"Please refer to the Consul Secondary Cluster configuration docs:\nhttps://developer.hashicorp.com/consul/docs/k8s/deployment-configurations/multi-cluster/kubernetes#secondary-cluster-s", fedSecret)
 		}
 	}
 

--- a/control-plane/api/v1alpha1/proxydefaults_types.go
+++ b/control-plane/api/v1alpha1/proxydefaults_types.go
@@ -80,7 +80,7 @@ type ProxyDefaultsSpec struct {
 	MutualTLSMode MutualTLSMode `json:"mutualTLSMode,omitempty"`
 	// Config is an arbitrary map of configuration values used by Connect proxies.
 	// Any values that your proxy allows can be configured globally here.
-	// Supports JSON config values. See https://www.consul.io/docs/connect/proxies/envoy#configuration-formatting
+	// Supports JSON config values. See https://developer.hashicorp.com/consul/docs/connect/proxies/envoy#configuration-formatting
 	// +kubebuilder:validation:Type=object
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields

--- a/control-plane/config/crd/bases/consul.hashicorp.com_proxydefaults.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_proxydefaults.yaml
@@ -88,7 +88,7 @@ spec:
               config:
                 description: Config is an arbitrary map of configuration values used
                   by Connect proxies. Any values that your proxy allows can be configured
-                  globally here. Supports JSON config values. See https://www.consul.io/docs/connect/proxies/envoy#configuration-formatting
+                  globally here. Supports JSON config values. See https://developer.hashicorp.com/consul/docs/connect/proxies/envoy#configuration-formatting
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               envoyExtensions:

--- a/control-plane/subcommand/common/common.go
+++ b/control-plane/subcommand/common/common.go
@@ -164,7 +164,7 @@ func ConsulLogin(client *api.Client, params LoginParams, log hclog.Logger) (stri
 	//
 	// A consul client may reach out to a follower instead of a leader to resolve the token for an API call
 	// with that token. This is because clients talk to servers in the stale consistency mode
-	// to decrease the load on the servers (see https://www.consul.io/docs/architecture/consensus#stale).
+	// to decrease the load on the servers (see https://developer.hashicorp.com/consul/docs/architecture/consensus#stale).
 	// In that case, it's possible that the token isn't replicated
 	// to that server instance yet. The client will then get an "ACL not found" error
 	// and subsequently cache this not found response. Then on any API call with the token,
@@ -175,7 +175,7 @@ func ConsulLogin(client *api.Client, params LoginParams, log hclog.Logger) (stri
 	//
 	// To help with that, we try to first read the token in the stale consistency mode until we
 	// get a successful response. This should not take more than 100ms because raft replication
-	// should in most cases take less than that (see https://www.consul.io/docs/install/performance#read-write-tuning)
+	// should in most cases take less than that (see https://developer.hashicorp.com/consul/docs/install/performance#read-write-tuning)
 	// but we set the timeout to 2s to be sure.
 	//
 	// Note though that this workaround does not eliminate this problem completely. It's still possible

--- a/hack/helm-reference-gen/fixtures/full-values.golden
+++ b/hack/helm-reference-gen/fixtures/full-values.golden
@@ -32,7 +32,7 @@ Use these links to navigate to a particular top-level stanza.
     the prefix will be `<helm release name>-consul`.
 
   - `domain` ((#v-global-domain)) (`string: consul`) - The domain Consul will answer DNS queries for
-    (see `-domain` (https://consul.io/docs/agent/options#_domain)) and the domain services synced from
+    (see `-domain` (https://developer.hashicorp.com/consul/docs/agent/config/config-files#_domain)) and the domain services synced from
     Consul into Kubernetes will have, e.g. `service-name.service.consul`.
 
   - `image` ((#v-global-image)) (`string: hashicorp/consul:1.9.0`) - The name (and tag) of the Consul Docker image for clients and servers.
@@ -121,7 +121,7 @@ Use these links to navigate to a particular top-level stanza.
     - `verify` ((#v-global-tls-verify)) (`boolean: true`) - If true, `verify_outgoing`, `verify_server_hostname`,
       and `verify_incoming_rpc` will be set to `true` for Consul servers and clients.
       Set this to false to incrementally roll out TLS on an existing Consul cluster.
-      Please see https://consul.io/docs/k8s/operations/tls-on-existing-cluster
+      Please see https://developer.hashicorp.com/consul/docs/k8s/operations/tls-on-existing-cluster
       for more details.
 
     - `httpsOnly` ((#v-global-tls-httpsonly)) (`boolean: true`) - If true, the Helm chart will configure Consul to disable the HTTP port on
@@ -259,7 +259,7 @@ Use these links to navigate to a particular top-level stanza.
     Consul server agents.
 
   - `replicas` ((#v-server-replicas)) (`integer: 3`) - The number of server agents to run. This determines the fault tolerance of
-    the cluster. Please see the deployment table (https://consul.io/docs/internals/consensus#deployment-table)
+    the cluster. Please see the deployment table (https://developer.hashicorp.com/consul/docs/architecture/consensus#deployment-table)
     for more information.
 
   - `bootstrapExpect` ((#v-server-bootstrapexpect)) (`integer: 3`) - For new clusters, this is the number of servers to wait for before performing
@@ -346,7 +346,7 @@ Use these links to navigate to a particular top-level stanza.
       --set 'server.disruptionBudget.maxUnavailable=0'` flag to the helm chart installation
       command because of a limitation in the Helm templating language.
 
-  - `extraConfig` ((#v-server-extraconfig)) (`string: {}`) - A raw string of extra JSON configuration (https://consul.io/docs/agent/options) for Consul
+  - `extraConfig` ((#v-server-extraconfig)) (`string: {}`) - A raw string of extra JSON configuration (https://developer.hashicorp.com/consul/docs/agent/config/config-files) for Consul
     servers. This will be saved as-is into a ConfigMap that is read by the Consul
     server agents. This can be used to add additional configuration that
     isn't directly exposed by the chart.
@@ -514,7 +514,7 @@ Use these links to navigate to a particular top-level stanza.
   - `image` ((#v-client-image)) (`string: null`) - The name of the Docker image (including any tag) for the containers
     running Consul client agents.
 
-  - `join` ((#v-client-join)) (`array<string>: null`) - A list of valid `-retry-join` values (https://consul.io/docs/agent/options#retry-join).
+  - `join` ((#v-client-join)) (`array<string>: null`) - A list of valid `-retry-join` values (https://developer.hashicorp.com/consul/docs/agent/config/config-files#retry_join).
     If this is `null` (default), then the clients will attempt to automatically
     join the server cluster running within Kubernetes.
     This means that with `server.enabled` set to true, clients will automatically
@@ -555,7 +555,7 @@ Use these links to navigate to a particular top-level stanza.
 
       - `cpu` ((#v-client-resources-limits-cpu)) (`string: 100m`)
 
-  - `extraConfig` ((#v-client-extraconfig)) (`string: {}`) - A raw string of extra JSON configuration (https://consul.io/docs/agent/options) for Consul
+  - `extraConfig` ((#v-client-extraconfig)) (`string: {}`) - A raw string of extra JSON configuration (https://developer.hashicorp.com/consul/docs/agent/config/config-files) for Consul
     clients. This will be saved as-is into a ConfigMap that is read by the Consul
     client agents. This can be used to add additional configuration that
     isn't directly exposed by the chart.

--- a/hack/helm-reference-gen/fixtures/full-values.golden
+++ b/hack/helm-reference-gen/fixtures/full-values.golden
@@ -237,7 +237,7 @@ Use these links to navigate to a particular top-level stanza.
 
   - `imageEnvoy` ((#v-global-imageenvoy)) (`string: envoyproxy/envoy-alpine:v1.16.0`) - The name (and tag) of the Envoy Docker image used for the
     connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
-    See https://www.consul.io/docs/connect/proxies/envoy for full compatibility matrix between Consul and Envoy.
+    See https://developer.hashicorp.com/consul/docs/connect/proxies/envoy for full compatibility matrix between Consul and Envoy.
 
   - `openshift` ((#v-global-openshift)) - Configuration for running this Helm chart on the Red Hat OpenShift platform.
     This Helm chart currently supports OpenShift v4.x+.
@@ -1093,8 +1093,8 @@ Use these links to navigate to a particular top-level stanza.
     If set to an empty string all service accounts can log in.
     This only has effect if ACLs are enabled.
 
-    See https://www.consul.io/docs/acl/acl-auth-methods.html#binding-rules
-    and https://www.consul.io/docs/acl/auth-methods/kubernetes.html#trusted-identity-attributes
+    See https://developer.hashicorp.com/consul/docs/security/acl/auth-methods#binding-rules
+    and https://developer.hashicorp.com/consul/docs/security/acl/auth-methods/kubernetes#trusted-identity-attributes
     for more details.
     Requires Consul >= v1.5 and consul-k8s >= v0.8.0.
 
@@ -1116,7 +1116,7 @@ Use these links to navigate to a particular top-level stanza.
   - `centralConfig` ((#v-connectinject-centralconfig)) - Requires Consul >= v1.5 and consul-k8s >= v0.8.1.
 
     - `enabled` ((#v-connectinject-centralconfig-enabled)) (`boolean: true`) - enabled controls whether central config is enabled on all servers and clients.
-      See https://www.consul.io/docs/agent/options.html#enable_central_service_config.
+      See https://developer.hashicorp.com/consul/docs/agent/config/config-files#enable_central_service_config.
       If changing this after installation, servers and clients must be restarted
       for the change to take effect.
 
@@ -1127,7 +1127,7 @@ Use these links to navigate to a particular top-level stanza.
 
     - `proxyDefaults` ((#v-connectinject-centralconfig-proxydefaults)) (`string: {}`) - proxyDefaults is a raw json string that will be written as the value of
       the "config" key of the global proxy-defaults config entry.
-      See: https://www.consul.io/docs/agent/config-entries/proxy-defaults.html
+      See: https://developer.hashicorp.com/consul/docs/connect/config-entries/proxy-defaults
       NOTE: Changes to this value after the chart is first installed have *no*
       effect. In order to change the proxy-defaults config after installation,
       you must use the Consul API.
@@ -1211,13 +1211,13 @@ Use these links to navigate to a particular top-level stanza.
 
   - `enabled` ((#v-meshgateway-enabled)) (`boolean: false`) - If mesh gateways are enabled, a Deployment will be created that runs
     gateways and Consul Connect will be configured to use gateways.
-    See https://www.consul.io/docs/connect/mesh_gateway.html
+    See https://developer.hashicorp.com/consul/docs/connect/gateways/mesh-gateway
     Requirements: consul 1.6.0+ and consul-k8s 0.15.0+ if using
     global.acls.manageSystemACLs.
 
   - `globalMode` ((#v-meshgateway-globalmode)) (`string: local`) - Globally configure which mode the gateway should run in.
     Can be set to either "remote", "local", "none" or empty string or null.
-    See https://consul.io/docs/connect/mesh_gateway.html#modes-of-operation for
+    See https://developer.hashicorp.com/consul/docs/connect/gateways/mesh-gateway#modes for
     a description of each mode.
     If set to anything other than "" or null, connectInject.centralConfig.enabled
     should be set to true so that the global config will actually be used.

--- a/hack/helm-reference-gen/fixtures/full-values.yaml
+++ b/hack/helm-reference-gen/fixtures/full-values.yaml
@@ -18,7 +18,7 @@ global:
   name: null
 
   # The domain Consul will answer DNS queries for
-  # (see `-domain` (https://consul.io/docs/agent/options#_domain)) and the domain services synced from
+  # (see `-domain` (https://developer.hashicorp.com/consul/docs/agent/config/config-files#_domain)) and the domain services synced from
   # Consul into Kubernetes will have, e.g. `service-name.service.consul`.
   domain: consul
 
@@ -121,7 +121,7 @@ global:
     # If true, `verify_outgoing`, `verify_server_hostname`,
     # and `verify_incoming_rpc` will be set to `true` for Consul servers and clients.
     # Set this to false to incrementally roll out TLS on an existing Consul cluster.
-    # Please see https://consul.io/docs/k8s/operations/tls-on-existing-cluster
+    # Please see https://developer.hashicorp.com/consul/docs/k8s/operations/tls-on-existing-cluster
     # for more details.
     verify: true
 
@@ -271,7 +271,7 @@ server:
   image: null
 
   # The number of server agents to run. This determines the fault tolerance of
-  # the cluster. Please see the deployment table (https://consul.io/docs/internals/consensus#deployment-table)
+  # the cluster. Please see the deployment table (https://developer.hashicorp.com/consul/docs/architecture/consensus#deployment-table)
   # for more information.
   replicas: 3
 
@@ -364,7 +364,7 @@ server:
     # @type: integer
     maxUnavailable: null
 
-  # A raw string of extra JSON configuration (https://consul.io/docs/agent/options) for Consul
+  # A raw string of extra JSON configuration (https://developer.hashicorp.com/consul/docs/agent/config/config-files) for Consul
   # servers. This will be saved as-is into a ConfigMap that is read by the Consul
   # server agents. This can be used to add additional configuration that
   # isn't directly exposed by the chart.
@@ -573,7 +573,7 @@ client:
   # @type: string
   image: null
 
-  # A list of valid `-retry-join` values (https://consul.io/docs/agent/options#retry-join).
+  # A list of valid `-retry-join` values (https://developer.hashicorp.com/consul/docs/agent/config/config-files#retry_join).
   # If this is `null` (default), then the clients will attempt to automatically
   # join the server cluster running within Kubernetes.
   # This means that with `server.enabled` set to true, clients will automatically
@@ -615,7 +615,7 @@ client:
       memory: "100Mi"
       cpu: "100m"
 
-  # A raw string of extra JSON configuration (https://consul.io/docs/agent/options) for Consul
+  # A raw string of extra JSON configuration (https://developer.hashicorp.com/consul/docs/agent/config/config-files) for Consul
   # clients. This will be saved as-is into a ConfigMap that is read by the Consul
   # client agents. This can be used to add additional configuration that
   # isn't directly exposed by the chart.

--- a/hack/helm-reference-gen/fixtures/full-values.yaml
+++ b/hack/helm-reference-gen/fixtures/full-values.yaml
@@ -243,7 +243,7 @@ global:
 
   # The name (and tag) of the Envoy Docker image used for the
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
-  # See https://www.consul.io/docs/connect/proxies/envoy for full compatibility matrix between Consul and Envoy.
+  # See https://developer.hashicorp.com/consul/docs/connect/proxies/envoy for full compatibility matrix between Consul and Envoy.
   imageEnvoy: "envoyproxy/envoy-alpine:v1.16.0"
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
@@ -1239,8 +1239,8 @@ connectInject:
   # If set to an empty string all service accounts can log in.
   # This only has effect if ACLs are enabled.
   #
-  # See https://www.consul.io/docs/acl/acl-auth-methods.html#binding-rules
-  # and https://www.consul.io/docs/acl/auth-methods/kubernetes.html#trusted-identity-attributes
+  # See https://developer.hashicorp.com/consul/docs/security/acl/auth-methods#binding-rules
+  # and https://developer.hashicorp.com/consul/docs/security/acl/auth-methods/kubernetes#trusted-identity-attributes
   # for more details.
   # Requires Consul >= v1.5 and consul-k8s >= v0.8.0.
   aclBindingRuleSelector: "serviceaccount.name!=default"
@@ -1263,7 +1263,7 @@ connectInject:
   # Requires Consul >= v1.5 and consul-k8s >= v0.8.1.
   centralConfig:
     # enabled controls whether central config is enabled on all servers and clients.
-    # See https://www.consul.io/docs/agent/options.html#enable_central_service_config.
+    # See https://developer.hashicorp.com/consul/docs/agent/config/config-files#enable_central_service_config.
     # If changing this after installation, servers and clients must be restarted
     # for the change to take effect.
     enabled: true
@@ -1277,7 +1277,7 @@ connectInject:
 
     # proxyDefaults is a raw json string that will be written as the value of
     # the "config" key of the global proxy-defaults config entry.
-    # See: https://www.consul.io/docs/agent/config-entries/proxy-defaults.html
+    # See: https://developer.hashicorp.com/consul/docs/connect/config-entries/proxy-defaults
     # NOTE: Changes to this value after the chart is first installed have *no*
     # effect. In order to change the proxy-defaults config after installation,
     # you must use the Consul API.
@@ -1357,14 +1357,14 @@ controller:
 meshGateway:
   # If mesh gateways are enabled, a Deployment will be created that runs
   # gateways and Consul Connect will be configured to use gateways.
-  # See https://www.consul.io/docs/connect/mesh_gateway.html
+  # See https://developer.hashicorp.com/consul/docs/connect/gateways/mesh-gateway
   # Requirements: consul 1.6.0+ and consul-k8s 0.15.0+ if using
   # global.acls.manageSystemACLs.
   enabled: false
 
   # Globally configure which mode the gateway should run in.
   # Can be set to either "remote", "local", "none" or empty string or null.
-  # See https://consul.io/docs/connect/mesh_gateway.html#modes-of-operation for
+  # See https://developer.hashicorp.com/consul/docs/connect/gateways/mesh-gateway#modes for
   # a description of each mode.
   # If set to anything other than "" or null, connectInject.centralConfig.enabled
   # should be set to true so that the global config will actually be used.


### PR DESCRIPTION
Changes proposed in this PR:

Update outdated consul.io links that now redirect to https://developer.hashicorp.com/consul/docs and https://developer.hashicorp.com/consul/api-docs

How I've tested this PR: 

NA, documentation update

How I expect reviewers to test this PR:

NA, documentation update


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


