### PR TITLE
Update ci.hcl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ on:
       - main
       # Push events to branches matching refs/heads/release/**
       - "release/**"
-      - "crt-move-to-prepare-workflow"
 
 env:
   PKG_NAME: "consul-k8s"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
       - main
       # Push events to branches matching refs/heads/release/**
       - "release/**"
+      - "crt-move-to-prepare-workflow"
 
 env:
   PKG_NAME: "consul-k8s"

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -32,156 +32,22 @@ event "build" {
   }
 }
 
-event "upload-dev" {
+event "prepare" {
   depends = ["build"]
-  action "upload-dev" {
+  action "prepare" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "upload-dev"
-    depends = ["build"]
+    repository   = "crt-workflows-common"
+    workflow     = "prepare"
+    depends      = ["build"]
   }
 
   notification {
     on = "fail"
   }
 }
-
-event "security-scan-binaries" {
-  depends = ["upload-dev"]
-  action "security-scan-binaries" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "security-scan-binaries"
-    config = "security-scan.hcl"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "security-scan-containers" {
-  depends = ["security-scan-binaries"]
-  action "security-scan-containers" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "security-scan-containers"
-    config = "security-scan.hcl"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-darwin-amd64" {
-  depends = ["security-scan-containers"]
-  action "notarize-darwin-amd64" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-darwin-amd64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-darwin-arm64" {
-  depends = ["notarize-darwin-amd64"]
-  action "notarize-darwin-arm64" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-darwin-arm64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-windows-386" {
-  depends = ["notarize-darwin-arm64"]
-  action "notarize-windows-386" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-windows-386"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-windows-amd64" {
-  depends = ["notarize-windows-386"]
-  action "notarize-windows-amd64" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-windows-amd64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "sign" {
-  depends = ["notarize-windows-amd64"]
-  action "sign" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "sign"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "sign-linux-rpms" {
-  depends = ["sign"]
-  action "sign-linux-rpms" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "sign-linux-rpms"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "verify" {
-  depends = ["sign-linux-rpms"]
-  action "verify" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "verify"
-  }
-
-  notification {
-    on = "always"
-  }
-}
-
-event "promote-dev-docker" {
-  depends = ["verify"]
-  action "promote-dev-docker" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-dev-docker"
-    depends = ["verify"]
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
 
 ## These are promotion and post-publish events
-## they should be added to the end of the file after the verify event stanza.
+## they should be added to the end of the file after the prepare event stanza.
 
 event "trigger-staging" {
 // This event is dispatched by the bob trigger-promotion command

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -14,6 +14,7 @@ project "consul-k8s" {
     release_branches = [
       "main",
       "release/**",
+      "crt-move-to-prepare-workflow",
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -14,7 +14,6 @@ project "consul-k8s" {
     release_branches = [
       "main",
       "release/**",
-      "crt-move-to-prepare-workflow",
     ]
   }
 }


### PR DESCRIPTION
Changes proposed in this PR:

This update, moves consul-k8s to use the prepare workflow. This workflow encapsulates several previous workflows, running jobs in parallel to reduce the artifact processing time. See [here](https://hashicorp.atlassian.net/wiki/spaces/RELENG/pages/2489712686/Dec+7th+2022+-+Introducing+the+new+Prepare+workflow) for more info .

How I've tested this PR:

- Added this branch to the build and ci.hcl for testing the prepare workflow.

- Successful prepare workflow can be seen in the PR checks and also [here](https://github.com/hashicorp/crt-workflows-common/actions/runs/6407034567).

Manually checked the artifacts were present in the stable channel in Artifactory for this [version/sha](https://artifactory.hashicorp.engineering/ui/repos/tree/General/hashicorp-crt-stable-local/consul-k8s/1.3.0-dev/4105f02c74faa698333e5a2632b2375ad660e26b).

How I expect reviewers to test this PR:
Quick sanity check that all the expected build artifacts are in the stable channel in artifactory (for this [version/commit sha](https://artifactory.hashicorp.engineering/ui/repos/tree/General/hashicorp-crt-stable-local/consul-k8s/1.3.0-dev/4105f02c74faa698333e5a2632b2375ad660e26b)).

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


