### PR TITLE
Add refreshes and retries to server-acl-init job

### DIFF
--- a/.changelog/3137.txt
+++ b/.changelog/3137.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+control-plane: fixes an issue with the server-acl-init job where the job would fail on upgrades due to consul server ip address changes.
+```

--- a/control-plane/consul/dynamic.go
+++ b/control-plane/consul/dynamic.go
@@ -1,0 +1,65 @@
+package consul
+
+import (
+	"time"
+
+	capi "github.com/hashicorp/consul/api"
+)
+
+type DynamicClient struct {
+	ConsulClient *capi.Client
+	Config       *Config
+	watcher      ServerConnectionManager
+}
+
+func NewDynamicClientFromConnMgr(config *Config, watcher ServerConnectionManager) (*DynamicClient, error) {
+	client, err := NewClientFromConnMgr(config, watcher)
+	if err != nil {
+		return nil, err
+	}
+	return &DynamicClient{
+		ConsulClient: client,
+		Config:       config,
+		watcher:      watcher,
+	}, nil
+}
+
+func (d *DynamicClient) RefreshClient() error {
+	var err error
+	var client *capi.Client
+	// If the watcher is not set then we did not create the client using NewDynamicClientFromConnMgr and are using it in
+	// testing
+	// TODO: Use watcher in testing ;)
+	if d.watcher == nil {
+		return nil
+	}
+	client, err = NewClientFromConnMgr(d.Config, d.watcher)
+	if err != nil {
+		return err
+	}
+	d.ConsulClient = client
+	return nil
+}
+
+func NewDynamicClientWithTimeout(config *capi.Config, consulAPITimeout time.Duration) (*DynamicClient, error) {
+	client, err := NewClient(config, consulAPITimeout)
+	if err != nil {
+		return nil, err
+	}
+	return &DynamicClient{
+		ConsulClient: client,
+		Config: &Config{
+			APIClientConfig: config,
+		},
+	}, nil
+}
+
+func NewDynamicClient(config *capi.Config) (*DynamicClient, error) {
+	// defaultTimeout is taken from flags.go..
+	defaultTimeout := 5 * time.Second
+	client, err := NewDynamicClientWithTimeout(config, defaultTimeout)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}

--- a/control-plane/consul/dynamic_test.go
+++ b/control-plane/consul/dynamic_test.go
@@ -1,0 +1,73 @@
+package consul
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/consul-server-connection-manager/discovery"
+	capi "github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefreshDynamicClient(t *testing.T) {
+	// Create a server
+	consulServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "\"leader\"")
+	}))
+	defer consulServer.Close()
+
+	serverURL, err := url.Parse(consulServer.URL)
+	require.NoError(t, err)
+	serverIP := net.ParseIP(serverURL.Hostname())
+
+	port, err := strconv.Atoi(serverURL.Port())
+	require.NoError(t, err)
+
+	connMgr := &MockServerConnectionManager{}
+
+	// Use a bad IP so that the client call fails
+	badState := discovery.State{
+		Address: discovery.Addr{
+			TCPAddr: net.TCPAddr{
+				IP:   net.ParseIP("126.0.0.1"),
+				Port: port,
+			},
+		},
+	}
+
+	goodState := discovery.State{
+		Address: discovery.Addr{
+			TCPAddr: net.TCPAddr{
+				IP:   serverIP,
+				Port: port,
+			},
+		},
+	}
+
+	// testify/mock has a weird behaviour when returning function calls. You cannot update On("State") to return
+	// something different but instead need to load up the returns. Here we are simulating a bad consul server manager
+	// state and then a good one
+	connMgr.On("State").Return(badState, nil).Once()
+	connMgr.On("State").Return(goodState, nil).Once()
+
+	cfg := capi.DefaultConfig()
+	client, err := NewDynamicClientFromConnMgr(&Config{APIClientConfig: cfg, HTTPPort: port, GRPCPort: port}, connMgr)
+	require.NoError(t, err)
+
+	// Make a request to the bad ip of the server
+	_, err = client.ConsulClient.Status().Leader()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connection refused")
+
+	// Refresh the client and make a call to the server now that consul-server-connection-manager state is good
+	err = client.RefreshClient()
+	require.NoError(t, err)
+	leader, err := client.ConsulClient.Status().Leader()
+	require.NoError(t, err)
+	require.Equal(t, "leader", leader)
+}

--- a/control-plane/subcommand/server-acl-init/anonymous_token.go
+++ b/control-plane/subcommand/server-acl-init/anonymous_token.go
@@ -4,6 +4,7 @@
 package serveraclinit
 
 import (
+	"github.com/hashicorp/consul-k8s/control-plane/consul"
 	"github.com/hashicorp/consul/api"
 )
 
@@ -14,8 +15,8 @@ const (
 
 // configureAnonymousPolicy sets up policies and tokens so that Consul DNS and
 // cross-datacenter Consul connect calls will work.
-func (c *Command) configureAnonymousPolicy(consulClient *api.Client) error {
-	exists, err := checkIfAnonymousTokenPolicyExists(consulClient)
+func (c *Command) configureAnonymousPolicy(client *consul.DynamicClient) error {
+	exists, err := checkIfAnonymousTokenPolicyExists(client)
 	if err != nil {
 		c.log.Error("Error checking if anonymous token policy exists", "err", err)
 		return err
@@ -40,7 +41,7 @@ func (c *Command) configureAnonymousPolicy(consulClient *api.Client) error {
 
 	err = c.untilSucceeds("creating anonymous token policy - PUT /v1/acl/policy",
 		func() error {
-			return c.createOrUpdateACLPolicy(anonPolicy, consulClient)
+			return c.createOrUpdateACLPolicy(anonPolicy, client)
 		})
 	if err != nil {
 		return err
@@ -55,13 +56,17 @@ func (c *Command) configureAnonymousPolicy(consulClient *api.Client) error {
 	// Update anonymous token to include this policy
 	return c.untilSucceeds("updating anonymous token with policy",
 		func() error {
-			_, _, err := consulClient.ACL().TokenUpdate(&aToken, &api.WriteOptions{})
+			err := client.RefreshClient()
+			if err != nil {
+				c.log.Error("could not refresh client", err)
+			}
+			_, _, err = client.ConsulClient.ACL().TokenUpdate(&aToken, &api.WriteOptions{})
 			return err
 		})
 }
 
-func checkIfAnonymousTokenPolicyExists(consulClient *api.Client) (bool, error) {
-	token, _, err := consulClient.ACL().TokenRead(anonymousTokenAccessorID, nil)
+func checkIfAnonymousTokenPolicyExists(client *consul.DynamicClient) (bool, error) {
+	token, _, err := client.ConsulClient.ACL().TokenRead(anonymousTokenAccessorID, nil)
 	if err != nil {
 		return false, err
 	}

--- a/control-plane/subcommand/server-acl-init/command_test.go
+++ b/control-plane/subcommand/server-acl-init/command_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/hashicorp/consul-k8s/control-plane/consul"
 	"github.com/hashicorp/consul-k8s/control-plane/helper/cert"
 	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
@@ -1389,14 +1390,14 @@ func TestConsulDatacenterList(t *testing.T) {
 			}))
 			defer consulServer.Close()
 
-			consulClient, err := api.NewClient(&api.Config{Address: consulServer.URL})
+			client, err := consul.NewDynamicClient(&api.Config{Address: consulServer.URL})
 			require.NoError(t, err)
 
 			command := Command{
 				log: hclog.New(hclog.DefaultOptions),
 				ctx: context.Background(),
 			}
-			actDC, actPrimaryDC, err := command.consulDatacenterList(consulClient)
+			actDC, actPrimaryDC, err := command.consulDatacenterList(client)
 			if c.expErr != "" {
 				require.EqualError(t, err, c.expErr)
 			} else {

--- a/control-plane/subcommand/server-acl-init/create_or_update.go
+++ b/control-plane/subcommand/server-acl-init/create_or_update.go
@@ -11,13 +11,14 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/hashicorp/consul-k8s/control-plane/consul"
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
 )
 
 // createACLPolicyRoleAndBindingRule will create the ACL Policy for the component
 // then create a set of ACLRole and ACLBindingRule which tie the component's serviceaccount
 // to the authMethod, allowing the serviceaccount to later be allowed to issue a Consul Login.
-func (c *Command) createACLPolicyRoleAndBindingRule(componentName, rules, dc, primaryDC string, global, primary bool, authMethodName, serviceAccountName string, client *api.Client) error {
+func (c *Command) createACLPolicyRoleAndBindingRule(componentName, rules, dc, primaryDC string, global, primary bool, authMethodName, serviceAccountName string, client *consul.DynamicClient) error {
 	// Create policy with the given rules.
 	policyName := fmt.Sprintf("%s-policy", componentName)
 	if c.flagFederation && !primary {
@@ -55,7 +56,7 @@ func (c *Command) createACLPolicyRoleAndBindingRule(componentName, rules, dc, pr
 }
 
 // addRoleAndBindingRule adds an ACLRole and ACLBindingRule which reference the authMethod.
-func (c *Command) addRoleAndBindingRule(client *api.Client, componentName, serviceAccountName, authMethodName string, policies []*api.ACLRolePolicyLink, global, primary bool, primaryDC, dc string) error {
+func (c *Command) addRoleAndBindingRule(client *consul.DynamicClient, componentName, serviceAccountName, authMethodName string, policies []*api.ACLRolePolicyLink, global, primary bool, primaryDC, dc string) error {
 	// This is the ACLRole which will allow the component which uses the serviceaccount
 	// to be able to do a consul login.
 	aclRoleName := c.withPrefix(fmt.Sprintf("%s-acl-role", componentName))
@@ -92,24 +93,28 @@ func (c *Command) addRoleAndBindingRule(client *api.Client, componentName, servi
 
 // updateOrCreateACLRole will query to see if existing role is in place and update them
 // or create them if they do not yet exist.
-func (c *Command) updateOrCreateACLRole(client *api.Client, role *api.ACLRole) error {
+func (c *Command) updateOrCreateACLRole(client *consul.DynamicClient, role *api.ACLRole) error {
 	err := c.untilSucceeds(fmt.Sprintf("update or create acl role for %s", role.Name),
 		func() error {
 			var err error
-			aclRole, _, err := client.ACL().RoleReadByName(role.Name, &api.QueryOptions{})
+			err = client.RefreshClient()
+			if err != nil {
+				c.log.Error("could not refresh client", err)
+			}
+			aclRole, _, err := client.ConsulClient.ACL().RoleReadByName(role.Name, &api.QueryOptions{})
 			if err != nil {
 				c.log.Error("unable to read ACL Roles", err)
 				return err
 			}
 			if aclRole != nil {
-				_, _, err := client.ACL().RoleUpdate(aclRole, &api.WriteOptions{})
+				_, _, err := client.ConsulClient.ACL().RoleUpdate(aclRole, &api.WriteOptions{})
 				if err != nil {
 					c.log.Error("unable to update role", err)
 					return err
 				}
 				return nil
 			}
-			_, _, err = client.ACL().RoleCreate(role, &api.WriteOptions{})
+			_, _, err = client.ConsulClient.ACL().RoleCreate(role, &api.WriteOptions{})
 			if err != nil {
 				c.log.Error("unable to create role", err)
 				return err
@@ -121,7 +126,7 @@ func (c *Command) updateOrCreateACLRole(client *api.Client, role *api.ACLRole) e
 
 // createConnectBindingRule will query to see if existing binding rules are in place and update them
 // or create them if they do not yet exist.
-func (c *Command) createConnectBindingRule(client *api.Client, authMethodName string, abr *api.ACLBindingRule) error {
+func (c *Command) createConnectBindingRule(client *consul.DynamicClient, authMethodName string, abr *api.ACLBindingRule) error {
 	// Binding rule list api call query options.
 	queryOptions := api.QueryOptions{}
 
@@ -136,12 +141,16 @@ func (c *Command) createConnectBindingRule(client *api.Client, authMethodName st
 	return c.createOrUpdateBindingRule(client, authMethodName, abr, &queryOptions, nil)
 }
 
-func (c *Command) createOrUpdateBindingRule(client *api.Client, authMethodName string, abr *api.ACLBindingRule, queryOptions *api.QueryOptions, writeOptions *api.WriteOptions) error {
+func (c *Command) createOrUpdateBindingRule(client *consul.DynamicClient, authMethodName string, abr *api.ACLBindingRule, queryOptions *api.QueryOptions, writeOptions *api.WriteOptions) error {
 	var existingRules []*api.ACLBindingRule
 	err := c.untilSucceeds(fmt.Sprintf("listing binding rules for auth method %s", authMethodName),
 		func() error {
 			var err error
-			existingRules, _, err = client.ACL().BindingRuleList(authMethodName, queryOptions)
+			err = client.RefreshClient()
+			if err != nil {
+				c.log.Error("could not refresh client", err)
+			}
+			existingRules, _, err = client.ConsulClient.ACL().BindingRuleList(authMethodName, queryOptions)
 			return err
 		})
 	if err != nil {
@@ -170,13 +179,21 @@ func (c *Command) createOrUpdateBindingRule(client *api.Client, authMethodName s
 			c.log.Info("unable to find a matching ACL binding rule to update. creating ACL binding rule.")
 			err = c.untilSucceeds(fmt.Sprintf("creating acl binding rule for %s", authMethodName),
 				func() error {
-					_, _, err := client.ACL().BindingRuleCreate(abr, writeOptions)
+					err = client.RefreshClient()
+					if err != nil {
+						c.log.Error("could not refresh client", err)
+					}
+					_, _, err := client.ConsulClient.ACL().BindingRuleCreate(abr, writeOptions)
 					return err
 				})
 		} else {
 			err = c.untilSucceeds(fmt.Sprintf("updating acl binding rule for %s", authMethodName),
 				func() error {
-					_, _, err := client.ACL().BindingRuleUpdate(abr, writeOptions)
+					err = client.RefreshClient()
+					if err != nil {
+						c.log.Error("could not refresh client", err)
+					}
+					_, _, err := client.ConsulClient.ACL().BindingRuleUpdate(abr, writeOptions)
 					return err
 				})
 		}
@@ -184,7 +201,11 @@ func (c *Command) createOrUpdateBindingRule(client *api.Client, authMethodName s
 		// Otherwise create the binding rule
 		err = c.untilSucceeds(fmt.Sprintf("creating acl binding rule for %s", authMethodName),
 			func() error {
-				_, _, err := client.ACL().BindingRuleCreate(abr, writeOptions)
+				err = client.RefreshClient()
+				if err != nil {
+					c.log.Error("could not refresh client", err)
+				}
+				_, _, err := client.ConsulClient.ACL().BindingRuleCreate(abr, writeOptions)
 				return err
 			})
 	}
@@ -193,19 +214,19 @@ func (c *Command) createOrUpdateBindingRule(client *api.Client, authMethodName s
 
 // createLocalACL creates a policy and acl token for this dc (datacenter), i.e.
 // the policy is only valid for this datacenter and the token is a local token.
-func (c *Command) createLocalACL(name, rules, dc string, isPrimary bool, consulClient *api.Client) error {
+func (c *Command) createLocalACL(name, rules, dc string, isPrimary bool, consulClient *consul.DynamicClient) error {
 	return c.createACL(name, rules, true, dc, isPrimary, consulClient, "")
 }
 
 // createGlobalACL creates a global policy and acl token. The policy is valid
 // for all datacenters and the token is global. dc must be passed because the
 // policy name may have the datacenter name appended.
-func (c *Command) createGlobalACL(name, rules, dc string, isPrimary bool, consulClient *api.Client) error {
+func (c *Command) createGlobalACL(name, rules, dc string, isPrimary bool, consulClient *consul.DynamicClient) error {
 	return c.createACL(name, rules, false, dc, isPrimary, consulClient, "")
 }
 
 // createACLWithSecretID creates a global policy and acl token with provided secret ID.
-func (c *Command) createACLWithSecretID(name, rules, dc string, isPrimary bool, consulClient *api.Client, secretID string, local bool) error {
+func (c *Command) createACLWithSecretID(name, rules, dc string, isPrimary bool, consulClient *consul.DynamicClient, secretID string, local bool) error {
 	return c.createACL(name, rules, local, dc, isPrimary, consulClient, secretID)
 }
 
@@ -215,7 +236,7 @@ func (c *Command) createACLWithSecretID(name, rules, dc string, isPrimary bool, 
 // When secretID is provided, we will use that value for the created token and
 // will skip writing it to a Kubernetes secret (because in this case we assume that
 // this value already exists in some secrets storage).
-func (c *Command) createACL(name, rules string, localToken bool, dc string, isPrimary bool, consulClient *api.Client, secretID string) error {
+func (c *Command) createACL(name, rules string, localToken bool, dc string, isPrimary bool, client *consul.DynamicClient, secretID string) error {
 	// Create policy with the given rules.
 	policyName := fmt.Sprintf("%s-token", name)
 	if c.flagFederation && !isPrimary {
@@ -235,7 +256,7 @@ func (c *Command) createACL(name, rules string, localToken bool, dc string, isPr
 	}
 	err := c.untilSucceeds(fmt.Sprintf("creating %s policy", policyTmpl.Name),
 		func() error {
-			return c.createOrUpdateACLPolicy(policyTmpl, consulClient)
+			return c.createOrUpdateACLPolicy(policyTmpl, client)
 		})
 	if err != nil {
 		return err
@@ -263,7 +284,7 @@ func (c *Command) createACL(name, rules string, localToken bool, dc string, isPr
 	} else {
 		// If secretID is provided, we check if the token with secretID already exists in Consul
 		// and exit if it does. Otherwise, set the secretID to the provided value.
-		_, _, err = consulClient.ACL().TokenReadSelf(&api.QueryOptions{Token: secretID})
+		_, _, err = client.ConsulClient.ACL().TokenReadSelf(&api.QueryOptions{Token: secretID})
 		if err == nil {
 			c.log.Info("ACL replication token already exists; skipping creation")
 			return nil
@@ -275,7 +296,11 @@ func (c *Command) createACL(name, rules string, localToken bool, dc string, isPr
 	var token string
 	err = c.untilSucceeds(fmt.Sprintf("creating token for policy %s", policyTmpl.Name),
 		func() error {
-			createdToken, _, err := consulClient.ACL().TokenCreate(&tokenTmpl, &api.WriteOptions{})
+			err = client.RefreshClient()
+			if err != nil {
+				c.log.Error("could not refresh client", err)
+			}
+			createdToken, _, err := client.ConsulClient.ACL().TokenCreate(&tokenTmpl, &api.WriteOptions{})
 			if err == nil {
 				token = createdToken.SecretID
 			}
@@ -305,9 +330,14 @@ func (c *Command) createACL(name, rules string, localToken bool, dc string, isPr
 	return nil
 }
 
-func (c *Command) createOrUpdateACLPolicy(policy api.ACLPolicy, consulClient *api.Client) error {
+func (c *Command) createOrUpdateACLPolicy(policy api.ACLPolicy, client *consul.DynamicClient) error {
+	err := client.RefreshClient()
+	if err != nil {
+		c.log.Error("could not refresh client", err)
+	}
+
 	// Attempt to create the ACL policy.
-	_, _, err := consulClient.ACL().PolicyCreate(&policy, &api.WriteOptions{})
+	_, _, err = client.ConsulClient.ACL().PolicyCreate(&policy, &api.WriteOptions{})
 
 	// With the introduction of Consul namespaces, if someone upgrades into a
 	// Consul version with namespace support or changes any of their namespace
@@ -320,7 +350,7 @@ func (c *Command) createOrUpdateACLPolicy(policy api.ACLPolicy, consulClient *ap
 
 		// The policy ID is required in any PolicyUpdate call, so first we need to
 		// get the existing policy to extract its ID.
-		existingPolicies, _, err := consulClient.ACL().PolicyList(&api.QueryOptions{})
+		existingPolicies, _, err := client.ConsulClient.ACL().PolicyList(&api.QueryOptions{})
 		if err != nil {
 			return err
 		}
@@ -345,7 +375,7 @@ func (c *Command) createOrUpdateACLPolicy(policy api.ACLPolicy, consulClient *ap
 		}
 
 		// Update the policy now that we've found its ID
-		_, _, err = consulClient.ACL().PolicyUpdate(&policy, &api.WriteOptions{})
+		_, _, err = client.ConsulClient.ACL().PolicyUpdate(&policy, &api.WriteOptions{})
 		return err
 	}
 	return err


### PR DESCRIPTION
Changes proposed in this PR:
- When the server-acl-init job runs it boostraps ACL tokens and sets a bunch of things on the server up
- It gets the static IPs for the servers, creates a boostrap token and sets a policy using that IP
- Then consul-server-connection-manager runs and other ACLs get set up using the consul client
- Usually this is fine.
- But during upgrades the servers statefulsets can change and thus the server IPs change.
- Our code was set to retry over and over again and would eventually timeout after 10 minutes
- This does not work as it forces customers to run the upgrades several times in hopes that the server IPs do not change.
- I've created a wrapper around the consul client called DynamicClient that allows you to refresh the IPs using consul-server-connection-manager
- The DynamicClient will be useful in other place also.
- A customer reported a single error but in my testing I discovered about 5 other places where the IPs would be incorrect and we needed to refresh.
- The key areas are around 'untilSucceeds()' as these consul calls would fail forever

How I've tested this PR:

- Added a unit test to DynamicClient that simulates a bad server ip, a refresh with a good ip and a client call.
- The race condition does not occur all the time but I have been able to reproduce it manually by upgrading over and over again, which sometimes forces the servers to change IPs.

How I expect reviewers to test this PR:

👀 

Checklist:
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


