### PR TITLE
Update rate limiting acceptance test to burst requests in one exec

### DIFF
--- a/acceptance/tests/connect/local_rate_limit_test.go
+++ b/acceptance/tests/connect/local_rate_limit_test.go
@@ -4,23 +4,29 @@
 package connect
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	terratestK8s "github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul-k8s/acceptance/framework/connhelper"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/stretchr/testify/require"
 )
 
 // TestConnectInject_LocalRateLimiting tests that local rate limiting works as expected between services.
 func TestConnectInject_LocalRateLimiting(t *testing.T) {
 	cfg := suite.Config()
+
+	if !cfg.EnableEnterprise {
+		t.Skipf("rate limiting is an enterprise only feature. -enable-enterprise must be set to run this test.")
+	}
+
 	ctx := suite.Environment().DefaultContext(t)
 
 	releaseName := helpers.RandomName()
@@ -56,29 +62,35 @@ func TestConnectInject_LocalRateLimiting(t *testing.T) {
 
 	opts := newRateLimitOptions(t, ctx)
 
-	// Ensure that all requests from static-client to static-server succeed (no rate limiting set).
-	for addr, rps := range rateLimitMap {
-		opts.rps = rps
-		assertRateLimits(t, opts, addr)
-	}
+	t.Run("without ratelimiting", func(t *testing.T) {
+		// Ensure that all requests from static-client to static-server succeed (no rate limiting set).
+		for addr, rps := range rateLimitMap {
+			opts.rps = rps
+			assertRateLimits(t, opts, addr)
+		}
+	})
 
 	// Apply local rate limiting to the static-server
 	writeCrd(t, connHelper, "../fixtures/cases/local-rate-limiting")
 
-	// Ensure that going over the limit causes the static-server to apply rate limiting and
-	// reply with 429 Too Many Requests
-	opts.enforced = true
-	for addr, reqPerSec := range rateLimitMap {
-		opts.rps = reqPerSec
-		assertRateLimits(t, opts, addr)
-	}
+	t.Run("with ratelimiting", func(t *testing.T) {
+		// Ensure that going over the limit causes the static-server to apply rate limiting and
+		// reply with 429 Too Many Requests
+		opts.enforced = true
+		for addr, reqPerSec := range rateLimitMap {
+			opts.rps = reqPerSec
+			assertRateLimits(t, opts, addr)
+		}
+	})
 }
 
-func assertRateLimits(t *testing.T, opts *assertRateLimitOptions, curlArgs ...string) {
+func assertRateLimits(t *testing.T, opts *assertRateLimitOptions, addr string) {
 	t.Helper()
-
 	args := []string{"exec", opts.resourceType + opts.sourceApp, "-c", opts.sourceApp, "--", "curl", opts.curlOpts}
-	args = append(args, curlArgs...)
+	// curl can glob URLs to make requests to a range of addresses.
+	// We append a number as a query param since it will be ignored by
+	// the rate limit path matcher.
+	repeatAddr := fmt.Sprintf("%s?[1-%d]", addr, opts.rps)
 
 	// This check is time sensitive due to the nature of rate limiting.
 	// Run the entire assertion in a retry block and on each pass:
@@ -89,22 +101,21 @@ func assertRateLimits(t *testing.T, opts *assertRateLimitOptions, curlArgs ...st
 	retry.RunWith(opts.retryTimer, t, func(r *retry.R) {
 		// Make up to the allowed numbers of calls in a second
 		t0 := time.Now()
-		for i := 0; i < opts.rps; i++ {
-			output, err := k8s.RunKubectlAndGetOutputE(t, opts.k8sOpts, args...)
-			require.NoError(r, err)
-			require.Contains(r, output, opts.successOutput)
-		}
+
+		output, err := k8s.RunKubectlAndGetOutputE(t, opts.k8sOpts, append(args, repeatAddr)...)
+		require.NoError(r, err)
+		require.Contains(r, output, opts.successOutput)
 
 		// Exceed the configured rate limit.
-		output, err := k8s.RunKubectlAndGetOutputE(t, opts.k8sOpts, args...)
+		output, err = k8s.RunKubectlAndGetOutputE(t, opts.k8sOpts, append(args, addr)...)
+		require.True(r, time.Since(t0) < time.Second, "failed to make all requests within one second window")
 		if opts.enforced {
 			require.Error(r, err)
 			require.Contains(r, output, opts.rateLimitOutput, "request was not rate limited")
 		} else {
 			require.NoError(r, err)
-			require.Contains(r, output, opts.successOutput, "request was not successful")
+			require.NotContains(r, output, opts.rateLimitOutput, "request was not successful")
 		}
-		require.True(r, time.Since(t0) < time.Second, "failed to make all requests within one second window")
 	})
 }
 
@@ -128,6 +139,6 @@ func newRateLimitOptions(t *testing.T, ctx environment.TestContext) *assertRateL
 		k8sOpts:         ctx.KubectlOptions(t),
 		sourceApp:       connhelper.StaticClientName,
 		retryTimer:      &retry.Timer{Timeout: 120 * time.Second, Wait: 2 * time.Second},
-		curlOpts:        "-vvvsSf",
+		curlOpts:        "-f",
 	}
 }


### PR DESCRIPTION
Changes proposed in this PR:
- Fix tests to reduce overhead of exec-ing into pods in CI which was causing rate limiting tests to flake

How I've tested this PR:

Passed tests locally

How I expect reviewers to test this PR:

👀 


