### PR TITLE
release/1.3.x - Update Envoy

### DIFF
--- a/.changelog/3118.txt
+++ b/.changelog/3118.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Update Envoy version to 1.25.11 to address [CVE-2023-44487](https://github.com/envoyproxy/envoy/security/advisories/GHSA-jhv4-f7mr-xx76)
+```

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -22,7 +22,7 @@ annotations:
     - name: consul-dataplane
       image: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.3-dev
     - name: envoy
-      image: envoyproxy/envoy:v1.26.2
+      image: envoyproxy/envoy:v1.25.11
   artifacthub.io/license: MPL-2.0
   artifacthub.io/links: |
     - name: Documentation

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -3233,7 +3233,7 @@ terminatingGateways:
   gateways:
     - name: terminating-gateway
 
-# [DEPRECATED] Use connectInject.apiGateway instead. This stanza will be removed with the release of Consul 1.17
+# [DEPRECATED] Use connectInject.apiGateway instead.
 # Configuration settings for the Consul API Gateway integration
 apiGateway:
   # When true the helm chart will install the Consul API Gateway controller
@@ -3248,7 +3248,7 @@ apiGateway:
   # The name (and tag) of the Envoy Docker image used for the
   # apiGateway. For other Consul compoenents, imageEnvoy has been replaced with Consul Dataplane.
   # @default: envoyproxy/envoy:<latest supported version>
-  imageEnvoy: "envoyproxy/envoy:v1.25.1"
+  imageEnvoy: "envoyproxy/envoy:v1.25.11"
 
   # Override global log verbosity level for api-gateway-controller pods. One of "debug", "info", "warn", or "error".
   # @type: string


### PR DESCRIPTION
This PR updates Envoy to the latest patch releases to address [CVE-2023-44487](https://github.com/envoyproxy/envoy/security/advisories/GHSA-jhv4-f7mr-xx76).

Note that the Envoy image version is only applicable to the legacy API Gateway since the Envoy sidecars are now packaged directly with Consul dataplane.

Checklist:
- [x] ~Tests added~
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
