### PR TITLE
Use HTTP Get for readiness probe

### DIFF
--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -509,20 +509,15 @@ spec:
               containerPort: 8600
               protocol: "UDP"
           readinessProbe:
-            # NOTE(mitchellh): when our HTTP status endpoints support the
-            # proper status codes, we should switch to that. This is temporary.
-            exec:
-              command:
-                - "/bin/sh"
-                - "-ec"
-                - |
-                  {{- if .Values.global.tls.enabled }}
-                  curl -k \
-                    https://127.0.0.1:8501/v1/status/leader \
-                  {{- else }}
-                  curl http://127.0.0.1:8500/v1/status/leader \
-                  {{- end }}
-                  2>/dev/null | grep -E '".+"'
+            httpGet:
+              path: /v1/status/leader
+              {{- if .Values.global.tls.enabled }}
+              scheme: "HTTPS"
+              port: 8501
+              {{- else }}
+              scheme: "HTTP"
+              port: 8500
+              {{- end}}
             failureThreshold: 2
             initialDelaySeconds: 5
             periodSeconds: 3


### PR DESCRIPTION
Changes proposed in this PR:
- Use `httpGet` for the Server StatefulSet readiness probe

How I've tested this PR:
- Acceptance tests will be the best way to check that this does not break anything.

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


