### PR TITLE
fix(control-plane): sidecar CPU limit incorrectly validated against CPU request

### DIFF
--- a/.changelog/3209.txt
+++ b/.changelog/3209.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+control-plane: Fixes a bug with the control-plane CLI validation where the consul-dataplane sidecar CPU request is
+compared against the memory limit instead of the CPU limit.
+```

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -461,7 +461,7 @@ func (c *Command) parseAndValidateSidecarProxyFlags() error {
 			return fmt.Errorf("-default-sidecar-proxy-cpu-limit is invalid: %w", err)
 		}
 	}
-	if c.sidecarProxyCPULimit.Value() != 0 && c.sidecarProxyCPURequest.Cmp(c.sidecarProxyMemoryLimit) > 0 {
+	if c.sidecarProxyCPULimit.Value() != 0 && c.sidecarProxyCPURequest.Cmp(c.sidecarProxyCPULimit) > 0 {
 		return fmt.Errorf("request must be <= limit: -default-sidecar-proxy-cpu-request value of %q is greater than the -default-sidecar-proxy-cpu-limit value of %q",
 			c.flagDefaultSidecarProxyCPURequest, c.flagDefaultSidecarProxyCPULimit)
 	}


### PR DESCRIPTION
Fixes #3205 

Changes proposed in this PR:
- Fixes a bug with the control-plane CLI validation where the consul-dataplane sidecar CPU request is compared against the memory limit instead of the CPU limit.

How I've tested this PR:
* Unit tests + 👁️ 

The test only validated failure cases and I didn't think it was the effort to create a new suite that test successful cross-validation of memory and CPU allocations.

How I expect reviewers to test this PR: 👀 


Checklist:
- [ ] ~Tests added~
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


