### PR TITLE
NET-4413 Implement translation + validation of TLS options

### DIFF
--- a/.changelog/2711.txt
+++ b/.changelog/2711.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+api-gateway: validate TLS configuration options, including min/max version and cipher suites, and set Gateway status appropriately
+```

--- a/.changelog/2711.txt
+++ b/.changelog/2711.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-api-gateway: validate TLS configuration options, including min/max version and cipher suites, and set Gateway status appropriately
+api-gateway: translate and validate TLS configuration options, including min/max version and cipher suites, setting Gateway status appropriately
 ```

--- a/control-plane/api-gateway/binding/result.go
+++ b/control-plane/api-gateway/binding/result.go
@@ -241,7 +241,11 @@ var (
 	// Below is where any custom generic listener validation errors should go.
 	// We map anything under here to a custom ListenerConditionReason of Invalid on
 	// an Accepted status type.
-	errListenerNoTLSPassthrough = errors.New("TLS passthrough is not supported")
+	errListenerNoTLSPassthrough              = errors.New("TLS passthrough is not supported")
+	errListenerTLSCipherSuiteNotConfigurable = errors.New("tls_min_version does not allow tls_cipher_suites configuration")
+	errListenerUnsupportedTLSCipherSuite     = errors.New("unsupported cipher suite in tls_cipher_suites")
+	errListenerUnsupportedTLSMaxVersion      = errors.New("unsupported tls_max_version")
+	errListenerUnsupportedTLSMinVersion      = errors.New("unsupported tls_min_version")
 
 	// This custom listener validation error is used to differentiate between an errListenerPortUnavailable because of
 	// direct port conflicts defined by the user (two listeners on the same port) vs a port conflict because we map

--- a/control-plane/api-gateway/binding/validation.go
+++ b/control-plane/api-gateway/binding/validation.go
@@ -83,6 +83,12 @@ var (
 	}
 )
 
+const (
+	tlsCipherSuitesAnnotationKey = "api-gateway.consul.hashicorp.com/tls_cipher_suites"
+	tlsMaxVersionAnnotationKey = "api-gateway.consul.hashicorp.com/tls_max_version"
+	tlsMinVersionAnnotationKey = "api-gateway.consul.hashicorp.com/tls_min_version"
+)
+
 // validateRefs validates backend references for a route, determining whether or
 // not they were found in the list of known connect-injected services.
 func validateRefs(route client.Object, refs []gwv1beta1.BackendRef, resources *common.ResourceMap) routeValidationResults {
@@ -261,22 +267,21 @@ func validateTLSOptions(options map[gwv1beta1.AnnotationKey]gwv1beta1.Annotation
 		return nil
 	}
 
-	// TODO Use constants for annotation keys
-	tlsMinVersionValue := string(options["api-gateway.consul.hashicorp.com/tls_min_version"])
+	tlsMinVersionValue := string(options[tlsMinVersionAnnotationKey])
 	if tlsMinVersionValue != "" {
 		if _, supported := allSupportedTLSVersions[tlsMinVersionValue]; !supported {
 			return errors.New("unsupported tls_min_version")
 		}
 	}
 
-	tlsMaxVersionValue := string(options["api-gateway.consul.hashicorp.com/tls_max_version"])
+	tlsMaxVersionValue := string(options[tlsMaxVersionAnnotationKey])
 	if tlsMaxVersionValue != "" {
 		if _, supported := allSupportedTLSVersions[tlsMaxVersionValue]; !supported {
 			return errors.New("unsupported tls_max_version")
 		}
 	}
 
-	tlsCipherSuitesValue := string(options["api-gateway.consul.hashicorp.com/tls_cipher_suites"])
+	tlsCipherSuitesValue := string(options[tlsCipherSuitesAnnotationKey])
 	if tlsCipherSuitesValue != "" {
 		// If a minimum TLS version is configured, verify that it supports configuring cipher suites
 		if tlsMinVersionValue != "" {

--- a/control-plane/api-gateway/binding/validation.go
+++ b/control-plane/api-gateway/binding/validation.go
@@ -83,12 +83,6 @@ var (
 	}
 )
 
-const (
-	tlsCipherSuitesAnnotationKey = "api-gateway.consul.hashicorp.com/tls_cipher_suites"
-	tlsMaxVersionAnnotationKey = "api-gateway.consul.hashicorp.com/tls_max_version"
-	tlsMinVersionAnnotationKey = "api-gateway.consul.hashicorp.com/tls_min_version"
-)
-
 // validateRefs validates backend references for a route, determining whether or
 // not they were found in the list of known connect-injected services.
 func validateRefs(route client.Object, refs []gwv1beta1.BackendRef, resources *common.ResourceMap) routeValidationResults {
@@ -267,21 +261,21 @@ func validateTLSOptions(options map[gwv1beta1.AnnotationKey]gwv1beta1.Annotation
 		return nil
 	}
 
-	tlsMinVersionValue := string(options[tlsMinVersionAnnotationKey])
+	tlsMinVersionValue := string(options[common.TLSMinVersionAnnotationKey])
 	if tlsMinVersionValue != "" {
 		if _, supported := allSupportedTLSVersions[tlsMinVersionValue]; !supported {
 			return errors.New("unsupported tls_min_version")
 		}
 	}
 
-	tlsMaxVersionValue := string(options[tlsMaxVersionAnnotationKey])
+	tlsMaxVersionValue := string(options[common.TLSMaxVersionAnnotationKey])
 	if tlsMaxVersionValue != "" {
 		if _, supported := allSupportedTLSVersions[tlsMaxVersionValue]; !supported {
 			return errors.New("unsupported tls_max_version")
 		}
 	}
 
-	tlsCipherSuitesValue := string(options[tlsCipherSuitesAnnotationKey])
+	tlsCipherSuitesValue := string(options[common.TLSCipherSuitesAnnotationKey])
 	if tlsCipherSuitesValue != "" {
 		// If a minimum TLS version is configured, verify that it supports configuring cipher suites
 		if tlsMinVersionValue != "" {

--- a/control-plane/api-gateway/binding/validation.go
+++ b/control-plane/api-gateway/binding/validation.go
@@ -51,7 +51,7 @@ var (
 	}
 
 	allTLSVersionsWithConfigurableCipherSuites = map[string]struct{}{
-		// Remove these two if Envoy ever sets TLS 1.3 as default minimum
+		// Remove "" and "TLS_AUTO" if Envoy ever sets TLS 1.3 as default minimum
 		"":         {},
 		"TLS_AUTO": {},
 		"TLSv1_0":  {},

--- a/control-plane/api-gateway/binding/validation.go
+++ b/control-plane/api-gateway/binding/validation.go
@@ -4,6 +4,7 @@
 package binding
 
 import (
+	"errors"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -40,6 +41,45 @@ var (
 	allSupportedRouteKinds = map[gwv1beta1.Kind]struct{}{
 		gwv1beta1.Kind("HTTPRoute"): {},
 		gwv1beta1.Kind("TCPRoute"):  {},
+	}
+
+	allSupportedTLSVersions = map[string]struct{}{
+		"TLS_AUTO": {},
+		"TLSv1_0":  {},
+		"TLSv1_1":  {},
+		"TLSv1_2":  {},
+		"TLSv1_3":  {},
+	}
+
+	allTLSVersionsWithConfigurableCipherSuites = map[string]struct{}{
+		// Remove these two if Envoy ever sets TLS 1.3 as default minimum
+		"":         {},
+		"TLS_AUTO": {},
+		"TLSv1_0":  {},
+		"TLSv1_1":  {},
+		"TLSv1_2":  {},
+	}
+
+	allSupportedTLSCipherSuites = map[string]struct{}{
+		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256":       {},
+		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256": {},
+		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":         {},
+		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256":   {},
+		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384":       {},
+		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":         {},
+
+		// NOTE: the following cipher suites are currently supported by Envoy
+		// but have been identified as insecure and are pending removal
+		// https://github.com/envoyproxy/envoy/issues/5399
+		"TLS_RSA_WITH_AES_128_GCM_SHA256": {},
+		"TLS_RSA_WITH_AES_128_CBC_SHA":    {},
+		"TLS_RSA_WITH_AES_256_GCM_SHA384": {},
+		"TLS_RSA_WITH_AES_256_CBC_SHA":    {},
+		// https://github.com/envoyproxy/envoy/issues/5400
+		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA": {},
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":   {},
+		"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA": {},
+		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":   {},
 	}
 )
 
@@ -167,43 +207,93 @@ func (m mergedListeners) validateHostname(index int, listener gwv1beta1.Listener
 // validateTLS validates that the TLS configuration for a given listener is valid and that
 // the certificates that it references exist.
 func validateTLS(gateway gwv1beta1.Gateway, tls *gwv1beta1.GatewayTLSConfig, resources *common.ResourceMap) (error, error) {
-	namespace := gateway.Namespace
-
+	// If there's no TLS, there's nothing to validate
 	if tls == nil {
 		return nil, nil
 	}
 
-	var err error
-
-	for _, cert := range tls.CertificateRefs {
-		// break on the first error
-		if !common.NilOrEqual(cert.Group, "") || !common.NilOrEqual(cert.Kind, common.KindSecret) {
-			err = errListenerInvalidCertificateRef_NotSupported
-			break
-		}
-
-		if !resources.GatewayCanReferenceSecret(gateway, cert) {
-			err = errRefNotPermitted
-			break
-		}
-
-		key := common.IndexedNamespacedNameWithDefault(cert.Name, cert.Namespace, namespace)
-		secret := resources.Certificate(key)
-
-		if secret == nil {
-			err = errListenerInvalidCertificateRef_NotFound
-			break
-		}
-
-		err = validateCertificateData(*secret)
-	}
+	// Validate the certificate references and then return any error
+	// alongside any TLS configuration error that we find below.
+	refsErr := validateCertificateRefs(gateway, tls.CertificateRefs, resources)
 
 	if tls.Mode != nil && *tls.Mode == gwv1beta1.TLSModePassthrough {
-		return errListenerNoTLSPassthrough, err
+		return errListenerNoTLSPassthrough, refsErr
 	}
 
-	// TODO: validate tls options
-	return nil, err
+	if err := validateTLSOptions(tls.Options); err != nil {
+		return err, refsErr
+	}
+
+	return nil, refsErr
+}
+
+func validateCertificateRefs(gateway gwv1beta1.Gateway, refs []gwv1beta1.SecretObjectReference, resources *common.ResourceMap) error {
+	for _, cert := range refs {
+		// Verify that the reference has a group and kind that we support
+		if !common.NilOrEqual(cert.Group, "") || !common.NilOrEqual(cert.Kind, common.KindSecret) {
+			return errListenerInvalidCertificateRef_NotSupported
+		}
+
+		// Verify that the reference is within the namespace or,
+		// if cross-namespace, that it's allowed by a ReferenceGrant
+		if !resources.GatewayCanReferenceSecret(gateway, cert) {
+			return errRefNotPermitted
+		}
+
+		// Verify that the referenced resource actually exists
+		key := common.IndexedNamespacedNameWithDefault(cert.Name, cert.Namespace, gateway.Namespace)
+		secret := resources.Certificate(key)
+		if secret == nil {
+			return errListenerInvalidCertificateRef_NotFound
+		}
+
+		// Verify that the referenced resource contains the data shape that we expect
+		if err := validateCertificateData(*secret); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateTLSOptions(options map[gwv1beta1.AnnotationKey]gwv1beta1.AnnotationValue) error {
+	if options == nil {
+		return nil
+	}
+
+	// TODO Use constants for annotation keys
+	tlsMinVersionValue := string(options["api-gateway.consul.hashicorp.com/tls_min_version"])
+	if tlsMinVersionValue != "" {
+		if _, supported := allSupportedTLSVersions[tlsMinVersionValue]; !supported {
+			return errors.New("unsupported tls_min_version")
+		}
+	}
+
+	tlsMaxVersionValue := string(options["api-gateway.consul.hashicorp.com/tls_max_version"])
+	if tlsMaxVersionValue != "" {
+		if _, supported := allSupportedTLSVersions[tlsMaxVersionValue]; !supported {
+			return errors.New("unsupported tls_max_version")
+		}
+	}
+
+	tlsCipherSuitesValue := string(options["api-gateway.consul.hashicorp.com/tls_cipher_suites"])
+	if tlsCipherSuitesValue != "" {
+		// If a minimum TLS version is configured, verify that it supports configuring cipher suites
+		if tlsMinVersionValue != "" {
+			if _, supported := allTLSVersionsWithConfigurableCipherSuites[tlsMinVersionValue]; !supported {
+				return errors.New("tls_min_version does not allow tls_cipher_suites configuration")
+			}
+		}
+
+		for _, tlsCipherSuiteValue := range strings.Split(tlsCipherSuitesValue, ",") {
+			tlsCipherSuite := strings.TrimSpace(tlsCipherSuiteValue)
+			if _, supported := allSupportedTLSCipherSuites[tlsCipherSuite]; !supported {
+				return errors.New("unsupported cipher suite in tls_cipher_suites")
+			}
+		}
+	}
+
+	return nil
 }
 
 func validateCertificateData(secret corev1.Secret) error {

--- a/control-plane/api-gateway/binding/validation.go
+++ b/control-plane/api-gateway/binding/validation.go
@@ -4,7 +4,6 @@
 package binding
 
 import (
-	"errors"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -264,14 +263,14 @@ func validateTLSOptions(options map[gwv1beta1.AnnotationKey]gwv1beta1.Annotation
 	tlsMinVersionValue := string(options[common.TLSMinVersionAnnotationKey])
 	if tlsMinVersionValue != "" {
 		if _, supported := allSupportedTLSVersions[tlsMinVersionValue]; !supported {
-			return errors.New("unsupported tls_min_version")
+			return errListenerUnsupportedTLSMinVersion
 		}
 	}
 
 	tlsMaxVersionValue := string(options[common.TLSMaxVersionAnnotationKey])
 	if tlsMaxVersionValue != "" {
 		if _, supported := allSupportedTLSVersions[tlsMaxVersionValue]; !supported {
-			return errors.New("unsupported tls_max_version")
+			return errListenerUnsupportedTLSMaxVersion
 		}
 	}
 
@@ -280,14 +279,14 @@ func validateTLSOptions(options map[gwv1beta1.AnnotationKey]gwv1beta1.Annotation
 		// If a minimum TLS version is configured, verify that it supports configuring cipher suites
 		if tlsMinVersionValue != "" {
 			if _, supported := allTLSVersionsWithConfigurableCipherSuites[tlsMinVersionValue]; !supported {
-				return errors.New("tls_min_version does not allow tls_cipher_suites configuration")
+				return errListenerTLSCipherSuiteNotConfigurable
 			}
 		}
 
 		for _, tlsCipherSuiteValue := range strings.Split(tlsCipherSuitesValue, ",") {
 			tlsCipherSuite := strings.TrimSpace(tlsCipherSuiteValue)
 			if _, supported := allSupportedTLSCipherSuites[tlsCipherSuite]; !supported {
-				return errors.New("unsupported cipher suite in tls_cipher_suites")
+				return errListenerUnsupportedTLSCipherSuite
 			}
 		}
 	}

--- a/control-plane/api-gateway/binding/validation_test.go
+++ b/control-plane/api-gateway/binding/validation_test.go
@@ -510,6 +510,47 @@ func TestValidateTLS(t *testing.T) {
 			expectedResolvedRefsErr: nil,
 			expectedAcceptedErr:     nil,
 		},
+		"invalid cipher suite": {
+			gateway: gatewayWithFinalizer(gwv1beta1.GatewaySpec{}),
+			tls: &gwv1beta1.GatewayTLSConfig{
+				Options: map[gwv1beta1.AnnotationKey]gwv1beta1.AnnotationValue{
+					common.TLSCipherSuitesAnnotationKey: "invalid",
+				},
+			},
+			certificates:        nil,
+			expectedAcceptedErr: errListenerUnsupportedTLSCipherSuite,
+		},
+		"cipher suite not configurable": {
+			gateway: gatewayWithFinalizer(gwv1beta1.GatewaySpec{}),
+			tls: &gwv1beta1.GatewayTLSConfig{
+				Options: map[gwv1beta1.AnnotationKey]gwv1beta1.AnnotationValue{
+					common.TLSMinVersionAnnotationKey:   "TLSv1_3",
+					common.TLSCipherSuitesAnnotationKey: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+				},
+			},
+			certificates:        nil,
+			expectedAcceptedErr: errListenerTLSCipherSuiteNotConfigurable,
+		},
+		"invalid max version": {
+			gateway: gatewayWithFinalizer(gwv1beta1.GatewaySpec{}),
+			tls: &gwv1beta1.GatewayTLSConfig{
+				Options: map[gwv1beta1.AnnotationKey]gwv1beta1.AnnotationValue{
+					common.TLSMaxVersionAnnotationKey: "invalid",
+				},
+			},
+			certificates:        nil,
+			expectedAcceptedErr: errListenerUnsupportedTLSMaxVersion,
+		},
+		"invalid min version": {
+			gateway: gatewayWithFinalizer(gwv1beta1.GatewaySpec{}),
+			tls: &gwv1beta1.GatewayTLSConfig{
+				Options: map[gwv1beta1.AnnotationKey]gwv1beta1.AnnotationValue{
+					common.TLSMinVersionAnnotationKey: "invalid",
+				},
+			},
+			certificates:        nil,
+			expectedAcceptedErr: errListenerUnsupportedTLSMinVersion,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			resources := common.NewResourceMap(common.ResourceTranslator{}, NewReferenceValidator(tt.grants), logrtest.NewTestLogger(t))

--- a/control-plane/api-gateway/common/constants.go
+++ b/control-plane/api-gateway/common/constants.go
@@ -8,7 +8,7 @@ const (
 
 	AnnotationGatewayClassConfig = "consul.hashicorp.com/gateway-class-config"
 
-	// The following annotation keys are used in the v1beta1.GatewayTLSConfig's Options on a v1beta1.Listener
+	// The following annotation keys are used in the v1beta1.GatewayTLSConfig's Options on a v1beta1.Listener.
 	TLSCipherSuitesAnnotationKey = "api-gateway.consul.hashicorp.com/tls_cipher_suites"
 	TLSMaxVersionAnnotationKey   = "api-gateway.consul.hashicorp.com/tls_max_version"
 	TLSMinVersionAnnotationKey   = "api-gateway.consul.hashicorp.com/tls_min_version"

--- a/control-plane/api-gateway/common/constants.go
+++ b/control-plane/api-gateway/common/constants.go
@@ -7,4 +7,9 @@ const (
 	GatewayClassControllerName = "consul.hashicorp.com/gateway-controller"
 
 	AnnotationGatewayClassConfig = "consul.hashicorp.com/gateway-class-config"
+
+	// The following annotation keys are used in the v1beta1.GatewayTLSConfig's Options on a v1beta1.Listener
+	TLSCipherSuitesAnnotationKey = "api-gateway.consul.hashicorp.com/tls_cipher_suites"
+	TLSMaxVersionAnnotationKey   = "api-gateway.consul.hashicorp.com/tls_max_version"
+	TLSMinVersionAnnotationKey   = "api-gateway.consul.hashicorp.com/tls_min_version"
 )

--- a/control-plane/api-gateway/common/translation.go
+++ b/control-plane/api-gateway/common/translation.go
@@ -85,8 +85,17 @@ func (t ResourceTranslator) toAPIGatewayListener(gateway gwv1beta1.Gateway, list
 	namespace := gateway.Namespace
 
 	var certificates []api.ResourceReference
+	var cipherSuites []string
+	var maxVersion, minVersion string
 
 	if listener.TLS != nil {
+		cipherSuitsVal := string(listener.TLS.Options[TLSCipherSuitesAnnotationKey])
+		if cipherSuitsVal != "" {
+			cipherSuites = strings.Split(cipherSuitsVal, ",")
+		}
+		maxVersion = string(listener.TLS.Options[TLSMaxVersionAnnotationKey])
+		minVersion = string(listener.TLS.Options[TLSMinVersionAnnotationKey])
+
 		for _, ref := range listener.TLS.CertificateRefs {
 			if !resources.GatewayCanReferenceSecret(gateway, ref) {
 				return api.APIGatewayListener{}, false
@@ -116,6 +125,9 @@ func (t ResourceTranslator) toAPIGatewayListener(gateway gwv1beta1.Gateway, list
 		Protocol: listenerProtocolMap[strings.ToLower(string(listener.Protocol))],
 		TLS: api.APIGatewayTLSConfiguration{
 			Certificates: certificates,
+			CipherSuites: cipherSuites,
+			MaxVersion:   maxVersion,
+			MinVersion:   minVersion,
 		},
 	}, true
 }

--- a/control-plane/api-gateway/common/translation.go
+++ b/control-plane/api-gateway/common/translation.go
@@ -89,9 +89,9 @@ func (t ResourceTranslator) toAPIGatewayListener(gateway gwv1beta1.Gateway, list
 	var maxVersion, minVersion string
 
 	if listener.TLS != nil {
-		cipherSuitsVal := string(listener.TLS.Options[TLSCipherSuitesAnnotationKey])
-		if cipherSuitsVal != "" {
-			cipherSuites = strings.Split(cipherSuitsVal, ",")
+		cipherSuitesVal := string(listener.TLS.Options[TLSCipherSuitesAnnotationKey])
+		if cipherSuitesVal != "" {
+			cipherSuites = strings.Split(cipherSuitesVal, ",")
 		}
 		maxVersion = string(listener.TLS.Options[TLSMaxVersionAnnotationKey])
 		minVersion = string(listener.TLS.Options[TLSMinVersionAnnotationKey])


### PR DESCRIPTION
**Changes proposed in this PR:**
- Update translation logic to pull TLS min version, max version + cipher suites from the `Gateway` resource in K8s and write them to the `api-gateway` config entry in Consul
- Update validation logic to compare TLS options against allowed values + combinations of values

**How I've tested this PR:**
- Added unit tests covering changes in translation + validation logic

**How I expect reviewers to test this PR:**
- 🤖 tests pass
- Visual comparison with the [legacy implementation of translation + validation](https://github.com/hashicorp/consul-api-gateway/blob/a0774e4543104267009b034164d9bf50c5b498e8/internal/k8s/reconciler/validator/gateway.go#L402-L451) which were combined in the same code path at the time

**Checklist:**
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


