### PR TITLE
fix(v2): ca cert mounting path in mesh-init and dataplane

### DIFF
--- a/control-plane/api-gateway/gatekeeper/dataplane.go
+++ b/control-plane/api-gateway/gatekeeper/dataplane.go
@@ -10,11 +10,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 	"github.com/hashicorp/consul-k8s/control-plane/namespaces"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -162,7 +163,7 @@ func getDataplaneArgs(namespace string, config common.HelmConfig, bearerTokenFil
 			args = append(args, "-tls-server-name="+config.ConsulTLSServerName)
 		}
 		if config.ConsulCACert != "" {
-			args = append(args, "-ca-certs="+constants.ConsulCAFile)
+			args = append(args, "-ca-certs="+constants.LegacyConsulCAFile)
 		}
 	} else {
 		args = append(args, "-tls-disabled")

--- a/control-plane/connect-inject/constants/constants.go
+++ b/control-plane/connect-inject/constants/constants.go
@@ -4,8 +4,13 @@
 package constants
 
 const (
+	// LegacyConsulCAFile is the location of the Consul CA file inside the injected pod.
+	// This is used with the V1 API.
+	LegacyConsulCAFile = "/consul/connect-inject/consul-ca.pem"
+
 	// ConsulCAFile is the location of the Consul CA file inside the injected pod.
-	ConsulCAFile = "/consul/connect-inject/consul-ca.pem"
+	// This is used with the V2 API.
+	ConsulCAFile = "/consul/mesh-inject/consul-ca.pem"
 
 	// DefaultConsulNS is the default Consul namespace name.
 	DefaultConsulNS = "default"

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
@@ -10,12 +10,13 @@ import (
 	"strings"
 
 	"github.com/google/shlex"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 )
 
 const (
@@ -255,7 +256,7 @@ func (w *MeshWebhook) getContainerSidecarArgs(namespace corev1.Namespace, mpi mu
 			args = append(args, "-tls-server-name="+w.ConsulTLSServerName)
 		}
 		if w.ConsulCACert != "" {
-			args = append(args, "-ca-certs="+constants.ConsulCAFile)
+			args = append(args, "-ca-certs="+constants.LegacyConsulCAFile)
 		}
 	} else {
 		args = append(args, "-tls-disabled")

--- a/control-plane/connect-inject/webhookv2/consul_dataplane_sidecar_test.go
+++ b/control-plane/connect-inject/webhookv2/consul_dataplane_sidecar_test.go
@@ -77,7 +77,7 @@ func TestHandlerConsulDataplaneSidecar(t *testing.T) {
 				w.ConsulTLSServerName = "server.dc1.consul"
 				w.ConsulCACert = "consul-ca-cert"
 			},
-			additionalExpCmdArgs: " -tls-server-name=server.dc1.consul -ca-certs=/consul/connect-inject/consul-ca.pem -graceful-port=20600 -telemetry-prom-scrape-path=/metrics",
+			additionalExpCmdArgs: " -tls-server-name=server.dc1.consul -ca-certs=/consul/mesh-inject/consul-ca.pem -graceful-port=20600 -telemetry-prom-scrape-path=/metrics",
 		},
 		"with TLS and no CA cert provided": {
 			webhookSetupFunc: func(w *MeshWebhook) {

--- a/control-plane/subcommand/connect-init/command.go
+++ b/control-plane/subcommand/connect-init/command.go
@@ -199,7 +199,7 @@ func (c *Command) Run(args []string) int {
 
 	// todo (agentless): this should eventually be passed to consul-dataplane as a string so we don't need to write it to file.
 	if c.consul.UseTLS && c.consul.CACertPEM != "" {
-		if err = common.WriteFileWithPerms(constants.ConsulCAFile, c.consul.CACertPEM, 0444); err != nil {
+		if err = common.WriteFileWithPerms(constants.LegacyConsulCAFile, c.consul.CACertPEM, 0444); err != nil {
 			c.logger.Error("error writing CA cert file", "error", err)
 			return 1
 		}


### PR DESCRIPTION
Changes proposed in this PR:
- Fix the path where CA certs are copied to the new `/consul/mesh-init` directory.

I need to figure out a way to backport to the RC.

How I've tested this PR: 👀 

How I expect reviewers to test this PR: 👀 


Checklist:
- [X] Tests added
- [ ] ~[CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)~


