### PR TITLE
support mesh v2 annotations in cni

### DIFF
--- a/control-plane/cni/main.go
+++ b/control-plane/cni/main.go
@@ -33,6 +33,10 @@ const (
 	// a pod after an injection is done.
 	keyInjectStatus = "consul.hashicorp.com/connect-inject-status"
 
+	// keyMeshInjectStatus is the mesh v2 key of the annotation that is added to
+	// a pod after an injection is done.
+	keyMeshInjectStatus = "consul.hashicorp.com/mesh-inject-status"
+
 	// keyTransparentProxyStatus is the key of the annotation that is added to
 	// a pod when transparent proxy is done.
 	keyTransparentProxyStatus = "consul.hashicorp.com/transparent-proxy-status"
@@ -246,11 +250,15 @@ func main() {
 }
 
 // skipTrafficRedirection looks for annotations on the pod and determines if it should skip traffic redirection.
-// The absence of the annotations is the equivalent of "disabled" because it means that the connect inject mutating
+// The absence of the annotations is the equivalent of "disabled" because it means that the connect-inject mutating
 // webhook did not run against the pod.
 func skipTrafficRedirection(pod corev1.Pod) bool {
+	// If keyInjectStatus exists, then we are dealing with a mesh v1 pod
+	// else we have a mesh v2 pod. We need to check for both before we can skip.
 	if anno, ok := pod.Annotations[keyInjectStatus]; !ok || anno == "" {
-		return true
+		if anno, ok := pod.Annotations[keyMeshInjectStatus]; !ok || anno == "" {
+			return true
+		}
 	}
 
 	if anno, ok := pod.Annotations[keyTransparentProxyStatus]; !ok || anno == "" {

--- a/control-plane/cni/main_test.go
+++ b/control-plane/cni/main_test.go
@@ -175,6 +175,15 @@ func TestSkipTrafficRedirection(t *testing.T) {
 			expectedSkip: false,
 		},
 		{
+			name: "Pod with v2 annotations correctly set",
+			annotatedPod: func(pod *corev1.Pod) *corev1.Pod {
+				pod.Annotations[keyMeshInjectStatus] = "foo"
+				pod.Annotations[keyTransparentProxyStatus] = "bar"
+				return pod
+			},
+			expectedSkip: false,
+		},
+		{
 			name: "Pod without annotations, will timeout waiting",
 			annotatedPod: func(pod *corev1.Pod) *corev1.Pod {
 				return pod


### PR DESCRIPTION


Changes proposed in this PR:
- include the "consul.hashicorp.com/mesh-inject-status" when checking if traffic redirection can be skipped
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


