### PR TITLE
Fixing diff resulting from make copy-crds-to-chart

### DIFF
--- a/charts/consul/templates/crd-gatewayclassconfigs.yaml
+++ b/charts/consul/templates/crd-gatewayclassconfigs.yaml
@@ -2,6 +2,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/consul/templates/crd-meshservices.yaml
+++ b/charts/consul/templates/crd-meshservices.yaml
@@ -2,6 +2,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/consul/templates/crd-routeretryfilters.yaml
+++ b/charts/consul/templates/crd-routeretryfilters.yaml
@@ -1,18 +1,21 @@
 {{- if .Values.connectInject.enabled }}
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
-  name: routeretryfilters.consul.hashicorp.com
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: crd
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: routeretryfilters.consul.hashicorp.com
 spec:
   group: consul.hashicorp.com
   names:

--- a/charts/consul/templates/crd-routetimeoutfilters.yaml
+++ b/charts/consul/templates/crd-routetimeoutfilters.yaml
@@ -1,18 +1,21 @@
 {{- if .Values.connectInject.enabled }}
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
-  name: routetimeoutfilters.consul.hashicorp.com
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: crd
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: routetimeoutfilters.consul.hashicorp.com
 spec:
   group: consul.hashicorp.com
   names:


### PR DESCRIPTION
Changes proposed in this PR:
- When working on https://github.com/hashicorp/consul-k8s/pull/2881, I noticed there was an additional diff when trying to copy generated CRD YAML into charts/consul
- `make copy-crds-to-chart` seems to be creating a diff locally on main. My assumption is: folks are manually creating the charts. Not sure what the expectation is  

How I've tested this PR:
- Running `make copy-crds-to-chart` locally 

How I expect reviewers to test this PR:
- If needed, provide any obvious context I may be missing. 
- Callout any expected tests I need to update 


