### PR TITLE
NET-5389- Remove global.acls.nodeSelector and global.acls.annotations from Gateway Resources Jobs

### DIFF
--- a/.changelog/2869.txt
+++ b/.changelog/2869.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+bug: Remove `global.acls.nodeSelector` and `global.acls.annotations` from Gateway Resources Jobs
+```

--- a/charts/consul/templates/gateway-cleanup-job.yaml
+++ b/charts/consul/templates/gateway-cleanup-job.yaml
@@ -31,9 +31,6 @@ spec:
         {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
-        {{- if .Values.global.acls.annotations }}
-          {{- tpl .Values.global.acls.annotations . | nindent 8 }}
-        {{- end }}
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-gateway-cleanup
@@ -57,9 +54,5 @@ spec:
       {{- if .Values.global.acls.tolerations }}
       tolerations:
         {{ tpl .Values.global.acls.tolerations . | indent 8 | trim }}
-      {{- end }}
-      {{- if .Values.global.acls.nodeSelector }}
-      nodeSelector:
-        {{ tpl .Values.global.acls.nodeSelector . | indent 8 | trim }}
       {{- end }}
 {{- end }}

--- a/charts/consul/templates/gateway-resources-job.yaml
+++ b/charts/consul/templates/gateway-resources-job.yaml
@@ -31,9 +31,6 @@ spec:
         {{- end }}
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
-        {{- if .Values.global.acls.annotations }}
-          {{- tpl .Values.global.acls.annotations . | nindent 8 }}
-        {{- end }}
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-gateway-resources
@@ -118,10 +115,6 @@ spec:
       {{- if .Values.global.acls.tolerations }}
       tolerations:
         {{ tpl .Values.global.acls.tolerations . | indent 8 | trim }}
-      {{- end }}
-      {{- if .Values.global.acls.nodeSelector }}
-      nodeSelector:
-        {{ tpl .Values.global.acls.nodeSelector . | indent 8 | trim }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/consul/test/unit/gateway-cleanup-job.bats
+++ b/charts/consul/test/unit/gateway-cleanup-job.bats
@@ -33,13 +33,3 @@ target=templates/gateway-cleanup-job.yaml
         yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."consul.hashicorp.com/config-checksum")' | tee /dev/stderr)
     [ "${actual}" = "{}" ]
 }
-
-@test "gatewaycleanup/Job: annotations can be set" {
-  cd `chart_dir`
-  local actual=$(helm template \
-        -s $target \
-        --set 'global.acls.annotations=foo: bar' \
-        . | tee /dev/stderr |
-        yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
-    [ "${actual}" = "bar" ]
-}

--- a/charts/consul/test/unit/gateway-resources-job.bats
+++ b/charts/consul/test/unit/gateway-resources-job.bats
@@ -152,13 +152,3 @@ target=templates/gateway-resources-job.yaml
         yq -r '.spec.template.metadata.annotations | del(."consul.hashicorp.com/connect-inject") | del(."consul.hashicorp.com/config-checksum")' | tee /dev/stderr)
     [ "${actual}" = "{}" ]
 }
-
-@test "gatewayresources/Job: annotations can be set" {
-  cd `chart_dir`
-  local actual=$(helm template \
-        -s $target \
-        --set 'global.acls.annotations=foo: bar' \
-        . | tee /dev/stderr |
-        yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
-    [ "${actual}" = "bar" ]
-}


### PR DESCRIPTION
Changes proposed in this PR:
Remove global.acls.nodeSelector and global.acls.annotations from the Gateway Resources Job and Gateway Cleanup Job

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


