### PR TITLE
Manual Backport of #2669 into 1.2.x

### DIFF
--- a/acceptance/tests/connect/connect_proxy_lifecycle_test.go
+++ b/acceptance/tests/connect/connect_proxy_lifecycle_test.go
@@ -205,3 +205,172 @@ func TestConnectInject_ProxyLifecycleShutdown(t *testing.T) {
 		})
 	}
 }
+
+func TestConnectInject_ProxyLifecycleShutdownJob(t *testing.T) {
+	cfg := suite.Config()
+
+	if cfg.EnableTransparentProxy {
+		// TODO t-eckert: Come back and review this with wise counsel.
+		t.Skip("Skipping test because transparent proxy is enabled")
+	}
+
+	defaultGracePeriod := 5
+
+	cases := map[string]int{
+		"../fixtures/cases/jobs/job-client-inject":                  defaultGracePeriod,
+		"../fixtures/cases/jobs/job-client-inject-grace-period-0s":  0,
+		"../fixtures/cases/jobs/job-client-inject-grace-period-10s": 10,
+	}
+
+	// Set up the installation and static-server once.
+	ctx := suite.Environment().DefaultContext(t)
+	releaseName := helpers.RandomName()
+
+	connHelper := connhelper.ConnectHelper{
+		ClusterKind: consul.Helm,
+		ReleaseName: releaseName,
+		Ctx:         ctx,
+		Cfg:         cfg,
+		HelmValues: map[string]string{
+			"connectInject.sidecarProxy.lifecycle.defaultShutdownGracePeriodSeconds": strconv.FormatInt(int64(defaultGracePeriod), 10),
+			"connectInject.sidecarProxy.lifecycle.defaultEnabled":                    strconv.FormatBool(true),
+		},
+	}
+
+	connHelper.Setup(t)
+	connHelper.Install(t)
+	connHelper.DeployServer(t)
+
+	logger.Log(t, "waiting for static-server to be registered with Consul")
+	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 5 * time.Second}, t, func(r *retry.R) {
+		for _, name := range []string{
+			"static-server",
+			"static-server-sidecar-proxy",
+		} {
+			logger.Logf(t, "checking for %s service in Consul catalog", name)
+			instances, _, err := connHelper.ConsulClient.Catalog().Service(name, "", nil)
+			r.Check(err)
+
+			if len(instances) != 1 {
+				r.Errorf("expected 1 instance of %s", name)
+
+			}
+		}
+	})
+
+	// Iterate over the Job cases and test connection.
+	for path, gracePeriod := range cases {
+		connHelper.DeployJob(t, path) // Default case.
+
+		logger.Log(t, "waiting for job-client to be registered with Consul")
+		retry.RunWith(&retry.Timer{Timeout: 300 * time.Second, Wait: 5 * time.Second}, t, func(r *retry.R) {
+			for _, name := range []string{
+				"job-client",
+				"job-client-sidecar-proxy",
+			} {
+				logger.Logf(t, "checking for %s service in Consul catalog", name)
+				instances, _, err := connHelper.ConsulClient.Catalog().Service(name, "", nil)
+				r.Check(err)
+
+				if len(instances) != 1 {
+					r.Errorf("expected 1 instance of %s", name)
+				}
+			}
+		})
+
+		connHelper.TestConnectionSuccess(t, connhelper.JobName)
+
+		// Get job-client pod name
+		ns := ctx.KubectlOptions(t).Namespace
+		pods, err := ctx.KubernetesClient(t).CoreV1().Pods(ns).List(
+			context.Background(),
+			metav1.ListOptions{
+				LabelSelector: "app=job-client",
+			},
+		)
+		require.NoError(t, err)
+		require.Len(t, pods.Items, 1)
+		jobName := pods.Items[0].Name
+
+		// Exec into job and send shutdown request to running proxy.
+		// curl --max-time 2 -s -f -XPOST http://127.0.0.1:20600/graceful_shutdown
+		sendProxyShutdownArgs := []string{"exec", jobName, "-c", connhelper.JobName, "--", "curl", "--max-time", "2", "-s", "-f", "-XPOST", "http://127.0.0.1:20600/graceful_shutdown"}
+		_, err = k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), sendProxyShutdownArgs...)
+		require.NoError(t, err)
+
+		logger.Log(t, "Proxy killed...")
+
+		args := []string{"exec", jobName, "-c", connhelper.JobName, "--", "curl", "-vvvsSf"}
+		if cfg.EnableTransparentProxy {
+			args = append(args, "http://static-server")
+		} else {
+			args = append(args, "http://localhost:1234")
+		}
+
+		if gracePeriod > 0 {
+			logger.Log(t, "Checking if connection successful within grace period...")
+			retry.RunWith(&retry.Timer{Timeout: time.Duration(gracePeriod) * time.Second, Wait: 2 * time.Second}, t, func(r *retry.R) {
+				output, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), args...)
+				require.NoError(r, err)
+				require.True(r, !strings.Contains(output, "curl: (7) Failed to connect"))
+			})
+			//wait for the grace period to end after successful request
+			time.Sleep(time.Duration(gracePeriod) * time.Second)
+		}
+
+		// Test that requests fail once grace period has ended, or there was no grace period set.
+		logger.Log(t, "Checking that requests fail now that proxy is killed...")
+		retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 2 * time.Second}, t, func(r *retry.R) {
+			output, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), args...)
+			require.Error(r, err)
+			require.True(r, strings.Contains(output, "curl: (7) Failed to connect"))
+		})
+
+		// Wait for the job to complete.
+		retry.RunWith(&retry.Timer{Timeout: 4 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
+			logger.Log(t, "Checking if job completed...")
+			jobs, err := ctx.KubernetesClient(t).BatchV1().Jobs(ns).List(
+				context.Background(),
+				metav1.ListOptions{
+					LabelSelector: "app=job-client",
+				},
+			)
+			require.NoError(r, err)
+			require.True(r, jobs.Items[0].Status.Succeeded == 1)
+		})
+
+		// Delete the job and its associated Pod.
+		pods, err = ctx.KubernetesClient(t).CoreV1().Pods(ns).List(
+			context.Background(),
+			metav1.ListOptions{
+				LabelSelector: "app=job-client",
+			},
+		)
+		require.NoError(t, err)
+		podName := pods.Items[0].Name
+
+		err = ctx.KubernetesClient(t).BatchV1().Jobs(ns).Delete(context.Background(), "job-client", metav1.DeleteOptions{})
+		require.NoError(t, err)
+
+		err = ctx.KubernetesClient(t).CoreV1().Pods(ns).Delete(context.Background(), podName, metav1.DeleteOptions{})
+		require.NoError(t, err)
+
+		logger.Log(t, "ensuring job is deregistered after termination")
+		retry.RunWith(&retry.Timer{Timeout: 4 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
+			for _, name := range []string{
+				"job-client",
+				"job-client-sidecar-proxy",
+			} {
+				logger.Logf(t, "checking for %s service in Consul catalog", name)
+				instances, _, err := connHelper.ConsulClient.Catalog().Service(name, "", nil)
+				r.Check(err)
+
+				for _, instance := range instances {
+					if strings.Contains(instance.ServiceID, jobName) {
+						r.Errorf("%s is still registered", instance.ServiceID)
+					}
+				}
+			}
+		})
+	}
+}

--- a/acceptance/tests/fixtures/bases/job-client/job.yaml
+++ b/acceptance/tests/fixtures/bases/job-client/job.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+   name: job-client
+   namespace: default
+   labels:
+     app: job-client
+spec:
+  template:
+    metadata:
+      labels:
+        app: job-client
+    spec:
+      containers:
+      - name: job-client
+        image: alpine/curl:3.14
+        ports:
+        - containerPort: 80
+        command:
+          - /bin/sh
+          - -c
+          - |
+            echo "Started test job"
+            sleep 120
+            echo "Ended test job"
+      serviceAccountName: job-client
+      restartPolicy: Never

--- a/acceptance/tests/fixtures/bases/job-client/kustomization.yaml
+++ b/acceptance/tests/fixtures/bases/job-client/kustomization.yaml
@@ -1,0 +1,7 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - ./job.yaml
+  - service.yaml
+  - serviceaccount.yaml

--- a/acceptance/tests/fixtures/bases/job-client/service.yaml
+++ b/acceptance/tests/fixtures/bases/job-client/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: job-client
+  namespace: default
+spec:
+  selector:
+    app: job-client
+  ports:
+    - port: 80

--- a/acceptance/tests/fixtures/bases/job-client/serviceaccount.yaml
+++ b/acceptance/tests/fixtures/bases/job-client/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: job-client
+  namespace: default

--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-0s/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-0s/kustomization.yaml
@@ -1,0 +1,6 @@
+
+resources:
+  - ../../../bases/job-client
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-0s/patch.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-0s/patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-client
+spec:
+  template:
+    metadata:
+      annotations:
+        "consul.hashicorp.com/connect-inject": "true"
+        "consul.hashicorp.com/transparent-proxy": "false"
+        "consul.hashicorp.com/connect-service-upstreams": "static-server:1234"
+        "consul.hashicorp.com/sidecar-proxy-lifecycle-shutdown-grace-period-seconds": "0"

--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-10s/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-10s/kustomization.yaml
@@ -1,0 +1,6 @@
+
+resources:
+  - ../../../bases/job-client
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-10s/patch.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-10s/patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-client
+spec:
+  template:
+    metadata:
+      annotations:
+        "consul.hashicorp.com/connect-inject": "true"
+        "consul.hashicorp.com/transparent-proxy": "false"
+        "consul.hashicorp.com/connect-service-upstreams": "static-server:1234"
+        "consul.hashicorp.com/sidecar-proxy-lifecycle-shutdown-grace-period-seconds": "10"

--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject/kustomization.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - ../../../bases/job-client
+
+patchesStrategicMerge:
+  - patch.yaml

--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject/patch.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject/patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-client
+spec:
+  template:
+    metadata:
+      annotations:
+        "consul.hashicorp.com/connect-inject": "true"
+        "consul.hashicorp.com/transparent-proxy": "false"
+        "consul.hashicorp.com/sidecar-proxy-lifecycle-shutdown-grace-period-seconds": "5"
+        "consul.hashicorp.com/connect-service-upstreams": "static-server:1234"


### PR DESCRIPTION
Manual backport of #2669 into release 1.2.x. Addresses backport failure #2826.
