### PR TITLE
[CC 5965] Improve HCP Observability E2E tests and add periodic tests

### DIFF
--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -13,6 +13,8 @@ require (
 	github.com/hashicorp/serf v0.10.1
 	github.com/hashicorp/vault/api v1.8.3
 	github.com/stretchr/testify v1.8.3
+	go.opentelemetry.io/proto/otlp v1.0.0
+	google.golang.org/protobuf v1.31.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
@@ -30,7 +32,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
-	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/deckarep/golang-set v1.7.1 // indirect
@@ -61,6 +63,7 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/gruntwork-io/gruntwork-cli v0.7.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.11 // indirect
@@ -123,7 +126,7 @@ require (
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/oauth2 v0.6.0 // indirect
+	golang.org/x/oauth2 v0.8.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/term v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
@@ -131,9 +134,9 @@ require (
 	golang.org/x/tools v0.7.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.3.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21 // indirect
-	google.golang.org/grpc v1.49.0 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc // indirect
+	google.golang.org/grpc v1.56.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -81,7 +81,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -111,8 +110,9 @@ github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -120,11 +120,6 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
-github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/containerd/containerd v1.3.0/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -177,8 +172,6 @@ github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
-github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
-github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -306,6 +299,7 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -355,7 +349,6 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.0.0-20200110202235-f4fb41bf00a3/go.mod h1:2wIuQute9+hhWqvL3vEI7YB0EKluF4WcPzI1eAliazk=
@@ -375,7 +368,6 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -392,7 +384,8 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
-github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/gruntwork-io/gruntwork-cli v0.7.0 h1:YgSAmfCj9c61H+zuvHwKfYUwlMhu5arnQQLM4RH+CYs=
 github.com/gruntwork-io/gruntwork-cli v0.7.0/go.mod h1:jp6Z7NcLF2avpY8v71fBx6hds9eOFPELSuD/VPv7w00=
 github.com/gruntwork-io/terratest v0.31.2 h1:xvYHA80MUq5kx670dM18HInewOrrQrAN+XbVVtytUHg=
@@ -517,7 +510,7 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -674,7 +667,6 @@ github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
-github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -776,7 +768,8 @@ go.opentelemetry.io/otel v1.11.1/go.mod h1:1nNhXBbWSD0nsL38H6btgnFN2k4i0sNLHNNMZ
 go.opentelemetry.io/otel/sdk v1.11.1 h1:F7KmQgoHljhUuJyA+9BiU+EkJfyX5nVVF4wyzWZpKxs=
 go.opentelemetry.io/otel/trace v1.11.1 h1:ofxdnzsNrGBYXbP7t7zpUK281+go5rF7dvdIZXF8gdQ=
 go.opentelemetry.io/otel/trace v1.11.1/go.mod h1:f/Q9G7vzk5u91PhbmKbg1Qn0rzH1LJ4vbPHFGkTPtOk=
-go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
+go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
+go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
@@ -896,8 +889,8 @@ golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
-golang.org/x/oauth2 v0.6.0 h1:Lh8GPgSKBfWSwFvtuWOfeI3aAAnbXTSutYxJiOJFgIw=
-golang.org/x/oauth2 v0.6.0/go.mod h1:ycmewcwgD4Rpr3eZJLSB4Kyyljb3qDh40vJ8STE5HKw=
+golang.org/x/oauth2 v0.8.0 h1:6dkIjl3j3LtZ/O3sTgZTMsLKSftL/B8Zgq4huOIIUu8=
+golang.org/x/oauth2 v0.8.0/go.mod h1:yr7u4HXZRm1R1kBWqr/xKNqewf0plRYoB7sla+BCIXE=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -965,7 +958,6 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1127,7 +1119,6 @@ google.golang.org/genproto v0.0.0-20200312145019-da6875a35672/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200430143042-b979b6f78d84/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200511104702-f5ebc3bea380/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
-google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
@@ -1135,8 +1126,11 @@ google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21 h1:hrbNEivu7Zn1pxvHk6MBrq9iE22woVILTHqexqBxe6I=
-google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
+google.golang.org/genproto v0.0.0-20230526203410-71b5a4ffd15e h1:Ao9GzfUMPH3zjVfzXG5rlWlk+Q8MXWKwWpwVQE1MXfw=
+google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc h1:kVKPf/IiYSBWEWtkIn6wZXwWGCnLKcC8oWfZvXjsGnM=
+google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc/go.mod h1:vHYtlOoi6TsQ3Uk2yxR7NI5z8uoV+3pZtR4jmHIkRig=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc h1:XSJ8Vk1SWuNr8S18z1NZSziL0CPIXLCCMDOEFtHBOFc=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc/go.mod h1:66JfowdXAEgad5O9NnYcsNPLCPZJD++2L9X0PCMODrA=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -1151,11 +1145,8 @@ google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKa
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
-google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
-google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
-google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
-google.golang.org/grpc v1.49.0 h1:WTLtQzmQori5FUH25Pq4WT22oCsv8USpQ+F6rqtsmxw=
-google.golang.org/grpc v1.49.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
+google.golang.org/grpc v1.56.2 h1:fVRFRnXvU+x6C4IlHZewvJOVHoOv1TUuQyoRsYnB4bI=
+google.golang.org/grpc v1.56.2/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -1168,10 +1159,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
-google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -1195,7 +1184,6 @@ gopkg.in/warnings.v0 v0.1.1/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRN
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/acceptance/tests/cloud/fakeserver_client.go
+++ b/acceptance/tests/cloud/fakeserver_client.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	// Validation are used in the validationBody to distinguish metrics for consul vs. collector during validation.
+	// validationPathConsul and validationPathCollector distinguish metrics for consul vs. collector during validation.
 	validationPathConsul    = "/v1/metrics/consul"
 	validationPathCollector = "/v1/metrics/collector"
 )

--- a/acceptance/tests/cloud/fakeserver_client.go
+++ b/acceptance/tests/cloud/fakeserver_client.go
@@ -71,8 +71,8 @@ func newfakeServerClient(tunnel string) *fakeServerClient {
 }
 
 // requestToken retrieves a token from the fakeserver's token endpoint.
-func (f *fakeServerClient) requestToken(endpoint string) (string, error) {
-	url := fmt.Sprintf("https://%s/token", endpoint)
+func (f *fakeServerClient) requestToken() (string, error) {
+	url := fmt.Sprintf("https://%s/token", f.tunnel)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", fmt.Errorf("%w: %w", errCreatingRequest, err)

--- a/acceptance/tests/cloud/http_client.go
+++ b/acceptance/tests/cloud/http_client.go
@@ -1,0 +1,156 @@
+package cloud
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	validationPathConsul    = "/v1/metrics/consul"
+	validationPathCollector = "/v1/metrics/collector"
+)
+
+type httpClient struct {
+	client *http.Client
+	tunnel string
+}
+
+type errMsg struct {
+	Error string `json:"error"`
+}
+
+type TokenResponse struct {
+	Token string `json:"token"`
+}
+
+type modifyTelemetryConfigBody struct {
+	Filters  []string          `json:"filters"`
+	Labels   map[string]string `json:"labels"`
+	Disabled bool              `json:"disabled"`
+	Time     int64             `json:"time"`
+}
+
+type validationBody struct {
+	Path                 string   `json:"path"`
+	ExpectedLabelKeys    []string `json:"expectedLabelKeys"`
+	DisallowedMetricName string   `json:"disallowedMetricName"`
+	ExpectedMetricName   string   `json:"expectedMetricName"`
+	MetricsDisabled      bool     `json:"metricsDisabled"`
+	RefreshTime          int64    `json:"refreshTime"`
+}
+
+func newHttpClient(tunnel string) *httpClient {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	return &httpClient{
+		client: &http.Client{Transport: tr},
+		tunnel: tunnel,
+	}
+}
+
+// The fake-server has a requestToken endpoint to retrieve the token.
+func (h *httpClient) requestToken(endpoint string) (string, error) {
+	url := fmt.Sprintf("https://%s/token", endpoint)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		fmt.Println("Error creating request:", err)
+		return "", errors.New("error creating request")
+	}
+
+	// Perform request
+	resp, err := h.client.Do(req)
+	if err != nil {
+		fmt.Println("Error sending request:", err)
+		return "", errors.New("error making request")
+	}
+	defer resp.Body.Close()
+
+	return handleTokenResponse(resp)
+}
+
+func (h *httpClient) modifyTelemetryConfig(payload *modifyTelemetryConfigBody) error {
+	url := fmt.Sprintf("https://%s/modify_telemetry_config", h.tunnel)
+	payloadBuf := new(bytes.Buffer)
+	json.NewEncoder(payloadBuf).Encode(payload)
+
+	req, err := http.NewRequest("POST", url, payloadBuf)
+	if err != nil {
+		fmt.Println("Error creating request:", err)
+		return errors.New("error creating modify_telemetry_config request")
+	}
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return errors.New("error making modify_telemetry_config request")
+	}
+
+	return handleResponse(resp)
+}
+
+func (h *httpClient) validateMetrics(payload *validationBody) error {
+	payloadBuf := new(bytes.Buffer)
+	json.NewEncoder(payloadBuf).Encode(payload)
+
+	url := fmt.Sprintf("https://%s/validation", h.tunnel)
+	req, err := http.NewRequest("POST", url, payloadBuf)
+	if err != nil {
+		return errors.New("error creating validation request")
+	}
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return errors.New("error making validation request")
+	}
+
+	return handleResponse(resp)
+}
+
+func handleTokenResponse(resp *http.Response) (string, error) {
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("Error reading response:", err)
+		return "", errors.New("error reading body")
+	}
+
+	var tokenResponse TokenResponse
+	err = json.Unmarshal(body, &tokenResponse)
+	if err != nil {
+		fmt.Println("Error parsing response:", err)
+		return "", errors.New("error parsing body")
+	}
+
+	return tokenResponse.Token, nil
+}
+
+func handleResponse(resp *http.Response) error {
+	if resp.StatusCode == http.StatusExpectationFailed {
+		// Read the response body
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Println("Error reading response:", err)
+			return errors.New("error reading body")
+		}
+		var message errMsg
+		err = json.Unmarshal(body, &message)
+		if err != nil {
+			fmt.Println("Error parsing response:", err)
+			return errors.New("error parsing body")
+		}
+
+		return fmt.Errorf("failed validation: %s", message)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("unexpected status code response from failure")
+	}
+
+	return nil
+}

--- a/acceptance/tests/cloud/metrics_validation.go
+++ b/acceptance/tests/cloud/metrics_validation.go
@@ -1,0 +1,114 @@
+package cloud
+
+import (
+	"strings"
+
+	"github.com/hashicorp/serf/testutil/retry"
+	"github.com/stretchr/testify/require"
+	otlpcolmetrics "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	otlpcommon "go.opentelemetry.io/proto/otlp/common/v1"
+	otlpmetrics "go.opentelemetry.io/proto/otlp/metrics/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+type metricValidations struct {
+	disabled             bool
+	expectedMetricName   string
+	disallowedMetricName string
+	expectedLabelKeys    []string
+}
+
+// validateMetrics ensure OTLP metrics as recorded by the Collector or Consul as expected.
+func validateMetrics(r *retry.R, records []*RequestRecord, validations *metricValidations, since int64) {
+	// If metrics are disabled, no metrics records should exist, and return early.
+	if validations.disabled {
+		require.Empty(r, records)
+		return
+	}
+
+	// If metrics are not disabled, records should not be empty.
+	require.NotEmpty(r, records)
+
+	for _, record := range records {
+		require.True(r, record.ValidRequest, "expected request to be valid")
+
+		req := &otlpcolmetrics.ExportMetricsServiceRequest{}
+		err := proto.Unmarshal(record.Body, req)
+		require.NoError(r, err, "failed to extract metrics from body")
+
+		// Basic validation that metrics are not empty.
+		require.NotEmpty(r, req.GetResourceMetrics())
+		require.NotEmpty(r, req.ResourceMetrics[0].GetScopeMetrics())
+		require.NotEmpty(r, req.ResourceMetrics[0].ScopeMetrics[0].GetMetrics())
+
+		// Verify expected key labels and metric names.
+		labels := externalLabels(req, since)
+		for _, key := range validations.expectedLabelKeys {
+			require.Contains(r, labels, key)
+		}
+		validateMetricName(r, req, validations)
+	}
+}
+
+// validateMetricName ensures an expected metric name has been recorded based on filters and disallowed metrics are not present.
+func validateMetricName(t *retry.R, request *otlpcolmetrics.ExportMetricsServiceRequest, validations *metricValidations) {
+	exists := false
+	for _, metric := range request.ResourceMetrics[0].ScopeMetrics[0].GetMetrics() {
+		require.NotContains(t, metric.Name, validations.disallowedMetricName)
+
+		if strings.Contains(metric.Name, validations.expectedMetricName) {
+			exists = true
+		}
+	}
+
+	require.True(t, exists)
+}
+
+// externalLabels converts OTLP labels to a map[string]string format.
+func externalLabels(request *otlpcolmetrics.ExportMetricsServiceRequest, since int64) map[string]string {
+	// For the Consul Telemetry Collector, labels are contained at the higher level scope.
+	attrs := request.ResourceMetrics[0].GetResource().GetAttributes()
+
+	// For Consul server metrics, labels are contained with individual metrics, and must be extracted.
+	if len(attrs) < 1 {
+		attrs = getMetricLabel(request.ResourceMetrics[0].GetScopeMetrics(), since)
+	}
+
+	labels := make(map[string]string, len(attrs))
+	for _, kv := range attrs {
+		k := strings.ReplaceAll(kv.GetKey(), ".", "_")
+		labels[k] = kv.GetValue().GetStringValue()
+	}
+
+	return labels
+}
+
+// getMetricLabel returns labels at each datapoint within a metric.
+func getMetricLabel(scopeMetrics []*otlpmetrics.ScopeMetrics, since int64) []*otlpcommon.KeyValue {
+	// The attributes field can only be accessed on the specific implementation (gauge, sum or hist).
+	for _, metric := range scopeMetrics[0].Metrics {
+		switch v := metric.Data.(type) {
+		case *otlpmetrics.Metric_Gauge:
+			for _, dp := range v.Gauge.GetDataPoints() {
+				// When a refresh has occured, filter time since last refresh as older data points may not have latest labels.
+				if dp.StartTimeUnixNano > uint64(since) {
+					return dp.Attributes
+				}
+			}
+		case *otlpmetrics.Metric_Histogram:
+			for _, dp := range v.Histogram.GetDataPoints() {
+				if dp.StartTimeUnixNano > uint64(since) {
+					return dp.Attributes
+				}
+			}
+		case *otlpmetrics.Metric_Sum:
+			for _, dp := range v.Sum.GetDataPoints() {
+				if dp.StartTimeUnixNano > uint64(since) {
+					return dp.Attributes
+				}
+			}
+		}
+	}
+
+	return []*otlpcommon.KeyValue{}
+}

--- a/acceptance/tests/cloud/observability_test.go
+++ b/acceptance/tests/cloud/observability_test.go
@@ -90,7 +90,7 @@ func TestObservabilityCloud(t *testing.T) {
 
 	fsClient := newfakeServerClient(tunnel.Endpoint())
 	logger.Log(t, "fake-server addr:"+tunnel.Endpoint())
-	consulToken, err := fsClient.requestToken(tunnel.Endpoint())
+	consulToken, err := fsClient.requestToken()
 	if err != nil {
 		logger.Log(t, "error finding consul token")
 		return

--- a/acceptance/tests/cloud/observability_test.go
+++ b/acceptance/tests/cloud/observability_test.go
@@ -224,7 +224,7 @@ func TestObservabilityCloud(t *testing.T) {
 			}
 
 			// Validate that exported metrics are correct using fakeserver's /validation endpoint, which records metric exports that occured.
-			// We need to use retry as we wait for Consul or the Collector to export metrics.
+			// We need to use retry as we wait for Consul or the Collector to export metrics. This is the best we can do to avoid flakiness.
 			retry.RunWith(&retry.Timer{Timeout: tc.timeout, Wait: tc.wait}, t, func(r *retry.R) {
 				err := fsClient.validateMetrics(tc.validation)
 				require.NoError(r, err)

--- a/acceptance/tests/cloud/observability_test.go
+++ b/acceptance/tests/cloud/observability_test.go
@@ -174,17 +174,6 @@ func TestObservabilityCloud(t *testing.T) {
 			timeout: 1 * time.Minute,
 			wait:    10 * time.Second,
 		},
-		"consulExportsMetrics": {
-			validation: &validationBody{
-				Path:                 validationPathCollector,
-				ExpectedLabelKeys:    []string{"service_name", "service_instance_id"},
-				ExpectedMetricName:   "otelcol_receiver_accepted_metric_points",
-				DisallowedMetricName: "server.memory_heap_size",
-			},
-			// High timeout as Consul server metrics exported every 1 minute (https://github.com/hashicorp/consul/blob/9776c10efb4472f196b47f88bc0db58b1bfa12ef/agent/hcp/telemetry/otel_sink.go#L27)
-			timeout: 3 * time.Minute,
-			wait:    30 * time.Second,
-		},
 		"consulPeriodicRefreshUpdateConfig": {
 			refresh: &modifyTelemetryConfigBody{
 				Filters: []string{"consul.state"},

--- a/acceptance/tests/cloud/observability_test.go
+++ b/acceptance/tests/cloud/observability_test.go
@@ -130,7 +130,7 @@ func TestObservabilityCloud(t *testing.T) {
 		// TODO: Take this out
 
 		"telemetryCollector.enabled":                   "true",
-		"telemetryCollector.image":                     "hashicorp/consul-telemetry-collector:0.0.1",
+		"telemetryCollector.image":                     cfg.ConsulCollectorImage,
 		"telemetryCollector.cloud.clientId.secretName": clientIDSecretName,
 		"telemetryCollector.cloud.clientId.secretKey":  clientIDSecretKey,
 

--- a/acceptance/tests/fixtures/bases/cloud/hcp-mock/deployment.yaml
+++ b/acceptance/tests/fixtures/bases/cloud/hcp-mock/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: fake-server
           # TODO: move this to a hashicorp mirror
-          image: docker.io/chaapppie/fakeserver:latest
+          image: docker.io/achooo/fakeserver:latest
           ports:
             - containerPort: 443
               name: https


### PR DESCRIPTION
Impact of this test in reality is minimal as this test currently **does not run** in CI yet, it is used locally for confidence in our Consul Core changes.

Changes proposed in this PR:
1. Rename the test `TestBasicCloud` to `TestObservabilityCloud` and filename`cloud/test_observability.go`
2. Refactor (cleanup) the test with a fakeserver http client object
3. Add a table driven set of scenarios to the Cloud tests for observability:
- Collector exports metrics
- Consul exports metrics
- Periodic refresh: metrics configuration changes, Consul exports metrics with this new config (new filters and label)
- Periodic refresh : disabled metrics, configuration changes to disable metrics, Consul stops exporting metrics

How I've tested this PR:
- Ran tests locally using custom docker images for both the fakeserver and consul

see below:

```
❯ go test -run TestObservabilityCloud -v -p 1 -timeout 20m \
                -use-kind \
                -consul-collector-image hashicorp/consul-telemetry-collector:0.0.1 -consul-image docker.io/achooo/consul01:17
=== RUN   TestObservabilityCloud
    command.go:100: 2023-09-12T11:12:28-04:00 Running command kubectl with args [--namespace default apply -k ../fixtures/bases/cloud/hcp-mock]
    command.go:179: 2023-09-12T11:12:28-04:00 serviceaccount/fake-server created
    command.go:179: 2023-09-12T11:12:28-04:00 service/fake-server created
    command.go:179: 2023-09-12T11:12:28-04:00 deployment.apps/fake-server created
    command.go:100: 2023-09-12T11:12:28-04:00 Running command kubectl with args [--namespace default kustomize ../fixtures/bases/cloud/hcp-mock]
    command.go:179: 2023-09-12T11:12:28-04:00 apiVersion: v1
    command.go:179: 2023-09-12T11:12:28-04:00 kind: ServiceAccount
    command.go:179: 2023-09-12T11:12:28-04:00 metadata:
    command.go:179: 2023-09-12T11:12:28-04:00   name: fake-server
    command.go:179: 2023-09-12T11:12:28-04:00 ---
    command.go:179: 2023-09-12T11:12:28-04:00 apiVersion: v1
    command.go:179: 2023-09-12T11:12:28-04:00 kind: Service
    command.go:179: 2023-09-12T11:12:28-04:00 metadata:
    command.go:179: 2023-09-12T11:12:28-04:00   name: fake-server
    command.go:179: 2023-09-12T11:12:28-04:00 spec:
    command.go:179: 2023-09-12T11:12:28-04:00   ports:
    command.go:179: 2023-09-12T11:12:28-04:00   - name: https
    command.go:179: 2023-09-12T11:12:28-04:00     port: 443
    command.go:179: 2023-09-12T11:12:28-04:00     targetPort: 443
    command.go:179: 2023-09-12T11:12:28-04:00   - name: http
    command.go:179: 2023-09-12T11:12:28-04:00     port: 8080
    command.go:179: 2023-09-12T11:12:28-04:00     targetPort: 8080
    command.go:179: 2023-09-12T11:12:28-04:00   selector:
    command.go:179: 2023-09-12T11:12:28-04:00     app: fake-server
    command.go:179: 2023-09-12T11:12:28-04:00 ---
    command.go:179: 2023-09-12T11:12:28-04:00 apiVersion: apps/v1
    command.go:179: 2023-09-12T11:12:28-04:00 kind: Deployment
    command.go:179: 2023-09-12T11:12:28-04:00 metadata:
    command.go:179: 2023-09-12T11:12:28-04:00   name: fake-server
    command.go:179: 2023-09-12T11:12:28-04:00 spec:
    command.go:179: 2023-09-12T11:12:28-04:00   replicas: 1
    command.go:179: 2023-09-12T11:12:28-04:00   selector:
    command.go:179: 2023-09-12T11:12:28-04:00     matchLabels:
    command.go:179: 2023-09-12T11:12:28-04:00       app: fake-server
    command.go:179: 2023-09-12T11:12:28-04:00   template:
    command.go:179: 2023-09-12T11:12:28-04:00     metadata:
    command.go:179: 2023-09-12T11:12:28-04:00       labels:
    command.go:179: 2023-09-12T11:12:28-04:00         app: fake-server
    command.go:179: 2023-09-12T11:12:28-04:00       name: fake-server
    command.go:179: 2023-09-12T11:12:28-04:00     spec:
    command.go:179: 2023-09-12T11:12:28-04:00       containers:
    command.go:179: 2023-09-12T11:12:28-04:00       - image: docker.io/achooo/fakeserver:test50
    command.go:179: 2023-09-12T11:12:28-04:00         name: fake-server
    command.go:179: 2023-09-12T11:12:28-04:00         ports:
    command.go:179: 2023-09-12T11:12:28-04:00         - containerPort: 443
    command.go:179: 2023-09-12T11:12:28-04:00           name: https
    command.go:179: 2023-09-12T11:12:28-04:00         - containerPort: 8080
    command.go:179: 2023-09-12T11:12:28-04:00           name: http
    command.go:179: 2023-09-12T11:12:28-04:00       serviceAccountName: fake-server
    command.go:179: 2023-09-12T11:12:28-04:00       terminationGracePeriodSeconds: 0
    command.go:100: 2023-09-12T11:12:28-04:00 Running command kubectl with args [--namespace default wait --for=condition=available --timeout=5m deploy/fake-server]
    command.go:179: 2023-09-12T11:12:31-04:00 deployment.apps/fake-server condition met
    command.go:100: 2023-09-12T11:12:31-04:00 Running command kubectl with args [--namespace default get pod -l app=fake-server -o jsonpath="{.items[0].metadata.name}"]
    command.go:179: 2023-09-12T11:12:31-04:00 "fake-server-6c495cf7dc-j9ljn"
    observability_test.go:73: 2023-09-12T11:12:31-04:00 fake-server pod name:fake-server-6c495cf7dc-j9ljn
    tunnel.go:153: 2023-09-12T11:12:31-04:00 Creating a port forwarding tunnel for resource pod/fake-server-6c495cf7dc-j9ljn routing local port 57171 to remote port 443
TestObservabilityCloud 2023-09-12T11:12:31-04:00 client.go:33: Configuring kubectl using config file /Users/<omitted>/.kube/config with context 
    tunnel.go:185: 2023-09-12T11:12:31-04:00 Selected pod fake-server-6c495cf7dc-j9ljn to open port forward to
    tunnel.go:198: 2023-09-12T11:12:31-04:00 Using URL https://127.0.0.1:57123/api/v1/namespaces/default/pods/fake-server-6c495cf7dc-j9ljn/portforward to create portforward
    tunnel.go:247: 2023-09-12T11:12:31-04:00 Successfully created port forwarding tunnel
    observability_test.go:92: 2023-09-12T11:12:31-04:00 fake-server addr:localhost:57171
    observability_test.go:99: 2023-09-12T11:12:31-04:00 consul test token :7a3e7c8c-6c9e-4ec9-b6d2-d3f0c1ae2621
    command.go:100: 2023-09-12T11:12:31-04:00 Running command helm with args [list --output json]
    command.go:179: 2023-09-12T11:12:31-04:00 []
    command.go:100: 2023-09-12T11:12:31-04:00 Running command helm with args [install --timeout 15m --namespace default --version ../../../charts/consul --set client.extraConfig="{\"log_level\": \"TRACE\"}" --set connectInject.default=true --set connectInject.transparentProxy.defaultEnabled=false --set dns.enabled=false --set global.acls.manageSystemACLs=false --set global.cloud.apiHost.secretKey=apihost-sec-key --set global.cloud.apiHost.secretName=apihost-sec-name --set global.cloud.authUrl.secretKey=authurl-sec-key --set global.cloud.authUrl.secretName=authurl-sec-name --set global.cloud.clientId.secretKey=clientid-sec-key --set global.cloud.clientId.secretName=clientid-sec-name --set global.cloud.clientSecret.secretKey=client-sec-key --set global.cloud.clientSecret.secretName=client-sec-name --set global.cloud.enabled=true --set global.cloud.resourceId.secretKey=resource-sec-key --set global.cloud.resourceId.secretName=resource-sec-name --set global.cloud.scadaAddress.secretKey=scadaaddress-sec-key --set global.cloud.scadaAddress.secretName=scadaaddress-sec-name --set global.gossipEncryption.autoGenerate=false --set global.image=docker.io/achooo/consul01:17 --set global.imagePullPolicy=IfNotPresent --set global.logLevel=debug --set global.tls.enableAutoEncrypt=true --set global.tls.enabled=true --set server.extraConfig="{\"log_level\": \"TRACE\"}" --set server.extraEnvironmentVars.HCP_API_TLS=insecure --set server.extraEnvironmentVars.HCP_AUTH_TLS=insecure --set server.extraEnvironmentVars.HCP_SCADA_TLS=insecure --set server.replicas=1 --set telemetryCollector.cloud.clientId.secretKey=clientid-sec-key --set telemetryCollector.cloud.clientId.secretName=clientid-sec-name --set telemetryCollector.cloud.clientSecret.secretKey=client-sec-key --set telemetryCollector.cloud.clientSecret.secretName=client-sec-name --set telemetryCollector.enabled=true --set telemetryCollector.extraEnvironmentVars.HCP_API_TLS=insecure --set telemetryCollector.extraEnvironmentVars.HCP_AUTH_TLS=insecure --set telemetryCollector.extraEnvironmentVars.HCP_SCADA_TLS=insecure --set telemetryCollector.extraEnvironmentVars.OTLP_EXPORTER_TLS=insecure --set telemetryCollector.image=hashicorp/consul-telemetry-collector:0.0.1 test-hlzobx /<omitted>/Github/HashiCorp/consul-k8s/charts/consul]
    command.go:179: 2023-09-12T11:13:30-04:00 NAME: test-hlzobx
    command.go:179: 2023-09-12T11:13:30-04:00 LAST DEPLOYED: Tue Sep 12 11:12:31 2023
    command.go:179: 2023-09-12T11:13:30-04:00 NAMESPACE: default
    command.go:179: 2023-09-12T11:13:30-04:00 STATUS: deployed
    command.go:179: 2023-09-12T11:13:30-04:00 REVISION: 1
    command.go:179: 2023-09-12T11:13:30-04:00 NOTES:
    command.go:179: 2023-09-12T11:13:30-04:00 Thank you for installing HashiCorp Consul!
    command.go:179: 2023-09-12T11:13:30-04:00 
    command.go:179: 2023-09-12T11:13:30-04:00 Your release is named test-hlzobx.
    command.go:179: 2023-09-12T11:13:30-04:00 
    command.go:179: 2023-09-12T11:13:30-04:00 To learn more about the release, run:
    command.go:179: 2023-09-12T11:13:30-04:00 
    command.go:179: 2023-09-12T11:13:30-04:00   $ helm status test-hlzobx --namespace default
    command.go:179: 2023-09-12T11:13:30-04:00   $ helm get all test-hlzobx --namespace default
    command.go:179: 2023-09-12T11:13:30-04:00 
    command.go:179: 2023-09-12T11:13:30-04:00 Consul on Kubernetes Documentation:
    command.go:179: 2023-09-12T11:13:30-04:00 https://www.consul.io/docs/platform/k8s
    command.go:179: 2023-09-12T11:13:30-04:00 
    command.go:179: 2023-09-12T11:13:30-04:00 Consul on Kubernetes CLI Reference:
    command.go:179: 2023-09-12T11:13:30-04:00 https://www.consul.io/docs/k8s/k8s-cli
    observability_test.go:154: 2023-09-12T11:13:30-04:00 Waiting for pods with label "release=test-hlzobx" to be ready.
    observability_test.go:154: 2023-09-12T11:14:48-04:00 Finished waiting for pods to be ready.
    observability_test.go:156: 2023-09-12T11:14:48-04:00 creating static-server deployment
    command.go:100: 2023-09-12T11:14:48-04:00 Running command kubectl with args [--namespace default apply -k ../fixtures/bases/static-server]
    command.go:179: 2023-09-12T11:14:49-04:00 serviceaccount/static-server created
    command.go:179: 2023-09-12T11:14:49-04:00 rolebinding.rbac.authorization.k8s.io/static-server created
    command.go:179: 2023-09-12T11:14:49-04:00 rolebinding.rbac.authorization.k8s.io/static-server-openshift-anyuid created
    command.go:179: 2023-09-12T11:14:49-04:00 rolebinding.rbac.authorization.k8s.io/static-server-openshift-privileged created
    command.go:179: 2023-09-12T11:14:49-04:00 service/static-server created
    command.go:179: 2023-09-12T11:14:49-04:00 deployment.apps/static-server created
    command.go:100: 2023-09-12T11:14:49-04:00 Running command kubectl with args [--namespace default kustomize ../fixtures/bases/static-server]
    command.go:179: 2023-09-12T11:14:49-04:00 apiVersion: v1
    command.go:179: 2023-09-12T11:14:49-04:00 kind: ServiceAccount
    command.go:179: 2023-09-12T11:14:49-04:00 metadata:
    command.go:179: 2023-09-12T11:14:49-04:00   name: static-server
    command.go:179: 2023-09-12T11:14:49-04:00 ---
    command.go:179: 2023-09-12T11:14:49-04:00 apiVersion: rbac.authorization.k8s.io/v1
    command.go:179: 2023-09-12T11:14:49-04:00 kind: RoleBinding
    command.go:179: 2023-09-12T11:14:49-04:00 metadata:
    command.go:179: 2023-09-12T11:14:49-04:00   name: static-server
    command.go:179: 2023-09-12T11:14:49-04:00 roleRef:
    command.go:179: 2023-09-12T11:14:49-04:00   apiGroup: rbac.authorization.k8s.io
    command.go:179: 2023-09-12T11:14:49-04:00   kind: ClusterRole
    command.go:179: 2023-09-12T11:14:49-04:00   name: test-psp
    command.go:179: 2023-09-12T11:14:49-04:00 subjects:
    command.go:179: 2023-09-12T11:14:49-04:00 - kind: ServiceAccount
    command.go:179: 2023-09-12T11:14:49-04:00   name: static-server
    command.go:179: 2023-09-12T11:14:49-04:00 ---
    command.go:179: 2023-09-12T11:14:49-04:00 apiVersion: rbac.authorization.k8s.io/v1
    command.go:179: 2023-09-12T11:14:49-04:00 kind: RoleBinding
    command.go:179: 2023-09-12T11:14:49-04:00 metadata:
    command.go:179: 2023-09-12T11:14:49-04:00   name: static-server-openshift-anyuid
    command.go:179: 2023-09-12T11:14:49-04:00 roleRef:
    command.go:179: 2023-09-12T11:14:49-04:00   apiGroup: rbac.authorization.k8s.io
    command.go:179: 2023-09-12T11:14:49-04:00   kind: ClusterRole
    command.go:179: 2023-09-12T11:14:49-04:00   name: system:openshift:scc:anyuid
    command.go:179: 2023-09-12T11:14:49-04:00 subjects:
    command.go:179: 2023-09-12T11:14:49-04:00 - kind: ServiceAccount
    command.go:179: 2023-09-12T11:14:49-04:00   name: static-server
    command.go:179: 2023-09-12T11:14:49-04:00 ---
    command.go:179: 2023-09-12T11:14:49-04:00 apiVersion: rbac.authorization.k8s.io/v1
    command.go:179: 2023-09-12T11:14:49-04:00 kind: RoleBinding
    command.go:179: 2023-09-12T11:14:49-04:00 metadata:
    command.go:179: 2023-09-12T11:14:49-04:00   name: static-server-openshift-privileged
    command.go:179: 2023-09-12T11:14:49-04:00 roleRef:
    command.go:179: 2023-09-12T11:14:49-04:00   apiGroup: rbac.authorization.k8s.io
    command.go:179: 2023-09-12T11:14:49-04:00   kind: ClusterRole
    command.go:179: 2023-09-12T11:14:49-04:00   name: system:openshift:scc:privileged
    command.go:179: 2023-09-12T11:14:49-04:00 subjects:
    command.go:179: 2023-09-12T11:14:49-04:00 - kind: ServiceAccount
    command.go:179: 2023-09-12T11:14:49-04:00   name: static-server
    command.go:179: 2023-09-12T11:14:49-04:00 ---
    command.go:179: 2023-09-12T11:14:49-04:00 apiVersion: v1
    command.go:179: 2023-09-12T11:14:49-04:00 kind: Service
    command.go:179: 2023-09-12T11:14:49-04:00 metadata:
    command.go:179: 2023-09-12T11:14:49-04:00   name: static-server
    command.go:179: 2023-09-12T11:14:49-04:00 spec:
    command.go:179: 2023-09-12T11:14:49-04:00   ports:
    command.go:179: 2023-09-12T11:14:49-04:00   - name: http
    command.go:179: 2023-09-12T11:14:49-04:00     port: 80
    command.go:179: 2023-09-12T11:14:49-04:00     targetPort: 8080
    command.go:179: 2023-09-12T11:14:49-04:00   selector:
    command.go:179: 2023-09-12T11:14:49-04:00     app: static-server
    command.go:179: 2023-09-12T11:14:49-04:00 ---
    command.go:179: 2023-09-12T11:14:49-04:00 apiVersion: apps/v1
    command.go:179: 2023-09-12T11:14:49-04:00 kind: Deployment
    command.go:179: 2023-09-12T11:14:49-04:00 metadata:
    command.go:179: 2023-09-12T11:14:49-04:00   name: static-server
    command.go:179: 2023-09-12T11:14:49-04:00 spec:
    command.go:179: 2023-09-12T11:14:49-04:00   replicas: 1
    command.go:179: 2023-09-12T11:14:49-04:00   selector:
    command.go:179: 2023-09-12T11:14:49-04:00     matchLabels:
    command.go:179: 2023-09-12T11:14:49-04:00       app: static-server
    command.go:179: 2023-09-12T11:14:49-04:00   template:
    command.go:179: 2023-09-12T11:14:49-04:00     metadata:
    command.go:179: 2023-09-12T11:14:49-04:00       labels:
    command.go:179: 2023-09-12T11:14:49-04:00         app: static-server
    command.go:179: 2023-09-12T11:14:49-04:00       name: static-server
    command.go:179: 2023-09-12T11:14:49-04:00     spec:
    command.go:179: 2023-09-12T11:14:49-04:00       containers:
    command.go:179: 2023-09-12T11:14:49-04:00       - args:
    command.go:179: 2023-09-12T11:14:49-04:00         - -text="hello world"
    command.go:179: 2023-09-12T11:14:49-04:00         - -listen=:8080
    command.go:179: 2023-09-12T11:14:49-04:00         image: docker.mirror.hashicorp.services/hashicorp/http-echo:alpine
    command.go:179: 2023-09-12T11:14:49-04:00         name: static-server
    command.go:179: 2023-09-12T11:14:49-04:00         ports:
    command.go:179: 2023-09-12T11:14:49-04:00         - containerPort: 8080
    command.go:179: 2023-09-12T11:14:49-04:00           name: http
    command.go:179: 2023-09-12T11:14:49-04:00       serviceAccountName: static-server
    command.go:179: 2023-09-12T11:14:49-04:00       terminationGracePeriodSeconds: 0
    command.go:100: 2023-09-12T11:14:49-04:00 Running command kubectl with args [--namespace default wait --for=condition=available --timeout=5m deploy/static-server]
    command.go:179: 2023-09-12T11:15:02-04:00 deployment.apps/static-server condition met
    observability_test.go:159: Finished deployment. Validating expected conditions now
=== RUN   TestObservabilityCloud/collectorExportsMetrics
=== RUN   TestObservabilityCloud/consulExportsMetrics
=== RUN   TestObservabilityCloud/consulPeriodicRefreshUpdateConfig
=== RUN   TestObservabilityCloud/consulPeriodicRefreshDisabled
=== NAME  TestObservabilityCloud
    helpers.go:101: 2023-09-12T11:16:02-04:00 cleaning up resources for TestObservabilityCloud
    command.go:100: 2023-09-12T11:16:02-04:00 Running command kubectl with args [--namespace default delete --timeout=120s --ignore-not-found -k ../fixtures/bases/static-server]
    command.go:179: 2023-09-12T11:16:02-04:00 serviceaccount "static-server" deleted
    command.go:179: 2023-09-12T11:16:02-04:00 rolebinding.rbac.authorization.k8s.io "static-server" deleted
    command.go:179: 2023-09-12T11:16:02-04:00 rolebinding.rbac.authorization.k8s.io "static-server-openshift-anyuid" deleted
    command.go:179: 2023-09-12T11:16:02-04:00 rolebinding.rbac.authorization.k8s.io "static-server-openshift-privileged" deleted
    command.go:179: 2023-09-12T11:16:02-04:00 service "static-server" deleted
    command.go:179: 2023-09-12T11:16:02-04:00 deployment.apps "static-server" deleted
    helpers.go:101: 2023-09-12T11:16:02-04:00 cleaning up resources for TestObservabilityCloud
    command.go:100: 2023-09-12T11:16:02-04:00 Running command helm with args [delete --keep-history --namespace default test-hlzobx]
    command.go:179: 2023-09-12T11:16:14-04:00 release "test-hlzobx" uninstalled
    helpers.go:101: 2023-09-12T11:16:15-04:00 cleaning up resources for TestObservabilityCloud
    command.go:100: 2023-09-12T11:16:15-04:00 Running command kubectl with args [--namespace default delete --timeout=120s --ignore-not-found -k ../fixtures/bases/cloud/hcp-mock]
    command.go:179: 2023-09-12T11:16:15-04:00 serviceaccount "fake-server" deleted
    command.go:179: 2023-09-12T11:16:15-04:00 service "fake-server" deleted
    command.go:179: 2023-09-12T11:16:15-04:00 deployment.apps "fake-server" deleted
    helpers.go:101: 2023-09-12T11:16:15-04:00 cleaning up resources for TestObservabilityCloud
    helpers.go:101: 2023-09-12T11:16:15-04:00 cleaning up resources for TestObservabilityCloud
    helpers.go:101: 2023-09-12T11:16:15-04:00 cleaning up resources for TestObservabilityCloud
    helpers.go:101: 2023-09-12T11:16:15-04:00 cleaning up resources for TestObservabilityCloud
    helpers.go:101: 2023-09-12T11:16:15-04:00 cleaning up resources for TestObservabilityCloud
    helpers.go:101: 2023-09-12T11:16:15-04:00 cleaning up resources for TestObservabilityCloud
--- PASS: TestObservabilityCloud (227.52s)
    --- PASS: TestObservabilityCloud/collectorExportsMetrics (0.02s)
    --- PASS: TestObservabilityCloud/consulExportsMetrics (0.01s)
    --- PASS: TestObservabilityCloud/consulPeriodicRefreshUpdateConfig (60.02s)
    --- PASS: TestObservabilityCloud/consulPeriodicRefreshDisabled (0.00s)
PASS
ok      github.com/hashicorp/consul-k8s/acceptance/tests/cloud  228.133s
```

How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


