### PR TITLE
Filter api-gateway cache logging to reduce log output on server disconnect

### DIFF
--- a/.changelog/2880.txt
+++ b/.changelog/2880.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api-gateway: reduce log output when disconnecting from consul server 
+```

--- a/control-plane/api-gateway/cache/consul.go
+++ b/control-plane/api-gateway/cache/consul.go
@@ -196,7 +196,9 @@ func (c *Cache) subscribeToConsul(ctx context.Context, kind string) {
 		if err != nil {
 			// if we timeout we don't care about the error message because it's expected to happen on long polls
 			// any other error we want to alert on
-			if !strings.Contains(strings.ToLower(err.Error()), "timeout") {
+			if !strings.Contains(strings.ToLower(err.Error()), "timeout") &&
+				!strings.Contains(strings.ToLower(err.Error()), "no such host") &&
+				!strings.Contains(strings.ToLower(err.Error()), "connection refused") {
 				c.logger.Error(err, fmt.Sprintf("error fetching config entries for kind: %s", kind))
 			}
 			continue


### PR DESCRIPTION
Changes proposed in this PR:
- I noticed this when I was working on a customer issue and it made debugging more difficult
- I was working on an issue that was reproduced by deleting the consul-server-0 pod and the api-gateway logging spit out about 20k log lines in about 5 seconds
- I don't think we need to log these errors out at the api-gateway level as other parts of the controller will log a similar error out but less frequently.
- The customer will still see that the consul server is unreachable in the logs (see below)

Instead of 20k of these:
  
> 2023-08-31T14:33:54.861Z        ERROR   error fetching config entries for kind: http-route      {"error": "Get \"http://10.244.0.8:8500/v1/config/http-route?dc=dc1&index=10\": dial tcp 10.244.0.8:8500: connect: connection refused"}

They still see:

> 2023-08-31T14:41:43.031Z        ERROR   Reconciler error        {"controller": "endpoints", "controllerGroup": "", "controllerKind": "Endpoints", "Endpoints": {"name":"consul-ui","namespace":"consul"}, "namespace": "consul", "name": "consul-ui", "reconcileID": "ce66b001-0173-40d1-95ab-a7a5363a6612", "error": "1 error occurred:\n\t* Get \"http://<nil>:8500/v1/catalog/nodes?dc=dc1&filter=Meta%5B%22synthetic-node%22%5D+%3D%3D+%22true%22+&ns=%2A\": dial tcp: lookup <nil>: no such host\n\n"}

How I've tested this PR:

- build locally, delete consul-server-0 and look at the connect injector logs.

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


