### PR TITLE
Tests: Fix/improve tests with Restricted PSA enforcement

### DIFF
--- a/acceptance/framework/connhelper/connect_helper.go
+++ b/acceptance/framework/connhelper/connect_helper.go
@@ -144,11 +144,11 @@ func (c *ConnectHelper) DeployClientAndServer(t *testing.T) {
 			k8s.DeployKustomize(t, opts, c.Cfg.NoCleanupOnFailure, c.Cfg.NoCleanup, c.Cfg.DebugDirectory, "../fixtures/cases/static-client-openshift-inject")
 		}
 	} else {
-		k8s.DeployKustomize(t, c.Ctx.KubectlOptions(t), c.Cfg.NoCleanupOnFailure, c.Cfg.NoCleanup, c.Cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
+		k8s.DeployKustomize(t, opts, c.Cfg.NoCleanupOnFailure, c.Cfg.NoCleanup, c.Cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
 		if c.Cfg.EnableTransparentProxy {
-			k8s.DeployKustomize(t, c.Ctx.KubectlOptions(t), c.Cfg.NoCleanupOnFailure, c.Cfg.NoCleanup, c.Cfg.DebugDirectory, "../fixtures/cases/static-client-tproxy")
+			k8s.DeployKustomize(t, opts, c.Cfg.NoCleanupOnFailure, c.Cfg.NoCleanup, c.Cfg.DebugDirectory, "../fixtures/cases/static-client-tproxy")
 		} else {
-			k8s.DeployKustomize(t, c.Ctx.KubectlOptions(t), c.Cfg.NoCleanupOnFailure, c.Cfg.NoCleanup, c.Cfg.DebugDirectory, "../fixtures/cases/static-client-inject")
+			k8s.DeployKustomize(t, opts, c.Cfg.NoCleanupOnFailure, c.Cfg.NoCleanup, c.Cfg.DebugDirectory, "../fixtures/cases/static-client-inject")
 		}
 	}
 	// Check that both static-server and static-client have been injected and

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -64,6 +64,10 @@ func NewHelmCluster(
 	cfg *config.TestConfig,
 	releaseName string,
 ) *HelmCluster {
+	if cfg.EnableRestrictedPSAEnforcement {
+		configureNamespace(t, ctx.KubernetesClient(t), cfg, ctx.KubectlOptions(t).Namespace)
+	}
+
 	if cfg.EnablePodSecurityPolicies {
 		configurePodSecurityPolicies(t, ctx.KubernetesClient(t), cfg, ctx.KubectlOptions(t).Namespace)
 	}
@@ -519,6 +523,35 @@ func configurePodSecurityPolicies(t *testing.T, client kubernetes.Interface, cfg
 
 func createOrUpdateLicenseSecret(t *testing.T, client kubernetes.Interface, cfg *config.TestConfig, namespace string) {
 	CreateK8sSecret(t, client, cfg, namespace, config.LicenseSecretName, config.LicenseSecretKey, cfg.EnterpriseLicense)
+}
+
+func configureNamespace(t *testing.T, client kubernetes.Interface, cfg *config.TestConfig, namespace string) {
+	ctx := context.Background()
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   namespace,
+			Labels: map[string]string{},
+		},
+	}
+	if cfg.EnableRestrictedPSAEnforcement {
+		ns.ObjectMeta.Labels["pod-security.kubernetes.io/enforce"] = "restricted"
+		ns.ObjectMeta.Labels["pod-security.kubernetes.io/enforce-version"] = "latest"
+	}
+
+	_, createErr := client.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	if createErr == nil {
+		logger.Logf(t, "Created namespace %s", namespace)
+		return
+	}
+
+	_, updateErr := client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
+	if updateErr == nil {
+		logger.Logf(t, "Updated namespace %s", namespace)
+		return
+	}
+
+	require.Failf(t, "Failed to create or update namespace", "Namespace=%s, CreateError=%s, UpdateError=%s", namespace, createErr, updateErr)
 }
 
 // configureSCCs creates RoleBindings that bind the default service account to cluster roles

--- a/acceptance/framework/flags/flags.go
+++ b/acceptance/framework/flags/flags.go
@@ -117,13 +117,13 @@ func (t *TestFlags) init() {
 	flag.BoolVar(&t.flagEnableCNI, "enable-cni", false,
 		"If true, the test suite will run tests with consul-cni plugin enabled. "+
 			"In general, this will only run against tests that are mesh related (connect, mesh-gateway, peering, etc")
+
 	flag.BoolVar(&t.flagEnableRestrictedPSAEnforcement, "enable-restricted-psa-enforcement", false,
-		"If true, this indicates that Consul is being run in a namespace with restricted PSA enforcement enabled. "+
-			"The tests do not configure Consul's namespace with PSA enforcement enabled. This must configured before tests are run. "+
-			"The CNI and test applications need more privilege than is allowed in a restricted namespace. "+
-			"When set, the CNI will be deployed into the kube-system namespace, and in supported test cases, applications "+
-			"are deployed, by default, into a namespace named '<consul-namespace>-apps' instead of being deployed into the "+
-			"Consul namespace.")
+		"If true, deploy Consul into a namespace with restricted PSA enforcement enabled. "+
+			"The Consul namespaces (-kube-namespaces) will be configured with restricted PSA enforcement. "+
+			"The CNI and test applications are deployed in different namespaces because they need more privilege than is allowed in a restricted namespace. "+
+			"The CNI will be deployed into the kube-system namespace, which is a privileged namespace that should always exist. "+
+			"Test applications are deployed, by default, into a namespace named '<consul-namespace>-apps' instead of the Consul namespace.")
 
 	flag.BoolVar(&t.flagEnableTransparentProxy, "enable-transparent-proxy", false,
 		"If true, the test suite will run tests with transparent proxy enabled. "+


### PR DESCRIPTION
Changes proposed in this PR:

In the acceptance tests:

- fix: Deploy apps to a separate namespace in ConnectHelper when not on OpenShift and `-enable-restricted-psa-enforcement` is set
- improvement: Auto-configure the restricted PSA enforcement label when `-enable-restricted-psa-enforcement` is set

How I've tested this PR:

Run the following commands:

```
$ make kind-cni
$ ./test-psa-kind.sh -cni
```

Where the `./test-psa-kind.sh` script is the following

<details>

<summary>Test script</summary>

```shell
#!/usr/bin/env bash

set -euo pipefail

SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

export CONSUL_LICENSE=$(cat ~/.consul-ent-license)
export CONSUL_ENT_LICENSE=$CONSUL_LICENSE

# Cleanup old namespaces
# for context in $(kubectl config get-contexts -o name | grep '^kind-') ; do
for context in kind-dc1 kind-dc2 ; do
    kubectl --context $context get ns \
		| grep ^acceptance | awk '{print $1}' \
		| xargs -n 1 -I '{}' kubectl --context $context delete ns '{}' || true
done

EXTRA_FLAGS=""

while [[ $# -gt 0 ]]; do
    case $1 in
        -tproxy)
            EXTRA_FLAGS+=" -enable-transparent-proxy"
            shift;
            ;;
        -cni)
            EXTRA_FLAGS+=" -enable-cni -enable-transparent-proxy"
            shift;
            ;;
        *)
            echo "Unrecognized argument: '$1'"
            exit 1
    esac
done

function runtest() {
    local testdir=$1
    local runtest=$2

    if [ -n "$runtest" ]; then
        runtest="-run $runtest"
    fi

    # Create consul namespaces with restricted PSA enformcement.
    set -xeuo pipefail

    local ns_base="acceptance-$1-$RANDOM"
    local contexts=""
    local namespaces=""
    #for context in $(kubectl config get-contexts -o name | grep '^kind-') ; do
    for context in kind-dc1 kind-dc2 ; do
        local consul_namespace="${ns_base}-$context"
        if [ -n "$contexts" ]; then
            contexts+=","
            namespaces+=","
        fi
        contexts+="$context"
        namespaces+="$consul_namespace"
    done

    # Grab the default image versions from the helm values.
    imageK8S=$(cat ../charts/consul/values.yaml | yq -r '.global.imageK8S')
    imageConsul=$(cat ../charts/consul/values.yaml | yq -r '.global.image' | sed 's/consul:/consul-enterprise:/')
    imageDataplane=$(cat ../charts/consul/values.yaml | yq -r '.global.imageConsulDataplane')

    cd "${SCRIPT_DIR}/tests/$testdir"
    rm -rf ./_debug
    mkdir ./_debug
    go test  -v -p 1 -timeout 15m -failfast \
        -consul-k8s-image "$imageK8S" \
        -consul-image "$imageConsul" \
        -consul-dataplane-image "$imageDataplane" \
        -debug-directory ./_debug \
        -enable-enterprise \
        -kube-contexts "$contexts" \
        -kube-namespaces "$namespaces" \
        -enable-multi-cluster -use-kind \
        -enable-restricted-psa-enforcement \
        $EXTRA_FLAGS $runtest \
        ./...
}

runtest "connect" 'TestConnectInject$'
```

</details>

How I expect reviewers to test this PR:

:eyes: or try to run the tests if you want

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


