### PR TITLE
Add failover wan fed acceptance tests

### DIFF
--- a/acceptance/tests/fixtures/bases/service-resolver/kustomization.yaml
+++ b/acceptance/tests/fixtures/bases/service-resolver/kustomization.yaml
@@ -1,0 +1,5 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - service-resolver.yaml

--- a/acceptance/tests/fixtures/bases/service-resolver/service-resolver.yaml
+++ b/acceptance/tests/fixtures/bases/service-resolver/service-resolver.yaml
@@ -1,0 +1,7 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceResolver
+metadata:
+  name: static-server

--- a/acceptance/tests/fixtures/cases/wan-federation/dc1-static-server/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/dc1-static-server/kustomization.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - ../../../bases/static-server
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/acceptance/tests/fixtures/cases/wan-federation/dc1-static-server/patch.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/dc1-static-server/patch.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-server
+spec:
+  template:
+    metadata:
+      annotations:
+        "consul.hashicorp.com/connect-inject": "true"
+    spec:
+      containers:
+        - name: static-server
+          image: docker.mirror.hashicorp.services/kschoche/http-echo:latest
+          args:
+            - -text="dc1"
+            - -listen=:8080
+          ports:
+            - containerPort: 8080
+              name: http
+          livenessProbe:
+            httpGet:
+              port: 8080
+            initialDelaySeconds: 1
+            failureThreshold: 1
+            periodSeconds: 1
+          startupProbe:
+            httpGet:
+              port: 8080
+            initialDelaySeconds: 1
+            failureThreshold: 30
+            periodSeconds: 1
+          readinessProbe:
+            exec:
+              command: ['sh', '-c', 'test ! -f /tmp/unhealthy']
+            initialDelaySeconds: 1
+            failureThreshold: 1
+            periodSeconds: 1
+      serviceAccountName: static-server

--- a/acceptance/tests/fixtures/cases/wan-federation/dc2-static-server/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/dc2-static-server/kustomization.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - ../../../bases/static-server
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/acceptance/tests/fixtures/cases/wan-federation/dc2-static-server/patch.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/dc2-static-server/patch.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-server
+spec:
+  template:
+    metadata:
+      annotations:
+        "consul.hashicorp.com/connect-inject": "true"
+    spec:
+      containers:
+        - name: static-server
+          image: docker.mirror.hashicorp.services/kschoche/http-echo:latest
+          args:
+            - -text="dc2"
+            - -listen=:8080
+          ports:
+            - containerPort: 8080
+              name: http
+          livenessProbe:
+            httpGet:
+              port: 8080
+            initialDelaySeconds: 1
+            failureThreshold: 1
+            periodSeconds: 1
+          startupProbe:
+            httpGet:
+              port: 8080
+            initialDelaySeconds: 1
+            failureThreshold: 30
+            periodSeconds: 1
+          readinessProbe:
+            exec:
+              command: ['sh', '-c', 'test ! -f /tmp/unhealthy']
+            initialDelaySeconds: 1
+            failureThreshold: 1
+            periodSeconds: 1
+      serviceAccountName: static-server

--- a/acceptance/tests/fixtures/cases/wan-federation/service-resolver/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/service-resolver/kustomization.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - ../../../bases/service-resolver
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/acceptance/tests/fixtures/cases/wan-federation/service-resolver/patch.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/service-resolver/patch.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceResolver
+metadata:
+  name: static-server
+spec:
+  connectTimeout: 15s
+  failover:
+    '*':
+      targets:
+      - datacenter: "dc2"
+

--- a/acceptance/tests/fixtures/cases/wan-federation/static-client/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/static-client/kustomization.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - ../../../bases/static-client
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/acceptance/tests/fixtures/cases/wan-federation/static-client/patch.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/static-client/patch.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-client
+spec:
+  template:
+    metadata:
+      annotations:
+        'consul.hashicorp.com/connect-inject': 'true'
+        "consul.hashicorp.com/connect-service-upstreams": "static-server:1234"
+    spec:
+      containers:
+        - name: static-client
+          image: anubhavmishra/tiny-tools:latest
+          # Just spin & wait forever, we'll use `kubectl exec` to demo
+          command: ['/bin/sh', '-c', '--']
+          args: ['while true; do sleep 30; done;']
+      # If ACLs are enabled, the serviceAccountName must match the Consul service name.
+      serviceAccountName: static-client


### PR DESCRIPTION
Changes proposed in this PR:
- Added test scenarios for failover for Wan federated dcs
- There is probably some refactoring that can be done to support failiover in multiple scenarios (i.e. the failover check function)... I plan at looking at that once the other failover tests are written
- The meat of the PR is in the wan federation test

How I've tested this PR:
👀 

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


