### PR TITLE
Bump all versions to v2beta1 and re-use types from proto-public

### DIFF
--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/consul-k8s/control-plane
 // TODO: remove these when the SDK is released for Consul 1.17 and coinciding patch releases
 replace (
 	// This replace directive is needed because `api` requires 0.4.1 of proto-public but we need an unreleased version
-	github.com/hashicorp/consul/proto-public v0.4.1 => github.com/hashicorp/consul/proto-public v0.1.2-0.20230921190229-d8ac6ee34f5e
+	github.com/hashicorp/consul/proto-public v0.4.1 => github.com/hashicorp/consul/proto-public v0.1.2-0.20230922204015-ac9209d8fba9
 	// This replace directive is needed because `api` requires 0.14.1 of `sdk` but we need an unreleased version
 	github.com/hashicorp/consul/sdk v0.14.1 => github.com/hashicorp/consul/sdk v0.4.1-0.20230911164019-a69e901660bd
 )

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -265,8 +265,8 @@ github.com/hashicorp/consul-server-connection-manager v0.1.4 h1:wrcSRV6WGXFBNpNb
 github.com/hashicorp/consul-server-connection-manager v0.1.4/go.mod h1:LMqHkALoLP0HUQKOG21xXYr0YPUayIQIHNTlmxG100E=
 github.com/hashicorp/consul/api v1.10.1-0.20230914174054-e5808d85f751 h1:LnzgDq4e7ZfM1+XS6S21B9taQrbfdydXenL1xHyG1PQ=
 github.com/hashicorp/consul/api v1.10.1-0.20230914174054-e5808d85f751/go.mod h1:/Fz5sgOC0a5XY0BmPGj7aDSZRNgySLm02lV4xkU4DS4=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20230921190229-d8ac6ee34f5e h1:DY0NJAjjFze8PxZjTsVYLCrNBxTZKqy21MY6LDfBvig=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20230921190229-d8ac6ee34f5e/go.mod h1:KAOxsaELPpA7JX10kMeygAskAqsQnu3SPgeruMhYZMU=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20230922204015-ac9209d8fba9 h1:3Xux09euVvBRlu66yJaPVasZf+OxFUlmCBzaigHwtEs=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20230922204015-ac9209d8fba9/go.mod h1:KAOxsaELPpA7JX10kMeygAskAqsQnu3SPgeruMhYZMU=
 github.com/hashicorp/consul/sdk v0.4.1-0.20230911164019-a69e901660bd h1:tRrSgVY71Jl6T2lJUokMLj3T1MO9uiSvW0CieBkjTvo=
 github.com/hashicorp/consul/sdk v0.4.1-0.20230911164019-a69e901660bd/go.mod h1:vFt03juSzocLRFo59NkeQHHmQa6+g7oU0pfzdI1mUhg=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
Changes proposed in this PR:
- Once https://github.com/hashicorp/consul/pull/18930 gets merged, we need to update k8s to use latest versions
- With https://github.com/hashicorp/consul/pull/18935, we can re-use type definitions from the `proto-public` module

How I've tested this PR:

Ran unit tests locally with the consul binary built from ☝️ PRs. Note the pipeline tests will fail because those are not merged yet.

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


