### PR TITLE
build(docker): remove extraneous docker build for UBI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -332,7 +332,6 @@ jobs:
       - name: Copy LICENSE
         run:
           cp LICENSE ./control-plane
-      - uses: hashicorp/actions-docker-build@v1
 
       # This naming convention will be used ONLY for per-commit dev images
       - name: Set docker dev tag


### PR DESCRIPTION
Changes proposed in this PR:
- Fixes a[ build error ](https://github.com/hashicorp/consul-k8s/actions/runs/6697671470/job/18201205351)because of an extra `actions-docker-build` step



