### PR TITLE
[APIGW] Add comparison of gateway policies to diffing logic

### DIFF
--- a/control-plane/api-gateway/common/diff.go
+++ b/control-plane/api-gateway/common/diff.go
@@ -157,8 +157,20 @@ func (e entryComparator) equalJWTProviders(a, b *api.APIGatewayJWTRequirement) b
 		for j := range aProvider.VerifyClaims {
 			aClaim := aProvider.VerifyClaims[j]
 			bClaim := bProvider.VerifyClaims[j]
-			if aClaim != bClaim {
+			if aClaim.Value != bClaim.Value {
 				return false
+			}
+
+			if len(aClaim.Path) != len(bClaim.Path) {
+				return false
+			}
+
+			for idx, _ := range aClaim.Path {
+			    aPath := aClaim.Path[idx]
+			    bPath := bClaim.Path[idx]
+			    if aPath != bPath {
+				return false
+			    }
 			}
 		}
 	}

--- a/control-plane/api-gateway/common/diff.go
+++ b/control-plane/api-gateway/common/diff.go
@@ -131,48 +131,44 @@ func (e entryComparator) equalJWTProviders(a, b *api.APIGatewayJWTRequirement) b
 		return false
 	}
 
-	if len(a.Providers) != len(b.Providers) {
+	return slices.EqualFunc(a.Providers, b.Providers, providersEqual)
+}
+
+func providersEqual(a, b *api.APIGatewayJWTProvider) bool {
+	if a == nil && b == nil {
+		return true
+	}
+
+	if a == nil || b == nil {
 		return false
 	}
 
-	for i := range a.Providers {
-		aProvider := a.Providers[i]
-		bProvider := b.Providers[i]
-		if aProvider == nil && bProvider == nil {
-			continue
-		}
+	if a.Name != b.Name {
+		return false
+	}
 
-		if aProvider == nil || bProvider == nil {
-			return false
-		}
+	return slices.EqualFunc(a.VerifyClaims, b.VerifyClaims, equalClaims)
+}
 
-		if aProvider.Name != bProvider.Name {
-			return false
-		}
+func equalClaims(a, b *api.APIGatewayJWTClaimVerification) bool {
+	if a == nil && b == nil {
+		return true
+	}
 
-		if len(aProvider.VerifyClaims) != len(bProvider.VerifyClaims) {
-			return false
-		}
+	if a == nil || b == nil {
+		return false
+	}
 
-		for j := range aProvider.VerifyClaims {
-			aClaim := aProvider.VerifyClaims[j]
-			bClaim := bProvider.VerifyClaims[j]
-			if aClaim.Value != bClaim.Value {
-				return false
-			}
+	if a.Value != b.Value {
+		return false
+	}
 
-			if len(aClaim.Path) != len(bClaim.Path) {
-				return false
-			}
+	if len(a.Path) != len(b.Path) {
+		return false
+	}
 
-			for idx, _ := range aClaim.Path {
-			    aPath := aClaim.Path[idx]
-			    bPath := bClaim.Path[idx]
-			    if aPath != bPath {
-				return false
-			    }
-			}
-		}
+	if !slices.Equal(a.Path, b.Path) {
+		return false
 	}
 
 	return true

--- a/control-plane/api-gateway/common/diff.go
+++ b/control-plane/api-gateway/common/diff.go
@@ -155,11 +155,11 @@ func (e entryComparator) equalJWTProviders(a, b *api.APIGatewayJWTRequirement) b
 		}
 
 		for j := range aProvider.VerifyClaims {
-		    aClaim := aProvider.VerifyClaims[j]
-		    bClaim := bProvider.VerifyClaims[j]
-		    if aClaim != bClaim {
-			return false
-		    }
+			aClaim := aProvider.VerifyClaims[j]
+			bClaim := bProvider.VerifyClaims[j]
+			if aClaim != bClaim {
+				return false
+			}
 		}
 	}
 

--- a/control-plane/api-gateway/common/diff_test.go
+++ b/control-plane/api-gateway/common/diff_test.go
@@ -16,7 +16,7 @@ func TestEntriesEqual(t *testing.T) {
 		b              api.ConfigEntry
 		expectedResult bool
 	}{
-		"gateway_equal": {
+		"gateway equal": {
 			a: &api.APIGatewayConfigEntry{
 				Kind: api.APIGateway,
 				Name: "api-gateway",
@@ -140,6 +140,2006 @@ func TestEntriesEqual(t *testing.T) {
 				Namespace: "ns",
 			},
 			expectedResult: true,
+		},
+		"gateway name different": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway-2",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
+		},
+		"gateway meta different": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey2": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
+		},
+		"gateway listeners different name": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l2",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
+		},
+		"gateway listeners different hostname": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host-different.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
+		},
+		"gateway listeners different port": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     123,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
+		},
+		"gateway listeners different protocol": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "https",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
+		},
+		"gateway listeners different TLS max version": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "15",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
+		},
+		"gateway listeners different TLS min version": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "0",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
+		},
+		"gateway listeners different TLS cipher suites": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher", "another one"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
+		},
+		"gateway listeners different TLS certificate references": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert-2",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
+		},
+		"gateway listeners different override policies jwt provider name": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "auth0",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
+		},
+		"gateway listeners different override policy jwt claims path": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"roles"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
+		},
+		"gateway listeners different override policy jwt claims value": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "user",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
+		},
+		"gateway listeners different default policies jwt provider name": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "auth0",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
+		},
+		"gateway listeners different default policy jwt claims path": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"roles"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
+		},
+		"gateway listeners different default policy jwt claims value": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "user",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: false,
 		},
 	}
 

--- a/control-plane/api-gateway/common/diff_test.go
+++ b/control-plane/api-gateway/common/diff_test.go
@@ -1,0 +1,155 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntriesEqual(t *testing.T) {
+	testCases := map[string]struct {
+		a              api.ConfigEntry
+		b              api.ConfigEntry
+		expectedResult bool
+	}{
+		"gateway_equal": {
+			a: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			b: &api.APIGatewayConfigEntry{
+				Kind: api.APIGateway,
+				Name: "api-gateway",
+				Meta: map[string]string{
+					"somekey": "somevalue",
+				},
+				Listeners: []api.APIGatewayListener{
+					{
+						Name:     "l1",
+						Hostname: "host.com",
+						Port:     590,
+						Protocol: "http",
+						TLS: api.APIGatewayTLSConfiguration{
+							Certificates: []api.ResourceReference{
+								{
+									Kind:        api.InlineCertificate,
+									Name:        "cert",
+									SectionName: "section",
+									Partition:   "partition",
+									Namespace:   "ns",
+								},
+							},
+							MaxVersion:   "5",
+							MinVersion:   "2",
+							CipherSuites: []string{"cipher"},
+						},
+						Override: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"role"},
+												Value: "admin",
+											},
+										},
+									},
+								},
+							},
+						},
+						Default: &api.APIGatewayPolicy{
+							JWT: &api.APIGatewayJWTRequirement{
+								Providers: []*api.APIGatewayJWTProvider{
+									{
+										Name: "okta",
+										VerifyClaims: []*api.APIGatewayJWTClaimVerification{
+											{
+												Path:  []string{"aud"},
+												Value: "consul.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Partition: "partition",
+				Namespace: "ns",
+			},
+			expectedResult: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actual := EntriesEqual(tc.a, tc.b)
+			require.Equal(t, tc.expectedResult, actual)
+		})
+	}
+}

--- a/control-plane/api-gateway/common/resources.go
+++ b/control-plane/api-gateway/common/resources.go
@@ -407,11 +407,17 @@ func (s *ResourceMap) AddGatewayPolicy(gatewayPolicy *v1alpha1.GatewayPolicy) *v
 	if gatewayPolicy.Spec.TargetRef.SectionName != nil {
 		sectionName = string(*gatewayPolicy.Spec.TargetRef.SectionName)
 	}
+
+	gwNamespace := gatewayPolicy.Spec.TargetRef.Namespace
+	if gwNamespace == "" {
+		gwNamespace = gatewayPolicy.Namespace
+	}
+
 	key := api.ResourceReference{
 		Kind:        gatewayPolicy.Spec.TargetRef.Kind,
 		Name:        gatewayPolicy.Spec.TargetRef.Name,
 		SectionName: sectionName,
-		Namespace:   gatewayPolicy.Spec.TargetRef.Namespace,
+		Namespace:   gwNamespace,
 	}
 
 	if s.gatewayPolicies == nil {

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -598,8 +598,12 @@ func (r *GatewayController) transformGatewayPolicy(ctx context.Context) func(obj
 	return func(o client.Object) []reconcile.Request {
 		gatewayPolicy := o.(*v1alpha1.GatewayPolicy)
 
+		gwNamespace := gatewayPolicy.Spec.TargetRef.Namespace
+		if gwNamespace == "" {
+			gwNamespace = gatewayPolicy.Namespace
+		}
 		gatewayRef := types.NamespacedName{
-			Namespace: gatewayPolicy.Spec.TargetRef.Namespace,
+			Namespace: gwNamespace,
 			Name:      gatewayPolicy.Spec.TargetRef.Name,
 		}
 		return []reconcile.Request{
@@ -607,7 +611,6 @@ func (r *GatewayController) transformGatewayPolicy(ctx context.Context) func(obj
 				NamespacedName: gatewayRef,
 			},
 		}
-
 	}
 }
 


### PR DESCRIPTION
Changes proposed in this PR:
- Add comparison of gateway policies to diffing logic
-

How I've tested this PR:
Ran kind cluster to see diffs being generated and sent to consul correctly:
1. run start script from https://github.com/jm96441n/consul-experiments/blob/main/k8s/jwts/README.md
2. shell into the `consul-server-0` pod and run `consul config read -kind api-gateway -name api-gateway` to see the gw without the JWT info
3. run `kubectl apply -f ./consul/gatewaypolicy.yaml` from the root of this above repo
4. again run `consul config read -kind api-gateway -name api-gateway` from the `consul-server-0` shell to see the gw config entry updated with the JWT info

How I expect reviewers to test this PR:
read the code
run the above steps

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


