### PR TITLE
Stop running api-gateway as root in vanilla k8s

### DIFF
--- a/control-plane/api-gateway/gatekeeper/dataplane.go
+++ b/control-plane/api-gateway/gatekeeper/dataplane.go
@@ -105,18 +105,14 @@ func consulDataplaneContainer(config common.HelmConfig, gcc v1alpha1.GatewayClas
 		container.Resources = *gcc.Spec.DeploymentSpec.Resources
 	}
 
-	// If running in vanilla K8s, run as root to allow binding to privileged ports;
-	// otherwise, allow the user to be assigned by OpenShift.
 	container.SecurityContext = &corev1.SecurityContext{
 		ReadOnlyRootFilesystem: pointer.Bool(true),
+		RunAsNonRoot:           pointer.Bool(true),
 		// Drop any Linux capabilities you'd get as root other than NET_BIND_SERVICE.
 		Capabilities: &corev1.Capabilities{
 			Add:  []corev1.Capability{netBindCapability},
 			Drop: []corev1.Capability{allCapabilities},
 		},
-	}
-	if !config.EnableOpenShift {
-		container.SecurityContext.RunAsUser = pointer.Int64(0)
 	}
 
 	return container, nil

--- a/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
@@ -1016,6 +1016,9 @@ func validateResourcesExist(t *testing.T, client client.Client, resources resour
 				hasDataplaneContainer = true
 				require.NotNil(t, container.SecurityContext)
 				require.NotNil(t, container.SecurityContext.Capabilities)
+				require.NotNil(t, container.SecurityContext.RunAsNonRoot)
+				assert.True(t, *container.SecurityContext.RunAsNonRoot)
+				assert.Nil(t, container.SecurityContext.RunAsUser)
 				require.NotNil(t, container.SecurityContext.ReadOnlyRootFilesystem)
 				assert.True(t, *container.SecurityContext.ReadOnlyRootFilesystem)
 				assert.Equal(t, []corev1.Capability{netBindCapability}, container.SecurityContext.Capabilities.Add)


### PR DESCRIPTION
Changes proposed in this PR:
- Set `runAsNonRoot`
- Stop explicitly setting `runAsUser`

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


