### PR TITLE
Automate the k8s sameness tests add peering (#2725)

### DIFF
--- a/acceptance/tests/fixtures/bases/sameness/cluster-03-a-default-ns/sameness.yaml
+++ b/acceptance/tests/fixtures/bases/sameness/cluster-03-a-default-ns/sameness.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: SamenessGroup
 metadata:

--- a/acceptance/tests/fixtures/cases/sameness/static-client/ap1-partition-tproxy/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/static-client/ap1-partition-tproxy/kustomization.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - ../../../../bases/static-client
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/acceptance/tests/fixtures/cases/sameness/static-client/ap1-partition-tproxy/patch.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/static-client/ap1-partition-tproxy/patch.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-client
+spec:
+  template:
+    metadata:
+      annotations:
+        'consul.hashicorp.com/connect-inject': 'true'
+    spec:
+      containers:
+        - name: static-client
+          image: anubhavmishra/tiny-tools:latest
+          # Just spin & wait forever, we'll use `kubectl exec` to demo
+          command: ['/bin/sh', '-c', '--']
+          args: ['while true; do sleep 30; done;']
+      # If ACLs are enabled, the serviceAccountName must match the Consul service name.
+      serviceAccountName: static-client

--- a/acceptance/tests/fixtures/cases/sameness/static-client/default-partition-tproxy/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/static-client/default-partition-tproxy/kustomization.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - ../../../../bases/static-client
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/acceptance/tests/fixtures/cases/sameness/static-client/default-partition-tproxy/patch.yaml
+++ b/acceptance/tests/fixtures/cases/sameness/static-client/default-partition-tproxy/patch.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-client
+spec:
+  template:
+    metadata:
+      annotations:
+        'consul.hashicorp.com/connect-inject': 'true'
+    spec:
+      containers:
+        - name: static-client
+          image: anubhavmishra/tiny-tools:latest
+          # Just spin & wait forever, we'll use `kubectl exec` to demo
+          command: ['/bin/sh', '-c', '--']
+          args: ['while true; do sleep 30; done;']
+      # If ACLs are enabled, the serviceAccountName must match the Consul service name.
+      serviceAccountName: static-client

--- a/acceptance/tests/sameness/sameness_test.go
+++ b/acceptance/tests/sameness/sameness_test.go
@@ -425,21 +425,30 @@ func TestFailover_Connect(t *testing.T) {
 				"../fixtures/cases/sameness/static-server/dc3")
 
 			// Create static client deployments.
+			staticClientKustomizeDirDefault := "../fixtures/cases/sameness/static-client/default-partition"
+			staticClientKustomizeDirAP1 := "../fixtures/cases/sameness/static-client/ap1-partition"
+
+			// If transparent proxy is enabled create clients without explicit upstreams
+			if cfg.EnableTransparentProxy {
+				staticClientKustomizeDirDefault = fmt.Sprintf("%s-%s", staticClientKustomizeDirDefault, "tproxy")
+				staticClientKustomizeDirAP1 = fmt.Sprintf("%s-%s", staticClientKustomizeDirAP1, "tproxy")
+			}
+
 			k8s.DeployKustomize(t, testClusters[keyCluster01a].clientOpts, cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory,
-				"../fixtures/cases/sameness/static-client/default-partition")
+				staticClientKustomizeDirDefault)
 			k8s.DeployKustomize(t, testClusters[keyCluster02a].clientOpts, cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory,
-				"../fixtures/cases/sameness/static-client/default-partition")
+				staticClientKustomizeDirDefault)
 			k8s.DeployKustomize(t, testClusters[keyCluster03a].clientOpts, cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory,
-				"../fixtures/cases/sameness/static-client/default-partition")
+				staticClientKustomizeDirDefault)
 			k8s.DeployKustomize(t, testClusters[keyCluster01b].clientOpts, cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory,
-				"../fixtures/cases/sameness/static-client/ap1-partition")
+				staticClientKustomizeDirAP1)
 
 			// Verify that both static-server and static-client have been injected and now have 2 containers in each cluster.
 			// Also get the server IP
 			testClusters.setServerIP(t)
 
 			// Everything should be up and running now
-			testClusters.verifyServerUpState(t)
+			testClusters.verifyServerUpState(t, cfg.EnableTransparentProxy)
 			logger.Log(t, "all infrastructure up and running")
 
 			// Verify all the failover Scenarios
@@ -511,19 +520,23 @@ func TestFailover_Connect(t *testing.T) {
 					checkDNSPQ: true,
 				},
 			}
-
 			for _, sc := range subCases {
 				t.Run(sc.name, func(t *testing.T) {
 					// Reset the scale of all servers
 					testClusters.resetScale(t)
-					testClusters.verifyServerUpState(t)
+					testClusters.verifyServerUpState(t, cfg.EnableTransparentProxy)
 					// We're resetting the scale, so make sure we have all the new IP addresses saved
 					testClusters.setServerIP(t)
 
 					for _, v := range sc.failovers {
 						// Verify Failover (If this is the first check, then just verifying we're starting with the right server)
 						logger.Log(t, "checking service failover")
-						serviceFailoverCheck(t, sc.server, v.failoverServer.name)
+
+						if cfg.EnableTransparentProxy {
+							serviceFailoverCheck(t, sc.server, v.failoverServer.name, fmt.Sprintf("http://static-server.virtual.ns2.ns.%s.ap.consul", sc.server.fullTextPartition()))
+						} else {
+							serviceFailoverCheck(t, sc.server, v.failoverServer.name, "localhost:8080")
+						}
 
 						// Verify DNS
 						if sc.checkDNSPQ {
@@ -575,6 +588,14 @@ type cluster struct {
 	acceptors      []string
 }
 
+func (c cluster) fullTextPartition() string {
+	if c.partition == "" {
+		return "default"
+	} else {
+		return c.partition
+	}
+}
+
 type clusters map[string]*cluster
 
 func (c clusters) resetScale(t *testing.T) {
@@ -606,11 +627,15 @@ func (c clusters) setServerIP(t *testing.T) {
 
 // verifyServerUpState will verify that the static-servers are all up and running as
 // expected by curling them from their local datacenters.
-func (c clusters) verifyServerUpState(t *testing.T) {
+func (c clusters) verifyServerUpState(t *testing.T, isTproxyEnabled bool) {
 	logger.Logf(t, "verifying that static-servers are up")
 	for _, v := range c {
 		// Query using a client and expect its own name, no failover should occur
-		serviceFailoverCheck(t, v, v.name)
+		if isTproxyEnabled {
+			serviceFailoverCheck(t, v, v.name, fmt.Sprintf("http://static-server.virtual.ns2.ns.%s.ap.consul", v.fullTextPartition()))
+		} else {
+			serviceFailoverCheck(t, v, v.name, "localhost:8080")
+		}
 	}
 }
 
@@ -640,13 +665,13 @@ func applyResources(t *testing.T, cfg *config.TestConfig, kustomizeDir string, o
 // serviceFailoverCheck verifies that the server failed over as expected by checking that curling the `static-server`
 // using the `static-client` responds with the expected cluster name. Each static-server responds with a uniquue
 // name so that we can verify failover occured as expected.
-func serviceFailoverCheck(t *testing.T, server *cluster, expectedName string) {
+func serviceFailoverCheck(t *testing.T, server *cluster, expectedName string, curlAddress string) {
 	timer := &retry.Timer{Timeout: retryTimeout, Wait: 5 * time.Second}
 	var resp string
 	var err error
 	retry.RunWith(timer, t, func(r *retry.R) {
 		resp, err = k8s.RunKubectlAndGetOutputE(t, server.clientOpts, "exec", "-i",
-			staticClientDeployment, "-c", staticClientName, "--", "curl", "localhost:8080")
+			staticClientDeployment, "-c", staticClientName, "--", "curl", curlAddress)
 		require.NoError(r, err)
 		assert.Contains(r, resp, expectedName)
 	})


### PR DESCRIPTION
Changes proposed in this PR:
- This is a backport of https://github.com/hashicorp/consul-k8s/pull/2776

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


