### PR TITLE
Backport of Fix ENT Tests Now that They Are Running Again 🏃 into release/1.0.x

### DIFF
--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_ent_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_ent_test.go
@@ -637,6 +637,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
 							Service:   "service-updated",
@@ -649,6 +652,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -710,6 +716,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -722,6 +731,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-different-consul-svc-name-sidecar-proxy",
@@ -791,6 +803,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
 							Service:   "service-updated",
@@ -803,6 +818,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -873,6 +891,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
 							Service:   "service-updated",
@@ -885,6 +906,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -902,6 +926,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod2-service-updated",
 							Service:   "service-updated",
@@ -914,6 +941,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod2-service-updated-sidecar-proxy",
@@ -976,6 +1006,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -988,6 +1021,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-different-consul-svc-name-sidecar-proxy",
@@ -1005,6 +1041,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod2-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -1017,6 +1056,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod2-different-consul-svc-name-sidecar-proxy",
@@ -1065,6 +1107,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-service-updated",
 							Service:   "service-updated",
@@ -1077,6 +1122,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -1094,6 +1142,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod2-service-updated",
 							Service:   "service-updated",
@@ -1106,6 +1157,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod2-service-updated-sidecar-proxy",
@@ -1142,6 +1196,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod1-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -1154,6 +1211,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-different-consul-svc-name-sidecar-proxy",
@@ -1171,6 +1231,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:        "pod2-different-consul-svc-name",
 							Service:   "different-consul-svc-name",
@@ -1183,6 +1246,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod2-different-consul-svc-name-sidecar-proxy",
@@ -1232,6 +1298,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:      "pod1-service-updated",
 							Service: "service-updated",
@@ -1250,6 +1319,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -1318,6 +1390,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:      "pod1-service-updated",
 							Service: "service-updated",
@@ -1336,6 +1411,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod1-service-updated-sidecar-proxy",
@@ -1359,6 +1437,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							ID:      "pod2-service-updated",
 							Service: "service-updated",
@@ -1377,6 +1458,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 					{
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 						Service: &api.AgentService{
 							Kind:    api.ServiceKindConnectProxy,
 							ID:      "pod2-service-updated-sidecar-proxy",
@@ -1432,8 +1516,9 @@ func TestReconcileUpdateEndpointWithNamespaces(t *testing.T) {
 						c.ACL.Tokens.InitialManagement = adminToken
 					}
 				})
-
 				consulClient := testClient.APIClient
+				// Coincidentally, this allows enough time for the bootstrap token to be generated
+				testClient.TestServer.WaitForActiveCARoot(t)
 
 				_, err := namespaces.EnsureExists(consulClient, ts.ExpConsulNS, "")
 				require.NoError(t, err)
@@ -1738,6 +1823,8 @@ func TestReconcileDeleteEndpointWithNamespaces(t *testing.T) {
 					}
 				})
 				consulClient := testClient.APIClient
+				// Coincidentally, this allows enough time for the bootstrap token to be generated
+				testClient.TestServer.WaitForActiveCARoot(t)
 
 				_, err := namespaces.EnsureExists(consulClient, ts.ExpConsulNS, "")
 				require.NoError(t, err)
@@ -1749,6 +1836,9 @@ func TestReconcileDeleteEndpointWithNamespaces(t *testing.T) {
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
 						Service: svc,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 					}
 					_, err = consulClient.Catalog().Register(serviceRegistration, nil)
 					require.NoError(t, err)
@@ -2030,6 +2120,8 @@ func TestReconcileDeleteGatewayWithNamespaces(t *testing.T) {
 					}
 				})
 				consulClient := testClient.APIClient
+				// Coincidentally, this allows enough time for the bootstrap token to be generated
+				testClient.TestServer.WaitForActiveCARoot(t)
 
 				_, err := namespaces.EnsureExists(consulClient, ts.ConsulNS, "")
 				require.NoError(t, err)
@@ -2041,6 +2133,9 @@ func TestReconcileDeleteGatewayWithNamespaces(t *testing.T) {
 						Node:    consulNodeName,
 						Address: consulNodeAddress,
 						Service: svc,
+						NodeMeta: map[string]string{
+							metaKeySyntheticNode: "true",
+						},
 					}
 					_, err = consulClient.Catalog().Register(serviceRegistration, nil)
 					require.NoError(t, err)
@@ -2103,8 +2198,15 @@ func TestReconcileDeleteGatewayWithNamespaces(t *testing.T) {
 				require.Empty(t, append(defaultNS, testNS...))
 
 				if tt.enableACLs {
-					_, _, err = consulClient.ACL().TokenRead(token.AccessorID, nil)
-					require.EqualError(t, err, "Unexpected response code: 403 (ACL not found)")
+					queryOpts := &api.QueryOptions{}
+					if tt.initialConsulSvcs[0].Kind == api.ServiceKindMeshGateway {
+						queryOpts.Namespace = "default" // Mesh Gateways must always be registered in the "default" namespace.
+					} else {
+						queryOpts.Namespace = ts.ConsulNS
+					}
+
+					token, _, err = consulClient.ACL().TokenRead(token.AccessorID, queryOpts)
+					require.Contains(t, err.Error(), "ACL not found", token)
 				}
 			})
 		}

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
@@ -4073,6 +4073,7 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 				}
 			})
 			consulClient := testClient.APIClient
+			// TODO: stabilize this test by waiting for the ACL bootstrap
 
 			// Register service and proxy in consul
 			var token *api.ACLToken

--- a/control-plane/connect-inject/controllers/peering/peering_acceptor_controller_test.go
+++ b/control-plane/connect-inject/controllers/peering/peering_acceptor_controller_test.go
@@ -8,9 +8,6 @@ import (
 	"time"
 
 	logrtest "github.com/go-logr/logr/testr"
-	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
-	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
@@ -23,6 +20,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
+	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 )
 
 // TestReconcile_CreateUpdatePeeringAcceptor creates a peering acceptor.
@@ -505,6 +506,7 @@ func TestReconcile_CreateUpdatePeeringAcceptor(t *testing.T) {
 			// Create test consul server.
 			testClient := test.TestServerWithMockConnMgrWatcher(t, nil)
 			consulClient := testClient.APIClient
+			testClient.TestServer.WaitForActiveCARoot(t)
 
 			if tt.initialConsulPeerName != "" {
 				// Add the initial peerings into Consul by calling the Generate token endpoint.
@@ -628,6 +630,7 @@ func TestReconcile_DeletePeeringAcceptor(t *testing.T) {
 	// Create test consul server.
 	testClient := test.TestServerWithMockConnMgrWatcher(t, nil)
 	consulClient := testClient.APIClient
+	testClient.TestServer.WaitForActiveCARoot(t)
 
 	// Add the initial peerings into Consul by calling the Generate token endpoint.
 	_, _, err := consulClient.Peerings().GenerateToken(context.Background(), api.PeeringGenerateTokenRequest{PeerName: "acceptor-deleted"}, nil)
@@ -774,6 +777,7 @@ func TestReconcile_VersionAnnotation(t *testing.T) {
 			// Create test consul server.
 			testClient := test.TestServerWithMockConnMgrWatcher(t, nil)
 			consulClient := testClient.APIClient
+			testClient.TestServer.WaitForActiveCARoot(t)
 
 			_, _, err := consulClient.Peerings().GenerateToken(context.Background(), api.PeeringGenerateTokenRequest{PeerName: "acceptor-created"}, nil)
 			require.NoError(t, err)

--- a/control-plane/connect-inject/controllers/peering/peering_dialer_controller_test.go
+++ b/control-plane/connect-inject/controllers/peering/peering_dialer_controller_test.go
@@ -7,10 +7,6 @@ import (
 	"time"
 
 	logrtest "github.com/go-logr/logr/testr"
-	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
-	"github.com/hashicorp/consul-k8s/control-plane/consul"
-	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -25,6 +21,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
+	"github.com/hashicorp/consul-k8s/control-plane/consul"
+	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 )
 
 // TestReconcile_CreateUpdatePeeringDialer creates a peering dialer.
@@ -260,6 +261,7 @@ func TestReconcile_CreateUpdatePeeringDialer(t *testing.T) {
 			require.NoError(t, err)
 			defer acceptorPeerServer.Stop()
 			acceptorPeerServer.WaitForServiceIntentions(t)
+			acceptorPeerServer.WaitForActiveCARoot(t)
 
 			cfg := &api.Config{
 				Address: acceptorPeerServer.HTTPAddr,
@@ -295,6 +297,7 @@ func TestReconcile_CreateUpdatePeeringDialer(t *testing.T) {
 			// Create test consul server.
 			testClient := test.TestServerWithMockConnMgrWatcher(t, nil)
 			dialerClient := testClient.APIClient
+			testClient.TestServer.WaitForActiveCARoot(t)
 
 			// If the peering is supposed to already exist in Consul, then establish a peering with the existing token, so the peering will exist on the dialing side.
 			if tt.peeringExists {
@@ -440,6 +443,7 @@ func TestReconcile_VersionAnnotationPeeringDialer(t *testing.T) {
 			require.NoError(t, err)
 			defer acceptorPeerServer.Stop()
 			acceptorPeerServer.WaitForServiceIntentions(t)
+			acceptorPeerServer.WaitForActiveCARoot(t)
 
 			cfg := &api.Config{
 				Address: acceptorPeerServer.HTTPAddr,
@@ -495,6 +499,7 @@ func TestReconcile_VersionAnnotationPeeringDialer(t *testing.T) {
 			require.NoError(t, err)
 			defer dialerPeerServer.Stop()
 			dialerPeerServer.WaitForServiceIntentions(t)
+			dialerPeerServer.WaitForActiveCARoot(t)
 
 			consulConfig := &consul.Config{
 				APIClientConfig: &api.Config{Address: dialerPeerServer.HTTPAddr},
@@ -751,6 +756,7 @@ func TestReconcileDeletePeeringDialer(t *testing.T) {
 	// Create test consul server.
 	testClient := test.TestServerWithMockConnMgrWatcher(t, nil)
 	consulClient := testClient.APIClient
+	testClient.TestServer.WaitForActiveCARoot(t)
 
 	// Add the initial peerings into Consul by calling the Generate token endpoint.
 	_, _, err := consulClient.Peerings().GenerateToken(context.Background(), api.PeeringGenerateTokenRequest{PeerName: "dialer-deleted"}, nil)

--- a/control-plane/subcommand/server-acl-init/command_ent_test.go
+++ b/control-plane/subcommand/server-acl-init/command_ent_test.go
@@ -29,6 +29,7 @@ import (
 // and there's a single consul destination namespace.
 func TestRun_ConnectInject_SingleDestinationNamespace(t *testing.T) {
 	t.Parallel()
+
 	consulDestNamespaces := []string{"default", "destination"}
 	for _, consulDestNamespace := range consulDestNamespaces {
 		t.Run(consulDestNamespace, func(tt *testing.T) {
@@ -318,6 +319,11 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 			require.NoError(t, err)
 
 			// Check that the expected policies were created.
+			// There will be more policies returned in the List API that are defaults
+			// existing in Consul on startup, including but not limited to:
+			// * global-management
+			// * builtin/global-read-only
+			// * agent-token
 			firstRunExpectedPolicies := []string{
 				"anonymous-token-policy",
 				"client-policy",
@@ -333,12 +339,6 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 			}
 			policies, _, err := consul.ACL().PolicyList(nil)
 			require.NoError(t, err)
-
-			// Check that we have the right number of policies. The actual
-			// policies will have two more than expected because of the
-			// global management and namespace management polices that
-			// are automatically created, the latter in consul-ent v1.7+.
-			require.Equal(t, len(firstRunExpectedPolicies), len(policies)-2)
 
 			// Collect the actual policies into a map to make it easier to assert
 			// on their existence and contents.
@@ -386,12 +386,6 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 			policies, _, err = consul.ACL().PolicyList(nil)
 			require.NoError(t, err)
 
-			// Check that we have the right number of policies. The actual
-			// policies will have two more than expected because of the
-			// global management and namespace management polices that
-			// are automatically created, the latter in consul-ent v1.7+.
-			require.Equal(t, len(secondRunExpectedPolicies), len(policies)-2)
-
 			// Collect the actual policies into a map to make it easier to assert
 			// on their existence and contents.
 			actualPolicies = make(map[string]string)
@@ -415,6 +409,8 @@ func TestRun_ACLPolicyUpdates(t *testing.T) {
 					require.Contains(t, actRules, "acl = \"write\"")
 				case "partitions-token":
 					require.Contains(t, actRules, "operator = \"write\"")
+				case "anonymous-token-policy":
+					// TODO: This needs to be revisted due to recent changes in how we update the anonymous policy (NET-5174)
 				default:
 					// Assert that the policies have the word namespace in them. This
 					// tests that they were updated. The actual contents are tested
@@ -747,7 +743,7 @@ func TestRun_TokensWithNamespacesEnabled(t *testing.T) {
 	}
 }
 
-// Test the parsing the namespace from gateway names
+// Test the parsing the namespace from gateway names.
 func TestRun_GatewayNamespaceParsing(t *testing.T) {
 	t.Parallel()
 
@@ -1047,7 +1043,7 @@ func TestRun_NamespaceEnabled_ValidateLoginToken_PrimaryDatacenter(t *testing.T)
 				clientset: k8s,
 			}
 			cmdArgs := append([]string{
-				"-timeout=500ms",
+				"-timeout=1m",
 				"-resource-prefix=" + resourcePrefix,
 				"-enable-namespaces",
 				"-k8s-namespace=" + c.Namespace,


### PR DESCRIPTION
## Backport

This PR is manually generated from #3077 to be assessed for backporting.

The below text is copied from the body of the original PR.

---

ENT tests were just turned back on in CI. This revealed some failing test cases. This PR attempts to get everything in working order.