### PR TITLE
Fix issue where CLI install test was running Tproxy manually

### DIFF
--- a/acceptance/tests/cli/cli_install_test.go
+++ b/acceptance/tests/cli/cli_install_test.go
@@ -26,11 +26,9 @@ const ipv4RegEx = "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]
 func TestInstall(t *testing.T) {
 	cases := map[string]struct {
 		secure bool
-		tproxy bool
 	}{
-		"not-secure":        {secure: false, tproxy: false},
-		"secure":            {secure: true, tproxy: false},
-		"not-secure-tproxy": {secure: false, tproxy: true},
+		"not-secure": {secure: false},
+		"secure":     {secure: true},
 	}
 
 	for name, c := range cases {
@@ -39,7 +37,6 @@ func TestInstall(t *testing.T) {
 			require.NoError(t, err)
 
 			cfg := suite.Config()
-			cfg.EnableTransparentProxy = c.tproxy
 			ctx := suite.Environment().DefaultContext(t)
 
 			connHelper := connhelper.ConnectHelper{
@@ -102,7 +99,7 @@ func TestInstall(t *testing.T) {
 			logger.Log(t, string(upstreamsOut))
 			require.NoError(t, err)
 
-			if c.tproxy {
+			if cfg.EnableTransparentProxy {
 				// If tproxy is enabled we are looking for the upstream ip which is the ClusterIP of the Kubernetes Service
 				serverService, err := connHelper.Ctx.KubernetesClient(t).CoreV1().Services(connHelper.Ctx.KubectlOptions(t).Namespace).List(context.Background(), metav1.ListOptions{
 					FieldSelector: "metadata.name=static-server",


### PR DESCRIPTION
Changes proposed in this PR:
- Removes the case where transparent proxy is enabled in the test -- it should be set outside of the test with the flag

How I've tested this PR:
- Acceptance

How I expect reviewers to test this PR:
- Acceptance


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


