### PR TITLE
fix(controller): v2 pod controller errors for acl deletion

### DIFF
--- a/.changelog/3172.txt
+++ b/.changelog/3172.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+control-plane: remove extraneous error log in v2 pod controller when attempting to delete ACL tokens.
+```
+```
+release-note:bug
+init container: fix a bug that didn't clear ACL tokens for init container when tproxy is enabled.
+```

--- a/control-plane/config-entries/controllersv2/meshconfig_controller_test.go
+++ b/control-plane/config-entries/controllersv2/meshconfig_controller_test.go
@@ -70,13 +70,14 @@ func TestMeshConfigController_createsMeshConfig(t *testing.T) {
 									IdentityName: "source-identity",
 								},
 							},
-							DestinationRules: []*pbauth.DestinationRule{
-								{
-									PathExact: "/hello",
-									Methods:   []string{"GET", "POST"},
-									PortNames: []string{"web", "admin"},
-								},
-							},
+							// TODO: enable this when L7 traffic permissions are supported
+							//DestinationRules: []*pbauth.DestinationRule{
+							//	{
+							//		PathExact: "/hello",
+							//		Methods:   []string{"GET", "POST"},
+							//		PortNames: []string{"web", "admin"},
+							//	},
+							//},
 						},
 					},
 				},
@@ -101,13 +102,13 @@ func TestMeshConfigController_createsMeshConfig(t *testing.T) {
 								Peer:      constants.DefaultConsulPeer,
 							},
 						},
-						DestinationRules: []*pbauth.DestinationRule{
-							{
-								PathExact: "/hello",
-								Methods:   []string{"GET", "POST"},
-								PortNames: []string{"web", "admin"},
-							},
-						},
+						//DestinationRules: []*pbauth.DestinationRule{
+						//	{
+						//		PathExact: "/hello",
+						//		Methods:   []string{"GET", "POST"},
+						//		PortNames: []string{"web", "admin"},
+						//	},
+						//},
 					},
 				},
 			},
@@ -216,13 +217,14 @@ func TestMeshConfigController_updatesMeshConfig(t *testing.T) {
 									IdentityName: "source-identity",
 								},
 							},
-							DestinationRules: []*pbauth.DestinationRule{
-								{
-									PathExact: "/hello",
-									Methods:   []string{"GET", "POST"},
-									PortNames: []string{"web", "admin"},
-								},
-							},
+							// TODO: enable this when L7 traffic permissions are supported
+							//DestinationRules: []*pbauth.DestinationRule{
+							//	{
+							//		PathExact: "/hello",
+							//		Methods:   []string{"GET", "POST"},
+							//		PortNames: []string{"web", "admin"},
+							//	},
+							//},
 						},
 					},
 				},
@@ -241,13 +243,13 @@ func TestMeshConfigController_updatesMeshConfig(t *testing.T) {
 								Peer:      constants.DefaultConsulPeer,
 							},
 						},
-						DestinationRules: []*pbauth.DestinationRule{
-							{
-								PathExact: "/hello",
-								Methods:   []string{"GET", "POST"},
-								PortNames: []string{"web", "admin"},
-							},
-						},
+						//DestinationRules: []*pbauth.DestinationRule{
+						//	{
+						//		PathExact: "/hello",
+						//		Methods:   []string{"GET", "POST"},
+						//		PortNames: []string{"web", "admin"},
+						//	},
+						//},
 					},
 				},
 			},
@@ -373,13 +375,14 @@ func TestMeshConfigController_deletesMeshConfig(t *testing.T) {
 									IdentityName: "source-identity",
 								},
 							},
-							DestinationRules: []*pbauth.DestinationRule{
-								{
-									PathExact: "/hello",
-									Methods:   []string{"GET", "POST"},
-									PortNames: []string{"web", "admin"},
-								},
-							},
+							// TODO: enable this when L7 traffic permissions are supported
+							//DestinationRules: []*pbauth.DestinationRule{
+							//	{
+							//		PathExact: "/hello",
+							//		Methods:   []string{"GET", "POST"},
+							//		PortNames: []string{"web", "admin"},
+							//	},
+							//},
 						},
 					},
 				},

--- a/control-plane/connect-inject/controllers/pod/pod_controller_test.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller_test.go
@@ -1777,6 +1777,14 @@ func TestReconcileDeletePod(t *testing.T) {
 				},
 			}, nil)
 			require.NoError(t, err)
+
+			// We create another junk token here just to make sure it doesn't interfere with cleaning up the
+			// previous "real" token that has metadata.
+			_, _, err = testClient.APIClient.ACL().Login(&api.ACLLoginParams{
+				AuthMethod:  test.AuthMethod,
+				BearerToken: test.ServiceAccountJWTToken,
+			}, nil)
+			require.NoError(t, err)
 		}
 
 		namespacedName := types.NamespacedName{

--- a/control-plane/connect-inject/webhookv2/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhookv2/consul_dataplane_sidecar.go
@@ -112,6 +112,12 @@ func (w *MeshWebhook) consulDataplaneSidecar(namespace corev1.Namespace, pod cor
 				Name:  "DP_CREDENTIAL_LOGIN_META",
 				Value: "pod=$(POD_NAMESPACE)/$(POD_NAME)",
 			},
+			// This entry exists to support newer versions of consul dataplane, where environment variable entries
+			// utilize this numbered notation to indicate individual KV pairs in a map.
+			{
+				Name:  "DP_CREDENTIAL_LOGIN_META1",
+				Value: "pod=$(POD_NAMESPACE)/$(POD_NAME)",
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{

--- a/control-plane/connect-inject/webhookv2/consul_dataplane_sidecar_test.go
+++ b/control-plane/connect-inject/webhookv2/consul_dataplane_sidecar_test.go
@@ -219,7 +219,7 @@ func TestHandlerConsulDataplaneSidecar(t *testing.T) {
 			}
 			require.Equal(t, expectedProbe, container.ReadinessProbe)
 			require.Nil(t, container.StartupProbe)
-			require.Len(t, container.Env, 6)
+			require.Len(t, container.Env, 7)
 			require.Equal(t, container.Env[0].Name, "TMPDIR")
 			require.Equal(t, container.Env[0].Value, "/consul/mesh-inject")
 			require.Equal(t, container.Env[2].Name, "POD_NAME")

--- a/control-plane/subcommand/connect-init/command.go
+++ b/control-plane/subcommand/connect-init/command.go
@@ -206,6 +206,7 @@ func (c *Command) Run(args []string) int {
 	}
 
 	if c.flagRedirectTrafficConfig != "" {
+		c.watcher.Stop() // Explicitly stop the watcher so that ACLs are cleaned up before we apply re-direction.
 		err = c.applyTrafficRedirectionRules(proxyService)
 		if err != nil {
 			c.logger.Error("error applying traffic redirection rules", "err", err)

--- a/control-plane/subcommand/mesh-init/command.go
+++ b/control-plane/subcommand/mesh-init/command.go
@@ -183,6 +183,7 @@ func (c *Command) Run(args []string) int {
 	}
 
 	if c.flagRedirectTrafficConfig != "" {
+		c.watcher.Stop()                                        // Explicitly stop the watcher so that ACLs are cleaned up before we apply re-direction.
 		err := c.applyTrafficRedirectionRules(&bootstrapConfig) // BootstrapConfig is always populated non-nil from the RPC
 		if err != nil {
 			c.logger.Error("error applying traffic redirection rules", "err", err)


### PR DESCRIPTION
Changes proposed in this PR:
- Don't error out if a token is missing metadata.
- Make sure dataplane is injected with the correct metadata so that the ACL token is created with metadata on login.
- Explicitly call stop when in the init container when re-direction is enabled.

How I've tested this PR: manual K8S testing plus unit tests.

How I expect reviewers to test this PR: 👁️ 👃 👁️ 


Checklist:
- [X] Tests added
- [X] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


