### PR TITLE
Net 1784 inject sidecar first

### DIFF
--- a/.changelog/2743.txt
+++ b/.changelog/2743.txt
@@ -1,5 +1,3 @@
 ```release-note:improvement
-control-plane: Changed the container ordering in connect-inject to insert consul-dataplane
-container first if lifecycle is enabled. Container ordering is unchanged if lifecycle
-is disabled. 
+control-plane: Changed the container ordering in connect-inject to insert consul-dataplane container first if lifecycle is enabled. Container ordering is unchanged if lifecycle is disabled. 
 ```

--- a/.changelog/2743.txt
+++ b/.changelog/2743.txt
@@ -1,0 +1,5 @@
+```release-note:improvement
+control-plane: Changed the container ordering in connect-inject to insert consul-dataplane
+container first if lifecycle is enabled. Container ordering is unchanged if lifecycle
+is disabled. 
+```

--- a/acceptance/framework/connhelper/connect_helper.go
+++ b/acceptance/framework/connhelper/connect_helper.go
@@ -265,7 +265,7 @@ func (c *ConnectHelper) TestConnectionFailureWhenUnhealthy(t *testing.T) {
 	opts := c.KubectlOptsForApp(t)
 
 	logger.Log(t, "testing k8s -> consul health checks sync by making the static-server unhealthy")
-	k8s.RunKubectl(t, opts, "exec", "deploy/"+StaticServerName, "--", "touch", "/tmp/unhealthy")
+	k8s.RunKubectl(t, opts, "exec", "deploy/"+StaticServerName, "-c", "static-server", "--", "touch", "/tmp/unhealthy")
 
 	// The readiness probe should take a moment to be reflected in Consul,
 	// CheckStaticServerConnection will retry until Consul marks the service
@@ -290,7 +290,7 @@ func (c *ConnectHelper) TestConnectionFailureWhenUnhealthy(t *testing.T) {
 	}
 
 	// Return the static-server to a "healthy state".
-	k8s.RunKubectl(t, opts, "exec", "deploy/"+StaticServerName, "--", "rm", "/tmp/unhealthy")
+	k8s.RunKubectl(t, opts, "exec", "deploy/"+StaticServerName, "-c", "static-server", "--", "rm", "/tmp/unhealthy")
 }
 
 // helmValues uses the Secure and AutoEncrypt fields to set values for the Helm

--- a/acceptance/tests/connect/connect_external_servers_test.go
+++ b/acceptance/tests/connect/connect_external_servers_test.go
@@ -128,7 +128,7 @@ func TestConnectInject_ExternalServers(t *testing.T) {
 			// Test that kubernetes readiness status is synced to Consul.
 			// Create the file so that the readiness probe of the static-server pod fails.
 			logger.Log(t, "testing k8s -> consul health checks sync by making the static-server unhealthy")
-			k8s.RunKubectl(t, ctx.KubectlOptions(t), "exec", "deploy/"+connhelper.StaticServerName, "--", "touch", "/tmp/unhealthy")
+			k8s.RunKubectl(t, ctx.KubectlOptions(t), "exec", "deploy/"+connhelper.StaticServerName, "-c", "static-server", "--", "touch", "/tmp/unhealthy")
 
 			// The readiness probe should take a moment to be reflected in Consul, CheckStaticServerConnection will retry
 			// until Consul marks the service instance unavailable for mesh traffic, causing the connection to fail.

--- a/acceptance/tests/connect/connect_inject_namespaces_test.go
+++ b/acceptance/tests/connect/connect_inject_namespaces_test.go
@@ -221,7 +221,7 @@ func TestConnectInjectNamespaces(t *testing.T) {
 			// Test that kubernetes readiness status is synced to Consul.
 			// Create the file so that the readiness probe of the static-server pod fails.
 			logger.Log(t, "testing k8s -> consul health checks sync by making the static-server unhealthy")
-			k8s.RunKubectl(t, staticServerOpts, "exec", "deploy/"+connhelper.StaticServerName, "--", "touch", "/tmp/unhealthy")
+			k8s.RunKubectl(t, staticServerOpts, "exec", "deploy/"+connhelper.StaticServerName, "-c", "static-server", "--", "touch", "/tmp/unhealthy")
 
 			// The readiness probe should take a moment to be reflected in Consul, CheckStaticServerConnection will retry
 			// until Consul marks the service instance unavailable for mesh traffic, causing the connection to fail.

--- a/acceptance/tests/connect/connect_inject_test.go
+++ b/acceptance/tests/connect/connect_inject_test.go
@@ -298,9 +298,9 @@ func TestConnectInject_MultiportServices(t *testing.T) {
 			// and check inbound connections to the multi port pods' services.
 			// Create the files so that the readiness probes of the multi port pod fails.
 			logger.Log(t, "testing k8s -> consul health checks sync by making the multiport unhealthy")
-			k8s.RunKubectl(t, ctx.KubectlOptions(t), "exec", "deploy/"+multiport, "--", "touch", "/tmp/unhealthy-multiport")
+			k8s.RunKubectl(t, ctx.KubectlOptions(t), "exec", "deploy/"+multiport, "-c", "multiport", "--", "touch", "/tmp/unhealthy-multiport")
 			logger.Log(t, "testing k8s -> consul health checks sync by making the multiport-admin unhealthy")
-			k8s.RunKubectl(t, ctx.KubectlOptions(t), "exec", "deploy/"+multiport, "--", "touch", "/tmp/unhealthy-multiport-admin")
+			k8s.RunKubectl(t, ctx.KubectlOptions(t), "exec", "deploy/"+multiport, "-c", "multiport-admin", "--", "touch", "/tmp/unhealthy-multiport-admin")
 
 			// The readiness probe should take a moment to be reflected in Consul, CheckStaticServerConnection will retry
 			// until Consul marks the service instance unavailable for mesh traffic, causing the connection to fail.

--- a/acceptance/tests/metrics/metrics_test.go
+++ b/acceptance/tests/metrics/metrics_test.go
@@ -74,12 +74,12 @@ func TestComponentMetrics(t *testing.T) {
 	k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/bases/static-client")
 
 	// Server Metrics
-	metricsOutput, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+StaticClientName, "--", "curl", "--silent", "--show-error", fmt.Sprintf("http://%s:8500/v1/agent/metrics?format=prometheus", fmt.Sprintf("%s-consul-server.%s.svc", releaseName, ns)))
+	metricsOutput, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+StaticClientName, "-c", "static-client", "--", "curl", "--silent", "--show-error", fmt.Sprintf("http://%s:8500/v1/agent/metrics?format=prometheus", fmt.Sprintf("%s-consul-server.%s.svc", releaseName, ns)))
 	require.NoError(t, err)
 	require.Contains(t, metricsOutput, `consul_acl_ResolveToken{quantile="0.5"}`)
 
 	// Client Metrics
-	metricsOutput, err = k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+StaticClientName, "--", "sh", "-c", "curl --silent --show-error http://$HOST_IP:8500/v1/agent/metrics?format=prometheus")
+	metricsOutput, err = k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+StaticClientName, "-c", "static-client", "--", "sh", "-c", "curl --silent --show-error http://$HOST_IP:8500/v1/agent/metrics?format=prometheus")
 	require.NoError(t, err)
 	require.Contains(t, metricsOutput, `consul_acl_ResolveToken{quantile="0.5"}`)
 
@@ -133,7 +133,7 @@ func TestAppMetrics(t *testing.T) {
 	// Retry because sometimes the merged metrics server takes a couple hundred milliseconds
 	// to start.
 	retry.RunWith(&retry.Counter{Count: 20, Wait: 2 * time.Second}, t, func(r *retry.R) {
-		metricsOutput, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+StaticClientName, "--", "curl", "--silent", "--show-error", fmt.Sprintf("http://%s:20200/metrics", podIP))
+		metricsOutput, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+StaticClientName, "-c", "static-client", "--", "curl", "--silent", "--show-error", fmt.Sprintf("http://%s:20200/metrics", podIP))
 		require.NoError(r, err)
 		// This assertion represents the metrics from the envoy sidecar.
 		require.Contains(r, metricsOutput, `envoy_cluster_assignment_stale{local_cluster="server",consul_source_service="server"`)
@@ -147,7 +147,7 @@ func assertGatewayMetricsEnabled(t *testing.T, ctx environment.TestContext, ns, 
 	require.NoError(t, err)
 	for _, pod := range pods.Items {
 		podIP := pod.Status.PodIP
-		metricsOutput, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+StaticClientName, "--", "curl", "--silent", "--show-error", fmt.Sprintf("http://%s:20200/metrics", podIP))
+		metricsOutput, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "exec", "deploy/"+StaticClientName, "-c", "static-client", "--", "curl", "--silent", "--show-error", fmt.Sprintf("http://%s:20200/metrics", podIP))
 		require.NoError(t, err)
 		require.Contains(t, metricsOutput, metricsAssertion)
 	}

--- a/acceptance/tests/partitions/partitions_connect_test.go
+++ b/acceptance/tests/partitions/partitions_connect_test.go
@@ -405,8 +405,8 @@ func TestPartitions_Connect(t *testing.T) {
 				// Test that kubernetes readiness status is synced to Consul.
 				// Create the file so that the readiness probe of the static-server pod fails.
 				logger.Log(t, "testing k8s -> consul health checks sync by making the static-server unhealthy")
-				k8s.RunKubectl(t, defaultPartitionClusterStaticServerOpts, "exec", "deploy/"+staticServerName, "--", "touch", "/tmp/unhealthy")
-				k8s.RunKubectl(t, secondaryPartitionClusterStaticServerOpts, "exec", "deploy/"+staticServerName, "--", "touch", "/tmp/unhealthy")
+				k8s.RunKubectl(t, defaultPartitionClusterStaticServerOpts, "exec", "deploy/"+staticServerName, "-c", "static-server", "--", "touch", "/tmp/unhealthy")
+				k8s.RunKubectl(t, secondaryPartitionClusterStaticServerOpts, "exec", "deploy/"+staticServerName, "-c", "static-server", "--", "touch", "/tmp/unhealthy")
 
 				// The readiness probe should take a moment to be reflected in Consul, CheckStaticServerConnection will retry
 				// until Consul marks the service instance unavailable for mesh traffic, causing the connection to fail.
@@ -578,8 +578,8 @@ func TestPartitions_Connect(t *testing.T) {
 				// Test that kubernetes readiness status is synced to Consul.
 				// Create the file so that the readiness probe of the static-server pod fails.
 				logger.Log(t, "testing k8s -> consul health checks sync by making the static-server unhealthy")
-				k8s.RunKubectl(t, defaultPartitionClusterStaticServerOpts, "exec", "deploy/"+staticServerName, "--", "touch", "/tmp/unhealthy")
-				k8s.RunKubectl(t, secondaryPartitionClusterStaticServerOpts, "exec", "deploy/"+staticServerName, "--", "touch", "/tmp/unhealthy")
+				k8s.RunKubectl(t, defaultPartitionClusterStaticServerOpts, "exec", "deploy/"+staticServerName, "-c", "static-server", "--", "touch", "/tmp/unhealthy")
+				k8s.RunKubectl(t, secondaryPartitionClusterStaticServerOpts, "exec", "deploy/"+staticServerName, "-c", "static-server", "--", "touch", "/tmp/unhealthy")
 
 				// The readiness probe should take a moment to be reflected in Consul, CheckStaticServerConnection will retry
 				// until Consul marks the service instance unavailable for mesh traffic, causing the connection to fail.

--- a/control-plane/connect-inject/webhook/mesh_webhook.go
+++ b/control-plane/connect-inject/webhook/mesh_webhook.go
@@ -294,7 +294,10 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 	// port.
 	annotatedSvcNames := w.annotatedServiceNames(pod)
 	multiPort := len(annotatedSvcNames) > 1
-
+	lifecycleEnabled, ok := w.LifecycleConfig.EnableProxyLifecycle(pod)
+	if ok != nil {
+		w.Log.Error(err, "unable to get lifecycle enabled status")
+	}
 	// For single port pods, add the single init container and envoy sidecar.
 	if !multiPort {
 		// Add the init container that registers the service and sets up the Envoy configuration.
@@ -312,7 +315,7 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error configuring injection sidecar container: %s", err))
 		}
 		//Append the Envoy sidecar before the application container only if lifecycle enabled.
-		lifecycleEnabled, ok := w.LifecycleConfig.EnableProxyLifecycle(pod)
+
 		if lifecycleEnabled && ok == nil {
 			pod.Spec.Containers = append([]corev1.Container{envoySidecar}, pod.Spec.Containers...)
 		} else {
@@ -333,11 +336,8 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 			w.Log.Error(err, "checking unsupported cases for multi port pods")
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
-		lifecycleEnabled, ok := w.LifecycleConfig.EnableProxyLifecycle(pod)
-		if ok != nil {
-			lifecycleEnabled = false
-		}
-		//List of sidecar containers for each service. Build list to preserve correct ordering in relation
+
+		//List of sidecar containers for each service. Build as a list to preserve correct ordering in relation
 		//to services.
 		sidecarContainers := []corev1.Container{}
 		for i, svc := range annotatedSvcNames {
@@ -395,15 +395,18 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 				w.Log.Error(err, "error configuring injection sidecar container", "request name", req.Name)
 				return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error configuring injection sidecar container: %s", err))
 			}
-			if !lifecycleEnabled {
-				pod.Spec.Containers = append(pod.Spec.Containers, envoySidecar)
-			} else {
+			// If Lifecycle is enabled, add to the list of sidecar containers to be added
+			// to pod containers at the end in order to preserve relative ordering.
+			if lifecycleEnabled {
 				sidecarContainers = append(sidecarContainers, envoySidecar)
+			} else {
+				pod.Spec.Containers = append(pod.Spec.Containers, envoySidecar)
+
 			}
 
 		}
 
-		//Add sidecar containers first iff lifecycle enabled.
+		//Add sidecar containers first if lifecycle enabled.
 		if lifecycleEnabled {
 			pod.Spec.Containers = append(sidecarContainers, pod.Spec.Containers...)
 		}

--- a/control-plane/connect-inject/webhook/mesh_webhook.go
+++ b/control-plane/connect-inject/webhook/mesh_webhook.go
@@ -311,8 +311,8 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 			w.Log.Error(err, "error configuring injection sidecar container", "request name", req.Name)
 			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error configuring injection sidecar container: %s", err))
 		}
-		// TODO: invert to start the Envoy sidecar before the application container
-		pod.Spec.Containers = append(pod.Spec.Containers, envoySidecar)
+		//Append the Envoy sidecar before the application container
+		pod.Spec.Containers = append([]corev1.Container{envoySidecar}, pod.Spec.Containers...)
 	} else {
 		// For multi port pods, check for unsupported cases, mount all relevant service account tokens, and mount an init
 		// container and envoy sidecar per port. Tproxy, metrics, and metrics merging are not supported for multi port pods.
@@ -382,9 +382,8 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 				w.Log.Error(err, "error configuring injection sidecar container", "request name", req.Name)
 				return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error configuring injection sidecar container: %s", err))
 			}
-			// TODO: invert to start the Envoy sidecar container before the
-			// application container
-			pod.Spec.Containers = append(pod.Spec.Containers, envoySidecar)
+			//Append the Envoy sidecar before the application container
+			pod.Spec.Containers = append([]corev1.Container{envoySidecar}, pod.Spec.Containers...)
 		}
 	}
 

--- a/control-plane/connect-inject/webhook/mesh_webhook_test.go
+++ b/control-plane/connect-inject/webhook/mesh_webhook_test.go
@@ -880,6 +880,91 @@ func TestHandlerHandle(t *testing.T) {
 			},
 		},
 		{
+			"multiport pod kube < 1.24 with AuthMethod, serviceaccount has secret ref, lifecycle enabled",
+			MeshWebhook{
+				Log:                   logrtest.New(t),
+				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
+				DenyK8sNamespacesSet:  mapset.NewSet(),
+				decoder:               decoder,
+				Clientset:             testClientWithServiceAccountAndSecretRefs(),
+				AuthMethod:            "k8s",
+				LifecycleConfig:       lifecycle.Config{DefaultEnableProxyLifecycle: true},
+			},
+			admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Namespace: namespaces.DefaultNamespace,
+					Object: encodeRaw(t, &corev1.Pod{
+						Spec: basicSpec,
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								constants.AnnotationService: "web,web-admin",
+							},
+						},
+					}),
+				},
+			},
+			"",
+			[]jsonpatch.Operation{
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/env",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/volumeMounts",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/readinessProbe",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/securityContext",
+				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/0/name",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/args",
+				},
+
+				{
+					Operation: "add",
+					Path:      "/spec/volumes",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/1",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/2",
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/" + escapeJSONPointer(constants.KeyInjectStatus),
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/" + escapeJSONPointer(constants.AnnotationOriginalPod),
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/" + escapeJSONPointer(constants.AnnotationConsulK8sVersion),
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/labels",
+				},
+			},
+		},
+		{
 			"dns redirection enabled",
 			MeshWebhook{
 				Log:                    logrtest.New(t),

--- a/control-plane/connect-inject/webhook/mesh_webhook_test.go
+++ b/control-plane/connect-inject/webhook/mesh_webhook_test.go
@@ -12,6 +12,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	logrtest "github.com/go-logr/logr/testr"
 	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/lifecycle"
 	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/metrics"
 	"github.com/hashicorp/consul-k8s/control-plane/consul"
 	"github.com/hashicorp/consul-k8s/control-plane/namespaces"
@@ -136,6 +137,48 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/spec/containers/1",
 				},
+			},
+		},
+		{
+			"empty pod basic with lifecycle",
+			MeshWebhook{
+				Log:                   logrtest.New(t),
+				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
+				DenyK8sNamespacesSet:  mapset.NewSet(),
+				decoder:               decoder,
+				Clientset:             defaultTestClientWithNamespace(),
+				LifecycleConfig:       lifecycle.Config{DefaultEnableProxyLifecycle: true},
+			},
+			admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Namespace: namespaces.DefaultNamespace,
+					Object: encodeRaw(t, &corev1.Pod{
+						Spec: basicSpec,
+					}),
+				},
+			},
+			"",
+			[]jsonpatch.Operation{
+				{
+					Operation: "add",
+					Path:      "/metadata/labels",
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/volumes",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/initContainers",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/1",
+				},
 
 				{
 					Operation: "add",
@@ -220,26 +263,6 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/spec/containers/0/env",
 				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/securityContext",
-				},
-				{
-					Operation: "replace",
-					Path:      "/spec/containers/0/name",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/args",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/readinessProbe",
-				},
 			},
 		},
 
@@ -321,30 +344,6 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/labels",
 				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/readinessProbe",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/securityContext",
-				},
-				{
-					Operation: "replace",
-					Path:      "/spec/containers/0/name",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/args",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/env",
-				},
 			},
 		},
 
@@ -400,30 +399,6 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/labels",
 				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/env",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/readinessProbe",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/securityContext",
-				},
-				{
-					Operation: "replace",
-					Path:      "/spec/containers/0/name",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/args",
-				},
 			},
 		},
 		{
@@ -472,6 +447,10 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
+					Path:      "/spec/containers/2/volumeMounts",
+				},
+				{
+					Operation: "add",
 					Path:      "/spec/initContainers",
 				},
 				{
@@ -493,38 +472,6 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/labels",
-				},
-				{
-					Operation: "replace",
-					Path:      "/spec/containers/0/name",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/args",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/env",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/readinessProbe",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/securityContext",
-				},
-				{
-					Operation: "replace",
-					Path:      "/spec/containers/1/name",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/1/volumeMounts",
-				},
-				{
-					Operation: "replace",
-					Path:      "/spec/containers/2/name",
 				},
 			},
 		},
@@ -585,30 +532,6 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/labels",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/args",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/env",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/readinessProbe",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/securityContext",
-				},
-				{
-					Operation: "replace",
-					Path:      "/spec/containers/0/name",
 				},
 			},
 		},
@@ -695,30 +618,6 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/labels",
 				},
-				{
-					Operation: "replace",
-					Path:      "/spec/containers/0/name",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/args",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/env",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/readinessProbe",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/securityContext",
-				},
 			},
 		},
 
@@ -769,30 +668,6 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/labels/" + escapeJSONPointer(constants.KeyManagedBy),
-				},
-				{
-					Operation: "replace",
-					Path:      "/spec/containers/0/name",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/args",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/env",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/readinessProbe",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/securityContext",
 				},
 			},
 		},
@@ -877,40 +752,12 @@ func TestHandlerHandle(t *testing.T) {
 					Path:      "/metadata/annotations/" + escapeJSONPointer(constants.AnnotationConsulK8sVersion),
 				},
 				{
-					Operation: "add",
-					Path:      "/spec/containers/0/securityContext",
+					Operation: "replace",
+					Path:      "/spec/containers/0/livenessProbe/httpGet/port",
 				},
 				{
 					Operation: "replace",
-					Path:      "/spec/containers/0/name",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/args",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/env",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/readinessProbe/tcpSocket",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/readinessProbe/initialDelaySeconds",
-				},
-				{
-					Operation: "remove",
-					Path:      "/spec/containers/0/readinessProbe/httpGet",
-				},
-				{
-					Operation: "remove",
-					Path:      "/spec/containers/0/livenessProbe",
+					Path:      "/spec/containers/0/readinessProbe/httpGet/port",
 				},
 			},
 		},
@@ -971,30 +818,6 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/labels",
 				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/env",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/readinessProbe",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/securityContext",
-				},
-				{
-					Operation: "replace",
-					Path:      "/spec/containers/0/name",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/args",
-				},
 			},
 		},
 		{
@@ -1053,30 +876,6 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/labels",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/readinessProbe",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/securityContext",
-				},
-				{
-					Operation: "replace",
-					Path:      "/spec/containers/0/name",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/args",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/env",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts",
 				},
 			},
 		},
@@ -1152,30 +951,6 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/spec/dnsConfig",
 				},
-				{
-					Operation: "replace",
-					Path:      "/spec/containers/0/name",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/args",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/env",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/readinessProbe",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/securityContext",
-				},
 			},
 		},
 		{
@@ -1240,31 +1015,6 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/annotations/" + escapeJSONPointer(constants.AnnotationConsulK8sVersion),
 				},
-				{
-					Operation: "replace",
-					Path:      "/spec/containers/0/name",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/args",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/env",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/volumeMounts",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/readinessProbe",
-				},
-				{
-					Operation: "add",
-					Path:      "/spec/containers/0/securityContext",
-				},
-
 				// Note: no DNS policy/config additions.
 			},
 		},

--- a/control-plane/connect-inject/webhook/mesh_webhook_test.go
+++ b/control-plane/connect-inject/webhook/mesh_webhook_test.go
@@ -136,6 +136,31 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/spec/containers/1",
 				},
+
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/readinessProbe",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/securityContext",
+				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/0/name",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/args",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/env",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/volumeMounts",
+				},
 			},
 		},
 
@@ -194,6 +219,26 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/spec/containers/0/env",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/securityContext",
+				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/0/name",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/args",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/volumeMounts",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/readinessProbe",
 				},
 			},
 		},
@@ -276,6 +321,30 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/labels",
 				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/volumeMounts",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/readinessProbe",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/securityContext",
+				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/0/name",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/args",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/env",
+				},
 			},
 		},
 
@@ -331,6 +400,30 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/labels",
 				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/env",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/volumeMounts",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/readinessProbe",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/securityContext",
+				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/0/name",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/args",
+				},
 			},
 		},
 		{
@@ -379,10 +472,6 @@ func TestHandlerHandle(t *testing.T) {
 				},
 				{
 					Operation: "add",
-					Path:      "/spec/containers/2/volumeMounts",
-				},
-				{
-					Operation: "add",
 					Path:      "/spec/initContainers",
 				},
 				{
@@ -404,6 +493,38 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/labels",
+				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/0/name",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/args",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/env",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/readinessProbe",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/securityContext",
+				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/1/name",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/1/volumeMounts",
+				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/2/name",
 				},
 			},
 		},
@@ -464,6 +585,30 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/labels",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/args",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/env",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/volumeMounts",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/readinessProbe",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/securityContext",
+				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/0/name",
 				},
 			},
 		},
@@ -550,6 +695,30 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/labels",
 				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/0/name",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/args",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/env",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/volumeMounts",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/readinessProbe",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/securityContext",
+				},
 			},
 		},
 
@@ -600,6 +769,30 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/labels/" + escapeJSONPointer(constants.KeyManagedBy),
+				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/0/name",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/args",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/env",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/volumeMounts",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/readinessProbe",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/securityContext",
 				},
 			},
 		},
@@ -684,12 +877,40 @@ func TestHandlerHandle(t *testing.T) {
 					Path:      "/metadata/annotations/" + escapeJSONPointer(constants.AnnotationConsulK8sVersion),
 				},
 				{
-					Operation: "replace",
-					Path:      "/spec/containers/0/livenessProbe/httpGet/port",
+					Operation: "add",
+					Path:      "/spec/containers/0/securityContext",
 				},
 				{
 					Operation: "replace",
-					Path:      "/spec/containers/0/readinessProbe/httpGet/port",
+					Path:      "/spec/containers/0/name",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/args",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/env",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/volumeMounts",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/readinessProbe/tcpSocket",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/readinessProbe/initialDelaySeconds",
+				},
+				{
+					Operation: "remove",
+					Path:      "/spec/containers/0/readinessProbe/httpGet",
+				},
+				{
+					Operation: "remove",
+					Path:      "/spec/containers/0/livenessProbe",
 				},
 			},
 		},
@@ -750,6 +971,30 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/labels",
 				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/env",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/volumeMounts",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/readinessProbe",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/securityContext",
+				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/0/name",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/args",
+				},
 			},
 		},
 		{
@@ -808,6 +1053,30 @@ func TestHandlerHandle(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/labels",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/readinessProbe",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/securityContext",
+				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/0/name",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/args",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/env",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/volumeMounts",
 				},
 			},
 		},
@@ -883,6 +1152,30 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/spec/dnsConfig",
 				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/0/name",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/args",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/env",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/volumeMounts",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/readinessProbe",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/securityContext",
+				},
 			},
 		},
 		{
@@ -947,6 +1240,31 @@ func TestHandlerHandle(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/annotations/" + escapeJSONPointer(constants.AnnotationConsulK8sVersion),
 				},
+				{
+					Operation: "replace",
+					Path:      "/spec/containers/0/name",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/args",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/env",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/volumeMounts",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/readinessProbe",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/containers/0/securityContext",
+				},
+
 				// Note: no DNS policy/config additions.
 			},
 		},


### PR DESCRIPTION
Changes proposed in this PR:
- If lifecycle setting is enabled, inject consul-dataplane as the first container in the pod. Add unit tests where lifecycle is enabled in multiport enabled/disabled setting. 

How I've tested this PR:
I've added tests that specifically check the container ordering when lifecycle is turned on. 

How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


