### PR TITLE
Fix endpoints controller v2 tests

### DIFF
--- a/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller_test.go
@@ -136,7 +136,7 @@ func TestReconcile_CreateService(t *testing.T) {
 						{
 							VirtualPort: 10001,
 							TargetPort:  "10001",
-							Protocol:    pbcatalog.Protocol_PROTOCOL_UNSPECIFIED,
+							Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
 						},
 						{
 							TargetPort: "mesh",
@@ -250,7 +250,7 @@ func TestReconcile_CreateService(t *testing.T) {
 						{
 							VirtualPort: 10001,
 							TargetPort:  "10001",
-							Protocol:    pbcatalog.Protocol_PROTOCOL_UNSPECIFIED,
+							Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
 						},
 						{
 							TargetPort: "mesh",
@@ -537,6 +537,7 @@ func TestReconcile_CreateService(t *testing.T) {
 						{
 							VirtualPort: 8080,
 							TargetPort:  "my-svc-port",
+							Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
 						},
 						{
 							TargetPort: "mesh",

--- a/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller_test.go
@@ -549,8 +549,8 @@ func TestReconcile_CreateService(t *testing.T) {
 					VirtualIps: []string{"172.18.0.1"},
 				}),
 				Metadata: map[string]string{
-					constants.MetaKeyKubeNS: constants.DefaultConsulNS,
-					metaKeyManagedBy:        constants.ManagedByEndpointsValue,
+					constants.MetaKeyKubeNS:    constants.DefaultConsulNS,
+					constants.MetaKeyManagedBy: constants.ManagedByEndpointsValue,
 				},
 			},
 		},


### PR DESCRIPTION
The missing constant somehow slipped by in CI. Are we not running v2 tests? Fixing first before digging.

Also fixes test that is breaking due to a protocol defaulting fix in Consul merged today.