### PR TITLE
Manual backport of update backport assistant to use merge commits to 1.1.x

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,3 +1,5 @@
+# Copyright (c) HashiCorp, Inc.
+
 ---
 name: Backport Assistant Runner
 
@@ -11,11 +13,15 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.3.3
+    container: hashicorpdev/backport-assistant:0.3.5
     steps:
       - name: Run Backport Assistant
         run: backport-assistant backport -merge-method=squash -gh-automerge
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.x)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
+          # This forces the backport assistant to backport the merged commit
+          # instead of each commit individually. The environment variable
+          # just needs to exist for this to happen.
+          BACKPORT_MERGE_COMMIT: true
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}


### PR DESCRIPTION
Changes proposed in this PR:

Setting this environment variable causes the backport assistant to use the merge commit instead of individual commits when backporting a PR. This should prevent the assistant from trying to backport 100s of commits. Nomad uses this flag and it has helped a lot.

From the docs:

> BACKPORT_MERGE_COMMIT: When nonempty, backport-assistant will try to backport the merge commit instead of the individual commits that make of the PR. This will only work if you exclusively use the squash-merge commit
    strategy for PRs that get backported.


How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 