### PR TITLE
NET-5389- Remove `global.acls.nodeSelector` and `global.acls.annotations` from Gateway Resources Jobs

### DIFF
--- a/charts/consul/templates/gateway-cleanup-job.yaml
+++ b/charts/consul/templates/gateway-cleanup-job.yaml
@@ -31,9 +31,6 @@ spec:
         {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
-        {{- if .Values.global.acls.annotations }}
-          {{- tpl .Values.global.acls.annotations . | nindent 8 }}
-        {{- end }}
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-gateway-cleanup
@@ -57,9 +54,5 @@ spec:
       {{- if .Values.global.acls.tolerations }}
       tolerations:
         {{ tpl .Values.global.acls.tolerations . | indent 8 | trim }}
-      {{- end }}
-      {{- if .Values.global.acls.nodeSelector }}
-      nodeSelector:
-        {{ tpl .Values.global.acls.nodeSelector . | indent 8 | trim }}
       {{- end }}
 {{- end }}

--- a/charts/consul/templates/gateway-resources-job.yaml
+++ b/charts/consul/templates/gateway-resources-job.yaml
@@ -31,9 +31,6 @@ spec:
         {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
-        {{- if .Values.global.acls.annotations }}
-          {{- tpl .Values.global.acls.annotations . | nindent 8 }}
-        {{- end }}
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-gateway-resources
@@ -118,10 +115,6 @@ spec:
       {{- if .Values.global.acls.tolerations }}
       tolerations:
         {{ tpl .Values.global.acls.tolerations . | indent 8 | trim }}
-      {{- end }}
-      {{- if .Values.global.acls.nodeSelector }}
-      nodeSelector:
-        {{ tpl .Values.global.acls.nodeSelector . | indent 8 | trim }}
       {{- end }}
       volumes:
         - name: config


### PR DESCRIPTION
Changes proposed in this PR:
Remove `global.acls.nodeSelector` and `global.acls.annotations` from the  Gateway Resources Job and Gateway Cleanup Job


How I've tested this PR:

How I expect reviewers to test this PR:



