### PR TITLE
added check if anonymous token policy exists

### DIFF
--- a/.changelog/2790.txt
+++ b/.changelog/2790.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+control-plane: prevent updation of anonymous-token-policy and anonymous-token if anonymous-token-policy is already attached to the anonymous-token
+```

--- a/control-plane/subcommand/server-acl-init/anonymous_token.go
+++ b/control-plane/subcommand/server-acl-init/anonymous_token.go
@@ -7,6 +7,11 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
+const (
+	AnonymousTokenPolicyName = "anonymous-token-policy"
+	AnonymousTokenAccessorID = "00000000-0000-0000-0000-000000000002"
+)
+
 // configureAnonymousPolicy sets up policies and tokens so that Consul DNS and
 // cross-datacenter Consul connect calls will work.
 func (c *Command) configureAnonymousPolicy(consulClient *api.Client) error {
@@ -17,6 +22,7 @@ func (c *Command) configureAnonymousPolicy(consulClient *api.Client) error {
 	if exists {
 		return nil
 	}
+
 	anonRules, err := c.anonymousTokenRules()
 	if err != nil {
 		c.log.Error("Error templating anonymous token rules", "err", err)
@@ -25,7 +31,7 @@ func (c *Command) configureAnonymousPolicy(consulClient *api.Client) error {
 
 	// Create policy for the anonymous token
 	anonPolicy := api.ACLPolicy{
-		Name:        "anonymous-token-policy",
+		Name:        AnonymousTokenPolicyName,
 		Description: "Anonymous token Policy",
 		Rules:       anonRules,
 	}
@@ -40,7 +46,7 @@ func (c *Command) configureAnonymousPolicy(consulClient *api.Client) error {
 
 	// Create token to get sent to TokenUpdate
 	aToken := api.ACLToken{
-		AccessorID: "00000000-0000-0000-0000-000000000002",
+		AccessorID: AnonymousTokenAccessorID,
 		Policies:   []*api.ACLTokenPolicyLink{{Name: anonPolicy.Name}},
 	}
 
@@ -53,24 +59,16 @@ func (c *Command) configureAnonymousPolicy(consulClient *api.Client) error {
 }
 
 func checkIfAnonymousTokenPolicyExists(consulClient *api.Client) (bool, error) {
-	token, _, err := consulClient.ACL().TokenRead("00000000-0000-0000-0000-000000000002", nil)
+	token, _, err := consulClient.ACL().TokenRead(AnonymousTokenAccessorID, nil)
 	if err != nil {
 		return false, err
 	}
-	existingPolicies, _, err := consulClient.ACL().PolicyList(&api.QueryOptions{})
-	if err != nil {
-		return false, err
-	}
-	policyID := ""
-	for _, existingPolicy := range existingPolicies {
-		if existingPolicy.Name == "anonymous-token-policy" && existingPolicy.Description == "Anonymous token Policy" {
-			policyID = existingPolicy.ID
-		}
-	}
+
 	for _, policy := range token.Policies {
-		if policy.ID == policyID {
+		if policy.Name == AnonymousTokenPolicyName {
 			return true, nil
 		}
 	}
+
 	return false, nil
 }

--- a/control-plane/subcommand/server-acl-init/anonymous_token.go
+++ b/control-plane/subcommand/server-acl-init/anonymous_token.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	AnonymousTokenPolicyName = "anonymous-token-policy"
-	AnonymousTokenAccessorID = "00000000-0000-0000-0000-000000000002"
+	anonymousTokenPolicyName = "anonymous-token-policy"
+	anonymousTokenAccessorID = "00000000-0000-0000-0000-000000000002"
 )
 
 // configureAnonymousPolicy sets up policies and tokens so that Consul DNS and
@@ -31,7 +31,7 @@ func (c *Command) configureAnonymousPolicy(consulClient *api.Client) error {
 
 	// Create policy for the anonymous token
 	anonPolicy := api.ACLPolicy{
-		Name:        AnonymousTokenPolicyName,
+		Name:        anonymousTokenPolicyName,
 		Description: "Anonymous token Policy",
 		Rules:       anonRules,
 	}
@@ -46,7 +46,7 @@ func (c *Command) configureAnonymousPolicy(consulClient *api.Client) error {
 
 	// Create token to get sent to TokenUpdate
 	aToken := api.ACLToken{
-		AccessorID: AnonymousTokenAccessorID,
+		AccessorID: anonymousTokenAccessorID,
 		Policies:   []*api.ACLTokenPolicyLink{{Name: anonPolicy.Name}},
 	}
 
@@ -59,13 +59,13 @@ func (c *Command) configureAnonymousPolicy(consulClient *api.Client) error {
 }
 
 func checkIfAnonymousTokenPolicyExists(consulClient *api.Client) (bool, error) {
-	token, _, err := consulClient.ACL().TokenRead(AnonymousTokenAccessorID, nil)
+	token, _, err := consulClient.ACL().TokenRead(anonymousTokenAccessorID, nil)
 	if err != nil {
 		return false, err
 	}
 
 	for _, policy := range token.Policies {
-		if policy.Name == AnonymousTokenPolicyName {
+		if policy.Name == anonymousTokenPolicyName {
 			return true, nil
 		}
 	}

--- a/control-plane/subcommand/server-acl-init/anonymous_token.go
+++ b/control-plane/subcommand/server-acl-init/anonymous_token.go
@@ -10,6 +10,13 @@ import (
 // configureAnonymousPolicy sets up policies and tokens so that Consul DNS and
 // cross-datacenter Consul connect calls will work.
 func (c *Command) configureAnonymousPolicy(consulClient *api.Client) error {
+	exists, err := checkIfAnonymousTokenPolicyExists(consulClient)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
 	anonRules, err := c.anonymousTokenRules()
 	if err != nil {
 		c.log.Error("Error templating anonymous token rules", "err", err)
@@ -43,4 +50,27 @@ func (c *Command) configureAnonymousPolicy(consulClient *api.Client) error {
 			_, _, err := consulClient.ACL().TokenUpdate(&aToken, &api.WriteOptions{})
 			return err
 		})
+}
+
+func checkIfAnonymousTokenPolicyExists(consulClient *api.Client) (bool, error) {
+	token, _, err := consulClient.ACL().TokenRead("00000000-0000-0000-0000-000000000002", nil)
+	if err != nil {
+		return false, err
+	}
+	existingPolicies, _, err := consulClient.ACL().PolicyList(&api.QueryOptions{})
+	if err != nil {
+		return false, err
+	}
+	policyID := ""
+	for _, existingPolicy := range existingPolicies {
+		if existingPolicy.Name == "anonymous-token-policy" && existingPolicy.Description == "Anonymous token Policy" {
+			policyID = existingPolicy.ID
+		}
+	}
+	for _, policy := range token.Policies {
+		if policy.ID == policyID {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/control-plane/subcommand/server-acl-init/anonymous_token.go
+++ b/control-plane/subcommand/server-acl-init/anonymous_token.go
@@ -17,9 +17,11 @@ const (
 func (c *Command) configureAnonymousPolicy(consulClient *api.Client) error {
 	exists, err := checkIfAnonymousTokenPolicyExists(consulClient)
 	if err != nil {
+		c.log.Error("Error checking if anonymous token policy exists", "err", err)
 		return err
 	}
 	if exists {
+		c.log.Info("skipping creating anonymous token since it already exists")
 		return nil
 	}
 

--- a/control-plane/subcommand/server-acl-init/anonymous_token_test.go
+++ b/control-plane/subcommand/server-acl-init/anonymous_token_test.go
@@ -63,6 +63,6 @@ func Test_configureAnonymousPolicy(t *testing.T) {
 	newPolicy, _, err := consul.ACL().PolicyReadByName(anonymousTokenPolicyName, nil)
 	require.NoError(t, err)
 
-	// assert policy rule is still same.
+	// assert policy is still same.
 	require.Equal(t, updatedPolicy, newPolicy)
 }

--- a/control-plane/subcommand/server-acl-init/anonymous_token_test.go
+++ b/control-plane/subcommand/server-acl-init/anonymous_token_test.go
@@ -54,15 +54,15 @@ func Test_configureAnonymousPolicy(t *testing.T) {
 		Description: "Anonymous token Policy",
 		Rules:       `acl = "read"`,
 	}
-	updatedPolicy, _, err := consul.ACL().PolicyUpdate(&testPolicy, &api.WriteOptions{})
+	readOnlyPolicy, _, err := consul.ACL().PolicyUpdate(&testPolicy, &api.WriteOptions{})
 	require.NoError(t, err)
 
 	err = cmd.configureAnonymousPolicy(consul)
 	require.NoError(t, err)
 
-	newPolicy, _, err := consul.ACL().PolicyReadByName(anonymousTokenPolicyName, nil)
+	actualPolicy, _, err := consul.ACL().PolicyReadByName(anonymousTokenPolicyName, nil)
 	require.NoError(t, err)
 
 	// assert policy is still same.
-	require.Equal(t, updatedPolicy, newPolicy)
+	require.Equal(t, readOnlyPolicy, actualPolicy)
 }

--- a/control-plane/subcommand/server-acl-init/anonymous_token_test.go
+++ b/control-plane/subcommand/server-acl-init/anonymous_token_test.go
@@ -1,0 +1,53 @@
+package serveraclinit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_configureAnonymousPolicy(t *testing.T) {
+
+	k8s, testClient := completeSetup(t)
+	consulHTTPAddr := testClient.TestServer.HTTPAddr
+	consulGRPCAddr := testClient.TestServer.GRPCAddr
+
+	setUpK8sServiceAccount(t, k8s, ns)
+	ui := cli.NewMockUi()
+	cmd := Command{
+		UI:        ui,
+		clientset: k8s,
+	}
+	cmd.init()
+	flags := []string{"-connect-inject"}
+	cmdArgs := append([]string{
+		"-timeout=1m",
+		"-resource-prefix=" + resourcePrefix,
+		"-k8s-namespace=" + ns,
+		"-auth-method-host=https://my-kube.com",
+		"-addresses", strings.Split(consulHTTPAddr, ":")[0],
+		"-http-port", strings.Split(consulHTTPAddr, ":")[1],
+		"-grpc-port", strings.Split(consulGRPCAddr, ":")[1],
+	}, flags...)
+	responseCode := cmd.Run(cmdArgs)
+	require.Equal(t, 0, responseCode, ui.ErrorWriter.String())
+
+	bootToken := getBootToken(t, k8s, resourcePrefix, ns)
+	consul, err := api.NewClient(&api.Config{
+		Address: consulHTTPAddr,
+		Token:   bootToken,
+	})
+	require.NoError(t, err)
+
+	// creates new anonymous token policy
+	errx := cmd.configureAnonymousPolicy(consul)
+	require.NoError(t, errx)
+
+	// does not create/update anonymous token policy
+	erry := cmd.configureAnonymousPolicy(consul)
+	require.NoError(t, erry)
+
+}


### PR DESCRIPTION
Changes proposed in this PR:

Prevent updating anonymous token if it already exists and is attached to the anonymous token policy

How I've tested this PR:

- setup the deafault partiton and create a non-default partition called my-partition.
- modified the anonymous token policy rule.
- created helm deployment in my-partiton using acl bootstrap token with following policies.
```hcl
acl = "read"
operator = "read"
agent_prefix "" {
  policy = "read"
}
```
```hcl
partition "my-partition" {
  acl = "write"
  mesh = "write"
  peering = "write"
  namespace_prefix "" {
    policy = "write"
  }
  service_prefix "" {
    policy = "write"
  }
}
```

- server-acl-acl init was successfull and anonymous token policy rule didn't get updated


How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


