### PR TITLE
add probes now that expose paths are supported (#3096)

### DIFF
--- a/acceptance/tests/fixtures/bases/v2-multiport-app/deployment.yaml
+++ b/acceptance/tests/fixtures/bases/v2-multiport-app/deployment.yaml
@@ -31,18 +31,18 @@ spec:
           ports:
             - containerPort: 8080
               name: web
-#          livenessProbe:
-#            httpGet:
-#              port: 8080
-#            initialDelaySeconds: 1
-#            failureThreshold: 1
-#            periodSeconds: 1
-#          startupProbe:
-#            httpGet:
-#              port: 8080
-#            initialDelaySeconds: 1
-#            failureThreshold: 30
-#            periodSeconds: 1
+          livenessProbe:
+            httpGet:
+              port: 8080
+            initialDelaySeconds: 1
+            failureThreshold: 1
+            periodSeconds: 1
+          startupProbe:
+            httpGet:
+              port: 8080
+            initialDelaySeconds: 1
+            failureThreshold: 30
+            periodSeconds: 1
           readinessProbe:
             exec:
               command: ['sh', '-c', 'test ! -f /tmp/unhealthy-multiport']
@@ -59,19 +59,18 @@ spec:
               # This name is meant to be used alongside the _numeric_ K8s service target port
               # to verify that we can still route traffic to the named port when there's a mismatch.
               name: admin
-# TODO: (v2/nitya) add these probes back when expose paths and L7 are supported.
-#          livenessProbe:
-#            httpGet:
-#              port: 9090
-#            initialDelaySeconds: 1
-#            failureThreshold: 1
-#            periodSeconds: 1
-#          startupProbe:
-#            httpGet:
-#              port: 9090
-#            initialDelaySeconds: 1
-#            failureThreshold: 30
-#            periodSeconds: 1
+          livenessProbe:
+            httpGet:
+              port: 9090
+            initialDelaySeconds: 1
+            failureThreshold: 1
+            periodSeconds: 1
+          startupProbe:
+            httpGet:
+              port: 9090
+            initialDelaySeconds: 1
+            failureThreshold: 30
+            periodSeconds: 1
           readinessProbe:
             exec:
               command: ['sh', '-c', 'test ! -f /tmp/unhealthy-multiport-admin']

--- a/acceptance/tests/mesh_v2/mesh_inject_test.go
+++ b/acceptance/tests/mesh_v2/mesh_inject_test.go
@@ -35,6 +35,7 @@ func TestMeshInject_MultiportService(t *testing.T) {
 
 			helmValues := map[string]string{
 				"global.experiments[0]": "resource-apis",
+				"global.image":          "ndhanushkodi/consul-dev:expose2",
 				// The UI is not supported for v2 in 1.17, so for now it must be disabled.
 				"ui.enabled":            "false",
 				"connectInject.enabled": "true",

--- a/control-plane/connect-inject/webhookv2/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhookv2/consul_dataplane_sidecar.go
@@ -122,11 +122,7 @@ func (w *MeshWebhook) consulDataplaneSidecar(namespace corev1.Namespace, pod cor
 		Args: args,
 	}
 
-	// Omit the readiness probe in transparent proxy mode until expose paths are implemented. Otherwise all probes will fail.
-	// TODO: (v2/nitya) add probes in tproxy mode when expose paths and L7 are supported.
-	if !w.EnableTransparentProxy {
-		container.ReadinessProbe = probe
-	}
+	container.ReadinessProbe = probe
 
 	if w.AuthMethod != "" {
 		container.VolumeMounts = append(container.VolumeMounts, saTokenVolumeMount)


### PR DESCRIPTION
Changes proposed in this PR:
- Backport of #3096 
- Adds probe support for tproxy




