### PR TITLE
manual backport of AKS 1.25 into 1.0.x

### DIFF
--- a/charts/consul/test/terraform/aks/main.tf
+++ b/charts/consul/test/terraform/aks/main.tf
@@ -55,7 +55,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   location                          = azurerm_resource_group.default[count.index].location
   resource_group_name               = azurerm_resource_group.default[count.index].name
   dns_prefix                        = "consul-k8s-${random_id.suffix[count.index].dec}"
-  kubernetes_version                = "1.25"
+  kubernetes_version                = var.kubernetes_version
   role_based_access_control_enabled = true
 
   // We're setting the network plugin and other network properties explicitly

--- a/charts/consul/test/terraform/aks/variables.tf
+++ b/charts/consul/test/terraform/aks/variables.tf
@@ -39,4 +39,3 @@ variable "tags" {
   default     = {}
   description = "Tags to attach to the created resources."
 }
-

--- a/charts/consul/test/terraform/aks/variables.tf
+++ b/charts/consul/test/terraform/aks/variables.tf
@@ -6,6 +6,11 @@ variable "location" {
   description = "The location to launch this AKS cluster in."
 }
 
+variable "kubernetes_version" {
+  default     = "1.25"
+  description = "Kubernetes version supported on AKS"
+}
+
 variable "client_id" {
   default     = ""
   description = "The client ID of the service principal to be used by Kubernetes when creating Azure resources like load balancers."
@@ -34,3 +39,4 @@ variable "tags" {
   default     = {}
   description = "Tags to attach to the created resources."
 }
+


### PR DESCRIPTION
Changes proposed in this PR:
- Backports failed so manual backport of AKS changes
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


