### PR TITLE
release/1.0.x - Update Envoy

### DIFF
--- a/.changelog/3121.txt
+++ b/.changelog/3121.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Update Envoy version to 1.24.12 to address [CVE-2023-44487](https://github.com/envoyproxy/envoy/security/advisories/GHSA-jhv4-f7mr-xx76)
+```

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -19,7 +19,7 @@ annotations:
     - name: consul-dataplane
       image: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.0-dev
     - name: envoy
-      image: envoyproxy/envoy:v1.24.10
+      image: envoyproxy/envoy:v1.24.12
   artifacthub.io/license: MPL-2.0
   artifacthub.io/links: |
     - name: Documentation

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -3098,7 +3098,7 @@ apiGateway:
   # The name (and tag) of the Envoy Docker image used for the
   # apiGateway. For other Consul compoenents, imageEnvoy has been replaced with Consul Dataplane.
   # @default: envoyproxy/envoy:<latest supported version>
-  imageEnvoy: "envoyproxy/envoy:v1.24.10"
+  imageEnvoy: "envoyproxy/envoy:v1.24.12"
 
   # Override global log verbosity level for api-gateway-controller pods. One of "debug", "info", "warn", or "error".
   # @type: string


### PR DESCRIPTION
This PR updates Envoy to the latest patch releases to address [CVE-2023-44487](https://github.com/envoyproxy/envoy/security/advisories/GHSA-jhv4-f7mr-xx76).

Note that the Envoy image version is only applicable to the legacy API Gateway since the Envoy sidecars are now packaged directly with Consul dataplane.

Checklist:
- [x] ~Tests added~
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
