### PR TITLE
Fix local rate limiting acceptance tests

### DIFF
--- a/acceptance/tests/connect/local_rate_limit_test.go
+++ b/acceptance/tests/connect/local_rate_limit_test.go
@@ -20,7 +20,7 @@ import (
 
 // TestConnectInject_LocalRateLimiting tests that local rate limiting works as expected between services.
 func TestConnectInject_LocalRateLimiting(t *testing.T) {
-	t.Skipf("TODO(flaky-1.17): NET-XXXX")
+	//t.Skipf("TODO(flaky-1.17): NET-5727")
 	cfg := suite.Config()
 	ctx := suite.Environment().DefaultContext(t)
 

--- a/acceptance/tests/connect/local_rate_limit_test.go
+++ b/acceptance/tests/connect/local_rate_limit_test.go
@@ -39,13 +39,20 @@ func TestConnectInject_LocalRateLimiting(t *testing.T) {
 	connHelper.DeployClientAndServer(t)
 	connHelper.TestConnectionSuccess(t, connhelper.ConnHelperOpts{})
 
+	// By default, target the static-server on localhost:1234
+	staticServer := "localhost:1234"
+	if cfg.EnableTransparentProxy {
+		// When TProxy is enabled, use the service name.
+		staticServer = connhelper.StaticServerName
+	}
+
 	// Map the static-server URL and path to the rate limits defined in the service defaults at:
 	// ../fixtures/cases/local-rate-limiting/service-defaults-static-server.yaml
 	rateLimitMap := map[string]int{
-		"http://localhost:1234":             2,
-		"http://localhost:1234/exact":       3,
-		"http://localhost:1234/prefix-test": 4,
-		"http://localhost:1234/regex":       5,
+		"http://" + staticServer:                  2,
+		"http://" + staticServer + "/exact":       3,
+		"http://" + staticServer + "/prefix-test": 4,
+		"http://" + staticServer + "/regex":       5,
 	}
 
 	opts := newRateLimitOptions(t, ctx)

--- a/acceptance/tests/connect/local_rate_limit_test.go
+++ b/acceptance/tests/connect/local_rate_limit_test.go
@@ -20,7 +20,6 @@ import (
 
 // TestConnectInject_LocalRateLimiting tests that local rate limiting works as expected between services.
 func TestConnectInject_LocalRateLimiting(t *testing.T) {
-	//t.Skipf("TODO(flaky-1.17): NET-5727")
 	cfg := suite.Config()
 	ctx := suite.Environment().DefaultContext(t)
 


### PR DESCRIPTION
Changes proposed in this PR:
- This PR fixes the failing local rate limiting tests for tproxy and CNI.
- There was a bug in the test when tproxy was enabled where it would try to reach the `static-server` via `localhost:1234` (explict upstream) instead of using the service name. 

How I've tested this PR:
- Locally
- CI

How I expect reviewers to test this PR:
:eyes: 

Checklist:
- [x] Tests updated
- [x] ~[CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)~


