### PR TITLE
NET-5186 Add NET_BIND_SERVICE capability to Consul's restricted securityContext

### DIFF
--- a/.changelog/2787.txt
+++ b/.changelog/2787.txt
@@ -1,3 +1,3 @@
-```release-note:security
+```release-note:improvement
 Add NET_BIND_SERVICE capability to restricted security context used for consul-dataplane
 ```

--- a/.changelog/2787.txt
+++ b/.changelog/2787.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Add NET_BIND_SERVICE capability to restricted security context used for consul-dataplane
+```

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -22,6 +22,8 @@ securityContext:
   capabilities:
     drop:
     - ALL
+    add:
+    - NET_BIND_SERVICE
   runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -856,7 +856,8 @@ load _helpers
   local expected=$(echo '{
     "allowPrivilegeEscalation": false,
     "capabilities": {
-      "drop": ["ALL"]
+      "drop": ["ALL"],
+      "add": ["NET_BIND_SERVICE"]
     },
     "runAsNonRoot": true,
     "seccompProfile": {
@@ -887,7 +888,8 @@ load _helpers
   local expected=$(echo '{
     "allowPrivilegeEscalation": false,
     "capabilities": {
-      "drop": ["ALL"]
+      "drop": ["ALL"],
+      "add": ["NET_BIND_SERVICE"]
     },
     "runAsNonRoot": true,
     "seccompProfile": {


### PR DESCRIPTION
Changes proposed in this PR:
- Add the `NET_BIND_SERVICE` capability for consul-dataplane related to https://github.com/hashicorp/consul-dataplane/pull/238

How I've tested this PR:
- Install consul w/ ingress-gateway serving on a privileged port such as `443`
- Install consul under restricted pod security policy
- Install consul under restricted[-v2] OpenShift security context constraints

How I expect reviewers to test this PR:
- See above

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


