### PR TITLE
Manual backport of #2905 into release/1.2.x

### DIFF
--- a/.changelog/2905.txt
+++ b/.changelog/2905.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+audit-log: fix parsing error for some audit log configuration fields fail with uncovertible string to integer errors. 
+```

--- a/charts/consul/templates/server-config-configmap.yaml
+++ b/charts/consul/templates/server-config-configmap.yaml
@@ -198,16 +198,7 @@ data:
         "sink": {
           {{- range $index, $element := .Values.server.auditLogs.sinks }}
           {{- if ne $index 0 }},{{end}}
-          "{{ $element.name }}": {
-            {{- $firstKeyValuePair := false }}
-            {{- range $k, $v := $element }}
-              {{- if ne $k "name" }}
-              {{- if ne $firstKeyValuePair false }},{{end}}
-              {{- $firstKeyValuePair = true }}
-              "{{ $k }}": "{{ $v }}"
-              {{- end }}
-            {{- end }}
-          }
+          "{{ get $element "name" }}": {{ omit $element "name" | toJson }}
           {{- end }}
         }
       }

--- a/charts/consul/test/unit/server-config-configmap.bats
+++ b/charts/consul/test/unit/server-config-configmap.bats
@@ -1112,6 +1112,8 @@ load _helpers
       --set 'server.auditLogs.sinks[0].format=json' \
       --set 'server.auditLogs.sinks[0].delivery_guarantee=best-effort' \
       --set 'server.auditLogs.sinks[0].rotate_duration=24h' \
+      --set 'server.auditLogs.sinks[0].rotate_max_files=20' \
+      --set 'server.auditLogs.sinks[0].rotate_bytes=12455355' \
       --set 'server.auditLogs.sinks[0].path=/tmp/audit.json' \
       . | tee /dev/stderr |
       yq -r '.data["audit-logging.json"]' | tee /dev/stderr)
@@ -1124,6 +1126,12 @@ load _helpers
 
   local actual=$(echo $object |  jq -r .audit.sink.MySink.rotate_duration | tee /dev/stderr)
   [ "${actual}" = "24h" ]
+
+  local actual=$(echo $object |  jq -r .audit.sink.MySink.rotate_max_files | tee /dev/stderr)
+  [ ${actual} = 20 ]
+
+  local actual=$(echo $object |  jq -r .audit.sink.MySink.rotate_bytes | tee /dev/stderr)
+  [ ${actual} = 12455355 ]
 }
 
 @test "server/ConfigMap: server.auditLogs is enabled with 1 sink input object and it does not contain the name attribute" {
@@ -1137,6 +1145,8 @@ load _helpers
       --set 'server.auditLogs.sinks[0].format=json' \
       --set 'server.auditLogs.sinks[0].delivery_guarantee=best-effort' \
       --set 'server.auditLogs.sinks[0].rotate_duration=24h' \
+      --set 'server.auditLogs.sinks[0].rotate_max_files=20' \
+      --set 'server.auditLogs.sinks[0].rotate_bytes=12455355' \
       --set 'server.auditLogs.sinks[0].path=/tmp/audit.json' \
       . | tee /dev/stderr |
       yq -r '.data["audit-logging.json"]' | jq -r .audit.sink.name | tee /dev/stderr)
@@ -1155,19 +1165,23 @@ load _helpers
       --set 'server.auditLogs.sinks[0].format=json' \
       --set 'server.auditLogs.sinks[0].delivery_guarantee=best-effort' \
       --set 'server.auditLogs.sinks[0].rotate_duration=24h' \
+      --set 'server.auditLogs.sinks[0].rotate_max_files=15' \
+      --set 'server.auditLogs.sinks[0].rotate_bytes=12445' \
       --set 'server.auditLogs.sinks[0].path=/tmp/audit.json' \
       --set 'server.auditLogs.sinks[1].name=MySink2' \
       --set 'server.auditLogs.sinks[1].type=file' \
       --set 'server.auditLogs.sinks[1].format=json' \
       --set 'server.auditLogs.sinks[1].delivery_guarantee=best-effort' \
-      --set 'server.auditLogs.sinks[1].rotate_max_files=15' \
       --set 'server.auditLogs.sinks[1].rotate_duration=24h' \
+      --set 'server.auditLogs.sinks[1].rotate_max_files=25' \
+      --set 'server.auditLogs.sinks[1].rotate_bytes=152445' \
       --set 'server.auditLogs.sinks[1].path=/tmp/audit-2.json' \
       --set 'server.auditLogs.sinks[2].name=MySink3' \
       --set 'server.auditLogs.sinks[2].type=file' \
       --set 'server.auditLogs.sinks[2].format=json' \
       --set 'server.auditLogs.sinks[2].delivery_guarantee=best-effort' \
       --set 'server.auditLogs.sinks[2].rotate_max_files=20' \
+      --set 'server.auditLogs.sinks[2].rotate_bytes=12445' \
       --set 'server.auditLogs.sinks[2].rotate_duration=18h' \
       --set 'server.auditLogs.sinks[2].path=/tmp/audit-3.json' \
       . | tee /dev/stderr |
@@ -1178,6 +1192,9 @@ load _helpers
 
   local actual=$(echo $object |  jq -r .audit.sink.MySink3.path | tee /dev/stderr)
   [ "${actual}" = "/tmp/audit-3.json" ]
+
+  local actual=$(echo $object |  jq -r .audit.sink.MySink1.rotate_max_files | tee /dev/stderr)
+  [ ${actual} = 15 ]
 
   local actual=$(echo $object |  jq -r .audit.sink.MySink2.path | tee /dev/stderr)
   [ "${actual}" = "/tmp/audit-2.json" ]
@@ -1191,11 +1208,17 @@ load _helpers
   local actual=$(echo $object |  jq -r .audit.sink.MySink2.rotate_duration | tee /dev/stderr)
   [ "${actual}" = "24h" ]
 
+  local actual=$(echo $object |  jq -r .audit.sink.MySink2.rotate_bytes | tee /dev/stderr)
+  [ ${actual} = 152445 ]
+
   local actual=$(echo $object |  jq -r .audit.sink.MySink1.format | tee /dev/stderr)
   [ "${actual}" = "json" ]
 
   local actual=$(echo $object |  jq -r .audit.sink.MySink3.type | tee /dev/stderr)
   [ "${actual}" = "file" ]
+
+  local actual=$(echo $object |  jq -r .audit.sink.MySink3.rotate_max_files | tee /dev/stderr)
+  [ ${actual} = 20 ]
 }
 
 @test "server/ConfigMap: server.logLevel is empty" {


### PR DESCRIPTION
## Backport

This PR is manually backported from the #2905 and raised against `1.2.x`.


The below text is copied from the body of the original PR.

---

Changes proposed in this PR:
- Fixes a bug in parsing the following audit log helm configuration
```yaml
server:
  auditLogs:
      enabled: true
      sinks:
        - name: My Sink
          type: file
          format: json
          path: /tmp/audit.json
          delivery_guarantee: best-effort
          rotate_duration: 24h
          rotate_max_files: 15
          rotate_bytes: 25165824
```
where `rotate_max_files` and `rotate_bytes` get passed as string inputs to the server configuration file. This PR makes sure to perform special handling for `rotate_max_files` and `rotate_bytes` where they don't get passed with quotes.

**Generated config (Before the fix)**

```json
    {
      "audit": {
        "enabled": true,
        "sink": {
          "MySink": {
              "delivery_guarantee": "best-effort",
              "format": "json",
              "path": "/tmp/audit.json",
              "rotate_bytes": "12455355", // note the presence of braces here
              "rotate_duration": "24h",
              "rotate_max_files": "20",
              "type": "file"
          }
        }
      }
    }
``` 

**Generated config (After the fix)**

```json
    {
      "audit": {
        "enabled": true,
        "sink": {
          "MySink": {
              "delivery_guarantee": "best-effort",
              "format": "json",
              "path": "/tmp/audit.json",
              "rotate_bytes": 12455355, // note the absence of braces here
              "rotate_duration": "24h",
              "rotate_max_files": 20,
              "type": "file"
          }
        }
      }
    }
``` 

How I've tested this PR:

1. CI
2. Verified manually that the server no longer crashes with this issue.

How I expect reviewers to test this PR:

👀 

Checklist:
- [X] Tests added
- [X] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 




---

