### PR TITLE
Adds fields for PassiveHealthCheck on IngressGateway

### DIFF
--- a/.changelog/2796.txt
+++ b/.changelog/2796.txt
@@ -1,3 +1,3 @@
-```release-note:feature
+```release-note:bug
 ingress-gateway: Adds PassiveHealthCheck to IngressGateway CRD
 ```

--- a/.changelog/2796.txt
+++ b/.changelog/2796.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ingress-gateway: Adds PassiveHealthCheck to IngressGateway CRD
+```

--- a/.changelog/2796.txt
+++ b/.changelog/2796.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-ingress-gateway: Adds PassiveHealthCheck to IngressGateway CRD
+ingress-gateway: Adds missing PassiveHealthCheck to IngressGateways CRD and updates missing fields on ServiceDefaults CRD
 ```

--- a/acceptance/tests/fixtures/bases/job-client/job.yaml
+++ b/acceptance/tests/fixtures/bases/job-client/job.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/acceptance/tests/fixtures/bases/job-client/service.yaml
+++ b/acceptance/tests/fixtures/bases/job-client/service.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/acceptance/tests/fixtures/bases/job-client/serviceaccount.yaml
+++ b/acceptance/tests/fixtures/bases/job-client/serviceaccount.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-0s/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-0s/kustomization.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 
 resources:
   - ../../../bases/job-client

--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-0s/patch.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-0s/patch.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-10s/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-10s/kustomization.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 
 resources:
   - ../../../bases/job-client

--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-10s/patch.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-10s/patch.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject/patch.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject/patch.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/consul/templates/crd-ingressgateways.yaml
+++ b/charts/consul/templates/crd-ingressgateways.yaml
@@ -90,13 +90,14 @@ spec:
                         description: The base time that a host is ejected for. The
                           real time is equal to the base time multiplied by the number
                           of times the host has been ejected and is capped by max_ejection_time
-                          (Default 300s). Defaults to 30000ms or 30s.
+                          (Default 300s). Defaults to 30s.
                         type: string
                       enforcingConsecutive5xx:
                         description: EnforcingConsecutive5xx is the % chance that
                           a host will be actually ejected when an outlier status is
                           detected through consecutive 5xx. This setting can be used
-                          to disable ejection or to ramp it up slowly.
+                          to disable ejection or to ramp it up slowly. Ex. Setting this to
+                          10 will make it a 10% chance that the host will be ejected.
                         format: int32
                         type: integer
                       interval:
@@ -204,14 +205,15 @@ spec:
                                   for. The real time is equal to the base time multiplied
                                   by the number of times the host has been ejected
                                   and is capped by max_ejection_time (Default 300s).
-                                  Defaults to 30000ms or 30s.
+                                  Defaults to 30s.
                                 type: string
                               enforcingConsecutive5xx:
                                 description: EnforcingConsecutive5xx is the % chance
                                   that a host will be actually ejected when an outlier
                                   status is detected through consecutive 5xx. This
                                   setting can be used to disable ejection or to ramp
-                                  it up slowly.
+                                  it up slowly. Ex. Setting this to 10 will make it a 
+                                  10% chance that the host will be ejected.
                                 format: int32
                                 type: integer
                               interval:

--- a/charts/consul/templates/crd-ingressgateways.yaml
+++ b/charts/consul/templates/crd-ingressgateways.yaml
@@ -96,13 +96,15 @@ spec:
                         description: EnforcingConsecutive5xx is the % chance that
                           a host will be actually ejected when an outlier status is
                           detected through consecutive 5xx. This setting can be used
-                          to disable ejection or to ramp it up slowly. Ex. Setting this to
-                          10 will make it a 10% chance that the host will be ejected.
+                          to disable ejection or to ramp it up slowly. Ex. Setting
+                          this to 10 will make it a 10% chance that the host will
+                          be ejected.
                         format: int32
                         type: integer
                       interval:
                         description: Interval between health check analysis sweeps.
                           Each sweep may remove hosts or return hosts to the pool.
+                          Ex. setting this to "10s" will set the interval to 10 seconds.
                         type: string
                       maxEjectionPercent:
                         description: The maximum % of an upstream cluster that can
@@ -212,14 +214,15 @@ spec:
                                   that a host will be actually ejected when an outlier
                                   status is detected through consecutive 5xx. This
                                   setting can be used to disable ejection or to ramp
-                                  it up slowly. Ex. Setting this to 10 will make it a 
-                                  10% chance that the host will be ejected.
+                                  it up slowly. Ex. Setting this to 10 will make it
+                                  a 10% chance that the host will be ejected.
                                 format: int32
                                 type: integer
                               interval:
                                 description: Interval between health check analysis
                                   sweeps. Each sweep may remove hosts or return hosts
-                                  to the pool.
+                                  to the pool. Ex. setting this to "10s" will set
+                                  the interval to 10 seconds.
                                 type: string
                               maxEjectionPercent:
                                 description: The maximum % of an upstream cluster

--- a/charts/consul/templates/crd-ingressgateways.yaml
+++ b/charts/consul/templates/crd-ingressgateways.yaml
@@ -81,6 +81,40 @@ spec:
                       while waiting for a connection to be established.
                     format: int32
                     type: integer
+                  passiveHealthCheck:
+                    description: PassiveHealthCheck configuration determines how upstream
+                      proxy instances will be monitored for removal from the load
+                      balancing pool.
+                    properties:
+                      baseEjectionTime:
+                        description: The base time that a host is ejected for. The
+                          real time is equal to the base time multiplied by the number
+                          of times the host has been ejected and is capped by max_ejection_time
+                          (Default 300s). Defaults to 30000ms or 30s.
+                        type: string
+                      enforcingConsecutive5xx:
+                        description: EnforcingConsecutive5xx is the % chance that
+                          a host will be actually ejected when an outlier status is
+                          detected through consecutive 5xx. This setting can be used
+                          to disable ejection or to ramp it up slowly.
+                        format: int32
+                        type: integer
+                      interval:
+                        description: Interval between health check analysis sweeps.
+                          Each sweep may remove hosts or return hosts to the pool.
+                        type: string
+                      maxEjectionPercent:
+                        description: The maximum % of an upstream cluster that can
+                          be ejected due to outlier detection. Defaults to 10% but
+                          will eject at least one host regardless of the value.
+                        format: int32
+                        type: integer
+                      maxFailures:
+                        description: MaxFailures is the count of consecutive failures
+                          that results in a host being removed from the pool.
+                        format: int32
+                        type: integer
+                    type: object
                 type: object
               listeners:
                 description: Listeners declares what ports the ingress gateway should
@@ -160,6 +194,45 @@ spec:
                               service is located. Partitioning is a Consul Enterprise
                               feature.
                             type: string
+                          passiveHealthCheck:
+                            description: PassiveHealthCheck configuration determines
+                              how upstream proxy instances will be monitored for removal
+                              from the load balancing pool.
+                            properties:
+                              baseEjectionTime:
+                                description: The base time that a host is ejected
+                                  for. The real time is equal to the base time multiplied
+                                  by the number of times the host has been ejected
+                                  and is capped by max_ejection_time (Default 300s).
+                                  Defaults to 30000ms or 30s.
+                                type: string
+                              enforcingConsecutive5xx:
+                                description: EnforcingConsecutive5xx is the % chance
+                                  that a host will be actually ejected when an outlier
+                                  status is detected through consecutive 5xx. This
+                                  setting can be used to disable ejection or to ramp
+                                  it up slowly.
+                                format: int32
+                                type: integer
+                              interval:
+                                description: Interval between health check analysis
+                                  sweeps. Each sweep may remove hosts or return hosts
+                                  to the pool.
+                                type: string
+                              maxEjectionPercent:
+                                description: The maximum % of an upstream cluster
+                                  that can be ejected due to outlier detection. Defaults
+                                  to 10% but will eject at least one host regardless
+                                  of the value.
+                                format: int32
+                                type: integer
+                              maxFailures:
+                                description: MaxFailures is the count of consecutive
+                                  failures that results in a host being removed from
+                                  the pool.
+                                format: int32
+                                type: integer
+                            type: object
                           requestHeaders:
                             description: Allow HTTP header manipulation to be configured.
                             properties:

--- a/charts/consul/templates/crd-proxydefaults.yaml
+++ b/charts/consul/templates/crd-proxydefaults.yaml
@@ -163,15 +163,6 @@ spec:
                       type: string
                     type: array
                 type: object
-              prioritizeByLocality:
-                description: PrioritizeByLocality contains the configuration for
-                  locality aware routing.
-                properties:
-                  mode:
-                    description: Mode specifies the behavior of PrioritizeByLocality
-                      routing. Valid values are "", "none", and "failover".
-                    type: string
-                type: object
               meshGateway:
                 description: MeshGateway controls the default mesh gateway configuration
                   for this service.
@@ -204,6 +195,16 @@ spec:
                   your services secure, we recommend using "strict" mode whenever
                   possible and enabling "permissive" mode only when necessary.'
                 type: string
+              prioritizeByLocality:
+                description: PrioritizeByLocality controls whether the locality of
+                  services within the local partition will be used to prioritize connectivity.
+                properties:
+                  mode:
+                    description: 'Mode specifies the type of prioritization that will
+                      be performed when selecting nodes in the local partition. Valid
+                      values are: "" (default "none"), "none", and "failover".'
+                    type: string
+                type: object
               transparentProxy:
                 description: 'TransparentProxy controls configuration specific to
                   proxies in transparent mode. Note: This cannot be set using the

--- a/charts/consul/templates/crd-routeretryfilters.yaml
+++ b/charts/consul/templates/crd-routeretryfilters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: routeretryfilters.consul.hashicorp.com
   labels:
@@ -53,7 +53,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: RouteRetryFilterSpec defines the desired state of RouteRetryFilter
+            description: RouteRetryFilterSpec defines the desired state of RouteRetryFilter.
             properties:
               numRetries:
                 format: int32
@@ -114,4 +114,10 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 {{- end }}

--- a/charts/consul/templates/crd-routetimeoutfilters.yaml
+++ b/charts/consul/templates/crd-routetimeoutfilters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: routetimeoutfilters.consul.hashicorp.com
   labels:
@@ -54,7 +54,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: RouteTimeoutFilterSpec defines the desired state of RouteTimeoutFilter
+            description: RouteTimeoutFilterSpec defines the desired state of RouteTimeoutFilter.
             properties:
               idleTimeout:
                 description: A Duration represents the elapsed time between two instants
@@ -112,4 +112,10 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 {{- end }}

--- a/charts/consul/templates/crd-servicedefaults.yaml
+++ b/charts/consul/templates/crd-servicedefaults.yaml
@@ -294,7 +294,7 @@ spec:
                               The real time is equal to the base time multiplied by
                               the number of times the host has been ejected and is
                               capped by max_ejection_time (Default 300s). Defaults
-                              to 30000ms or 30s.
+                              to 30s.
                             type: string
                           enforcingConsecutive5xx:
                             description: EnforcingConsecutive5xx is the % chance that
@@ -411,7 +411,7 @@ spec:
                                 The real time is equal to the base time multiplied
                                 by the number of times the host has been ejected and
                                 is capped by max_ejection_time (Default 300s). Defaults
-                                to 30000ms or 30s.
+                                to 30s.
                               type: string
                             enforcingConsecutive5xx:
                               description: EnforcingConsecutive5xx is the % chance

--- a/charts/consul/templates/crd-servicedefaults.yaml
+++ b/charts/consul/templates/crd-servicedefaults.yaml
@@ -301,11 +301,15 @@ spec:
                               a host will be actually ejected when an outlier status
                               is detected through consecutive 5xx. This setting can
                               be used to disable ejection or to ramp it up slowly.
+                              Ex. Setting this to 10 will make it a 10% chance that
+                              the host will be ejected.
                             format: int32
                             type: integer
                           interval:
                             description: Interval between health check analysis sweeps.
                               Each sweep may remove hosts or return hosts to the pool.
+                              Ex. setting this to "10s" will set the interval to 10
+                              seconds.
                             type: string
                           maxEjectionPercent:
                             description: The maximum % of an upstream cluster that
@@ -418,12 +422,15 @@ spec:
                                 that a host will be actually ejected when an outlier
                                 status is detected through consecutive 5xx. This setting
                                 can be used to disable ejection or to ramp it up slowly.
+                                Ex. Setting this to 10 will make it a 10% chance that
+                                the host will be ejected.
                               format: int32
                               type: integer
                             interval:
                               description: Interval between health check analysis
                                 sweeps. Each sweep may remove hosts or return hosts
-                                to the pool.
+                                to the pool. Ex. setting this to "10s" will set the
+                                interval to 10 seconds.
                               type: string
                             maxEjectionPercent:
                               description: The maximum % of an upstream cluster that

--- a/control-plane/api/v1alpha1/ingressgateway_types.go
+++ b/control-plane/api/v1alpha1/ingressgateway_types.go
@@ -6,7 +6,6 @@ package v1alpha1
 import (
 	"encoding/json"
 	"fmt"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/consul-k8s/control-plane/api/common"
@@ -77,6 +76,9 @@ type IngressServiceConfig struct {
 	// will be allowed at a single point in time. Use this to limit HTTP/2 traffic,
 	// since HTTP/2 has many requests per connection.
 	MaxConcurrentRequests *uint32 `json:"maxConcurrentRequests,omitempty"`
+	// PassiveHealthCheck configuration determines how upstream proxy instances will
+	// be monitored for removal from the load balancing pool.
+	PassiveHealthCheck *PassiveHealthCheck `json:"passiveHealthCheck,omitempty"`
 }
 
 type GatewayTLSConfig struct {
@@ -364,6 +366,7 @@ func (in IngressService) toConsul() capi.IngressService {
 		MaxConnections:        in.MaxConnections,
 		MaxPendingRequests:    in.MaxPendingRequests,
 		MaxConcurrentRequests: in.MaxConcurrentRequests,
+		PassiveHealthCheck:    in.PassiveHealthCheck.toConsul(),
 	}
 }
 
@@ -457,6 +460,7 @@ func (in *IngressServiceConfig) validate(path *field.Path) field.ErrorList {
 	if in.MaxPendingRequests != nil && *in.MaxPendingRequests <= 0 {
 		errs = append(errs, field.Invalid(path.Child("maxpendingrequests"), *in.MaxPendingRequests, "MaxPendingRequests must be > 0"))
 	}
+
 	return errs
 }
 
@@ -468,5 +472,6 @@ func (in *IngressServiceConfig) toConsul() *capi.IngressServiceConfig {
 		MaxConnections:        in.MaxConnections,
 		MaxPendingRequests:    in.MaxPendingRequests,
 		MaxConcurrentRequests: in.MaxConcurrentRequests,
+		PassiveHealthCheck:    in.PassiveHealthCheck.toConsul(),
 	}
 }

--- a/control-plane/api/v1alpha1/ingressgateway_types.go
+++ b/control-plane/api/v1alpha1/ingressgateway_types.go
@@ -460,7 +460,6 @@ func (in *IngressServiceConfig) validate(path *field.Path) field.ErrorList {
 	if in.MaxPendingRequests != nil && *in.MaxPendingRequests <= 0 {
 		errs = append(errs, field.Invalid(path.Child("maxpendingrequests"), *in.MaxPendingRequests, "MaxPendingRequests must be > 0"))
 	}
-
 	return errs
 }
 

--- a/control-plane/api/v1alpha1/ingressgateway_types_test.go
+++ b/control-plane/api/v1alpha1/ingressgateway_types_test.go
@@ -4,7 +4,6 @@
 package v1alpha1
 
 import (
-	"k8s.io/utils/pointer"
 	"testing"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
 func TestIngressGateway_MatchesConsul(t *testing.T) {

--- a/control-plane/api/v1alpha1/ingressgateway_types_test.go
+++ b/control-plane/api/v1alpha1/ingressgateway_types_test.go
@@ -4,6 +4,7 @@
 package v1alpha1
 
 import (
+	"k8s.io/utils/pointer"
 	"testing"
 	"time"
 
@@ -70,6 +71,17 @@ func TestIngressGateway_MatchesConsul(t *testing.T) {
 						MaxConnections:        &defaultMaxConnections,
 						MaxPendingRequests:    &defaultMaxPendingRequests,
 						MaxConcurrentRequests: &defaultMaxConcurrentRequests,
+						PassiveHealthCheck: &PassiveHealthCheck{
+							Interval: metav1.Duration{
+								Duration: 2 * time.Second,
+							},
+							MaxFailures:             uint32(20),
+							EnforcingConsecutive5xx: pointer.Uint32(100),
+							MaxEjectionPercent:      pointer.Uint32(10),
+							BaseEjectionTime: &metav1.Duration{
+								Duration: 10 * time.Second,
+							},
+						},
 					},
 					Listeners: []IngressListener{
 						{
@@ -170,6 +182,13 @@ func TestIngressGateway_MatchesConsul(t *testing.T) {
 					MaxConnections:        &defaultMaxConnections,
 					MaxPendingRequests:    &defaultMaxPendingRequests,
 					MaxConcurrentRequests: &defaultMaxConcurrentRequests,
+					PassiveHealthCheck: &capi.PassiveHealthCheck{
+						Interval:                2 * time.Second,
+						MaxFailures:             uint32(20),
+						EnforcingConsecutive5xx: pointer.Uint32(100),
+						MaxEjectionPercent:      pointer.Uint32(10),
+						BaseEjectionTime:        pointer.Duration(10 * time.Second),
+					},
 				},
 				Listeners: []capi.IngressListener{
 					{
@@ -332,6 +351,17 @@ func TestIngressGateway_ToConsul(t *testing.T) {
 						MaxConnections:        &defaultMaxConnections,
 						MaxPendingRequests:    &defaultMaxPendingRequests,
 						MaxConcurrentRequests: &defaultMaxConcurrentRequests,
+						PassiveHealthCheck: &PassiveHealthCheck{
+							Interval: metav1.Duration{
+								Duration: 2 * time.Second,
+							},
+							MaxFailures:             uint32(20),
+							EnforcingConsecutive5xx: pointer.Uint32(100),
+							MaxEjectionPercent:      pointer.Uint32(10),
+							BaseEjectionTime: &metav1.Duration{
+								Duration: 10 * time.Second,
+							},
+						},
 					},
 					Listeners: []IngressListener{
 						{
@@ -431,6 +461,13 @@ func TestIngressGateway_ToConsul(t *testing.T) {
 					MaxConnections:        &defaultMaxConnections,
 					MaxPendingRequests:    &defaultMaxPendingRequests,
 					MaxConcurrentRequests: &defaultMaxConcurrentRequests,
+					PassiveHealthCheck: &capi.PassiveHealthCheck{
+						Interval:                2 * time.Second,
+						MaxFailures:             uint32(20),
+						EnforcingConsecutive5xx: pointer.Uint32(100),
+						MaxEjectionPercent:      pointer.Uint32(10),
+						BaseEjectionTime:        pointer.Duration(10 * time.Second),
+					},
 				},
 				Listeners: []capi.IngressListener{
 					{

--- a/control-plane/api/v1alpha1/servicedefaults_types.go
+++ b/control-plane/api/v1alpha1/servicedefaults_types.go
@@ -187,7 +187,8 @@ type UpstreamLimits struct {
 // be monitored for removal from the load balancing pool.
 type PassiveHealthCheck struct {
 	// Interval between health check analysis sweeps. Each sweep may remove
-	// hosts or return hosts to the pool.
+	// hosts or return hosts to the pool. Ex. setting this to "10s" will set
+	// the interval to 10 seconds.
 	Interval metav1.Duration `json:"interval,omitempty"`
 	// MaxFailures is the count of consecutive failures that results in a host
 	// being removed from the pool.
@@ -195,6 +196,7 @@ type PassiveHealthCheck struct {
 	// EnforcingConsecutive5xx is the % chance that a host will be actually ejected
 	// when an outlier status is detected through consecutive 5xx.
 	// This setting can be used to disable ejection or to ramp it up slowly.
+	// Ex. Setting this to 10 will make it a 10% chance that the host will be ejected.
 	EnforcingConsecutive5xx *uint32 `json:"enforcingConsecutive5xx,omitempty"`
 	// The maximum % of an upstream cluster that can be ejected due to outlier detection.
 	// Defaults to 10% but will eject at least one host regardless of the value.

--- a/control-plane/api/v1alpha1/servicedefaults_types.go
+++ b/control-plane/api/v1alpha1/servicedefaults_types.go
@@ -201,7 +201,7 @@ type PassiveHealthCheck struct {
 	MaxEjectionPercent *uint32 `json:"maxEjectionPercent,omitempty"`
 	// The base time that a host is ejected for. The real time is equal to the base time
 	// multiplied by the number of times the host has been ejected and is capped by
-	// max_ejection_time (Default 300s). Defaults to 30000ms or 30s.
+	// max_ejection_time (Default 300s). Defaults to 30s.
 	BaseEjectionTime *metav1.Duration `json:"baseEjectionTime,omitempty"`
 }
 

--- a/control-plane/config/crd/bases/consul.hashicorp.com_ingressgateways.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_ingressgateways.yaml
@@ -74,6 +74,40 @@ spec:
                       while waiting for a connection to be established.
                     format: int32
                     type: integer
+                  passiveHealthCheck:
+                    description: PassiveHealthCheck configuration determines how upstream
+                      proxy instances will be monitored for removal from the load
+                      balancing pool.
+                    properties:
+                      baseEjectionTime:
+                        description: The base time that a host is ejected for. The
+                          real time is equal to the base time multiplied by the number
+                          of times the host has been ejected and is capped by max_ejection_time
+                          (Default 300s). Defaults to 30000ms or 30s.
+                        type: string
+                      enforcingConsecutive5xx:
+                        description: EnforcingConsecutive5xx is the % chance that
+                          a host will be actually ejected when an outlier status is
+                          detected through consecutive 5xx. This setting can be used
+                          to disable ejection or to ramp it up slowly.
+                        format: int32
+                        type: integer
+                      interval:
+                        description: Interval between health check analysis sweeps.
+                          Each sweep may remove hosts or return hosts to the pool.
+                        type: string
+                      maxEjectionPercent:
+                        description: The maximum % of an upstream cluster that can
+                          be ejected due to outlier detection. Defaults to 10% but
+                          will eject at least one host regardless of the value.
+                        format: int32
+                        type: integer
+                      maxFailures:
+                        description: MaxFailures is the count of consecutive failures
+                          that results in a host being removed from the pool.
+                        format: int32
+                        type: integer
+                    type: object
                 type: object
               listeners:
                 description: Listeners declares what ports the ingress gateway should
@@ -153,6 +187,45 @@ spec:
                               service is located. Partitioning is a Consul Enterprise
                               feature.
                             type: string
+                          passiveHealthCheck:
+                            description: PassiveHealthCheck configuration determines
+                              how upstream proxy instances will be monitored for removal
+                              from the load balancing pool.
+                            properties:
+                              baseEjectionTime:
+                                description: The base time that a host is ejected
+                                  for. The real time is equal to the base time multiplied
+                                  by the number of times the host has been ejected
+                                  and is capped by max_ejection_time (Default 300s).
+                                  Defaults to 30000ms or 30s.
+                                type: string
+                              enforcingConsecutive5xx:
+                                description: EnforcingConsecutive5xx is the % chance
+                                  that a host will be actually ejected when an outlier
+                                  status is detected through consecutive 5xx. This
+                                  setting can be used to disable ejection or to ramp
+                                  it up slowly.
+                                format: int32
+                                type: integer
+                              interval:
+                                description: Interval between health check analysis
+                                  sweeps. Each sweep may remove hosts or return hosts
+                                  to the pool.
+                                type: string
+                              maxEjectionPercent:
+                                description: The maximum % of an upstream cluster
+                                  that can be ejected due to outlier detection. Defaults
+                                  to 10% but will eject at least one host regardless
+                                  of the value.
+                                format: int32
+                                type: integer
+                              maxFailures:
+                                description: MaxFailures is the count of consecutive
+                                  failures that results in a host being removed from
+                                  the pool.
+                                format: int32
+                                type: integer
+                            type: object
                           requestHeaders:
                             description: Allow HTTP header manipulation to be configured.
                             properties:

--- a/control-plane/config/crd/bases/consul.hashicorp.com_ingressgateways.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_ingressgateways.yaml
@@ -89,12 +89,15 @@ spec:
                         description: EnforcingConsecutive5xx is the % chance that
                           a host will be actually ejected when an outlier status is
                           detected through consecutive 5xx. This setting can be used
-                          to disable ejection or to ramp it up slowly.
+                          to disable ejection or to ramp it up slowly. Ex. Setting
+                          this to 10 will make it a 10% chance that the host will
+                          be ejected.
                         format: int32
                         type: integer
                       interval:
                         description: Interval between health check analysis sweeps.
                           Each sweep may remove hosts or return hosts to the pool.
+                          Ex. setting this to "10s" will set the interval to 10 seconds.
                         type: string
                       maxEjectionPercent:
                         description: The maximum % of an upstream cluster that can
@@ -204,13 +207,15 @@ spec:
                                   that a host will be actually ejected when an outlier
                                   status is detected through consecutive 5xx. This
                                   setting can be used to disable ejection or to ramp
-                                  it up slowly.
+                                  it up slowly. Ex. Setting this to 10 will make it
+                                  a 10% chance that the host will be ejected.
                                 format: int32
                                 type: integer
                               interval:
                                 description: Interval between health check analysis
                                   sweeps. Each sweep may remove hosts or return hosts
-                                  to the pool.
+                                  to the pool. Ex. setting this to "10s" will set
+                                  the interval to 10 seconds.
                                 type: string
                               maxEjectionPercent:
                                 description: The maximum % of an upstream cluster

--- a/control-plane/config/crd/bases/consul.hashicorp.com_ingressgateways.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_ingressgateways.yaml
@@ -83,7 +83,7 @@ spec:
                         description: The base time that a host is ejected for. The
                           real time is equal to the base time multiplied by the number
                           of times the host has been ejected and is capped by max_ejection_time
-                          (Default 300s). Defaults to 30000ms or 30s.
+                          (Default 300s). Defaults to 30s.
                         type: string
                       enforcingConsecutive5xx:
                         description: EnforcingConsecutive5xx is the % chance that
@@ -197,7 +197,7 @@ spec:
                                   for. The real time is equal to the base time multiplied
                                   by the number of times the host has been ejected
                                   and is capped by max_ejection_time (Default 300s).
-                                  Defaults to 30000ms or 30s.
+                                  Defaults to 30s.
                                 type: string
                               enforcingConsecutive5xx:
                                 description: EnforcingConsecutive5xx is the % chance

--- a/control-plane/config/crd/bases/consul.hashicorp.com_proxydefaults.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_proxydefaults.yaml
@@ -156,15 +156,6 @@ spec:
                       type: string
                     type: array
                 type: object
-              prioritizeByLocality:
-                description: PrioritizeByLocality contains the configuration for
-                  locality aware routing.
-                properties:
-                  mode:
-                    description: Mode specifies the behavior of PrioritizeByLocality
-                      routing. Valid values are "", "none", and "failover".
-                    type: string
-                type: object
               meshGateway:
                 description: MeshGateway controls the default mesh gateway configuration
                   for this service.
@@ -197,6 +188,16 @@ spec:
                   your services secure, we recommend using "strict" mode whenever
                   possible and enabling "permissive" mode only when necessary.'
                 type: string
+              prioritizeByLocality:
+                description: PrioritizeByLocality controls whether the locality of
+                  services within the local partition will be used to prioritize connectivity.
+                properties:
+                  mode:
+                    description: 'Mode specifies the type of prioritization that will
+                      be performed when selecting nodes in the local partition. Valid
+                      values are: "" (default "none"), "none", and "failover".'
+                    type: string
+                type: object
               transparentProxy:
                 description: 'TransparentProxy controls configuration specific to
                   proxies in transparent mode. Note: This cannot be set using the

--- a/control-plane/config/crd/bases/consul.hashicorp.com_routeretryfilters.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_routeretryfilters.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: routeretryfilters.consul.hashicorp.com
 spec:
@@ -49,7 +49,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: RouteRetryFilterSpec defines the desired state of RouteRetryFilter
+            description: RouteRetryFilterSpec defines the desired state of RouteRetryFilter.
             properties:
               numRetries:
                 format: int32
@@ -110,3 +110,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/control-plane/config/crd/bases/consul.hashicorp.com_routetimeoutfilters.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_routetimeoutfilters.yaml
@@ -6,7 +6,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: routetimeoutfilters.consul.hashicorp.com
 spec:
@@ -50,7 +50,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: RouteTimeoutFilterSpec defines the desired state of RouteTimeoutFilter
+            description: RouteTimeoutFilterSpec defines the desired state of RouteTimeoutFilter.
             properties:
               idleTimeout:
                 description: A Duration represents the elapsed time between two instants
@@ -108,3 +108,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/control-plane/config/crd/bases/consul.hashicorp.com_servicedefaults.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_servicedefaults.yaml
@@ -287,7 +287,7 @@ spec:
                               The real time is equal to the base time multiplied by
                               the number of times the host has been ejected and is
                               capped by max_ejection_time (Default 300s). Defaults
-                              to 30000ms or 30s.
+                              to 30s.
                             type: string
                           enforcingConsecutive5xx:
                             description: EnforcingConsecutive5xx is the % chance that
@@ -404,7 +404,7 @@ spec:
                                 The real time is equal to the base time multiplied
                                 by the number of times the host has been ejected and
                                 is capped by max_ejection_time (Default 300s). Defaults
-                                to 30000ms or 30s.
+                                to 30s.
                               type: string
                             enforcingConsecutive5xx:
                               description: EnforcingConsecutive5xx is the % chance

--- a/control-plane/config/crd/bases/consul.hashicorp.com_servicedefaults.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_servicedefaults.yaml
@@ -294,11 +294,15 @@ spec:
                               a host will be actually ejected when an outlier status
                               is detected through consecutive 5xx. This setting can
                               be used to disable ejection or to ramp it up slowly.
+                              Ex. Setting this to 10 will make it a 10% chance that
+                              the host will be ejected.
                             format: int32
                             type: integer
                           interval:
                             description: Interval between health check analysis sweeps.
                               Each sweep may remove hosts or return hosts to the pool.
+                              Ex. setting this to "10s" will set the interval to 10
+                              seconds.
                             type: string
                           maxEjectionPercent:
                             description: The maximum % of an upstream cluster that
@@ -411,12 +415,15 @@ spec:
                                 that a host will be actually ejected when an outlier
                                 status is detected through consecutive 5xx. This setting
                                 can be used to disable ejection or to ramp it up slowly.
+                                Ex. Setting this to 10 will make it a 10% chance that
+                                the host will be ejected.
                               format: int32
                               type: integer
                             interval:
                               description: Interval between health check analysis
                                 sweeps. Each sweep may remove hosts or return hosts
-                                to the pool.
+                                to the pool. Ex. setting this to "10s" will set the
+                                interval to 10 seconds.
                               type: string
                             maxEjectionPercent:
                               description: The maximum % of an upstream cluster that

--- a/control-plane/consul/resource_client.go
+++ b/control-plane/consul/resource_client.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package consul
 
 import (

--- a/control-plane/consul/resource_client_test.go
+++ b/control-plane/consul/resource_client_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package consul
 
 import (


### PR DESCRIPTION
Changes proposed in this PR:
- This adds the PassiveHealthCheck onto IngressGateways. The fields were missing from the CRD.
- Related Docs PR: https://github.com/hashicorp/consul/pull/18532

How I've tested this PR:
Install Consul locally with the following values:
```
global:
  image: hashicorppreview/consul:1.17-dev
  imageK8S: YOUR_LOCALLY_BUILT_IMAGE_FROM_THIS_PR

ingressGateways:
  enabled: true
  defaults:
    replicas: 1
  gateways:
    - name: ingress-gateway
      service:
        type: ClusterIP
```
Running kubectl apply on the following IngressGateway configuration:
```
apiVersion: consul.hashicorp.com/v1alpha1
kind: IngressGateway
metadata:
  name: ingress-gateway
spec:
  defaults:
    passiveHealthCheck:
      interval: "10s"
      maxFailures: 5
      enforcingConsecutive5xx: 100
      maxEjectionPercent: 10
      baseEjectionTime: "10s"
```
The apply should succeed and you should be able to see the PassiveHealthCheck configured correctly in Consul:
`consul config read -kind ingress-gateway -name ingress-gateway`
```
{
    "Kind": "ingress-gateway",
    "Name": "ingress-gateway",
    "TLS": {
        "Enabled": false
    },
    "Listeners": null,
    "Meta": {
        "consul.hashicorp.com/source-datacenter": "dc1",
        "external-source": "kubernetes"
    },
    "Defaults": {
        "MaxConnections": 0,
        "MaxPendingRequests": 0,
        "MaxConcurrentRequests": 0,
        "PassiveHealthCheck": {
            "Interval": 10000000000,
            "MaxFailures": 5,
            "EnforcingConsecutive5xx": 100,
            "MaxEjectionPercent": 10,
            "BaseEjectionTime": 10000000000
        }
    },
    "CreateIndex": 88,
    "ModifyIndex": 88
}
```
How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


