### PR TITLE
made server locality-init configurable

### DIFF
--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -229,6 +229,7 @@ spec:
       priorityClassName: {{ .Values.server.priorityClassName | quote }}
       {{- end }}
       initContainers:
+      {{- if .Values.server.locality }}
       - name: locality-init
         image: {{ .Values.global.imageK8S }}
         env:
@@ -245,6 +246,7 @@ spec:
           - name: extra-config
             mountPath: /consul/extra-config
         {{- include "consul.restrictedSecurityContext" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: consul
           image: "{{ default .Values.global.image .Values.server.image }}"
@@ -417,7 +419,9 @@ spec:
                 {{- end }}
                 {{- end }}
                 -config-file=/consul/extra-config/extra-from-values.json \
+                {{- if .Values.server.locality }}
                 -config-file=/consul/extra-config/locality.json
+                {{- end }}
                 {{- if and .Values.global.cloud.enabled .Values.global.cloud.resourceId.secretName }}
                 -hcl="cloud { resource_id = \"${HCP_RESOURCE_ID}\" }"
                 {{- end }}

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -229,7 +229,7 @@ spec:
       priorityClassName: {{ .Values.server.priorityClassName | quote }}
       {{- end }}
       initContainers:
-      {{- if .Values.server.locality }}
+      {{- if .Values.server.locality.enabled }}
       - name: locality-init
         image: {{ .Values.global.imageK8S }}
         env:
@@ -419,7 +419,7 @@ spec:
                 {{- end }}
                 {{- end }}
                 -config-file=/consul/extra-config/extra-from-values.json \
-                {{- if .Values.server.locality }}
+                {{- if .Values.server.locality.enabled }}
                 -config-file=/consul/extra-config/locality.json
                 {{- end }}
                 {{- if and .Values.global.cloud.enabled .Values.global.cloud.resourceId.secretName }}

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -967,7 +967,7 @@ load _helpers
       --set 'server.locality.enabled=false' \
       . | tee /dev/stderr)
   local actual=$(echo "$manifest" | yq -r '.spec.template.spec.initContainers | map(select(.name == "locality-init"))')
-  [ "$actual" == "[]" ]
+  [ $actual == [] ]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -945,6 +945,32 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# server.locality.enabled = true
+
+@test "server/StatefulSet: server locality enabled by default" {
+  cd `chart_dir`
+  local manifest=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      . | tee /dev/stderr)
+  local actual=$(echo "$manifest" | yq -r '.spec.template.spec.initContainers | map(select(.name == "locality-init")) | .[0].name')
+  [ "$actual" == "locality-init" ]
+}
+
+#--------------------------------------------------------------------
+
+# server.locality.enabled = false
+
+@test "server/StatefulSet: server locality disabled" {
+  cd `chart_dir`
+  local manifest=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.locality.enabled=false' \
+      . | tee /dev/stderr)
+  local actual=$(echo "$manifest" | yq -r '.spec.template.spec.initContainers | map(select(.name == "locality-init"))')
+  [ "$actual" == "[]" ]
+}
+
+#--------------------------------------------------------------------
 # gossip encryption
 
 @test "server/StatefulSet: gossip encryption disabled in server StatefulSet by default" {

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -967,7 +967,7 @@ load _helpers
       --set 'server.locality.enabled=false' \
       . | tee /dev/stderr)
   local actual=$(echo "$manifest" | yq -r '.spec.template.spec.initContainers | map(select(.name == "locality-init"))')
-  [ $actual == [] ]
+  [ ${#actual[@]} -eq 0 ]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -776,6 +776,10 @@ server:
   # @type: string
   logLevel: ""
 
+  # If false locality of server nodes won't be stored 
+  # @type: boolean
+  locality: true
+
   # The name of the Docker image (including any tag) for the containers running
   # Consul server agents.
   # @type: string

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -776,9 +776,10 @@ server:
   # @type: string
   logLevel: ""
 
-  # If false locality of server nodes won't be stored 
-  # @type: boolean
-  locality: true
+  locality:
+    # If false locality of server nodes won't be stored 
+    # @type: boolean
+    enabled: true
 
   # The name of the Docker image (including any tag) for the containers running
   # Consul server agents.


### PR DESCRIPTION
Changes proposed in this PR:
- Made storing server locality configurable through helm chart.

How I've tested this PR:
installed consul using server.locality = true/false. 

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


