### PR TITLE
Fix ENT Tests Now that They Are Running Again 🏃 

### DIFF
--- a/control-plane/config-entries/controllers/configentry_controller_ent_test.go
+++ b/control-plane/config-entries/controllers/configentry_controller_ent_test.go
@@ -294,13 +294,13 @@ func TestConfigEntryController_updatesEntConfigEntry(t *testing.T) {
 			},
 			updateF: func(resource common.ConfigEntryResource) {
 				sg := resource.(*v1alpha1.SamenessGroup)
-				sg.Spec.IncludeLocal = false
+				sg.Spec.DefaultForFailover = false
 			},
 			compare: func(t *testing.T, consulEntry capi.ConfigEntry) {
 				resource, ok := consulEntry.(*capi.SamenessGroupConfigEntry)
 				require.True(t, ok, "cast error")
-				require.Equal(t, true, resource.DefaultForFailover)
-				require.Equal(t, false, resource.IncludeLocal)
+				require.Equal(t, false, resource.DefaultForFailover)
+				require.Equal(t, true, resource.IncludeLocal)
 				require.Equal(t, "dc1", resource.Members[0].Peer)
 				require.Equal(t, "", resource.Members[0].Partition)
 			},

--- a/control-plane/config-entries/controllersv2/meshconfig_controller_test.go
+++ b/control-plane/config-entries/controllersv2/meshconfig_controller_test.go
@@ -145,6 +145,11 @@ func TestMeshConfigController_createsMeshConfig(t *testing.T) {
 			resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 			require.NoError(t, err)
 
+			require.Eventually(t, func() bool {
+				_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+				return err == nil
+			}, 5*time.Second, 500*time.Millisecond)
+
 			r := c.reconciler(fakeClient, testClient.Cfg, testClient.Watcher, logrtest.New(t))
 			namespacedName := types.NamespacedName{
 				Namespace: metav1.NamespaceDefault,
@@ -284,6 +289,12 @@ func TestMeshConfigController_updatesMeshConfig(t *testing.T) {
 			})
 			resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+				return err == nil
+			}, 5*time.Second, 500*time.Millisecond)
+
 			// We haven't run reconcile yet, so we must create the MeshConfig
 			// in Consul ourselves.
 			{
@@ -400,6 +411,11 @@ func TestMeshConfigController_deletesMeshConfig(t *testing.T) {
 			resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 			require.NoError(t, err)
 
+			require.Eventually(t, func() bool {
+				_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+				return err == nil
+			}, 5*time.Second, 500*time.Millisecond)
+
 			// We haven't run reconcile yet, so we must create the config entry
 			// in Consul ourselves.
 			{
@@ -465,6 +481,11 @@ func TestMeshConfigController_errorUpdatesSyncStatus(t *testing.T) {
 	testClient := test.TestServerWithMockConnMgrWatcher(t, func(c *testutil.TestServerConfig) {
 		c.Experiments = []string{"resource-apis"}
 	})
+
+	require.Eventually(t, func() bool {
+		_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+		return err == nil
+	}, 5*time.Second, 500*time.Millisecond)
 
 	// Stop the server before calling reconcile imitating a server that's not running.
 	_ = testClient.TestServer.Stop()
@@ -547,6 +568,11 @@ func TestMeshConfigController_setsSyncedToTrue(t *testing.T) {
 	resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 	require.NoError(t, err)
 
+	require.Eventually(t, func() bool {
+		_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+		return err == nil
+	}, 5*time.Second, 500*time.Millisecond)
+
 	reconciler := &TrafficPermissionsController{
 		Client: fakeClient,
 		Log:    logrtest.New(t),
@@ -621,6 +647,11 @@ func TestMeshConfigController_doesNotCreateUnownedMeshConfig(t *testing.T) {
 	})
 	resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+		return err == nil
+	}, 5*time.Second, 500*time.Millisecond)
 
 	unmanagedResource := trafficpermissions.Resource(constants.DefaultConsulNS, constants.DefaultConsulPartition)
 	unmanagedResource.Metadata = make(map[string]string) // Zero out the metadata
@@ -724,6 +755,11 @@ func TestMeshConfigController_doesNotDeleteUnownedConfig(t *testing.T) {
 	})
 	resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+		return err == nil
+	}, 5*time.Second, 500*time.Millisecond)
 
 	reconciler := &TrafficPermissionsController{
 		Client: fakeClient,

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_ent_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_ent_test.go
@@ -641,6 +641,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
 							Service:   "service-updated",
@@ -653,6 +656,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -714,6 +720,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -726,6 +735,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-different-consul-svc-name-sidecar-proxy",
@@ -795,6 +807,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
 							Service:   "service-updated",
@@ -807,6 +822,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -877,6 +895,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
 							Service:   "service-updated",
@@ -889,6 +910,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -906,6 +930,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod2-service-updated",
 							Service:   "service-updated",
@@ -918,6 +945,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod2-service-updated-sidecar-proxy",
@@ -980,6 +1010,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -992,6 +1025,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-different-consul-svc-name-sidecar-proxy",
@@ -1009,6 +1045,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod2-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -1021,6 +1060,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod2-different-consul-svc-name-sidecar-proxy",
@@ -1069,6 +1111,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
 							Service:   "service-updated",
@@ -1081,6 +1126,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -1098,6 +1146,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod2-service-updated",
 							Service:   "service-updated",
@@ -1110,6 +1161,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod2-service-updated-sidecar-proxy",
@@ -1146,6 +1200,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -1158,6 +1215,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-different-consul-svc-name-sidecar-proxy",
@@ -1175,6 +1235,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod2-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -1187,6 +1250,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod2-different-consul-svc-name-sidecar-proxy",
@@ -1236,6 +1302,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:      "pod1-service-updated",
 							Service: "service-updated",
@@ -1254,6 +1323,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -1322,6 +1394,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:      "pod1-service-updated",
 							Service: "service-updated",
@@ -1340,6 +1415,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -1363,6 +1441,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:      "pod2-service-updated",
 							Service: "service-updated",
@@ -1381,6 +1462,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod2-service-updated-sidecar-proxy",
@@ -1436,8 +1520,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						c.ACL.Tokens.InitialManagement = adminToken
 					}
 				})
-
 				consulClient := testClient.APIClient
+				// Coincidentally, this allows enough time for the bootstrap token to be generated
+				testClient.TestServer.WaitForActiveCARoot(t)
 
 				_, err := namespaces.EnsureExists(consulClient, ts.ExpConsulNS, "")
 				require.NoError(t, err)
@@ -1742,6 +1827,8 @@ func TestReconcileDeleteEndpointWithNamespaces(t *testing.T) {
 					}
 				})
 				consulClient := testClient.APIClient
+				// Coincidentally, this allows enough time for the bootstrap token to be generated
+				testClient.TestServer.WaitForActiveCARoot(t)
 
 				_, err := namespaces.EnsureExists(consulClient, ts.ExpConsulNS, "")
 				require.NoError(t, err)
@@ -1753,6 +1840,9 @@ func TestReconcileDeleteEndpointWithNamespaces(t *testing.T) {
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
 						Service: svc,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 					}
 					_, err = consulClient.Catalog().Register(serviceRegistration, nil)
 					require.NoError(t, err)
@@ -2034,6 +2124,8 @@ func TestReconcileDeleteGatewayWithNamespaces(t *testing.T) {
 					}
 				})
 				consulClient := testClient.APIClient
+				// Coincidentally, this allows enough time for the bootstrap token to be generated
+				testClient.TestServer.WaitForActiveCARoot(t)
 
 				_, err := namespaces.EnsureExists(consulClient, ts.ConsulNS, "")
 				require.NoError(t, err)
@@ -2045,6 +2137,9 @@ func TestReconcileDeleteGatewayWithNamespaces(t *testing.T) {
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
 						Service: svc,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 					}
 					_, err = consulClient.Catalog().Register(serviceRegistration, nil)
 					require.NoError(t, err)
@@ -2107,8 +2202,15 @@ func TestReconcileDeleteGatewayWithNamespaces(t *testing.T) {
 				require.Empty(t, append(defaultNS, testNS...))
 
 				if tt.enableACLs {
-					_, _, err = consulClient.ACL().TokenRead(token.AccessorID, nil)
-					require.Contains(t, err.Error(), "ACL not found")
+					queryOpts := &api.QueryOptions{}
+					if tt.initialConsulSvcs[0].Kind == api.ServiceKindMeshGateway {
+						queryOpts.Namespace = "default" // Mesh Gateways must always be registered in the "default" namespace.
+					} else {
+						queryOpts.Namespace = ts.ConsulNS
+					}
+
+					token, _, err = consulClient.ACL().TokenRead(token.AccessorID, queryOpts)
+					require.Contains(t, err.Error(), "ACL not found", token)
 				}
 			})
 		}

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
@@ -4167,6 +4167,7 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 				}
 			})
 			consulClient := testClient.APIClient
+			// TODO: stabilize this test by waiting for the ACL bootstrap
 
 			// Register service and proxy in consul
 			var token *api.ACLToken

--- a/control-plane/connect-inject/controllers/peering/peering_acceptor_controller_test.go
+++ b/control-plane/connect-inject/controllers/peering/peering_acceptor_controller_test.go
@@ -11,9 +11,6 @@ import (
 	"time"
 
 	logrtest "github.com/go-logr/logr/testr"
-	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
-	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
@@ -26,6 +23,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
+	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 )
 
 // TestReconcile_CreateUpdatePeeringAcceptor creates a peering acceptor.
@@ -508,6 +509,7 @@ func TestReconcile_CreateUpdatePeeringAcceptor(t *testing.T) {
 			// Create test consul server.
 			testClient := test.TestServerWithMockConnMgrWatcher(t, nil)
 			consulClient := testClient.APIClient
+			testClient.TestServer.WaitForActiveCARoot(t)
 
 			if tt.initialConsulPeerName != "" {
 				// Add the initial peerings into Consul by calling the Generate token endpoint.
@@ -631,6 +633,7 @@ func TestReconcile_DeletePeeringAcceptor(t *testing.T) {
 	// Create test consul server.
 	testClient := test.TestServerWithMockConnMgrWatcher(t, nil)
 	consulClient := testClient.APIClient
+	testClient.TestServer.WaitForActiveCARoot(t)
 
 	// Add the initial peerings into Consul by calling the Generate token endpoint.
 	_, _, err := consulClient.Peerings().GenerateToken(context.Background(), api.PeeringGenerateTokenRequest{PeerName: "acceptor-deleted"}, nil)
@@ -777,6 +780,7 @@ func TestReconcile_VersionAnnotation(t *testing.T) {
 			// Create test consul server.
 			testClient := test.TestServerWithMockConnMgrWatcher(t, nil)
 			consulClient := testClient.APIClient
+			testClient.TestServer.WaitForActiveCARoot(t)
 
 			_, _, err := consulClient.Peerings().GenerateToken(context.Background(), api.PeeringGenerateTokenRequest{PeerName: "acceptor-created"}, nil)
 			require.NoError(t, err)

--- a/control-plane/connect-inject/controllers/pod/pod_controller_ent_test.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller_ent_test.go
@@ -8,6 +8,7 @@ package pod
 import (
 	"context"
 	"testing"
+	"time"
 
 	mapset "github.com/deckarep/golang-set"
 	logrtest "github.com/go-logr/logr/testr"
@@ -673,6 +674,11 @@ func runControllerTest(t *testing.T, tc testCase) {
 
 	resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+		return err == nil
+	}, 5*time.Second, 500*time.Millisecond)
 
 	// Create the partition in Consul.
 	if tc.partition != "" {

--- a/control-plane/connect-inject/controllers/pod/pod_controller_test.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller_test.go
@@ -121,6 +121,11 @@ func TestWorkloadWrite(t *testing.T) {
 		resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 		require.NoError(t, err)
 
+		require.Eventually(t, func() bool {
+			_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+			return err == nil
+		}, 5*time.Second, 500*time.Millisecond)
+
 		// Create the pod controller.
 		pc := &Controller{
 			Client:              fakeClient,
@@ -307,6 +312,11 @@ func TestWorkloadDelete(t *testing.T) {
 		resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 		require.NoError(t, err)
 
+		require.Eventually(t, func() bool {
+			_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+			return err == nil
+		}, 5*time.Second, 500*time.Millisecond)
+
 		// Create the pod controller.
 		pc := &Controller{
 			Client:              fakeClient,
@@ -390,6 +400,11 @@ func TestHealthStatusWrite(t *testing.T) {
 		})
 		resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+			return err == nil
+		}, 5*time.Second, 500*time.Millisecond)
 
 		// Create the pod controller.
 		pc := &Controller{
@@ -507,6 +522,11 @@ func TestProxyConfigurationWrite(t *testing.T) {
 		resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 		require.NoError(t, err)
 
+		require.Eventually(t, func() bool {
+			_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+			return err == nil
+		}, 5*time.Second, 500*time.Millisecond)
+
 		// Create the pod controller.
 		pc := &Controller{
 			Client:              fakeClient,
@@ -602,6 +622,9 @@ func TestProxyConfigurationWrite(t *testing.T) {
 							},
 						},
 					},
+					TransparentProxy: &pbmesh.TransparentProxy{
+						OutboundListenerPort: 15001,
+					},
 				},
 				BootstrapConfig: &pbmesh.BootstrapConfig{
 					PrometheusBindAddr:              "0.0.0.0:5678",
@@ -645,6 +668,9 @@ func TestProxyConfigurationWrite(t *testing.T) {
 							},
 						},
 					},
+					TransparentProxy: &pbmesh.TransparentProxy{
+						OutboundListenerPort: 15001,
+					},
 				},
 				BootstrapConfig: &pbmesh.BootstrapConfig{
 					PrometheusBindAddr: "0.0.0.0:21234",
@@ -663,6 +689,9 @@ func TestProxyConfigurationWrite(t *testing.T) {
 				},
 				DynamicConfig: &pbmesh.DynamicConfig{
 					Mode: pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT,
+					TransparentProxy: &pbmesh.TransparentProxy{
+						OutboundListenerPort: 15001,
+					},
 				},
 			},
 		},
@@ -699,6 +728,11 @@ func TestProxyConfigurationDelete(t *testing.T) {
 		})
 		resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+			return err == nil
+		}, 5*time.Second, 500*time.Millisecond)
 
 		// Create the pod controller.
 		pc := &Controller{
@@ -979,6 +1013,11 @@ func TestDestinationsWrite(t *testing.T) {
 			resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 			require.NoError(t, err)
 
+			require.Eventually(t, func() bool {
+				_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+				return err == nil
+			}, 5*time.Second, 500*time.Millisecond)
+
 			pc := &Controller{
 				Log: logrtest.New(t),
 				K8sNamespaceConfig: common.K8sNamespaceConfig{
@@ -1061,6 +1100,11 @@ func TestDestinationsDelete(t *testing.T) {
 			})
 			resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+				return err == nil
+			}, 5*time.Second, 500*time.Millisecond)
 
 			pc := &Controller{
 				Log: logrtest.New(t),
@@ -1146,6 +1190,11 @@ func TestReconcileCreatePod(t *testing.T) {
 		})
 		resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+			return err == nil
+		}, 5*time.Second, 500*time.Millisecond)
 
 		// Create the pod controller.
 		pc := &Controller{
@@ -1343,6 +1392,11 @@ func TestReconcileUpdatePod(t *testing.T) {
 		resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 		require.NoError(t, err)
 
+		require.Eventually(t, func() bool {
+			_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+			return err == nil
+		}, 5*time.Second, 500*time.Millisecond)
+
 		// Create the pod controller.
 		pc := &Controller{
 			Client:              fakeClient,
@@ -1499,6 +1553,9 @@ func TestReconcileUpdatePod(t *testing.T) {
 							},
 						},
 					},
+					TransparentProxy: &pbmesh.TransparentProxy{
+						OutboundListenerPort: 15001,
+					},
 				},
 				BootstrapConfig: &pbmesh.BootstrapConfig{
 					PrometheusBindAddr: "0.0.0.0:21234",
@@ -1603,6 +1660,11 @@ func TestReconcileDeletePod(t *testing.T) {
 		})
 		resourceClient, err := consul.NewResourceServiceClient(testClient.Watcher)
 		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+			return err == nil
+		}, 5*time.Second, 500*time.Millisecond)
 
 		// Create the pod controller.
 		pc := &Controller{
@@ -1835,7 +1897,7 @@ func createCriticalHealthStatus(name string, namespace string) *pbcatalog.Health
 // createProxyConfiguration creates a proxyConfiguration that matches the pod from createPod,
 // assuming that metrics, telemetry, and overwrite probes are enabled separately.
 func createProxyConfiguration(podName string, mode pbmesh.ProxyMode) *pbmesh.ProxyConfiguration {
-	return &pbmesh.ProxyConfiguration{
+	mesh := &pbmesh.ProxyConfiguration{
 		Workloads: &pbcatalog.WorkloadSelector{
 			Names: []string{podName},
 		},
@@ -1866,6 +1928,14 @@ func createProxyConfiguration(podName string, mode pbmesh.ProxyMode) *pbmesh.Pro
 			TelemetryCollectorBindSocketDir: DefaultTelemetryBindSocketDir,
 		},
 	}
+
+	if mode == pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT {
+		mesh.DynamicConfig.TransparentProxy = &pbmesh.TransparentProxy{
+			OutboundListenerPort: 15001,
+		}
+	}
+
+	return mesh
 }
 
 // createCriticalHealthStatus creates a failing HealthStatus that matches the pod from createPod.

--- a/control-plane/connect-inject/controllers/serviceaccount/serviceaccount_controller_test.go
+++ b/control-plane/connect-inject/controllers/serviceaccount/serviceaccount_controller_test.go
@@ -6,6 +6,7 @@ package serviceaccount
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/proto"
@@ -242,6 +243,11 @@ func runReconcileCase(t *testing.T, tc reconcileCase) {
 	}
 	resourceClient, err := consul.NewResourceServiceClient(sa.ConsulServerConnMgr)
 	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		_, _, err := testClient.APIClient.Partitions().Read(context.Background(), constants.DefaultConsulPartition, nil)
+		return err == nil
+	}, 5*time.Second, 500*time.Millisecond)
 
 	// Default ns and partition if not specified in test.
 	if tc.targetConsulNs == "" {

--- a/control-plane/subcommand/server-acl-init/command_ent_test.go
+++ b/control-plane/subcommand/server-acl-init/command_ent_test.go
@@ -33,6 +33,7 @@ import (
 // and there's a single consul destination namespace.
 func TestRun_ConnectInject_SingleDestinationNamespace(t *testing.T) {
 	t.Parallel()
+
 	consulDestNamespaces := []string{"default", "destination"}
 	for _, consulDestNamespace := range consulDestNamespaces {
 		t.Run(consulDestNamespace, func(tt *testing.T) {
@@ -321,6 +322,11 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 			require.NoError(t, err)
 
 			// Check that the expected policies were created.
+			// There will be more policies returned in the List API that are defaults
+			// existing in Consul on startup, including but not limited to:
+			// * global-management
+			// * builtin/global-read-only
+			// * agent-token
 			firstRunExpectedPolicies := []string{
 				"anonymous-token-policy",
 				"client-policy",
@@ -336,12 +342,6 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 			}
 			policies, _, err := consul.ACL().PolicyList(nil)
 			require.NoError(t, err)
-
-			// Check that we have the right number of policies. The actual
-			// policies will have two more than expected because of the
-			// global management and namespace management polices that
-			// are automatically created, the latter in consul-ent v1.7+.
-			require.Equal(t, len(firstRunExpectedPolicies), len(policies)-2)
 
 			// Collect the actual policies into a map to make it easier to assert
 			// on their existence and contents.
@@ -389,12 +389,6 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 			policies, _, err = consul.ACL().PolicyList(nil)
 			require.NoError(t, err)
 
-			// Check that we have the right number of policies. The actual
-			// policies will have two more than expected because of the
-			// global management and namespace management polices that
-			// are automatically created, the latter in consul-ent v1.7+.
-			require.Equal(t, len(secondRunExpectedPolicies), len(policies)-2)
-
 			// Collect the actual policies into a map to make it easier to assert
 			// on their existence and contents.
 			actualPolicies = make(map[string]string)
@@ -418,6 +412,8 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 					require.Contains(t, actRules, "acl = \"write\"")
 				case "partitions-token":
 					require.Contains(t, actRules, "operator = \"write\"")
+				case "anonymous-token-policy":
+					// TODO: This needs to be revisted due to recent changes in how we update the anonymous policy (NET-5174)
 				default:
 					// Assert that the policies have the word namespace in them. This
 					// tests that they were updated. The actual contents are tested
@@ -750,7 +746,7 @@ func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
 	}
 }
 
-// Test the parsing the namespace from gateway names
+// Test the parsing the namespace from gateway names.
 func TestRun_GatewayNamespaceParsing(t *testing.T) {
 	t.Parallel()
 
@@ -1050,7 +1046,7 @@ func TestRun_NamespaceEnabled_ValidateLoginToken_PrimaryDatacenter(t *testing.T)
 				clientset: k8s,
 			}
 			cmdArgs := append([]string{
-				"-timeout=500ms",
+				"-timeout=1m",
 				"-resource-prefix=" + resourcePrefix,
 				"-enable-namespaces",
 				"-k8s-namespace=" + c.Namespace,


### PR DESCRIPTION
ENT tests were just turned back on in CI. This revealed some failing test cases. This PR attempts to get everything in working order.

