### PR TITLE
GKE Autopilot support

### DIFF
--- a/.changelog/2952.txt
+++ b/.changelog/2952.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Add support for running on GKE Autopilot.
+```

--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -157,7 +157,7 @@ func (t *TestConfig) HelmValuesFromConfig() (map[string]string, error) {
 	}
 
 	// UseGKEAutopilot is a temporary hack that we need in place as GKE Autopilot is already installing
-	// Gateway CRDs in the clusters. There are still other CRDs we need to install though (see helm cluster installE)
+	// Gateway CRDs in the clusters. There are still other CRDs we need to install though (see helm cluster install)
 	if t.UseGKEAutopilot {
 		setIfNotEmpty(helmValues, "global.server.resources.requests.cpu", "500m")
 		setIfNotEmpty(helmValues, "global.server.resources.limits.cpu", "500m")

--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -99,10 +99,11 @@ type TestConfig struct {
 	NoCleanup          bool
 	DebugDirectory     string
 
-	UseAKS  bool
-	UseEKS  bool
-	UseGKE  bool
-	UseKind bool
+	UseAKS          bool
+	UseEKS          bool
+	UseGKE          bool
+	UseGKEAutopilot bool
+	UseKind         bool
 
 	helmChartPath string
 }
@@ -153,6 +154,15 @@ func (t *TestConfig) HelmValuesFromConfig() (map[string]string, error) {
 			// namespace it must be run in a different privileged namespace.
 			setIfNotEmpty(helmValues, "connectInject.cni.namespace", "kube-system")
 		}
+	}
+
+	// UseGKEAutopilot is a temporary hack that we need in place as GKE Autopilot is already installing
+	// Gateway CRDs in the clusters. There are still other CRDs we need to install though (see helm cluster installE)
+	if t.UseGKEAutopilot {
+		setIfNotEmpty(helmValues, "global.server.resources.requests.cpu", "500m")
+		setIfNotEmpty(helmValues, "global.server.resources.limits.cpu", "500m")
+		setIfNotEmpty(helmValues, "connectInject.apiGateway.manageExternalCRDs", "false")
+		setIfNotEmpty(helmValues, "connectInject.apiGateway.manageCustomCRDs", "true")
 	}
 
 	setIfNotEmpty(helmValues, "connectInject.transparentProxy.defaultEnabled", strconv.FormatBool(t.EnableTransparentProxy))

--- a/acceptance/framework/config/config.go
+++ b/acceptance/framework/config/config.go
@@ -162,7 +162,7 @@ func (t *TestConfig) HelmValuesFromConfig() (map[string]string, error) {
 		setIfNotEmpty(helmValues, "global.server.resources.requests.cpu", "500m")
 		setIfNotEmpty(helmValues, "global.server.resources.limits.cpu", "500m")
 		setIfNotEmpty(helmValues, "connectInject.apiGateway.manageExternalCRDs", "false")
-		setIfNotEmpty(helmValues, "connectInject.apiGateway.manageCustomCRDs", "true")
+		setIfNotEmpty(helmValues, "connectInject.apiGateway.manageNonStandardCRDs", "true")
 	}
 
 	setIfNotEmpty(helmValues, "connectInject.transparentProxy.defaultEnabled", strconv.FormatBool(t.EnableTransparentProxy))

--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -143,6 +143,7 @@ func (h *HelmCluster) Create(t *testing.T) {
 			logger.Logf(t, "Unable to update helm repository, proceeding anyway: %s.", err)
 		}
 	}
+
 	helm.Install(t, h.helmOptions, chartName, h.releaseName)
 
 	k8s.WaitForAllPodsToBeReady(t, h.kubernetesClient, h.helmOptions.KubectlOptions.Namespace, fmt.Sprintf("release=%s", h.releaseName))

--- a/acceptance/framework/flags/flags.go
+++ b/acceptance/framework/flags/flags.go
@@ -50,10 +50,11 @@ type TestFlags struct {
 
 	flagDebugDirectory string
 
-	flagUseAKS  bool
-	flagUseEKS  bool
-	flagUseGKE  bool
-	flagUseKind bool
+	flagUseAKS          bool
+	flagUseEKS          bool
+	flagUseGKE          bool
+	flagUseGKEAutopilot bool
+	flagUseKind         bool
 
 	flagDisablePeering bool
 
@@ -145,6 +146,9 @@ func (t *TestFlags) init() {
 		"If true, the tests will assume they are running against an EKS cluster(s).")
 	flag.BoolVar(&t.flagUseGKE, "use-gke", false,
 		"If true, the tests will assume they are running against a GKE cluster(s).")
+	flag.BoolVar(&t.flagUseGKEAutopilot, "use-gke-autopilot", false,
+		"If true, the tests will assume they are running against a GKE Autopilot cluster(s).")
+
 	flag.BoolVar(&t.flagUseKind, "use-kind", false,
 		"If true, the tests will assume they are running against a local kind cluster(s).")
 
@@ -235,6 +239,7 @@ func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 		UseAKS:             t.flagUseAKS,
 		UseEKS:             t.flagUseEKS,
 		UseGKE:             t.flagUseGKE,
+		UseGKEAutopilot:    t.flagUseGKEAutopilot,
 		UseKind:            t.flagUseKind,
 	}
 

--- a/charts/consul/templates/crd-tcproutes.yaml
+++ b/charts/consul/templates/crd-tcproutes.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.connectInject.enabled (or .Values.connectInject.apiGateway.manageExternalCRDs .Values.connectInject.apiGateway.manageCustomCRDs ) }}
+{{- if and .Values.connectInject.enabled (or .Values.connectInject.apiGateway.manageExternalCRDs .Values.connectInject.apiGateway.manageNonStandardCRDs ) }}
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 

--- a/charts/consul/templates/crd-tcproutes.yaml
+++ b/charts/consul/templates/crd-tcproutes.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.connectInject.enabled .Values.connectInject.apiGateway.manageExternalCRDs }}
+{{- if and .Values.connectInject.enabled (or .Values.connectInject.apiGateway.manageExternalCRDs .Values.connectInject.apiGateway.manageCustomCRDs ) }}
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 

--- a/charts/consul/test/unit/crd-tcproutes.bats
+++ b/charts/consul/test/unit/crd-tcproutes.bats
@@ -26,3 +26,22 @@ load _helpers
         --set 'connectInject.apiGateway.manageExternalCRDs=false' \
         . 
 }
+
+@test "tcproutes/CustomResourceDefinition: disabled with connectInject.apiGateway.manageExternalCRDs=false and connectInject.apiGateway.manageCustomCRDs=false" {
+    cd `chart_dir`
+    assert_empty helm template \
+        -s templates/crd-tcproutes.yaml \
+        --set 'connectInject.apiGateway.manageExternalCRDs=false' \
+        --set 'connectInject.apiGateway.manageCustomCRDs=false' \
+        . 
+}
+
+@test "tcproutes/CustomResourceDefinition: enabled with connectInject.apiGateway.manageCustomCRDs=true" {
+    cd `chart_dir`
+    local actual=$(helm template \
+        -s templates/crd-tcproutes.yaml \
+        --set 'connectInject.apiGateway.manageCustomCRDs=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/crd-tcproutes.bats
+++ b/charts/consul/test/unit/crd-tcproutes.bats
@@ -27,20 +27,20 @@ load _helpers
         . 
 }
 
-@test "tcproutes/CustomResourceDefinition: disabled with connectInject.apiGateway.manageExternalCRDs=false and connectInject.apiGateway.manageCustomCRDs=false" {
+@test "tcproutes/CustomResourceDefinition: disabled with connectInject.apiGateway.manageExternalCRDs=false and connectInject.apiGateway.manageNonStandardCRDs=false" {
     cd `chart_dir`
     assert_empty helm template \
         -s templates/crd-tcproutes.yaml \
         --set 'connectInject.apiGateway.manageExternalCRDs=false' \
-        --set 'connectInject.apiGateway.manageCustomCRDs=false' \
+        --set 'connectInject.apiGateway.manageNonStandardCRDs=false' \
         . 
 }
 
-@test "tcproutes/CustomResourceDefinition: enabled with connectInject.apiGateway.manageCustomCRDs=true" {
+@test "tcproutes/CustomResourceDefinition: enabled with connectInject.apiGateway.manageNonStandardCRDs=true" {
     cd `chart_dir`
     local actual=$(helm template \
         -s templates/crd-tcproutes.yaml \
-        --set 'connectInject.apiGateway.manageCustomCRDs=true' \
+        --set 'connectInject.apiGateway.manageNonStandardCRDs=true' \
       . | tee /dev/stderr |
       yq -s 'length > 0' | tee /dev/stderr)
     [ "${actual}" = "true" ]

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2185,10 +2185,10 @@ connectInject:
     # If this setting is false, you will need to install the Gateway API CRDs manually.
     manageExternalCRDs: true
 
-    # Enables Consul on Kubernets to manage only the custom CRDs used for Gateway API. If manageExternalCRDs is true 
-    # then all CRDs will be installed. If manageCustomCRDs is true then only TCPRoute, GatewayClassConfig and MeshService
+    # Enables Consul on Kubernets to manage only the non-standard CRDs used for Gateway API. If manageExternalCRDs is true 
+    # then all CRDs will be installed. If manageNonStandardCRDs is true then only TCPRoute, GatewayClassConfig and MeshService
     # will be installed.
-    manageCustomCRDs: false
+    manageNonStandardCRDs: false
 
     # Configuration settings for the GatewayClass installed by Consul on Kubernetes.
     managedGatewayClass:

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2186,7 +2186,7 @@ connectInject:
     manageExternalCRDs: true
 
     # Enables Consul on Kubernets to manage only the non-standard CRDs used for Gateway API. If manageExternalCRDs is true 
-    # then all CRDs will be installed. If manageNonStandardCRDs is true then only TCPRoute, GatewayClassConfig and MeshService
+    # then all CRDs will be installed; otherwise, if manageNonStandardCRDs is true then only TCPRoute, GatewayClassConfig and MeshService
     # will be installed.
     manageNonStandardCRDs: false
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2185,6 +2185,11 @@ connectInject:
     # If this setting is false, you will need to install the Gateway API CRDs manually.
     manageExternalCRDs: true
 
+    # Enables Consul on Kubernets to manage only the custom CRDs used for Gateway API. If manageExternalCRDs is true 
+    # then all CRDs will be installed. If manageCustomerCRDs is true then only TCPRoute, gatewayclassconfigs and meshservice
+    # will be installed.
+    manageCustomCRDs: false
+
     # Configuration settings for the GatewayClass installed by Consul on Kubernetes.
     managedGatewayClass:
       # This value defines [`nodeSelector`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2186,7 +2186,7 @@ connectInject:
     manageExternalCRDs: true
 
     # Enables Consul on Kubernets to manage only the custom CRDs used for Gateway API. If manageExternalCRDs is true 
-    # then all CRDs will be installed. If manageCustomerCRDs is true then only TCPRoute, gatewayclassconfigs and meshservice
+    # then all CRDs will be installed. If manageCustomCRDs is true then only TCPRoute, GatewayClassConfig and MeshService
     # will be installed.
     manageCustomCRDs: false
 


### PR DESCRIPTION
Changes proposed in this PR:
- This adds a first pass of support for running on GKE Autopilot.
- We won't know how things fully work until we are certified with 1.2.2 (next patch release)
- I tried to do this without any helm chart values changes but it would have been considerably more messy than it is now.

How I've tested this PR:

- went through an initial acceptance pass with the Autopilot team
- installed consul-k8s using the following helm values:
```
global:
  name: consul
  datacenter: dc1
  logLevel: "debug"
  tls:
    enabled: false
ingress:
  enabled: false
server:
  replicas: 1
  resources:
    requests:
      memory: "200Mi"
      cpu: "500m"
    limits:
      memory: "200Mi"
      cpu: "500m"
connectInject:
  enabled: true
  default: true
  replicas: 1
  transparentProxy:
    defaultEnabled: true
  apiGateway:
    manageExternalCRDs: false
    manageCustomCRDs: true
dns:
  enabled: false
ui:
  enabled: true
  service:
    enabled: true
controller:
  enabled: true
```
	

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


