### PR TITLE
[NET-5674] v2: Conditional target port when numeric in k8s

### DIFF
--- a/acceptance/tests/fixtures/bases/v2-multiport-app/deployment.yaml
+++ b/acceptance/tests/fixtures/bases/v2-multiport-app/deployment.yaml
@@ -56,6 +56,8 @@ spec:
             - -listen=:9090
           ports:
             - containerPort: 9090
+              # This name is meant to be used alongside the _numeric_ K8s service target port
+              # to verify that we can still route traffic to the named port when there's a mismatch.
               name: admin
 # TODO: (v2/nitya) add these probes back when expose paths and L7 are supported.
 #          livenessProbe:

--- a/acceptance/tests/fixtures/bases/v2-multiport-app/service.yaml
+++ b/acceptance/tests/fixtures/bases/v2-multiport-app/service.yaml
@@ -11,8 +11,8 @@ spec:
   ports:
     - name: web
       port: 8080
-      # TODO: (v2/nitya) ensure this works with numeric target ports also once support for that is merged.
       targetPort: web
     - name: admin
       port: 9090
-      targetPort: admin
+      # Test with a mix of named and numeric target ports.
+      targetPort: 9090

--- a/control-plane/connect-inject/common/common.go
+++ b/control-plane/connect-inject/common/common.go
@@ -184,6 +184,9 @@ func PortValueFromIntOrString(pod corev1.Pod, port intstr.IntOrString) (uint32, 
 // HasBeenMeshInjected checks the value of the status annotation and returns true if the Pod has been injected.
 // Does not apply to V1 pods, which use a different key (`constants.KeyInjectStatus`).
 func HasBeenMeshInjected(pod corev1.Pod) bool {
+	if pod.Annotations == nil {
+		return false
+	}
 	if anno, ok := pod.Annotations[constants.KeyMeshInjectStatus]; ok && anno == constants.Injected {
 		return true
 	}

--- a/control-plane/connect-inject/common/common_test.go
+++ b/control-plane/connect-inject/common/common_test.go
@@ -457,6 +457,17 @@ func TestHasBeenMeshInjected(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "Pod with nil annotations",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: metav1.NamespaceDefault,
+					Labels:    map[string]string{},
+				},
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
When choosing a Consul service TargetPort (name) in the v2 Endpoints Controller, attempt to find the best match among endpoint container ports when the K8s service target port value is a number.

This bridges an existing gap between Consul (which always expects a Workload port to be named), and K8s (where container ports need not be named, and names are ignored when the K8s service targets by number).

This change will be mostly reverted in a future release once Consul's v2 data model allows for target ports to be a name or number in alignment w/ K8s behavior: [NET-5585](https://hashicorp.atlassian.net/browse/NET-5585)

Changes proposed in this PR:
- Conditionally choose Consul target port based on container port names when K8s target port is numeric.
- Small `nil` safety check for mesh-inject detection.

How I've tested this PR:
* Added unit tests ✅ 
* Run new v2 mesh acceptance test w/ numeric target ports to verify bug and fix ✅ 

How I expect reviewers to test this PR: 👀 


Checklist:
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 




[NET-5585]: https://hashicorp.atlassian.net/browse/NET-5585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ