### PR TITLE
NET-5186 Add NET_BIND_SERVICE to built-in PSPs for consul-dataplane deployments

### DIFF
--- a/charts/consul/templates/ingress-gateways-podsecuritypolicy.yaml
+++ b/charts/consul/templates/ingress-gateways-podsecuritypolicy.yaml
@@ -21,6 +21,8 @@ spec:
   # but we can provide it for defense in depth.
   requiredDropCapabilities:
     - ALL
+  defaultAddCapabilities:
+    - NET_BIND_SERVICE
   # Allow core volume types.
   volumes:
     - 'configMap'

--- a/charts/consul/templates/mesh-gateway-podsecuritypolicy.yaml
+++ b/charts/consul/templates/mesh-gateway-podsecuritypolicy.yaml
@@ -18,6 +18,8 @@ spec:
   # but we can provide it for defense in depth.
   requiredDropCapabilities:
     - ALL
+  defaultAddCapabilities:
+    - NET_BIND_SERVICE
   # Allow core volume types.
   volumes:
     - 'configMap'

--- a/charts/consul/templates/telemetry-collector-podsecuritypolicy.yaml
+++ b/charts/consul/templates/telemetry-collector-podsecuritypolicy.yaml
@@ -18,6 +18,8 @@ spec:
   # but we can provide it for defense in depth.
   requiredDropCapabilities:
     - ALL
+  defaultAddCapabilities:
+    - NET_BIND_SERVICE
   # Allow core volume types.
   volumes:
     - 'configMap'

--- a/charts/consul/templates/terminating-gateways-podsecuritypolicy.yaml
+++ b/charts/consul/templates/terminating-gateways-podsecuritypolicy.yaml
@@ -21,6 +21,8 @@ spec:
   # but we can provide it for defense in depth.
   requiredDropCapabilities:
     - ALL
+  defaultAddCapabilities:
+    - NET_BIND_SERVICE
   # Allow core volume types.
   volumes:
     - 'configMap'


### PR DESCRIPTION
**Changes proposed in this PR:**
PodSecurityPolicy needs to add the `NET_BIND_SERVICE` capability for any Deployment that includes consul-dataplane.

A search for these in the consul-k8s repo yields:
![CleanShot 2023-09-01 at 16 25 06@2x](https://github.com/hashicorp/consul-k8s/assets/3476400/538e4be2-67ac-4724-b3c1-3065c83dd903)


**How I've tested this PR:**
1. Create a GKE cluster with PodSecurityPolicy enforcement enabled
  ```shell
  $ gcloud beta container clusters create cluster-1 --cluster-version=1.24 --enable-pod-security-policy
  ```
3. Deploy Consul with PodSecurityPolicy enabled as well as the various gateway types and the telemetry collector
  ```yaml
  global:
    enablePodSecurityPolicies: true
  telemetryCollector:
    enabled: true
  meshGateway:
    enabled: true
  terminatingGateways:
    enabled: true
  ingressGateways:
    enabled: true
    gateways:
    - name: ingress-gateway
      service:
        type: LoadBalancer
        ports:
        - port: 80
  ```
4. Verify that dataplane container in ingress-gateway, mesh-gateway, terminating-gateway and telemetry-collector pods successfully starts up. A failure scenario looks like `exec /usr/local/bin/consul-dataplane: operation not permitted`.

**How I expect reviewers to test this PR:**


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


