### PR TITLE
[NET-5805] Fixing validating cert webhooks, fixing replace statements for go mod

### DIFF
--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/consul-k8s/control-plane
 // TODO: remove these when the SDK is released for Consul 1.17 and coinciding patch releases
 replace (
 	// This replace directive is needed because `api` requires 0.4.1 of proto-public but we need an unreleased version
-	github.com/hashicorp/consul/proto-public v0.4.1 => github.com/hashicorp/consul/proto-public v0.1.2-0.20230923011829-3436b2921af5
+	github.com/hashicorp/consul/proto-public v0.4.1 => github.com/hashicorp/consul/proto-public v0.1.2-0.20230929231147-632fd65c091c
 	// This replace directive is needed because `api` requires 0.14.1 of `sdk` but we need an unreleased version
 	github.com/hashicorp/consul/sdk v0.14.1 => github.com/hashicorp/consul/sdk v0.4.1-0.20230911164019-a69e901660bd
 )

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -265,8 +265,8 @@ github.com/hashicorp/consul-server-connection-manager v0.1.4 h1:wrcSRV6WGXFBNpNb
 github.com/hashicorp/consul-server-connection-manager v0.1.4/go.mod h1:LMqHkALoLP0HUQKOG21xXYr0YPUayIQIHNTlmxG100E=
 github.com/hashicorp/consul/api v1.10.1-0.20230914174054-e5808d85f751 h1:LnzgDq4e7ZfM1+XS6S21B9taQrbfdydXenL1xHyG1PQ=
 github.com/hashicorp/consul/api v1.10.1-0.20230914174054-e5808d85f751/go.mod h1:/Fz5sgOC0a5XY0BmPGj7aDSZRNgySLm02lV4xkU4DS4=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20230923011829-3436b2921af5 h1:5u/qgx4HVbPlTN6xvbgEd7ayjl1AL2pXThvipdE7ofw=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20230923011829-3436b2921af5/go.mod h1:KAOxsaELPpA7JX10kMeygAskAqsQnu3SPgeruMhYZMU=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20230929231147-632fd65c091c h1:d1ULTfDs6Hha01yfITC55MPGIsQpv0VqQfS45WZHJiY=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20230929231147-632fd65c091c/go.mod h1:KAOxsaELPpA7JX10kMeygAskAqsQnu3SPgeruMhYZMU=
 github.com/hashicorp/consul/sdk v0.4.1-0.20230911164019-a69e901660bd h1:tRrSgVY71Jl6T2lJUokMLj3T1MO9uiSvW0CieBkjTvo=
 github.com/hashicorp/consul/sdk v0.4.1-0.20230911164019-a69e901660bd/go.mod h1:vFt03juSzocLRFo59NkeQHHmQa6+g7oU0pfzdI1mUhg=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/control-plane/helper/webhook-configuration/webhook_configuration.go
+++ b/control-plane/helper/webhook-configuration/webhook_configuration.go
@@ -29,14 +29,20 @@ func UpdateWithCABundle(ctx context.Context, clientset kubernetes.Interface, web
 		return err
 	}
 
+	if !k8serrors.IsNotFound(err) {
 	err = updateMutatingWebhooksWithCABundle(ctx, clientset, mutatingWebhookCfg, caCert)
 	if err != nil {
 		return err
 	}
+    }
 
 	validatingWebhookCfg, err := clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, webhookConfigName, metav1.GetOptions{})
-	if err != nil {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		return err
+	}
+
+	if k8serrors.IsNotFound(err) {
+		return nil
 	}
 
 	return updateValidatingWebhooksWithCABundle(ctx, clientset, validatingWebhookCfg, caCert)

--- a/control-plane/helper/webhook-configuration/webhook_configuration.go
+++ b/control-plane/helper/webhook-configuration/webhook_configuration.go
@@ -30,11 +30,11 @@ func UpdateWithCABundle(ctx context.Context, clientset kubernetes.Interface, web
 	}
 
 	if !k8serrors.IsNotFound(err) {
-	err = updateMutatingWebhooksWithCABundle(ctx, clientset, mutatingWebhookCfg, caCert)
-	if err != nil {
-		return err
+		err = updateMutatingWebhooksWithCABundle(ctx, clientset, mutatingWebhookCfg, caCert)
+		if err != nil {
+			return err
+		}
 	}
-    }
 
 	validatingWebhookCfg, err := clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, webhookConfigName, metav1.GetOptions{})
 	if err != nil && !k8serrors.IsNotFound(err) {

--- a/control-plane/helper/webhook-configuration/webhook_configuration.go
+++ b/control-plane/helper/webhook-configuration/webhook_configuration.go
@@ -25,11 +25,12 @@ func UpdateWithCABundle(ctx context.Context, clientset kubernetes.Interface, web
 	}
 
 	mutatingWebhookCfg, err := clientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, webhookConfigName, metav1.GetOptions{})
-	if err == nil {
-		return updateMutatingWebhooksWithCABundle(ctx, clientset, mutatingWebhookCfg, caCert)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
 	}
 
-	if !k8serrors.IsNotFound(err) {
+	err = updateMutatingWebhooksWithCABundle(ctx, clientset, mutatingWebhookCfg, caCert)
+	if err != nil {
 		return err
 	}
 

--- a/control-plane/helper/webhook-configuration/webhook_configuration_test.go
+++ b/control-plane/helper/webhook-configuration/webhook_configuration_test.go
@@ -69,3 +69,44 @@ func TestUpdateWithCABundle_patchesExistingConfigurationForValidating(t *testing
 	require.NoError(t, err)
 	require.Equal(t, caBundleOne, mwcFetched.Webhooks[0].ClientConfig.CABundle)
 }
+
+func TestUpdateWithCABundle_patchesExistingConfigurationWhenMutatingAndValidatingExist(t *testing.T) {
+	caBundleOne := []byte("ca-bundle-for-mwc")
+	ctx := context.Background()
+	clientset := fake.NewSimpleClientset()
+
+	vwc := &admissionv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mwc-one",
+		},
+		Webhooks: []admissionv1.ValidatingWebhook{
+			{
+				Name: "webhook-under-test",
+			},
+		},
+	}
+
+	mwc := &admissionv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mwc-one",
+		},
+		Webhooks: []admissionv1.MutatingWebhook{
+			{
+				Name: "webhook-under-test",
+			},
+		},
+	}
+	mwcCreated, err := clientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(ctx, mwc, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(ctx, vwc, metav1.CreateOptions{})
+	require.NoError(t, err)
+	err = UpdateWithCABundle(ctx, clientset, mwcCreated.Name, caBundleOne)
+	require.NoError(t, err)
+	vwcFetched, err := clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, vwc.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, caBundleOne, vwcFetched.Webhooks[0].ClientConfig.CABundle)
+
+	mwcFetched, err := clientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, mwc.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, caBundleOne, mwcFetched.Webhooks[0].ClientConfig.CABundle)
+}


### PR DESCRIPTION
Changes proposed in this PR:
- Fix replace statements for proto-public to point to an existing commit
- Fix cert issue on validating webhooks

How I've tested this PR:
Ran setup locally using https://github.com/hashicorp/shared-consul-examples/tree/main/k8s/jwts and saw prior to these changes we had webhook cert errors, after we no longer have them

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


