### PR TITLE
Add readOnlyRootFilesystem to security context (#2771) backport to 1.2.x

### DIFF
--- a/.changelog/2789.txt
+++ b/.changelog/2789.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+helm: Add readOnlyRootFilesystem to the default restricted security context when runnning `consul-k8s` in a restricted namespaces. 
+```

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -19,6 +19,7 @@ as well as the global.name setting.
 {{- if not .Values.global.enablePodSecurityPolicies -}}
 securityContext:
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
     - ALL

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -154,6 +154,9 @@ spec:
       terminationGracePeriodSeconds: {{ default $defaults.terminationGracePeriodSeconds .terminationGracePeriodSeconds }}
       serviceAccountName: {{ template "consul.fullname" $root }}-{{ .name }}
       volumes:
+      - name: tmp
+        emptyDir:
+          medium: "Memory"
       - name: consul-service
         emptyDir:
           medium: "Memory"
@@ -215,6 +218,8 @@ spec:
           -log-level={{ default $root.Values.global.logLevel $root.Values.ingressGateways.logLevel }} \
           -log-json={{ $root.Values.global.logJSON }}
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         - name: consul-service
           mountPath: /consul/service
         {{- if $root.Values.global.tls.enabled }}
@@ -239,6 +244,8 @@ spec:
         resources: {{ toYaml (default $defaults.resources .resources) | nindent 10 }}
         {{- end }}
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         - name: consul-service
           mountPath: /consul/service
           readOnly: true

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -141,6 +141,8 @@ spec:
         {{- toYaml .Values.server.securityContext | nindent 8 }}
       {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: config
           configMap:
             name: {{ template "consul.fullname" . }}-server-config
@@ -449,6 +451,9 @@ spec:
               mountPath: /trusted-cas
               readOnly: false
             {{- end }}
+            - name: tmp
+              mountPath: /tmp
+              readOnly: false
           ports:
             {{- if (or (not .Values.global.tls.enabled) (not .Values.global.tls.httpsOnly)) }}
             - name: http

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -123,6 +123,9 @@ spec:
       terminationGracePeriodSeconds: 10
       serviceAccountName: {{ template "consul.fullname" $root }}-{{ .name }}
       volumes:
+      - name: tmp
+        emptyDir:
+          medium: "Memory"
       - name: consul-service
         emptyDir:
           medium: "Memory"
@@ -200,6 +203,8 @@ spec:
                   -log-level={{ default $root.Values.global.logLevel $root.Values.terminatingGateways.logLevel }} \
                   -log-json={{ $root.Values.global.logJSON }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
             - name: consul-service
               mountPath: /consul/service
             {{- if $root.Values.global.tls.enabled }}
@@ -221,6 +226,8 @@ spec:
           image: {{ $root.Values.global.imageConsulDataplane | quote }}
           {{- include "consul.restrictedSecurityContext" $ | nindent 10 }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
             - name: consul-service
               mountPath: /consul/service
               readOnly: true

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -858,6 +858,7 @@ load _helpers
     "capabilities": {
       "drop": ["ALL"]
     },
+    "readOnlyRootFilesystem": true,
     "runAsNonRoot": true,
     "seccompProfile": {
       "type": "RuntimeDefault"
@@ -889,6 +890,7 @@ load _helpers
     "capabilities": {
       "drop": ["ALL"]
     },
+    "readOnlyRootFilesystem": true,
     "runAsNonRoot": true,
     "seccompProfile": {
       "type": "RuntimeDefault"


### PR DESCRIPTION
* Manual backport of https://github.com/hashicorp/consul-k8s/pull/2789 to Add readOnlyRootFilesystem to security context from (#2771)

---------

Changes proposed in this PR:
-
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


