### PR TITLE
removed deprecated `patchesStrategicMerge`

### DIFF
--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-0s/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-0s/kustomization.yaml
@@ -3,7 +3,9 @@
 
 
 resources:
-  - ../../../bases/job-client
+- ../../../bases/job-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-0s/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-0s/kustomization.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-
 resources:
 - ../../../bases/job-client
 

--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-10s/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-10s/kustomization.yaml
@@ -3,7 +3,9 @@
 
 
 resources:
-  - ../../../bases/job-client
+- ../../../bases/job-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-10s/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject-grace-period-10s/kustomization.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-
 resources:
 - ../../../bases/job-client
 

--- a/acceptance/tests/fixtures/cases/jobs/job-client-inject/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/jobs/job-client-inject/kustomization.yaml
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resources:
-  - ../../../bases/job-client
+- ../../../bases/job-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/wan-federation/dc1-ns2-static-server/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/dc1-ns2-static-server/kustomization.yaml
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resources:
-  - ../../../bases/static-server
+- ../../../bases/static-server
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/wan-federation/dc1-static-server/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/dc1-static-server/kustomization.yaml
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resources:
-  - ../../../bases/static-server
+- ../../../bases/static-server
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/wan-federation/dc2-static-server/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/dc2-static-server/kustomization.yaml
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resources:
-  - ../../../bases/static-server
+- ../../../bases/static-server
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/wan-federation/service-resolver/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/service-resolver/kustomization.yaml
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resources:
-  - ../../../bases/service-resolver
+- ../../../bases/service-resolver
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/wan-federation/static-client/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/wan-federation/static-client/kustomization.yaml
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resources:
-  - ../../../bases/static-client
+- ../../../bases/static-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml


### PR DESCRIPTION
Changes proposed in this PR:
- Removed some more deprecated uses of `patchesStrategicMerge` added after Thomas's PR to remove the majority https://github.com/hashicorp/consul-k8s/pull/2786

@t-eckert Thanks for the script :)
How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


