### PR TITLE
[NET-5818] Fix Status for Gateway Policy 

### DIFF
--- a/charts/consul/templates/crd-gatewaypolicies.yaml
+++ b/charts/consul/templates/crd-gatewaypolicies.yaml
@@ -202,17 +202,6 @@ spec:
             description: GatewayPolicyStatus defines the observed state of the gateway.
             properties:
               conditions:
-                default:
-                - lastTransitionTime: "1970-01-01T00:00:00Z"
-                  message: Waiting for controller
-                  reason: Pending
-                  status: Unknown
-                  type: Accepted
-                - lastTransitionTime: "1970-01-01T00:00:00Z"
-                  message: Waiting for controller
-                  reason: Pending
-                  status: Unknown
-                  type: ResolvedRefs
                 description: "Conditions describe the current conditions of the Policy.
                   \n Known condition types are: \n * \"Accepted\" * \"ResolvedRefs\""
                 items:

--- a/control-plane/api-gateway/binding/binder.go
+++ b/control-plane/api-gateway/binding/binder.go
@@ -291,6 +291,7 @@ func (b *Binder) Snapshot() *Snapshot {
 		if common.RemoveFinalizer(&b.config.Gateway) {
 			snapshot.Kubernetes.Updates.Add(&b.config.Gateway)
 			for _, policy := range b.config.Policies {
+				policy := policy
 				policy.Status = v1alpha1.GatewayPolicyStatus{}
 				snapshot.Kubernetes.StatusUpdates.Add(&policy)
 			}

--- a/control-plane/api-gateway/binding/binder.go
+++ b/control-plane/api-gateway/binding/binder.go
@@ -287,8 +287,13 @@ func (b *Binder) Snapshot() *Snapshot {
 				Namespace: service.Namespace,
 			})
 		}
+
 		if common.RemoveFinalizer(&b.config.Gateway) {
 			snapshot.Kubernetes.Updates.Add(&b.config.Gateway)
+			for _, policy := range b.config.Policies {
+				policy.Status = v1alpha1.GatewayPolicyStatus{}
+				snapshot.Kubernetes.StatusUpdates.Add(&policy)
+			}
 		}
 	}
 

--- a/control-plane/api/v1alpha1/gatewaypolicy_types.go
+++ b/control-plane/api/v1alpha1/gatewaypolicy_types.go
@@ -130,6 +130,5 @@ type GatewayPolicyStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	// +kubebuilder:validation:MaxItems=8
-	// +kubebuilder:default={{type: "Accepted", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type: "ResolvedRefs", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/control-plane/config/crd/bases/consul.hashicorp.com_gatewaypolicies.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_gatewaypolicies.yaml
@@ -198,17 +198,6 @@ spec:
             description: GatewayPolicyStatus defines the observed state of the gateway.
             properties:
               conditions:
-                default:
-                - lastTransitionTime: "1970-01-01T00:00:00Z"
-                  message: Waiting for controller
-                  reason: Pending
-                  status: Unknown
-                  type: Accepted
-                - lastTransitionTime: "1970-01-01T00:00:00Z"
-                  message: Waiting for controller
-                  reason: Pending
-                  status: Unknown
-                  type: ResolvedRefs
                 description: "Conditions describe the current conditions of the Policy.
                   \n Known condition types are: \n * \"Accepted\" * \"ResolvedRefs\""
                 items:


### PR DESCRIPTION
Changes proposed in this PR:
- Fixes status for Gateway Policies when the gateway they reference is removed. Previously we set some default values, now we show no status to mimic the behavior on routes when a gateway they reference cannot be found 

How I've tested this PR:
Ran locally

How I expect reviewers to test this PR:


Checklist:
- [X] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


