### PR TITLE
Remove copyright headers from external crds

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -11,7 +11,7 @@ project {
 
     # ignoring charts templates as adding copyright headers breaks all tests
     "charts/consul/templates/**",
-    # we don't own these and copyright headers break them
+    # we don't own these and the tool that adds copyright headers breaks them
     "control-plane/config/crds/external/**",
 
   ]

--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -12,7 +12,7 @@ project {
     # ignoring charts templates as adding copyright headers breaks all tests
     "charts/consul/templates/**",
     # we don't own these and the tool that adds copyright headers breaks them
-    "control-plane/config/crds/external/**",
+    "control-plane/config/crd/external/**",
 
   ]
 }

--- a/control-plane/config/crd/external/gatewayclasses.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/gatewayclasses.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/control-plane/config/crd/external/gateways.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/gateways.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/control-plane/config/crd/external/grpcroutes.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/grpcroutes.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/control-plane/config/crd/external/httproutes.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/httproutes.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/control-plane/config/crd/external/referencegrants.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/referencegrants.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/control-plane/config/crd/external/tcproutes.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/tcproutes.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/control-plane/config/crd/external/tlsroutes.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/tlsroutes.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/control-plane/config/crd/external/udproutes.gateway.networking.k8s.io.yaml
+++ b/control-plane/config/crd/external/udproutes.gateway.networking.k8s.io.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
**Context**
#3065 removed the copyright headers in the generated external CRD definitions because they are defined by the Gateway API Kubernetes SIG, not by HashiCorp.

#3019 then accidentally re-introduced the headers that were removed due to unfortunate timing.

These headers would have been re-introduced later anyway due to the fact that the exclude path in `.copywrite.hcl` was a little off.

In addition, the comment in `.copywrite.hcl` was a little misleading as the problem is caused by the _tool that generates the copyright headers_ as opposed to the copyright headers themselves.

**How I've tested this PR:**
- Visual inspection
- `$ make generate-external-crds` produces no diff

**How I expect reviewers to test this PR:**
See above

**Checklist:**
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


