### PR TITLE
[NET-5318] feat: add v2 service account controller

### DIFF
--- a/control-plane/connect-inject/common/config.go
+++ b/control-plane/connect-inject/common/config.go
@@ -1,0 +1,36 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import mapset "github.com/deckarep/golang-set"
+
+// K8sNamespaceConfig manages allow/deny Kubernetes namespaces.
+type K8sNamespaceConfig struct {
+	// Only endpoints in the AllowK8sNamespacesSet are reconciled.
+	AllowK8sNamespacesSet mapset.Set
+	// Endpoints in the DenyK8sNamespacesSet are ignored.
+	DenyK8sNamespacesSet mapset.Set
+}
+
+// ConsulTenancyConfig manages settings related to Consul namespaces and partitions.
+type ConsulTenancyConfig struct {
+	// EnableConsulPartitions indicates that a user is running Consul Enterprise.
+	EnableConsulPartitions bool
+	// ConsulPartition is the Consul Partition to which this controller belongs.
+	ConsulPartition string
+	// EnableConsulNamespaces indicates that a user is running Consul Enterprise.
+	EnableConsulNamespaces bool
+	// ConsulDestinationNamespace is the name of the Consul namespace to create
+	// all config entries in. If EnableNSMirroring is true this is ignored.
+	ConsulDestinationNamespace string
+	// EnableNSMirroring causes Consul namespaces to be created to match the
+	// k8s namespace of any config entry custom resource. Config entries will
+	// be created in the matching Consul namespace.
+	EnableNSMirroring bool
+	// NSMirroringPrefix is an optional prefix that can be added to the Consul
+	// namespaces created while mirroring. For example, if it is set to "k8s-",
+	// then the k8s `default` namespace will be mirrored in Consul's
+	// `k8s-default` namespace.
+	NSMirroringPrefix string
+}

--- a/control-plane/connect-inject/constants/annotations_and_labels.go
+++ b/control-plane/connect-inject/constants/annotations_and_labels.go
@@ -230,6 +230,10 @@ const (
 	// of resources.
 	ManagedByPodValue = "consul-k8s-pod-controller"
 
+	// ManagedByServiceAccountValue is used in Consul metadata to identify the manager
+	// of resources.
+	ManagedByServiceAccountValue = "consul-k8s-service-account-controller"
+
 	// AnnotationMeshDestinations is a list of upstreams to register with the
 	// proxy. The service name should map to a Consul service namd and the local
 	// port is the local port in the pod that the listener will bind to. It can

--- a/control-plane/connect-inject/constants/constants.go
+++ b/control-plane/connect-inject/constants/constants.go
@@ -22,6 +22,9 @@ const (
 	// ProxyDefaultHealthPort is the default HTTP health check port for the proxy.
 	ProxyDefaultHealthPort = 21000
 
+	// MetaKeyManagedBy is the meta key name for indicating which Kubernetes controller manages a Consul resource.
+	MetaKeyManagedBy = "managed-by"
+
 	// MetaKeyKubeNS is the meta key name for Kubernetes namespace used for the Consul services.
 	MetaKeyKubeNS = "k8s-namespace"
 

--- a/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller.go
+++ b/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
+
 package endpointsv2
 
 import (
@@ -8,7 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	mapset "github.com/deckarep/golang-set"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,36 +28,17 @@ import (
 )
 
 const (
-	metaKeyManagedBy = "managed-by"
-	kindReplicaSet   = "ReplicaSet"
+	kindReplicaSet = "ReplicaSet"
 )
 
 type Controller struct {
 	client.Client
 	// ConsulServerConnMgr is the watcher for the Consul server addresses used to create Consul API v2 clients.
 	ConsulServerConnMgr consul.ServerConnectionManager
-	// Only endpoints in the AllowK8sNamespacesSet are reconciled.
-	AllowK8sNamespacesSet mapset.Set
-	// Endpoints in the DenyK8sNamespacesSet are ignored.
-	DenyK8sNamespacesSet mapset.Set
-	// EnableConsulPartitions indicates that a user is running Consul Enterprise.
-	EnableConsulPartitions bool
-	// ConsulPartition is the Consul Partition to which this controller belongs.
-	ConsulPartition string
-	// EnableConsulNamespaces indicates that a user is running Consul Enterprise.
-	EnableConsulNamespaces bool
-	// ConsulDestinationNamespace is the name of the Consul namespace to create
-	// all config entries in. If EnableNSMirroring is true this is ignored.
-	ConsulDestinationNamespace string
-	// EnableNSMirroring causes Consul namespaces to be created to match the
-	// k8s namespace of any config entry custom resource. Config entries will
-	// be created in the matching Consul namespace.
-	EnableNSMirroring bool
-	// NSMirroringPrefix is an optional prefix that can be added to the Consul
-	// namespaces created while mirroring. For example, if it is set to "k8s-",
-	// then the k8s `default` namespace will be mirrored in Consul's
-	// `k8s-default` namespace.
-	NSMirroringPrefix string
+	// K8sNamespaceConfig manages allow/deny Kubernetes namespaces.
+	common.K8sNamespaceConfig
+	// ConsulTenancyConfig manages settings related to Consul namespaces and partitions.
+	common.ConsulTenancyConfig
 
 	Log logr.Logger
 
@@ -225,7 +206,7 @@ func (r *Controller) registerService(ctx context.Context, resourceClient pbresou
 	return nil
 }
 
-// getServiceResource converts the given Consul service and metadata as a Consul resource API record.
+// getServiceResource converts the given Consul service and metadata to a Consul resource API record.
 func (r *Controller) getServiceResource(svc *pbcatalog.Service, name, namespace, partition string, meta map[string]string) *pbresource.Resource {
 	return &pbresource.Resource{
 		Id:       getServiceID(name, namespace, partition),
@@ -245,6 +226,7 @@ func getServiceID(name, namespace, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
+			PeerName:  constants.DefaultConsulPeer,
 		},
 	}
 }
@@ -291,8 +273,8 @@ func (r *Controller) getServiceVIPs(service corev1.Service) []string {
 
 func getServiceMeta(service corev1.Service) map[string]string {
 	meta := map[string]string{
-		constants.MetaKeyKubeNS: service.Namespace,
-		metaKeyManagedBy:        constants.ManagedByEndpointsValue,
+		constants.MetaKeyKubeNS:    service.Namespace,
+		constants.MetaKeyManagedBy: constants.ManagedByEndpointsValue,
 	}
 	//TODO: Support arbitrary meta injection via annotation? (see v1)
 	return meta

--- a/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller_ent_test.go
+++ b/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller_ent_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 )
 
+// TODO: ConsulDestinationNamespace and EnableNSMirroring +/- prefix
+
 // TODO(zalimeni)
 // Tests new Service registration in a non-default NS and Partition with namespaces set to mirroring
 func TestReconcile_CreateService_WithNamespaces(t *testing.T) {

--- a/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller_test.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/go-cmp/cmp/cmpopts"
-
 	mapset "github.com/deckarep/golang-set"
 	logrtest "github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
@@ -17,7 +15,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/anypb"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,7 +53,6 @@ type reconcileCase struct {
 }
 
 // TODO: Allow/deny namespaces for reconcile tests
-// TODO: ConsulDestinationNamespace and EnableNSMirroring +/- prefix
 
 func TestReconcile_CreateService(t *testing.T) {
 	t.Parallel()
@@ -148,8 +144,8 @@ func TestReconcile_CreateService(t *testing.T) {
 					VirtualIps: []string{"172.18.0.1"},
 				}),
 				Metadata: map[string]string{
-					constants.MetaKeyKubeNS: constants.DefaultConsulNS,
-					metaKeyManagedBy:        constants.ManagedByEndpointsValue,
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByEndpointsValue,
 				},
 			},
 		},
@@ -259,8 +255,8 @@ func TestReconcile_CreateService(t *testing.T) {
 					VirtualIps: []string{"172.18.0.1"},
 				}),
 				Metadata: map[string]string{
-					constants.MetaKeyKubeNS: constants.DefaultConsulNS,
-					metaKeyManagedBy:        constants.ManagedByEndpointsValue,
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByEndpointsValue,
 				},
 			},
 		},
@@ -344,8 +340,8 @@ func TestReconcile_CreateService(t *testing.T) {
 					VirtualIps: []string{"172.18.0.1"},
 				}),
 				Metadata: map[string]string{
-					constants.MetaKeyKubeNS: constants.DefaultConsulNS,
-					metaKeyManagedBy:        constants.ManagedByEndpointsValue,
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByEndpointsValue,
 				},
 			},
 		},
@@ -449,8 +445,8 @@ func TestReconcile_CreateService(t *testing.T) {
 					VirtualIps: []string{"172.18.0.1"},
 				}),
 				Metadata: map[string]string{
-					constants.MetaKeyKubeNS: constants.DefaultConsulNS,
-					metaKeyManagedBy:        constants.ManagedByEndpointsValue,
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByEndpointsValue,
 				},
 			},
 		},
@@ -548,8 +544,8 @@ func TestReconcile_UpdateService(t *testing.T) {
 					VirtualIps: []string{"172.18.0.1"},
 				}),
 				Metadata: map[string]string{
-					constants.MetaKeyKubeNS: constants.DefaultConsulNS,
-					metaKeyManagedBy:        constants.ManagedByEndpointsValue,
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByEndpointsValue,
 				},
 			},
 			expectedResource: &pbresource.Resource{
@@ -591,8 +587,8 @@ func TestReconcile_UpdateService(t *testing.T) {
 					VirtualIps: []string{"172.18.0.1"},
 				}),
 				Metadata: map[string]string{
-					constants.MetaKeyKubeNS: constants.DefaultConsulNS,
-					metaKeyManagedBy:        constants.ManagedByEndpointsValue,
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByEndpointsValue,
 				},
 			},
 		},
@@ -692,8 +688,8 @@ func TestReconcile_UpdateService(t *testing.T) {
 					VirtualIps: []string{"172.18.0.1"},
 				}),
 				Metadata: map[string]string{
-					constants.MetaKeyKubeNS: constants.DefaultConsulNS,
-					metaKeyManagedBy:        constants.ManagedByEndpointsValue,
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByEndpointsValue,
 				},
 			},
 			expectedResource: &pbresource.Resource{
@@ -734,8 +730,8 @@ func TestReconcile_UpdateService(t *testing.T) {
 					VirtualIps: []string{"172.18.0.1"},
 				}),
 				Metadata: map[string]string{
-					constants.MetaKeyKubeNS: constants.DefaultConsulNS,
-					metaKeyManagedBy:        constants.ManagedByEndpointsValue,
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByEndpointsValue,
 				},
 			},
 		},
@@ -785,8 +781,8 @@ func TestReconcile_DeleteService(t *testing.T) {
 					VirtualIps: []string{"172.18.0.1"},
 				}),
 				Metadata: map[string]string{
-					constants.MetaKeyKubeNS: constants.DefaultConsulNS,
-					metaKeyManagedBy:        constants.ManagedByEndpointsValue,
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByEndpointsValue,
 				},
 			},
 		},
@@ -921,9 +917,7 @@ func TestGetWorkloadSelectorFromEndpoints(t *testing.T) {
 			resp, err := ep.getWorkloadSelectorFromEndpoints(ctx, &pf, tc.endpoints)
 			require.NoError(t, err)
 
-			// We don't care about order, so configure cmp.Diff to ignore slice order.
-			sorter := func(a, b string) bool { return a < b }
-			if diff := cmp.Diff(tc.expected, resp, protocmp.Transform(), cmpopts.SortSlices(sorter)); diff != "" {
+			if diff := cmp.Diff(tc.expected, resp, test.CmpProtoIgnoreOrder()...); diff != "" {
 				t.Errorf("unexpected difference:\n%v", diff)
 			}
 			tc.mockFn(t, &pf)
@@ -962,11 +956,13 @@ func runReconcileCase(t *testing.T, tc reconcileCase) {
 
 	// Create the Endpoints controller.
 	ep := &Controller{
-		Client:                fakeClient,
-		Log:                   logrtest.New(t),
-		ConsulServerConnMgr:   testClient.Watcher,
-		AllowK8sNamespacesSet: mapset.NewSetWith("*"),
-		DenyK8sNamespacesSet:  mapset.NewSetWith(),
+		Client:              fakeClient,
+		Log:                 logrtest.New(t),
+		ConsulServerConnMgr: testClient.Watcher,
+		K8sNamespaceConfig: common.K8sNamespaceConfig{
+			AllowK8sNamespacesSet: mapset.NewSetWith("*"),
+			DenyK8sNamespacesSet:  mapset.NewSetWith(),
+		},
 	}
 	resourceClient, err := consul.NewResourceServiceClient(ep.ConsulServerConnMgr)
 	require.NoError(t, err)
@@ -1002,7 +998,6 @@ func runReconcileCase(t *testing.T, tc reconcileCase) {
 	require.False(t, resp.Requeue)
 
 	expectedServiceMatches(t, resourceClient, tc.svcName, tc.targetConsulNs, tc.targetConsulPartition, tc.expectedResource)
-
 }
 
 func expectedServiceMatches(t *testing.T, client pbresource.ResourceServiceClient, name, namespace, partition string, expectedResource *pbresource.Resource) {
@@ -1030,7 +1025,7 @@ func expectedServiceMatches(t *testing.T, client pbresource.ResourceServiceClien
 	err = res.GetResource().GetData().UnmarshalTo(actualService)
 	require.NoError(t, err)
 
-	if diff := cmp.Diff(expectedService, actualService, protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(expectedService, actualService, test.CmpProtoIgnoreOrder()...); diff != "" {
 		t.Errorf("unexpected difference:\n%v", diff)
 	}
 }

--- a/control-plane/connect-inject/controllers/serviceaccount/serviceaccount_controller_ent_test.go
+++ b/control-plane/connect-inject/controllers/serviceaccount/serviceaccount_controller_ent_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build enterprise
+
+package serviceaccount
+
+import (
+	"testing"
+)
+
+// TODO: ConsulDestinationNamespace and EnableNSMirroring +/- prefix
+
+// TODO(zalimeni)
+// Tests new WorkloadIdentity registration in a non-default NS and Partition with namespaces set to mirroring
+func TestReconcile_CreateWorkloadIdentity_WithNamespaces(t *testing.T) {
+
+}
+
+// TODO(zalimeni)
+// Tests removing WorkloadIdentity registration in a non-default NS and Partition with namespaces set to mirroring
+func TestReconcile_DeleteWorkloadIdentity_WithNamespaces(t *testing.T) {
+
+}

--- a/control-plane/connect-inject/controllers/serviceaccount/serviceaccount_controller_test.go
+++ b/control-plane/connect-inject/controllers/serviceaccount/serviceaccount_controller_test.go
@@ -1,0 +1,347 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package serviceaccount
+
+import (
+	"context"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/proto"
+	"testing"
+
+	mapset "github.com/deckarep/golang-set"
+	logrtest "github.com/go-logr/logr/testr"
+	pbauth "github.com/hashicorp/consul/proto-public/pbauth/v1alpha1"
+	"github.com/hashicorp/consul/proto-public/pbresource"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
+	"github.com/hashicorp/consul-k8s/control-plane/consul"
+	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
+)
+
+type reconcileCase struct {
+	name                  string
+	svcAccountName        string
+	k8sObjects            func() []runtime.Object
+	existingResource      *pbresource.Resource
+	expectedResource      *pbresource.Resource
+	targetConsulNs        string
+	targetConsulPartition string
+	expErr                string
+}
+
+// TODO: Allow/deny namespaces for reconcile tests
+
+// TestReconcile_CreateWorkloadIdentity ensures that a new ServiceAccount is reconciled
+// to a Consul WorkloadIdentity.
+func TestReconcile_CreateWorkloadIdentity(t *testing.T) {
+	t.Parallel()
+	cases := []reconcileCase{
+		{
+			name:           "Default ServiceAccount",
+			svcAccountName: "default",
+			k8sObjects: func() []runtime.Object {
+				return []runtime.Object{createServiceAccount("default", "default")}
+			},
+			expectedResource: &pbresource.Resource{
+				Id: &pbresource.ID{
+					Name: "default",
+					Type: &pbresource.Type{
+						Group:        "auth",
+						GroupVersion: "v1alpha1",
+						Kind:         "WorkloadIdentity",
+					},
+					Tenancy: &pbresource.Tenancy{
+						Namespace: constants.DefaultConsulNS,
+						Partition: constants.DefaultConsulPartition,
+					},
+				},
+				Data: getWorkloadIdentityData(),
+				Metadata: map[string]string{
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByServiceAccountValue,
+				},
+			},
+		},
+		{
+			name:           "Custom ServiceAccount",
+			svcAccountName: "my-svc-account",
+			k8sObjects: func() []runtime.Object {
+				return []runtime.Object{
+					createServiceAccount("default", "default"),
+					createServiceAccount("my-svc-account", "default"),
+				}
+			},
+			expectedResource: &pbresource.Resource{
+				Id: &pbresource.ID{
+					Name: "my-svc-account",
+					Type: &pbresource.Type{
+						Group:        "auth",
+						GroupVersion: "v1alpha1",
+						Kind:         "WorkloadIdentity",
+					},
+					Tenancy: &pbresource.Tenancy{
+						Namespace: constants.DefaultConsulNS,
+						Partition: constants.DefaultConsulPartition,
+					},
+				},
+				Data: getWorkloadIdentityData(),
+				Metadata: map[string]string{
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByServiceAccountValue,
+				},
+			},
+		},
+		{
+			name:           "Already exists",
+			svcAccountName: "my-svc-account",
+			k8sObjects: func() []runtime.Object {
+				return []runtime.Object{
+					createServiceAccount("default", "default"),
+					createServiceAccount("my-svc-account", "default"),
+				}
+			},
+			existingResource: &pbresource.Resource{
+				Id: &pbresource.ID{
+					Name: "my-svc-account",
+					Type: &pbresource.Type{
+						Group:        "auth",
+						GroupVersion: "v1alpha1",
+						Kind:         "WorkloadIdentity",
+					},
+					Tenancy: &pbresource.Tenancy{
+						Namespace: constants.DefaultConsulNS,
+						Partition: constants.DefaultConsulPartition,
+					},
+				},
+				Data: getWorkloadIdentityData(),
+				Metadata: map[string]string{
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByServiceAccountValue,
+				},
+			},
+			expectedResource: &pbresource.Resource{
+				Id: &pbresource.ID{
+					Name: "my-svc-account",
+					Type: &pbresource.Type{
+						Group:        "auth",
+						GroupVersion: "v1alpha1",
+						Kind:         "WorkloadIdentity",
+					},
+					Tenancy: &pbresource.Tenancy{
+						Namespace: constants.DefaultConsulNS,
+						Partition: constants.DefaultConsulPartition,
+					},
+				},
+				Data: getWorkloadIdentityData(),
+				Metadata: map[string]string{
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByServiceAccountValue,
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runReconcileCase(t, tc)
+		})
+	}
+}
+
+// Tests deleting a WorkloadIdentity object, with and without matching Consul resources.
+func TestReconcile_DeleteWorkloadIdentity(t *testing.T) {
+	t.Parallel()
+	cases := []reconcileCase{
+		{
+			name:           "Basic ServiceAccount not found (deleted)",
+			svcAccountName: "my-svc-account",
+			k8sObjects: func() []runtime.Object {
+				// Only default exists (always exists).
+				return []runtime.Object{createServiceAccount("default", "default")}
+			},
+			existingResource: &pbresource.Resource{
+				Id: &pbresource.ID{
+					Name: "my-svc-account",
+					Type: &pbresource.Type{
+						Group:        "auth",
+						GroupVersion: "v1alpha1",
+						Kind:         "WorkloadIdentity",
+					},
+					Tenancy: &pbresource.Tenancy{
+						Namespace: constants.DefaultConsulNS,
+						Partition: constants.DefaultConsulPartition,
+					},
+				},
+				Data: getWorkloadIdentityData(),
+				Metadata: map[string]string{
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByServiceAccountValue,
+				},
+			},
+		},
+		{
+			name:           "Other ServiceAccount exists",
+			svcAccountName: "my-svc-account",
+			k8sObjects: func() []runtime.Object {
+				// Default and other ServiceAccount exist
+				return []runtime.Object{
+					createServiceAccount("default", "default"),
+					createServiceAccount("other-svc-account", "default"),
+				}
+			},
+			existingResource: &pbresource.Resource{
+				Id: &pbresource.ID{
+					Name: "my-svc-account",
+					Type: &pbresource.Type{
+						Group:        "auth",
+						GroupVersion: "v1alpha1",
+						Kind:         "WorkloadIdentity",
+					},
+					Tenancy: &pbresource.Tenancy{
+						Namespace: constants.DefaultConsulNS,
+						Partition: constants.DefaultConsulPartition,
+					},
+				},
+				Data: getWorkloadIdentityData(),
+				Metadata: map[string]string{
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByServiceAccountValue,
+				},
+			},
+		},
+		{
+			name:           "Already deleted",
+			svcAccountName: "my-svc-account",
+			k8sObjects: func() []runtime.Object {
+				// Only default exists (always exists).
+				return []runtime.Object{createServiceAccount("default", "default")}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runReconcileCase(t, tc)
+		})
+	}
+}
+
+func runReconcileCase(t *testing.T, tc reconcileCase) {
+	t.Helper()
+
+	// Create fake k8s client
+	var k8sObjects []runtime.Object
+	if tc.k8sObjects != nil {
+		k8sObjects = tc.k8sObjects()
+	}
+	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
+
+	// Create test Consul server.
+	testClient := test.TestServerWithMockConnMgrWatcher(t, func(c *testutil.TestServerConfig) {
+		c.Experiments = []string{"resource-apis"}
+	})
+
+	// Create the ServiceAccount controller.
+	sa := &Controller{
+		Client:              fakeClient,
+		Log:                 logrtest.New(t),
+		ConsulServerConnMgr: testClient.Watcher,
+		K8sNamespaceConfig: common.K8sNamespaceConfig{
+			AllowK8sNamespacesSet: mapset.NewSetWith("*"),
+			DenyK8sNamespacesSet:  mapset.NewSetWith(),
+		},
+	}
+	resourceClient, err := consul.NewResourceServiceClient(sa.ConsulServerConnMgr)
+	require.NoError(t, err)
+
+	// Default ns and partition if not specified in test.
+	if tc.targetConsulNs == "" {
+		tc.targetConsulNs = constants.DefaultConsulNS
+	}
+	if tc.targetConsulPartition == "" {
+		tc.targetConsulPartition = constants.DefaultConsulPartition
+	}
+
+	// If existing resource specified, create it and ensure it exists.
+	if tc.existingResource != nil {
+		writeReq := &pbresource.WriteRequest{Resource: tc.existingResource}
+		_, err = resourceClient.Write(context.Background(), writeReq)
+		require.NoError(t, err)
+		test.ResourceHasPersisted(t, resourceClient, tc.existingResource.Id)
+	}
+
+	// Run actual reconcile and verify results.
+	resp, err := sa.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      tc.svcAccountName,
+			Namespace: tc.targetConsulNs,
+		},
+	})
+	if tc.expErr != "" {
+		require.ErrorContains(t, err, tc.expErr)
+	} else {
+		require.NoError(t, err)
+	}
+	require.False(t, resp.Requeue)
+
+	expectedWorkloadIdentityMatches(t, resourceClient, tc.svcAccountName, tc.targetConsulNs, tc.targetConsulPartition, tc.expectedResource)
+}
+
+func expectedWorkloadIdentityMatches(t *testing.T, client pbresource.ResourceServiceClient, name, namespace, partition string, expectedResource *pbresource.Resource) {
+	req := &pbresource.ReadRequest{Id: getWorkloadIdentityID(name, namespace, partition)}
+
+	res, err := client.Read(context.Background(), req)
+
+	if expectedResource == nil {
+		require.Error(t, err)
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.NotFound, s.Code())
+		return
+	}
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, res.GetResource().GetData())
+
+	// This equality check isn't technically necessary because WorkloadIdentity is an empty message,
+	// but this supports the addition of fields in the future.
+	expectedWorkloadIdentity := &pbauth.WorkloadIdentity{}
+	err = anypb.UnmarshalTo(expectedResource.Data, expectedWorkloadIdentity, proto.UnmarshalOptions{})
+	require.NoError(t, err)
+
+	actualWorkloadIdentity := &pbauth.WorkloadIdentity{}
+	err = res.GetResource().GetData().UnmarshalTo(actualWorkloadIdentity)
+	require.NoError(t, err)
+
+	if diff := cmp.Diff(expectedWorkloadIdentity, actualWorkloadIdentity, test.CmpProtoIgnoreOrder()...); diff != "" {
+		t.Errorf("unexpected difference:\n%v", diff)
+	}
+}
+
+// getWorkloadIdentityData returns a WorkloadIdentity resource payload.
+// This function takes no arguments because WorkloadIdentity is currently an empty proto message.
+func getWorkloadIdentityData() *anypb.Any {
+	return common.ToProtoAny(&pbauth.WorkloadIdentity{})
+}
+
+func createServiceAccount(name, namespace string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		// Other fields exist, but we ignore them in this controller.
+	}
+}

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/consul-k8s/control-plane
 // TODO: remove these when the SDK is released for Consul 1.17 and coinciding patch releases
 replace (
 	// This replace directive is needed because `api` requires 0.4.1 of proto-public but we need an unreleased version
-	github.com/hashicorp/consul/proto-public v0.4.1 => github.com/hashicorp/consul/proto-public v0.1.2-0.20230911164019-a69e901660bd
+	github.com/hashicorp/consul/proto-public v0.4.1 => github.com/hashicorp/consul/proto-public v0.1.2-0.20230914174054-e5808d85f751
 	// This replace directive is needed because `api` requires 0.14.1 of `sdk` but we need an unreleased version
 	github.com/hashicorp/consul/sdk v0.14.1 => github.com/hashicorp/consul/sdk v0.4.1-0.20230911164019-a69e901660bd
 )
@@ -18,7 +18,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20230825213844-4ea04860c5ed
 	github.com/hashicorp/consul-server-connection-manager v0.1.4
-	github.com/hashicorp/consul/api v1.10.1-0.20230911164019-a69e901660bd
+	github.com/hashicorp/consul/api v1.10.1-0.20230914174054-e5808d85f751
 	github.com/hashicorp/consul/proto-public v0.4.1
 	github.com/hashicorp/consul/sdk v0.14.1
 	github.com/hashicorp/go-bexpr v0.1.11

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -263,10 +263,10 @@ github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20230825213844-4ea04860
 github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20230825213844-4ea04860c5ed/go.mod h1:mwODEC+VTCA1LY/m2RUG4S2c5lNRvBcsvqaMJtMLLos=
 github.com/hashicorp/consul-server-connection-manager v0.1.4 h1:wrcSRV6WGXFBNpNbN6XsdoGgBOyso7ZbN5VaWPEX1jY=
 github.com/hashicorp/consul-server-connection-manager v0.1.4/go.mod h1:LMqHkALoLP0HUQKOG21xXYr0YPUayIQIHNTlmxG100E=
-github.com/hashicorp/consul/api v1.10.1-0.20230911164019-a69e901660bd h1:TXcz98wzcjBdCUa8q8BgossUKh9slyVCgzE91chvJTc=
-github.com/hashicorp/consul/api v1.10.1-0.20230911164019-a69e901660bd/go.mod h1:/Fz5sgOC0a5XY0BmPGj7aDSZRNgySLm02lV4xkU4DS4=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20230911164019-a69e901660bd h1:3qvFUa6FTiYPiHmZadPnsVskphYIjv4n6vZlB57oiPM=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20230911164019-a69e901660bd/go.mod h1:KAOxsaELPpA7JX10kMeygAskAqsQnu3SPgeruMhYZMU=
+github.com/hashicorp/consul/api v1.10.1-0.20230914174054-e5808d85f751 h1:LnzgDq4e7ZfM1+XS6S21B9taQrbfdydXenL1xHyG1PQ=
+github.com/hashicorp/consul/api v1.10.1-0.20230914174054-e5808d85f751/go.mod h1:/Fz5sgOC0a5XY0BmPGj7aDSZRNgySLm02lV4xkU4DS4=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20230914174054-e5808d85f751 h1:kFfExHyeRbC5hi0REatLNSYwMFONnhkn/IyhnG3vG2A=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20230914174054-e5808d85f751/go.mod h1:KAOxsaELPpA7JX10kMeygAskAqsQnu3SPgeruMhYZMU=
 github.com/hashicorp/consul/sdk v0.4.1-0.20230911164019-a69e901660bd h1:tRrSgVY71Jl6T2lJUokMLj3T1MO9uiSvW0CieBkjTvo=
 github.com/hashicorp/consul/sdk v0.4.1-0.20230911164019-a69e901660bd/go.mod h1:vFt03juSzocLRFo59NkeQHHmQa6+g7oU0pfzdI1mUhg=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/control-plane/helper/test/test_util.go
+++ b/control-plane/helper/test/test_util.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/proto-public/pbresource"
@@ -21,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/hashicorp/consul-k8s/control-plane/consul"
 	"github.com/hashicorp/consul-k8s/control-plane/helper/cert"
@@ -339,6 +342,16 @@ func ServiceAccountGetResponse(name, ns string) string {
    }
  ]
 }`, name, ns, ns, name, name)
+}
+
+// CmpProtoIgnoreOrder returns a slice of cmp.Option useful for comparing proto messages independent of the order of
+// their repeated fields.
+func CmpProtoIgnoreOrder() []cmp.Option {
+	return []cmp.Option{
+		protocmp.Transform(),
+		// Stringify any type passed to the sorter so that we can reliably compare most values.
+		cmpopts.SortSlices(func(a, b any) bool { return fmt.Sprintf("%v", a) < fmt.Sprintf("%v", b) }),
+	}
 }
 
 const AuthMethod = "consul-k8s-auth-method"

--- a/control-plane/subcommand/inject-connect/v2controllers.go
+++ b/control-plane/subcommand/inject-connect/v2controllers.go
@@ -5,19 +5,20 @@ package connectinject
 
 import (
 	"context"
-
-	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	ctrlRuntimeWebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
 	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/controllers/endpointsv2"
 	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/controllers/pod"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/controllers/serviceaccount"
 	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/lifecycle"
 	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/metrics"
 	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/namespace"
 	webhookV2 "github.com/hashicorp/consul-k8s/control-plane/connect-inject/webhook_v2"
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/flags"
+	"github.com/hashicorp/consul-server-connection-manager/discovery"
 )
 
 func (c *Command) configureV2Controllers(ctx context.Context, mgr manager.Manager, watcher *discovery.Watcher) error {
@@ -25,9 +26,21 @@ func (c *Command) configureV2Controllers(ctx context.Context, mgr manager.Manage
 	// Create Consul API config object.
 	consulConfig := c.consul.ConsulClientConfig()
 
-	//Convert allow/deny lists to sets.
+	// Convert allow/deny lists to sets.
 	allowK8sNamespaces := flags.ToSet(c.flagAllowK8sNamespacesList)
 	denyK8sNamespaces := flags.ToSet(c.flagDenyK8sNamespacesList)
+	k8sNsConfig := common.K8sNamespaceConfig{
+		AllowK8sNamespacesSet: allowK8sNamespaces,
+		DenyK8sNamespacesSet:  denyK8sNamespaces,
+	}
+	consulTenancyConfig := common.ConsulTenancyConfig{
+		EnableConsulPartitions:     c.flagEnablePartitions,
+		EnableConsulNamespaces:     c.flagEnableNamespaces,
+		ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
+		EnableNSMirroring:          c.flagEnableK8SNSMirroring,
+		NSMirroringPrefix:          c.flagK8SNSMirroringPrefix,
+		ConsulPartition:            c.consul.Partition,
+	}
 
 	lifecycleConfig := lifecycle.Config{
 		DefaultEnableProxyLifecycle:         c.flagDefaultEnableSidecarProxyLifecycle,
@@ -47,43 +60,45 @@ func (c *Command) configureV2Controllers(ctx context.Context, mgr manager.Manage
 	}
 
 	if err := (&pod.Controller{
-		Client:                     mgr.GetClient(),
-		ConsulClientConfig:         consulConfig,
-		ConsulServerConnMgr:        watcher,
-		AllowK8sNamespacesSet:      allowK8sNamespaces,
-		DenyK8sNamespacesSet:       denyK8sNamespaces,
-		EnableConsulPartitions:     c.flagEnablePartitions,
-		EnableConsulNamespaces:     c.flagEnableNamespaces,
-		ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
-		EnableNSMirroring:          c.flagEnableK8SNSMirroring,
-		NSMirroringPrefix:          c.flagK8SNSMirroringPrefix,
-		ConsulPartition:            c.consul.Partition,
-		EnableTransparentProxy:     c.flagDefaultEnableTransparentProxy,
-		TProxyOverwriteProbes:      c.flagTransparentProxyDefaultOverwriteProbes,
-		AuthMethod:                 c.flagACLAuthMethod,
-		MetricsConfig:              metricsConfig,
-		EnableTelemetryCollector:   c.flagEnableTelemetryCollector,
-		Log:                        ctrl.Log.WithName("controller").WithName("pod"),
+		Client:                   mgr.GetClient(),
+		ConsulClientConfig:       consulConfig,
+		ConsulServerConnMgr:      watcher,
+		K8sNamespaceConfig:       k8sNsConfig,
+		ConsulTenancyConfig:      consulTenancyConfig,
+		EnableTransparentProxy:   c.flagDefaultEnableTransparentProxy,
+		TProxyOverwriteProbes:    c.flagTransparentProxyDefaultOverwriteProbes,
+		AuthMethod:               c.flagACLAuthMethod,
+		MetricsConfig:            metricsConfig,
+		EnableTelemetryCollector: c.flagEnableTelemetryCollector,
+		Log:                      ctrl.Log.WithName("controller").WithName("pod"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", pod.Controller{})
 		return err
 	}
 
 	if err := (&endpointsv2.Controller{
-		Client:                     mgr.GetClient(),
-		ConsulServerConnMgr:        watcher,
-		AllowK8sNamespacesSet:      allowK8sNamespaces,
-		DenyK8sNamespacesSet:       denyK8sNamespaces,
-		EnableConsulPartitions:     c.flagEnablePartitions,
-		EnableConsulNamespaces:     c.flagEnableNamespaces,
-		ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
-		EnableNSMirroring:          c.flagEnableK8SNSMirroring,
-		NSMirroringPrefix:          c.flagK8SNSMirroringPrefix,
-		Log:                        ctrl.Log.WithName("controller").WithName("endpoints"),
-		Scheme:                     mgr.GetScheme(),
-		Context:                    ctx,
+		Client:              mgr.GetClient(),
+		ConsulServerConnMgr: watcher,
+		K8sNamespaceConfig:  k8sNsConfig,
+		ConsulTenancyConfig: consulTenancyConfig,
+		Log:                 ctrl.Log.WithName("controller").WithName("endpoints"),
+		Scheme:              mgr.GetScheme(),
+		Context:             ctx,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", endpointsv2.Controller{})
+		return err
+	}
+
+	if err := (&serviceaccount.Controller{
+		Client:              mgr.GetClient(),
+		ConsulServerConnMgr: watcher,
+		K8sNamespaceConfig:  k8sNsConfig,
+		ConsulTenancyConfig: consulTenancyConfig,
+		Log:                 ctrl.Log.WithName("controller").WithName("serviceaccount"),
+		Scheme:              mgr.GetScheme(),
+		Context:             ctx,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", serviceaccount.Controller{})
 		return err
 	}
 
@@ -105,8 +120,6 @@ func (c *Command) configureV2Controllers(ctx context.Context, mgr manager.Manage
 			return err
 		}
 	}
-
-	// TODO: Serviceaccounts Controller
 
 	// TODO: V2 Config Controller(s)
 


### PR DESCRIPTION
Implement the basic requirements of a new Service Account controller that registers Workload Identities via Consul's V2 API.

Also lightly refactor some of the shared controller data in V2.

Further tests and `TODO`s will be addressed in follow-up changes.

Changes proposed in this PR:
- Add the controller and implement basic CruD logic
- Add tests 
  - _Now fully operational since protos were merged_
- Light refactoring of some shared data

How I've tested this PR: Existing tests should continue to pass post-refactoring

How I expect reviewers to test this PR: 👀 


Checklist:
- [x] Tests added(ish)
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


