### PR TITLE
manual backport of AKS 1.25 into 1.1.x

### DIFF
--- a/charts/consul/test/terraform/aks/main.tf
+++ b/charts/consul/test/terraform/aks/main.tf
@@ -1,5 +1,15 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+terraform {
+  required_providers {
+    azurerm = {
+      version = "3.40.0"
+    }
+  }
+}
+
 provider "azurerm" {
-  version = "3.40.0"
   features {}
 }
 
@@ -45,7 +55,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   location                          = azurerm_resource_group.default[count.index].location
   resource_group_name               = azurerm_resource_group.default[count.index].name
   dns_prefix                        = "consul-k8s-${random_id.suffix[count.index].dec}"
-  kubernetes_version                = "1.24.6"
+  kubernetes_version                = var.kubernetes_version
   role_based_access_control_enabled = true
 
   // We're setting the network plugin and other network properties explicitly

--- a/charts/consul/test/terraform/aks/variables.tf
+++ b/charts/consul/test/terraform/aks/variables.tf
@@ -1,6 +1,14 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 variable "location" {
   default     = "West US 2"
   description = "The location to launch this AKS cluster in."
+}
+
+variable "kubernetes_version" {
+  default     = "1.25"
+  description = "Kubernetes version supported on AKS"
 }
 
 variable "client_id" {


### PR DESCRIPTION
Changes proposed in this PR:
- Manually backporting changes into 1.1.x
- The files weren't exactly the same for some reason so make that happen.


How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


