### PR TITLE
disable TestPartitions_Connect for CNI due to flake

### DIFF
--- a/acceptance/tests/partitions/partitions_connect_test.go
+++ b/acceptance/tests/partitions/partitions_connect_test.go
@@ -30,6 +30,11 @@ func TestPartitions_Connect(t *testing.T) {
 	env := suite.Environment()
 	cfg := suite.Config()
 
+	// Currently there is a bug which causes flakes when CNI is enabled
+	if cfg.EnableCNI {
+		t.Skipf("TODO(flaky): NET-5819")
+	}
+
 	if !cfg.EnableEnterprise {
 		t.Skipf("skipping this test because -enable-enterprise is not set")
 	}


### PR DESCRIPTION
Changes proposed in this PR:
- This disables a flaky test, cherry pick off of: https://github.com/hashicorp/consul-k8s/pull/3078
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


