### PR TITLE
fix(controller): v2 pod controller error log for missing ip

### DIFF
--- a/.changelog/3162.txt
+++ b/.changelog/3162.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+control-plane: remove extraneous error log in v2 pod controller when a pod is scheduled, but not yet allocated an IP.
+```


### PR DESCRIPTION
Changes proposed in this PR:
- Fixes an extraneous error log when a pod is first scheduled but not yet allocated an IP.

How I've tested this PR: unit tests and manual integration.

How I expect reviewers to test this PR: 👀 


Checklist:
- [X] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


