### PR TITLE
[NET-5017] APIGW Status Conditions for Gateway for JWT/Reconcile on JWTProvider Changes

### DIFF
--- a/control-plane/api-gateway/binding/binder_test.go
+++ b/control-plane/api-gateway/binding/binder_test.go
@@ -23,9 +23,10 @@ import (
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	"github.com/hashicorp/consul/api"
+
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
-	"github.com/hashicorp/consul/api"
 )
 
 func init() {
@@ -61,6 +62,8 @@ type resourceMapResources struct {
 	tcpRoutes                []gwv1alpha2.TCPRoute
 	meshServices             []v1alpha1.MeshService
 	services                 []types.NamespacedName
+	jwtProviders             []*v1alpha1.JWTProvider
+	gatewayPolicies          []*v1alpha1.GatewayPolicy
 	consulInlineCertificates []api.InlineCertificateConfigEntry
 	consulHTTPRoutes         []api.HTTPRouteConfigEntry
 	consulTCPRoutes          []api.TCPRouteConfigEntry
@@ -92,6 +95,12 @@ func newTestResourceMap(t *testing.T, resources resourceMapResources) *common.Re
 	}
 	for _, r := range resources.consulTCPRoutes {
 		resourceMap.ReferenceCountConsulTCPRoute(r)
+	}
+	for _, r := range resources.gatewayPolicies {
+		resourceMap.AddGatewayPolicy(r)
+	}
+	for _, r := range resources.jwtProviders {
+		resourceMap.AddJWTProvider(r)
 	}
 	return resourceMap
 }

--- a/control-plane/api-gateway/binding/result.go
+++ b/control-plane/api-gateway/binding/result.go
@@ -240,6 +240,7 @@ var (
 	errListenerInvalidCertificateRef_InvalidData      = errors.New("certificate is invalid or does not contain a supported server name")
 	errListenerInvalidCertificateRef_NonFIPSRSAKeyLen = errors.New("certificate has an invalid length: RSA Keys must be at least 2048-bit")
 	errListenerInvalidCertificateRef_FIPSRSAKeyLen    = errors.New("certificate has an invalid length: RSA keys must be either 2048-bit, 3072-bit, or 4096-bit in FIPS mode")
+	errListenerJWTProviderNotFound                    = errors.New("policy referencing this listener references unknown JWT provider")
 	errListenerInvalidRouteKinds                      = errors.New("allowed route kind is invalid")
 	errListenerProgrammed_Invalid                     = errors.New("listener cannot be programmed because it is invalid")
 
@@ -269,7 +270,7 @@ type listenerValidationResult struct {
 	// status type: Conflicted
 	conflictedErr error
 	// status type: ResolvedRefs
-	refErr error
+	refErrs []error
 	// status type: ResolvedRefs (but with internal validation)
 	routeKindErr error
 }
@@ -281,7 +282,7 @@ func (l listenerValidationResult) programmedCondition(generation int64) metav1.C
 	now := timeFunc()
 
 	switch {
-	case l.acceptedErr != nil, l.conflictedErr != nil, l.refErr != nil, l.routeKindErr != nil:
+	case l.acceptedErr != nil, l.conflictedErr != nil, len(l.refErrs) != 0, l.routeKindErr != nil:
 		return metav1.Condition{
 			Type:               "Programmed",
 			Status:             metav1.ConditionFalse,
@@ -382,59 +383,75 @@ func (l listenerValidationResult) conflictedCondition(generation int64) metav1.C
 }
 
 // acceptedCondition constructs the condition for the ResolvedRefs status type.
-func (l listenerValidationResult) resolvedRefsCondition(generation int64) metav1.Condition {
+func (l listenerValidationResult) resolvedRefsConditions(generation int64) []metav1.Condition {
 	now := timeFunc()
 
+	conditions := make([]metav1.Condition, 0)
+
 	if l.routeKindErr != nil {
-		return metav1.Condition{
+		return []metav1.Condition{{
 			Type:               "ResolvedRefs",
 			Status:             metav1.ConditionFalse,
 			Reason:             "InvalidRouteKinds",
 			ObservedGeneration: generation,
 			Message:            l.routeKindErr.Error(),
 			LastTransitionTime: now,
-		}
+		}}
 	}
 
-	switch l.refErr {
-	case errListenerInvalidCertificateRef_NotFound, errListenerInvalidCertificateRef_NotSupported, errListenerInvalidCertificateRef_InvalidData, errListenerInvalidCertificateRef_NonFIPSRSAKeyLen, errListenerInvalidCertificateRef_FIPSRSAKeyLen:
-		return metav1.Condition{
-			Type:               "ResolvedRefs",
-			Status:             metav1.ConditionFalse,
-			Reason:             "InvalidCertificateRef",
-			ObservedGeneration: generation,
-			Message:            l.refErr.Error(),
-			LastTransitionTime: now,
+	for _, refErr := range l.refErrs {
+		switch refErr {
+		case errListenerInvalidCertificateRef_NotFound, errListenerInvalidCertificateRef_NotSupported, errListenerInvalidCertificateRef_InvalidData, errListenerInvalidCertificateRef_NonFIPSRSAKeyLen, errListenerInvalidCertificateRef_FIPSRSAKeyLen:
+			conditions = append(conditions, metav1.Condition{
+				Type:               "ResolvedRefs",
+				Status:             metav1.ConditionFalse,
+				Reason:             "InvalidCertificateRef",
+				ObservedGeneration: generation,
+				Message:            refErr.Error(),
+				LastTransitionTime: now,
+			})
+		case errListenerJWTProviderNotFound:
+			conditions = append(conditions, metav1.Condition{
+				Type:               "ResolvedRefs",
+				Status:             metav1.ConditionFalse,
+				Reason:             "InvalidJWTProviderRef",
+				ObservedGeneration: generation,
+				Message:            refErr.Error(),
+				LastTransitionTime: now,
+			})
+		case errRefNotPermitted:
+			conditions = append(conditions, metav1.Condition{
+				Type:               "ResolvedRefs",
+				Status:             metav1.ConditionFalse,
+				Reason:             "RefNotPermitted",
+				ObservedGeneration: generation,
+				Message:            refErr.Error(),
+				LastTransitionTime: now,
+			})
 		}
-	case errRefNotPermitted:
-		return metav1.Condition{
-			Type:               "ResolvedRefs",
-			Status:             metav1.ConditionFalse,
-			Reason:             "RefNotPermitted",
-			ObservedGeneration: generation,
-			Message:            l.refErr.Error(),
-			LastTransitionTime: now,
-		}
-	default:
-		return metav1.Condition{
+	}
+	if len(conditions) == 0 {
+		conditions = append(conditions, metav1.Condition{
 			Type:               "ResolvedRefs",
 			Status:             metav1.ConditionTrue,
 			Reason:             "ResolvedRefs",
 			ObservedGeneration: generation,
 			Message:            "resolved certificate references",
 			LastTransitionTime: now,
-		}
+		})
 	}
+	return conditions
 }
 
 // Conditions constructs the entire set of conditions for a given gateway listener.
 func (l listenerValidationResult) Conditions(generation int64) []metav1.Condition {
-	return []metav1.Condition{
+	conditions := []metav1.Condition{
 		l.acceptedCondition(generation),
 		l.programmedCondition(generation),
 		l.conflictedCondition(generation),
-		l.resolvedRefsCondition(generation),
 	}
+	conditions = append(conditions, l.resolvedRefsConditions(generation)...)
+	return conditions
 }
 
 // listenerValidationResults holds all of the results for a gateway's listeners

--- a/control-plane/api-gateway/binding/result.go
+++ b/control-plane/api-gateway/binding/result.go
@@ -401,7 +401,11 @@ func (l listenerValidationResult) resolvedRefsConditions(generation int64) []met
 
 	for _, refErr := range l.refErrs {
 		switch refErr {
-		case errListenerInvalidCertificateRef_NotFound, errListenerInvalidCertificateRef_NotSupported, errListenerInvalidCertificateRef_InvalidData, errListenerInvalidCertificateRef_NonFIPSRSAKeyLen, errListenerInvalidCertificateRef_FIPSRSAKeyLen:
+		case errListenerInvalidCertificateRef_NotFound,
+			errListenerInvalidCertificateRef_NotSupported,
+			errListenerInvalidCertificateRef_InvalidData,
+			errListenerInvalidCertificateRef_NonFIPSRSAKeyLen,
+			errListenerInvalidCertificateRef_FIPSRSAKeyLen:
 			conditions = append(conditions, metav1.Condition{
 				Type:               "ResolvedRefs",
 				Status:             metav1.ConditionFalse,
@@ -450,8 +454,7 @@ func (l listenerValidationResult) Conditions(generation int64) []metav1.Conditio
 		l.programmedCondition(generation),
 		l.conflictedCondition(generation),
 	}
-	conditions = append(conditions, l.resolvedRefsConditions(generation)...)
-	return conditions
+	return append(conditions, l.resolvedRefsConditions(generation)...)
 }
 
 // listenerValidationResults holds all of the results for a gateway's listeners

--- a/control-plane/api-gateway/binding/validation.go
+++ b/control-plane/api-gateway/binding/validation.go
@@ -362,13 +362,19 @@ func validateListeners(gateway gwv1beta1.Gateway, listeners []gwv1beta1.Listener
 		var result listenerValidationResult
 
 		err, refErr := validateTLS(gateway, listener.TLS, resources)
-		result.refErrs = append(result.refErrs, refErr)
+		if refErr != nil {
+			result.refErrs = append(result.refErrs, refErr)
+		}
 
 		jwtErr := validateJWT(gateway, listener, resources)
+		if jwtErr != nil {
 		result.refErrs = append(result.refErrs, jwtErr)
+	    }
 
-		if err != nil || jwtErr != nil {
+		if err != nil {
 			result.acceptedErr = err
+		} else if jwtErr != nil {
+			result.acceptedErr = jwtErr
 		} else {
 			_, supported := supportedKindsForProtocol[listener.Protocol]
 			if !supported {

--- a/control-plane/api-gateway/binding/validation.go
+++ b/control-plane/api-gateway/binding/validation.go
@@ -15,10 +15,11 @@ import (
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	"github.com/hashicorp/consul/api"
+
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	"github.com/hashicorp/consul-k8s/control-plane/version"
-	"github.com/hashicorp/consul/api"
 )
 
 var (
@@ -234,7 +235,7 @@ func validateJWT(gateway gwv1beta1.Gateway, listener gwv1beta1.Listener, resourc
 
 	if policy.Spec.Override != nil && policy.Spec.Override.JWT != nil {
 		for _, provider := range policy.Spec.Override.JWT.Providers {
-			_, ok := resources.GetJWTProviderForProvider(provider)
+			_, ok := resources.GetJWTProviderForGatewayJWTProvider(provider)
 			if !ok {
 				return errListenerJWTProviderNotFound
 			}
@@ -243,7 +244,7 @@ func validateJWT(gateway gwv1beta1.Gateway, listener gwv1beta1.Listener, resourc
 
 	if policy.Spec.Default != nil && policy.Spec.Default.JWT != nil {
 		for _, provider := range policy.Spec.Default.JWT.Providers {
-			_, ok := resources.GetJWTProviderForProvider(provider)
+			_, ok := resources.GetJWTProviderForGatewayJWTProvider(provider)
 			if !ok {
 				return errListenerJWTProviderNotFound
 			}
@@ -368,8 +369,8 @@ func validateListeners(gateway gwv1beta1.Gateway, listeners []gwv1beta1.Listener
 
 		jwtErr := validateJWT(gateway, listener, resources)
 		if jwtErr != nil {
-		result.refErrs = append(result.refErrs, jwtErr)
-	    }
+			result.refErrs = append(result.refErrs, jwtErr)
+		}
 
 		if err != nil {
 			result.acceptedErr = err

--- a/control-plane/api-gateway/cache/consul.go
+++ b/control-plane/api-gateway/cache/consul.go
@@ -223,16 +223,18 @@ func (c *Cache) updateAndNotify(ctx context.Context, once *sync.Once, kind strin
 
 	for _, entry := range entries {
 		meta := entry.GetMeta()
-		if (meta[constants.MetaKeyKubeName] == "" || meta[constants.MetaKeyDatacenter] != c.datacenter) && kind != api.JWTProvider {
-			// Don't process things that don't belong to us. The main reason
-			// for this is so that we don't garbage collect config entries that
-			// are either user-created or that another controller running in a
-			// federated datacenter creates. While we still allow for competing controllers
-			// syncing/overriding each other due to conflicting Kubernetes objects in
-			// two federated clusters (which is what the rest of the controllers also allow
-			// for), we don't want to delete a config entry just because we don't have
-			// its corresponding Kubernetes object if we know it belongs to another datacenter.
-			continue
+		if kind != api.JWTProvider {
+			if meta[constants.MetaKeyKubeName] == "" || meta[constants.MetaKeyDatacenter] != c.datacenter {
+				// Don't process things that don't belong to us. The main reason
+				// for this is so that we don't garbage collect config entries that
+				// are either user-created or that another controller running in a
+				// federated datacenter creates. While we still allow for competing controllers
+				// syncing/overriding each other due to conflicting Kubernetes objects in
+				// two federated clusters (which is what the rest of the controllers also allow
+				// for), we don't want to delete a config entry just because we don't have
+				// its corresponding Kubernetes object if we know it belongs to another datacenter.
+				continue
+			}
 		}
 
 		cache.Set(common.EntryToReference(entry), entry)

--- a/control-plane/api-gateway/cache/consul.go
+++ b/control-plane/api-gateway/cache/consul.go
@@ -55,7 +55,7 @@ const (
 	apiTimeout        = 5 * time.Minute
 )
 
-var Kinds = []string{api.APIGateway, api.HTTPRoute, api.TCPRoute, api.InlineCertificate}
+var Kinds = []string{api.APIGateway, api.HTTPRoute, api.TCPRoute, api.InlineCertificate, api.JWTProvider}
 
 type Config struct {
 	ConsulClientConfig      *consul.Config
@@ -94,6 +94,7 @@ func New(config Config) *Cache {
 	for _, kind := range Kinds {
 		cache[kind] = common.NewReferenceMap()
 	}
+
 	config.ConsulClientConfig.APITimeout = apiTimeout
 
 	return &Cache{
@@ -222,7 +223,7 @@ func (c *Cache) updateAndNotify(ctx context.Context, once *sync.Once, kind strin
 
 	for _, entry := range entries {
 		meta := entry.GetMeta()
-		if meta[constants.MetaKeyKubeName] == "" || meta[constants.MetaKeyDatacenter] != c.datacenter {
+		if (meta[constants.MetaKeyKubeName] == "" || meta[constants.MetaKeyDatacenter] != c.datacenter) && kind != api.JWTProvider {
 			// Don't process things that don't belong to us. The main reason
 			// for this is so that we don't garbage collect config entries that
 			// are either user-created or that another controller running in a

--- a/control-plane/api-gateway/cache/consul_test.go
+++ b/control-plane/api-gateway/cache/consul_test.go
@@ -21,11 +21,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
+	"github.com/hashicorp/consul/api"
+
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 	"github.com/hashicorp/consul-k8s/control-plane/consul"
 	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
-	"github.com/hashicorp/consul/api"
 )
 
 func Test_resourceCache_diff(t *testing.T) {
@@ -1542,6 +1543,10 @@ func Test_Run(t *testing.T) {
 	inlineCert := setupInlineCertificate()
 	certs := []*api.InlineCertificateConfigEntry{inlineCert}
 
+	// setup jwt providers
+	jwtProvider := setupJWTProvider()
+	providers := []*api.JWTProviderConfigEntry{jwtProvider}
+
 	consulServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/config/http-route":
@@ -1570,6 +1575,14 @@ func Test_Run(t *testing.T) {
 			fmt.Fprintln(w, string(val))
 		case "/v1/config/inline-certificate":
 			val, err := json.Marshal(certs)
+			if err != nil {
+				w.WriteHeader(500)
+				fmt.Fprintln(w, err)
+				return
+			}
+			fmt.Fprintln(w, string(val))
+		case "/v1/config/jwt-provider":
+			val, err := json.Marshal(providers)
 			if err != nil {
 				w.WriteHeader(500)
 				fmt.Fprintln(w, err)
@@ -1614,7 +1627,7 @@ func Test_Run(t *testing.T) {
 	}
 
 	expectedCache := loadedReferenceMaps([]api.ConfigEntry{
-		gw, tcpRoute, httpRouteOne, httpRouteTwo, inlineCert,
+		gw, tcpRoute, httpRouteOne, httpRouteTwo, inlineCert, jwtProvider,
 	})
 
 	ctx, cancelFn := context.WithCancel(context.Background())
@@ -1674,6 +1687,16 @@ func Test_Run(t *testing.T) {
 		}
 	})
 
+	jwtProviderNsn := types.NamespacedName{
+		Name:      jwtProvider.Name,
+		Namespace: jwtProvider.Namespace,
+	}
+
+	jwtSubscriber := c.Subscribe(ctx, api.JWTProvider, func(cfe api.ConfigEntry) []types.NamespacedName {
+		return []types.NamespacedName{
+			{Name: cfe.GetName(), Namespace: cfe.GetNamespace()},
+		}
+	})
 	// mark this subscription as ended
 	canceledSub.Cancel()
 
@@ -1684,9 +1707,10 @@ func Test_Run(t *testing.T) {
 	gwExpectedEvent := event.GenericEvent{Object: newConfigEntryObject(gwNsn)}
 	tcpExpectedEvent := event.GenericEvent{Object: newConfigEntryObject(tcpRouteNsn)}
 	certExpectedEvent := event.GenericEvent{Object: newConfigEntryObject(certNsn)}
+	jwtProviderExpectedEvent := event.GenericEvent{Object: newConfigEntryObject(jwtProviderNsn)}
 
-	// 2 http routes + 1 gw + 1 tcp route + 1 cert = 5
-	i := 5
+	// 2 http routes + 1 gw + 1 tcp route + 1 cert + 1 jwtProvider = 6
+	i := 6
 	for {
 		if i == 0 {
 			break
@@ -1700,6 +1724,8 @@ func Test_Run(t *testing.T) {
 			require.Equal(t, tcpExpectedEvent, actualTCPRouteEvent)
 		case actualCertExpectedEvent := <-certSubscriber.Events():
 			require.Equal(t, certExpectedEvent, actualCertExpectedEvent)
+		case actualJWTExpectedEvent := <-jwtSubscriber.Events():
+			require.Equal(t, jwtProviderExpectedEvent, actualJWTExpectedEvent)
 		}
 		i -= 1
 	}
@@ -1952,6 +1978,13 @@ func setupInlineCertificate() *api.InlineCertificateConfigEntry {
 			"metaKey":                 "meta val",
 			constants.MetaKeyKubeName: "name",
 		},
+	}
+}
+
+func setupJWTProvider() *api.JWTProviderConfigEntry {
+	return &api.JWTProviderConfigEntry{
+		Kind: api.JWTProvider,
+		Name: "okta",
 	}
 }
 

--- a/control-plane/api-gateway/common/resources.go
+++ b/control-plane/api-gateway/common/resources.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"fmt"
+
 	mapset "github.com/deckarep/golang-set"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -12,8 +14,9 @@ import (
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	"github.com/hashicorp/consul/api"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 )
 
 // ConsulUpdateOperation is an operation representing an
@@ -142,6 +145,7 @@ func NewResourceMap(translator ResourceTranslator, validator ReferenceValidator,
 		tcpRouteGateways:      make(map[api.ResourceReference]*tcpRoute),
 		httpRouteGateways:     make(map[api.ResourceReference]*httpRoute),
 		gatewayResources:      make(map[api.ResourceReference]*resourceSet),
+		gatewayPolicies:       make(map[api.ResourceReference]*v1alpha1.GatewayPolicy),
 		jwtProviders:          make(map[api.ResourceReference]*v1alpha1.JWTProvider),
 	}
 }
@@ -436,7 +440,6 @@ func (s *ResourceMap) AddJWTProvider(provider *v1alpha1.JWTProvider) {
 		Kind: provider.Kind,
 		Name: provider.Name,
 	}
-	s.logger.Info("resourceMap", "key when adding", key)
 	s.jwtProviders[key] = provider
 }
 
@@ -445,7 +448,6 @@ func (s *ResourceMap) GetJWTProviderForProvider(provider *v1alpha1.GatewayJWTPro
 		Name: provider.Name,
 		Kind: "JWTProvider",
 	}
-	s.logger.Info("resourceMap", "providers", s.jwtProviders[key], "key", key)
 	value, exists := s.jwtProviders[key]
 	return value, exists
 }

--- a/control-plane/api-gateway/common/resources.go
+++ b/control-plane/api-gateway/common/resources.go
@@ -460,6 +460,7 @@ func (s *ResourceMap) GetPolicyForGatewayListener(gateway gwv1beta1.Gateway, gat
 		Namespace:   gateway.Namespace,
 	}
 
+	fmt.Printf("%#v\n", s.gatewayPolicies)
 	value, exists := s.gatewayPolicies[key]
 
 	return value, exists

--- a/control-plane/api-gateway/common/resources.go
+++ b/control-plane/api-gateway/common/resources.go
@@ -4,8 +4,6 @@
 package common
 
 import (
-	"fmt"
-
 	mapset "github.com/deckarep/golang-set"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -448,8 +446,7 @@ func (s *ResourceMap) GetJWTProviderForProvider(provider *v1alpha1.GatewayJWTPro
 		Name: provider.Name,
 		Kind: "JWTProvider",
 	}
-	value, exists := s.jwtProviders[key]
-	return value, exists
+	return s.jwtProviders[key]
 }
 
 func (s *ResourceMap) GetPolicyForGatewayListener(gateway gwv1beta1.Gateway, gatewayListener gwv1beta1.Listener) (*v1alpha1.GatewayPolicy, bool) {
@@ -460,7 +457,6 @@ func (s *ResourceMap) GetPolicyForGatewayListener(gateway gwv1beta1.Gateway, gat
 		Namespace:   gateway.Namespace,
 	}
 
-	fmt.Printf("%#v\n", s.gatewayPolicies)
 	value, exists := s.gatewayPolicies[key]
 
 	return value, exists

--- a/control-plane/api-gateway/common/resources.go
+++ b/control-plane/api-gateway/common/resources.go
@@ -446,7 +446,9 @@ func (s *ResourceMap) GetJWTProviderForProvider(provider *v1alpha1.GatewayJWTPro
 		Name: provider.Name,
 		Kind: "JWTProvider",
 	}
-	return s.jwtProviders[key]
+
+	value, exists := s.jwtProviders[key]
+	return value, exists
 }
 
 func (s *ResourceMap) GetPolicyForGatewayListener(gateway gwv1beta1.Gateway, gatewayListener gwv1beta1.Listener) (*v1alpha1.GatewayPolicy, bool) {

--- a/control-plane/api-gateway/common/resources.go
+++ b/control-plane/api-gateway/common/resources.go
@@ -441,7 +441,7 @@ func (s *ResourceMap) AddJWTProvider(provider *v1alpha1.JWTProvider) {
 	s.jwtProviders[key] = provider
 }
 
-func (s *ResourceMap) GetJWTProviderForProvider(provider *v1alpha1.GatewayJWTProvider) (*v1alpha1.JWTProvider, bool) {
+func (s *ResourceMap) GetJWTProviderForGatewayJWTProvider(provider *v1alpha1.GatewayJWTProvider) (*v1alpha1.JWTProvider, bool) {
 	key := api.ResourceReference{
 		Name: provider.Name,
 		Kind: "JWTProvider",

--- a/control-plane/api-gateway/common/resources.go
+++ b/control-plane/api-gateway/common/resources.go
@@ -121,6 +121,7 @@ type ResourceMap struct {
 	// consul resources for a gateway
 	consulTCPRoutes  map[api.ResourceReference]*consulTCPRoute
 	consulHTTPRoutes map[api.ResourceReference]*consulHTTPRoute
+	jwtProviders     map[api.ResourceReference]*v1alpha1.JWTProvider
 
 	// mutations
 	consulMutations []*ConsulUpdateOperation
@@ -141,6 +142,7 @@ func NewResourceMap(translator ResourceTranslator, validator ReferenceValidator,
 		tcpRouteGateways:      make(map[api.ResourceReference]*tcpRoute),
 		httpRouteGateways:     make(map[api.ResourceReference]*httpRoute),
 		gatewayResources:      make(map[api.ResourceReference]*resourceSet),
+		jwtProviders:          make(map[api.ResourceReference]*v1alpha1.JWTProvider),
 	}
 }
 
@@ -427,6 +429,25 @@ func (s *ResourceMap) AddGatewayPolicy(gatewayPolicy *v1alpha1.GatewayPolicy) *v
 	s.gatewayPolicies[key] = gatewayPolicy
 
 	return s.gatewayPolicies[key]
+}
+
+func (s *ResourceMap) AddJWTProvider(provider *v1alpha1.JWTProvider) {
+	key := api.ResourceReference{
+		Kind: provider.Kind,
+		Name: provider.Name,
+	}
+	s.logger.Info("resourceMap", "key when adding", key)
+	s.jwtProviders[key] = provider
+}
+
+func (s *ResourceMap) GetJWTProviderForProvider(provider *v1alpha1.GatewayJWTProvider) (*v1alpha1.JWTProvider, bool) {
+	key := api.ResourceReference{
+		Name: provider.Name,
+		Kind: "JWTProvider",
+	}
+	s.logger.Info("resourceMap", "providers", s.jwtProviders[key], "key", key)
+	value, exists := s.jwtProviders[key]
+	return value, exists
 }
 
 func (s *ResourceMap) GetPolicyForGatewayListener(gateway gwv1beta1.Gateway, gatewayListener gwv1beta1.Listener) (*v1alpha1.GatewayPolicy, bool) {

--- a/control-plane/api-gateway/common/resources_test.go
+++ b/control-plane/api-gateway/common/resources_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"testing"
+
+	logrtest "github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/hashicorp/consul/api"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+)
+
+func TestResourceMap_JWTProvider(t *testing.T) {
+	resourceMap := NewResourceMap(ResourceTranslator{}, mockReferenceValidator{}, logrtest.New(t))
+	require.Empty(t, resourceMap.jwtProviders)
+	provider := &v1alpha1.JWTProvider{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "JWTProvider",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-jwt",
+		},
+		Spec: v1alpha1.JWTProviderSpec{},
+	}
+
+	key := api.ResourceReference{
+		Name: provider.Name,
+		Kind: "JWTProvider",
+	}
+
+	resourceMap.AddJWTProvider(provider)
+
+	require.Len(t, resourceMap.jwtProviders,1 )
+	require.NotNil(t, resourceMap.jwtProviders[key])
+	require.Equal(t, resourceMap.jwtProviders[key], provider)
+}
+
+type mockReferenceValidator struct{}
+
+func (m mockReferenceValidator) GatewayCanReferenceSecret(gateway gwv1beta1.Gateway, secretRef gwv1beta1.SecretObjectReference) bool {
+	return true
+}
+
+func (m mockReferenceValidator) HTTPRouteCanReferenceBackend(httproute gwv1beta1.HTTPRoute, backendRef gwv1beta1.BackendRef) bool {
+	return true
+}
+
+func (m mockReferenceValidator) TCPRouteCanReferenceBackend(tcpRoute gwv1alpha2.TCPRoute, backendRef gwv1beta1.BackendRef) bool {
+	return true
+}

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -174,6 +174,12 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
+	_, err = r.getJWTProviders(ctx, resources)
+	if err != nil {
+		log.Error(err, "unable to list JWT providers")
+		return ctrl.Result{}, err
+	}
+
 	// fetch the rest of the consul objects from cache
 	consulServices := r.getConsulServices(consulKey)
 	consulGateway := r.getConsulGateway(consulKey)
@@ -467,6 +473,10 @@ func SetupGatewayControllerWithManager(ctx context.Context, mgr ctrl.Manager, co
 			&handler.EnqueueRequestForObject{},
 		).
 		Watches(
+			&source.Channel{Source: c.Subscribe(ctx, api.JWTProvider, r.transformConsulJWTProvider(ctx)).Events()},
+			&handler.EnqueueRequestForObject{},
+		).
+		Watches(
 			source.NewKindWithCache((&v1alpha1.GatewayPolicy{}), mgr.GetCache()),
 			handler.EnqueueRequestsFromMapFunc(r.transformGatewayPolicy(ctx)),
 		).
@@ -667,6 +677,42 @@ func (r *GatewayController) transformConsulInlineCertificate(ctx context.Context
 			}
 		}
 
+		return gateways
+	}
+}
+
+func (r *GatewayController) transformConsulJWTProvider(ctx context.Context) func(entry api.ConfigEntry) []types.NamespacedName {
+	return func(entry api.ConfigEntry) []types.NamespacedName {
+		var gateways []types.NamespacedName
+
+		jwtEntry := entry.(*api.JWTProviderConfigEntry)
+		r.Log.Info("gatewaycontroller", "gateway items", r.cache.List(api.APIGateway))
+		for _, gwEntry := range r.cache.List(api.APIGateway) {
+			gateway := gwEntry.(*api.APIGatewayConfigEntry)
+		LISTENER_LOOP:
+			for _, listener := range gateway.Listeners {
+
+				r.Log.Info("override names", "listener", fmt.Sprintf("%#v", listener))
+				if listener.Override != nil && listener.Override.JWT != nil {
+					for _, provider := range listener.Override.JWT.Providers {
+						r.Log.Info("override names", "provider", provider.Name, "entry", jwtEntry.Name)
+						if provider.Name == jwtEntry.Name {
+							gateways = append(gateways, common.EntryToNamespacedName(gateway))
+							continue LISTENER_LOOP
+						}
+					}
+				}
+
+				if listener.Default != nil && listener.Default.JWT != nil {
+					for _, provider := range listener.Default.JWT.Providers {
+						if provider.Name == jwtEntry.Name {
+							gateways = append(gateways, common.EntryToNamespacedName(gateway))
+							continue LISTENER_LOOP
+						}
+					}
+				}
+			}
+		}
 		return gateways
 	}
 }
@@ -922,6 +968,21 @@ func (c *GatewayController) getRelatedGatewayPolicies(ctx context.Context, gatew
 	//add all policies to the resourcemap
 	for _, policy := range list.Items {
 		resources.AddGatewayPolicy(&policy)
+	}
+
+	return list.Items, nil
+}
+
+func (c *GatewayController) getJWTProviders(ctx context.Context, resources *common.ResourceMap) ([]v1alpha1.JWTProvider, error) {
+	var list v1alpha1.JWTProviderList
+
+	if err := c.Client.List(ctx, &list, &client.ListOptions{}); err != nil {
+		return nil, err
+	}
+
+	// add all policies to the resourcemap
+	for _, provider := range list.Items {
+		resources.AddJWTProvider(&provider)
 	}
 
 	return list.Items, nil


### PR DESCRIPTION
Changes proposed in this PR:
- Adds status conditions translation for JWT related issues on Gateways (gateway policy will be a follow up PR)
- Sets up the reconcile workflow for when changes to a referenced JWT provider occur

How I've tested this PR:
1. clone the following repo https://github.com/jm96441n/consul-experiments/tree/main/k8s/jwts
1. from the `k8s/jwts` directory run the `start` script, this sets up a k8s cluster with an apigw, 3 services, a httproute, and a jwt provider named "local"
1. after that finishes run `kubectl describe gateway api-gateway` to see all the statuses as valid
1. run `kubectl apply ./consul/gatewaypolicy-okta.yaml`, this will add a policy to the gateway listener that references a non-existent jwt provider named `okta`
1. run `kubectl describe gateway api-gateway`  again to see the gateway has an invalid jwt providers status as well as the listener having an invalid jwt provider status
1. run `kubectl apply ./consul/okta.yaml` to create the `okta` jwt provider
1. run `kubectl describe gateway api-gateway`  again to see the gateway back in a healthy status

How I expect reviewers to test this PR:
Read the code
Run against kind cluster using steps above

Checklist:
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


