### PR TITLE
NET-5392 Replace dev dependencies w/ latest release tags

### DIFF
--- a/control-plane/api-gateway/common/diff.go
+++ b/control-plane/api-gateway/common/diff.go
@@ -274,8 +274,10 @@ func (e entryComparator) urlRewritesEqual(a, b api.URLRewrite) bool {
 }
 
 func (e entryComparator) retryFiltersEqual(a, b api.RetryFilter) bool {
-	return BothNilOrEqual(a.NumRetries, b.NumRetries) && BothNilOrEqual(a.RetryOnConnectFailure, b.RetryOnConnectFailure) &&
-		slices.Equal(a.RetryOn, b.RetryOn) && slices.Equal(a.RetryOnStatusCodes, b.RetryOnStatusCodes)
+	return a.NumRetries == b.NumRetries &&
+		a.RetryOnConnectFailure == b.RetryOnConnectFailure &&
+		slices.Equal(a.RetryOn, b.RetryOn) &&
+		slices.Equal(a.RetryOnStatusCodes, b.RetryOnStatusCodes)
 }
 
 func (e entryComparator) timeoutFiltersEqual(a, b api.TimeoutFilter) bool {

--- a/control-plane/api-gateway/common/translation.go
+++ b/control-plane/api-gateway/common/translation.go
@@ -149,12 +149,20 @@ func ToContainerPort(portNumber gwv1beta1.PortNumber, mapPrivilegedContainerPort
 }
 
 func (t ResourceTranslator) translateRouteRetryFilter(routeRetryFilter *v1alpha1.RouteRetryFilter) *api.RetryFilter {
-	return &api.RetryFilter{
-		NumRetries:            routeRetryFilter.Spec.NumRetries,
+	filter := &api.RetryFilter{
 		RetryOn:               routeRetryFilter.Spec.RetryOn,
 		RetryOnStatusCodes:    routeRetryFilter.Spec.RetryOnStatusCodes,
-		RetryOnConnectFailure: routeRetryFilter.Spec.RetryOnConnectFailure,
 	}
+
+	if routeRetryFilter.Spec.NumRetries != nil {
+		filter.NumRetries = *routeRetryFilter.Spec.NumRetries
+	}
+
+	if routeRetryFilter.Spec.RetryOnConnectFailure != nil {
+		filter.RetryOnConnectFailure = *routeRetryFilter.Spec.RetryOnConnectFailure
+	}
+
+	return filter
 }
 
 func (t ResourceTranslator) translateRouteTimeoutFilter(routeTimeoutFilter *v1alpha1.RouteTimeoutFilter) *api.TimeoutFilter {

--- a/control-plane/api-gateway/common/translation.go
+++ b/control-plane/api-gateway/common/translation.go
@@ -150,8 +150,8 @@ func ToContainerPort(portNumber gwv1beta1.PortNumber, mapPrivilegedContainerPort
 
 func (t ResourceTranslator) translateRouteRetryFilter(routeRetryFilter *v1alpha1.RouteRetryFilter) *api.RetryFilter {
 	filter := &api.RetryFilter{
-		RetryOn:               routeRetryFilter.Spec.RetryOn,
-		RetryOnStatusCodes:    routeRetryFilter.Spec.RetryOnStatusCodes,
+		RetryOn:            routeRetryFilter.Spec.RetryOn,
+		RetryOnStatusCodes: routeRetryFilter.Spec.RetryOnStatusCodes,
 	}
 
 	if routeRetryFilter.Spec.NumRetries != nil {

--- a/control-plane/api-gateway/common/translation_test.go
+++ b/control-plane/api-gateway/common/translation_test.go
@@ -1428,10 +1428,10 @@ func TestTranslator_ToHTTPRoute(t *testing.T) {
 							Headers:    []api.HTTPHeaderFilter{},
 							URLRewrite: nil,
 							RetryFilter: &api.RetryFilter{
-								NumRetries:            pointer.Uint32(3),
+								NumRetries:            3,
 								RetryOn:               []string{"cancelled"},
 								RetryOnStatusCodes:    []uint32{500, 502},
-								RetryOnConnectFailure: pointer.Bool(false),
+								RetryOnConnectFailure: false,
 							},
 							TimeoutFilter: &api.TimeoutFilter{
 								RequestTimeout: time.Duration(10 * time.Nanosecond),
@@ -1484,10 +1484,10 @@ func TestTranslator_ToHTTPRoute(t *testing.T) {
 								Filters: api.HTTPFilters{
 									Headers: []api.HTTPHeaderFilter{},
 									RetryFilter: &api.RetryFilter{
-										NumRetries:            pointer.Uint32(3),
+										NumRetries:            3,
 										RetryOn:               []string{"cancelled"},
 										RetryOnStatusCodes:    []uint32{500, 502},
-										RetryOnConnectFailure: pointer.Bool(false),
+										RetryOnConnectFailure: false,
 									},
 								},
 								ResponseFilters: api.HTTPResponseFilters{

--- a/control-plane/api/mesh/v2beta1/proxy_configuration_types_test.go
+++ b/control-plane/api/mesh/v2beta1/proxy_configuration_types_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -109,20 +108,6 @@ func TestProxyConfiguration_MatchesConsul(t *testing.T) {
 							JsonFormat:          "jsonFormat",
 							TextFormat:          "text format.",
 						},
-						EnvoyExtensions: []*pbmesh.EnvoyExtension{
-							{
-								Name:     "extension-1",
-								Required: true,
-								Arguments: &structpb.Struct{
-									Fields: map[string]*structpb.Value{
-										"field-1": {},
-										"field-2": {},
-									},
-								},
-								ConsulVersion: "1.22.3-beta1",
-								EnvoyVersion:  "1.33.4",
-							},
-						},
 						PublicListenerJson:  "publicListenerJson{}",
 						ListenerTracingJson: "listenerTracingJson{}",
 						LocalClusterJson:    "localClusterJson{}",
@@ -195,20 +180,6 @@ func TestProxyConfiguration_MatchesConsul(t *testing.T) {
 						Path:                "/path",
 						JsonFormat:          "jsonFormat",
 						TextFormat:          "text format.",
-					},
-					EnvoyExtensions: []*pbmesh.EnvoyExtension{
-						{
-							Name:     "extension-1",
-							Required: true,
-							Arguments: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"field-1": {},
-									"field-2": {},
-								},
-							},
-							ConsulVersion: "1.22.3-beta1",
-							EnvoyVersion:  "1.33.4",
-						},
 					},
 					PublicListenerJson:  "publicListenerJson{}",
 					ListenerTracingJson: "listenerTracingJson{}",
@@ -347,20 +318,6 @@ func TestProxyConfiguration_Resource(t *testing.T) {
 							JsonFormat:          "jsonFormat",
 							TextFormat:          "text format.",
 						},
-						EnvoyExtensions: []*pbmesh.EnvoyExtension{
-							{
-								Name:     "extension-1",
-								Required: true,
-								Arguments: &structpb.Struct{
-									Fields: map[string]*structpb.Value{
-										"field-1": {},
-										"field-2": {},
-									},
-								},
-								ConsulVersion: "1.22.3-beta1",
-								EnvoyVersion:  "1.33.4",
-							},
-						},
 						PublicListenerJson:  "publicListenerJson{}",
 						ListenerTracingJson: "listenerTracingJson{}",
 						LocalClusterJson:    "localClusterJson{}",
@@ -433,20 +390,6 @@ func TestProxyConfiguration_Resource(t *testing.T) {
 						Path:                "/path",
 						JsonFormat:          "jsonFormat",
 						TextFormat:          "text format.",
-					},
-					EnvoyExtensions: []*pbmesh.EnvoyExtension{
-						{
-							Name:     "extension-1",
-							Required: true,
-							Arguments: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"field-1": {},
-									"field-2": {},
-								},
-							},
-							ConsulVersion: "1.22.3-beta1",
-							EnvoyVersion:  "1.33.4",
-						},
 					},
 					PublicListenerJson:  "publicListenerJson{}",
 					ListenerTracingJson: "listenerTracingJson{}",

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -1,13 +1,5 @@
 module github.com/hashicorp/consul-k8s/control-plane
 
-// TODO: remove these when the SDK is released for Consul 1.17 and coinciding patch releases
-replace (
-	// This replace directive is needed because `api` requires 0.4.1 of proto-public but we need an unreleased version
-	github.com/hashicorp/consul/proto-public v0.4.1 => github.com/hashicorp/consul/proto-public v0.1.2-0.20231013204122-3d1a606c3b58
-	// This replace directive is needed because `api` requires 0.14.1 of `sdk` but we need an unreleased version
-	github.com/hashicorp/consul/sdk v0.14.1 => github.com/hashicorp/consul/sdk v0.4.1-0.20231011203909-c26d5cf62cb9
-)
-
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/containernetworking/cni v1.1.1
@@ -18,9 +10,9 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20230825213844-4ea04860c5ed
 	github.com/hashicorp/consul-server-connection-manager v0.1.6
-	github.com/hashicorp/consul/api v1.10.1-0.20231011171434-ca1a755f0c5a
-	github.com/hashicorp/consul/proto-public v0.4.1
-	github.com/hashicorp/consul/sdk v0.14.1
+	github.com/hashicorp/consul/api v1.26.1
+	github.com/hashicorp/consul/proto-public v0.5.1
+	github.com/hashicorp/consul/sdk v0.15.0
 	github.com/hashicorp/go-bexpr v0.1.11
 	github.com/hashicorp/go-discover v0.0.0-20230519164032-214571b6a530
 	github.com/hashicorp/go-hclog v1.5.0

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -263,14 +263,11 @@ github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20230825213844-4ea04860
 github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20230825213844-4ea04860c5ed/go.mod h1:mwODEC+VTCA1LY/m2RUG4S2c5lNRvBcsvqaMJtMLLos=
 github.com/hashicorp/consul-server-connection-manager v0.1.6 h1:ktj8Fi+dRXn9hhM+FXsfEJayhzzgTqfH08Ne5M6Fmug=
 github.com/hashicorp/consul-server-connection-manager v0.1.6/go.mod h1:HngMIv57MT+pqCVeRQMa1eTB5dqnyMm8uxjyv+Hn8cs=
-github.com/hashicorp/consul/api v1.10.1-0.20231011171434-ca1a755f0c5a h1:+cjavDME42W6nzw+xyCQ+eczqTFA+Qk4SLl7BHZ2dxI=
-github.com/hashicorp/consul/api v1.10.1-0.20231011171434-ca1a755f0c5a/go.mod h1:+pNEP6hQgkrBLjQlYLI13/tyyb1GK3MGVw1PC/IHk9M=
 github.com/hashicorp/consul/api v1.26.1 h1:5oSXOO5fboPZeW5SN+TdGFP/BILDgBm19OrPZ/pICIM=
 github.com/hashicorp/consul/api v1.26.1/go.mod h1:B4sQTeaSO16NtynqrAdwOlahJ7IUDZM9cj2420xYL8A=
 github.com/hashicorp/consul/proto-public v0.5.1 h1:g4xHZ7rJ56iktDi1uThKp+IbvHrP6nveZeGVt2Qw5x0=
 github.com/hashicorp/consul/proto-public v0.5.1/go.mod h1:SayEhfXS3DQDnW/vKSZXvkwDObg7XK60KTfrJcp0wrg=
-github.com/hashicorp/consul/sdk v0.14.1 h1:ZiwE2bKb+zro68sWzZ1SgHF3kRMBZ94TwOCFRF4ylPs=
-github.com/hashicorp/consul/sdk v0.14.1/go.mod h1:vFt03juSzocLRFo59NkeQHHmQa6+g7oU0pfzdI1mUhg=
+github.com/hashicorp/consul/sdk v0.15.0 h1:2qK9nDrr4tiJKRoxPGhm6B7xJjLVIQqkjiab2M4aKjU=
 github.com/hashicorp/consul/sdk v0.15.0/go.mod h1:r/OmRRPbHOe0yxNahLw7G9x5WG17E1BIECMtCjcPSNo=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -265,10 +265,13 @@ github.com/hashicorp/consul-server-connection-manager v0.1.6 h1:ktj8Fi+dRXn9hhM+
 github.com/hashicorp/consul-server-connection-manager v0.1.6/go.mod h1:HngMIv57MT+pqCVeRQMa1eTB5dqnyMm8uxjyv+Hn8cs=
 github.com/hashicorp/consul/api v1.10.1-0.20231011171434-ca1a755f0c5a h1:+cjavDME42W6nzw+xyCQ+eczqTFA+Qk4SLl7BHZ2dxI=
 github.com/hashicorp/consul/api v1.10.1-0.20231011171434-ca1a755f0c5a/go.mod h1:+pNEP6hQgkrBLjQlYLI13/tyyb1GK3MGVw1PC/IHk9M=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20231013204122-3d1a606c3b58 h1:3VHvqLs2zTa9YWMsE4A9IricAZB6rAcXVe8e+pb5slw=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20231013204122-3d1a606c3b58/go.mod h1:KAOxsaELPpA7JX10kMeygAskAqsQnu3SPgeruMhYZMU=
-github.com/hashicorp/consul/sdk v0.4.1-0.20231011203909-c26d5cf62cb9 h1:j0Rvt1KiKIKlMc2UnA0ilHfIGo66SzrBztGZaCou3+w=
-github.com/hashicorp/consul/sdk v0.4.1-0.20231011203909-c26d5cf62cb9/go.mod h1:vFt03juSzocLRFo59NkeQHHmQa6+g7oU0pfzdI1mUhg=
+github.com/hashicorp/consul/api v1.26.1 h1:5oSXOO5fboPZeW5SN+TdGFP/BILDgBm19OrPZ/pICIM=
+github.com/hashicorp/consul/api v1.26.1/go.mod h1:B4sQTeaSO16NtynqrAdwOlahJ7IUDZM9cj2420xYL8A=
+github.com/hashicorp/consul/proto-public v0.5.1 h1:g4xHZ7rJ56iktDi1uThKp+IbvHrP6nveZeGVt2Qw5x0=
+github.com/hashicorp/consul/proto-public v0.5.1/go.mod h1:SayEhfXS3DQDnW/vKSZXvkwDObg7XK60KTfrJcp0wrg=
+github.com/hashicorp/consul/sdk v0.14.1 h1:ZiwE2bKb+zro68sWzZ1SgHF3kRMBZ94TwOCFRF4ylPs=
+github.com/hashicorp/consul/sdk v0.14.1/go.mod h1:vFt03juSzocLRFo59NkeQHHmQa6+g7oU0pfzdI1mUhg=
+github.com/hashicorp/consul/sdk v0.15.0/go.mod h1:r/OmRRPbHOe0yxNahLw7G9x5WG17E1BIECMtCjcPSNo=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
**Changes proposed in this PR:**
Some dependencies were previously pinned to utilize unreleased features of the Consul SDK.
This replaces those with the tagged releases containing those features.

In addition, there were some breaking changes in the API submodule that were never released but didn't yet have the consuming end updated in control-plane. I've addressed those as well.

**How I've tested this PR:**
- Robot tests pass
- Visual inspection

**How I expect reviewers to test this PR:**
See above

**Checklist:**
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 