### PR TITLE
[NET-5717] feat(control-plane): v2 add service account name to workload identity meta

### DIFF
--- a/control-plane/connect-inject/constants/constants.go
+++ b/control-plane/connect-inject/constants/constants.go
@@ -42,6 +42,10 @@ const (
 	// MetaKeyKubeServiceName is the meta key name for Kubernetes service name used for the Consul services.
 	MetaKeyKubeServiceName = "k8s-service-name"
 
+	// MetaKeyKubeServiceAccountName is the meta key name for Kubernetes service account name used for the Consul
+	// v2 workload identity.
+	MetaKeyKubeServiceAccountName = "k8s-service-account-name"
+
 	// MetaKeyPodName is the meta key name for Kubernetes pod name used for the Consul services.
 	MetaKeyPodName = "pod-name"
 

--- a/control-plane/connect-inject/controllers/serviceaccount/serviceaccount_controller.go
+++ b/control-plane/connect-inject/controllers/serviceaccount/serviceaccount_controller.go
@@ -83,8 +83,9 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		r.getConsulNamespace(serviceAccount.Namespace),
 		r.getConsulPartition(),
 		map[string]string{
-			constants.MetaKeyKubeNS:    serviceAccount.Namespace,
-			constants.MetaKeyManagedBy: constants.ManagedByServiceAccountValue,
+			constants.MetaKeyKubeNS:                 serviceAccount.Namespace,
+			constants.MetaKeyKubeServiceAccountName: serviceAccount.Name,
+			constants.MetaKeyManagedBy:              constants.ManagedByServiceAccountValue,
 		},
 	)
 


### PR DESCRIPTION
Changes proposed in this PR:
- Add missing meta key per RFC

How I've tested this PR: Unit tests pass

How I expect reviewers to test this PR: 👀 


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


