### PR TITLE
Fix consul-telemetry-collector deployment templates

### DIFF
--- a/charts/consul/templates/telemetry-collector-deployment.yaml
+++ b/charts/consul/templates/telemetry-collector-deployment.yaml
@@ -287,13 +287,12 @@ spec:
           - -login-auth-method={{ template "consul.fullname" . }}-k8s-auth-method
           {{- if .Values.global.enableConsulNamespaces }}
           {{- if .Values.syncCatalog.consulNamespaces.mirroringK8S }}
-          - -login-namespace="default"
+          - -login-namespace=default
           {{- else }}
           - -login-namespace={{ .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }}
           {{- end }}
           {{- end }}
           {{- if .Values.global.adminPartitions.enabled }}
-          - foo
           - -login-partition={{ .Values.global.adminPartitions.name }}
           {{- end }}
           {{- end }}

--- a/charts/consul/templates/telemetry-collector-v2-deployment.yaml
+++ b/charts/consul/templates/telemetry-collector-v2-deployment.yaml
@@ -275,13 +275,12 @@ spec:
           - -login-auth-method={{ template "consul.fullname" . }}-k8s-auth-method
           {{- if .Values.global.enableConsulNamespaces }}
           {{- if .Values.syncCatalog.consulNamespaces.mirroringK8S }}
-          - -login-namespace="default"
+          - -login-namespace=default
           {{- else }}
           - -login-namespace={{ .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }}
           {{- end }}
           {{- end }}
           {{- if .Values.global.adminPartitions.enabled }}
-          - foo
           - -login-partition={{ .Values.global.adminPartitions.name }}
           {{- end }}
           {{- end }}


### PR DESCRIPTION
Changes proposed in this PR:
- remove `foo` arg
- remove the quotes around `"default"` auth login namespace that break auth 

How I've tested this PR:

I reproduced the behavior described by @david-yu 

I did a Helm install using a template that includes `global.acls.manageSystemACLs=true`: https://github.com/jjti/consul-experiments/blob/main/telemetry-collector/helm/consul.yaml

I `kubectl apply` a manually created deployment (based on a fixed version of helm's output): https://github.com/jjti/consul-experiments/blame/e2da8fe2d768472b549780f8eea2cc10e7da04e4/telemetry-collector/resources/consul-telemetry-collector.yaml#L231

I saw the telemetry collector start and push metrics:

```
# josh @ josh-XWGWHJ0JV2 in ~/GitHub/jjti/consul-exp/telemetry-collector on git:main x [21:21:02]
$ k get pods
NAME                                           READY   STATUS    RESTARTS   AGE
consul-connect-injector-74d6fb76b8-87pck       1/1     Running   0          15m
consul-server-0                                1/1     Running   0          15m
consul-telemetry-collector-9d858d459-5c6gq     2/2     Running   0          7m47s
consul-terminating-gateway-7f5877fdb8-rgtcj    1/1     Running   0          15m
consul-webhook-cert-manager-7c5bc5fb59-ln2m4   1/1     Running   0          15m
prometheus-server-695744d587-k9k6l             2/2     Running   0          15m
```

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


