### PR TITLE
Increase timeout while waiting for vault server to be ready

### DIFF
--- a/acceptance/framework/vault/vault_cluster.go
+++ b/acceptance/framework/vault/vault_cluster.go
@@ -414,12 +414,12 @@ func (v *VaultCluster) initAndUnseal(t *testing.T) {
 
 	v.logger.Logf(t, "initializing and unsealing Vault")
 	namespace := v.helmOptions.KubectlOptions.Namespace
-	retrier := &retry.Timer{Timeout: 2 * time.Minute, Wait: 1 * time.Second}
+	retrier := &retry.Timer{Timeout: 4 * time.Minute, Wait: 1 * time.Second}
 	retry.RunWith(retrier, t, func(r *retry.R) {
 		// Wait for vault server pod to be running so that we can create Vault client without errors.
 		serverPod, err := v.kubernetesClient.CoreV1().Pods(namespace).Get(context.Background(), fmt.Sprintf("%s-vault-0", v.releaseName), metav1.GetOptions{})
 		require.NoError(r, err)
-		require.Equal(r, serverPod.Status.Phase, corev1.PodRunning)
+		require.Equal(r, corev1.PodRunning, serverPod.Status.Phase)
 
 		// Set up the client so that we can make API calls to initialize and unseal.
 		v.vaultClient = v.SetupVaultClient(t)


### PR DESCRIPTION

Changes proposed in this PR:
- Increase the timeout when waiting for the vault server to be started
- Also, the error was backwards so fix the argument order for the pod status check.

How I've tested this PR:
  
- Ran CI 
  
How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


