### PR TITLE
NET-6406 Adds GatewayClassConfig and MeshGateway resources to the gateway-reso…

### DIFF
--- a/charts/consul/templates/gateway-resources-configmap.yaml
+++ b/charts/consul/templates/gateway-resources-configmap.yaml
@@ -19,13 +19,17 @@ data:
   {{- if (mustHas "resource-apis" .Values.global.experiments) }}
   config.yaml: |
     gatewayClassConfigs:
-      - apiVersion: consul.hashicorp.com/v2beta1
+      - apiVersion: mesh.consul.hashicorp.com/v2beta1
         metadata:
           name: consul-mesh-gateway
           namespace: {{ .Release.Namespace }}
-        deployment:
-          resources:
-            {{ .Values.meshGateway.resources }}
+        kind: gatewayClassConfig
+        spec:
+          deployment:
+            resources:
+              {{ .Values.meshGateway.resources }}
+          nodeSelector: {{ .Values.meshGateway.nodeSelector }}
+          serviceType: {{ .Values.meshGateway.service.type }}
     meshGateways:
       - name: mesh-gateway
         spec:

--- a/charts/consul/templates/gateway-resources-configmap.yaml
+++ b/charts/consul/templates/gateway-resources-configmap.yaml
@@ -16,4 +16,19 @@ data:
   resources.json: |
     {{ toJson .Values.connectInject.apiGateway.managedGatewayClass.resources }}
   {{- end }}
+  {{- if (mustHas "resource-apis" .Values.global.experiments) }}
+  config.yaml: |
+    gatewayClassConfigs:
+      - apiVersion: consul.hashicorp.com/v2beta1
+        metadata:
+          name: consul-mesh-gateway
+          namespace: {{ .Release.Namespace }}
+        deployment:
+          resources:
+            {{ .Values.meshGateway.resources }}
+    meshGateways:
+      - name: mesh-gateway
+        spec:
+          gatewayClassName: consul-mesh-gateway
+    {{- end }}
 {{- end }}

--- a/charts/consul/templates/gateway-resources-job.yaml
+++ b/charts/consul/templates/gateway-resources-job.yaml
@@ -51,7 +51,7 @@ spec:
             - -heritage={{ .Release.Service }}
             - -release-name={{ .Release.Name }}
             - -component=api-gateway
-            {{- if .Values.apiGateway.enabled }} # Overide values from the old stanza. To be removed in 1.17 (t-eckert 2023-05-19)
+            {{- if .Values.apiGateway.enabled }} # Override values from the old stanza. To be removed after ~1.18 (t-eckert 2023-05-19) NET-6263
             {{- if .Values.apiGateway.managedGatewayClass.deployment }}
             {{- if .Values.apiGateway.managedGatewayClass.deployment.defaultInstances }}
             - -deployment-default-instances={{ .Values.apiGateway.managedGatewayClass.deployment.defaultInstances }}

--- a/charts/consul/test/unit/gateway-resources-configmap.bats
+++ b/charts/consul/test/unit/gateway-resources-configmap.bats
@@ -44,3 +44,28 @@ load _helpers
     local actual=$(echo $resources | jq -r '.limits.cpu')
     [ $actual = '220m' ]
 }
+
+@test "gateway-resources/ConfigMap: does not contain config.yaml resources without .global.experiments equal to resource-apis" {
+    cd `chart_dir`
+    local resources=$(helm template \
+        -s templates/gateway-resources-configmap.yaml \
+        --set 'connectInject.enabled=true' \
+        --set 'ui.enabled=false' \
+        . | tee /dev/stderr |
+        yq '.data["config.yaml"]' | tee /dev/stderr)
+    [ $resources = null ]
+
+}
+
+@test "gateway-resources/ConfigMap: contains config.yaml resources with .global.experiments equal to resource-apis" {
+    cd `chart_dir`
+    local resources=$(helm template \
+        -s templates/gateway-resources-configmap.yaml \
+        --set 'connectInject.enabled=true' \
+        --set 'global.experiments[0]=resource-apis' \
+        --set 'ui.enabled=false' \
+        . | tee /dev/stderr |
+        yq '.data["config.yaml"]' | tee /dev/stderr)
+
+    [ "$resources" != null ]
+}


### PR DESCRIPTION
…urces-configmap.yaml in the Helm chart

Changes proposed in this PR:
- This adds the MeshGateway and GatewayClassConfigs to the gateway-resources-configmap.yaml. 

How I've tested this PR:
Added bats tests, also manual testing.

How I expect reviewers to test this PR:
```
helm template consul . -s templates/gateway-resources-configmap.yaml --set 'connectInject.enabled=true' --set 'global.experiments[0]=resource-apis' --set 'ui.enabled=false'
``` 
and check the output

Checklist:
- [x] Tests added


