### PR TITLE
add health status syncing check in acceptance test

### DIFF
--- a/acceptance/tests-v2/mesh/mesh_inject_test.go
+++ b/acceptance/tests-v2/mesh/mesh_inject_test.go
@@ -38,7 +38,7 @@ func TestMeshInject_MultiportService(t *testing.T) {
 
 			helmValues := map[string]string{
 				"global.image":                "ndhanushkodi/consul-dev:multiport37",
-				"global.imageK8S":             "ndhanushkodi/consul-k8s-dev:multiport23",
+				"global.imageK8S":             "ndhanushkodi/consul-k8s-dev:multiport25",
 				"global.imageConsulDataplane": "hashicorppreview/consul-dataplane:1.3-dev",
 				"global.experiments[0]":       "resource-apis",
 				// The UI is not supported for v2 in 1.17, so for now it must be disabled.

--- a/acceptance/tests-v2/mesh/mesh_inject_test.go
+++ b/acceptance/tests-v2/mesh/mesh_inject_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
 )
 
+const multiport = "multiport"
+
 // Test that mesh sidecar proxies work for an application with multiple ports. The multiport application is a Pod listening on
 // two ports. This tests inbound connections to each port of the multiport app, and outbound connections from the
 // multiport app to static-server.
@@ -35,8 +37,8 @@ func TestMeshInject_MultiportService(t *testing.T) {
 			ctx := suite.Environment().DefaultContext(t)
 
 			helmValues := map[string]string{
-				"global.image":                "ndhanushkodi/consul-dev:multiport36",
-				"global.imageK8S":             "ndhanushkodi/consul-k8s-dev:multiport20",
+				"global.image":                "ndhanushkodi/consul-dev:multiport37",
+				"global.imageK8S":             "ndhanushkodi/consul-k8s-dev:multiport23",
 				"global.imageConsulDataplane": "hashicorppreview/consul-dataplane:1.3-dev",
 				"global.experiments[0]":       "resource-apis",
 				// The UI is not supported for v2 in 1.17, so for now it must be disabled.
@@ -79,6 +81,22 @@ func TestMeshInject_MultiportService(t *testing.T) {
 
 			// Check connection from static-client to multiport-admin.
 			k8s.CheckStaticServerConnectionSuccessfulWithMessage(t, ctx.KubectlOptions(t), connhelper.StaticClientName, "hello world from 9090 admin", "http://multiport:9090")
+
+			// Test that kubernetes readiness status is synced to Consul. This will make the multi port pods unhealthy
+			// and check inbound connections to the multi port pods' services.
+			// Create the files so that the readiness probes of the multi port pod fails.
+			logger.Log(t, "testing k8s -> consul health checks sync by making the multiport unhealthy")
+			k8s.RunKubectl(t, ctx.KubectlOptions(t), "exec", "deploy/"+multiport, "-c", "multiport", "--", "touch", "/tmp/unhealthy-multiport")
+			logger.Log(t, "testing k8s -> consul health checks sync by making the multiport-admin unhealthy")
+			k8s.RunKubectl(t, ctx.KubectlOptions(t), "exec", "deploy/"+multiport, "-c", "multiport-admin", "--", "touch", "/tmp/unhealthy-multiport-admin")
+
+			// The readiness probe should take a moment to be reflected in Consul, CheckStaticServerConnection will retry
+			// until Consul marks the service instance unavailable for mesh traffic, causing the connection to fail.
+			// We are expecting a "connection reset by peer" error because in a case of health checks,
+			// there will be no healthy proxy host to connect to. That's why we can't assert that we receive an empty reply
+			// from server, which is the case when a connection is unsuccessful due to intentions in other tests.
+			k8s.CheckStaticServerConnectionMultipleFailureMessages(t, ctx.KubectlOptions(t), connhelper.StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"}, "", "http://multiport:8080")
+			k8s.CheckStaticServerConnectionMultipleFailureMessages(t, ctx.KubectlOptions(t), connhelper.StaticClientName, false, []string{"curl: (56) Recv failure: Connection reset by peer", "curl: (52) Empty reply from server"}, "", "http://multiport:9090")
 		})
 	}
 }

--- a/control-plane/connect-inject/controllers/pod/pod_controller.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller.go
@@ -811,12 +811,12 @@ func getHealthStatusFromPod(pod corev1.Pod) pbcatalog.Health {
 	}
 
 	for _, condition := range pod.Status.Conditions {
-		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionFalse {
-			return pbcatalog.Health_HEALTH_CRITICAL
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return pbcatalog.Health_HEALTH_PASSING
 		}
 	}
 
-	return pbcatalog.Health_HEALTH_PASSING
+	return pbcatalog.Health_HEALTH_CRITICAL
 }
 
 // getHealthStatusReason takes Consul's health check status (either passing or critical)

--- a/control-plane/connect-inject/controllers/pod/pod_controller.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller.go
@@ -811,11 +811,12 @@ func getHealthStatusFromPod(pod corev1.Pod) pbcatalog.Health {
 	}
 
 	for _, condition := range pod.Status.Conditions {
-		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
-			return pbcatalog.Health_HEALTH_PASSING
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionFalse {
+			return pbcatalog.Health_HEALTH_CRITICAL
 		}
 	}
-	return pbcatalog.Health_HEALTH_CRITICAL
+
+	return pbcatalog.Health_HEALTH_PASSING
 }
 
 // getHealthStatusReason takes Consul's health check status (either passing or critical)


### PR DESCRIPTION

Changes proposed in this PR:
- ~~needed to tweak pod controller to report unhealthy if any container is unhealthy, and healthy only if all containers are healthy~~
- add health status check in acceptance test. This was failing before the pod controller fix and the consul fix here: https://github.com/hashicorp/consul/pull/18958

How I've tested this PR:

built images off of this branch and this consul branch with a fix in consul: https://github.com/hashicorp/consul/pull/18958 and the acceptance test passes.

How I expect reviewers to test this PR:


Checklist:
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


