### PR TITLE
[NET-4498] Test locality propagation to services from k8s

### DIFF
--- a/acceptance/framework/k8s/kubectl.go
+++ b/acceptance/framework/k8s/kubectl.go
@@ -122,6 +122,14 @@ func KubectlScale(t *testing.T, options *k8s.KubectlOptions, deployment string, 
 	require.NoError(t, err)
 }
 
+// KubectlLabel takes an object and applies the given label to it.
+// Example: `KubectlLabel(t, options, "node", nodeId, corev1.LabelTopologyRegion, "us-east-1")`.
+func KubectlLabel(t *testing.T, options *k8s.KubectlOptions, objectType string, objectId string, key string, value string) {
+	// `kubectl label` doesn't support timeouts
+	_, err := RunKubectlAndGetOutputE(t, options, "label", objectType, objectId, "--overwrite", fmt.Sprintf("%s=%s", key, value))
+	require.NoError(t, err)
+}
+
 // RunKubectl runs an arbitrary kubectl command provided via args and ignores the output.
 // If there's an error running the command, fail the test.
 func RunKubectl(t *testing.T, options *k8s.KubectlOptions, args ...string) {


### PR DESCRIPTION
Verify that we propagate locality (region and zone) from standard k8s annotations to services registered by consul-k8s.

This will later be expanded to exercise multi-cluster locality-based failover.

Changes proposed in this PR:
- Add locality labels to k8s cluster nodes
- Assert that registered services receive corresponding locality config

How I've tested this PR: run locally and in CI

How I expect reviewers to test this PR: 👀 


Checklist:
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


