### PR TITLE
Add validation to account for type change

### DIFF
--- a/control-plane/api/v1alpha1/routetimeoutfilter_types.go
+++ b/control-plane/api/v1alpha1/routetimeoutfilter_types.go
@@ -40,9 +40,13 @@ type RouteTimeoutFilterList struct {
 // RouteTimeoutFilterSpec defines the desired state of RouteTimeoutFilter.
 type RouteTimeoutFilterSpec struct {
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	RequestTimeout metav1.Duration `json:"requestTimeout"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
 	IdleTimeout metav1.Duration `json:"idleTimeout"`
 }
 

--- a/control-plane/config/crd/bases/consul.hashicorp.com_routetimeoutfilters.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_routetimeoutfilters.yaml
@@ -51,8 +51,10 @@ spec:
             description: RouteTimeoutFilterSpec defines the desired state of RouteTimeoutFilter.
             properties:
               idleTimeout:
+                format: duration
                 type: string
               requestTimeout:
+                format: duration
                 type: string
             type: object
           status:


### PR DESCRIPTION
Changes proposed in this PR:
- At some point prior to release the types on filters changed from time.Duration to metav1.Duration
- This is a perfectly valid change, but it modified the behavior of how the CRD was being parsed from as an integer to a string. This feature is not broken, but is currently fragile based on user input. This adds additional safeguards to make sure the user won't accidentally pass anything that will cause the controller to break. 
- https://github.com/hashicorp/consul/pull/19601 This PR updates the docs to match the behavior change as well. 

How I've tested this PR:
- Built locally and applied new filters ensuring that the validation failed

How I expect reviewers to test this PR:
- CI passes. 

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


