### PR TITLE
Set privileged to false unless on OpenShift without CNI

### DIFF
--- a/.changelog/2755.txt
+++ b/.changelog/2755.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+control-plane: When using transparent proxy or CNI, reduced required permissions by setting privileged to false. Privileged must be true when using OpenShift without CNI.
+```


### PR DESCRIPTION
Changes proposed in this PR:
- Sets privileged=false for regular transparent proxy connect injects
- Also false when CNI is used 
- True for OpenShift with transparent proxy

How I've tested this PR:

- unit tests and accpetance, manual tests on OpenShift

How I expect reviewers to test this PR:

👀 

Checklist:
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


