### PR TITLE
Backport of Fix ENT Tests Now that They Are Running Again 🏃 into release/1.1.x

### DIFF
--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_ent_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_ent_test.go
@@ -640,6 +640,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
 							Service:   "service-updated",
@@ -652,6 +655,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -713,6 +719,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -725,6 +734,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-different-consul-svc-name-sidecar-proxy",
@@ -794,6 +806,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
 							Service:   "service-updated",
@@ -806,6 +821,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -876,6 +894,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
 							Service:   "service-updated",
@@ -888,6 +909,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -905,6 +929,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod2-service-updated",
 							Service:   "service-updated",
@@ -917,6 +944,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod2-service-updated-sidecar-proxy",
@@ -979,6 +1009,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -991,6 +1024,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-different-consul-svc-name-sidecar-proxy",
@@ -1008,6 +1044,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod2-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -1020,6 +1059,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod2-different-consul-svc-name-sidecar-proxy",
@@ -1068,6 +1110,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
 							Service:   "service-updated",
@@ -1080,6 +1125,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -1097,6 +1145,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod2-service-updated",
 							Service:   "service-updated",
@@ -1109,6 +1160,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod2-service-updated-sidecar-proxy",
@@ -1145,6 +1199,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -1157,6 +1214,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-different-consul-svc-name-sidecar-proxy",
@@ -1174,6 +1234,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod2-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -1186,6 +1249,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod2-different-consul-svc-name-sidecar-proxy",
@@ -1235,6 +1301,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:      "pod1-service-updated",
 							Service: "service-updated",
@@ -1253,6 +1322,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -1321,6 +1393,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:      "pod1-service-updated",
 							Service: "service-updated",
@@ -1339,6 +1414,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -1362,6 +1440,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:      "pod2-service-updated",
 							Service: "service-updated",
@@ -1380,6 +1461,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod2-service-updated-sidecar-proxy",
@@ -1435,8 +1519,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						c.ACL.Tokens.InitialManagement = adminToken
 					}
 				})
-
 				consulClient := testClient.APIClient
+				// Coincidentally, this allows enough time for the bootstrap token to be generated
+				testClient.TestServer.WaitForActiveCARoot(t)
 
 				_, err := namespaces.EnsureExists(consulClient, ts.ExpConsulNS, "")
 				require.NoError(t, err)
@@ -1741,6 +1826,8 @@ func TestReconcileDeleteEndpointWithNamespaces(t *testing.T) {
 					}
 				})
 				consulClient := testClient.APIClient
+				// Coincidentally, this allows enough time for the bootstrap token to be generated
+				testClient.TestServer.WaitForActiveCARoot(t)
 
 				_, err := namespaces.EnsureExists(consulClient, ts.ExpConsulNS, "")
 				require.NoError(t, err)
@@ -1752,6 +1839,9 @@ func TestReconcileDeleteEndpointWithNamespaces(t *testing.T) {
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
 						Service: svc,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 					}
 					_, err = consulClient.Catalog().Register(serviceRegistration, nil)
 					require.NoError(t, err)
@@ -2033,6 +2123,8 @@ func TestReconcileDeleteGatewayWithNamespaces(t *testing.T) {
 					}
 				})
 				consulClient := testClient.APIClient
+				// Coincidentally, this allows enough time for the bootstrap token to be generated
+				testClient.TestServer.WaitForActiveCARoot(t)
 
 				_, err := namespaces.EnsureExists(consulClient, ts.ConsulNS, "")
 				require.NoError(t, err)
@@ -2044,6 +2136,9 @@ func TestReconcileDeleteGatewayWithNamespaces(t *testing.T) {
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
 						Service: svc,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 					}
 					_, err = consulClient.Catalog().Register(serviceRegistration, nil)
 					require.NoError(t, err)
@@ -2106,8 +2201,15 @@ func TestReconcileDeleteGatewayWithNamespaces(t *testing.T) {
 				require.Empty(t, append(defaultNS, testNS...))
 
 				if tt.enableACLs {
-					_, _, err = consulClient.ACL().TokenRead(token.AccessorID, nil)
-					require.Contains(t, err.Error(), "ACL not found")
+					queryOpts := &api.QueryOptions{}
+					if tt.initialConsulSvcs[0].Kind == api.ServiceKindMeshGateway {
+						queryOpts.Namespace = "default" // Mesh Gateways must always be registered in the "default" namespace.
+					} else {
+						queryOpts.Namespace = ts.ConsulNS
+					}
+
+					token, _, err = consulClient.ACL().TokenRead(token.AccessorID, queryOpts)
+					require.Contains(t, err.Error(), "ACL not found", token)
 				}
 			})
 		}

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
@@ -4168,6 +4168,7 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 				}
 			})
 			consulClient := testClient.APIClient
+			// TODO: stabilize this test by waiting for the ACL bootstrap
 
 			// Register service and proxy in consul
 			var token *api.ACLToken

--- a/control-plane/connect-inject/controllers/peering/peering_acceptor_controller_test.go
+++ b/control-plane/connect-inject/controllers/peering/peering_acceptor_controller_test.go
@@ -8,9 +8,6 @@ import (
 	"time"
 
 	logrtest "github.com/go-logr/logr/testr"
-	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
-	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
@@ -23,6 +20,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
+	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 )
 
 // TestReconcile_CreateUpdatePeeringAcceptor creates a peering acceptor.
@@ -505,6 +506,7 @@ func TestReconcile_CreateUpdatePeeringAcceptor(t *testing.T) {
 			// Create test consul server.
 			testClient := test.TestServerWithMockConnMgrWatcher(t, nil)
 			consulClient := testClient.APIClient
+			testClient.TestServer.WaitForActiveCARoot(t)
 
 			if tt.initialConsulPeerName != "" {
 				// Add the initial peerings into Consul by calling the Generate token endpoint.
@@ -628,6 +630,7 @@ func TestReconcile_DeletePeeringAcceptor(t *testing.T) {
 	// Create test consul server.
 	testClient := test.TestServerWithMockConnMgrWatcher(t, nil)
 	consulClient := testClient.APIClient
+	testClient.TestServer.WaitForActiveCARoot(t)
 
 	// Add the initial peerings into Consul by calling the Generate token endpoint.
 	_, _, err := consulClient.Peerings().GenerateToken(context.Background(), api.PeeringGenerateTokenRequest{PeerName: "acceptor-deleted"}, nil)
@@ -774,6 +777,7 @@ func TestReconcile_VersionAnnotation(t *testing.T) {
 			// Create test consul server.
 			testClient := test.TestServerWithMockConnMgrWatcher(t, nil)
 			consulClient := testClient.APIClient
+			testClient.TestServer.WaitForActiveCARoot(t)
 
 			_, _, err := consulClient.Peerings().GenerateToken(context.Background(), api.PeeringGenerateTokenRequest{PeerName: "acceptor-created"}, nil)
 			require.NoError(t, err)

--- a/control-plane/connect-inject/controllers/peering/peering_dialer_controller_test.go
+++ b/control-plane/connect-inject/controllers/peering/peering_dialer_controller_test.go
@@ -7,10 +7,6 @@ import (
 	"time"
 
 	logrtest "github.com/go-logr/logr/testr"
-	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
-	"github.com/hashicorp/consul-k8s/control-plane/consul"
-	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -25,6 +21,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
+	"github.com/hashicorp/consul-k8s/control-plane/consul"
+	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 )
 
 // TestReconcile_CreateUpdatePeeringDialer creates a peering dialer.
@@ -260,6 +261,7 @@ func TestReconcile_CreateUpdatePeeringDialer(t *testing.T) {
 			require.NoError(t, err)
 			defer acceptorPeerServer.Stop()
 			acceptorPeerServer.WaitForServiceIntentions(t)
+			acceptorPeerServer.WaitForActiveCARoot(t)
 
 			cfg := &api.Config{
 				Address: acceptorPeerServer.HTTPAddr,
@@ -295,6 +297,7 @@ func TestReconcile_CreateUpdatePeeringDialer(t *testing.T) {
 			// Create test consul server.
 			testClient := test.TestServerWithMockConnMgrWatcher(t, nil)
 			dialerClient := testClient.APIClient
+			testClient.TestServer.WaitForActiveCARoot(t)
 
 			// If the peering is supposed to already exist in Consul, then establish a peering with the existing token, so the peering will exist on the dialing side.
 			if tt.peeringExists {
@@ -440,6 +443,7 @@ func TestReconcile_VersionAnnotationPeeringDialer(t *testing.T) {
 			require.NoError(t, err)
 			defer acceptorPeerServer.Stop()
 			acceptorPeerServer.WaitForServiceIntentions(t)
+			acceptorPeerServer.WaitForActiveCARoot(t)
 
 			cfg := &api.Config{
 				Address: acceptorPeerServer.HTTPAddr,
@@ -495,6 +499,7 @@ func TestReconcile_VersionAnnotationPeeringDialer(t *testing.T) {
 			require.NoError(t, err)
 			defer dialerPeerServer.Stop()
 			dialerPeerServer.WaitForServiceIntentions(t)
+			dialerPeerServer.WaitForActiveCARoot(t)
 
 			consulConfig := &consul.Config{
 				APIClientConfig: &api.Config{Address: dialerPeerServer.HTTPAddr},
@@ -751,6 +756,7 @@ func TestReconcileDeletePeeringDialer(t *testing.T) {
 	// Create test consul server.
 	testClient := test.TestServerWithMockConnMgrWatcher(t, nil)
 	consulClient := testClient.APIClient
+	testClient.TestServer.WaitForActiveCARoot(t)
 
 	// Add the initial peerings into Consul by calling the Generate token endpoint.
 	_, _, err := consulClient.Peerings().GenerateToken(context.Background(), api.PeeringGenerateTokenRequest{PeerName: "dialer-deleted"}, nil)

--- a/control-plane/subcommand/server-acl-init/command_ent_test.go
+++ b/control-plane/subcommand/server-acl-init/command_ent_test.go
@@ -29,6 +29,7 @@ import (
 // and there's a single consul destination namespace.
 func TestRun_ConnectInject_SingleDestinationNamespace(t *testing.T) {
 	t.Parallel()
+
 	consulDestNamespaces := []string{"default", "destination"}
 	for _, consulDestNamespace := range consulDestNamespaces {
 		t.Run(consulDestNamespace, func(tt *testing.T) {
@@ -317,6 +318,11 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 			require.NoError(t, err)
 
 			// Check that the expected policies were created.
+			// There will be more policies returned in the List API that are defaults
+			// existing in Consul on startup, including but not limited to:
+			// * global-management
+			// * builtin/global-read-only
+			// * agent-token
 			firstRunExpectedPolicies := []string{
 				"anonymous-token-policy",
 				"client-policy",
@@ -332,12 +338,6 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 			}
 			policies, _, err := consul.ACL().PolicyList(nil)
 			require.NoError(t, err)
-
-			// Check that we have the right number of policies. The actual
-			// policies will have two more than expected because of the
-			// global management and namespace management polices that
-			// are automatically created, the latter in consul-ent v1.7+.
-			require.Equal(t, len(firstRunExpectedPolicies), len(policies)-2)
 
 			// Collect the actual policies into a map to make it easier to assert
 			// on their existence and contents.
@@ -385,12 +385,6 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 			policies, _, err = consul.ACL().PolicyList(nil)
 			require.NoError(t, err)
 
-			// Check that we have the right number of policies. The actual
-			// policies will have two more than expected because of the
-			// global management and namespace management polices that
-			// are automatically created, the latter in consul-ent v1.7+.
-			require.Equal(t, len(secondRunExpectedPolicies), len(policies)-2)
-
 			// Collect the actual policies into a map to make it easier to assert
 			// on their existence and contents.
 			actualPolicies = make(map[string]string)
@@ -414,6 +408,8 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 					require.Contains(t, actRules, "acl = \"write\"")
 				case "partitions-token":
 					require.Contains(t, actRules, "operator = \"write\"")
+				case "anonymous-token-policy":
+					// TODO: This needs to be revisted due to recent changes in how we update the anonymous policy (NET-5174)
 				default:
 					// Assert that the policies have the word namespace in them. This
 					// tests that they were updated. The actual contents are tested
@@ -746,7 +742,7 @@ func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
 	}
 }
 
-// Test the parsing the namespace from gateway names
+// Test the parsing the namespace from gateway names.
 func TestRun_GatewayNamespaceParsing(t *testing.T) {
 	t.Parallel()
 
@@ -1046,7 +1042,7 @@ func TestRun_NamespaceEnabled_ValidateLoginToken_PrimaryDatacenter(t *testing.T)
 				clientset: k8s,
 			}
 			cmdArgs := append([]string{
-				"-timeout=500ms",
+				"-timeout=1m",
 				"-resource-prefix=" + resourcePrefix,
 				"-enable-namespaces",
 				"-k8s-namespace=" + c.Namespace,


### PR DESCRIPTION
## Backport

This PR is manually generated from #3077 to be assessed for backporting.

The below text is copied from the body of the original PR.

---

ENT tests were just turned back on in CI. This revealed some failing test cases. This PR attempts to get everything in working order.