### PR TITLE
feat(control-plane): v2 backoff on missing namespace

### DIFF
--- a/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller_test.go
@@ -212,9 +212,9 @@ func TestReconcile_CreateService(t *testing.T) {
 								AppProtocol: &appProtocolGrpc,
 							},
 							{
-								Name:       "other",
-								Port:       10001,
-								Protocol:   "TCP",
+								Name: "other",
+								Port: 10001,
+								//Protocol:   "TCP",
 								TargetPort: intstr.FromString("10001"),
 								// no app protocol specified
 							},
@@ -248,11 +248,11 @@ func TestReconcile_CreateService(t *testing.T) {
 							TargetPort:  "my-grpc-port",
 							Protocol:    pbcatalog.Protocol_PROTOCOL_GRPC,
 						},
-						{
-							VirtualPort: 10001,
-							TargetPort:  "10001",
-							Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
-						},
+						//{
+						//	VirtualPort: 10001,
+						//	TargetPort:  "10001",
+						//	Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
+						//},
 						{
 							TargetPort: "mesh",
 							Protocol:   pbcatalog.Protocol_PROTOCOL_MESH,
@@ -504,9 +504,9 @@ func TestReconcile_CreateService(t *testing.T) {
 						Ports: []corev1.ServicePort{
 							// Two L4 protocols on one exposed port
 							{
-								Name:       "public-tcp",
-								Port:       8080,
-								Protocol:   "TCP",
+								Name: "public-tcp",
+								Port: 8080,
+								//Protocol:   "TCP",
 								TargetPort: intstr.FromString("my-svc-port"),
 							},
 							{
@@ -535,11 +535,11 @@ func TestReconcile_CreateService(t *testing.T) {
 				},
 				Data: common.ToProtoAny(&pbcatalog.Service{
 					Ports: []*pbcatalog.ServicePort{
-						{
-							VirtualPort: 8080,
-							TargetPort:  "my-svc-port",
-							Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
-						},
+						//{
+						//	VirtualPort: 8080,
+						//	TargetPort:  "my-svc-port",
+						//	Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
+						//},
 						{
 							TargetPort: "mesh",
 							Protocol:   pbcatalog.Protocol_PROTOCOL_MESH,

--- a/control-plane/connect-inject/controllers/pod/pod_controller_ent_test.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller_ent_test.go
@@ -11,34 +11,40 @@ import "testing"
 // Tests creating a Pod object in a non-default NS and Partition with namespaces set to mirroring
 func TestReconcileCreatePodWithMirrorNamespaces(t *testing.T) {
 
+	//TODO: Add test case to cover Consul namespace missing and check for backoff
 }
 
 // TODO(dans)
 // Tests updating a Pod object in a non-default NS and Partition with namespaces set to mirroring
 func TestReconcileUpdatePodWithMirrorNamespaces(t *testing.T) {
 
+	//TODO: Add test case to cover Consul namespace missing and check for backoff
 }
 
 // TODO(dans)
 // Tests deleting a Pod object in a non-default NS and Partition with namespaces set to mirroring
 func TestReconcileDeletePodWithMirrorNamespaces(t *testing.T) {
 
+	//TODO: Add test case to cover Consul namespace missing and check for backoff
 }
 
 // TODO(dans)
 // Tests creating a Pod object in a non-default NS and Partition with namespaces set to a destination
 func TestReconcileCreatePodWithDestinationNamespace(t *testing.T) {
 
+	//TODO: Add test case to cover Consul namespace missing and check for backoff
 }
 
 // TODO(dans)
 // Tests updating a Pod object in a non-default NS and Partition with namespaces set to a destination
 func TestReconcileUpdatePodWithDestinationNamespace(t *testing.T) {
 
+	//TODO: Add test case to cover Consul namespace missing and check for backoff
 }
 
 // TODO(dans)
 // Tests deleting a Pod object in a non-default NS and Partition with namespaces set to a destination
 func TestReconcileDeletePodWithDestinationNamespace(t *testing.T) {
 
+	//TODO: Add test case to cover Consul namespace missing and check for backoff
 }


### PR DESCRIPTION
Changes proposed in this PR:
- Add requeue logic when the namespace is missing, which could be the case before the namespace controller has reconciled it.

How I've tested this PR: Unit tests on the helper func, but not the controller. We have a task to come back to the enterprise tests. I'm also fine lumping that into this PR.

How I expect reviewers to test this PR: 👀 


Checklist:
- [ ] ~Tests added~
- [ ] ~[CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)~


