### PR TITLE
Enable leader election for Consul sync catalog

### DIFF
--- a/charts/consul/templates/sync-catalog-clusterrole.yaml
+++ b/charts/consul/templates/sync-catalog-clusterrole.yaml
@@ -45,4 +45,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["create"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  resourceNames:
+  - {{ template "consul.fullname" . }}-sync-catalog-lease
+  verbs: ["get", "patch", "delete", "create", "update"]
 {{- end }}

--- a/charts/consul/templates/sync-catalog-deployment.yaml
+++ b/charts/consul/templates/sync-catalog-deployment.yaml
@@ -192,6 +192,19 @@ spec:
             -loadBalancer-ips=true \
             {{- end }}
             {{- end }}
+            {{- if .Values.syncCatalog.leaderElection.enabled }}
+            -enable-leaderElection=true \
+            -leaderElection-lease-name={{ template "consul.fullname" . }}-sync-catalog-lease \
+            {{- if .Values.syncCatalog.leaderElection.leaseDuration }}
+            -leaderElection-lease-duration={{ .Values.syncCatalog.leaderElection.leaseDuration }} \
+            {{- end }}
+            {{- if .Values.syncCatalog.leaderElection.renewDeadline }}
+            -leaderElection-renew-deadline={{ .Values.syncCatalog.leaderElection.renewDeadline }} \
+            {{- end }}
+            {{- if .Values.syncCatalog.leaderElection.retryPeriod }}
+            -leaderElection-retry-period={{ .Values.syncCatalog.leaderElection.retryPeriod }} \
+            {{- end }}
+            {{- end }}
         livenessProbe:
           httpGet:
             path: /health/ready

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1891,6 +1891,18 @@ syncCatalog:
   # In either case an annotation can override the default.
   default: true
 
+  leaderElection:
+    # Leader election is still experimental and not enabled by default
+    enabled: false
+    # Number of replicas for the sync catalog deployment.
+    # For replicas > 1, this will run in [leader election mode](https://pkg.go.dev/k8s.io/client-go/tools/leaderelection)
+    # to avoid race condition where multiple replicas sync at the same time.
+    replicas: 3
+    # Options to [optimize leasing](https://pkg.go.dev/k8s.io/component-base/config#LeaderElectionConfiguration)
+    leaseDuration: 15s
+    renewDeadline: 10s
+    retryPeriod: 2s
+
   # Optional priorityClassName.
   priorityClassName: ""
 


### PR DESCRIPTION
Changes proposed in this PR:
- Enabling leader election for Consul catalog sync, following the discussion in #1815 

How it works:
- Number of replicas for sync catalog can be configured.
- There is only 1 leader at one time who holds the lease, the rest will stay idle and keep checking if current leader is still active, and start voting for a new leader when the current leader is no longer responsive.
- Implementation is built on top of the [leaderelection](https://pkg.go.dev/k8s.io/client-go/tools/leaderelection) package.

How I've tested this PR:
- Run a local cluster using [kind](https://kind.sigs.k8s.io/), deploy this change there and observe the behavior of replicas under different condition - on startup, during voting, new leader is determined, new leader is gone (pod deleted for example).

How I expect reviewers to test this PR:
- Same as above.

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


