### PR TITLE
Revert "Add readOnlyRootFilesystem to security context (#2771)"

### DIFF
--- a/.changelog/2789.txt
+++ b/.changelog/2789.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-helm: Add readOnlyRootFilesystem to the default restricted security context when runnning `consul-k8s` in a restricted namespaces. 
-```

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -19,7 +19,6 @@ as well as the global.name setting.
 {{- if not .Values.global.enablePodSecurityPolicies -}}
 securityContext:
   allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: true
   capabilities:
     drop:
     - ALL

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -154,9 +154,6 @@ spec:
       terminationGracePeriodSeconds: {{ default $defaults.terminationGracePeriodSeconds .terminationGracePeriodSeconds }}
       serviceAccountName: {{ template "consul.fullname" $root }}-{{ .name }}
       volumes:
-      - name: tmp
-        emptyDir:
-          medium: "Memory"
       - name: consul-service
         emptyDir:
           medium: "Memory"
@@ -218,8 +215,6 @@ spec:
           -log-level={{ default $root.Values.global.logLevel $root.Values.ingressGateways.logLevel }} \
           -log-json={{ $root.Values.global.logJSON }}
         volumeMounts:
-        - name: tmp
-          mountPath: /tmp
         - name: consul-service
           mountPath: /consul/service
         {{- if $root.Values.global.tls.enabled }}
@@ -244,8 +239,6 @@ spec:
         resources: {{ toYaml (default $defaults.resources .resources) | nindent 10 }}
         {{- end }}
         volumeMounts:
-        - name: tmp
-          mountPath: /tmp
         - name: consul-service
           mountPath: /consul/service
           readOnly: true

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -141,8 +141,6 @@ spec:
         {{- toYaml .Values.server.securityContext | nindent 8 }}
       {{- end }}
       volumes:
-        - name: tmp
-          emptyDir: {}
         - name: config
           configMap:
             name: {{ template "consul.fullname" . }}-server-config
@@ -455,9 +453,6 @@ spec:
               mountPath: /trusted-cas
               readOnly: false
             {{- end }}
-            - name: tmp
-              mountPath: /tmp
-              readOnly: false
           ports:
             {{- if (or (not .Values.global.tls.enabled) (not .Values.global.tls.httpsOnly)) }}
             - name: http

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -123,9 +123,6 @@ spec:
       terminationGracePeriodSeconds: 10
       serviceAccountName: {{ template "consul.fullname" $root }}-{{ .name }}
       volumes:
-      - name: tmp
-        emptyDir:
-          medium: "Memory"
       - name: consul-service
         emptyDir:
           medium: "Memory"
@@ -203,8 +200,6 @@ spec:
                   -log-level={{ default $root.Values.global.logLevel $root.Values.terminatingGateways.logLevel }} \
                   -log-json={{ $root.Values.global.logJSON }}
           volumeMounts:
-            - name: tmp
-              mountPath: /tmp
             - name: consul-service
               mountPath: /consul/service
             {{- if $root.Values.global.tls.enabled }}
@@ -226,8 +221,6 @@ spec:
           image: {{ $root.Values.global.imageConsulDataplane | quote }}
           {{- include "consul.restrictedSecurityContext" $ | nindent 10 }}
           volumeMounts:
-            - name: tmp
-              mountPath: /tmp
             - name: consul-service
               mountPath: /consul/service
               readOnly: true

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -859,7 +859,6 @@ load _helpers
       "drop": ["ALL"],
       "add": ["NET_BIND_SERVICE"]
     },
-    "readOnlyRootFilesystem": true,
     "runAsNonRoot": true,
     "seccompProfile": {
       "type": "RuntimeDefault"
@@ -892,7 +891,6 @@ load _helpers
       "drop": ["ALL"],
       "add": ["NET_BIND_SERVICE"]
     },
-    "readOnlyRootFilesystem": true,
     "runAsNonRoot": true,
     "seccompProfile": {
       "type": "RuntimeDefault"


### PR DESCRIPTION
Reverts hashicorp/consul-k8s#2789

Causing problems in our acceptance tests since Envoy needs to write to disk for bootstrap config. 