### PR TITLE
Mw/net 5340 add support for explicit upstreams

### DIFF
--- a/control-plane/connect-inject/constants/annotations_and_labels.go
+++ b/control-plane/connect-inject/constants/annotations_and_labels.go
@@ -75,7 +75,7 @@ const (
 
 	// AnnotationUpstreams is a list of upstreams to register with the
 	// proxy in the format of `<service-name>:<local-port>,...`. The
-	// service name should map to a Consul service namd and the local port
+	// service name should map to a Consul service name and the local port
 	// is the local port in the pod that the listener will bind to. It can
 	// be a named port.
 	AnnotationUpstreams = "consul.hashicorp.com/connect-service-upstreams"
@@ -235,7 +235,7 @@ const (
 	ManagedByServiceAccountValue = "consul-k8s-service-account-controller"
 
 	// AnnotationMeshDestinations is a list of upstreams to register with the
-	// proxy. The service name should map to a Consul service namd and the local
+	// proxy. The service name should map to a Consul service name and the local
 	// port is the local port in the pod that the listener will bind to. It can
 	// be a named port.
 	AnnotationMeshDestinations = "consul.hashicorp.com/mesh-service-destinations"

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
@@ -1164,8 +1164,9 @@ func processPreparedQueryUpstream(pod corev1.Pod, rawUpstream string) api.Upstre
 
 // processUnlabeledUpstream processes an upstream in the format:
 // [service-name].[service-namespace].[service-partition]:[port]:[optional datacenter].
+// There is no unlabeled field for peering.
 func (r *Controller) processUnlabeledUpstream(pod corev1.Pod, rawUpstream string) (api.Upstream, error) {
-	var datacenter, svcName, namespace, partition, peer string
+	var datacenter, svcName, namespace, partition string
 	var port int32
 	var upstream api.Upstream
 
@@ -1199,7 +1200,7 @@ func (r *Controller) processUnlabeledUpstream(pod corev1.Pod, rawUpstream string
 		upstream = api.Upstream{
 			DestinationType:      api.UpstreamDestTypeService,
 			DestinationPartition: partition,
-			DestinationPeer:      peer,
+			DestinationPeer:      "",
 			DestinationNamespace: namespace,
 			DestinationName:      svcName,
 			Datacenter:           datacenter,

--- a/control-plane/connect-inject/controllers/pod/pod_controller.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/go-logr/logr"
 	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v1alpha1"
@@ -32,6 +33,10 @@ const (
 	DefaultTelemetryBindSocketDir = "/consul/mesh-inject"
 )
 
+// Controller watches Pod events and converts them to V2 Workloads and HealthStatus.
+// The translation from Pod to Workload is 1:1 and the HealthStatus object is a representation
+// of the Pod's Status field. Controller is also responsible for generating V2 Upstreams resources
+// when not in transparent proxy mode.
 type Controller struct {
 	client.Client
 	// ConsulClientConfig is the config for the Consul API client.
@@ -53,7 +58,7 @@ type Controller struct {
 	TProxyOverwriteProbes bool
 
 	// AuthMethod is the name of the Kubernetes Auth Method that
-	// was used to login with Consul. The Endpoints controller
+	// was used to login with Consul. The pods controller
 	// will delete any tokens associated with this auth method
 	// whenever service instances are deregistered.
 	AuthMethod string
@@ -104,10 +109,10 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 		// TODO: clean up ACL Tokens
 
-		// TODO: delete explicit upstreams
-		//if err := r.deleteUpstreams(ctx, pod); err != nil {
-		//	errs = multierror.Append(errs, err)
-		//}
+		// Delete upstreams, if any exist
+		if err := r.deleteUpstreams(ctx, req.NamespacedName); err != nil {
+			errs = multierror.Append(errs, err)
+		}
 
 		if err := r.deleteProxyConfiguration(ctx, req.NamespacedName); err != nil {
 			errs = multierror.Append(errs, err)
@@ -146,10 +151,10 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			errs = multierror.Append(errs, err)
 		}
 
-		// TODO: create explicit upstreams
-		//if err := r.writeUpstreams(ctx, pod); err != nil {
-		//	errs = multierror.Append(errs, err)
-		//}
+		// Create explicit upstreams (if any exist)
+		if err := r.writeUpstreams(ctx, pod); err != nil {
+			errs = multierror.Append(errs, err)
+		}
 
 		if err := r.writeHealthStatus(ctx, pod); err != nil {
 			// Technically this is not needed, but keeping in case this gets refactored in
@@ -435,10 +440,249 @@ func (r *Controller) writeHealthStatus(ctx context.Context, pod corev1.Pod) erro
 // has been configured with and will only delete tokens for the provided podName.
 // func (r *Controller) deleteACLTokensForWorkload(apiClient *api.Client, svc *api.AgentService, k8sNS, podName string) error {
 
-// TODO: add support for explicit upstreams
-//func (r *Controller) writeUpstreams(pod corev1.Pod) error
+// writeUpstreams will write explicit upstreams if pod annotations exist.
+func (r *Controller) writeUpstreams(ctx context.Context, pod corev1.Pod) error {
+	if _, ok := pod.Annotations[constants.AnnotationMeshDestinations]; !ok {
+		return nil
+	}
 
-//func (r *Controller) deleteUpstreams(pod corev1.Pod) error
+	uss, err := r.processUpstreams(pod)
+	if err != nil {
+		return err
+	}
+
+	data := common.ToProtoAny(uss)
+	req := &pbresource.WriteRequest{
+		Resource: &pbresource.Resource{
+			Id:       getUpstreamsID(pod.GetName(), r.getConsulNamespace(pod.Namespace), r.getPartition()),
+			Metadata: metaFromPod(pod),
+			Data:     data,
+		},
+	}
+	_, err = r.ResourceClient.Write(ctx, req)
+
+	return err
+}
+
+func (r *Controller) deleteUpstreams(ctx context.Context, pod types.NamespacedName) error {
+	req := &pbresource.DeleteRequest{
+		Id: getUpstreamsID(pod.Name, r.getConsulNamespace(pod.Namespace), r.getPartition()),
+	}
+
+	_, err := r.ResourceClient.Delete(ctx, req)
+	return err
+}
+
+// processUpstreams reads the list of upstreams from the Pod annotation and converts them into a list of pbmesh.Upstreams
+// objects.
+func (r *Controller) processUpstreams(pod corev1.Pod) (*pbmesh.Upstreams, error) {
+	upstreams := &pbmesh.Upstreams{}
+	if raw, ok := pod.Annotations[constants.AnnotationMeshDestinations]; ok && raw != "" {
+		upstreams.Workloads = &pbcatalog.WorkloadSelector{
+			Names: []string{pod.Name},
+		}
+
+		for _, raw := range strings.Split(raw, ",") {
+			var upstream *pbmesh.Upstream
+
+			// Determine the type of processing required unlabeled or labeled
+			// [service-port-name].[service-name].[service-namespace].[service-partition]:[port]:[optional datacenter]
+			// or
+			// [service-port-name].port.[service-name].svc.[service-namespace].ns.[service-peer].peer:[port]
+			// [service-port-name].port.[service-name].svc.[service-namespace].ns.[service-partition].ap:[port]
+			// [service-port-name].port.[service-name].svc.[service-namespace].ns.[service-datacenter].dc:[port]
+
+			// Scan the string for the annotation keys.
+			// Even if the first key is missing, and the order is unexpected, we should let the processing
+			// provide us with errors
+			labeledFormat := false
+			keys := []string{"port", "svc", "ns", "ap", "peer", "dc"}
+			for _, v := range keys {
+				if strings.Contains(raw, fmt.Sprintf(".%s.", v)) {
+					labeledFormat = true
+					break
+				}
+			}
+
+			if labeledFormat {
+				var err error
+				upstream, err = r.processLabeledUpstream(pod, raw)
+				if err != nil {
+					return &pbmesh.Upstreams{}, err
+				}
+			} else {
+				upstream = r.processUnlabeledUpstream(pod, raw)
+			}
+
+			upstreams.Upstreams = append(upstreams.Upstreams, upstream)
+		}
+	}
+
+	return upstreams, nil
+}
+
+// processLabeledUpstream processes an upstream in the format:
+// [service-port-name].port.[service-name].svc.[service-namespace].ns.[service-peer].peer:[port]
+// [service-port-name].port.[service-name].svc.[service-namespace].ns.[service-partition].ap:[port]
+// [service-port-name].port.[service-name].svc.[service-namespace].ns.[service-datacenter].dc:[port].
+// peer/ap/dc are mutually exclusive. At minimum service-port-name and service-name are required.
+func (r *Controller) processLabeledUpstream(pod corev1.Pod, rawUpstream string) (*pbmesh.Upstream, error) {
+	parts := strings.SplitN(rawUpstream, ":", 3)
+	var port int32
+	port, _ = common.PortValue(pod, strings.TrimSpace(parts[1]))
+
+	service := parts[0]
+	pieces := strings.Split(service, ".")
+
+	var portName, datacenter, svcName, namespace, partition, peer string
+	if r.EnableConsulNamespaces || r.EnableConsulPartitions {
+		switch len(pieces) {
+		case 8:
+			end := strings.TrimSpace(pieces[7])
+			switch end {
+			case "peer":
+				peer = strings.TrimSpace(pieces[6])
+			case "ap":
+				partition = strings.TrimSpace(pieces[6])
+			case "dc":
+				datacenter = strings.TrimSpace(pieces[6])
+			default:
+				return &pbmesh.Upstream{}, fmt.Errorf("upstream structured incorrectly: %s", rawUpstream)
+			}
+			fallthrough
+		case 6:
+			if strings.TrimSpace(pieces[5]) == "ns" {
+				namespace = strings.TrimSpace(pieces[4])
+			} else {
+				return &pbmesh.Upstream{}, fmt.Errorf("upstream structured incorrectly: %s", rawUpstream)
+			}
+			fallthrough
+		case 4:
+			if strings.TrimSpace(pieces[3]) == "svc" {
+				svcName = strings.TrimSpace(pieces[2])
+			} else {
+				return &pbmesh.Upstream{}, fmt.Errorf("upstream structured incorrectly: %s", rawUpstream)
+			}
+			if strings.TrimSpace(pieces[1]) == "port" {
+				portName = strings.TrimSpace(pieces[0])
+			} else {
+				return &pbmesh.Upstream{}, fmt.Errorf("upstream structured incorrectly: %s", rawUpstream)
+			}
+		default:
+			return &pbmesh.Upstream{}, fmt.Errorf("upstream structured incorrectly: %s", rawUpstream)
+		}
+	} else {
+		switch len(pieces) {
+		case 6:
+			end := strings.TrimSpace(pieces[5])
+			switch end {
+			case "peer":
+				peer = strings.TrimSpace(pieces[4])
+			case "dc":
+				datacenter = strings.TrimSpace(pieces[4])
+			default:
+				return &pbmesh.Upstream{}, fmt.Errorf("upstream structured incorrectly: %s", rawUpstream)
+			}
+			fallthrough
+		case 4:
+			if strings.TrimSpace(pieces[3]) == "svc" {
+				svcName = strings.TrimSpace(pieces[2])
+			} else {
+				return &pbmesh.Upstream{}, fmt.Errorf("upstream structured incorrectly: %s", rawUpstream)
+			}
+			if strings.TrimSpace(pieces[1]) == "port" {
+				portName = strings.TrimSpace(pieces[0])
+			} else {
+				return &pbmesh.Upstream{}, fmt.Errorf("upstream structured incorrectly: %s", rawUpstream)
+			}
+		default:
+			return &pbmesh.Upstream{}, fmt.Errorf("upstream structured incorrectly: %s", rawUpstream)
+		}
+	}
+
+	var upstream pbmesh.Upstream
+	if port > 0 {
+		upstream = pbmesh.Upstream{
+			DestinationRef: &pbresource.Reference{
+				Tenancy: &pbresource.Tenancy{
+					Partition: partition,
+					Namespace: namespace,
+					PeerName:  peer,
+				},
+				Name: svcName,
+			},
+			DestinationPort: portName,
+			Datacenter:      datacenter,
+			ListenAddr: &pbmesh.Upstream_IpPort{
+				IpPort: &pbmesh.IPPortAddress{
+					Port: uint32(port),
+				},
+			},
+		}
+	}
+
+	return &upstream, nil
+}
+
+// processUnlabeledUpstream processes an upstream in the format:
+// [service-port-name].[service-name].[service-namespace].[service-partition]:[port]:[optional datacenter].
+// There is no unlabeled field for peering.
+func (r *Controller) processUnlabeledUpstream(pod corev1.Pod, rawUpstream string) *pbmesh.Upstream {
+	var portName, datacenter, svcName, namespace, partition, peer string
+	var port int32
+	var upstream pbmesh.Upstream
+
+	parts := strings.SplitN(rawUpstream, ":", 3)
+
+	port, _ = common.PortValue(pod, strings.TrimSpace(parts[1]))
+
+	// If Consul Namespaces or Admin Partitions are enabled, attempt to parse the
+	// upstream for a namespace.
+	if r.EnableConsulNamespaces || r.EnableConsulPartitions {
+		pieces := strings.SplitN(parts[0], ".", 4)
+		switch len(pieces) {
+		case 4:
+			partition = strings.TrimSpace(pieces[3])
+			fallthrough
+		case 3:
+			namespace = strings.TrimSpace(pieces[2])
+			fallthrough
+		default:
+			svcName = strings.TrimSpace(pieces[1])
+			portName = strings.TrimSpace(pieces[0])
+		}
+	} else {
+		pieces := strings.SplitN(parts[0], ".", 2)
+		svcName = strings.TrimSpace(pieces[1])
+		portName = strings.TrimSpace(pieces[0])
+	}
+
+	// parse the optional datacenter
+	if len(parts) > 2 {
+		datacenter = strings.TrimSpace(parts[2])
+	}
+
+	if port > 0 {
+		upstream = pbmesh.Upstream{
+			DestinationRef: &pbresource.Reference{
+				Tenancy: &pbresource.Tenancy{
+					Partition: partition,
+					Namespace: namespace,
+					PeerName:  peer,
+				},
+				Name: svcName,
+			},
+			DestinationPort: portName,
+			Datacenter:      datacenter,
+			ListenAddr: &pbmesh.Upstream_IpPort{
+				IpPort: &pbmesh.IPPortAddress{
+					Port: uint32(port),
+				},
+			},
+		}
+	}
+	return &upstream
+}
 
 // consulNamespace returns the Consul destination namespace for a provided Kubernetes namespace
 // depending on Consul Namespaces being enabled and the value of namespace mirroring.
@@ -595,6 +839,25 @@ func getHealthStatusID(name, namespace, partition string) *pbresource.ID {
 			Group:        "catalog",
 			GroupVersion: "v1alpha1",
 			Kind:         "HealthStatus",
+		},
+		Tenancy: &pbresource.Tenancy{
+			Partition: partition,
+			Namespace: namespace,
+
+			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
+			// At a future point, this will move out of the Tenancy block.
+			PeerName: constants.DefaultConsulPeer,
+		},
+	}
+}
+
+func getUpstreamsID(name, namespace, partition string) *pbresource.ID {
+	return &pbresource.ID{
+		Name: name,
+		Type: &pbresource.Type{
+			Group:        "mesh",
+			GroupVersion: "v1alpha1",
+			Kind:         "Upstreams",
 		},
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,

--- a/control-plane/connect-inject/controllers/pod/pod_controller.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller.go
@@ -153,6 +153,14 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 		// Create explicit upstreams (if any exist)
 		if err := r.writeUpstreams(ctx, pod); err != nil {
+			// Technically this is not needed, but keeping in case this gets refactored in
+			// a different order
+			if common.ConsulNamespaceIsNotFound(err) {
+				r.Log.Info("Consul namespace not found; re-queueing request",
+					"pod", req.Name, "ns", req.Namespace, "consul-ns",
+					r.getConsulNamespace(req.Namespace), "err", err.Error())
+				return ctrl.Result{Requeue: true}, nil
+			}
 			errs = multierror.Append(errs, err)
 		}
 

--- a/control-plane/connect-inject/controllers/pod/pod_controller_test.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller_test.go
@@ -40,10 +40,9 @@ import (
 const (
 	// TODO: (v2/nitya) Bring back consulLocalityNodeName once node controller is implemented and assertions for
 	// workloads need node names again.
-	nodeName          = "test-node"
-	localityNodeName  = "test-node-w-locality"
-	consulNodeName    = "test-node-virtual"
-	consulNodeAddress = "127.0.0.1"
+	nodeName         = "test-node"
+	localityNodeName = "test-node-w-locality"
+	consulNodeName   = "test-node-virtual"
 )
 
 func TestParseLocality(t *testing.T) {

--- a/control-plane/connect-inject/controllers/pod/pod_controller_test.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller_test.go
@@ -818,30 +818,32 @@ func TestUpstreamsWrite(t *testing.T) {
 				pod1.Annotations[constants.AnnotationMeshDestinations] = "myPort.port.upstream1.svc.ns1.ns.peer1.peer:1234"
 				return pod1
 			},
-			expected: &pbmesh.Upstreams{
-				Workloads: &pbcatalog.WorkloadSelector{
-					Names: []string{podName},
-				},
-				Upstreams: []*pbmesh.Upstream{
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "ns1",
-								PeerName:  "peer1",
-							},
-							Name: "upstream1",
-						},
-						DestinationPort: "myPort",
-						Datacenter:      "",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(1234),
-							},
-						},
-					},
-				},
-			},
+			// TODO: uncomment this and remove expErr when peers is supported
+			//expected: &pbmesh.Upstreams{
+			//	Workloads: &pbcatalog.WorkloadSelector{
+			//		Names: []string{podName},
+			//	},
+			//	Upstreams: []*pbmesh.Upstream{
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "",
+			//					Namespace: "ns1",
+			//					PeerName:  "peer1",
+			//				},
+			//				Name: "upstream1",
+			//			},
+			//			DestinationPort: "myPort",
+			//			Datacenter:      "",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(1234),
+			//				},
+			//			},
+			//		},
+			//	},
+			//},
+			expErr:                  "upstream currently does not support peers: myPort.port.upstream1.svc.ns1.ns.peer1.peer:1234",
 			consulNamespacesEnabled: true,
 			consulPartitionsEnabled: false,
 		},
@@ -1049,30 +1051,32 @@ func TestProcessUpstreams(t *testing.T) {
 				pod1.Annotations[constants.AnnotationMeshDestinations] = "myPort.port.upstream1.svc.dc1.dc:1234"
 				return pod1
 			},
-			expected: &pbmesh.Upstreams{
-				Workloads: &pbcatalog.WorkloadSelector{
-					Names: []string{podName},
-				},
-				Upstreams: []*pbmesh.Upstream{
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "",
-								PeerName:  "",
-							},
-							Name: "upstream1",
-						},
-						DestinationPort: "myPort",
-						Datacenter:      "dc1",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(1234),
-							},
-						},
-					},
-				},
-			},
+			expErr: "upstream currently does not support datacenters: myPort.port.upstream1.svc.dc1.dc:1234",
+			// TODO: uncomment this and remove expErr when datacenters is supported
+			//expected: &pbmesh.Upstreams{
+			//	Workloads: &pbcatalog.WorkloadSelector{
+			//		Names: []string{podName},
+			//	},
+			//	Upstreams: []*pbmesh.Upstream{
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "",
+			//					Namespace: "",
+			//					PeerName:  "",
+			//				},
+			//				Name: "upstream1",
+			//			},
+			//			DestinationPort: "myPort",
+			//			Datacenter:      "dc1",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(1234),
+			//				},
+			//			},
+			//		},
+			//	},
+			//},
 			consulNamespacesEnabled: false,
 			consulPartitionsEnabled: false,
 		},
@@ -1083,30 +1087,32 @@ func TestProcessUpstreams(t *testing.T) {
 				pod1.Annotations[constants.AnnotationMeshDestinations] = "myPort.port.upstream1.svc.peer1.peer:1234"
 				return pod1
 			},
-			expected: &pbmesh.Upstreams{
-				Workloads: &pbcatalog.WorkloadSelector{
-					Names: []string{podName},
-				},
-				Upstreams: []*pbmesh.Upstream{
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "",
-								PeerName:  "peer1",
-							},
-							Name: "upstream1",
-						},
-						DestinationPort: "myPort",
-						Datacenter:      "",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(1234),
-							},
-						},
-					},
-				},
-			},
+			expErr: "upstream currently does not support peers: myPort.port.upstream1.svc.peer1.peer:1234",
+			// TODO: uncomment this and remove expErr when peers is supported
+			//expected: &pbmesh.Upstreams{
+			//	Workloads: &pbcatalog.WorkloadSelector{
+			//		Names: []string{podName},
+			//	},
+			//	Upstreams: []*pbmesh.Upstream{
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "",
+			//					Namespace: "",
+			//					PeerName:  "peer1",
+			//				},
+			//				Name: "upstream1",
+			//			},
+			//			DestinationPort: "myPort",
+			//			Datacenter:      "",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(1234),
+			//				},
+			//			},
+			//		},
+			//	},
+			//},
 			consulNamespacesEnabled: false,
 			consulPartitionsEnabled: false,
 		},
@@ -1117,30 +1123,32 @@ func TestProcessUpstreams(t *testing.T) {
 				pod1.Annotations[constants.AnnotationMeshDestinations] = "myPort.port.upstream1.svc.ns1.ns.peer1.peer:1234"
 				return pod1
 			},
-			expected: &pbmesh.Upstreams{
-				Workloads: &pbcatalog.WorkloadSelector{
-					Names: []string{podName},
-				},
-				Upstreams: []*pbmesh.Upstream{
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "ns1",
-								PeerName:  "peer1",
-							},
-							Name: "upstream1",
-						},
-						DestinationPort: "myPort",
-						Datacenter:      "",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(1234),
-							},
-						},
-					},
-				},
-			},
+			expErr: "upstream currently does not support peers: myPort.port.upstream1.svc.ns1.ns.peer1.peer:1234",
+			// TODO: uncomment this and remove expErr when peers is supported
+			//expected: &pbmesh.Upstreams{
+			//	Workloads: &pbcatalog.WorkloadSelector{
+			//		Names: []string{podName},
+			//	},
+			//	Upstreams: []*pbmesh.Upstream{
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "",
+			//					Namespace: "ns1",
+			//					PeerName:  "peer1",
+			//				},
+			//				Name: "upstream1",
+			//			},
+			//			DestinationPort: "myPort",
+			//			Datacenter:      "",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(1234),
+			//				},
+			//			},
+			//		},
+			//	},
+			//},
 			consulNamespacesEnabled: true,
 			consulPartitionsEnabled: false,
 		},
@@ -1185,30 +1193,32 @@ func TestProcessUpstreams(t *testing.T) {
 				pod1.Annotations[constants.AnnotationMeshDestinations] = "myPort.port.upstream1.svc.ns1.ns.dc1.dc:1234"
 				return pod1
 			},
-			expected: &pbmesh.Upstreams{
-				Workloads: &pbcatalog.WorkloadSelector{
-					Names: []string{podName},
-				},
-				Upstreams: []*pbmesh.Upstream{
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "ns1",
-								PeerName:  "",
-							},
-							Name: "upstream1",
-						},
-						DestinationPort: "myPort",
-						Datacenter:      "dc1",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(1234),
-							},
-						},
-					},
-				},
-			},
+			expErr: "upstream currently does not support datacenters: myPort.port.upstream1.svc.ns1.ns.dc1.dc:1234",
+			// TODO: uncomment this and remove expErr when datacenters is supported
+			//expected: &pbmesh.Upstreams{
+			//	Workloads: &pbcatalog.WorkloadSelector{
+			//		Names: []string{podName},
+			//	},
+			//	Upstreams: []*pbmesh.Upstream{
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "",
+			//					Namespace: "ns1",
+			//					PeerName:  "",
+			//				},
+			//				Name: "upstream1",
+			//			},
+			//			DestinationPort: "myPort",
+			//			Datacenter:      "dc1",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(1234),
+			//				},
+			//			},
+			//		},
+			//	},
+			//},
 			consulNamespacesEnabled: true,
 			consulPartitionsEnabled: false,
 		},
@@ -1219,81 +1229,83 @@ func TestProcessUpstreams(t *testing.T) {
 				pod1.Annotations[constants.AnnotationMeshDestinations] = "myPort.port.upstream1.svc.ns1.ns.dc1.dc:1234, myPort2.port.upstream2.svc:2234, myPort3.port.upstream3.svc.ns1.ns:3234, myPort4.port.upstream4.svc.ns1.ns.peer1.peer:4234"
 				return pod1
 			},
-			expected: &pbmesh.Upstreams{
-				Workloads: &pbcatalog.WorkloadSelector{
-					Names: []string{podName},
-				},
-				Upstreams: []*pbmesh.Upstream{
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "ns1",
-								PeerName:  "",
-							},
-							Name: "upstream1",
-						},
-						DestinationPort: "myPort",
-						Datacenter:      "dc1",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(1234),
-							},
-						},
-					},
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "",
-								PeerName:  "",
-							},
-							Name: "upstream2",
-						},
-						DestinationPort: "myPort2",
-						Datacenter:      "",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(2234),
-							},
-						},
-					},
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "ns1",
-								PeerName:  "",
-							},
-							Name: "upstream3",
-						},
-						DestinationPort: "myPort3",
-						Datacenter:      "",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(3234),
-							},
-						},
-					},
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "ns1",
-								PeerName:  "peer1",
-							},
-							Name: "upstream4",
-						},
-						DestinationPort: "myPort4",
-						Datacenter:      "",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(4234),
-							},
-						},
-					},
-				},
-			},
+			expErr: "upstream currently does not support datacenters: myPort.port.upstream1.svc.ns1.ns.dc1.dc:1234",
+			// TODO: uncomment this and remove expErr when datacenters is supported
+			//expected: &pbmesh.Upstreams{
+			//	Workloads: &pbcatalog.WorkloadSelector{
+			//		Names: []string{podName},
+			//	},
+			//	Upstreams: []*pbmesh.Upstream{
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "",
+			//					Namespace: "ns1",
+			//					PeerName:  "",
+			//				},
+			//				Name: "upstream1",
+			//			},
+			//			DestinationPort: "myPort",
+			//			Datacenter:      "dc1",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(1234),
+			//				},
+			//			},
+			//		},
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "",
+			//					Namespace: "",
+			//					PeerName:  "",
+			//				},
+			//				Name: "upstream2",
+			//			},
+			//			DestinationPort: "myPort2",
+			//			Datacenter:      "",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(2234),
+			//				},
+			//			},
+			//		},
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "",
+			//					Namespace: "ns1",
+			//					PeerName:  "",
+			//				},
+			//				Name: "upstream3",
+			//			},
+			//			DestinationPort: "myPort3",
+			//			Datacenter:      "",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(3234),
+			//				},
+			//			},
+			//		},
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "",
+			//					Namespace: "ns1",
+			//					PeerName:  "peer1",
+			//				},
+			//				Name: "upstream4",
+			//			},
+			//			DestinationPort: "myPort4",
+			//			Datacenter:      "",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(4234),
+			//				},
+			//			},
+			//		},
+			//	},
+			//},
 			consulNamespacesEnabled: true,
 			consulPartitionsEnabled: true,
 		},
@@ -1304,37 +1316,38 @@ func TestProcessUpstreams(t *testing.T) {
 				pod1.Annotations[constants.AnnotationMeshDestinations] = "myPort.upstream1:1234:dc1"
 				return pod1
 			},
-			expErr: "",
 			configEntry: func() api.ConfigEntry {
 				ce, _ := api.MakeConfigEntry(api.ProxyDefaults, "global")
 				pd := ce.(*api.ProxyConfigEntry)
 				pd.MeshGateway.Mode = "remote"
 				return pd
 			},
-			expected: &pbmesh.Upstreams{
-				Workloads: &pbcatalog.WorkloadSelector{
-					Names: []string{podName},
-				},
-				Upstreams: []*pbmesh.Upstream{
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "",
-								PeerName:  "",
-							},
-							Name: "upstream1",
-						},
-						DestinationPort: "myPort",
-						Datacenter:      "dc1",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(1234),
-							},
-						},
-					},
-				},
-			},
+			expErr: "upstream currently does not support datacenters: myPort.upstream1:1234:dc1",
+			// TODO: uncomment this and remove expErr when datacenters is supported
+			//expected: &pbmesh.Upstreams{
+			//	Workloads: &pbcatalog.WorkloadSelector{
+			//		Names: []string{podName},
+			//	},
+			//	Upstreams: []*pbmesh.Upstream{
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "",
+			//					Namespace: "",
+			//					PeerName:  "",
+			//				},
+			//				Name: "upstream1",
+			//			},
+			//			DestinationPort: "myPort",
+			//			Datacenter:      "dc1",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(1234),
+			//				},
+			//			},
+			//		},
+			//	},
+			//},
 			consulUnavailable:       true,
 			consulNamespacesEnabled: false,
 			consulPartitionsEnabled: false,
@@ -1453,10 +1466,10 @@ func TestProcessUpstreams(t *testing.T) {
 			name: "error labeled annotated upstream error: wrong ordering for port and svc with namespace partition disabled",
 			pod: func() *corev1.Pod {
 				pod1 := createPod(podName, "1.2.3.4", "foo", true, true)
-				pod1.Annotations[constants.AnnotationMeshDestinations] = "upstream1.svc.myPort.port.dc1.dc:1234"
+				pod1.Annotations[constants.AnnotationMeshDestinations] = "upstream1.svc.myPort.port:1234"
 				return pod1
 			},
-			expErr:                  "upstream structured incorrectly: upstream1.svc.myPort.port.dc1.dc:1234",
+			expErr:                  "upstream structured incorrectly: upstream1.svc.myPort.port:1234",
 			consulNamespacesEnabled: false,
 			consulPartitionsEnabled: false,
 		},
@@ -1475,10 +1488,10 @@ func TestProcessUpstreams(t *testing.T) {
 			name: "error labeled annotated upstream error: incorrect key name namespace partition disabled",
 			pod: func() *corev1.Pod {
 				pod1 := createPod(podName, "1.2.3.4", "foo", true, true)
-				pod1.Annotations[constants.AnnotationMeshDestinations] = "myPort.portage.upstream1.svc.dc1.dc:1234"
+				pod1.Annotations[constants.AnnotationMeshDestinations] = "myPort.portage.upstream1.svc:1234"
 				return pod1
 			},
-			expErr:                  "upstream structured incorrectly: myPort.portage.upstream1.svc.dc1.dc:1234",
+			expErr:                  "upstream structured incorrectly: myPort.portage.upstream1.svc:1234",
 			consulNamespacesEnabled: false,
 			consulPartitionsEnabled: false,
 		},
@@ -1648,64 +1661,66 @@ func TestProcessUpstreams(t *testing.T) {
 				pd.MeshGateway.Mode = "remote"
 				return pd
 			},
-			expected: &pbmesh.Upstreams{
-				Workloads: &pbcatalog.WorkloadSelector{
-					Names: []string{podName},
-				},
-				Upstreams: []*pbmesh.Upstream{
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "",
-								PeerName:  "",
-							},
-							Name: "upstream1",
-						},
-						DestinationPort: "myPort",
-						Datacenter:      "",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(1234),
-							},
-						},
-					},
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "bar",
-								PeerName:  "",
-							},
-							Name: "upstream2",
-						},
-						DestinationPort: "myPort2",
-						Datacenter:      "",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(2234),
-							},
-						},
-					},
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "baz",
-								Namespace: "foo",
-								PeerName:  "",
-							},
-							Name: "upstream3",
-						},
-						DestinationPort: "myPort3",
-						Datacenter:      "dc2",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(3234),
-							},
-						},
-					},
-				},
-			},
+			expErr: "upstream currently does not support datacenters:  myPort3.upstream3.foo.baz:3234:dc2",
+			// TODO: uncomment this and remove expErr when datacenters is supported
+			//expected: &pbmesh.Upstreams{
+			//	Workloads: &pbcatalog.WorkloadSelector{
+			//		Names: []string{podName},
+			//	},
+			//	Upstreams: []*pbmesh.Upstream{
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "",
+			//					Namespace: "",
+			//					PeerName:  "",
+			//				},
+			//				Name: "upstream1",
+			//			},
+			//			DestinationPort: "myPort",
+			//			Datacenter:      "",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(1234),
+			//				},
+			//			},
+			//		},
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "",
+			//					Namespace: "bar",
+			//					PeerName:  "",
+			//				},
+			//				Name: "upstream2",
+			//			},
+			//			DestinationPort: "myPort2",
+			//			Datacenter:      "",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(2234),
+			//				},
+			//			},
+			//		},
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "baz",
+			//					Namespace: "foo",
+			//					PeerName:  "",
+			//				},
+			//				Name: "upstream3",
+			//			},
+			//			DestinationPort: "myPort3",
+			//			Datacenter:      "dc2",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(3234),
+			//				},
+			//			},
+			//		},
+			//	},
+			//},
 			consulNamespacesEnabled: true,
 			consulPartitionsEnabled: true,
 		},
@@ -1722,64 +1737,66 @@ func TestProcessUpstreams(t *testing.T) {
 				pd.MeshGateway.Mode = "remote"
 				return pd
 			},
-			expected: &pbmesh.Upstreams{
-				Workloads: &pbcatalog.WorkloadSelector{
-					Names: []string{podName},
-				},
-				Upstreams: []*pbmesh.Upstream{
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "",
-								PeerName:  "",
-							},
-							Name: "upstream1",
-						},
-						DestinationPort: "myPort",
-						Datacenter:      "",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(1234),
-							},
-						},
-					},
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "bar",
-								PeerName:  "",
-							},
-							Name: "upstream2",
-						},
-						DestinationPort: "myPort2",
-						Datacenter:      "",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(2234),
-							},
-						},
-					},
-					{
-						DestinationRef: &pbresource.Reference{
-							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "foo",
-								PeerName:  "",
-							},
-							Name: "upstream3",
-						},
-						DestinationPort: "myPort3",
-						Datacenter:      "dc2",
-						ListenAddr: &pbmesh.Upstream_IpPort{
-							IpPort: &pbmesh.IPPortAddress{
-								Port: uint32(3234),
-							},
-						},
-					},
-				},
-			},
+			expErr: "upstream currently does not support datacenters:  myPort3.upstream3.foo:3234:dc2",
+			// TODO: uncomment this and remove expErr when datacenters is supported
+			//expected: &pbmesh.Upstreams{
+			//	Workloads: &pbcatalog.WorkloadSelector{
+			//		Names: []string{podName},
+			//	},
+			//	Upstreams: []*pbmesh.Upstream{
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "",
+			//					Namespace: "",
+			//					PeerName:  "",
+			//				},
+			//				Name: "upstream1",
+			//			},
+			//			DestinationPort: "myPort",
+			//			Datacenter:      "",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(1234),
+			//				},
+			//			},
+			//		},
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "",
+			//					Namespace: "bar",
+			//					PeerName:  "",
+			//				},
+			//				Name: "upstream2",
+			//			},
+			//			DestinationPort: "myPort2",
+			//			Datacenter:      "",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(2234),
+			//				},
+			//			},
+			//		},
+			//		{
+			//			DestinationRef: &pbresource.Reference{
+			//				Tenancy: &pbresource.Tenancy{
+			//					Partition: "",
+			//					Namespace: "foo",
+			//					PeerName:  "",
+			//				},
+			//				Name: "upstream3",
+			//			},
+			//			DestinationPort: "myPort3",
+			//			Datacenter:      "dc2",
+			//			ListenAddr: &pbmesh.Upstream_IpPort{
+			//				IpPort: &pbmesh.IPPortAddress{
+			//					Port: uint32(3234),
+			//				},
+			//			},
+			//		},
+			//	},
+			//},
 			consulNamespacesEnabled: true,
 		},
 	}

--- a/control-plane/connect-inject/controllers/pod/pod_controller_test.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller_test.go
@@ -772,8 +772,6 @@ func TestUpstreamsWrite(t *testing.T) {
 		pod                     func() *corev1.Pod
 		expected                *pbmesh.Upstreams
 		expErr                  string
-		configEntry             func() api.ConfigEntry
-		consulUnavailable       bool
 		consulNamespacesEnabled bool
 		consulPartitionsEnabled bool
 	}{
@@ -791,10 +789,11 @@ func TestUpstreamsWrite(t *testing.T) {
 				Upstreams: []*pbmesh.Upstream{
 					{
 						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
 							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "",
-								PeerName:  "",
+								Partition: getDefaultConsulPartition(""),
+								Namespace: getDefaultConsulNamespace(""),
+								PeerName:  getDefaultConsulPeer(""),
 							},
 							Name: "upstream1",
 						},
@@ -803,6 +802,7 @@ func TestUpstreamsWrite(t *testing.T) {
 						ListenAddr: &pbmesh.Upstream_IpPort{
 							IpPort: &pbmesh.IPPortAddress{
 								Port: uint32(1234),
+								Ip:   consulNodeAddress,
 							},
 						},
 					},
@@ -818,6 +818,7 @@ func TestUpstreamsWrite(t *testing.T) {
 				pod1.Annotations[constants.AnnotationMeshDestinations] = "myPort.port.upstream1.svc.ns1.ns.peer1.peer:1234"
 				return pod1
 			},
+			expErr: "error processing upstream annotations: upstream currently does not support peers: myPort.port.upstream1.svc.ns1.ns.peer1.peer:1234",
 			// TODO: uncomment this and remove expErr when peers is supported
 			//expected: &pbmesh.Upstreams{
 			//	Workloads: &pbcatalog.WorkloadSelector{
@@ -826,8 +827,9 @@ func TestUpstreamsWrite(t *testing.T) {
 			//	Upstreams: []*pbmesh.Upstream{
 			//		{
 			//			DestinationRef: &pbresource.Reference{
+			//              Type: upstreamReferenceType(),
 			//				Tenancy: &pbresource.Tenancy{
-			//					Partition: "",
+			//					Partition: getDefaultConsulPartition(""),
 			//					Namespace: "ns1",
 			//					PeerName:  "peer1",
 			//				},
@@ -838,12 +840,12 @@ func TestUpstreamsWrite(t *testing.T) {
 			//			ListenAddr: &pbmesh.Upstream_IpPort{
 			//				IpPort: &pbmesh.IPPortAddress{
 			//					Port: uint32(1234),
+			//                  Ip:   consulNodeAddress,
 			//				},
 			//			},
 			//		},
 			//	},
 			//},
-			expErr:                  "upstream currently does not support peers: myPort.port.upstream1.svc.ns1.ns.peer1.peer:1234",
 			consulNamespacesEnabled: true,
 			consulPartitionsEnabled: false,
 		},
@@ -861,10 +863,11 @@ func TestUpstreamsWrite(t *testing.T) {
 				Upstreams: []*pbmesh.Upstream{
 					{
 						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
 							Tenancy: &pbresource.Tenancy{
 								Partition: "part1",
 								Namespace: "ns1",
-								PeerName:  "",
+								PeerName:  getDefaultConsulPeer(""),
 							},
 							Name: "upstream1",
 						},
@@ -873,6 +876,7 @@ func TestUpstreamsWrite(t *testing.T) {
 						ListenAddr: &pbmesh.Upstream_IpPort{
 							IpPort: &pbmesh.IPPortAddress{
 								Port: uint32(1234),
+								Ip:   consulNodeAddress,
 							},
 						},
 					},
@@ -888,7 +892,7 @@ func TestUpstreamsWrite(t *testing.T) {
 				pod1.Annotations[constants.AnnotationMeshDestinations] = "myPort.port.upstream1.svc.ns1.ns.part1.err:1234"
 				return pod1
 			},
-			expErr:                  "upstream structured incorrectly: myPort.port.upstream1.svc.ns1.ns.part1.err:1234",
+			expErr:                  "error processing upstream annotations: upstream structured incorrectly: myPort.port.upstream1.svc.ns1.ns.part1.err:1234",
 			consulNamespacesEnabled: true,
 			consulPartitionsEnabled: false,
 		},
@@ -906,10 +910,11 @@ func TestUpstreamsWrite(t *testing.T) {
 				Upstreams: []*pbmesh.Upstream{
 					{
 						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
 							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "",
-								PeerName:  "",
+								Partition: getDefaultConsulPartition(""),
+								Namespace: getDefaultConsulNamespace(""),
+								PeerName:  getDefaultConsulPeer(""),
 							},
 							Name: "upstream",
 						},
@@ -918,6 +923,7 @@ func TestUpstreamsWrite(t *testing.T) {
 						ListenAddr: &pbmesh.Upstream_IpPort{
 							IpPort: &pbmesh.IPPortAddress{
 								Port: uint32(1234),
+								Ip:   consulNodeAddress,
 							},
 						},
 					},
@@ -940,10 +946,11 @@ func TestUpstreamsWrite(t *testing.T) {
 				Upstreams: []*pbmesh.Upstream{
 					{
 						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
 							Tenancy: &pbresource.Tenancy{
 								Partition: "bar",
 								Namespace: "foo",
-								PeerName:  "",
+								PeerName:  getDefaultConsulPeer(""),
 							},
 							Name: "upstream",
 						},
@@ -952,6 +959,7 @@ func TestUpstreamsWrite(t *testing.T) {
 						ListenAddr: &pbmesh.Upstream_IpPort{
 							IpPort: &pbmesh.IPPortAddress{
 								Port: uint32(1234),
+								Ip:   consulNodeAddress,
 							},
 						},
 					},
@@ -1024,10 +1032,11 @@ func TestProcessUpstreams(t *testing.T) {
 				Upstreams: []*pbmesh.Upstream{
 					{
 						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
 							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "",
-								PeerName:  "",
+								Partition: getDefaultConsulPartition(""),
+								Namespace: getDefaultConsulNamespace(""),
+								PeerName:  getDefaultConsulPeer(""),
 							},
 							Name: "upstream1",
 						},
@@ -1036,6 +1045,7 @@ func TestProcessUpstreams(t *testing.T) {
 						ListenAddr: &pbmesh.Upstream_IpPort{
 							IpPort: &pbmesh.IPPortAddress{
 								Port: uint32(1234),
+								Ip:   consulNodeAddress,
 							},
 						},
 					},
@@ -1060,10 +1070,11 @@ func TestProcessUpstreams(t *testing.T) {
 			//	Upstreams: []*pbmesh.Upstream{
 			//		{
 			//			DestinationRef: &pbresource.Reference{
+			//				Type: upstreamReferenceType(),
 			//				Tenancy: &pbresource.Tenancy{
-			//					Partition: "",
-			//					Namespace: "",
-			//					PeerName:  "",
+			//					Partition: getDefaultConsulPartition(""),
+			//					Namespace: getDefaultConsulNamespace(""),
+			//					PeerName: getDefaultConsulPeer(""),
 			//				},
 			//				Name: "upstream1",
 			//			},
@@ -1072,6 +1083,7 @@ func TestProcessUpstreams(t *testing.T) {
 			//			ListenAddr: &pbmesh.Upstream_IpPort{
 			//				IpPort: &pbmesh.IPPortAddress{
 			//					Port: uint32(1234),
+			//                  Ip:   consulNodeAddress,
 			//				},
 			//			},
 			//		},
@@ -1096,9 +1108,10 @@ func TestProcessUpstreams(t *testing.T) {
 			//	Upstreams: []*pbmesh.Upstream{
 			//		{
 			//			DestinationRef: &pbresource.Reference{
+			//              Type: upstreamReferenceType(),
 			//				Tenancy: &pbresource.Tenancy{
-			//					Partition: "",
-			//					Namespace: "",
+			//					Partition: getDefaultConsulPartition(""),
+			//					Namespace: getDefaultConsulNamespace(""),
 			//					PeerName:  "peer1",
 			//				},
 			//				Name: "upstream1",
@@ -1108,6 +1121,7 @@ func TestProcessUpstreams(t *testing.T) {
 			//			ListenAddr: &pbmesh.Upstream_IpPort{
 			//				IpPort: &pbmesh.IPPortAddress{
 			//					Port: uint32(1234),
+			//                  Ip:   consulNodeAddress,
 			//				},
 			//			},
 			//		},
@@ -1132,8 +1146,9 @@ func TestProcessUpstreams(t *testing.T) {
 			//	Upstreams: []*pbmesh.Upstream{
 			//		{
 			//			DestinationRef: &pbresource.Reference{
+			// 			    Type: upstreamReferenceType(),
 			//				Tenancy: &pbresource.Tenancy{
-			//					Partition: "",
+			//					Partition: getDefaultConsulPartition(""),
 			//					Namespace: "ns1",
 			//					PeerName:  "peer1",
 			//				},
@@ -1144,6 +1159,7 @@ func TestProcessUpstreams(t *testing.T) {
 			//			ListenAddr: &pbmesh.Upstream_IpPort{
 			//				IpPort: &pbmesh.IPPortAddress{
 			//					Port: uint32(1234),
+			//                  Ip:   consulNodeAddress,
 			//				},
 			//			},
 			//		},
@@ -1166,10 +1182,11 @@ func TestProcessUpstreams(t *testing.T) {
 				Upstreams: []*pbmesh.Upstream{
 					{
 						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
 							Tenancy: &pbresource.Tenancy{
 								Partition: "part1",
 								Namespace: "ns1",
-								PeerName:  "",
+								PeerName:  getDefaultConsulPeer(""),
 							},
 							Name: "upstream1",
 						},
@@ -1178,6 +1195,7 @@ func TestProcessUpstreams(t *testing.T) {
 						ListenAddr: &pbmesh.Upstream_IpPort{
 							IpPort: &pbmesh.IPPortAddress{
 								Port: uint32(1234),
+								Ip:   consulNodeAddress,
 							},
 						},
 					},
@@ -1202,10 +1220,11 @@ func TestProcessUpstreams(t *testing.T) {
 			//	Upstreams: []*pbmesh.Upstream{
 			//		{
 			//			DestinationRef: &pbresource.Reference{
+			//              Type: upstreamReferenceType(),
 			//				Tenancy: &pbresource.Tenancy{
-			//					Partition: "",
+			//					Partition: getDefaultConsulPartition(""),
 			//					Namespace: "ns1",
-			//					PeerName:  "",
+			//					PeerName: getDefaultConsulPeer(""),
 			//				},
 			//				Name: "upstream1",
 			//			},
@@ -1214,6 +1233,7 @@ func TestProcessUpstreams(t *testing.T) {
 			//			ListenAddr: &pbmesh.Upstream_IpPort{
 			//				IpPort: &pbmesh.IPPortAddress{
 			//					Port: uint32(1234),
+			//                  Ip:   consulNodeAddress,
 			//				},
 			//			},
 			//		},
@@ -1224,6 +1244,80 @@ func TestProcessUpstreams(t *testing.T) {
 		},
 		{
 			name: "labeled multiple annotated upstreams",
+			pod: func() *corev1.Pod {
+				pod1 := createPod(podName, "1.2.3.4", "foo", true, true)
+				pod1.Annotations[constants.AnnotationMeshDestinations] = "myPort.port.upstream1.svc.ns1.ns:1234, myPort2.port.upstream2.svc:2234, myPort4.port.upstream4.svc.ns1.ns.ap1.ap:4234"
+				return pod1
+			},
+			expected: &pbmesh.Upstreams{
+				Workloads: &pbcatalog.WorkloadSelector{
+					Names: []string{podName},
+				},
+				Upstreams: []*pbmesh.Upstream{
+					{
+						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
+							Tenancy: &pbresource.Tenancy{
+								Partition: getDefaultConsulPartition(""),
+								Namespace: "ns1",
+								PeerName:  getDefaultConsulPeer(""),
+							},
+							Name: "upstream1",
+						},
+						DestinationPort: "myPort",
+						Datacenter:      "",
+						ListenAddr: &pbmesh.Upstream_IpPort{
+							IpPort: &pbmesh.IPPortAddress{
+								Port: uint32(1234),
+								Ip:   consulNodeAddress,
+							},
+						},
+					},
+					{
+						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
+							Tenancy: &pbresource.Tenancy{
+								Partition: getDefaultConsulPartition(""),
+								Namespace: getDefaultConsulNamespace(""),
+								PeerName:  getDefaultConsulPeer(""),
+							},
+							Name: "upstream2",
+						},
+						DestinationPort: "myPort2",
+						Datacenter:      "",
+						ListenAddr: &pbmesh.Upstream_IpPort{
+							IpPort: &pbmesh.IPPortAddress{
+								Port: uint32(2234),
+								Ip:   consulNodeAddress,
+							},
+						},
+					},
+					{
+						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
+							Tenancy: &pbresource.Tenancy{
+								Partition: "ap1",
+								Namespace: "ns1",
+								PeerName:  getDefaultConsulPeer(""),
+							},
+							Name: "upstream4",
+						},
+						DestinationPort: "myPort4",
+						Datacenter:      "",
+						ListenAddr: &pbmesh.Upstream_IpPort{
+							IpPort: &pbmesh.IPPortAddress{
+								Port: uint32(4234),
+								Ip:   consulNodeAddress,
+							},
+						},
+					},
+				},
+			},
+			consulNamespacesEnabled: true,
+			consulPartitionsEnabled: true,
+		},
+		{
+			name: "labeled multiple annotated upstreams with dcs and peers",
 			pod: func() *corev1.Pod {
 				pod1 := createPod(podName, "1.2.3.4", "foo", true, true)
 				pod1.Annotations[constants.AnnotationMeshDestinations] = "myPort.port.upstream1.svc.ns1.ns.dc1.dc:1234, myPort2.port.upstream2.svc:2234, myPort3.port.upstream3.svc.ns1.ns:3234, myPort4.port.upstream4.svc.ns1.ns.peer1.peer:4234"
@@ -1238,10 +1332,11 @@ func TestProcessUpstreams(t *testing.T) {
 			//	Upstreams: []*pbmesh.Upstream{
 			//		{
 			//			DestinationRef: &pbresource.Reference{
+			//              Type: upstreamReferenceType(),
 			//				Tenancy: &pbresource.Tenancy{
-			//					Partition: "",
+			//					Partition: getDefaultConsulPartition(""),
 			//					Namespace: "ns1",
-			//					PeerName:  "",
+			//					PeerName: getDefaultConsulPeer(""),
 			//				},
 			//				Name: "upstream1",
 			//			},
@@ -1250,15 +1345,17 @@ func TestProcessUpstreams(t *testing.T) {
 			//			ListenAddr: &pbmesh.Upstream_IpPort{
 			//				IpPort: &pbmesh.IPPortAddress{
 			//					Port: uint32(1234),
+			//                  Ip:   consulNodeAddress,
 			//				},
 			//			},
 			//		},
 			//		{
 			//			DestinationRef: &pbresource.Reference{
+			//              Type: upstreamReferenceType(),
 			//				Tenancy: &pbresource.Tenancy{
-			//					Partition: "",
-			//					Namespace: "",
-			//					PeerName:  "",
+			//					Partition: getDefaultConsulPartition(""),
+			//					Namespace: getDefaultConsulNamespace(""),
+			//					PeerName: getDefaultConsulPeer(""),
 			//				},
 			//				Name: "upstream2",
 			//			},
@@ -1267,15 +1364,17 @@ func TestProcessUpstreams(t *testing.T) {
 			//			ListenAddr: &pbmesh.Upstream_IpPort{
 			//				IpPort: &pbmesh.IPPortAddress{
 			//					Port: uint32(2234),
+			//                  Ip:   consulNodeAddress,
 			//				},
 			//			},
 			//		},
 			//		{
 			//			DestinationRef: &pbresource.Reference{
+			//              Type: upstreamReferenceType(),
 			//				Tenancy: &pbresource.Tenancy{
-			//					Partition: "",
+			//					Partition: getDefaultConsulPartition(""),
 			//					Namespace: "ns1",
-			//					PeerName:  "",
+			//					PeerName: getDefaultConsulPeer(""),
 			//				},
 			//				Name: "upstream3",
 			//			},
@@ -1284,13 +1383,15 @@ func TestProcessUpstreams(t *testing.T) {
 			//			ListenAddr: &pbmesh.Upstream_IpPort{
 			//				IpPort: &pbmesh.IPPortAddress{
 			//					Port: uint32(3234),
+			//                  Ip:   consulNodeAddress,
 			//				},
 			//			},
 			//		},
 			//		{
 			//			DestinationRef: &pbresource.Reference{
+			//              Type: upstreamReferenceType(),
 			//				Tenancy: &pbresource.Tenancy{
-			//					Partition: "",
+			//					Partition: getDefaultConsulPartition(""),
 			//					Namespace: "ns1",
 			//					PeerName:  "peer1",
 			//				},
@@ -1301,6 +1402,7 @@ func TestProcessUpstreams(t *testing.T) {
 			//			ListenAddr: &pbmesh.Upstream_IpPort{
 			//				IpPort: &pbmesh.IPPortAddress{
 			//					Port: uint32(4234),
+			//                  Ip:   consulNodeAddress,
 			//				},
 			//			},
 			//		},
@@ -1308,49 +1410,6 @@ func TestProcessUpstreams(t *testing.T) {
 			//},
 			consulNamespacesEnabled: true,
 			consulPartitionsEnabled: true,
-		},
-		{
-			name: "labeled when consul is unavailable, we don't return an error",
-			pod: func() *corev1.Pod {
-				pod1 := createPod(podName, "1.2.3.4", "foo", true, true)
-				pod1.Annotations[constants.AnnotationMeshDestinations] = "myPort.upstream1:1234:dc1"
-				return pod1
-			},
-			configEntry: func() api.ConfigEntry {
-				ce, _ := api.MakeConfigEntry(api.ProxyDefaults, "global")
-				pd := ce.(*api.ProxyConfigEntry)
-				pd.MeshGateway.Mode = "remote"
-				return pd
-			},
-			expErr: "upstream currently does not support datacenters: myPort.upstream1:1234:dc1",
-			// TODO: uncomment this and remove expErr when datacenters is supported
-			//expected: &pbmesh.Upstreams{
-			//	Workloads: &pbcatalog.WorkloadSelector{
-			//		Names: []string{podName},
-			//	},
-			//	Upstreams: []*pbmesh.Upstream{
-			//		{
-			//			DestinationRef: &pbresource.Reference{
-			//				Tenancy: &pbresource.Tenancy{
-			//					Partition: "",
-			//					Namespace: "",
-			//					PeerName:  "",
-			//				},
-			//				Name: "upstream1",
-			//			},
-			//			DestinationPort: "myPort",
-			//			Datacenter:      "dc1",
-			//			ListenAddr: &pbmesh.Upstream_IpPort{
-			//				IpPort: &pbmesh.IPPortAddress{
-			//					Port: uint32(1234),
-			//				},
-			//			},
-			//		},
-			//	},
-			//},
-			consulUnavailable:       true,
-			consulNamespacesEnabled: false,
-			consulPartitionsEnabled: false,
 		},
 		{
 			name: "error labeled annotated upstream error: invalid partition/dc/peer",
@@ -1496,6 +1555,80 @@ func TestProcessUpstreams(t *testing.T) {
 			consulPartitionsEnabled: false,
 		},
 		{
+			name: "unlabeled and labeled multiple annotated upstreams",
+			pod: func() *corev1.Pod {
+				pod1 := createPod(podName, "1.2.3.4", "foo", true, true)
+				pod1.Annotations[constants.AnnotationMeshDestinations] = "myPort.port.upstream1.svc.ns1.ns:1234, myPort2.upstream2:2234, myPort4.port.upstream4.svc.ns1.ns.ap1.ap:4234"
+				return pod1
+			},
+			expected: &pbmesh.Upstreams{
+				Workloads: &pbcatalog.WorkloadSelector{
+					Names: []string{podName},
+				},
+				Upstreams: []*pbmesh.Upstream{
+					{
+						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
+							Tenancy: &pbresource.Tenancy{
+								Partition: getDefaultConsulPartition(""),
+								Namespace: "ns1",
+								PeerName:  getDefaultConsulPeer(""),
+							},
+							Name: "upstream1",
+						},
+						DestinationPort: "myPort",
+						Datacenter:      "",
+						ListenAddr: &pbmesh.Upstream_IpPort{
+							IpPort: &pbmesh.IPPortAddress{
+								Port: uint32(1234),
+								Ip:   consulNodeAddress,
+							},
+						},
+					},
+					{
+						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
+							Tenancy: &pbresource.Tenancy{
+								Partition: getDefaultConsulPartition(""),
+								Namespace: getDefaultConsulNamespace(""),
+								PeerName:  getDefaultConsulPeer(""),
+							},
+							Name: "upstream2",
+						},
+						DestinationPort: "myPort2",
+						Datacenter:      "",
+						ListenAddr: &pbmesh.Upstream_IpPort{
+							IpPort: &pbmesh.IPPortAddress{
+								Port: uint32(2234),
+								Ip:   consulNodeAddress,
+							},
+						},
+					},
+					{
+						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
+							Tenancy: &pbresource.Tenancy{
+								Partition: "ap1",
+								Namespace: "ns1",
+								PeerName:  getDefaultConsulPeer(""),
+							},
+							Name: "upstream4",
+						},
+						DestinationPort: "myPort4",
+						Datacenter:      "",
+						ListenAddr: &pbmesh.Upstream_IpPort{
+							IpPort: &pbmesh.IPPortAddress{
+								Port: uint32(4234),
+								Ip:   consulNodeAddress,
+							},
+						},
+					},
+				},
+			},
+			consulNamespacesEnabled: true,
+			consulPartitionsEnabled: true,
+		},
+		{
 			name: "unlabeled single upstream",
 			pod: func() *corev1.Pod {
 				pod1 := createPod(podName, "1.2.3.4", "foo", true, true)
@@ -1509,10 +1642,11 @@ func TestProcessUpstreams(t *testing.T) {
 				Upstreams: []*pbmesh.Upstream{
 					{
 						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
 							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "",
-								PeerName:  "",
+								Partition: getDefaultConsulPartition(""),
+								Namespace: getDefaultConsulNamespace(""),
+								PeerName:  getDefaultConsulPeer(""),
 							},
 							Name: "upstream",
 						},
@@ -1521,6 +1655,7 @@ func TestProcessUpstreams(t *testing.T) {
 						ListenAddr: &pbmesh.Upstream_IpPort{
 							IpPort: &pbmesh.IPPortAddress{
 								Port: uint32(1234),
+								Ip:   consulNodeAddress,
 							},
 						},
 					},
@@ -1543,10 +1678,11 @@ func TestProcessUpstreams(t *testing.T) {
 				Upstreams: []*pbmesh.Upstream{
 					{
 						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
 							Tenancy: &pbresource.Tenancy{
-								Partition: "",
+								Partition: getDefaultConsulPartition(""),
 								Namespace: "foo",
-								PeerName:  "",
+								PeerName:  getDefaultConsulPeer(""),
 							},
 							Name: "upstream",
 						},
@@ -1555,6 +1691,7 @@ func TestProcessUpstreams(t *testing.T) {
 						ListenAddr: &pbmesh.Upstream_IpPort{
 							IpPort: &pbmesh.IPPortAddress{
 								Port: uint32(1234),
+								Ip:   consulNodeAddress,
 							},
 						},
 					},
@@ -1577,10 +1714,11 @@ func TestProcessUpstreams(t *testing.T) {
 				Upstreams: []*pbmesh.Upstream{
 					{
 						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
 							Tenancy: &pbresource.Tenancy{
 								Partition: "bar",
 								Namespace: "foo",
-								PeerName:  "",
+								PeerName:  getDefaultConsulPeer(""),
 							},
 							Name: "upstream",
 						},
@@ -1589,6 +1727,7 @@ func TestProcessUpstreams(t *testing.T) {
 						ListenAddr: &pbmesh.Upstream_IpPort{
 							IpPort: &pbmesh.IPPortAddress{
 								Port: uint32(1234),
+								Ip:   consulNodeAddress,
 							},
 						},
 					},
@@ -1611,10 +1750,11 @@ func TestProcessUpstreams(t *testing.T) {
 				Upstreams: []*pbmesh.Upstream{
 					{
 						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
 							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "",
-								PeerName:  "",
+								Partition: getDefaultConsulPartition(""),
+								Namespace: getDefaultConsulNamespace(""),
+								PeerName:  getDefaultConsulPeer(""),
 							},
 							Name: "upstream1",
 						},
@@ -1623,15 +1763,17 @@ func TestProcessUpstreams(t *testing.T) {
 						ListenAddr: &pbmesh.Upstream_IpPort{
 							IpPort: &pbmesh.IPPortAddress{
 								Port: uint32(1234),
+								Ip:   consulNodeAddress,
 							},
 						},
 					},
 					{
 						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
 							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "",
-								PeerName:  "",
+								Partition: getDefaultConsulPartition(""),
+								Namespace: getDefaultConsulNamespace(""),
+								PeerName:  getDefaultConsulPeer(""),
 							},
 							Name: "upstream2",
 						},
@@ -1640,6 +1782,7 @@ func TestProcessUpstreams(t *testing.T) {
 						ListenAddr: &pbmesh.Upstream_IpPort{
 							IpPort: &pbmesh.IPPortAddress{
 								Port: uint32(2234),
+								Ip:   consulNodeAddress,
 							},
 						},
 					},
@@ -1670,10 +1813,11 @@ func TestProcessUpstreams(t *testing.T) {
 			//	Upstreams: []*pbmesh.Upstream{
 			//		{
 			//			DestinationRef: &pbresource.Reference{
+			//              Type: upstreamReferenceType(),
 			//				Tenancy: &pbresource.Tenancy{
-			//					Partition: "",
-			//					Namespace: "",
-			//					PeerName:  "",
+			//					Partition: getDefaultConsulPartition(""),
+			//					Namespace: getDefaultConsulNamespace(""),
+			//					PeerName: getDefaultConsulPeer(""),
 			//				},
 			//				Name: "upstream1",
 			//			},
@@ -1682,15 +1826,17 @@ func TestProcessUpstreams(t *testing.T) {
 			//			ListenAddr: &pbmesh.Upstream_IpPort{
 			//				IpPort: &pbmesh.IPPortAddress{
 			//					Port: uint32(1234),
+			//                  Ip:   consulNodeAddress,
 			//				},
 			//			},
 			//		},
 			//		{
 			//			DestinationRef: &pbresource.Reference{
+			//              Type: upstreamReferenceType(),
 			//				Tenancy: &pbresource.Tenancy{
-			//					Partition: "",
+			//					Partition: getDefaultConsulPartition(""),
 			//					Namespace: "bar",
-			//					PeerName:  "",
+			//					PeerName: getDefaultConsulPeer(""),
 			//				},
 			//				Name: "upstream2",
 			//			},
@@ -1699,15 +1845,17 @@ func TestProcessUpstreams(t *testing.T) {
 			//			ListenAddr: &pbmesh.Upstream_IpPort{
 			//				IpPort: &pbmesh.IPPortAddress{
 			//					Port: uint32(2234),
+			//                  Ip:   consulNodeAddress,
 			//				},
 			//			},
 			//		},
 			//		{
 			//			DestinationRef: &pbresource.Reference{
+			//              Type: upstreamReferenceType(),
 			//				Tenancy: &pbresource.Tenancy{
 			//					Partition: "baz",
 			//					Namespace: "foo",
-			//					PeerName:  "",
+			//					PeerName: getDefaultConsulPeer(""),
 			//				},
 			//				Name: "upstream3",
 			//			},
@@ -1716,6 +1864,7 @@ func TestProcessUpstreams(t *testing.T) {
 			//			ListenAddr: &pbmesh.Upstream_IpPort{
 			//				IpPort: &pbmesh.IPPortAddress{
 			//					Port: uint32(3234),
+			//                  Ip:   consulNodeAddress,
 			//				},
 			//			},
 			//		},
@@ -1746,10 +1895,11 @@ func TestProcessUpstreams(t *testing.T) {
 			//	Upstreams: []*pbmesh.Upstream{
 			//		{
 			//			DestinationRef: &pbresource.Reference{
+			//              Type: upstreamReferenceType(),
 			//				Tenancy: &pbresource.Tenancy{
-			//					Partition: "",
-			//					Namespace: "",
-			//					PeerName:  "",
+			//					Partition: getDefaultConsulPartition(""),
+			//					Namespace: getDefaultConsulNamespace(""),
+			//					PeerName: getDefaultConsulPeer(""),
 			//				},
 			//				Name: "upstream1",
 			//			},
@@ -1758,15 +1908,17 @@ func TestProcessUpstreams(t *testing.T) {
 			//			ListenAddr: &pbmesh.Upstream_IpPort{
 			//				IpPort: &pbmesh.IPPortAddress{
 			//					Port: uint32(1234),
+			//                  Ip:   consulNodeAddress,
 			//				},
 			//			},
 			//		},
 			//		{
 			//			DestinationRef: &pbresource.Reference{
+			//              Type: upstreamReferenceType(),
 			//				Tenancy: &pbresource.Tenancy{
-			//					Partition: "",
+			//					Partition: getDefaultConsulPartition(""),
 			//					Namespace: "bar",
-			//					PeerName:  "",
+			//					PeerName: getDefaultConsulPeer(""),
 			//				},
 			//				Name: "upstream2",
 			//			},
@@ -1775,15 +1927,17 @@ func TestProcessUpstreams(t *testing.T) {
 			//			ListenAddr: &pbmesh.Upstream_IpPort{
 			//				IpPort: &pbmesh.IPPortAddress{
 			//					Port: uint32(2234),
+			//                  Ip:   consulNodeAddress,
 			//				},
 			//			},
 			//		},
 			//		{
 			//			DestinationRef: &pbresource.Reference{
+			//              Type: upstreamReferenceType(),
 			//				Tenancy: &pbresource.Tenancy{
-			//					Partition: "",
+			//					Partition: getDefaultConsulPartition(""),
 			//					Namespace: "foo",
-			//					PeerName:  "",
+			//					PeerName: getDefaultConsulPeer(""),
 			//				},
 			//				Name: "upstream3",
 			//			},
@@ -1792,6 +1946,7 @@ func TestProcessUpstreams(t *testing.T) {
 			//			ListenAddr: &pbmesh.Upstream_IpPort{
 			//				IpPort: &pbmesh.IPPortAddress{
 			//					Port: uint32(3234),
+			//                  Ip:   consulNodeAddress,
 			//				},
 			//			},
 			//		},
@@ -1856,10 +2011,11 @@ func TestUpstreamsDelete(t *testing.T) {
 				Upstreams: []*pbmesh.Upstream{
 					{
 						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
 							Tenancy: &pbresource.Tenancy{
-								Partition: "",
-								Namespace: "",
-								PeerName:  "",
+								Partition: getDefaultConsulPartition(""),
+								Namespace: getDefaultConsulNamespace(""),
+								PeerName:  getDefaultConsulPeer(""),
 							},
 							Name: "upstream1",
 						},
@@ -1868,6 +2024,7 @@ func TestUpstreamsDelete(t *testing.T) {
 						ListenAddr: &pbmesh.Upstream_IpPort{
 							IpPort: &pbmesh.IPPortAddress{
 								Port: uint32(1234),
+								Ip:   consulNodeAddress,
 							},
 						},
 					},
@@ -2328,10 +2485,11 @@ func TestReconcileUpdatePod(t *testing.T) {
 				Upstreams: []*pbmesh.Upstream{
 					{
 						DestinationRef: &pbresource.Reference{
+							Type: upstreamReferenceType(),
 							Tenancy: &pbresource.Tenancy{
 								Partition: "ap1",
 								Namespace: "ns1",
-								PeerName:  "",
+								PeerName:  getDefaultConsulPeer(""),
 							},
 							Name: "mySVC3",
 						},
@@ -2340,6 +2498,7 @@ func TestReconcileUpdatePod(t *testing.T) {
 						ListenAddr: &pbmesh.Upstream_IpPort{
 							IpPort: &pbmesh.IPPortAddress{
 								Port: uint32(1234),
+								Ip:   consulNodeAddress,
 							},
 						},
 					},
@@ -2669,10 +2828,11 @@ func createUpstreams() *pbmesh.Upstreams {
 		Upstreams: []*pbmesh.Upstream{
 			{
 				DestinationRef: &pbresource.Reference{
+					Type: upstreamReferenceType(),
 					Tenancy: &pbresource.Tenancy{
-						Partition: "",
-						Namespace: "",
-						PeerName:  "",
+						Partition: getDefaultConsulPartition(""),
+						Namespace: getDefaultConsulNamespace(""),
+						PeerName:  getDefaultConsulPeer(""),
 					},
 					Name: "mySVC",
 				},
@@ -2681,6 +2841,7 @@ func createUpstreams() *pbmesh.Upstreams {
 				ListenAddr: &pbmesh.Upstream_IpPort{
 					IpPort: &pbmesh.IPPortAddress{
 						Port: uint32(24601),
+						Ip:   consulNodeAddress,
 					},
 				},
 			},


### PR DESCRIPTION
Changes proposed in this PR:
*Note to Reviewer* I cleaned up the commits, so see each commit for more details in the tab above.

This PR adds support for V2 pod annotations (in both cases the order matters):

## Labeled Style: 

[service-port-name].port.[service-name].svc.[service-namespace].ns.[service-dc].dc:[bind-port]
eg. `myPort.port.mySVC.svc.ns2.ns.dc1.dc:1234`

## Unlabeled Style:

[service-port-name].[service-name].[service-namespace].[service-partition]:[bind-port]:[optional datacenter]
eg. `myPort.mySVC.ns2.dc1:1234`

Since we will not be supporting dcs and peers at first in the annotations, there is a final commit that addresses this and adds errors if those keys are used.

How I've tested this PR:
- unit and integration tests

How I expect reviewers to test this PR:
👀 


Checklist:
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


