### PR TITLE
Reconcile Route Auth Filter changes

### DIFF
--- a/charts/consul/templates/connect-inject-clusterrole.yaml
+++ b/charts/consul/templates/connect-inject-clusterrole.yaml
@@ -37,6 +37,7 @@ rules:
   - peeringdialers
   {{- end }}
   - jwtproviders
+  - routeauthfilters
   verbs:
   - create
   - delete
@@ -65,6 +66,7 @@ rules:
   - peeringdialers/status
   {{- end }}
   - jwtproviders/status
+  - routeauthfilters/status
   verbs:
   - get
   - patch

--- a/control-plane/api-gateway/common/diff.go
+++ b/control-plane/api-gateway/common/diff.go
@@ -219,7 +219,8 @@ func (e entryComparator) httpRouteRulesEqual(a, b api.HTTPRouteRule) bool {
 		slices.EqualFunc(a.Matches, b.Matches, e.httpMatchesEqual) &&
 		slices.EqualFunc(a.Services, b.Services, e.httpServicesEqual) &&
 		bothNilOrEqualFunc(a.Filters.RetryFilter, b.Filters.RetryFilter, e.retryFiltersEqual) &&
-		bothNilOrEqualFunc(a.Filters.TimeoutFilter, b.Filters.TimeoutFilter, e.timeoutFiltersEqual)
+		bothNilOrEqualFunc(a.Filters.TimeoutFilter, b.Filters.TimeoutFilter, e.timeoutFiltersEqual) &&
+		bothNilOrEqualFunc(a.Filters.JWT, b.Filters.JWT, e.jwtFiltersEqual)
 }
 
 func (e entryComparator) httpServicesEqual(a, b api.HTTPService) bool {
@@ -267,6 +268,16 @@ func (e entryComparator) retryFiltersEqual(a, b api.RetryFilter) bool {
 
 func (e entryComparator) timeoutFiltersEqual(a, b api.TimeoutFilter) bool {
 	return a.RequestTimeout == b.RequestTimeout && a.IdleTimeout == b.IdleTimeout
+}
+
+// jwtFiltersEqual compares the contents of the list of providers on the JWT filters for a route, returning true if the
+// filters have equal contents.
+func (e entryComparator) jwtFiltersEqual(a, b api.JWTFilter) bool {
+	if len(a.Providers) != len(b.Providers) {
+		return false
+	}
+
+	return slices.EqualFunc(a.Providers, b.Providers, providersEqual)
 }
 
 func tcpRoutesEqual(a, b *api.TCPRouteConfigEntry) bool {

--- a/control-plane/api-gateway/common/helpers.go
+++ b/control-plane/api-gateway/common/helpers.go
@@ -38,7 +38,7 @@ func FilterIsExternalFilter(filter gwv1beta1.HTTPRouteFilter) bool {
 	}
 
 	switch filter.ExtensionRef.Kind {
-	case v1alpha1.RouteRetryFilterKind, v1alpha1.RouteTimeoutFilterKind:
+	case v1alpha1.RouteRetryFilterKind, v1alpha1.RouteTimeoutFilterKind, v1alpha1.RouteAuthFilterKind:
 		return true
 	}
 

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -477,7 +477,13 @@ func SetupGatewayControllerWithManager(ctx context.Context, mgr ctrl.Manager, co
 		Watches(
 			source.NewKindWithCache((&v1alpha1.RouteTimeoutFilter{}), mgr.GetCache()),
 			handler.EnqueueRequestsFromMapFunc(r.transformRouteTimeoutFilter(ctx)),
-		).Complete(r)
+		).
+		Watches(
+			// Subscribe to changes in RouteAuthFilter custom resources referenced by HTTPRoutes.
+			source.NewKindWithCache((&v1alpha1.RouteAuthFilter{}), mgr.GetCache()),
+			handler.EnqueueRequestsFromMapFunc(r.transformRouteAuthFilter(ctx)),
+		).
+		Complete(r)
 }
 
 // transformGatewayClass will check the list of GatewayClass objects for a matching
@@ -625,6 +631,12 @@ func (r *GatewayController) transformRouteRetryFilter(ctx context.Context) func(
 func (r *GatewayController) transformRouteTimeoutFilter(ctx context.Context) func(object client.Object) []reconcile.Request {
 	return func(o client.Object) []reconcile.Request {
 		return r.gatewaysForRoutesReferencing(ctx, "", HTTPRoute_RouteTimeoutFilterIndex, client.ObjectKeyFromObject(o).String())
+	}
+}
+
+func (r *GatewayController) transformRouteAuthFilter(ctx context.Context) func(object client.Object) []reconcile.Request {
+	return func(o client.Object) []reconcile.Request {
+		return r.gatewaysForRoutesReferencing(ctx, "", HTTPRoute_RouteAuthFilterIndex, client.ObjectKeyFromObject(o).String())
 	}
 }
 

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -895,6 +895,8 @@ func (c *GatewayController) filterFiltersForExternalRefs(ctx context.Context, ro
 			externalFilter = &v1alpha1.RouteRetryFilter{}
 		case v1alpha1.RouteTimeoutFilterKind:
 			externalFilter = &v1alpha1.RouteTimeoutFilter{}
+		case v1alpha1.RouteAuthFilterKind:
+			externalFilter = &v1alpha1.RouteAuthFilter{}
 		default:
 			continue
 		}

--- a/control-plane/api-gateway/controllers/index.go
+++ b/control-plane/api-gateway/controllers/index.go
@@ -5,6 +5,7 @@ package controllers
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/types"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -20,18 +21,22 @@ const (
 	// Naming convention: TARGET_REFERENCE.
 	GatewayClass_GatewayClassConfigIndex = "__gatewayclass_referencing_gatewayclassconfig"
 	GatewayClass_ControllerNameIndex     = "__gatewayclass_controller_name"
-	Gateway_GatewayClassIndex            = "__gateway_referencing_gatewayclass"
-	HTTPRoute_GatewayIndex               = "__httproute_referencing_gateway"
-	HTTPRoute_ServiceIndex               = "__httproute_referencing_service"
-	HTTPRoute_MeshServiceIndex           = "__httproute_referencing_mesh_service"
-	TCPRoute_GatewayIndex                = "__tcproute_referencing_gateway"
-	TCPRoute_ServiceIndex                = "__tcproute_referencing_service"
-	TCPRoute_MeshServiceIndex            = "__tcproute_referencing_mesh_service"
-	MeshService_PeerIndex                = "__meshservice_referencing_peer"
-	Secret_GatewayIndex                  = "__secret_referencing_gateway"
-	HTTPRoute_RouteRetryFilterIndex      = "__httproute_referencing_retryfilter"
-	HTTPRoute_RouteTimeoutFilterIndex    = "__httproute_referencing_timeoutfilter"
-	Gatewaypolicy_GatewayIndex           = "__gatewaypolicy_referencing_gateway"
+
+	Gateway_GatewayClassIndex = "__gateway_referencing_gatewayclass"
+
+	HTTPRoute_GatewayIndex            = "__httproute_referencing_gateway"
+	HTTPRoute_ServiceIndex            = "__httproute_referencing_service"
+	HTTPRoute_MeshServiceIndex        = "__httproute_referencing_mesh_service"
+	HTTPRoute_RouteRetryFilterIndex   = "__httproute_referencing_retryfilter"
+	HTTPRoute_RouteTimeoutFilterIndex = "__httproute_referencing_timeoutfilter"
+
+	TCPRoute_GatewayIndex     = "__tcproute_referencing_gateway"
+	TCPRoute_ServiceIndex     = "__tcproute_referencing_service"
+	TCPRoute_MeshServiceIndex = "__tcproute_referencing_mesh_service"
+
+	MeshService_PeerIndex      = "__meshservice_referencing_peer"
+	Secret_GatewayIndex        = "__secret_referencing_gateway"
+	Gatewaypolicy_GatewayIndex = "__gatewaypolicy_referencing_gateway"
 )
 
 // RegisterFieldIndexes registers all of the field indexes for the API gateway controllers.

--- a/control-plane/api-gateway/controllers/index.go
+++ b/control-plane/api-gateway/controllers/index.go
@@ -29,6 +29,7 @@ const (
 	HTTPRoute_MeshServiceIndex        = "__httproute_referencing_mesh_service"
 	HTTPRoute_RouteRetryFilterIndex   = "__httproute_referencing_retryfilter"
 	HTTPRoute_RouteTimeoutFilterIndex = "__httproute_referencing_timeoutfilter"
+	HTTPRoute_RouteAuthFilterIndex    = "__httproute_referencing_routeauthfilter"
 
 	TCPRoute_GatewayIndex     = "__tcproute_referencing_gateway"
 	TCPRoute_ServiceIndex     = "__tcproute_referencing_service"
@@ -120,6 +121,11 @@ var indexes = []index{
 	},
 	{
 		name:        HTTPRoute_RouteTimeoutFilterIndex,
+		target:      &gwv1beta1.HTTPRoute{},
+		indexerFunc: filtersForHTTPRoute,
+	},
+	{
+		name:        HTTPRoute_RouteAuthFilterIndex,
 		target:      &gwv1beta1.HTTPRoute{},
 		indexerFunc: filtersForHTTPRoute,
 	},


### PR DESCRIPTION
Changes proposed in this PR:
- Triggers reconciliation and syncing of JWT configuration for an HTTP Route when a RouteAuthFilter is modified.
- Group indices by resource
- Add index for HTTPRoutes referencing RouteAuthFilters
- Add watch for HTTPRoutes referencing RouteAuthFilters
- Add permissions to connect-inject clusterrole
- Compare JWT filters for equality
- Add RouteAuthFilter to resource translator

How I've tested this PR:

In a local K8s cluster, I created a Gateway with an HTTP Route that points to a RouteAuthFilter.
When that RouteAuthFilter is created/updated/deleted, I can see that the controller runs to reconcile the change.
I then looked at the configuration in the Consul server. It matches the expected configuration based on the change.

How I expect reviewers to test this PR:

You can do the same as I did!
<details><summary>Resources</summary>
<p>
```yaml
# consul-values.yaml
global:
  image: hashicorppreview/consul-enterprise:1.17-dev
  imageK8S: consul-k8s-control-plane-dev:local
  imageConsulDataplane: hashicorppreview/consul-dataplane:1.2-dev
  logLevel: "debug"
  enterpriseLicense:
    secretName: consul-enterprise-license
    secretKey: license
  acls:
    manageSystemACLs: false

server:
  replicas: 1

controller:
  enabled: true
```

```sh
#!/bin/bash
# install.sh

CONSUL_K8S=~/Repos/consul-k8s
HELM_CHART=~/Repos/consul-k8s/charts/consul

cd $CONSUL_K8S
make control-plane-dev-docker
docker tag consul-k8s-control-plane-dev consul-k8s-control-plane-dev:local
kind load docker-image consul-k8s-control-plane-dev:local -n one
cd -

# Load enterprise secret
kubectl create namespace consul
kubectl create secret generic consul-enterprise-license --from-literal="license=$CONSUL_ENT_LICENSE" -n consul

helm install consul $HELM_CHART -f consul-values.yaml --namespace consul --create-namespace --wait
```

```yaml
# resources.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: server
spec:
  replicas: 1
  selector:
    matchLabels:
      app: server
  template:
    metadata:
      name: server
      labels:
        app: server
      annotations:
        consul.hashicorp.com/connect-inject: "true"
    spec:
      containers:
        - name: server
          image: docker.mirror.hashicorp.services/hashicorp/http-echo:latest
          args:
            - -text="hello world"
            - -listen=:8080
          ports:
            - containerPort: 8080
              name: http
          resources:
            requests:
              memory: "64Mi"
              cpu: "250m"
            limits:
              memory: "128Mi"
              cpu: "500m"
      serviceAccountName: server
      terminationGracePeriodSeconds: 0
---
apiVersion: v1
kind: Service
metadata:
  name: server
spec:
  selector:
    app: server
  ports:
    - name: http
      port: 80
      targetPort: 8080
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: server
---
apiVersion: consul.hashicorp.com/v1alpha1
kind: ServiceDefaults
metadata:
  name: server
spec:
  protocol: http
---
apiVersion: gateway.networking.k8s.io/v1beta1
kind: Gateway
metadata:
  name: gateway
spec:
  gatewayClassName: consul
  listeners:
    - protocol: HTTP
      port: 80
      name: to-server
---
apiVersion: gateway.networking.k8s.io/v1beta1
kind: HTTPRoute
metadata:
  name: server-httproute
spec:
  parentRefs:
    - name: gateway
  rules:
    - matches:
      - path:
          type: PathPrefix
          value: /
      backendRefs:
        - kind: Service
          name: server
          port: 80
      filters:
        - type: ExtensionRef
          extensionRef:
            group: consul.hashicorp.com
            kind: RouteAuthFilter
            name: auth-filter
---
apiVersion: consul.hashicorp.com/v1alpha1
kind: JWTProvider
metadata:
  name: local
spec:
  issuer: local
  jsonWebKeySet:
    local:
      jwks: "ewogICAgImtleXMiOiBbCiAgICAgICAgewogICAgICAgICAgICAicCI6ICI5TTlWSVhJR0hpR3FlTnhseEJ2V0xFV09oUFh3dXhXZUpod01uM3dGdG9STEtfZmF6VWxjWEc1cUViLTdpMXo3VmlPUWVZRnh6WUZYTS1pbVU3OVFRa1dTVUVSazR2dHZuc2R5UnpUSnVPc3A0ZUhuWFVMSHJPOU51NkJ5bC1VeVprMzFvSnFGeGllM0pHQXlRLUM2OVF2NVFkVjFZV0hfVDkyTzk4d1hYZGMiLAogICAgICAgICAgICAia3R5IjogIlJTQSIsCiAgICAgICAgICAgICJxIjogInFIVnZBb3h0ckgxUTVza25veXNMMkhvbC1ubnU3ZlM3Mjg4clRGdE9jeG9Jb29nWXBKVTljemxwcjctSlo2bjc0TUViVHBBMHRkSUR5TEtQQ0xIN3JKTFRrZzBDZVZNQWpmY01zdkRUcWdFOHNBWE42bzd2ZjYya2hwcExYOHVCU3JxSHkyV1JhZXJsbDROU09hcmRGSkQ2MWhHSVF2cEpXRk4xazFTV3pWcyIsCiAgICAgICAgICAgICJkIjogIlp3elJsVklRZkg5ekZ6d1hOZ2hEMHhkZVctalBCbmRkWnJNZ0wwQ2JjeXZZYlg2X1c0ajlhM1dmYWpobmI2bTFILW9CWjRMczVmNXNRVTB2ZFJ2ZG1laFItUG43aWNRcUdURFNKUTYtdWVtNm15UVRWaEo2UmZiM0lINVJ2VDJTOXUzcVFDZWFadWN3aXFoZ1RCbFhnOWFfV0pwVHJYNFhPQ3JCR1ZsTng3Z2JETVJOamNEN0FnRkZ3S2p2TEZVdDRLTkZmdEJqaFF0TDFLQ2VwblNmamtvRm1RUTVlX3RSS2ozX2U1V3pNSkJkekpQejNkR2YxZEk3OF9wYmJFbmFMcWhqNWg0WUx2UU5JUUhVcURYSGx4ZDc1Qlh3aFJReE1nUDRfd1EwTFk2cVRKNGFDa2Q0RDJBTUtqMzJqeVFiVTRKTE9jQjFNMnZBRWFyc2NTU3l0USIsCiAgICAgICAgICAgICJlIjogIkFRQUIiLAogICAgICAgICAgICAidXNlIjogInNpZyIsCiAgICAgICAgICAgICJraWQiOiAiQy1FMW5DandnQkMtUHVHTTJPNDY3RlJEaEt4OEFrVmN0SVNBYm8zcmlldyIsCiAgICAgICAgICAgICJxaSI6ICJ0N2VOQjhQV21xVHdKREZLQlZKZExrZnJJT2drMFJ4MnREODBGNHB5cjhmNzRuNGlVWXFmWG1haVZtbGx2c2FlT3JlNHlIczQ4UE45NVZsZlVvS3Z6ZEJFaDNZTDFINGZTOGlYYXNzNGJiVnVuWHR4U0hMZFFPYUNZYUplSmhBbGMyUWQ4elR0NFFQWk9yRWVWLVJTYU0tN095ekkwUWtSSF9tcmk1YmRrOXMiLAogICAgICAgICAgICAiZHAiOiAiYnBLckQtVXhrRENDal81MFZLU0NFeE1Ec1Zob2VBZm1tNjMxb1o5aDhUTkZ4TUU1YVptbUJ2VzBJUG9wMm1PUF9qTW9FVWxfUG1RYUlBOEgtVEdqTFp2QTMxSlZBeFN3TU5aQzdwaVFPRjYzVnhneTZUTzlmb1hENVdndC1oLUNxU1N6T2V3eFdmUWNTMmpMcTA3NUFxOTYwTnA2SHhjbE8weUdRN1JDSlpjIiwKICAgICAgICAgICAgImFsZyI6ICJQUzI1NiIsCiAgICAgICAgICAgICJkcSI6ICJpdVZveGwwckFKSEM1c2JzbTZpZWQ3c2ZIVXIwS2Rja0hiVFBLb0lPU1BFcU5YaXBlT3BrWkdEdU55NWlDTXNyRnNHaDFrRW9kTkhZdE40ay1USm5KSDliV296SGdXbGloNnN2R1V0Zi1raFMxWC16ckxaMTJudzlyNDRBbjllWG54bjFaVXMxZm5OakltM3dtZ083algyTWxIeVlNVUZVd0RMd09xNEFPUWsiLAogICAgICAgICAgICAibiI6ICJvUmhjeUREdmp3NFZ4SHRRNTZhRDlNSmRTaWhWSk1nTHd1b2FCQVhhc0RjVDNEWVZjcENlVGxDMVBPdzdPNW1Ec2ZSWVFtcGpoendyRDVZWU8yeDE4REl4czdyNTNJdFMxRy1ybnQxQ1diVE9fUzFJT01DR2xxYzh5VWJnLUhSUkRETXQyb2V3TjJoRGtxYlBKVFJNbXpjRkpNMHRpTm1RZVVMcWViZEVYaWVUblJMT1BkMWg2ZmJycVNLS01mSXlIbGZ1WXFQc1VWSEdkMVBESGljZ3NMazFtZDhtYTNIS1hWM0hJdzZrdUV6R0hQb1gxNHo4YWF6RFFZWndUR3ZxVGlPLUdRUlVDZUJueVo4bVhyWnRmSjNqVk83UUhXcEx3MlM1VDVwVTRwcE0xQXppWTFxUDVfY3ZpOTNZT2Zrb09PalRTX3V3RENZWGFxWjB5bTJHYlEiCiAgICAgICAgfQogICAgXQp9Cg=="
```

```yaml
# RouteAuthFilter
apiVersion: consul.hashicorp.com/v1alpha1
kind: RouteAuthFilter
metadata:
  name: auth-filter
spec:
  jwt:
    providers:
      - name: local
```



</p>
</details> 


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

Completes:
- https://hashicorp.atlassian.net/browse/NET-5043
- https://hashicorp.atlassian.net/browse/NET-4981
