### PR TITLE
fix: adding namespaceOverride option to values

### DIFF
--- a/charts/consul/templates/NOTES.txt
+++ b/charts/consul/templates/NOTES.txt
@@ -5,8 +5,8 @@ Your release is named {{ .Release.Name }}.
 
 To learn more about the release, run:
 
-  $ helm status {{ .Release.Name }} {{- if .Release.Namespace }} --namespace {{ .Release.Namespace }}{{ end }}
-  $ helm get all {{ .Release.Name }} {{- if .Release.Namespace }} --namespace {{ .Release.Namespace }}{{ end }}
+  $ helm status {{ .Release.Name }} {{- if .Release.Namespace }} --namespace {{ default .Release.Namespace }}{{ end }}
+  $ helm get all {{ .Release.Name }} {{- if .Release.Namespace }} --namespace {{ default .Release.Namespace }}{{ end }}
 
 Consul on Kubernetes Documentation:
 https://www.consul.io/docs/platform/k8s

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -100,7 +100,7 @@ and consul-k8s-control-plane images.
 
 {{- define "consul.serverTLSAltNames" -}}
 {{- $name := include "consul.fullname" . -}}
-{{- $ns := .Release.Namespace -}}
+{{- $ns := default .Release.Namespace .Values.namespaceOverride -}}
 {{ printf "localhost,%s-server,*.%s-server,*.%s-server.%s,%s-server.%s,*.%s-server.%s.svc,%s-server.%s.svc,*.server.%s.%s" $name $name $name $ns $name $ns $name $ns $name $ns (.Values.global.datacenter ) (.Values.global.domain) }}{{ include "consul.serverAdditionalDNSSANs" . }}
 {{- end -}}
 
@@ -114,7 +114,7 @@ and consul-k8s-control-plane images.
 
 {{- define "consul.connectInjectorTLSAltNames" -}}
 {{- $name := include "consul.fullname" . -}}
-{{- $ns := .Release.Namespace -}}
+{{- $ns := default .Release.Namespace .Values.namespaceOverride -}}
 {{ printf "%s-connect-injector,%s-connect-injector.%s,%s-connect-injector.%s.svc,%s-connect-injector.%s.svc.cluster.local" $name $name $ns $name $ns $name $ns}}
 {{- end -}}
 
@@ -311,7 +311,7 @@ Consul server environment variables for consul-k8s commands.
   {{- if .Values.externalServers.enabled }}
   value: {{ .Values.externalServers.hosts | first }}
   {{- else }}
-  value: {{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc
+  value: {{ template "consul.fullname" . }}-server.{{ default .Release.Namespace .Values.namespaceOverride }}.svc
   {{- end }}
 - name: CONSUL_GRPC_PORT
   {{- if .Values.externalServers.enabled }}

--- a/charts/consul/templates/api-gateway-controller-clusterrolebinding.yaml
+++ b/charts/consul/templates/api-gateway-controller-clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-api-gateway-controller
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
 {{- end }}

--- a/charts/consul/templates/api-gateway-controller-deployment.yaml
+++ b/charts/consul/templates/api-gateway-controller-deployment.yaml
@@ -8,7 +8,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "consul.fullname" . }}-api-gateway-controller
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -144,8 +144,8 @@ spec:
         - "-ec"
         - |
           consul-api-gateway server \
-            -sds-server-host {{ template "consul.fullname" . }}-api-gateway-controller.{{ .Release.Namespace }}.svc \
-            -k8s-namespace {{ .Release.Namespace }} \
+            -sds-server-host {{ template "consul.fullname" . }}-api-gateway-controller.{{ default .Release.Namespace .Values.namespaceOverride }}.svc \
+            -k8s-namespace {{ default .Release.Namespace .Values.namespaceOverride }} \
             {{- if .Values.global.enableConsulNamespaces }}
             {{- if .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
             -consul-destination-namespace={{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }} \

--- a/charts/consul/templates/api-gateway-controller-podsecuritypolicy.yaml
+++ b/charts/consul/templates/api-gateway-controller-podsecuritypolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-api-gateway-controller
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/api-gateway-controller-service.yaml
+++ b/charts/consul/templates/api-gateway-controller-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "consul.fullname" . }}-api-gateway-controller
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/api-gateway-controller-serviceaccount.yaml
+++ b/charts/consul/templates/api-gateway-controller-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-api-gateway-controller
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
+++ b/charts/consul/templates/api-gateway-gatewayclassconfig.yaml
@@ -31,7 +31,7 @@ spec:
       We have local network connectivity between deployments and the internal cluster, this
       should be supported in all versions of api-gateway
     */}}
-    address: {{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc
+    address: {{ template "consul.fullname" . }}-server.{{ default .Release.Namespace .Values.namespaceOverride }}.svc
     {{- end }}
     authentication:
       {{- if .Values.global.acls.manageSystemACLs }}

--- a/charts/consul/templates/api-gateway-podsecuritypolicy.yaml
+++ b/charts/consul/templates/api-gateway-podsecuritypolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-api-gateway
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/auth-method-clusterrolebinding.yaml
+++ b/charts/consul/templates/auth-method-clusterrolebinding.yaml
@@ -16,7 +16,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-auth-method
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -35,5 +35,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-auth-method
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
 {{- end }}

--- a/charts/consul/templates/auth-method-secret.yaml
+++ b/charts/consul/templates/auth-method-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "consul.fullname" . }}-auth-method
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/auth-method-serviceaccount.yaml
+++ b/charts/consul/templates/auth-method-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-auth-method
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/client-config-configmap.yaml
+++ b/charts/consul/templates/client-config-configmap.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "consul.fullname" . }}-client-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -17,7 +17,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "consul.fullname" . }}-client
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/client-podsecuritypolicy.yaml
+++ b/charts/consul/templates/client-podsecuritypolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-client
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/client-role.yaml
+++ b/charts/consul/templates/client-role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-client
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/client-rolebinding.yaml
+++ b/charts/consul/templates/client-rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-client
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/client-securitycontextconstraints.yaml
+++ b/charts/consul/templates/client-securitycontextconstraints.yaml
@@ -3,7 +3,7 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   name: {{ template "consul.fullname" . }}-client
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/client-serviceaccount.yaml
+++ b/charts/consul/templates/client-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-client
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/connect-inject-clusterrolebinding.yaml
+++ b/charts/consul/templates/connect-inject-clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-connect-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
 {{- end }}

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -17,7 +17,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -148,7 +148,7 @@ spec:
                 -consul-dataplane-image="{{ .Values.global.imageConsulDataplane }}" \
                 -consul-k8s-image="{{ default .Values.global.imageK8S .Values.connectInject.image }}" \
                 -release-name="{{ .Release.Name }}" \
-                -release-namespace="{{ .Release.Namespace }}" \
+                -release-namespace="{{ default .Release.Namespace .Values.namespaceOverride }}" \
                 -resource-prefix={{ template "consul.fullname" . }} \
                 -listen=:8080 \
                 {{- if (mustHas "resource-apis" .Values.global.experiments) }}

--- a/charts/consul/templates/connect-inject-leader-election-role.yaml
+++ b/charts/consul/templates/connect-inject-leader-election-role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-connect-inject-leader-election
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/connect-inject-leader-election-rolebinding.yaml
+++ b/charts/consul/templates/connect-inject-leader-election-rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-connect-inject-leader-election
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -17,5 +17,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-connect-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
 {{- end }}

--- a/charts/consul/templates/connect-inject-mutatingwebhookconfiguration.yaml
+++ b/charts/consul/templates/connect-inject-mutatingwebhookconfiguration.yaml
@@ -4,7 +4,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -15,7 +15,7 @@ webhooks:
 - clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: /mutate-v1alpha1-proxydefaults
   failurePolicy: Fail
   admissionReviewVersions:
@@ -36,7 +36,7 @@ webhooks:
 - clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: /mutate-v1alpha1-mesh
   failurePolicy: Fail
   admissionReviewVersions:
@@ -57,7 +57,7 @@ webhooks:
 - clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: /mutate-v1alpha1-servicedefaults
   failurePolicy: Fail
   admissionReviewVersions:
@@ -78,7 +78,7 @@ webhooks:
 - clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: /mutate-v1alpha1-serviceresolver
   failurePolicy: Fail
   admissionReviewVersions:
@@ -99,7 +99,7 @@ webhooks:
 - clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: /mutate-v1alpha1-servicerouter
   failurePolicy: Fail
   admissionReviewVersions:
@@ -120,7 +120,7 @@ webhooks:
 - clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: /mutate-v1alpha1-servicesplitter
   failurePolicy: Fail
   admissionReviewVersions:
@@ -141,7 +141,7 @@ webhooks:
 - clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: /mutate-v1alpha1-serviceintentions
   failurePolicy: Fail
   admissionReviewVersions:
@@ -162,7 +162,7 @@ webhooks:
 - clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: /mutate-v1alpha1-ingressgateway
   failurePolicy: Fail
   admissionReviewVersions:
@@ -183,7 +183,7 @@ webhooks:
 - clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: /mutate-v1alpha1-terminatinggateway
   failurePolicy: Fail
   admissionReviewVersions:
@@ -204,7 +204,7 @@ webhooks:
 - clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: /mutate-v1alpha1-exportedservices
   failurePolicy: Fail
   admissionReviewVersions:
@@ -225,7 +225,7 @@ webhooks:
 - clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: /mutate-v1alpha1-controlplanerequestlimits
   failurePolicy: Fail
   admissionReviewVersions:
@@ -258,7 +258,7 @@ webhooks:
   clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: "/mutate"
   rules:
   - operations: [ "CREATE" ]
@@ -274,7 +274,7 @@ webhooks:
   clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: "/mutate-v1alpha1-peeringacceptors"
   rules:
   - apiGroups:
@@ -295,7 +295,7 @@ webhooks:
   clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: "/mutate-v1alpha1-peeringdialers"
   rules:
   - apiGroups:
@@ -318,7 +318,7 @@ webhooks:
   clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: /mutate-v1alpha1-samenessgroup
   failurePolicy: Fail
   name: mutate-samenessgroup.consul.hashicorp.com
@@ -340,7 +340,7 @@ webhooks:
   clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: /mutate-v2beta1-trafficpermissions
   failurePolicy: Fail
   name: mutate-trafficpermissions.auth.consul.hashicorp.com
@@ -363,7 +363,7 @@ webhooks:
   clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: /mutate-v1alpha1-jwtprovider
   failurePolicy: Fail
   name: mutate-jwtprovider.consul.hashicorp.com

--- a/charts/consul/templates/connect-inject-podsecuritypolicy.yaml
+++ b/charts/consul/templates/connect-inject-podsecuritypolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/connect-inject-service.yaml
+++ b/charts/consul/templates/connect-inject-service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/connect-inject-serviceaccount.yaml
+++ b/charts/consul/templates/connect-inject-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/connect-inject-validatingwebhookconfiguration.yaml
+++ b/charts/consul/templates/connect-inject-validatingwebhookconfiguration.yaml
@@ -4,7 +4,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -26,6 +26,6 @@ webhooks:
   clientConfig:
     service:
       name: {{ template "consul.fullname" . }}-connect-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
       path: /validate-v1alpha1-gatewaypolicy
 {{- end }}

--- a/charts/consul/templates/connect-injector-disruptionbudget.yaml
+++ b/charts/consul/templates/connect-injector-disruptionbudget.yaml
@@ -9,7 +9,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "consul.fullname" . }}-connect-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/create-federation-secret-job.yaml
+++ b/charts/consul/templates/create-federation-secret-job.yaml
@@ -8,7 +8,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "consul.fullname" . }}-create-federation-secret
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -101,7 +101,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CONSUL_HTTP_ADDR
-              value: "https://{{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc:8501"
+              value: "https://{{ template "consul.fullname" . }}-server.{{ default .Release.Namespace .Values.namespaceOverride }}.svc:8501"
             - name: CONSUL_CACERT
               value: /consul/tls/ca/tls.crt
           volumeMounts:

--- a/charts/consul/templates/create-federation-secret-podsecuritypolicy.yaml
+++ b/charts/consul/templates/create-federation-secret-podsecuritypolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-create-federation-secret
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/create-federation-secret-role.yaml
+++ b/charts/consul/templates/create-federation-secret-role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-create-federation-secret
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/create-federation-secret-rolebinding.yaml
+++ b/charts/consul/templates/create-federation-secret-rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-create-federation-secret
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/create-federation-secret-serviceaccount.yaml
+++ b/charts/consul/templates/create-federation-secret-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-create-federation-secret
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/dns-service.yaml
+++ b/charts/consul/templates/dns-service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "consul.fullname" . }}-dns
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/enterprise-license-job.yaml
+++ b/charts/consul/templates/enterprise-license-job.yaml
@@ -5,7 +5,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "consul.fullname" . }}-enterprise-license
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app.kubernetes.io/managed-by: {{.Release.Service | quote }}
     app.kubernetes.io/instance: {{.Release.Name | quote }}
@@ -131,7 +131,7 @@ spec:
           - |
             consul-k8s-control-plane acl-init \
               -secret-name="{{ template "consul.fullname" . }}-enterprise-license-acl-token" \
-              -k8s-namespace={{ .Release.Namespace }} \
+              -k8s-namespace={{ default .Release.Namespace .Values.namespaceOverride }} \
               -consul-api-timeout={{ .Values.global.consulAPITimeout }}
         resources:
           requests:

--- a/charts/consul/templates/enterprise-license-podsecuritypolicy.yaml
+++ b/charts/consul/templates/enterprise-license-podsecuritypolicy.yaml
@@ -5,7 +5,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-enterprise-license
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/enterprise-license-role.yaml
+++ b/charts/consul/templates/enterprise-license-role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-enterprise-license
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/enterprise-license-rolebinding.yaml
+++ b/charts/consul/templates/enterprise-license-rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-enterprise-license
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/enterprise-license-serviceaccount.yaml
+++ b/charts/consul/templates/enterprise-license-serviceaccount.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-enterprise-license
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/expose-servers-service.yaml
+++ b/charts/consul/templates/expose-servers-service.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "consul.fullname" . }}-expose-servers
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/gateway-cleanup-clusterrolebinding.yaml
+++ b/charts/consul/templates/gateway-cleanup-clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-gateway-cleanup
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
 {{- end }}

--- a/charts/consul/templates/gateway-cleanup-job.yaml
+++ b/charts/consul/templates/gateway-cleanup-job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "consul.fullname" . }}-gateway-cleanup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/gateway-cleanup-podsecuritypolicy.yaml
+++ b/charts/consul/templates/gateway-cleanup-podsecuritypolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-gateway-cleanup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/gateway-cleanup-serviceaccount.yaml
+++ b/charts/consul/templates/gateway-cleanup-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-gateway-cleanup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/gateway-resources-clusterrolebinding.yaml
+++ b/charts/consul/templates/gateway-resources-clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-gateway-resources
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
 {{- end }}

--- a/charts/consul/templates/gateway-resources-configmap.yaml
+++ b/charts/consul/templates/gateway-resources-configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "consul.fullname" . }}-gateway-resources-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels: 
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/gateway-resources-job.yaml
+++ b/charts/consul/templates/gateway-resources-job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "consul.fullname" . }}-gateway-resources
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/gateway-resources-podsecuritypolicy.yaml
+++ b/charts/consul/templates/gateway-resources-podsecuritypolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-gateway-resources
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/gateway-resources-serviceaccount.yaml
+++ b/charts/consul/templates/gateway-resources-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-gateway-resources
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/gossip-encryption-autogenerate-job.yaml
+++ b/charts/consul/templates/gossip-encryption-autogenerate-job.yaml
@@ -7,7 +7,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "consul.fullname" . }}-gossip-encryption-autogenerate
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -55,7 +55,7 @@ spec:
             - "-ec"
             - |
               consul-k8s-control-plane gossip-encryption-autogenerate \
-                -namespace={{ .Release.Namespace }} \
+                -namespace={{ default .Release.Namespace .Values.namespaceOverride }} \
                 -secret-name={{ template "consul.fullname" . }}-gossip-encryption-key \
                 -secret-key="key" \
                 -log-level={{ default .Values.global.logLevel .Values.global.gossipEncryption.logLevel }} \

--- a/charts/consul/templates/gossip-encryption-autogenerate-podsecuritypolicy.yaml
+++ b/charts/consul/templates/gossip-encryption-autogenerate-podsecuritypolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-gossip-encryption-autogenerate
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/gossip-encryption-autogenerate-role.yaml
+++ b/charts/consul/templates/gossip-encryption-autogenerate-role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-gossip-encryption-autogenerate
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/gossip-encryption-autogenerate-rolebinding.yaml
+++ b/charts/consul/templates/gossip-encryption-autogenerate-rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-gossip-encryption-autogenerate
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/gossip-encryption-autogenerate-serviceaccount.yaml
+++ b/charts/consul/templates/gossip-encryption-autogenerate-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-gossip-encryption-autogenerate
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -38,7 +38,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "consul.fullname" $root }}-{{ .name }}
-  namespace: {{ $root.Release.Namespace }}
+  namespace: {{ default $root.Release.Namespace $root.Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" $root }}
     chart: {{ template "consul.chart" $root }}
@@ -287,7 +287,7 @@ spec:
         {{- if $root.Values.externalServers.enabled }}
         - -addresses={{ $root.Values.externalServers.hosts | first }}
         {{- else }}
-        - -addresses={{ template "consul.fullname" $root }}-server.{{ $root.Release.Namespace }}.svc
+        - -addresses={{ template "consul.fullname" $root }}-server.{{ default $root.Release.Namespace $root.Values.namespaceOverride }}.svc
         {{- end }}
         {{- if $root.Values.externalServers.enabled }}
         - -grpc-port={{ $root.Values.externalServers.grpcPort }}

--- a/charts/consul/templates/ingress-gateways-podsecuritypolicy.yaml
+++ b/charts/consul/templates/ingress-gateways-podsecuritypolicy.yaml
@@ -5,7 +5,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" $root }}-{{ .name }}
-  namespace: {{ $root.Release.Namespace }}
+  namespace: {{ default $root.Release.Namespace $root.Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" $root }}
     chart: {{ template "consul.chart" $root }}

--- a/charts/consul/templates/ingress-gateways-role.yaml
+++ b/charts/consul/templates/ingress-gateways-role.yaml
@@ -8,7 +8,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" $root }}-{{ .name }}
-  namespace: {{ $root.Release.Namespace }}
+  namespace: {{ default $root.Release.Namespace $root.Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" $root }}
     chart: {{ template "consul.chart" $root }}

--- a/charts/consul/templates/ingress-gateways-rolebinding.yaml
+++ b/charts/consul/templates/ingress-gateways-rolebinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" $root }}-{{ .name }}
-  namespace: {{ $root.Release.Namespace }}
+  namespace: {{ default $root.Release.Namespace $root.Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" $root }}
     chart: {{ template "consul.chart" $root }}

--- a/charts/consul/templates/ingress-gateways-service.yaml
+++ b/charts/consul/templates/ingress-gateways-service.yaml
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "consul.fullname" $root }}-{{ .name }}
-  namespace: {{ $root.Release.Namespace }}
+  namespace: {{ default $root.Release.Namespace $root.Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" $root }}
     chart: {{ template "consul.chart" $root }}

--- a/charts/consul/templates/ingress-gateways-serviceaccount.yaml
+++ b/charts/consul/templates/ingress-gateways-serviceaccount.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" $root }}-{{ .name }}
-  namespace: {{ $root.Release.Namespace }}
+  namespace: {{ default $root.Release.Namespace $root.Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" $root }}
     chart: {{ template "consul.chart" $root }}

--- a/charts/consul/templates/mesh-gateway-clusterrolebinding.yaml
+++ b/charts/consul/templates/mesh-gateway-clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-mesh-gateway
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
 {{- end }}

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -12,7 +12,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "consul.fullname" . }}-mesh-gateway
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -231,7 +231,7 @@ spec:
         {{- if .Values.externalServers.enabled }}
         - -addresses={{ .Values.externalServers.hosts | first }}
         {{- else }}
-        - -addresses={{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc
+        - -addresses={{ template "consul.fullname" . }}-server.{{ default .Release.Namespace .Values.namespaceOverride }}.svc
         {{- end }}
         {{- if .Values.externalServers.enabled }}
         - -grpc-port={{ .Values.externalServers.grpcPort }}

--- a/charts/consul/templates/mesh-gateway-podsecuritypolicy.yaml
+++ b/charts/consul/templates/mesh-gateway-podsecuritypolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-mesh-gateway
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/mesh-gateway-service.yaml
+++ b/charts/consul/templates/mesh-gateway-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "consul.fullname" . }}-mesh-gateway
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/mesh-gateway-serviceaccount.yaml
+++ b/charts/consul/templates/mesh-gateway-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-mesh-gateway
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/partition-init-job.yaml
+++ b/charts/consul/templates/partition-init-job.yaml
@@ -8,7 +8,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "consul.fullname" . }}-partition-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/partition-init-podsecuritypolicy.yaml
+++ b/charts/consul/templates/partition-init-podsecuritypolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-partition-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/partition-init-role.yaml
+++ b/charts/consul/templates/partition-init-role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-partition-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/partition-init-rolebinding.yaml
+++ b/charts/consul/templates/partition-init-rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-partition-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/partition-init-serviceaccount.yaml
+++ b/charts/consul/templates/partition-init-serviceaccount.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-partition-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/partition-name-configmap.yaml
+++ b/charts/consul/templates/partition-name-configmap.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "consul.fullname" . }}-partition
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/prometheus.yaml
+++ b/charts/consul/templates/prometheus.yaml
@@ -12,7 +12,7 @@ metadata:
     chart: prometheus-13.2.1
     heritage: Helm
   name: prometheus-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   annotations:
     {}
 ---
@@ -27,7 +27,7 @@ metadata:
     chart: prometheus-13.2.1
     heritage: Helm
   name: prometheus-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
 data:
   alerting_rules.yml: |
     {}
@@ -357,7 +357,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: prometheus-server
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -374,7 +374,7 @@ metadata:
     chart: prometheus-13.2.1
     heritage: Helm
   name: prometheus-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
 spec:
   ports:
     - name: http
@@ -399,7 +399,7 @@ metadata:
     chart: prometheus-13.2.1
     heritage: Helm
   name: prometheus-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
 spec:
   selector:
     matchLabels:

--- a/charts/consul/templates/server-acl-init-cleanup-job.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-job.yaml
@@ -16,7 +16,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -70,7 +70,7 @@ spec:
             - delete-completed-job
             - -log-level={{ default .Values.global.logLevel .Values.global.acls.logLevel }}
             - -log-json={{ .Values.global.logJSON }}
-            - -k8s-namespace={{ .Release.Namespace }}
+            - -k8s-namespace={{ default .Release.Namespace .Values.namespaceOverride }}
             - {{ template "consul.fullname" . }}-server-acl-init
           {{- if .Values.global.acls.resources }}
           resources:

--- a/charts/consul/templates/server-acl-init-cleanup-podsecuritypolicy.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-podsecuritypolicy.yaml
@@ -6,7 +6,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-acl-init-cleanup-role.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-role.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-acl-init-cleanup-rolebinding.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-rolebinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-acl-init-cleanup-serviceaccount.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-serviceaccount.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -22,7 +22,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -185,7 +185,7 @@ spec:
             -log-level={{ default .Values.global.logLevel .Values.global.acls.logLevel}} \
             -log-json={{ .Values.global.logJSON }} \
             -resource-prefix=${CONSUL_FULLNAME} \
-            -k8s-namespace={{ .Release.Namespace }} \
+            -k8s-namespace={{ default .Release.Namespace .Values.namespaceOverride }} \
             -set-server-tokens={{ $serverEnabled }} \
             {{- if .Values.global.secretsBackend.vault.enabled }}
             -secrets-backend=vault \

--- a/charts/consul/templates/server-acl-init-podsecuritypolicy.yaml
+++ b/charts/consul/templates/server-acl-init-podsecuritypolicy.yaml
@@ -6,7 +6,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-acl-init-role.yaml
+++ b/charts/consul/templates/server-acl-init-role.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-acl-init-rolebinding.yaml
+++ b/charts/consul/templates/server-acl-init-rolebinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-acl-init-serviceaccount.yaml
+++ b/charts/consul/templates/server-acl-init-serviceaccount.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-server-acl-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-clusterrole.yaml
+++ b/charts/consul/templates/server-clusterrole.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "consul.fullname" . }}-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-clusterrolebinding.yaml
+++ b/charts/consul/templates/server-clusterrolebinding.yaml
@@ -15,4 +15,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}

--- a/charts/consul/templates/server-config-configmap.yaml
+++ b/charts/consul/templates/server-config-configmap.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "consul.fullname" . }}-server-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -50,7 +50,7 @@ data:
         "serf_lan": {{ .Values.server.ports.serflan.port }}
       },
       "recursors": {{ .Values.global.recursors | toJson }},
-      "retry_join": ["{{template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc:{{ .Values.server.ports.serflan.port }}"],
+      "retry_join": ["{{template "consul.fullname" . }}-server.{{ default .Release.Namespace .Values.namespaceOverride }}.svc:{{ .Values.server.ports.serflan.port }}"],
       {{- if .Values.global.peering.enabled }}
       "peering": {
         "enabled": true

--- a/charts/consul/templates/server-disruptionbudget.yaml
+++ b/charts/consul/templates/server-disruptionbudget.yaml
@@ -9,7 +9,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "consul.fullname" . }}-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-podsecuritypolicy.yaml
+++ b/charts/consul/templates/server-podsecuritypolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-role.yaml
+++ b/charts/consul/templates/server-role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-rolebinding.yaml
+++ b/charts/consul/templates/server-rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-securitycontextconstraints.yaml
+++ b/charts/consul/templates/server-securitycontextconstraints.yaml
@@ -3,7 +3,7 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   name: {{ template "consul.fullname" . }}-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-service.yaml
+++ b/charts/consul/templates/server-service.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "consul.fullname" . }}-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-serviceaccount.yaml
+++ b/charts/consul/templates/server-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-snapshot-agent-configmap.yaml
+++ b/charts/consul/templates/server-snapshot-agent-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "consul.fullname" . }}-snapshot-agent-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -24,7 +24,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "consul.fullname" . }}-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -429,7 +429,7 @@ spec:
                 -hcl="experiments=[\"resource-apis\"]"
                 {{- end }}
           volumeMounts:
-            - name: data-{{ .Release.Namespace | trunc 58 | trimSuffix "-" }}
+            - name: data-{{ default .Release.Namespace .Values.namespaceOverride | trunc 58 | trimSuffix "-" }}
               mountPath: /consul/data
             - name: config
               mountPath: /consul/config
@@ -637,7 +637,7 @@ spec:
       {{- end }}
   volumeClaimTemplates:
     - metadata:
-        name: data-{{ .Release.Namespace | trunc 58 | trimSuffix "-" }}
+        name: data-{{ default .Release.Namespace .Values.namespaceOverride | trunc 58 | trimSuffix "-" }}
       spec:
         accessModes:
           - ReadWriteOnce

--- a/charts/consul/templates/sync-catalog-clusterrolebinding.yaml
+++ b/charts/consul/templates/sync-catalog-clusterrolebinding.yaml
@@ -17,5 +17,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-sync-catalog
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
 {{- end }}

--- a/charts/consul/templates/sync-catalog-deployment.yaml
+++ b/charts/consul/templates/sync-catalog-deployment.yaml
@@ -7,7 +7,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "consul.fullname" . }}-sync-catalog
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/sync-catalog-podsecuritypolicy.yaml
+++ b/charts/consul/templates/sync-catalog-podsecuritypolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-sync-catalog
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/sync-catalog-serviceaccount.yaml
+++ b/charts/consul/templates/sync-catalog-serviceaccount.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-sync-catalog
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/telemetry-collector-configmap.yaml
+++ b/charts/consul/templates/telemetry-collector-configmap.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "consul.fullname" . }}-telemetry-collector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/telemetry-collector-deployment.yaml
+++ b/charts/consul/templates/telemetry-collector-deployment.yaml
@@ -9,7 +9,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "consul.fullname" . }}-telemetry-collector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -254,7 +254,7 @@ spec:
           {{- if .Values.externalServers.enabled }}
           - -addresses={{ .Values.externalServers.hosts | first }}
           {{- else }}
-          - -addresses={{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc
+          - -addresses={{ template "consul.fullname" . }}-server.{{ default .Release.Namespace .Values.namespaceOverride }}.svc
           {{- end }}
           # grpc
           {{- if .Values.externalServers.enabled }}

--- a/charts/consul/templates/telemetry-collector-podsecuritypolicy.yaml
+++ b/charts/consul/templates/telemetry-collector-podsecuritypolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-telemetry-collector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/telemetry-collector-role.yaml
+++ b/charts/consul/templates/telemetry-collector-role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-telemetry-collector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/telemetry-collector-rolebinding.yaml
+++ b/charts/consul/templates/telemetry-collector-rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-telemetry-collector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/telemetry-collector-service.yaml
+++ b/charts/consul/templates/telemetry-collector-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: consul-telemetry-collector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/telemetry-collector-serviceaccount.yaml
+++ b/charts/consul/templates/telemetry-collector-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: consul-telemetry-collector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/telemetry-collector-v2-deployment.yaml
+++ b/charts/consul/templates/telemetry-collector-v2-deployment.yaml
@@ -9,7 +9,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "consul.fullname" . }}-telemetry-collector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -243,7 +243,7 @@ spec:
           {{- if .Values.externalServers.enabled }}
           - -addresses={{ .Values.externalServers.hosts | first }}
           {{- else }}
-          - -addresses={{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc
+          - -addresses={{ template "consul.fullname" . }}-server.{{ default .Release.Namespace .Values.namespaceOverride }}.svc
           {{- end }}
           # grpc
           {{- if .Values.externalServers.enabled }}

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -40,7 +40,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "consul.fullname" $root }}-{{ .name }}
-  namespace: {{ $root.Release.Namespace }}
+  namespace: {{ default $root.Release.Namespace $root.Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" $root }}
     chart: {{ template "consul.chart" $root }}
@@ -268,7 +268,7 @@ spec:
           {{- if $root.Values.externalServers.enabled }}
           - -addresses={{ $root.Values.externalServers.hosts | first }}
           {{- else }}
-          - -addresses={{ template "consul.fullname" $root }}-server.{{ $root.Release.Namespace }}.svc
+          - -addresses={{ template "consul.fullname" $root }}-server.{{ default $root.Release.Namespace $root.Values.namespaceOverride }}.svc
           {{- end }}
           {{- if $root.Values.externalServers.enabled }}
           - -grpc-port={{ $root.Values.externalServers.grpcPort }}

--- a/charts/consul/templates/terminating-gateways-podsecuritypolicy.yaml
+++ b/charts/consul/templates/terminating-gateways-podsecuritypolicy.yaml
@@ -5,7 +5,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name:  {{ template "consul.fullname" $root }}-{{ .name }}
-  namespace: {{ $root.Release.Namespace }}
+  namespace: {{ default $root.Release.Namespace $root.Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" $root }}
     chart: {{ template "consul.chart" $root }}

--- a/charts/consul/templates/terminating-gateways-role.yaml
+++ b/charts/consul/templates/terminating-gateways-role.yaml
@@ -8,7 +8,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name:  {{ template "consul.fullname" $root }}-{{ .name }}
-  namespace: {{ $root.Release.Namespace }}
+  namespace: {{ default $root.Release.Namespace $root.Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" $root }}
     chart: {{ template "consul.chart" $root }}

--- a/charts/consul/templates/terminating-gateways-rolebinding.yaml
+++ b/charts/consul/templates/terminating-gateways-rolebinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name:  {{ template "consul.fullname" $root }}-{{ .name }}
-  namespace: {{ $root.Release.Namespace }}
+  namespace: {{ default $root.Release.Namespace $root.Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" $root }}
     chart: {{ template "consul.chart" $root }}
@@ -20,7 +20,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name:  {{ template "consul.fullname" $root }}-{{ .name }}
-    namespace: {{ $root.Release.Namespace }}
+    namespace: {{ default $root.Release.Namespace $root.Values.namespaceOverride }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/terminating-gateways-service.yaml
+++ b/charts/consul/templates/terminating-gateways-service.yaml
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "consul.fullname" $root }}-{{ .name }}
-  namespace: {{ $root.Release.Namespace }}
+  namespace: {{ default $root.Release.Namespace $root.Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" $root }}
     chart: {{ template "consul.chart" $root }}

--- a/charts/consul/templates/terminating-gateways-serviceaccount.yaml
+++ b/charts/consul/templates/terminating-gateways-serviceaccount.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name:  {{ template "consul.fullname" $root }}-{{ .name }}
-  namespace: {{ $root.Release.Namespace }}
+  namespace: {{ default $root.Release.Namespace $root.Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" $root }}
     chart: {{ template "consul.chart" $root }}

--- a/charts/consul/templates/tests/test-runner.yaml
+++ b/charts/consul/templates/tests/test-runner.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ template "consul.fullname" . }}-test"
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/tls-init-cleanup-job.yaml
+++ b/charts/consul/templates/tls-init-cleanup-job.yaml
@@ -6,7 +6,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init-cleanup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/tls-init-cleanup-podsecuritypolicy.yaml
+++ b/charts/consul/templates/tls-init-cleanup-podsecuritypolicy.yaml
@@ -5,7 +5,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init-cleanup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/tls-init-cleanup-role.yaml
+++ b/charts/consul/templates/tls-init-cleanup-role.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init-cleanup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/tls-init-cleanup-rolebinding.yaml
+++ b/charts/consul/templates/tls-init-cleanup-rolebinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init-cleanup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/tls-init-cleanup-serviceaccount.yaml
+++ b/charts/consul/templates/tls-init-cleanup-serviceaccount.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init-cleanup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/tls-init-job.yaml
+++ b/charts/consul/templates/tls-init-job.yaml
@@ -7,7 +7,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/tls-init-podsecuritypolicy.yaml
+++ b/charts/consul/templates/tls-init-podsecuritypolicy.yaml
@@ -5,7 +5,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/tls-init-role.yaml
+++ b/charts/consul/templates/tls-init-role.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/tls-init-rolebinding.yaml
+++ b/charts/consul/templates/tls-init-rolebinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/tls-init-serviceaccount.yaml
+++ b/charts/consul/templates/tls-init-serviceaccount.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-tls-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/ui-ingress.yaml
+++ b/charts/consul/templates/ui-ingress.yaml
@@ -13,7 +13,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "consul.fullname" . }}-ui
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/ui-service.yaml
+++ b/charts/consul/templates/ui-service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "consul.fullname" . }}-ui
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/webhook-cert-manager-clusterrolebinding.yaml
+++ b/charts/consul/templates/webhook-cert-manager-clusterrolebinding.yaml
@@ -17,5 +17,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-webhook-cert-manager
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
 {{- end }}

--- a/charts/consul/templates/webhook-cert-manager-configmap.yaml
+++ b/charts/consul/templates/webhook-cert-manager-configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "consul.fullname" . }}-webhook-cert-manager-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -18,12 +18,12 @@ data:
         "name": "{{ template "consul.fullname" . }}-connect-injector",
         "tlsAutoHosts": [
           "{{ template "consul.fullname" . }}-connect-injector",
-          "{{ template "consul.fullname" . }}-connect-injector.{{ .Release.Namespace }}",
-          "{{ template "consul.fullname" . }}-connect-injector.{{ .Release.Namespace }}.svc",
-          "{{ template "consul.fullname" . }}-connect-injector.{{ .Release.Namespace }}.svc.cluster.local"
+          "{{ template "consul.fullname" . }}-connect-injector.{{ default .Release.Namespace .Values.namespaceOverride }}",
+          "{{ template "consul.fullname" . }}-connect-injector.{{ default .Release.Namespace .Values.namespaceOverride }}.svc",
+          "{{ template "consul.fullname" . }}-connect-injector.{{ default .Release.Namespace .Values.namespaceOverride }}.svc.cluster.local"
         ],
         "secretName": "{{ template "consul.fullname" . }}-connect-inject-webhook-cert",
-        "secretNamespace": "{{ .Release.Namespace }}"
+        "secretNamespace": "{{ default .Release.Namespace .Values.namespaceOverride }}"
       }
     ]
   {{- end }}

--- a/charts/consul/templates/webhook-cert-manager-deployment.yaml
+++ b/charts/consul/templates/webhook-cert-manager-deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "consul.fullname" . }}-webhook-cert-manager
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}
@@ -49,7 +49,7 @@ spec:
             -log-json={{ .Values.global.logJSON }} \
             -config-file=/bootstrap/config/webhook-config.json \
             -deployment-name={{ template "consul.fullname" . }}-webhook-cert-manager \
-            -deployment-namespace={{ .Release.Namespace }}
+            -deployment-namespace={{ default .Release.Namespace .Values.namespaceOverride }}
         image: {{ .Values.global.imageK8S }}
         name: webhook-cert-manager
         {{- include "consul.restrictedSecurityContext" . | nindent 8 }}

--- a/charts/consul/templates/webhook-cert-manager-podsecuritypolicy.yaml
+++ b/charts/consul/templates/webhook-cert-manager-podsecuritypolicy.yaml
@@ -5,7 +5,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "consul.fullname" . }}-webhook-cert-manager
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/charts/consul/templates/webhook-cert-manager-serviceaccount.yaml
+++ b/charts/consul/templates/webhook-cert-manager-serviceaccount.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "consul.fullname" . }}-webhook-cert-manager
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}


### PR DESCRIPTION
Changes proposed in this PR:
- Add the option to have a `namespaceOverride` value to replace `.Release.Namespace`
  - Useful in cases where umbrella Helm charts are used (i.e. declaring the consul chart as a dependency to a parent)

How I've tested this PR:
`helm template . --namespace foobar123 --set namespaceOverride=consul-namespace | grep foobar123`

How I expect reviewers to test this PR:
- Double-check edge cases for missed overrides/defaults
- If they have existing deployments configure to compare again, ensure the override is backwards compatible and presents zero diffs.

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


