### PR TITLE
feat: add helm value for consul resource-apis experiment

### DIFF
--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -446,3 +446,52 @@ Usage: {{ template "consul.validateTelemetryCollectorCloud" . }}
 {{fail "When telemetryCollector has clientId and clientSecret .global.cloud.resourceId.secretKey must be set"}}
 {{- end }}
 {{- end -}}
+
+{{/*
+Fails if global.experiments.resourceAPIs is set along with any of these unsupported features.
+- global.peering.enabled
+- global.federation.enabled
+- global.cloud.enabled
+- client.enabled
+- ui.enabled
+- syncCatalog.enabled
+- meshGateway.enabled
+- ingressGateways.enabled
+- terminatingGateways.enabled
+- apiGateway.enabled
+
+Usage: {{ template "consul.validateResourceAPIs" . }}
+
+*/}}
+{{- define "consul.validateResourceAPIs" -}}
+{{- if (and (mustHas "resource-apis" .Values.global.experiments) .Values.global.peering.enabled ) }}
+{{fail "When the value global.experiments.resourceAPIs is set, global.peering.enabled is currently unsupported."}}
+{{- end }}
+{{- if (and (mustHas "resource-apis" .Values.global.experiments) .Values.global.federation.enabled ) }}
+{{fail "When the value global.experiments.resourceAPIs is set, global.federation.enabled is currently unsupported."}}
+{{- end }}
+{{- if (and (mustHas "resource-apis" .Values.global.experiments) .Values.global.cloud.enabled ) }}
+{{fail "When the value global.experiments.resourceAPIs is set, global.cloud.enabled is currently unsupported."}}
+{{- end }}
+{{- if (and (mustHas "resource-apis" .Values.global.experiments) .Values.client.enabled ) }}
+{{fail "When the value global.experiments.resourceAPIs is set, client.enabled is currently unsupported."}}
+{{- end }}
+{{- if (and (mustHas "resource-apis" .Values.global.experiments) .Values.ui.enabled ) }}
+{{fail "When the value global.experiments.resourceAPIs is set, ui.enabled is currently unsupported."}}
+{{- end }}
+{{- if (and (mustHas "resource-apis" .Values.global.experiments) .Values.syncCatalog.enabled ) }}
+{{fail "When the value global.experiments.resourceAPIs is set, syncCatalog.enabled is currently unsupported."}}
+{{- end }}
+{{- if (and (mustHas "resource-apis" .Values.global.experiments) .Values.meshGateway.enabled ) }}
+{{fail "When the value global.experiments.resourceAPIs is set, meshGateway.enabled is currently unsupported."}}
+{{- end }}
+{{- if (and (mustHas "resource-apis" .Values.global.experiments) .Values.ingressGateways.enabled ) }}
+{{fail "When the value global.experiments.resourceAPIs is set, ingressGateways.enabled is currently unsupported."}}
+{{- end }}
+{{- if (and (mustHas "resource-apis" .Values.global.experiments) .Values.terminatingGateways.enabled ) }}
+{{fail "When the value global.experiments.resourceAPIs is set, terminatingGateways.enabled is currently unsupported."}}
+{{- end }}
+{{- if (and (mustHas "resource-apis" .Values.global.experiments) .Values.apiGateway.enabled ) }}
+{{fail "When the value global.experiments.resourceAPIs is set, apiGateway.enabled is currently unsupported."}}
+{{- end }}
+{{- end }}

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -11,6 +11,7 @@
 {{- $dnsRedirectionEnabled := (or (and (ne (.Values.dns.enableRedirection | toString) "-") .Values.dns.enableRedirection) (and (eq (.Values.dns.enableRedirection | toString) "-") .Values.connectInject.transparentProxy.defaultEnabled)) -}}
 {{ template "consul.validateRequiredCloudSecretsExist" . }}
 {{ template "consul.validateCloudSecretKeys" . }}
+{{ template "consul.validateResourceAPIs" . }}
 # The deployment for running the Connect sidecar injector
 apiVersion: apps/v1
 kind: Deployment
@@ -146,6 +147,9 @@ spec:
                 -release-namespace="{{ .Release.Namespace }}" \
                 -resource-prefix={{ template "consul.fullname" . }} \
                 -listen=:8080 \
+                {{- if (mustHas "resource-apis" .Values.global.experiments) }}
+                -resource-apis=true
+                {{- end }}
                 {{- range $k, $v := .Values.connectInject.consulNode.meta }}
                 -node-meta={{ $k }}={{ $v }} \
                 {{- end }}

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -148,7 +148,7 @@ spec:
                 -resource-prefix={{ template "consul.fullname" . }} \
                 -listen=:8080 \
                 {{- if (mustHas "resource-apis" .Values.global.experiments) }}
-                -resource-apis=true
+                -enable-resource-apis=true
                 {{- end }}
                 {{- range $k, $v := .Values.connectInject.consulNode.meta }}
                 -node-meta={{ $k }}={{ $v }} \

--- a/charts/consul/templates/partition-init-job.yaml
+++ b/charts/consul/templates/partition-init-job.yaml
@@ -115,7 +115,7 @@ spec:
                 -tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
                 {{- end }}
                 {{- if (mustHas "resource-apis" .Values.global.experiments) }}
-                -resource-apis=true
+                -enable-resource-apis=true
                 {{- end }}
           resources:
             requests:

--- a/charts/consul/templates/partition-init-job.yaml
+++ b/charts/consul/templates/partition-init-job.yaml
@@ -114,6 +114,9 @@ spec:
                 {{- if .Values.global.cloud.enabled }}
                 -tls-server-name=server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}} \
                 {{- end }}
+                {{- if (mustHas "resource-apis" .Values.global.experiments) }}
+                -resource-apis=true
+                {{- end }}
           resources:
             requests:
               memory: "50Mi"

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -415,6 +415,9 @@ spec:
                 {{- if and .Values.global.cloud.enabled .Values.global.cloud.resourceId.secretName }}
                 -hcl="cloud { resource_id = \"${HCP_RESOURCE_ID}\" }"
                 {{- end }}
+                {{- if (mustHas "resource-apis" .Values.global.experiments) }}
+                -hcl="experiments=[\"resource-apis\"]"
+                {{- end }}
           volumeMounts:
             - name: data-{{ .Release.Namespace | trunc 58 | trimSuffix "-" }}
               mountPath: /consul/data

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -2597,12 +2597,12 @@ reservedNameTest() {
       -s templates/connect-inject-deployment.yaml  \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-resource-apis=true"))' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-resource-apis=true"))' | tee /dev/stderr)
 
   [ "${actual}" = "false" ]
 }
 
-@test "connectInject/Deployment: -resource-apis=true is set when global.experiments contains [\"resource-apis\"] " {
+@test "connectInject/Deployment: -enable-resource-apis=true is set when global.experiments contains [\"resource-apis\"] " {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/connect-inject-deployment.yaml  \
@@ -2610,7 +2610,7 @@ reservedNameTest() {
       --set 'global.experiments[0]=resource-apis' \
       --set 'ui.enabled=false' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-resource-apis=true"))' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command | any(contains("-enable-resource-apis=true"))' | tee /dev/stderr)
 
   [ "${actual}" = "true" ]
 }

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -2587,3 +2587,30 @@ reservedNameTest() {
     jq -r '. | select( .name == "CONSUL_TLS_SERVER_NAME").value' | tee /dev/stderr)
   [ "${actual}" = "server.dc1.consul" ]
 }
+
+#--------------------------------------------------------------------
+# resource-apis
+
+@test "connectInject/Deployment: resource-apis is not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-resource-apis=true"))' | tee /dev/stderr)
+
+  [ "${actual}" = "false" ]
+}
+
+@test "connectInject/Deployment: -resource-apis=true is set when global.experiments contains [\"resource-apis\"] " {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.experiments[0]=resource-apis' \
+      --set 'ui.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-resource-apis=true"))' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/helpers.bats
+++ b/charts/consul/test/unit/helpers.bats
@@ -327,3 +327,140 @@ load _helpers
   actual=$(echo $object | jq '.volumeMounts[] | select(.name == "consul-ca-cert")')
   [ "${actual}" = "" ]
 }
+
+#--------------------------------------------------------------------
+# consul.validateResourceAPIs
+# These tests use test-runner.yaml to test the
+# consul.validateResourceAPIs helper since we need an existing template
+
+@test "connectInject/Deployment: fails if resource-apis is set and peering is enabled" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/tests/test-runner.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.experiments[0]=resource-apis' \
+      --set 'ui.enabled=false' \
+      --set 'global.tls.enabled=true' \
+      --set 'meshGateway.enabled=true' \
+      --set 'global.peering.enabled=true' \
+      .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "When the value global.experiments.resourceAPIs is set, global.peering.enabled is currently unsupported." ]]
+}
+
+@test "connectInject/Deployment: fails if resource-apis is set and federation is enabled" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/tests/test-runner.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.experiments[0]=resource-apis' \
+      --set 'ui.enabled=false' \
+      --set 'global.tls.enabled=true' \
+      --set 'meshGateway.enabled=true' \
+      --set 'global.federation.enabled=true' \
+      .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "When the value global.experiments.resourceAPIs is set, global.federation.enabled is currently unsupported." ]]
+}
+
+@test "connectInject/Deployment: fails if resource-apis is set and cloud is enabled" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/tests/test-runner.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.experiments[0]=resource-apis' \
+      --set 'ui.enabled=false' \
+      --set 'global.cloud.enabled=true' \
+      --set 'global.cloud.resourceId.secretName=hello' \
+      --set 'global.cloud.resourceId.secretKey=hello' \
+      --set 'global.cloud.clientId.secretName=hello' \
+      --set 'global.cloud.clientId.secretKey=hello' \
+      --set 'global.cloud.clientSecret.secretName=hello' \
+      --set 'global.cloud.clientSecret.secretKey=hello' \
+      .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "When the value global.experiments.resourceAPIs is set, global.cloud.enabled is currently unsupported." ]]
+}
+
+@test "connectInject/Deployment: fails if resource-apis is set and client is enabled" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/tests/test-runner.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.experiments[0]=resource-apis' \
+      --set 'ui.enabled=false' \
+      --set 'client.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "When the value global.experiments.resourceAPIs is set, client.enabled is currently unsupported." ]]
+}
+
+@test "connectInject/Deployment: fails if resource-apis is set and ui is enabled" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/tests/test-runner.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.experiments[0]=resource-apis' \
+      .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "When the value global.experiments.resourceAPIs is set, ui.enabled is currently unsupported." ]]
+}
+
+@test "connectInject/Deployment: fails if resource-apis is set and syncCatalog is enabled" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/tests/test-runner.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.experiments[0]=resource-apis' \
+      --set 'ui.enabled=false' \
+      --set 'syncCatalog.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "When the value global.experiments.resourceAPIs is set, syncCatalog.enabled is currently unsupported." ]]
+}
+
+@test "connectInject/Deployment: fails if resource-apis is set and meshGateway is enabled" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/tests/test-runner.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.experiments[0]=resource-apis' \
+      --set 'ui.enabled=false' \
+      --set 'meshGateway.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "When the value global.experiments.resourceAPIs is set, meshGateway.enabled is currently unsupported." ]]
+}
+
+@test "connectInject/Deployment: fails if resource-apis is set and ingressGateways is enabled" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/tests/test-runner.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.experiments[0]=resource-apis' \
+      --set 'ui.enabled=false' \
+      --set 'ingressGateways.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "When the value global.experiments.resourceAPIs is set, ingressGateways.enabled is currently unsupported." ]]
+}
+
+@test "connectInject/Deployment: fails if resource-apis is set and terminatingGateways is enabled" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/tests/test-runner.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.experiments[0]=resource-apis' \
+      --set 'ui.enabled=false' \
+      --set 'terminatingGateways.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "When the value global.experiments.resourceAPIs is set, terminatingGateways.enabled is currently unsupported." ]]
+}
+
+@test "connectInject/Deployment: fails if resource-apis is set and apiGateway is enabled" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/tests/test-runner.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.experiments[0]=resource-apis' \
+      --set 'ui.enabled=false' \
+      --set 'apiGateway.enabled=true' .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "When the value global.experiments.resourceAPIs is set, apiGateway.enabled is currently unsupported." ]]
+}

--- a/charts/consul/test/unit/partition-init-job.bats
+++ b/charts/consul/test/unit/partition-init-job.bats
@@ -942,7 +942,7 @@ reservedNameTest() {
 #--------------------------------------------------------------------
 # global.experiments=["resource-apis"]
 
-@test "partitionInit/Job: experiments=[\"resource-apis\"] is not set in command when global.experiments is empty" {
+@test "partitionInit/Job: -enable-resource-apis=true is not set in command when global.experiments is empty" {
   cd `chart_dir`
   local object=$(helm template \
       -s templates/partition-init-job.yaml \
@@ -956,11 +956,11 @@ reservedNameTest() {
 
   # Test the flag is set.
   local actual=$(echo "$object" |
-    yq '.spec.template.spec.containers[] | select(.name == "partition-init-job") | .command | any(contains("-resource-apis=true"))' | tee /dev/stderr)
+    yq '.spec.template.spec.containers[] | select(.name == "partition-init-job") | .command | any(contains("-enable-resource-apis=true"))' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
 
-@test "partitionInit/Job:  experiments=[\"resource-apis\"] is set in command when global.experiments contains \"resource-apis\"" {
+@test "partitionInit/Job:  -enable-resource-apis=true is set in command when global.experiments contains \"resource-apis\"" {
   cd `chart_dir`
   local object=$(helm template \
       -s templates/partition-init-job.yaml \
@@ -975,6 +975,6 @@ reservedNameTest() {
       . | tee /dev/stderr)
 
   local actual=$(echo "$object" |
-    yq '.spec.template.spec.containers[] | select(.name == "partition-init-job") | .command | any(contains("-resource-apis=true"))' | tee /dev/stderr)
+    yq '.spec.template.spec.containers[] | select(.name == "partition-init-job") | .command | any(contains("-enable-resource-apis=true"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }

--- a/charts/consul/test/unit/partition-init-job.bats
+++ b/charts/consul/test/unit/partition-init-job.bats
@@ -938,3 +938,43 @@ reservedNameTest() {
   [ "${actualTemplateFoo}" = "bar" ]
   [ "${actualTemplateBaz}" = "qux" ]
 }
+
+#--------------------------------------------------------------------
+# global.experiments=["resource-apis"]
+
+@test "partitionInit/Job: experiments=[\"resource-apis\"] is not set in command when global.experiments is empty" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/partition-init-job.yaml \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'server.enabled=false' \
+      --set 'global.adminPartitions.name=bar' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=foo' \
+      . | tee /dev/stderr)
+
+  # Test the flag is set.
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.containers[] | select(.name == "partition-init-job") | .command | any(contains("-resource-apis=true"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "partitionInit/Job:  experiments=[\"resource-apis\"] is set in command when global.experiments contains \"resource-apis\"" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/partition-init-job.yaml \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'server.enabled=false' \
+      --set 'global.adminPartitions.name=bar' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=foo' \
+      --set 'global.experiments[0]=resource-apis' \
+      --set 'ui.enabled=false' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.containers[] | select(.name == "partition-init-job") | .command | any(contains("-resource-apis=true"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -2896,3 +2896,31 @@ MIICFjCCAZsCCQCdwLtdjbzlYzAKBggqhkjOPQQDAjB0MQswCQYDVQQGEwJDQTEL' \
       yq -r '.spec.template.spec.containers[1].command[2] | contains("-interval=10h34m5s")' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.experiments=["resource-apis"]
+
+@test "server/StatefulSet: experiments=[\"resource-apis\"] is not set in command when global.experiments is empty" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      . | tee /dev/stderr)
+
+  # Test the flag is set.
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.containers[] | select(.name == "consul") | .command | any(contains("-hcl=\"experiments=[\\\"resource-apis\\\"]\""))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/StatefulSet: experiments=[\"resource-apis\"] is set in command when global.experiments contains \"resource-apis\"" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'global.experiments[0]=resource-apis' \
+      --set 'ui.enabled=false' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+    yq '.spec.template.spec.containers[] | select(.name == "consul") | .command | any(contains("-hcl=\"experiments=[\\\"resource-apis\\\"]\""))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -735,6 +735,24 @@ global:
   # @type: array<string>
   trustedCAs: [ ]
 
+  # Consul feature flags that will be enabled across components.
+  # Supported feature flags:
+  # * `resource-apis`:
+  #   _**Danger**_! This feature is under active development. It is not
+  #   recommended for production use. Setting this flag during an
+  #   upgrade could risk breaking your Consul cluster.
+  #   If this flag is set, Consul components will use the
+  #   V2 resources APIs for all operations.
+  #
+  # Example:
+  #
+  # ```yaml
+  # experiments: [ "resource-apis" ]
+  # ```
+  # @type: array<string>
+  experiments: [ ]
+
+
 # Server, when enabled, configures a server cluster to run. This should
 # be disabled if you plan on connecting to a Consul cluster external to
 # the Kube cluster.

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -224,7 +224,7 @@ func (c *Command) init() {
 			"%q, %q, %q, and %q.", zapcore.DebugLevel.String(), zapcore.InfoLevel.String(), zapcore.WarnLevel.String(), zapcore.ErrorLevel.String()))
 	c.flagSet.BoolVar(&c.flagLogJSON, "log-json", false,
 		"Enable or disable JSON output format for logging.")
-	c.flagSet.BoolVar(&c.flagResourceAPIs, "resource-apis", false,
+	c.flagSet.BoolVar(&c.flagResourceAPIs, "enable-resource-apis", false,
 		"Enable of disable Consul V2 Resource APIs.")
 
 	// Proxy sidecar resource setting flags.

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -15,20 +15,6 @@ import (
 	"sync"
 	"syscall"
 
-	gatewaycommon "github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
-	gatewaycontrollers "github.com/hashicorp/consul-k8s/control-plane/api-gateway/controllers"
-	apicommon "github.com/hashicorp/consul-k8s/control-plane/api/common"
-	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/controllers/endpoints"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/controllers/peering"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/lifecycle"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/metrics"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/webhook"
-	"github.com/hashicorp/consul-k8s/control-plane/controllers"
-	mutatingwebhookconfiguration "github.com/hashicorp/consul-k8s/control-plane/helper/mutating-webhook-configuration"
-	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
-	"github.com/hashicorp/consul-k8s/control-plane/subcommand/flags"
 	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/mitchellh/cli"
 	"go.uber.org/zap/zapcore"
@@ -44,6 +30,21 @@ import (
 	ctrlRuntimeWebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	gatewaycommon "github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
+	gatewaycontrollers "github.com/hashicorp/consul-k8s/control-plane/api-gateway/controllers"
+	apicommon "github.com/hashicorp/consul-k8s/control-plane/api/common"
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/controllers/endpoints"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/controllers/peering"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/lifecycle"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/metrics"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/webhook"
+	"github.com/hashicorp/consul-k8s/control-plane/controllers"
+	mutatingwebhookconfiguration "github.com/hashicorp/consul-k8s/control-plane/helper/mutating-webhook-configuration"
+	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
+	"github.com/hashicorp/consul-k8s/control-plane/subcommand/flags"
 )
 
 const (
@@ -64,6 +65,7 @@ type Command struct {
 	flagEnableWebhookCAUpdate bool
 	flagLogLevel              string
 	flagLogJSON               bool
+	flagResourceAPIs          bool // Use V2 APIs
 
 	flagAllowK8sNamespacesList []string // K8s namespaces to explicitly inject
 	flagDenyK8sNamespacesList  []string // K8s namespaces to deny injection (has precedence)
@@ -222,6 +224,8 @@ func (c *Command) init() {
 			"%q, %q, %q, and %q.", zapcore.DebugLevel.String(), zapcore.InfoLevel.String(), zapcore.WarnLevel.String(), zapcore.ErrorLevel.String()))
 	c.flagSet.BoolVar(&c.flagLogJSON, "log-json", false,
 		"Enable or disable JSON output format for logging.")
+	c.flagSet.BoolVar(&c.flagResourceAPIs, "resource-apis", false,
+		"Enable of disable Consul V2 Resource APIs.")
 
 	// Proxy sidecar resource setting flags.
 	c.flagSet.StringVar(&c.flagDefaultSidecarProxyCPURequest, "default-sidecar-proxy-cpu-request", "", "Default sidecar proxy CPU request.")

--- a/control-plane/subcommand/partition-init/command.go
+++ b/control-plane/subcommand/partition-init/command.go
@@ -54,7 +54,7 @@ func (c *Command) init() {
 			"\"debug\", \"info\", \"warn\", and \"error\".")
 	c.flags.BoolVar(&c.flagLogJSON, "log-json", false,
 		"Enable or disable JSON output format for logging.")
-	c.flags.BoolVar(&c.flagResourceAPIs, "resource-apis", false,
+	c.flags.BoolVar(&c.flagResourceAPIs, "enable-resource-apis", false,
 		"Enable of disable V2 Resource APIs.")
 
 	c.consul = &flags.ConsulFlags{}
@@ -179,7 +179,7 @@ func (c *Command) validateFlags() error {
 
 	// TODO(dans) this needs to be replaced when the partition workflow is available.
 	if c.flagResourceAPIs {
-		return errors.New("partition-init is not implemented when the -resource-apis flag is set for V2 Resource APIs")
+		return errors.New("partition-init is not implemented when the -enable-resource-apis flag is set for V2 Resource APIs")
 	}
 
 	return nil

--- a/control-plane/subcommand/partition-init/command.go
+++ b/control-plane/subcommand/partition-init/command.go
@@ -11,13 +11,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/consul-k8s/control-plane/consul"
-	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
-	"github.com/hashicorp/consul-k8s/control-plane/subcommand/flags"
 	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
+
+	"github.com/hashicorp/consul-k8s/control-plane/consul"
+	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
+	"github.com/hashicorp/consul-k8s/control-plane/subcommand/flags"
 )
 
 type Command struct {
@@ -29,6 +30,8 @@ type Command struct {
 	flagLogLevel string
 	flagLogJSON  bool
 	flagTimeout  time.Duration
+
+	flagResourceAPIs bool // Use V2 APIs
 
 	// ctx is cancelled when the command timeout is reached.
 	ctx           context.Context
@@ -51,6 +54,8 @@ func (c *Command) init() {
 			"\"debug\", \"info\", \"warn\", and \"error\".")
 	c.flags.BoolVar(&c.flagLogJSON, "log-json", false,
 		"Enable or disable JSON output format for logging.")
+	c.flags.BoolVar(&c.flagResourceAPIs, "resource-apis", false,
+		"Enable of disable V2 Resource APIs.")
 
 	c.consul = &flags.ConsulFlags{}
 	flags.Merge(c.flags, c.consul.Flags())
@@ -171,6 +176,12 @@ func (c *Command) validateFlags() error {
 	if c.consul.APITimeout <= 0 {
 		return errors.New("-api-timeout must be set to a value greater than 0")
 	}
+
+	// TODO(dans) this needs to be replaced when the partition workflow is available.
+	if c.flagResourceAPIs {
+		return errors.New("partition-init is not implemented when the -resource-apis flag is set for V2 Resource APIs")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Changes proposed in this PR:
- Add a value to the Helm chart that allows free-form feature flags, similar to [Consul](https://github.com/hashicorp/consul/blob/main/agent/config/config.go#L186-L186).
- Add placeholder flags for relevant components when `resource-apis` is enabled.

How I've tested this PR: 
- Helm unit tests

How I expect reviewers to test this PR: 👀 + CI/CD is green


Checklist:
- [X] Tests added
- [ ] ~[CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)~ waiting until more support is added for this feature.


