### PR TITLE
Update consul-enterprise-version script to add -ent

### DIFF
--- a/control-plane/build-support/scripts/consul-enterprise-version.sh
+++ b/control-plane/build-support/scripts/consul-enterprise-version.sh
@@ -4,8 +4,10 @@
 FILE=$1
 VERSION=$(yq .global.image $FILE)
 
-if [[ !"${VERSION}" == *"consul:"* ]]; then
+if [[ !"${VERSION}" == *"hashicorppreview/consul:"* ]]; then
 	VERSION=$(echo ${VERSION} | sed "s/consul:/consul-enterprise:/g")
+elif [[ !"${VERSION}" == *"hashicorp/consul:"* ]]; then
+	VERSION=$(echo ${VERSION} | sed "s/consul:/consul-enterprise:/g" | sed "s/$/-ent/g")
 fi
 
 echo "${VERSION}"


### PR DESCRIPTION
Changes proposed in this PR:
- This script change is in the release branches but is missing from main.

How I've tested this PR:

Note: the missing script piece was only apparent during release time. I used fake version numbers.

```
> make consul-enterprise-version
docker.mirror.hashicorp.services/hashicorppreview/consul-enterprise:1.17-dev

> make prepare-release
prepare_release: dir:/Users/curtbushko/workspace/github.com/hashicorp/consul-k8s/curtbushko/add-ent-to-consul-enterprise-image consul-k8s:9.0.0 consul:1.13.9 consul-dataplane:1.2 date:July 12, 2023 git tag:v0.49.7
==> Updating control-plane version/version.go with version info: 9.0.0
==> Updating cli version/version.go with version info: 9.0.0
==> Updating Helm chart version, consul-k8s: 9.0.0  consul: 1.13.9  consul-dataplane: 1.2

> make consul-enterprise-version
hashicorp/consul-enterprise:1.13.9-ent
```

Notice how `-ent` is added.

How I expect reviewers to test this PR:

:eyes:

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


