### PR TITLE
docs: Fix missed consul.io/docs links

### DIFF
--- a/hack/helm-reference-gen/fixtures/full-values.golden
+++ b/hack/helm-reference-gen/fixtures/full-values.golden
@@ -493,7 +493,7 @@ Use these links to navigate to a particular top-level stanza.
   - `k8sAuthMethodHost` ((#v-externalservers-k8sauthmethodhost)) (`string: null`) - If you are setting `global.acls.manageSystemACLs` and
     `connectInject.enabled` to true, set `k8sAuthMethodHost` to the address of the Kubernetes API server.
     This address must be reachable from the Consul servers.
-    Please see the Kubernetes Auth Method documentation (https://consul.io/docs/acl/auth-methods/kubernetes).
+    Please see the Kubernetes Auth Method documentation (https://developer.hashicorp.com/consul/docs/security/acl/auth-methods/kubernetes).
     Requires consul-k8s >= 0.14.0.
 
     You could retrieve this value from your `kubeconfig` by running:
@@ -792,7 +792,7 @@ Use these links to navigate to a particular top-level stanza.
 
   - `default` ((#v-synccatalog-default)) (`boolean: true`) - If true, all valid services in K8S are
     synced by default. If false, the service must be annotated
-    (https://consul.io/docs/k8s/service-sync#sync-enable-disable) properly to sync.
+    (https://developer.hashicorp.com/consul/docs/k8s/service-sync) properly to sync.
     In either case an annotation can override the default.
 
   - `priorityClassName` ((#v-synccatalog-priorityclassname)) (`string: ""`) - Optional priorityClassName.
@@ -949,7 +949,7 @@ Use these links to navigate to a particular top-level stanza.
 
   - `default` ((#v-connectinject-default)) (`boolean: false`) - If true, the injector will inject the
     Connect sidecar into all pods by default. Otherwise, pods must specify the
-    injection annotation (https://consul.io/docs/k8s/connect#consul-hashicorp-com-connect-inject)
+    injection annotation (https://developer.hashicorp.com/consul/docs/k8s/connect)
     to opt-in to Connect injection. If this is true, pods can use the same annotation
     to explicitly opt-out of injection.
 

--- a/hack/helm-reference-gen/fixtures/full-values.yaml
+++ b/hack/helm-reference-gen/fixtures/full-values.yaml
@@ -546,7 +546,7 @@ externalServers:
   # If you are setting `global.acls.manageSystemACLs` and
   # `connectInject.enabled` to true, set `k8sAuthMethodHost` to the address of the Kubernetes API server.
   # This address must be reachable from the Consul servers.
-  # Please see the Kubernetes Auth Method documentation (https://consul.io/docs/acl/auth-methods/kubernetes).
+  # Please see the Kubernetes Auth Method documentation (https://developer.hashicorp.com/consul/docs/security/acl/auth-methods/kubernetes).
   # Requires consul-k8s >= 0.14.0.
   #
   # You could retrieve this value from your `kubeconfig` by running:
@@ -888,7 +888,7 @@ syncCatalog:
 
   # If true, all valid services in K8S are
   # synced by default. If false, the service must be annotated
-  # (https://consul.io/docs/k8s/service-sync#sync-enable-disable) properly to sync.
+  # (https://developer.hashicorp.com/consul/docs/k8s/service-sync) properly to sync.
   # In either case an annotation can override the default.
   default: true
 
@@ -1075,7 +1075,7 @@ connectInject:
 
   # If true, the injector will inject the
   # Connect sidecar into all pods by default. Otherwise, pods must specify the
-  # injection annotation (https://consul.io/docs/k8s/connect#consul-hashicorp-com-connect-inject)
+  # injection annotation (https://developer.hashicorp.com/consul/docs/k8s/connect)
   # to opt-in to Connect injection. If this is true, pods can use the same annotation
   # to explicitly opt-out of injection.
   default: false


### PR DESCRIPTION
Changes proposed in this PR:
Fix `consul.io/docs` links missed as part of https://github.com/hashicorp/consul-k8s/pull/2708

How I've tested this PR:

How I expect reviewers to test this PR:

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


