### PR TITLE
Fix Gateway API CRDs

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -11,6 +11,8 @@ project {
 
     # ignoring charts templates as adding copyright headers breaks all tests
     "charts/consul/templates/**",
+    # we don't own these and copyright headers break them
+    "control-plane/config/crds/external/**",
 
   ]
 }

--- a/control-plane/config/crd/external/.yml
+++ b/control-plane/config/crd/external/.yml
@@ -1,4 +1,0 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
-

--- a/control-plane/config/crd/external/gatewayclasses.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/gatewayclasses.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/control-plane/config/crd/external/gateways.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/gateways.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/control-plane/config/crd/external/grpcroutes.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/grpcroutes.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/control-plane/config/crd/external/httproutes.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/httproutes.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/control-plane/config/crd/external/referencegrants.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/referencegrants.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/control-plane/config/crd/external/tcproutes.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/tcproutes.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/control-plane/config/crd/external/tlsroutes.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/tlsroutes.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/control-plane/config/crd/external/udproutes.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/udproutes.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
It looks like the `copywrite` CLI deleted the Gateway CRDs we install. This would have broken us if it was released. I regenerated the external CRDs and added them to the Copywrite ignore given they are just pulled in from the Gateway SIG anyway and are not our IP.

Changes proposed in this PR:
- Regenerate external Gateway CRDs
- Remove errant .yml
- Add external CRDs to copywrite ignore
