### PR TITLE
correct prometheus port and scheme annotations if tls is enabled

### DIFF
--- a/.changelog/2782.txt
+++ b/.changelog/2782.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+helm: Update prometheus port and scheme annotations if tls is enabled
+```

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -119,7 +119,13 @@ spec:
         {{- if (and .Values.global.metrics.enabled .Values.global.metrics.enableAgentMetrics) }}
         "prometheus.io/scrape": "true"
         "prometheus.io/path": "/v1/agent/metrics"
+        {{- if .Values.global.tls.enabled }}
+        "prometheus.io/port": "8501"
+        "prometheus.io/scheme": "https"
+        {{- else }}
         "prometheus.io/port": "8500"
+        "prometheus.io/scheme": "http"
+        {{- end }}
         {{- end }}
     spec:
     {{- if .Values.server.affinity }}

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -677,6 +677,41 @@ load _helpers
   [ "${actual}" = "/v1/agent/metrics" ]
 }
 
+@test "server/StatefulSet: when global.metrics.enableAgentMetrics=true, adds prometheus scheme=http annotation" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'global.metrics.enabled=true'  \
+      --set 'global.metrics.enableAgentMetrics=true'  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations."prometheus.io/scheme"' | tee /dev/stderr)
+  [ "${actual}" = "http" ]
+}
+
+@test "server/StatefulSet: when global.metrics.enableAgentMetrics=true and global.tls.enabled=true, adds prometheus port=8501 annotation" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'global.metrics.enabled=true'  \
+      --set 'global.metrics.enableAgentMetrics=true'  \
+      --set 'global.tls.enabled=true'  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations."prometheus.io/port"' | tee /dev/stderr)
+  [ "${actual}" = "8501" ]
+}
+
+@test "server/StatefulSet: when global.metrics.enableAgentMetrics=true and global.tls.enabled=true, adds prometheus scheme=https annotation" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'global.metrics.enabled=true'  \
+      --set 'global.metrics.enableAgentMetrics=true'  \
+      --set 'global.tls.enabled=true'  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations."prometheus.io/scheme"' | tee /dev/stderr)
+  [ "${actual}" = "https" ]
+}
+
 #--------------------------------------------------------------------
 # config-configmap
 


### PR DESCRIPTION
Changes proposed in this PR:
Fixing #1856 
- Correct prometheus port ( 8501) and scheme ( https) annotations if tls is enabled.
- Setting prometheus scheme to http if tls is disabled. 

How I've tested this PR:
Created a local cluster using kind and checked prometheus annotations on consul-server  pod using kubectl.

kubectl get pod consul-server-0 --namespace consul -o jsonpath='{.metadata.annotations}'

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


