### PR TITLE
Backport of Support restricted PSA enforcement part 2 into release/1.1.x

### DIFF
--- a/acceptance/framework/connhelper/connect_helper.go
+++ b/acceptance/framework/connhelper/connect_helper.go
@@ -123,7 +123,7 @@ func (c *ConnectHelper) DeployClientAndServer(t *testing.T) {
 
 	logger.Log(t, "creating static-server and static-client deployments")
 
-	c.setupAppNamespace(t)
+	c.SetupAppNamespace(t)
 
 	opts := c.KubectlOptsForApp(t)
 	if c.Cfg.EnableCNI && c.Cfg.EnableOpenshift {
@@ -171,10 +171,10 @@ func (c *ConnectHelper) DeployClientAndServer(t *testing.T) {
 		})
 }
 
-// setupAppNamespace creates a namespace where applications are deployed. This
+// SetupAppNamespace creates a namespace where applications are deployed. This
 // does nothing if UseAppNamespace is not set. The app namespace is relevant
 // when testing with restricted PSA enforcement enabled.
-func (c *ConnectHelper) setupAppNamespace(t *testing.T) {
+func (c *ConnectHelper) SetupAppNamespace(t *testing.T) {
 	if !c.UseAppNamespace {
 		return
 	}

--- a/acceptance/framework/k8s/helpers.go
+++ b/acceptance/framework/k8s/helpers.go
@@ -136,6 +136,7 @@ func CopySecret(t *testing.T, sourceContext, destContext environment.TestContext
 		secret.ResourceVersion = ""
 		require.NoError(r, err)
 	})
+	secret.Namespace = destContext.KubectlOptions(t).Namespace
 	_, err = destContext.KubernetesClient(t).CoreV1().Secrets(destContext.KubectlOptions(t).Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 	require.NoError(t, err)
 }

--- a/acceptance/tests/wan-federation/wan_federation_test.go
+++ b/acceptance/tests/wan-federation/wan_federation_test.go
@@ -6,11 +6,11 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/consul-k8s/acceptance/framework/connhelper"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
-	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -39,10 +39,6 @@ func TestWANFederation(t *testing.T) {
 
 			env := suite.Environment()
 			cfg := suite.Config()
-
-			if cfg.UseKind {
-				t.Skipf("skipping wan federation tests as they currently fail on Kind even though they work on other clouds.")
-			}
 
 			primaryContext := env.DefaultContext(t)
 			secondaryContext := env.Context(t, 1)
@@ -83,6 +79,7 @@ func TestWANFederation(t *testing.T) {
 			federationSecret, err := primaryContext.KubernetesClient(t).CoreV1().Secrets(primaryContext.KubectlOptions(t).Namespace).Get(context.Background(), federationSecretName, metav1.GetOptions{})
 			require.NoError(t, err)
 			federationSecret.ResourceVersion = ""
+			federationSecret.Namespace = secondaryContext.KubectlOptions(t).Namespace
 			_, err = secondaryContext.KubernetesClient(t).CoreV1().Secrets(secondaryContext.KubectlOptions(t).Namespace).Create(context.Background(), federationSecret, metav1.CreateOptions{})
 			require.NoError(t, err)
 
@@ -158,30 +155,43 @@ func TestWANFederation(t *testing.T) {
 				k8s.KubectlDeleteK(t, secondaryContext.KubectlOptions(t), kustomizeDir)
 			})
 
+			primaryHelper := connhelper.ConnectHelper{
+				Secure:          c.secure,
+				ReleaseName:     releaseName,
+				Ctx:             primaryContext,
+				UseAppNamespace: cfg.EnableRestrictedPSAEnforcement,
+				Cfg:             cfg,
+				ConsulClient:    primaryClient,
+			}
+			secondaryHelper := connhelper.ConnectHelper{
+				Secure:          c.secure,
+				ReleaseName:     releaseName,
+				Ctx:             secondaryContext,
+				UseAppNamespace: cfg.EnableRestrictedPSAEnforcement,
+				Cfg:             cfg,
+				ConsulClient:    secondaryClient,
+			}
+
+			// When restricted PSA enforcement is enabled on the Consul
+			// namespace, deploy the test apps to a different unrestricted
+			// namespace because they can't run in a restricted namespace.
+			// This creates the app namespace only if necessary.
+			primaryHelper.SetupAppNamespace(t)
+			secondaryHelper.SetupAppNamespace(t)
+
 			// Check that we can connect services over the mesh gateways
 			logger.Log(t, "creating static-server in dc2")
-			k8s.DeployKustomize(t, secondaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
+			k8s.DeployKustomize(t, secondaryHelper.KubectlOptsForApp(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
 
 			logger.Log(t, "creating static-client in dc1")
-			k8s.DeployKustomize(t, primaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-multi-dc")
+			k8s.DeployKustomize(t, primaryHelper.KubectlOptsForApp(t), cfg.NoCleanupOnFailure, cfg.DebugDirectory, "../fixtures/cases/static-client-multi-dc")
 
 			if c.secure {
-				logger.Log(t, "creating intention")
-				_, _, err = primaryClient.ConfigEntries().Set(&api.ServiceIntentionsConfigEntry{
-					Kind: api.ServiceIntentions,
-					Name: "static-server",
-					Sources: []*api.SourceIntention{
-						{
-							Name:   StaticClientName,
-							Action: api.IntentionActionAllow,
-						},
-					},
-				}, nil)
-				require.NoError(t, err)
+				primaryHelper.CreateIntention(t)
 			}
 
 			logger.Log(t, "checking that connection is successful")
-			k8s.CheckStaticServerConnectionSuccessful(t, primaryContext.KubectlOptions(t), StaticClientName, "http://localhost:1234")
+			k8s.CheckStaticServerConnectionSuccessful(t, primaryHelper.KubectlOptsForApp(t), StaticClientName, "http://localhost:1234")
 		})
 	}
 }

--- a/charts/consul/templates/create-federation-secret-job.yaml
+++ b/charts/consul/templates/create-federation-secret-job.yaml
@@ -93,6 +93,7 @@ spec:
       containers:
         - name: create-federation-secret
           image: "{{ .Values.global.imageK8S }}"
+          {{- include "consul.restrictedSecurityContext" . | nindent 10 }}
           env:
             - name: NAMESPACE
               valueFrom:

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -175,6 +175,7 @@ spec:
       # ingress-gateway-init registers the ingress gateway service with Consul.
       - name: ingress-gateway-init
         image: {{ $root.Values.global.imageK8S }}
+        {{- include "consul.restrictedSecurityContext" $ | nindent 8 }}
         env:
         - name: NAMESPACE
           valueFrom:
@@ -233,6 +234,7 @@ spec:
       containers:
       - name: ingress-gateway
         image: {{ $root.Values.global.imageConsulDataplane | quote }}
+        {{- include "consul.restrictedSecurityContext" $ | nindent 8 }}
         {{- if (default $defaults.resources .resources) }}
         resources: {{ toYaml (default $defaults.resources .resources) | nindent 10 }}
         {{- end }}

--- a/charts/consul/templates/partition-init-job.yaml
+++ b/charts/consul/templates/partition-init-job.yaml
@@ -81,6 +81,7 @@ spec:
       containers:
         - name: partition-init-job
           image: {{ .Values.global.imageK8S }}
+          {{- include "consul.restrictedSecurityContext" . | nindent 10 }}
           env:
           {{- include "consul.consulK8sConsulServerEnvVars" . | nindent 10 }}
           {{- if (and .Values.global.acls.bootstrapToken.secretName .Values.global.acls.bootstrapToken.secretKey) }}

--- a/charts/consul/templates/sync-catalog-deployment.yaml
+++ b/charts/consul/templates/sync-catalog-deployment.yaml
@@ -77,6 +77,7 @@ spec:
       containers:
       - name: sync-catalog
         image: "{{ default .Values.global.imageK8S .Values.syncCatalog.image }}"
+        {{- include "consul.restrictedSecurityContext" . | nindent 8 }}
         env:
         {{- include "consul.consulK8sConsulServerEnvVars" . | nindent 8 }}
         {{- if .Values.global.acls.manageSystemACLs }}

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -160,6 +160,7 @@ spec:
         # terminating-gateway-init registers the terminating gateway service with Consul.
         - name: terminating-gateway-init
           image: {{ $root.Values.global.imageK8S }}
+          {{- include "consul.restrictedSecurityContext" $ | nindent 10 }}
           env:
           - name: NAMESPACE
             valueFrom:
@@ -218,6 +219,7 @@ spec:
       containers:
         - name: terminating-gateway
           image: {{ $root.Values.global.imageConsulDataplane | quote }}
+          {{- include "consul.restrictedSecurityContext" $ | nindent 10 }}
           volumeMounts:
             - name: consul-service
               mountPath: /consul/service


### PR DESCRIPTION
Manual backport of #2702 in release/1.1x because the backport job failed to generate a PR.

The below text is copied from the body of the original PR.

---

**Changes proposed in this PR:**

Part 2 of https://github.com/hashicorp/consul-k8s/pull/2572.

Update the following to set a "restricted" security context:

* create-federation-secret-job.yaml
* ingress-gateways-deployment.yaml
* ~mesh-gateway-deployment.yaml~
  * This is not included because adding the "restricted" security context settings to MGW makes it impossible to use hostNetwork=true
* partition-init-job.yaml
* terminating-gateways-deployment.yaml
* sync-catalog-deployment.yaml

Also, fix a WAN federation test to run on kind

**How I've tested this PR:**

Run acceptance tests on kind with restricted PSA enforcement enabled on the consul namespace (see script)

* Run the WAN fed test that is fixed in this PR, in order to validate the create federation secret job and mesh gateway deployment
* Run TestTerminatingGateway and TestIngressGateway and manually validate the gateways start and run successfully in the restricted consul namespace 
  * (note: these tests fail when test applications are deployed to a restricted namespace, because the test applications do not support running in a restricted namespace)
* Run TestPartitions_Gateway and manually validate the partitions-init job succeeds

Test script:
  * Run `make kind` and then `./test-psa-kind.sh` (no tproxy) or `./test-psa-kind.sh -tproxy` (tproxy enabled). Toggle comments at the bottom to try to run other tests.
  * Run `make kind-cni` and `./test-psa-kind.sh -cni` to test with tproxy+cni

<details>
 <summary>Test script</summary>

```shell
#!/usr/bin/env bash

set -euo pipefail

SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

export CONSUL_LICENSE=$(cat ~/.consul-ent-license)
export CONSUL_ENT_LICENSE=$CONSUL_LICENSE

# Cleanup old namespaces
# for context in $(kubectl config get-contexts -o name | grep '^kind-') ; do
for context in kind-dc1 kind-dc2 ; do
    kubectl --context $context get ns \
		| grep ^acceptance | awk '{print $1}' \
		| xargs -n 1 -I '{}' kubectl --context $context delete ns '{}' || true
done

EXTRA_FLAGS=""

while [[ $# -gt 0 ]]; do
    case $1 in
        -tproxy)
            EXTRA_FLAGS+=" -enable-transparent-proxy"
            shift;
            ;;
        -cni)
            EXTRA_FLAGS+=" -enable-cni -enable-transparent-proxy"
            shift;
            ;;
        *)
            echo "Unrecognized argument: '$1'"
            exit 1
    esac
done

function runtest() {
    local testdir=$1
    local runtest=$2

    if [ -n "$runtest" ]; then
        runtest="-run $runtest"
    fi

    # Create consul namespaces with restricted PSA enformcement.
    set -xeuo pipefail

    local ns_base="acceptance-$1-$RANDOM"
    local contexts=""
    local namespaces=""
    #for context in $(kubectl config get-contexts -o name | grep '^kind-') ; do
    for context in kind-dc1 kind-dc2 ; do
        local consul_namespace="${ns_base}-$context"
        kubectl --context $context create ns $consul_namespace
        kubectl --context $context label --overwrite ns $consul_namespace \
            pod-security.kubernetes.io/enforce=restricted \
            pod-security.kubernetes.io/enforce-version=v1.24

        if [ -n "$contexts" ]; then
            contexts+=","
            namespaces+=","
        fi
        contexts+="$context"
        namespaces+="$consul_namespace"
    done

    # Grab the default image versions from the helm values.
    imageK8S=$(cat ../charts/consul/values.yaml | yq -r '.global.imageK8S' \
        | sed 's/-dev/-dev-ubi/')
    imageConsul=$(cat ../charts/consul/values.yaml | yq -r '.global.image' \
        | sed 's/consul:/consul-enterprise:/' | sed 's/-dev/-dev-ubi/')
    imageDataplane=$(cat ../charts/consul/values.yaml | yq -r '.global.imageConsulDataplane' \
        | sed 's/-dev/-dev-ubi/')

    cd "${SCRIPT_DIR}/tests/$testdir"
    rm -rf ./_debug
    mkdir ./_debug
    go test  -v -p 1 -timeout 15m -failfast \
        -consul-k8s-image "$imageK8S" \
        -consul-image "$imageConsul" \
        -consul-dataplane-image "$imageDataplane" \
        -debug-directory ./_debug \
        -enable-enterprise \
        -kube-contexts "$contexts" \
        -kube-namespaces "$namespaces" \
        -enable-multi-cluster -use-kind \
        -enable-restricted-psa-enforcement \
        $EXTRA_FLAGS $runtest \
        ./...
}

runtest "connect" 'TestConnectInject$'
runtest wan-federation 'TestWANFederation/secure'
#runtest terminating-gateway 'TestTerminatingGateway$/secure:_true'
#runtest terminating-gateway 'TestTerminatingGatewaySingleNamespace'
#runtest ingress-gateway 'TestIngressGatewaySingleNamespace'
#runtest ingress-gateway 'TestIngressGateway$/secure:_true'
#runtest cloud 'TestBasicCloud'
#runtest partitions 'TestPartitions_Connect/default_destination_namespace'
```

</details>

How I expect reviewers to test this PR:



Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 




---

<details>
<summary> Overview of commits </summary>

  - 2a9ffe67d90c28bd23147978c8be5807beeca4a3  - 904bdb61cd0313e5c087aebe277b03712457bec7  - 2625d5b30d8bf88c5329da2cfe90a91e93f189c0  - cf582723c5e48a85177ebb949ba2c48799c6bccc 

</details>

