### PR TITLE
[NET-5682] Disable flaky Vault namespace test

### DIFF
--- a/acceptance/tests/vault/vault_namespaces_test.go
+++ b/acceptance/tests/vault/vault_namespaces_test.go
@@ -25,6 +25,8 @@ import (
 // It then configures Consul to use vault as the backend and checks that it works
 // with the vault namespace. Namespace is added in this via global.secretsBackend.vault.vaultNamespace.
 func TestVault_VaultNamespace(t *testing.T) {
+	t.Skipf("TODO(flaky): NET-5682")
+
 	cfg := suite.Config()
 	ctx := suite.Environment().DefaultContext(t)
 	ns := ctx.KubectlOptions(t).Namespace


### PR DESCRIPTION
This test has flaked consistently in the past few weeks. We need to figure out why and fix it before re-enabling.


