### PR TITLE
Update Kustomize to use `patches` instead of `patchesStrategicMerge`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,7 +376,7 @@ rebase the branch on main, fixing any conflicts along the way before the code ca
 
 ### Generating YAML
 1. Run `make ctrl-manifests` to generate the CRD and webhook YAML.
-1. Uncomment your CRD in `control-plane/config/crd/kustomization` under `patchesStrategicMerge:`
+1. Uncomment your CRD in `control-plane/config/crd/kustomization` under `patches:`
 1. Update the sample, e.g. `control-plane/config/samples/consul_v1alpha1_ingressgateway.yaml` to a valid resource
    that can be used for testing:
     ```yaml

--- a/acceptance/tests/fixtures/cases/api-gateways/jwt-auth/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/api-gateways/jwt-auth/kustomization.yaml
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resources:
-  - ../../../bases/api-gateway
-  - ../../static-server-inject
-  - ./httproute.yaml
-  - ./jwt-provider.yaml
+- ../../../bases/api-gateway
+- ../../static-server-inject
+- ./httproute.yaml
+- ./jwt-provider.yaml
 
-patchesStrategicMerge:
-  - httproute-no-auth.yaml
-  - api-gateway.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- patch: httproute-no-auth.yaml
+- path: api-gateway.yaml

--- a/acceptance/tests/fixtures/cases/crd-partitions/default-partition-default/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/crd-partitions/default-partition-default/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/exportedservices-default
-
-patchesStrategicMerge:
-- patch.yaml
+- ../../../bases/exportedservices-default
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/crd-partitions/default-partition-ns1/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/crd-partitions/default-partition-ns1/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/exportedservices-default
-
-patchesStrategicMerge:
-- patch.yaml
+- ../../../bases/exportedservices-default
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/crd-partitions/secondary-partition-default/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/crd-partitions/secondary-partition-default/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/exportedservices-secondary
-
-patchesStrategicMerge:
-- patch.yaml
+- ../../../bases/exportedservices-secondary
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/crd-partitions/secondary-partition-ns1/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/crd-partitions/secondary-partition-ns1/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/exportedservices-secondary
-
-patchesStrategicMerge:
-- patch.yaml
+- ../../../bases/exportedservices-secondary
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/crd-peers/default-namespace/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/crd-peers/default-namespace/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/exportedservices-default
-
-patchesStrategicMerge:
-- patch.yaml
+- ../../../bases/exportedservices-default
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/crd-peers/default/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/crd-peers/default/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/exportedservices-default
-
-patchesStrategicMerge:
-- patch.yaml
+- ../../../bases/exportedservices-default
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/crd-peers/non-default-namespace/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/crd-peers/non-default-namespace/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/exportedservices-default
-
-patchesStrategicMerge:
-- patch.yaml
+- ../../../bases/exportedservices-default
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/crds-ent/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/crds-ent/kustomization.yaml
@@ -1,7 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - ../../bases/crds-oss
-patchesStrategicMerge:
-- exportedservices.yaml
+patches:
+- path: exportedservices.yaml

--- a/acceptance/tests/fixtures/cases/sameness/cluster-01-a-acceptor/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/cluster-01-a-acceptor/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/sameness/peering/acceptor
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../bases/sameness/peering/acceptor
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/sameness/cluster-01-b-acceptor/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/cluster-01-b-acceptor/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/sameness/peering/acceptor
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../bases/sameness/peering/acceptor
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/sameness/cluster-02-a-acceptor/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/cluster-02-a-acceptor/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/sameness/peering/acceptor
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../bases/sameness/peering/acceptor
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/sameness/cluster-03-a-acceptor/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/cluster-03-a-acceptor/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/sameness/peering/acceptor
-
-patchesStrategicMerge:
-- patch.yaml
+- ../../../bases/sameness/peering/acceptor
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/sameness/exported-services/ap1-partition/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/exported-services/ap1-partition/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../../bases/sameness/exportedservices-ap1
-
-patchesStrategicMerge:
-- patch.yaml
+- ../../../../bases/sameness/exportedservices-ap1
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/sameness/exported-services/default-partition/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/exported-services/default-partition/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../../bases/exportedservices-default
-
-patchesStrategicMerge:
-- patch.yaml
+- ../../../../bases/exportedservices-default
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/sameness/static-client/ap1-partition-tproxy/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/static-client/ap1-partition-tproxy/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/sameness/static-client/ap1-partition/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/static-client/ap1-partition/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/sameness/static-client/default-partition-tproxy/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/static-client/default-partition-tproxy/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/sameness/static-client/default-partition/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/static-client/default-partition/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/sameness/static-server/dc1-default/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/static-server/dc1-default/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../../bases/static-server
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../../bases/static-server
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/sameness/static-server/dc1-partition/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/static-server/dc1-partition/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../../bases/static-server
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../../bases/static-server
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/sameness/static-server/dc2/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/static-server/dc2/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../../bases/static-server
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../../bases/static-server
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/sameness/static-server/dc3/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/static-server/dc3/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../../bases/static-server
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../../bases/static-server
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-inject-multiport/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-inject-multiport/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-inject/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-inject/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-multi-dc/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-multi-dc/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-namespaces/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-namespaces/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-openshift-inject/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-openshift-inject/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-openshift-tproxy/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-openshift-tproxy/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-partitions/default-ns-default-partition/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-partitions/default-ns-default-partition/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-partitions/default-ns-partition/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-partitions/default-ns-partition/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-partitions/ns-default-partition/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-partitions/ns-default-partition/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-partitions/ns-partition/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-partitions/ns-partition/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-peers/default-namespace/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-peers/default-namespace/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-peers/default/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-peers/default/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-peers/non-default-namespace/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-peers/non-default-namespace/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-tproxy/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-tproxy/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../bases/static-client
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../bases/static-client
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-server-inject/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-server-inject/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../bases/static-server
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../bases/static-server
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-server-openshift/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-server-openshift/kustomization.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../bases/static-server
-
-patchesStrategicMerge:
-  - patch.yaml
+- ../../bases/static-server
+patches:
+- path: patch.yaml

--- a/control-plane/config/crd/kustomization.yaml
+++ b/control-plane/config/crd/kustomization.yaml
@@ -1,6 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
@@ -8,7 +11,7 @@ resources:
 - bases/consul.hashicorp.com_controlplanerequestlimits.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_controlplanerequestlimits.yaml


### PR DESCRIPTION
Kustomize no-longer uses `patchesStrategicMerge` -- this feature will be removed in future versions of Kustomize. This PR gets ahead of that change by using the `kustomize edit fix` feature to change configuration to the new model.

We have been getting warnings in our acceptance tests that this change is coming and the new version should be used:

```shell
Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```

I wrote a little script to do this:

```bash
files=$(rg patchesStrategicMerge -l)

while IFS= read -r file; do
	dir_path=$(dirname "$file")

	cd "$dir_path" || exit

	kustomize edit fix

	cd - || exit
done <<< "$files"
```

Changes proposed in this PR:
- Fix Kustomization for cases
- Fix patches in config

How I've tested this PR:

- We'll observe that the warning is no-longer thrown when running acceptance tests.

How I expect reviewers to test this PR:

- We'll observe that the warning is no-longer thrown when running acceptance tests.

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


