### PR TITLE
traffic-permissions: fix unit tests to account for mutation hook

### DIFF
--- a/control-plane/config-entries/controllersv2/meshconfig_controller_test.go
+++ b/control-plane/config-entries/controllersv2/meshconfig_controller_test.go
@@ -92,9 +92,14 @@ func TestMeshConfigController_createsMeshConfig(t *testing.T) {
 						Sources: []*pbauth.Source{
 							{
 								IdentityName: "source-identity",
+								Namespace:    common.DefaultConsulNamespace,
+								Partition:    common.DefaultConsulPartition,
+								Peer:         constants.DefaultConsulPeer,
 							},
 							{
 								Namespace: "the space namespace space",
+								Partition: common.DefaultConsulPartition,
+								Peer:      constants.DefaultConsulPeer,
 							},
 						},
 						DestinationRules: []*pbauth.DestinationRule{
@@ -228,6 +233,8 @@ func TestMeshConfigController_updatesMeshConfig(t *testing.T) {
 						Sources: []*pbauth.Source{
 							{
 								Namespace: "the space namespace space",
+								Partition: common.DefaultConsulPartition,
+								Peer:      constants.DefaultConsulPeer,
 							},
 						},
 						DestinationRules: []*pbauth.DestinationRule{
@@ -604,6 +611,9 @@ func TestMeshConfigController_doesNotCreateUnownedMeshConfig(t *testing.T) {
 					Sources: v2beta1.Sources{
 						{
 							IdentityName: "source-identity",
+							Namespace:    common.DefaultConsulNamespace,
+							Partition:    common.DefaultConsulPartition,
+							Peer:         constants.DefaultConsulPeer,
 						},
 					},
 				},
@@ -704,6 +714,9 @@ func TestMeshConfigController_doesNotDeleteUnownedConfig(t *testing.T) {
 					Sources: v2beta1.Sources{
 						{
 							IdentityName: "source-identity",
+							Namespace:    common.DefaultConsulNamespace,
+							Partition:    common.DefaultConsulPartition,
+							Peer:         constants.DefaultConsulPeer,
 						},
 					},
 				},


### PR DESCRIPTION
Consul now will default tenancy for traffic permission sources. This PR changes unit tests to account for that

How I've tested this PR:
- unit tests

How I expect reviewers to test this PR:
👀 

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


