### PR TITLE
test(chart): fix telemetry V2 bats

### DIFF
--- a/charts/consul/test/unit/telemetry-collector-v2-deployment.bats
+++ b/charts/consul/test/unit/telemetry-collector-v2-deployment.bats
@@ -1031,28 +1031,29 @@ load _helpers
 
 #--------------------------------------------------------------------
 # Admin Partitions
+# TODO: re-enable this test when V2 supports admin partitions.
 
-@test "telemetryCollector/Deployment(V2):  partition flags are set when using admin partitions" {
-  cd `chart_dir`
-  local flags=$(helm template \
-      -s templates/telemetry-collector-v2-deployment.yaml  \
-      --set 'ui.enabled=false' \
-      --set 'global.experiments[0]=resource-apis' \
-      --set 'telemetryCollector.enabled=true' \
-      --set 'telemetryCollector.image=bar' \
-      --set 'global.enableConsulNamespaces=true' \
-      --set 'global.adminPartitions.enabled=true' \
-      --set 'global.adminPartitions.name=hashi' \
-      --set 'global.acls.manageSystemACLs=true' \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[1].args' | tee /dev/stderr)
-
-  local actual=$(echo $flags | jq -r '. | any(contains("-login-partition=hashi"))' | tee /dev/stderr)
-  [ "${actual}" = 'true' ]
-
-  local actual=$(echo $flags | jq -r '. | any(contains("-service-partition=hashi"))' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
+# @test "telemetryCollector/Deployment: partition flags are set when using admin partitions" {
+#   cd `chart_dir`
+#   local flags=$(helm template \
+#       -s templates/telemetry-collector-deployment.yaml  \
+#       --set 'ui.enabled=false' \
+#       --set 'global.experiments[0]=resource-apis' \
+#       --set 'telemetryCollector.enabled=true' \
+#       --set 'telemetryCollector.image=bar' \
+#       --set 'global.enableConsulNamespaces=true' \
+#       --set 'global.adminPartitions.enabled=true' \
+#       --set 'global.adminPartitions.name=hashi' \
+#       --set 'global.acls.manageSystemACLs=true' \
+#       . | tee /dev/stderr |
+#       yq '.spec.template.spec.containers[1].args' | tee /dev/stderr)
+#
+#   local actual=$(echo $flags | jq -r '. | any(contains("-login-partition=hashi"))' | tee /dev/stderr)
+#   [ "${actual}" = 'true' ]
+#
+#   local actual=$(echo $flags | jq -r '. | any(contains("-service-partition=hashi"))' | tee /dev/stderr)
+#   [ "${actual}" = "true" ]
+# }
 
 @test "telemetryCollector/Deployment(V2):  consul-ca-cert volume mount is not set when using externalServers and useSystemRoots" {
   cd `chart_dir`


### PR DESCRIPTION
Changes proposed in this PR:
- This `bats` test is failing because I disabled admin partitions for V2 deployments in a PR merged around the same time.

How I've tested this PR: running test locally

How I expect reviewers to test this PR: 👀 + CI



