### PR TITLE
fix deprecated kustomize strategic merge

### DIFF
--- a/acceptance/tests/fixtures/cases/crd-partitions/default-partition-default/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/crd-partitions/default-partition-default/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../../bases/exportedservices-default
+- ../../../bases/exportedservices-default
 
-patchesStrategicMerge:
-- patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/crd-partitions/default-partition-ns1/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/crd-partitions/default-partition-ns1/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../../bases/exportedservices-default
+- ../../../bases/exportedservices-default
 
-patchesStrategicMerge:
-- patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/crd-partitions/secondary-partition-default/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/crd-partitions/secondary-partition-default/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../../bases/exportedservices-secondary
+- ../../../bases/exportedservices-secondary
 
-patchesStrategicMerge:
-- patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/crd-partitions/secondary-partition-ns1/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/crd-partitions/secondary-partition-ns1/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../../bases/exportedservices-secondary
+- ../../../bases/exportedservices-secondary
 
-patchesStrategicMerge:
-- patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/crd-peers/default-namespace/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/crd-peers/default-namespace/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../../bases/exportedservices-default
+- ../../../bases/exportedservices-default
 
-patchesStrategicMerge:
-- patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/crd-peers/default/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/crd-peers/default/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../../bases/exportedservices-default
+- ../../../bases/exportedservices-default
 
-patchesStrategicMerge:
-- patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/crd-peers/non-default-namespace/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/crd-peers/non-default-namespace/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../../bases/exportedservices-default
+- ../../../bases/exportedservices-default
 
-patchesStrategicMerge:
-- patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-inject-multiport/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-inject-multiport/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../bases/static-client
+- ../../bases/static-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-inject/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-inject/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../bases/static-client
+- ../../bases/static-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-multi-dc/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-multi-dc/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../bases/static-client
+- ../../bases/static-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-namespaces/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-namespaces/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../bases/static-client
+- ../../bases/static-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-partitions/default-ns-default-partition/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-partitions/default-ns-default-partition/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../../bases/static-client
+- ../../../bases/static-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-partitions/default-ns-partition/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-partitions/default-ns-partition/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../../bases/static-client
+- ../../../bases/static-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-partitions/ns-default-partition/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-partitions/ns-default-partition/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../../bases/static-client
+- ../../../bases/static-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-partitions/ns-partition/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-partitions/ns-partition/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../../bases/static-client
+- ../../../bases/static-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-peers/default-namespace/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-peers/default-namespace/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../../bases/static-client
+- ../../../bases/static-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-peers/default/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-peers/default/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../../bases/static-client
+- ../../../bases/static-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-peers/non-default-namespace/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-peers/non-default-namespace/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../../bases/static-client
+- ../../../bases/static-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-client-tproxy/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-client-tproxy/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../bases/static-client
+- ../../bases/static-client
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml

--- a/acceptance/tests/fixtures/cases/static-server-inject/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/static-server-inject/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-  - ../../bases/static-server
+- ../../bases/static-server
 
-patchesStrategicMerge:
-  - patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml


### PR DESCRIPTION
Changes proposed in this PR:
- Removed some additional uses of deprecated strategic merge from 1.0.x
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


