### PR TITLE
Use Kubernetes 1.25 on AKS

### DIFF
--- a/charts/consul/test/terraform/aks/variables.tf
+++ b/charts/consul/test/terraform/aks/variables.tf
@@ -7,8 +7,8 @@ variable "location" {
 }
 
 variable "kubernetes_version" {
-  default     = "1.25.17"
-  description = "Kubernetes version supported on AKS (1.25.17 Released August 2nd, 2023)"
+  default     = "1.25"
+  description = "Kubernetes version supported on AKS"
 }
 
 variable "client_id" {


### PR DESCRIPTION
Changes proposed in this PR:
- Just use 1.25 in AKS to give us some breathing room
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


