### PR TITLE
Revert temporary fixes to endpoints v2 tests

### DIFF
--- a/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller_test.go
@@ -212,9 +212,9 @@ func TestReconcile_CreateService(t *testing.T) {
 								AppProtocol: &appProtocolGrpc,
 							},
 							{
-								Name: "other",
-								Port: 10001,
-								//Protocol:   "TCP",
+								Name:       "other",
+								Port:       10001,
+								Protocol:   "TCP",
 								TargetPort: intstr.FromString("10001"),
 								// no app protocol specified
 							},
@@ -248,11 +248,11 @@ func TestReconcile_CreateService(t *testing.T) {
 							TargetPort:  "my-grpc-port",
 							Protocol:    pbcatalog.Protocol_PROTOCOL_GRPC,
 						},
-						//{
-						//	VirtualPort: 10001,
-						//	TargetPort:  "10001",
-						//	Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
-						//},
+						{
+							VirtualPort: 10001,
+							TargetPort:  "10001",
+							Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
+						},
 						{
 							TargetPort: "mesh",
 							Protocol:   pbcatalog.Protocol_PROTOCOL_MESH,
@@ -504,9 +504,9 @@ func TestReconcile_CreateService(t *testing.T) {
 						Ports: []corev1.ServicePort{
 							// Two L4 protocols on one exposed port
 							{
-								Name: "public-tcp",
-								Port: 8080,
-								//Protocol:   "TCP",
+								Name:       "public-tcp",
+								Port:       8080,
+								Protocol:   "TCP",
 								TargetPort: intstr.FromString("my-svc-port"),
 							},
 							{
@@ -535,11 +535,11 @@ func TestReconcile_CreateService(t *testing.T) {
 				},
 				Data: common.ToProtoAny(&pbcatalog.Service{
 					Ports: []*pbcatalog.ServicePort{
-						//{
-						//	VirtualPort: 8080,
-						//	TargetPort:  "my-svc-port",
-						//	Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
-						//},
+						{
+							VirtualPort: 8080,
+							TargetPort:  "my-svc-port",
+							Protocol:    pbcatalog.Protocol_PROTOCOL_TCP,
+						},
 						{
 							TargetPort: "mesh",
 							Protocol:   pbcatalog.Protocol_PROTOCOL_MESH,


### PR DESCRIPTION
These were necessary to get tests to pass during the merge of several PRs across `consul` and `consul-k8s` but are no longer needed.

Changes proposed in this PR:
- Undo test commenting added in https://github.com/hashicorp/consul-k8s/pull/2960

How I've tested this PR: Local + CI

How I expect reviewers to test this PR: 👓


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


