### PR TITLE
NET-6289 Include standard gateway annotations on API gateway pods

### DIFF
--- a/cli/cmd/proxy/list/command.go
+++ b/cli/cmd/proxy/list/command.go
@@ -9,15 +9,16 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/consul-k8s/cli/common"
-	"github.com/hashicorp/consul-k8s/cli/common/flag"
-	"github.com/hashicorp/consul-k8s/cli/common/terminal"
 	"github.com/posener/complete"
 	helmCLI "helm.sh/helm/v3/pkg/cli"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/hashicorp/consul-k8s/cli/common"
+	"github.com/hashicorp/consul-k8s/cli/common/flag"
+	"github.com/hashicorp/consul-k8s/cli/common/terminal"
 )
 
 const (
@@ -200,21 +201,12 @@ func (c *ListCommand) fetchPods() ([]v1.Pod, error) {
 
 	// Fetch all pods in the namespace with labels matching the gateway component names.
 	gatewaypods, err := c.kubernetes.CoreV1().Pods(c.namespace()).List(c.Ctx, metav1.ListOptions{
-		LabelSelector: "component in (ingress-gateway, mesh-gateway, terminating-gateway), chart=consul-helm",
+		LabelSelector: "component in (api-gateway, ingress-gateway, mesh-gateway, terminating-gateway), chart=consul-helm",
 	})
 	if err != nil {
 		return nil, err
 	}
 	pods = append(pods, gatewaypods.Items...)
-
-	// Fetch all pods in the namespace with a label indicating they are an API gateway.
-	apigatewaypods, err := c.kubernetes.CoreV1().Pods(c.namespace()).List(c.Ctx, metav1.ListOptions{
-		LabelSelector: "api-gateway.consul.hashicorp.com/managed=true",
-	})
-	if err != nil {
-		return nil, err
-	}
-	pods = append(pods, apigatewaypods.Items...)
 
 	// Fetch all pods in the namespace with a label indicating they are a service networked by Consul.
 	sidecarpods, err := c.kubernetes.CoreV1().Pods(c.namespace()).List(c.Ctx, metav1.ListOptions{
@@ -257,21 +249,16 @@ func (c *ListCommand) output(pods []v1.Pod) {
 
 		// Get the type for ingress, mesh, and terminating gateways.
 		switch pod.Labels["component"] {
+		case "api-gateway":
+			proxyType = "API Gateway"
 		case "ingress-gateway":
 			proxyType = "Ingress Gateway"
 		case "mesh-gateway":
 			proxyType = "Mesh Gateway"
 		case "terminating-gateway":
 			proxyType = "Terminating Gateway"
-		}
-
-		// Determine if the pod is an API Gateway.
-		if pod.Labels["api-gateway.consul.hashicorp.com/managed"] == "true" {
-			proxyType = "API Gateway"
-		}
-
-		// Fallback to "Sidecar" as a default
-		if proxyType == "" {
+		default:
+			// Fallback to "Sidecar" as a default
 			proxyType = "Sidecar"
 		}
 

--- a/control-plane/api-gateway/common/labels.go
+++ b/control-plane/api-gateway/common/labels.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	componentLabel = "component"
 	nameLabel      = "gateway.consul.hashicorp.com/name"
 	namespaceLabel = "gateway.consul.hashicorp.com/namespace"
 	createdAtLabel = "gateway.consul.hashicorp.com/created"
@@ -21,6 +22,7 @@ const (
 // LabelsForGateway formats the default labels that appear on objects managed by the controllers.
 func LabelsForGateway(gateway *gwv1beta1.Gateway) map[string]string {
 	return map[string]string{
+		componentLabel: "api-gateway",
 		nameLabel:      gateway.Name,
 		namespaceLabel: gateway.Namespace,
 		createdAtLabel: fmt.Sprintf("%d", gateway.CreationTimestamp.Unix()),

--- a/control-plane/api-gateway/gatekeeper/deployment.go
+++ b/control-plane/api-gateway/gatekeeper/deployment.go
@@ -6,18 +6,19 @@ package gatekeeper
 import (
 	"context"
 
-	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
-	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
-	"k8s.io/apimachinery/pkg/types"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 )
 
 const (
@@ -110,7 +111,9 @@ func (g *Gatekeeper) deployment(gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayC
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: common.LabelsForGateway(&gateway),
 					Annotations: map[string]string{
-						"consul.hashicorp.com/connect-inject": "false",
+						constants.AnnotationInject:                   "false",
+						constants.AnnotationGatewayConsulServiceName: gateway.Name,
+						constants.AnnotationGatewayKind:              "api-gateway",
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
@@ -35,6 +35,7 @@ var (
 	name                = "test"
 	namespace           = "default"
 	labels              = map[string]string{
+		"component":                              "api-gateway",
 		"gateway.consul.hashicorp.com/name":      name,
 		"gateway.consul.hashicorp.com/namespace": namespace,
 		createdAtLabelKey:                        createdAtLabelValue,
@@ -1009,6 +1010,7 @@ func validateResourcesExist(t *testing.T, client client.Client, resources resour
 			require.EqualValues(t, *expected.Spec.Replicas, *actual.Spec.Replicas)
 		}
 		require.Equal(t, expected.Spec.Template.ObjectMeta.Annotations, actual.Spec.Template.ObjectMeta.Annotations)
+		require.Equal(t, expected.Spec.Template.ObjectMeta.Labels, actual.Spec.Template.Labels)
 
 		// Ensure there is a consul-dataplane container dropping ALL capabilities, adding
 		// back the NET_BIND_SERVICE capability, and establishing a read-only root filesystem

--- a/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 )
 
 var (
@@ -1007,6 +1008,7 @@ func validateResourcesExist(t *testing.T, client client.Client, resources resour
 			require.NotNil(t, actual.Spec.Replicas)
 			require.EqualValues(t, *expected.Spec.Replicas, *actual.Spec.Replicas)
 		}
+		require.Equal(t, expected.Spec.Template.ObjectMeta.Annotations, actual.Spec.Template.ObjectMeta.Annotations)
 
 		// Ensure there is a consul-dataplane container dropping ALL capabilities, adding
 		// back the NET_BIND_SERVICE capability, and establishing a read-only root filesystem
@@ -1189,7 +1191,9 @@ func configureDeployment(name, namespace string, labels map[string]string, repli
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
 					Annotations: map[string]string{
-						"consul.hashicorp.com/connect-inject": "false",
+						constants.AnnotationInject:                   "false",
+						constants.AnnotationGatewayConsulServiceName: name,
+						constants.AnnotationGatewayKind:              "api-gateway",
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/control-plane/connect-inject/constants/annotations_and_labels.go
+++ b/control-plane/connect-inject/constants/annotations_and_labels.go
@@ -25,7 +25,8 @@ const (
 
 	// AnnotationGatewayKind is the key of the annotation that indicates pods
 	// that represent Consul Connect Gateways. This should be set to a
-	// value that is either "mesh", "ingress" or "terminating".
+	// value that is either "mesh-gateway", "ingress-gateway", "terminating-gateway",
+	// or "api-gateway".
 	AnnotationGatewayKind = "consul.hashicorp.com/gateway-kind"
 
 	// AnnotationGatewayConsulServiceName is the key of the annotation whose value

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
@@ -43,6 +43,7 @@ const (
 	meshGateway        = "mesh-gateway"
 	terminatingGateway = "terminating-gateway"
 	ingressGateway     = "ingress-gateway"
+	apiGateway         = "api-gateway"
 
 	envoyPrometheusBindAddr              = "envoy_prometheus_bind_addr"
 	envoyTelemetryCollectorBindSocketDir = "envoy_telemetry_collector_bind_socket_dir"
@@ -770,9 +771,11 @@ func (r *Controller) createGatewayRegistrations(pod corev1.Pod, serviceEndpoints
 				},
 			},
 		}
-
+	case apiGateway:
+		// Do nothing. This is only here so that API gateway pods have annotations
+		// consistent with other gateway types but don't return an error below.
 	default:
-		return nil, fmt.Errorf("%s must be one of %s, %s, or %s", constants.AnnotationGatewayKind, meshGateway, terminatingGateway, ingressGateway)
+		return nil, fmt.Errorf("%s must be one of %s, %s, %s, or %s", constants.AnnotationGatewayKind, meshGateway, terminatingGateway, ingressGateway, apiGateway)
 	}
 
 	if r.MetricsConfig.DefaultEnableMetrics && r.MetricsConfig.EnableGatewayMetrics {

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
@@ -1333,10 +1333,11 @@ func hasBeenInjected(pod corev1.Pod) bool {
 	return false
 }
 
-// isGateway checks the value of the gateway annotation and returns true if the Pod represents a Gateway.
+// isGateway checks the value of the gateway annotation and returns true if the Pod
+// represents a Gateway kind that should be acted upon by the endpoints controller.
 func isGateway(pod corev1.Pod) bool {
 	anno, ok := pod.Annotations[constants.AnnotationGatewayKind]
-	return ok && anno != ""
+	return ok && anno != "" && anno != apiGateway
 }
 
 // mapAddresses combines all addresses to a mapping of address to its health status.


### PR DESCRIPTION
**Changes proposed in this PR:**
- Add the `component: api-gateway` label
- Add the `.../gateway-kind: api-gateway` annotation
- Add the `.../gateway-consul-service-name: <Gateway name>` annotation

**How I've tested this PR:**
Deploy a `Gateway` resource with `gatewayClassName: consul` and verify that the resulting `Pods` have the expected labls + annotations. [Here](https://github.com/nathancoleman/consul-lab/tree/6d27ecd8161d557330936d9bd9e7403e0bc556e0/k8s/api-gateway/basic) is a simple setup that I used.

**How I expect reviewers to test this PR:**
- See above

**Checklist:**
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


