### PR TITLE
Mw/net 4888 add namespace tests failover wan fed

### DIFF
--- a/acceptance/tests/cli/cli_install_test.go
+++ b/acceptance/tests/cli/cli_install_test.go
@@ -55,7 +55,7 @@ func TestInstall(t *testing.T) {
 			connHelper.Install(t)
 			connHelper.DeployClientAndServer(t)
 			if c.secure {
-				connHelper.TestConnectionFailureWithoutIntention(t)
+				connHelper.TestConnectionFailureWithoutIntention(t, connhelper.ConnHelperOpts{})
 				connHelper.CreateIntention(t, connhelper.IntentionOpts{})
 			}
 
@@ -124,7 +124,7 @@ func TestInstall(t *testing.T) {
 				logger.Log(t, string(proxyOut))
 			}
 
-			connHelper.TestConnectionSuccess(t)
+			connHelper.TestConnectionSuccess(t, connhelper.ConnHelperOpts{})
 			connHelper.TestConnectionFailureWhenUnhealthy(t)
 		})
 	}

--- a/acceptance/tests/cli/cli_install_test.go
+++ b/acceptance/tests/cli/cli_install_test.go
@@ -56,7 +56,7 @@ func TestInstall(t *testing.T) {
 			connHelper.DeployClientAndServer(t)
 			if c.secure {
 				connHelper.TestConnectionFailureWithoutIntention(t)
-				connHelper.CreateIntention(t)
+				connHelper.CreateIntention(t, connhelper.IntentionOpts{})
 			}
 
 			// Run proxy list and get the two results.

--- a/acceptance/tests/connect/connect_inject_test.go
+++ b/acceptance/tests/connect/connect_inject_test.go
@@ -51,11 +51,11 @@ func TestConnectInject(t *testing.T) {
 			connHelper.Install(t)
 			connHelper.DeployClientAndServer(t)
 			if c.secure {
-				connHelper.TestConnectionFailureWithoutIntention(t)
+				connHelper.TestConnectionFailureWithoutIntention(t, connhelper.ConnHelperOpts{})
 				connHelper.CreateIntention(t, connhelper.IntentionOpts{})
 			}
 
-			connHelper.TestConnectionSuccess(t)
+			connHelper.TestConnectionSuccess(t, connhelper.ConnHelperOpts{})
 			connHelper.TestConnectionFailureWhenUnhealthy(t)
 		})
 	}

--- a/acceptance/tests/connect/connect_inject_test.go
+++ b/acceptance/tests/connect/connect_inject_test.go
@@ -52,7 +52,7 @@ func TestConnectInject(t *testing.T) {
 			connHelper.DeployClientAndServer(t)
 			if c.secure {
 				connHelper.TestConnectionFailureWithoutIntention(t)
-				connHelper.CreateIntention(t)
+				connHelper.CreateIntention(t, connhelper.IntentionOpts{})
 			}
 
 			connHelper.TestConnectionSuccess(t)

--- a/acceptance/tests/connect/connect_proxy_lifecycle_test.go
+++ b/acceptance/tests/connect/connect_proxy_lifecycle_test.go
@@ -120,11 +120,11 @@ func TestConnectInject_ProxyLifecycleShutdown(t *testing.T) {
 			})
 
 			if testCfg.secure {
-				connHelper.TestConnectionFailureWithoutIntention(t)
+				connHelper.TestConnectionFailureWithoutIntention(t, connhelper.ConnHelperOpts{})
 				connHelper.CreateIntention(t, connhelper.IntentionOpts{})
 			}
 
-			connHelper.TestConnectionSuccess(t)
+			connHelper.TestConnectionSuccess(t, connhelper.ConnHelperOpts{})
 
 			// Get static-client pod name
 			ns := ctx.KubectlOptions(t).Namespace
@@ -278,7 +278,7 @@ func TestConnectInject_ProxyLifecycleShutdownJob(t *testing.T) {
 			}
 		})
 
-		connHelper.TestConnectionSuccess(t, connhelper.JobName)
+		connHelper.TestConnectionSuccess(t, connhelper.ConnHelperOpts{ClientType: connhelper.JobName})
 
 		// Get job-client pod name
 		ns := ctx.KubectlOptions(t).Namespace

--- a/acceptance/tests/connect/connect_proxy_lifecycle_test.go
+++ b/acceptance/tests/connect/connect_proxy_lifecycle_test.go
@@ -121,7 +121,7 @@ func TestConnectInject_ProxyLifecycleShutdown(t *testing.T) {
 
 			if testCfg.secure {
 				connHelper.TestConnectionFailureWithoutIntention(t)
-				connHelper.CreateIntention(t)
+				connHelper.CreateIntention(t, connhelper.IntentionOpts{})
 			}
 
 			connHelper.TestConnectionSuccess(t)

--- a/acceptance/tests/fixtures/bases/service-resolver/kustomization.yaml
+++ b/acceptance/tests/fixtures/bases/service-resolver/kustomization.yaml
@@ -1,0 +1,5 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - service-resolver.yaml

--- a/acceptance/tests/fixtures/bases/service-resolver/service-resolver.yaml
+++ b/acceptance/tests/fixtures/bases/service-resolver/service-resolver.yaml
@@ -1,0 +1,7 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceResolver
+metadata:
+  name: static-server

--- a/acceptance/tests/fixtures/cases/wan-federation/dc1-ns2-static-server/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/dc1-ns2-static-server/kustomization.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - ../../../bases/static-server
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/acceptance/tests/fixtures/cases/wan-federation/dc1-ns2-static-server/patch.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/dc1-ns2-static-server/patch.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-server
+spec:
+  template:
+    metadata:
+      annotations:
+        "consul.hashicorp.com/connect-inject": "true"
+    spec:
+      containers:
+        - name: static-server
+          image: docker.mirror.hashicorp.services/kschoche/http-echo:latest
+          args:
+            - -text="ns2"
+            - -listen=:8080
+          ports:
+            - containerPort: 8080
+              name: http
+          livenessProbe:
+            httpGet:
+              port: 8080
+            initialDelaySeconds: 1
+            failureThreshold: 1
+            periodSeconds: 1
+          startupProbe:
+            httpGet:
+              port: 8080
+            initialDelaySeconds: 1
+            failureThreshold: 30
+            periodSeconds: 1
+          readinessProbe:
+            exec:
+              command: ['sh', '-c', 'test ! -f /tmp/unhealthy']
+            initialDelaySeconds: 1
+            failureThreshold: 1
+            periodSeconds: 1
+      serviceAccountName: static-server

--- a/acceptance/tests/fixtures/cases/wan-federation/dc1-static-server/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/dc1-static-server/kustomization.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - ../../../bases/static-server
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/acceptance/tests/fixtures/cases/wan-federation/dc1-static-server/patch.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/dc1-static-server/patch.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-server
+spec:
+  template:
+    metadata:
+      annotations:
+        "consul.hashicorp.com/connect-inject": "true"
+    spec:
+      containers:
+        - name: static-server
+          image: docker.mirror.hashicorp.services/kschoche/http-echo:latest
+          args:
+            - -text="dc1"
+            - -listen=:8080
+          ports:
+            - containerPort: 8080
+              name: http
+          livenessProbe:
+            httpGet:
+              port: 8080
+            initialDelaySeconds: 1
+            failureThreshold: 1
+            periodSeconds: 1
+          startupProbe:
+            httpGet:
+              port: 8080
+            initialDelaySeconds: 1
+            failureThreshold: 30
+            periodSeconds: 1
+          readinessProbe:
+            exec:
+              command: ['sh', '-c', 'test ! -f /tmp/unhealthy']
+            initialDelaySeconds: 1
+            failureThreshold: 1
+            periodSeconds: 1
+      serviceAccountName: static-server

--- a/acceptance/tests/fixtures/cases/wan-federation/dc2-static-server/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/dc2-static-server/kustomization.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - ../../../bases/static-server
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/acceptance/tests/fixtures/cases/wan-federation/dc2-static-server/patch.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/dc2-static-server/patch.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-server
+spec:
+  template:
+    metadata:
+      annotations:
+        "consul.hashicorp.com/connect-inject": "true"
+    spec:
+      containers:
+        - name: static-server
+          image: docker.mirror.hashicorp.services/kschoche/http-echo:latest
+          args:
+            - -text="dc2"
+            - -listen=:8080
+          ports:
+            - containerPort: 8080
+              name: http
+          livenessProbe:
+            httpGet:
+              port: 8080
+            initialDelaySeconds: 1
+            failureThreshold: 1
+            periodSeconds: 1
+          startupProbe:
+            httpGet:
+              port: 8080
+            initialDelaySeconds: 1
+            failureThreshold: 30
+            periodSeconds: 1
+          readinessProbe:
+            exec:
+              command: ['sh', '-c', 'test ! -f /tmp/unhealthy']
+            initialDelaySeconds: 1
+            failureThreshold: 1
+            periodSeconds: 1
+      serviceAccountName: static-server

--- a/acceptance/tests/fixtures/cases/wan-federation/service-resolver/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/service-resolver/kustomization.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - ../../../bases/service-resolver
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/acceptance/tests/fixtures/cases/wan-federation/service-resolver/patch.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/service-resolver/patch.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceResolver
+metadata:
+  name: static-server
+spec:
+  connectTimeout: 15s
+  failover:
+    '*':
+      targets:
+      - datacenter: "dc2"
+      - namespace: "ns2"
+

--- a/acceptance/tests/fixtures/cases/wan-federation/static-client/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/static-client/kustomization.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - ../../../bases/static-client
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/acceptance/tests/fixtures/cases/wan-federation/static-client/patch.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/static-client/patch.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-client
+spec:
+  template:
+    metadata:
+      annotations:
+        'consul.hashicorp.com/connect-inject': 'true'
+        "consul.hashicorp.com/connect-service-upstreams": "static-server:1234"
+    spec:
+      containers:
+        - name: static-client
+          image: anubhavmishra/tiny-tools:latest
+          # Just spin & wait forever, we'll use `kubectl exec` to demo
+          command: ['/bin/sh', '-c', '--']
+          args: ['while true; do sleep 30; done;']
+      # If ACLs are enabled, the serviceAccountName must match the Consul service name.
+      serviceAccountName: static-client

--- a/acceptance/tests/wan-federation/wan_federation_gateway_test.go
+++ b/acceptance/tests/wan-federation/wan_federation_gateway_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul-k8s/acceptance/framework/connhelper"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
@@ -217,7 +218,7 @@ func checkConnectivity(t *testing.T, ctx environment.TestContext, client *api.Cl
 	targetAddress := fmt.Sprintf("http://%s/", gatewayAddress)
 
 	logger.Log(t, "checking that the connection is not successful because there's no intention")
-	k8s.CheckStaticServerHTTPConnectionFailing(t, ctx.KubectlOptions(t), StaticClientName, targetAddress)
+	k8s.CheckStaticServerHTTPConnectionFailing(t, ctx.KubectlOptions(t), connhelper.StaticClientName, targetAddress)
 
 	logger.Log(t, "creating intention")
 	_, _, err := client.ConfigEntries().Set(&api.ServiceIntentionsConfigEntry{
@@ -237,5 +238,5 @@ func checkConnectivity(t *testing.T, ctx environment.TestContext, client *api.Cl
 	}()
 
 	logger.Log(t, "checking that connection is successful")
-	k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), StaticClientName, targetAddress)
+	k8s.CheckStaticServerConnectionSuccessful(t, ctx.KubectlOptions(t), connhelper.StaticClientName, targetAddress)
 }

--- a/acceptance/tests/wan-federation/wan_federation_gateway_test.go
+++ b/acceptance/tests/wan-federation/wan_federation_gateway_test.go
@@ -61,15 +61,6 @@ func TestWANFederation_Gateway(t *testing.T) {
 	primaryConsulCluster := consul.NewHelmCluster(t, primaryHelmValues, primaryContext, cfg, releaseName)
 	primaryConsulCluster.Create(t)
 
-	// Get the federation secret from the primary cluster and apply it to secondary cluster
-	federationSecretName := fmt.Sprintf("%s-consul-federation", releaseName)
-	logger.Logf(t, "retrieving federation secret %s from the primary cluster and applying to the secondary", federationSecretName)
-	federationSecret, err := primaryContext.KubernetesClient(t).CoreV1().Secrets(primaryContext.KubectlOptions(t).Namespace).Get(context.Background(), federationSecretName, metav1.GetOptions{})
-	require.NoError(t, err)
-	federationSecret.ResourceVersion = ""
-	_, err = secondaryContext.KubernetesClient(t).CoreV1().Secrets(secondaryContext.KubectlOptions(t).Namespace).Create(context.Background(), federationSecret, metav1.CreateOptions{})
-	require.NoError(t, err)
-
 	var k8sAuthMethodHost string
 	// When running on kind, the kube API address in kubeconfig will have a localhost address
 	// which will not work from inside the container. That's why we need to use the endpoints address instead
@@ -82,6 +73,8 @@ func TestWANFederation_Gateway(t *testing.T) {
 	} else {
 		k8sAuthMethodHost = k8s.KubernetesAPIServerHostFromOptions(t, secondaryContext.KubectlOptions(t))
 	}
+
+	federationSecretName := copyFederationSecret(t, releaseName, primaryContext, secondaryContext)
 
 	// Create secondary cluster
 	secondaryHelmValues := map[string]string{

--- a/acceptance/tests/wan-federation/wan_federation_test.go
+++ b/acceptance/tests/wan-federation/wan_federation_test.go
@@ -8,17 +8,36 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"time"
 
+	terratestK8s "github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/connhelper"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const StaticClientName = "static-client"
+const (
+	StaticClientName = "static-client"
+
+	staticClientDeployment = "deploy/static-client"
+	staticServerDeployment = "deploy/static-server"
+
+	retryTimeout = 5 * time.Minute
+
+	primaryDatacenter   = "dc1"
+	secondaryDatacenter = "dc2"
+
+	localServerPort = "1234"
+
+	primaryNamespace   = "ns1"
+	secondaryNamespace = "ns2"
+)
 
 // Test that Connect and wan federation over mesh gateways work in a default installation
 // i.e. without ACLs because TLS is required for WAN federation over mesh gateways.
@@ -47,7 +66,7 @@ func TestWANFederation(t *testing.T) {
 			secondaryContext := env.Context(t, 1)
 
 			primaryHelmValues := map[string]string{
-				"global.datacenter": "dc1",
+				"global.datacenter": primaryDatacenter,
 
 				"global.tls.enabled":   "true",
 				"global.tls.httpsOnly": strconv.FormatBool(c.secure),
@@ -101,7 +120,7 @@ func TestWANFederation(t *testing.T) {
 
 			// Create secondary cluster
 			secondaryHelmValues := map[string]string{
-				"global.datacenter": "dc2",
+				"global.datacenter": secondaryDatacenter,
 
 				"global.tls.enabled":           "true",
 				"global.tls.httpsOnly":         "false",
@@ -130,7 +149,7 @@ func TestWANFederation(t *testing.T) {
 				secondaryHelmValues["global.acls.replicationToken.secretName"] = federationSecretName
 				secondaryHelmValues["global.acls.replicationToken.secretKey"] = "replicationToken"
 				secondaryHelmValues["global.federation.k8sAuthMethodHost"] = k8sAuthMethodHost
-				secondaryHelmValues["global.federation.primaryDatacenter"] = "dc1"
+				secondaryHelmValues["global.federation.primaryDatacenter"] = primaryDatacenter
 			}
 
 			if cfg.UseKind {
@@ -190,11 +209,259 @@ func TestWANFederation(t *testing.T) {
 			k8s.DeployKustomize(t, primaryHelper.KubectlOptsForApp(t), cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/cases/static-client-multi-dc")
 
 			if c.secure {
-				primaryHelper.CreateIntention(t)
+				primaryHelper.CreateIntention(t, connhelper.IntentionOpts{})
 			}
 
 			logger.Log(t, "checking that connection is successful")
 			k8s.CheckStaticServerConnectionSuccessful(t, primaryHelper.KubectlOptsForApp(t), StaticClientName, "http://localhost:1234")
 		})
 	}
+}
+
+// Test failover scenarios with a static-server in dc1 and a static-server
+// in dc2. Use the static-client on dc1 to reach static-server on dc1 in the
+// nominal scenario, then cause a failure in dc1 static-server to see the static-client failover to
+// the static-server in dc2
+/*
+	dc1-static-client -- nominal -- > dc1-static-server in namespace ns1
+	dc1-static-client -- failover --> dc2-static-server in namespace ns1
+	dc1-static-client -- failover --> dc1-static-server in namespace ns2
+*/
+func TestWANFederationFailover(t *testing.T) {
+	cases := []struct {
+		name   string
+		secure bool
+	}{
+		{
+			name:   "secure",
+			secure: true,
+		},
+		{
+			name:   "default",
+			secure: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			env := suite.Environment()
+			cfg := suite.Config()
+
+			if cfg.EnableRestrictedPSAEnforcement {
+				t.Skip("This test case is not run with enable restricted PSA enforcement enabled")
+			}
+
+			primaryContext := env.DefaultContext(t)
+			secondaryContext := env.Context(t, 1)
+
+			primaryHelmValues := map[string]string{
+				"global.datacenter": primaryDatacenter,
+
+				"global.tls.enabled":   "true",
+				"global.tls.httpsOnly": strconv.FormatBool(c.secure),
+
+				"global.federation.enabled":                "true",
+				"global.federation.createFederationSecret": "true",
+
+				"global.acls.manageSystemACLs":       strconv.FormatBool(c.secure),
+				"global.acls.createReplicationToken": strconv.FormatBool(c.secure),
+
+				"connectInject.enabled":  "true",
+				"connectInject.replicas": "1",
+
+				"meshGateway.enabled":  "true",
+				"meshGateway.replicas": "1",
+
+				"global.enableConsulNamespaces":               "true",
+				"connectInject.consulNamespaces.mirroringK8S": "true",
+			}
+
+			if cfg.UseKind {
+				primaryHelmValues["meshGateway.service.type"] = "NodePort"
+				primaryHelmValues["meshGateway.service.nodePort"] = "30000"
+			}
+
+			releaseName := helpers.RandomName()
+
+			// Install the primary consul cluster in the default kubernetes context
+			primaryConsulCluster := consul.NewHelmCluster(t, primaryHelmValues, primaryContext, cfg, releaseName)
+			primaryConsulCluster.Create(t)
+
+			// Get the federation secret from the primary cluster and apply it to secondary cluster
+			federationSecretName := fmt.Sprintf("%s-consul-federation", releaseName)
+			logger.Logf(t, "Retrieving federation secret %s from the primary cluster and applying to the secondary", federationSecretName)
+			federationSecret, err := primaryContext.KubernetesClient(t).CoreV1().Secrets(primaryContext.KubectlOptions(t).Namespace).Get(context.Background(), federationSecretName, metav1.GetOptions{})
+			require.NoError(t, err)
+			federationSecret.ResourceVersion = ""
+			federationSecret.Namespace = secondaryContext.KubectlOptions(t).Namespace
+			_, err = secondaryContext.KubernetesClient(t).CoreV1().Secrets(secondaryContext.KubectlOptions(t).Namespace).Create(context.Background(), federationSecret, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			var k8sAuthMethodHost string
+			// When running on kind, the kube API address in kubeconfig will have a localhost address
+			// which will not work from inside the container. That's why we need to use the endpoints address instead
+			// which will point the node IP.
+			if cfg.UseKind {
+				// The Kubernetes AuthMethod host is read from the endpoints for the Kubernetes service.
+				kubernetesEndpoint, err := secondaryContext.KubernetesClient(t).CoreV1().Endpoints("default").Get(context.Background(), "kubernetes", metav1.GetOptions{})
+				require.NoError(t, err)
+				k8sAuthMethodHost = fmt.Sprintf("%s:%d", kubernetesEndpoint.Subsets[0].Addresses[0].IP, kubernetesEndpoint.Subsets[0].Ports[0].Port)
+			} else {
+				k8sAuthMethodHost = k8s.KubernetesAPIServerHostFromOptions(t, secondaryContext.KubectlOptions(t))
+			}
+
+			// Create secondary cluster
+			secondaryHelmValues := map[string]string{
+				"global.datacenter": secondaryDatacenter,
+
+				"global.tls.enabled":           "true",
+				"global.tls.httpsOnly":         "false",
+				"global.acls.manageSystemACLs": strconv.FormatBool(c.secure),
+				"global.tls.caCert.secretName": federationSecretName,
+				"global.tls.caCert.secretKey":  "caCert",
+				"global.tls.caKey.secretName":  federationSecretName,
+				"global.tls.caKey.secretKey":   "caKey",
+
+				"global.federation.enabled": "true",
+
+				"server.extraVolumes[0].type":          "secret",
+				"server.extraVolumes[0].name":          federationSecretName,
+				"server.extraVolumes[0].load":          "true",
+				"server.extraVolumes[0].items[0].key":  "serverConfigJSON",
+				"server.extraVolumes[0].items[0].path": "config.json",
+
+				"connectInject.enabled":  "true",
+				"connectInject.replicas": "1",
+
+				"meshGateway.enabled":  "true",
+				"meshGateway.replicas": "1",
+
+				"global.enableConsulNamespaces":               "true",
+				"connectInject.consulNamespaces.mirroringK8S": "true",
+			}
+
+			if c.secure {
+				secondaryHelmValues["global.acls.replicationToken.secretName"] = federationSecretName
+				secondaryHelmValues["global.acls.replicationToken.secretKey"] = "replicationToken"
+				secondaryHelmValues["global.federation.k8sAuthMethodHost"] = k8sAuthMethodHost
+				secondaryHelmValues["global.federation.primaryDatacenter"] = primaryDatacenter
+			}
+
+			if cfg.UseKind {
+				secondaryHelmValues["meshGateway.service.type"] = "NodePort"
+				secondaryHelmValues["meshGateway.service.nodePort"] = "30000"
+			}
+
+			// Install the secondary consul cluster in the secondary kubernetes context
+			secondaryConsulCluster := consul.NewHelmCluster(t, secondaryHelmValues, secondaryContext, cfg, releaseName)
+			secondaryConsulCluster.Create(t)
+
+			primaryClient, _ := primaryConsulCluster.SetupConsulClient(t, c.secure)
+			secondaryClient, _ := secondaryConsulCluster.SetupConsulClient(t, c.secure)
+
+			// Verify federation between servers
+			logger.Log(t, "Verifying federation was successful")
+			helpers.VerifyFederation(t, primaryClient, secondaryClient, releaseName, c.secure)
+
+			// Create a ProxyDefaults resource to configure services to use the mesh
+			// gateways.
+			logger.Log(t, "Creating proxy-defaults config")
+			kustomizeDir := "../fixtures/bases/mesh-gateway"
+			k8s.KubectlApplyK(t, secondaryContext.KubectlOptions(t), kustomizeDir)
+			helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
+				k8s.KubectlDeleteK(t, secondaryContext.KubectlOptions(t), kustomizeDir)
+			})
+
+			primaryHelper := connhelper.ConnectHelper{
+				Secure:          c.secure,
+				ReleaseName:     releaseName,
+				Ctx:             primaryContext,
+				UseAppNamespace: false,
+				Cfg:             cfg,
+				ConsulClient:    primaryClient,
+			}
+			secondaryHelper := connhelper.ConnectHelper{
+				Secure:          c.secure,
+				ReleaseName:     releaseName,
+				Ctx:             secondaryContext,
+				UseAppNamespace: false,
+				Cfg:             cfg,
+				ConsulClient:    secondaryClient,
+			}
+
+			// Create Namespaces
+			primaryNamespaceOpts := primaryHelper.Ctx.KubectlOptionsForNamespace(primaryNamespace)
+			primaryHelper.SetupNamespace(t, primaryNamespaceOpts.Namespace)
+			primarySecondaryNamepsaceOpts := primaryHelper.Ctx.KubectlOptionsForNamespace(secondaryNamespace)
+			primaryHelper.SetupNamespace(t, primarySecondaryNamepsaceOpts.Namespace)
+			secondaryNamespaceOtps := secondaryHelper.Ctx.KubectlOptionsForNamespace(primaryNamespace)
+			secondaryHelper.SetupNamespace(t, secondaryNamespaceOtps.Namespace)
+
+			// Create a static-server in dc2 to respond with its own name for checking failover.
+			logger.Log(t, "Creating static-server in dc2")
+			k8s.DeployKustomize(t, secondaryNamespaceOtps, cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/cases/wan-federation/dc2-static-server")
+
+			// Spin up a server on dc1 which will be the primary upstream for our client
+			logger.Log(t, "Creating static-server in dc1")
+			k8s.DeployKustomize(t, primaryNamespaceOpts, cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/cases/wan-federation/dc1-static-server")
+			logger.Log(t, "Creating static-client in dc1")
+			k8s.DeployKustomize(t, primaryNamespaceOpts, cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/cases/wan-federation/static-client")
+
+			// Spin up a second server on dc1 in a separate namespace
+			logger.Logf(t, "Creating server on dc1 in namespace %s", primarySecondaryNamepsaceOpts.Namespace)
+			k8s.DeployKustomize(t, primarySecondaryNamepsaceOpts, cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/cases/wan-federation/dc1-ns2-static-server")
+
+			// There is currently an issue that requires the intentions and resolvers to be created after
+			// the static-server/clients when using namespaces. When created before, Consul gives a "namespace does not exist"
+			// error
+			if c.secure {
+				// Only need to create intentions in the primary datacenter as they will be replicated to the secondary
+				// ns1 static-client (source) -> ns1 static-server (destination)
+				primaryHelper.CreateIntention(t, connhelper.IntentionOpts{DestinationNamespace: primaryNamespaceOpts.Namespace, SourceNamespace: primaryNamespaceOpts.Namespace})
+
+				// ns1 static-client (source) -> ns2 static-sever (destination)
+				primaryHelper.CreateIntention(t, connhelper.IntentionOpts{DestinationNamespace: primarySecondaryNamepsaceOpts.Namespace, SourceNamespace: primaryNamespaceOpts.Namespace})
+			}
+
+			// Create a service resolver for failover
+			logger.Log(t, "Creating service resolver")
+			k8s.DeployKustomize(t, primaryNamespaceOpts, cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/cases/wan-federation/service-resolver")
+
+			// Verify that we respond with the static-server in the primary datacenter
+			logger.Log(t, "Verifying static-server in dc1 responds")
+			serviceFailoverCheck(t, primaryNamespaceOpts, localServerPort, primaryDatacenter)
+
+			// Scale down the primary datacenter static-server and see the failover
+			logger.Log(t, "Scale down dc1 static-server")
+			k8s.KubectlScale(t, primaryNamespaceOpts, staticServerDeployment, 0)
+
+			// Verify that we respond with the static-server in the secondary datacenter
+			logger.Log(t, "Verifying static-server in dc2 responds")
+			serviceFailoverCheck(t, primaryNamespaceOpts, localServerPort, secondaryDatacenter)
+
+			// scale down the primary datacenter static-server and see the failover
+			logger.Log(t, "Scale down dc2 static-server")
+			k8s.KubectlScale(t, secondaryNamespaceOtps, staticServerDeployment, 0)
+
+			// Verify that we respond with the static-server in the secondary datacenter
+			logger.Log(t, "Verifying static-server in secondary namespace (ns2) responds")
+			serviceFailoverCheck(t, primaryNamespaceOpts, localServerPort, secondaryNamespace)
+		})
+	}
+}
+
+// serviceFailoverCheck verifies that the server failed over as expected by checking that curling the `static-server`
+// using the `static-client` responds with the expected cluster name. Each static-server responds with a unique
+// name so that we can verify failover occurred as expected.
+func serviceFailoverCheck(t *testing.T, options *terratestK8s.KubectlOptions, port string, expectedName string) {
+	timer := &retry.Timer{Timeout: retryTimeout, Wait: 5 * time.Second}
+	var resp string
+	var err error
+	retry.RunWith(timer, t, func(r *retry.R) {
+		resp, err = k8s.RunKubectlAndGetOutputE(t, options, "exec", "-i",
+			staticClientDeployment, "-c", StaticClientName, "--", "curl", fmt.Sprintf("localhost:%s", port))
+		require.NoError(r, err)
+		assert.Contains(r, resp, expectedName)
+	})
+	logger.Log(t, resp)
 }

--- a/acceptance/tests/wan-federation/wan_federation_test.go
+++ b/acceptance/tests/wan-federation/wan_federation_test.go
@@ -103,18 +103,7 @@ func TestWANFederation(t *testing.T) {
 			_, err = secondaryContext.KubernetesClient(t).CoreV1().Secrets(secondaryContext.KubectlOptions(t).Namespace).Create(context.Background(), federationSecret, metav1.CreateOptions{})
 			require.NoError(t, err)
 
-			var k8sAuthMethodHost string
-			// When running on kind, the kube API address in kubeconfig will have a localhost address
-			// which will not work from inside the container. That's why we need to use the endpoints address instead
-			// which will point the node IP.
-			if cfg.UseKind {
-				// The Kubernetes AuthMethod host is read from the endpoints for the Kubernetes service.
-				kubernetesEndpoint, err := secondaryContext.KubernetesClient(t).CoreV1().Endpoints("default").Get(context.Background(), "kubernetes", metav1.GetOptions{})
-				require.NoError(t, err)
-				k8sAuthMethodHost = fmt.Sprintf("%s:%d", kubernetesEndpoint.Subsets[0].Addresses[0].IP, kubernetesEndpoint.Subsets[0].Ports[0].Port)
-			} else {
-				k8sAuthMethodHost = k8s.KubernetesAPIServerHostFromOptions(t, secondaryContext.KubectlOptions(t))
-			}
+			k8sAuthMethodHost := k8s.KubernetesAPIServerHost(t, cfg, secondaryContext)
 
 			// Create secondary cluster
 			secondaryHelmValues := map[string]string{
@@ -295,18 +284,7 @@ func TestWANFederationFailover(t *testing.T) {
 			_, err = secondaryContext.KubernetesClient(t).CoreV1().Secrets(secondaryContext.KubectlOptions(t).Namespace).Create(context.Background(), federationSecret, metav1.CreateOptions{})
 			require.NoError(t, err)
 
-			var k8sAuthMethodHost string
-			// When running on kind, the kube API address in kubeconfig will have a localhost address
-			// which will not work from inside the container. That's why we need to use the endpoints address instead
-			// which will point the node IP.
-			if cfg.UseKind {
-				// The Kubernetes AuthMethod host is read from the endpoints for the Kubernetes service.
-				kubernetesEndpoint, err := secondaryContext.KubernetesClient(t).CoreV1().Endpoints("default").Get(context.Background(), "kubernetes", metav1.GetOptions{})
-				require.NoError(t, err)
-				k8sAuthMethodHost = fmt.Sprintf("%s:%d", kubernetesEndpoint.Subsets[0].Addresses[0].IP, kubernetesEndpoint.Subsets[0].Ports[0].Port)
-			} else {
-				k8sAuthMethodHost = k8s.KubernetesAPIServerHostFromOptions(t, secondaryContext.KubectlOptions(t))
-			}
+			k8sAuthMethodHost := k8s.KubernetesAPIServerHost(t, cfg, secondaryContext)
 
 			// Create secondary cluster
 			secondaryHelmValues := map[string]string{


### PR DESCRIPTION
See commits for more details

Changes proposed in this PR:
- This test adds failover scenarios for Wan Federation
- Test the following scenarios:
	dc1-static-client -- nominal -- > dc1-static-server in namespace ns1
	dc1-static-client -- failover --> dc2-static-server in namespace ns1
	dc1-static-client -- failover --> dc1-static-server in namespace ns2

How I've tested this PR:
Pipeline issues out of my control, so ran the following locally for the tests connect, snapshot-agent, wan-federation:

- [x] acceptance
- [x] acceptance t-proxy
- [x] acceptance cni 

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


