### PR TITLE
Backport - Net 5229 create dedicated argocd stanza (#2785) in release 1.0.x

### DIFF
--- a/.changelog/2785.txt
+++ b/.changelog/2785.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Add new value `global.argocd.enabled`. Set this to `true` when using ArgoCD to deploy this chart.
+```

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -49,6 +49,10 @@ spec:
         {{- if .Values.global.acls.annotations }}
           {{- tpl .Values.global.acls.annotations . | nindent 8 }}
         {{- end }}
+        {{- if .Values.global.argocd.enabled }}
+        "argocd.argoproj.io/hook": "Sync"
+        "argocd.argoproj.io/hook-delete-policy": "HookSucceeded"
+        {{- end }}
         {{- if .Values.global.secretsBackend.vault.enabled }}
         "vault.hashicorp.com/agent-pre-populate-only": "true"
         "vault.hashicorp.com/agent-inject": "true"

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -2304,3 +2304,39 @@ load _helpers
       yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 }
+
+@test "serverACLInit/Job: argocd annotations are set if global.argocd.enabled is true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+     -s templates/server-acl-init-job.yaml \
+     --set 'global.acls.manageSystemACLs=true' \
+     --set 'global.argocd.enabled=true' \
+     . | tee /dev/stderr |
+     yq -r '.spec.template.metadata.annotations["argocd.argoproj.io/hook"]' | tee /dev/stderr)
+  [ "${actual}" = "Sync" ]
+  local actual=$(helm template \
+     -s templates/server-acl-init-job.yaml \
+     --set 'global.acls.manageSystemACLs=true' \
+     --set 'global.argocd.enabled=true' \
+     . | tee /dev/stderr |
+     yq -r '.spec.template.metadata.annotations["argocd.argoproj.io/hook-delete-policy"]' | tee /dev/stderr)
+  [ "${actual}" = "HookSucceeded" ]
+}
+
+@test "serverACLInit/Job: argocd annotations are not set if global.argocd.enabled is false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+     -s templates/server-acl-init-job.yaml \
+     --set 'global.acls.manageSystemACLs=true' \
+     --set 'global.argocd.enabled=false' \
+     . | tee /dev/stderr |
+     yq -r '.spec.template.metadata.annotations["argocd.argoproj.io/hook"]' | tee /dev/stderr)
+  [ "${actual}" = null ]
+  local actual=$(helm template \
+     -s templates/server-acl-init-job.yaml \
+     --set 'global.acls.manageSystemACLs=true' \
+     --set 'global.argocd.enabled=false' \
+     . | tee /dev/stderr |
+     yq -r '.spec.template.metadata.annotations["argocd.argoproj.io/hook-delete-policy"]' | tee /dev/stderr)
+  [ "${actual}" = null ]
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -543,6 +543,14 @@ global:
     # @type: string
     annotations: null
 
+  # If argocd.enabled is set to true, following annotations are added to
+  # job - server-acl-init-job
+  # annotations -
+  #   argocd.argoproj.io/hook: Sync
+  #   argocd.argoproj.io/hook-delete-policy: HookSucceeded
+  argocd:
+    enabled: false
+
   # [Enterprise Only] This value refers to a Kubernetes or Vault secret that you have created
   # that contains your enterprise license. It is required if you are using an
   # enterprise binary. Defining it here applies it to your cluster once a leader


### PR DESCRIPTION
Changes proposed in this PR:

* Add support for global.argocd.enabled flag in values.yaml which adds the 
```
        "argocd.argoproj.io/hook": "Sync"
        "argocd.argoproj.io/hook-delete-policy": "HookSucceeded"
```
 in the jobs -
server-acl-init-job

How I've tested this PR:
* Bats Tests
Manual Tests - 
* Created github pages to host helm charts following [this medium article](https://medium.com/@mattiaperi/create-a-public-helm-chart-repository-with-github-pages-49b180dbb417)
* Forked the repo and created a new branch - https://github.com/absolutelightning/consul-minikubes/tree/test-argocd.
* Updated the repo with values from github helm charts created in step 1
* Ran `bash argocd.sh`
* kubectl port-forward svc/argocd-server -n argocd 8087:443
* argocd admin initial-password -n argocd
* Input username - admin and password output from previous step in UI at localhost:8087.
* Recorded video

https://github.com/hashicorp/consul-k8s/assets/134911583/e09b51ff-e02e-44af-a216-440c38275bee




Checklist:
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


