### PR TITLE
NET-6204- Repeating error log in consul-connect-injector

### DIFF
--- a/.changelog/3128.txt
+++ b/.changelog/3128.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+control-plane: only alert on valid errors, not timeouts in gateway
+```

--- a/control-plane/api-gateway/cache/gateway.go
+++ b/control-plane/api-gateway/cache/gateway.go
@@ -6,14 +6,16 @@ package cache
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/cenkalti/backoff"
 	"github.com/go-logr/logr"
-	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
-	"github.com/hashicorp/consul-k8s/control-plane/consul"
 	"github.com/hashicorp/consul/api"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
+	"github.com/hashicorp/consul-k8s/control-plane/consul"
 )
 
 type GatewayCache struct {

--- a/control-plane/api-gateway/cache/gateway.go
+++ b/control-plane/api-gateway/cache/gateway.go
@@ -131,7 +131,7 @@ func (r *GatewayCache) subscribeToGateway(ctx context.Context, ref api.ResourceR
 			// any other error we want to alert on
 			if !strings.Contains(strings.ToLower(err.Error()), "timeout") &&
 				!strings.Contains(strings.ToLower(err.Error()), "no such host") &&
-				!strings.Contains(strings.ToLower(err.Error()), "connection refused") {	
+				!strings.Contains(strings.ToLower(err.Error()), "connection refused") {
 				r.logger.Error(err, fmt.Sprintf("unable to fetch config entry for gateway: %s/%s", ref.Namespace, ref.Name))
 			}
 			continue

--- a/control-plane/api-gateway/cache/gateway.go
+++ b/control-plane/api-gateway/cache/gateway.go
@@ -127,9 +127,9 @@ func (r *GatewayCache) subscribeToGateway(ctx context.Context, ref api.ResourceR
 		}, backoff.WithContext(retryBackoff, ctx)); err != nil {
 			// if we timeout we don't care about the error message because it's expected to happen on long polls
 			// any other error we want to alert on
-			if !refs.Contains(strings.ToLower(err.Error()), "timeout") &&
-				!refs.Contains(strings.ToLower(err.Error()), "no such host") &&
-				!refs.Contains(strings.ToLower(err.Error()), "connection refused") {	
+			if !strings.Contains(strings.ToLower(err.Error()), "timeout") &&
+				!strings.Contains(strings.ToLower(err.Error()), "no such host") &&
+				!strings.Contains(strings.ToLower(err.Error()), "connection refused") {	
 				r.logger.Error(err, fmt.Sprintf("unable to fetch config entry for gateway: %s/%s", ref.Namespace, ref.Name))
 			}
 			continue


### PR DESCRIPTION
Changes proposed in this PR:
-dont error on timeouts in gateway 

How I expect reviewers to test this PR:
Setup a consul server and let it sit for >5 minutes, we should not see this error pop up


Checklist:
- [ ] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


