### PR TITLE
Adding ability readinessProbe to use PODIP of consul server

### DIFF
--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -509,12 +509,27 @@ spec:
                 - "-ec"
                 - |
                   {{- if .Values.global.tls.enabled }}
-                  curl -k \
+                  {{- if .Values.server.readinessProbe.usePodIp.enabled }}
+                  POD_IP=$POD_IP /bin/sh -ce 'curl -k \
+                     --cacert /consul/tls/ca/tls.crt \
+                     https://"$POD_IP":8501/v1/status/leader \
+                  {{- else }}
+                  curl \
+                    --cacert /consul/tls/ca/tls.crt \
                     https://127.0.0.1:8501/v1/status/leader \
+                  {{- end }}
+                  {{- else }}
+                  {{- if .Values.server.readinessProbe.usePodIp.enabled }}
+                  POD_IP=$POD_IP /bin/sh -ce 'curl http://"$POD_IP":8500/v1/status/leader \
                   {{- else }}
                   curl http://127.0.0.1:8500/v1/status/leader \
                   {{- end }}
+                  {{- end }}
+                  {{- if .Values.server.readinessProbe.usePodIp.enabled }}
+                  2>/dev/null | grep -E '".+"''
+                  {{- else }}
                   2>/dev/null | grep -E '".+"'
+                  {{- end }}
             failureThreshold: 2
             initialDelaySeconds: 5
             periodSeconds: 3

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -745,7 +745,16 @@ server:
   # @default: global.enabled
   # @type: boolean
   enabled: "-"
-
+  # If True, then Readines probe url will be generated with POD IP for each replica
+  # This is disabled by default
+  # @default: readinessProbe.usePodIp.enabled
+  # @type: boolean
+  # This is used when you want to use more than one consul server
+  # in kubernetes cluster.
+  # This can accure when you are using CNI like a cilium.
+  readinessProbe:
+    usePodIp:
+      enabled: false
   # Override global log verbosity level. One of "trace", "debug", "info", "warn", or "error".
   # @type: string
   logLevel: ""


### PR DESCRIPTION
Changes proposed in this PR:
- Adding Consul server POD IP in readiness probe
- Adding additional key for it in values file.

How I've tested this PR:
   I have set values variable: **.server.readinessProbe.usePodIp.enabled** to true.
How I expect reviewers to test this PR:
  You have to change in values file set  **.server.readinessProbe.usePodIp.enabled** to true and then Readiness probe in statefullset  will render with corseponeding Pod IP of the current POD.

By default, it is set to false, ensuring backward compatibility, and it will use localhost.

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


