### PR TITLE
Add readOnlyRootFilesystem to security context

### DIFF
--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -19,6 +19,7 @@ as well as the global.name setting.
 {{- if not .Values.global.enablePodSecurityPolicies -}}
 securityContext:
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
     - ALL

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -244,6 +244,8 @@ spec:
         resources: {{ toYaml (default $defaults.resources .resources) | nindent 10 }}
         {{- end }}
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         - name: consul-service
           mountPath: /consul/service
           readOnly: true

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -154,6 +154,9 @@ spec:
       terminationGracePeriodSeconds: {{ default $defaults.terminationGracePeriodSeconds .terminationGracePeriodSeconds }}
       serviceAccountName: {{ template "consul.fullname" $root }}-{{ .name }}
       volumes:
+      - name: tmp
+        emptyDir:
+          medium: "Memory"
       - name: consul-service
         emptyDir:
           medium: "Memory"
@@ -215,6 +218,8 @@ spec:
           -log-level={{ default $root.Values.global.logLevel $root.Values.ingressGateways.logLevel }} \
           -log-json={{ $root.Values.global.logJSON }}
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         - name: consul-service
           mountPath: /consul/service
         {{- if $root.Values.global.tls.enabled }}

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -123,6 +123,9 @@ spec:
       terminationGracePeriodSeconds: 10
       serviceAccountName: {{ template "consul.fullname" $root }}-{{ .name }}
       volumes:
+      - name: tmp
+        emptyDir:
+          medium: "Memory"
       - name: consul-service
         emptyDir:
           medium: "Memory"
@@ -200,6 +203,8 @@ spec:
                   -log-level={{ default $root.Values.global.logLevel $root.Values.terminatingGateways.logLevel }} \
                   -log-json={{ $root.Values.global.logJSON }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
             - name: consul-service
               mountPath: /consul/service
             {{- if $root.Values.global.tls.enabled }}

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -226,6 +226,8 @@ spec:
           image: {{ $root.Values.global.imageConsulDataplane | quote }}
           {{- include "consul.restrictedSecurityContext" $ | nindent 10 }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
             - name: consul-service
               mountPath: /consul/service
               readOnly: true

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -858,6 +858,7 @@ load _helpers
     "capabilities": {
       "drop": ["ALL"]
     },
+    "readOnlyRootFilesystem": true,
     "runAsNonRoot": true,
     "seccompProfile": {
       "type": "RuntimeDefault"
@@ -889,6 +890,7 @@ load _helpers
     "capabilities": {
       "drop": ["ALL"]
     },
+    "readOnlyRootFilesystem": true,
     "runAsNonRoot": true,
     "seccompProfile": {
       "type": "RuntimeDefault"


### PR DESCRIPTION
Changes proposed in this PR:
- Explicitly label container security context as having a readonly root filesystem

How I've tested this PR:

I was attempting to run consul in a restricted namespace and our gatekeeper policy tripper on this.  I found I could not add the context by manipulating the helm values and so a PR was required,

I have tested it by deploying my updated package and confirming gatekeeper was not tripped

How I expect reviewers to test this PR:

Confirm it deploys fine in a standard test environment just for sanity: as the components don't write this labelling doesn't affect functionality and so is a no-op for anyone not already blocked by  security context.

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


