### PR TITLE
Add replace directive in Go mod for Control Plane so that we pull in the latest Consul submodules

### DIFF
--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -1,6 +1,7 @@
 module github.com/hashicorp/consul-k8s/control-plane
 
 // TODO: Remove this when the next version of the submodule is released.
+// We need to use a replace directive instead of directly pinning because `api` requires version `0.5.1` and will clobber the pin, but not the replace directive.
 replace github.com/hashicorp/consul/proto-public => github.com/hashicorp/consul/proto-public v0.1.2-0.20231109213314-40c57f10a0fb
 
 require (

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -1,5 +1,8 @@
 module github.com/hashicorp/consul-k8s/control-plane
 
+// TODO: Remove this when the next version of the submodule is released.
+replace github.com/hashicorp/consul/proto-public => github.com/hashicorp/consul/proto-public v0.1.2-0.20231109213314-40c57f10a0fb
+
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/containernetworking/cni v1.1.1

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -265,8 +265,8 @@ github.com/hashicorp/consul-server-connection-manager v0.1.6 h1:ktj8Fi+dRXn9hhM+
 github.com/hashicorp/consul-server-connection-manager v0.1.6/go.mod h1:HngMIv57MT+pqCVeRQMa1eTB5dqnyMm8uxjyv+Hn8cs=
 github.com/hashicorp/consul/api v1.26.1 h1:5oSXOO5fboPZeW5SN+TdGFP/BILDgBm19OrPZ/pICIM=
 github.com/hashicorp/consul/api v1.26.1/go.mod h1:B4sQTeaSO16NtynqrAdwOlahJ7IUDZM9cj2420xYL8A=
-github.com/hashicorp/consul/proto-public v0.5.1 h1:g4xHZ7rJ56iktDi1uThKp+IbvHrP6nveZeGVt2Qw5x0=
-github.com/hashicorp/consul/proto-public v0.5.1/go.mod h1:SayEhfXS3DQDnW/vKSZXvkwDObg7XK60KTfrJcp0wrg=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20231109213314-40c57f10a0fb h1:Vy9tVDskUrWMXCyMJHpChxRjzJVjWSsSZ457X1dZAWo=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20231109213314-40c57f10a0fb/go.mod h1:SayEhfXS3DQDnW/vKSZXvkwDObg7XK60KTfrJcp0wrg=
 github.com/hashicorp/consul/sdk v0.15.0 h1:2qK9nDrr4tiJKRoxPGhm6B7xJjLVIQqkjiab2M4aKjU=
 github.com/hashicorp/consul/sdk v0.15.0/go.mod h1:r/OmRRPbHOe0yxNahLw7G9x5WG17E1BIECMtCjcPSNo=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
This is a change that we should only keep until we publish the next version of the `proto-public` submodule. 

Changes proposed in this PR:
- Reference the latest `main` commit for the `proto-public` submodule.

How I've tested this PR:
I am now able to reference code that is in the latest version of the submodule.
