### PR TITLE
test: fix tests now that v1 catalog disabled in v2 mode

### DIFF
--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -5,7 +5,7 @@ replace (
 	// This replace directive is needed because `api` requires 0.4.1 of proto-public but we need an unreleased version
 	github.com/hashicorp/consul/proto-public v0.4.1 => github.com/hashicorp/consul/proto-public v0.1.2-0.20230929231147-632fd65c091c
 	// This replace directive is needed because `api` requires 0.14.1 of `sdk` but we need an unreleased version
-	github.com/hashicorp/consul/sdk v0.14.1 => github.com/hashicorp/consul/sdk v0.4.1-0.20230911164019-a69e901660bd
+	github.com/hashicorp/consul/sdk v0.14.1 => github.com/hashicorp/consul/sdk v0.4.1-0.20231011203909-c26d5cf62cb9
 )
 
 require (

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -267,8 +267,8 @@ github.com/hashicorp/consul/api v1.10.1-0.20230914174054-e5808d85f751 h1:LnzgDq4
 github.com/hashicorp/consul/api v1.10.1-0.20230914174054-e5808d85f751/go.mod h1:/Fz5sgOC0a5XY0BmPGj7aDSZRNgySLm02lV4xkU4DS4=
 github.com/hashicorp/consul/proto-public v0.1.2-0.20230929231147-632fd65c091c h1:d1ULTfDs6Hha01yfITC55MPGIsQpv0VqQfS45WZHJiY=
 github.com/hashicorp/consul/proto-public v0.1.2-0.20230929231147-632fd65c091c/go.mod h1:KAOxsaELPpA7JX10kMeygAskAqsQnu3SPgeruMhYZMU=
-github.com/hashicorp/consul/sdk v0.4.1-0.20230911164019-a69e901660bd h1:tRrSgVY71Jl6T2lJUokMLj3T1MO9uiSvW0CieBkjTvo=
-github.com/hashicorp/consul/sdk v0.4.1-0.20230911164019-a69e901660bd/go.mod h1:vFt03juSzocLRFo59NkeQHHmQa6+g7oU0pfzdI1mUhg=
+github.com/hashicorp/consul/sdk v0.4.1-0.20231011203909-c26d5cf62cb9 h1:j0Rvt1KiKIKlMc2UnA0ilHfIGo66SzrBztGZaCou3+w=
+github.com/hashicorp/consul/sdk v0.4.1-0.20231011203909-c26d5cf62cb9/go.mod h1:vFt03juSzocLRFo59NkeQHHmQa6+g7oU0pfzdI1mUhg=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/control-plane/helper/test/test_util.go
+++ b/control-plane/helper/test/test_util.go
@@ -54,7 +54,7 @@ func TestServerWithMockConnMgrWatcher(t *testing.T, callback testutil.ServerConf
 	t.Cleanup(func() {
 		_ = consulServer.Stop()
 	})
-	consulServer.WaitForSerfCheck(t)
+	consulServer.WaitForLeader(t)
 
 	consulConfig := &consul.Config{
 		APIClientConfig: &api.Config{Address: consulServer.HTTPAddr},

--- a/control-plane/namespaces/namespaces_test.go
+++ b/control-plane/namespaces/namespaces_test.go
@@ -40,7 +40,7 @@ func TestEnsureExists_AlreadyExists(tt *testing.T) {
 			})
 			req.NoError(err)
 			defer consul.Stop()
-			consul.WaitForSerfCheck(t)
+			consul.WaitForLeader(t)
 			consulClient, err := capi.NewClient(&capi.Config{
 				Address: consul.HTTPAddr,
 				Token:   masterToken,


### PR DESCRIPTION
Changes proposed in this PR:
- Fixes tests now that Consul doesn't run V1 catalog endpoints in V2 mode.

How I've tested this PR: running locally

How I expect reviewers to test this PR: check CI



