### PR TITLE
AKS 1.24 is deprecated, update to latest 1.25 patch

### DIFF
--- a/charts/consul/test/terraform/aks/main.tf
+++ b/charts/consul/test/terraform/aks/main.tf
@@ -55,7 +55,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   location                          = azurerm_resource_group.default[count.index].location
   resource_group_name               = azurerm_resource_group.default[count.index].name
   dns_prefix                        = "consul-k8s-${random_id.suffix[count.index].dec}"
-  kubernetes_version                = "1.24.10"
+  kubernetes_version                = var.kubernetes_version
   role_based_access_control_enabled = true
 
   // We're setting the network plugin and other network properties explicitly

--- a/charts/consul/test/terraform/aks/variables.tf
+++ b/charts/consul/test/terraform/aks/variables.tf
@@ -6,6 +6,11 @@ variable "location" {
   description = "The location to launch this AKS cluster in."
 }
 
+variable "kubernetes_version" {
+  default     = "1.25.17"
+  description = "Kubernetes version supported on AKS (1.25.17 Released August 2nd, 2023)"
+}
+
 variable "client_id" {
   default     = ""
   description = "The client ID of the service principal to be used by Kubernetes when creating Azure resources like load balancers."


### PR DESCRIPTION
Changes proposed in this PR:
- Updating kubernetes on AKS.
- Nightly acceptance are failing

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


