### PR TITLE
Add `telemetryCollector.cloud.resourceId` field that works even when `global.cloud.enabled` is false

### DIFF
--- a/.changelog/3219.txt
+++ b/.changelog/3219.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul-telemetry-collector: add telemetryCollector.cloud.resourceId that works even when not global.cloud.enabled
+```

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -424,10 +424,10 @@ Usage: {{ template "consul.validateTelemetryCollectorCloud" . }}
 
 */}}
 {{- define "consul.validateTelemetryCollectorCloud" -}}
-{{- if (and .Values.telemetryCollector.cloud.clientId.secretName (or (not .Values.global.cloud.resourceId.secretName) (not .Values.telemetryCollector.cloud.clientSecret.secretName))) }}
+{{- if (and .Values.telemetryCollector.cloud.clientId.secretName (and (not .Values.global.cloud.clientSecret.secretName) (not .Values.telemetryCollector.cloud.clientSecret.secretName))) }}
 {{fail "When telemetryCollector.cloud.clientId.secretName is set, telemetryCollector.cloud.clientSecret.secretName must also be set."}}
 {{- end }}
-{{- if (and .Values.telemetryCollector.cloud.clientSecret.secretName (or (not .Values.global.cloud.resourceId.secretName) (not .Values.telemetryCollector.cloud.clientSecret.secretName))) }}
+{{- if (and .Values.telemetryCollector.cloud.clientSecret.secretName (and (not .Values.global.cloud.clientId.secretName) (not .Values.telemetryCollector.cloud.clientId.secretName))) }}
 {{fail "When telemetryCollector.cloud.clientSecret.secretName is set, telemetryCollector.cloud.clientId.secretName must also be set."}}
 {{- end }}
 {{- end }}
@@ -452,7 +452,7 @@ Usage: {{ template "consul.validateTelemetryCollectorCloud" . }}
 {{/*
 Fails if telemetryCollector.cloud.resourceId is set but differs from global.cloud.resourceId. This should never happen. Either one or both are set, but they should never differ.
 If they differ, that implies we're configuring servers for one HCP Consul cluster but pushing envoy metrics for a different HCP Consul cluster. A user could set the same value
-in two secrets (it's questionable whether resourceId should be a secret at all) but we will not know at this point, so we just check secret name+key.
+in two secrets (it's questionable whether resourceId should be a secret at all) but we won't know at this point, so we just check secret name+key.
 
 Usage: {{ template "consul.validateTelemetryCollectorResourceId" . }}
 

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -415,7 +415,7 @@ Usage: {{ template "consul.validateCloudSecretKeys" . }}
 
 
 {{/*
-Fails if temeletryCollector.clientId or telemetryCollector.clientSecret exist and one of other secrets is nil or empty.
+Fails if telemetryCollector.clientId or telemetryCollector.clientSecret exist and one of other secrets is nil or empty.
 - telemetryCollector.cloud.clientId.secretName
 - telemetryCollector.cloud.clientSecret.secretName
 - global.cloud.resourceId.secretName
@@ -424,11 +424,11 @@ Usage: {{ template "consul.validateTelemetryCollectorCloud" . }}
 
 */}}
 {{- define "consul.validateTelemetryCollectorCloud" -}}
-{{- if (and .Values.telemetryCollector.cloud.clientId.secretName (or (not .Values.global.cloud.resourceId.secretName) (not .Values.telemetryCollector.resourceId.secretName) (not .Values.telemetryCollector.cloud.clientSecret.secretName))) }}
-{{fail "When telemetryCollector.cloud.clientId.secretName is set, global.telemetryCollector.resourceId.secretName, telemetryCollector.cloud.clientSecret.secretName must also be set."}}
+{{- if (and .Values.telemetryCollector.cloud.clientId.secretName (or (not .Values.global.cloud.resourceId.secretName) (not .Values.telemetryCollector.cloud.clientSecret.secretName))) }}
+{{fail "When telemetryCollector.cloud.clientId.secretName is set, telemetryCollector.cloud.clientSecret.secretName must also be set."}}
 {{- end }}
-{{- if (and .Values.telemetryCollector.cloud.clientSecret.secretName (or (not .Values.global.cloud.resourceId.secretName) (not .Values.telemetryCollector.resourceId.secretName) (not .Values.telemetryCollector.cloud.clientSecret.secretName))) }}
-{{fail "When telemetryCollector.cloud.clientSecret.secretName is set, global.telemetryCollector.resourceId.secretName,telemetryCollector.cloud.clientId.secretName must also be set."}}
+{{- if (and .Values.telemetryCollector.cloud.clientSecret.secretName (or (not .Values.global.cloud.resourceId.secretName) (not .Values.telemetryCollector.cloud.clientSecret.secretName))) }}
+{{fail "When telemetryCollector.cloud.clientSecret.secretName is set, telemetryCollector.cloud.clientId.secretName must also be set."}}
 {{- end }}
 {{- end }}
 
@@ -441,13 +441,32 @@ Usage: {{ template "consul.validateTelemetryCollectorCloud" . }}
 {{- if or (and .Values.telemetryCollector.cloud.clientSecret.secretName (not .Values.telemetryCollector.cloud.clientSecret.secretKey)) (and .Values.telemetryCollector.cloud.clientSecret.secretKey (not .Values.telemetryCollector.cloud.clientSecret.secretName)) }}
 {{fail "When either telemetryCollector.cloud.clientSecret.secretName or telemetryCollector.cloud.clientSecret.secretKey is defined, both must be set."}}
 {{- end }}
-{{- if or (and .Values.telemetryCollector.cloud.clientSecret.secretName .Values.telemetryCollector.cloud.clientSecret.secretKey .Values.telemetryCollector.cloud.clientId.secretName .Values.telemetryCollector.cloud.clientId.secretKey (not .Values.global.cloud.resourceId.secretName)) }}
-{{fail "When telemetryCollector has clientId and clientSecret global.cloud.resourceId.secretName must be set"}}
+{{- if or (and .Values.telemetryCollector.cloud.clientSecret.secretName .Values.telemetryCollector.cloud.clientSecret.secretKey .Values.telemetryCollector.cloud.clientId.secretName .Values.telemetryCollector.cloud.clientId.secretKey (not (or .Values.telemetryCollector.cloud.resourceId.secretName .Values.global.cloud.resourceId.secretName))) }}
+{{fail "When telemetryCollector has clientId and clientSecret, telemetryCollector.cloud.resourceId.secretName or global.cloud.resourceId.secretName must be set"}}
 {{- end }}
-{{- if or (and .Values.telemetryCollector.cloud.clientSecret.secretName .Values.telemetryCollector.cloud.clientSecret.secretKey .Values.telemetryCollector.cloud.clientId.secretName .Values.telemetryCollector.cloud.clientId.secretKey (not .Values.global.cloud.resourceId.secretKey)) }}
-{{fail "When telemetryCollector has clientId and clientSecret .global.cloud.resourceId.secretKey must be set"}}
+{{- if or (and .Values.telemetryCollector.cloud.clientSecret.secretName .Values.telemetryCollector.cloud.clientSecret.secretKey .Values.telemetryCollector.cloud.clientId.secretName .Values.telemetryCollector.cloud.clientId.secretKey (not (or .Values.telemetryCollector.cloud.resourceId.secretKey .Values.global.cloud.resourceId.secretKey))) }}
+{{fail "When telemetryCollector has clientId and clientSecret, telemetryCollector.cloud.resourceId.secretKey or global.cloud.resourceId.secretKey must be set"}}
 {{- end }}
 {{- end -}}
+
+{{/*
+Fails if telemetryCollector.cloud.resourceId is set but differs from global.cloud.resourceId. This should never happen. Either one or both are set, but they should never differ.
+If they differ, that implies we're configuring servers for one HCP Consul cluster but pushing envoy metrics for a different HCP Consul cluster. A user could set the same value
+in two secrets (it's questionable whether resourceId should be a secret at all) but we will not know at this point, so we just check secret name+key.
+
+Usage: {{ template "consul.validateTelemetryCollectorResourceId" . }}
+
+*/}}
+{{- define "consul.validateTelemetryCollectorResourceId" -}}
+{{- if and (and .Values.telemetryCollector.cloud.resourceId.secretName .Values.global.cloud.resourceId.secretName) (not (eq .Values.telemetryCollector.cloud.resourceId.secretName .Values.global.cloud.resourceId.secretName)) }}
+{{fail "When both global.cloud.resourceId.secretName and telemetryCollector.cloud.resourceId.secretName are set, they should be the same."}}
+{{- end }}
+{{- if and (and .Values.telemetryCollector.cloud.resourceId.secretKey .Values.global.cloud.resourceId.secretKey) (not (eq .Values.telemetryCollector.cloud.resourceId.secretKey .Values.global.cloud.resourceId.secretKey)) }}
+{{fail "When both global.cloud.resourceId.secretKey and telemetryCollector.cloud.resourceId.secretKey are set, they should be the same."}}
+{{- end }}
+{{- end }}
+
+{{/**/}}
 
 {{/*
 Fails if global.experiments.resourceAPIs is set along with any of these unsupported features.

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -424,11 +424,11 @@ Usage: {{ template "consul.validateTelemetryCollectorCloud" . }}
 
 */}}
 {{- define "consul.validateTelemetryCollectorCloud" -}}
-{{- if (and .Values.telemetryCollector.cloud.clientId.secretName (or (not .Values.global.cloud.resourceId.secretName) (not .Values.telemetryCollector.cloud.clientSecret.secretName))) }}
-{{fail "When telemetryCollector.cloud.clientId.secretName is set, global.cloud.resourceId.secretName, telemetryCollector.cloud.clientSecret.secretName must also be set."}}
+{{- if (and .Values.telemetryCollector.cloud.clientId.secretName (or (not .Values.global.cloud.resourceId.secretName) (not .Values.telemetryCollector.resourceId.secretName) (not .Values.telemetryCollector.cloud.clientSecret.secretName))) }}
+{{fail "When telemetryCollector.cloud.clientId.secretName is set, global.telemetryCollector.resourceId.secretName, telemetryCollector.cloud.clientSecret.secretName must also be set."}}
 {{- end }}
-{{- if (and .Values.telemetryCollector.cloud.clientSecret.secretName (or (not .Values.global.cloud.resourceId.secretName) (not .Values.telemetryCollector.cloud.clientSecret.secretName))) }}
-{{fail "When telemetryCollector.cloud.clientSecret.secretName is set, global.cloud.resourceId.secretName,telemetryCollector.cloud.clientId.secretName must also be set."}}
+{{- if (and .Values.telemetryCollector.cloud.clientSecret.secretName (or (not .Values.global.cloud.resourceId.secretName) (not .Values.telemetryCollector.resourceId.secretName) (not .Values.telemetryCollector.cloud.clientSecret.secretName))) }}
+{{fail "When telemetryCollector.cloud.clientSecret.secretName is set, global.telemetryCollector.resourceId.secretName,telemetryCollector.cloud.clientId.secretName must also be set."}}
 {{- end }}
 {{- end }}
 

--- a/charts/consul/templates/telemetry-collector-deployment.yaml
+++ b/charts/consul/templates/telemetry-collector-deployment.yaml
@@ -166,13 +166,32 @@ spec:
             # These are mounted as secrets so that the telemetry-collector can use them when cloud is enabled.
             # - the hcp-go-sdk in consul agent will already look for HCP_CLIENT_ID, HCP_CLIENT_SECRET, HCP_AUTH_URL,
             #   HCP_SCADA_ADDRESS, and HCP_API_HOST.  so nothing more needs to be done.
-            # - HCP_RESOURCE_ID is created for use in the global cloud section but we will share it here
+            # - HCP_RESOURCE_ID is created either in the global cloud section or in telemetryCollector.cloud
+            {{- if .Values.telemetryCollector.cloud.resourceId.secretName }}
+            - name: HCP_RESOURCE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.telemetryCollector.cloud.resourceId.secretName }}
+                  key: {{ .Values.telemetryCollector.cloud.resourceId.secretKey }}
+            {{- else if .Values.global.cloud.resourceId.secretName }}
+            - name: HCP_RESOURCE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.cloud.resourceId.secretName }}
+                  key: {{ .Values.global.cloud.resourceId.secretKey }}
+            {{- end }}
             {{- if .Values.telemetryCollector.cloud.clientId.secretName }}
             - name: HCP_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.telemetryCollector.cloud.clientId.secretName }}
                   key: {{ .Values.telemetryCollector.cloud.clientId.secretKey }}
+            {{- else if .Values.global.cloud.clientId.secretName }}
+            - name: HCP_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.cloud.clientId.secretName }}
+                  key: {{ .Values.global.cloud.clientId.secretKey }}
             {{- end }}
             {{- if .Values.telemetryCollector.cloud.clientSecret.secretName }}
             - name: HCP_CLIENT_SECRET
@@ -180,14 +199,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.telemetryCollector.cloud.clientSecret.secretName }}
                   key: {{ .Values.telemetryCollector.cloud.clientSecret.secretKey }}
-            {{- end}}
-            {{- if .Values.global.cloud.resourceId.secretName }}
-            - name: HCP_RESOURCE_ID
+            {{- else if .Values.global.cloud.clientSecret.secretName }}
+            - name: HCP_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.cloud.resourceId.secretName }}
-                  key: {{ .Values.global.cloud.resourceId.secretKey }}
-            {{- end }}
+                  name: {{ .Values.global.cloud.clientSecret.secretName }}
+                  key: {{ .Values.global.cloud.clientSecret.secretKey }}
+            {{- end}}
             {{- if .Values.global.cloud.authUrl.secretName }}
             - name: HCP_AUTH_URL
               valueFrom:
@@ -228,7 +246,7 @@ spec:
 
           consul-telemetry-collector agent \
           {{- if .Values.telemetryCollector.customExporterConfig }}
-          -config-file-path /consul/config/config.json \
+            -config-file-path /consul/config/config.json \
           {{ end }}
         volumeMounts:
           {{- if .Values.telemetryCollector.customExporterConfig }}

--- a/charts/consul/templates/telemetry-collector-deployment.yaml
+++ b/charts/consul/templates/telemetry-collector-deployment.yaml
@@ -5,6 +5,7 @@
 {{ template "consul.validateCloudSecretKeys" . }}
 {{ template "consul.validateTelemetryCollectorCloud" . }}
 {{ template "consul.validateTelemetryCollectorCloudSecretKeys" . }}
+{{ template "consul.validateTelemetryCollectorResourceId" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/consul/templates/telemetry-collector-v2-deployment.yaml
+++ b/charts/consul/templates/telemetry-collector-v2-deployment.yaml
@@ -155,7 +155,7 @@ spec:
             # These are mounted as secrets so that the telemetry-collector can use them when cloud is enabled.
             # - the hcp-go-sdk in consul agent will already look for HCP_CLIENT_ID, HCP_CLIENT_SECRET, HCP_AUTH_URL,
             #   HCP_SCADA_ADDRESS, and HCP_API_HOST.  so nothing more needs to be done.
-            # - HCP_RESOURCE_ID is created for use in the global cloud section but we will share it here
+            # - HCP_RESOURCE_ID is created either in the global cloud section or in telemetryCollector.cloud
             {{- if .Values.telemetryCollector.cloud.clientId.secretName }}
             - name: HCP_CLIENT_ID
               valueFrom:
@@ -176,6 +176,12 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.cloud.resourceId.secretName }}
                   key: {{ .Values.global.cloud.resourceId.secretKey }}
+            {{- else if .Values.telemetryCollector.cloud.resourceId.secretName }}
+            - name: HCP_RESOURCE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.telemetryCollector.cloud.resourceId.secretName }}
+                  key: {{ .Values.telemetryCollector.cloud.resourceId.secretKey }}
             {{- end }}
             {{- if .Values.global.cloud.authUrl.secretName }}
             - name: HCP_AUTH_URL

--- a/charts/consul/templates/telemetry-collector-v2-deployment.yaml
+++ b/charts/consul/templates/telemetry-collector-v2-deployment.yaml
@@ -156,12 +156,31 @@ spec:
             # - the hcp-go-sdk in consul agent will already look for HCP_CLIENT_ID, HCP_CLIENT_SECRET, HCP_AUTH_URL,
             #   HCP_SCADA_ADDRESS, and HCP_API_HOST.  so nothing more needs to be done.
             # - HCP_RESOURCE_ID is created either in the global cloud section or in telemetryCollector.cloud
+            {{- if .Values.telemetryCollector.cloud.resourceId.secretName }}
+            - name: HCP_RESOURCE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.telemetryCollector.cloud.resourceId.secretName }}
+                  key: {{ .Values.telemetryCollector.cloud.resourceId.secretKey }}
+            {{- else if .Values.global.cloud.resourceId.secretName }}
+            - name: HCP_RESOURCE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.cloud.resourceId.secretName }}
+                  key: {{ .Values.global.cloud.resourceId.secretKey }}
+            {{- end }}
             {{- if .Values.telemetryCollector.cloud.clientId.secretName }}
             - name: HCP_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.telemetryCollector.cloud.clientId.secretName }}
                   key: {{ .Values.telemetryCollector.cloud.clientId.secretKey }}
+            {{- else if .Values.global.cloud.clientId.secretName }}
+            - name: HCP_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.cloud.clientId.secretName }}
+                  key: {{ .Values.global.cloud.clientId.secretKey }}
             {{- end }}
             {{- if .Values.telemetryCollector.cloud.clientSecret.secretName }}
             - name: HCP_CLIENT_SECRET
@@ -169,20 +188,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.telemetryCollector.cloud.clientSecret.secretName }}
                   key: {{ .Values.telemetryCollector.cloud.clientSecret.secretKey }}
+            {{- else if .Values.global.cloud.clientSecret.secretName }}
+            - name: HCP_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.cloud.clientSecret.secretName }}
+                  key: {{ .Values.global.cloud.clientSecret.secretKey }}
             {{- end}}
-            {{- if .Values.global.cloud.resourceId.secretName }}
-            - name: HCP_RESOURCE_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.cloud.resourceId.secretName }}
-                  key: {{ .Values.global.cloud.resourceId.secretKey }}
-            {{- else if .Values.telemetryCollector.cloud.resourceId.secretName }}
-            - name: HCP_RESOURCE_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.telemetryCollector.cloud.resourceId.secretName }}
-                  key: {{ .Values.telemetryCollector.cloud.resourceId.secretKey }}
-            {{- end }}
             {{- if .Values.global.cloud.authUrl.secretName }}
             - name: HCP_AUTH_URL
               valueFrom:

--- a/charts/consul/templates/telemetry-collector-v2-deployment.yaml
+++ b/charts/consul/templates/telemetry-collector-v2-deployment.yaml
@@ -5,6 +5,7 @@
 {{ template "consul.validateCloudSecretKeys" . }}
 {{ template "consul.validateTelemetryCollectorCloud" . }}
 {{ template "consul.validateTelemetryCollectorCloudSecretKeys" . }}
+{{ template "consul.validateTelemetryCollectorResourceId" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/consul/test/unit/telemetry-collector-deployment.bats
+++ b/charts/consul/test/unit/telemetry-collector-deployment.bats
@@ -778,12 +778,12 @@ load _helpers
       --set 'telemetryCollector.cloud.clientId.secretName=client-id-name' \
       --set 'telemetryCollector.clientSecret.secretName=client-secret-id-name' \
       --set 'telemetryCollector.clientSecret.secretKey=client-secret-id-key' \
-      --set 'global.resourceId.secretName=resource-id-name' \
-      --set 'global.resourceId.secretKey=resource-id-key' \
+      --set 'global.cloud.resourceId.secretName=resource-id-name' \
+      --set 'global.cloud.resourceId.secretKey=resource-id-key' \
       .
   [ "$status" -eq 1 ]
 
-  [[ "$output" =~ "When telemetryCollector.cloud.clientId.secretName is set, global.cloud.resourceId.secretName, telemetryCollector.cloud.clientSecret.secretName must also be set." ]]
+  [[ "$output" =~ "When telemetryCollector.cloud.clientId.secretName is set, telemetryCollector.cloud.clientSecret.secretName must also be set." ]]
 }
 
 @test "telemetryCollector/Deployment: fails when telemetryCollector.cloud.clientId.secretKey is set but telemetryCollector.cloud.clientId.secretName is not set." {
@@ -795,12 +795,12 @@ load _helpers
       --set 'telemetryCollector.cloud.clientId.secretName=client-id-name' \
       --set 'telemetryCollector.cloud.clientId.secretKey=client-id-key' \
       --set 'telemetryCollector.clientSecret.secretName=client-secret-id-name' \
-      --set 'global.resourceId.secretName=resource-id-name' \
-      --set 'global.resourceId.secretKey=resource-id-key' \
+      --set 'global.cloud.resourceId.secretName=resource-id-name' \
+      --set 'global.cloud.resourceId.secretKey=resource-id-key' \
       .
   [ "$status" -eq 1 ]
 
-  [[ "$output" =~ "When telemetryCollector.cloud.clientId.secretName is set, global.cloud.resourceId.secretName, telemetryCollector.cloud.clientSecret.secretName must also be set." ]]
+  [[ "$output" =~ "When telemetryCollector.cloud.clientId.secretName is set, telemetryCollector.cloud.clientSecret.secretName must also be set." ]]
 }
 
 @test "telemetryCollector/Deployment: fails when telemetryCollector.cloud.clientSecret.secretName is set but telemetryCollector.cloud.clientId.secretName is not set." {
@@ -813,10 +813,12 @@ load _helpers
       --set 'telemetryCollector.cloud.clientId.secretKey=client-id-key' \
       --set 'telemetryCollector.clientSecret.secretName=client-secret-id-name' \
       --set 'telemetryCollector.clientSecret.secretKey=client-secret-key-name'  \
+      --set 'global.cloud.resourceId.secretName=resource-id-name' \
+      --set 'global.cloud.resourceId.secretKey=resource-id-key' \
       .
   [ "$status" -eq 1 ]
 
-  [[ "$output" =~ "When telemetryCollector.cloud.clientId.secretName is set, global.cloud.resourceId.secretName, telemetryCollector.cloud.clientSecret.secretName must also be set." ]]
+  [[ "$output" =~ "When telemetryCollector.cloud.clientId.secretName is set, telemetryCollector.cloud.clientSecret.secretName must also be set." ]]
 }
 
 @test "telemetryCollector/Deployment: fails when telemetryCollector.cloud.clientId.secretName is set but telemetry.cloud.clientId.secretKey is not set." {
@@ -828,6 +830,7 @@ load _helpers
       --set 'telemetryCollector.cloud.clientId.secretName=client-id-name' \
       --set 'telemetryCollector.cloud.clientSecret.secretName=client-secret-name' \
       --set 'global.cloud.resourceId.secretName=resource-id-name' \
+      --set 'global.cloud.resourceId.secretKey=resource-id-key' \
       .
   [ "$status" -eq 1 ]
 
@@ -844,6 +847,7 @@ load _helpers
       --set 'telemetryCollector.cloud.clientId.secretKey=client-id-key' \
       --set 'telemetryCollector.cloud.clientSecret.secretName=client-secret-name' \
       --set 'global.cloud.resourceId.secretName=resource-id-name' \
+      --set 'global.cloud.resourceId.secretKey=resource-id-key' \
       .
   [ "$status" -eq 1 ]
 
@@ -864,7 +868,47 @@ load _helpers
       .
   [ "$status" -eq 1 ]
 
-  [[ "$output" =~ "When telemetryCollector has clientId and clientSecret .global.cloud.resourceId.secretKey must be set" ]]
+  [[ "$output" =~ "When telemetryCollector has clientId and clientSecret, telemetryCollector.cloud.resourceId.secretKey or global.cloud.resourceId.secretKey must be set" ]]
+}
+
+@test "telemetryCollector/Deployment: fails when telemetryCollector.cloud.resourceId.secretName differs from global.cloud.resourceId.secretName." {
+  cd `chart_dir`
+  run helm template \
+      -s templates/telemetry-collector-deployment.yaml  \
+      --set 'telemetryCollector.enabled=true' \
+      --set 'telemetryCollector.image=bar' \
+      --set 'global.cloud.resourceId.secretName=resource-id-1' \
+      --set 'global.cloud.resourceId.secretKey=key' \
+      --set 'telemetryCollector.cloud.resourceId.secretName=resource-id-2' \
+      --set 'telemetryCollector.cloud.resourceId.secretKey=key' \
+      --set 'telemetryCollector.cloud.clientId.secretName=client-id-name' \
+      --set 'telemetryCollector.cloud.clientId.secretKey=client-id-key' \
+      --set 'telemetryCollector.cloud.clientSecret.secretName=client-secret-name' \
+      --set 'telemetryCollector.cloud.clientSecret.secretKey=client-secret-name' \
+      .
+  [ "$status" -eq 1 ]
+
+  [[ "$output" =~ "When both global.cloud.resourceId.secretName and telemetryCollector.cloud.resourceId.secretName are set, they should be the same." ]]
+}
+
+@test "telemetryCollector/Deployment: fails when telemetryCollector.cloud.resourceId.secretKey differs from global.cloud.resourceId.secretKey." {
+  cd `chart_dir`
+  run helm template \
+      -s templates/telemetry-collector-deployment.yaml  \
+      --set 'telemetryCollector.enabled=true' \
+      --set 'telemetryCollector.image=bar' \
+      --set 'global.cloud.resourceId.secretName=name' \
+      --set 'global.cloud.resourceId.secretKey=key-1' \
+      --set 'telemetryCollector.cloud.resourceId.secretName=name' \
+      --set 'telemetryCollector.cloud.resourceId.secretKey=key-2' \
+      --set 'telemetryCollector.cloud.clientId.secretName=client-id-name' \
+      --set 'telemetryCollector.cloud.clientId.secretKey=client-id-key' \
+      --set 'telemetryCollector.cloud.clientSecret.secretName=client-secret-name' \
+      --set 'telemetryCollector.cloud.clientSecret.secretKey=client-secret-name' \
+      .
+  [ "$status" -eq 1 ]
+
+  [[ "$output" =~ "When both global.cloud.resourceId.secretKey and telemetryCollector.cloud.resourceId.secretKey are set, they should be the same." ]]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/test/unit/telemetry-collector-deployment.bats
+++ b/charts/consul/test/unit/telemetry-collector-deployment.bats
@@ -528,20 +528,86 @@ load _helpers
 #--------------------------------------------------------------------
 # telemetryCollector.cloud
 
-@test "telemetryCollector/Deployment: success with all cloud bits set" {
+@test "telemetryCollector/Deployment: success with global.cloud env vars" {
   cd `chart_dir`
-  run helm template \
+  local object=$(helm template \
       -s templates/telemetry-collector-deployment.yaml  \
-      --set 'telemetryCollector.enabled=true' \
-      --set 'telemetryCollector.image=bar' \
       --set 'global.cloud.enabled=true' \
+      --set 'global.cloud.resourceId.secretName=client-resource-id-name' \
+      --set 'global.cloud.resourceId.secretKey=client-resource-id-key' \
       --set 'global.cloud.clientSecret.secretName=client-secret-name' \
       --set 'global.cloud.clientSecret.secretKey=client-secret-key' \
       --set 'global.cloud.clientId.secretName=client-id-name' \
       --set 'global.cloud.clientId.secretKey=client-id-key' \
-      --set 'global.cloud.resourceId.secretName=client-resource-id-name' \
-      --set 'global.cloud.resourceId.secretKey=client-resource-id-key' \
-      .
+      --set 'telemetryCollector.enabled=true' \
+      --set 'telemetryCollector.image=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r 'map(select(.name == "HCP_RESOURCE_ID")) | .[0].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${actual}" = "client-resource-id-name" ]
+
+  local actual=$(echo $object |
+      yq -r 'map(select(.name == "HCP_RESOURCE_ID")) | .[0].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${actual}" = "client-resource-id-key" ]
+
+  local actual=$(echo $object |
+      yq -r 'map(select(.name == "HCP_CLIENT_ID")) | .[0].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${actual}" = "client-id-name" ]
+
+  local actual=$(echo $object |
+      yq -r 'map(select(.name == "HCP_CLIENT_ID")) | .[0].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${actual}" = "client-id-key" ]
+
+  local actual=$(echo $object |
+      yq -r 'map(select(.name == "HCP_CLIENT_SECRET")) | .[0].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${actual}" = "client-secret-name" ]
+
+  local actual=$(echo $object |
+      yq -r 'map(select(.name == "HCP_CLIENT_SECRET")) | .[0].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${actual}" = "client-secret-key" ]
+}
+
+@test "telemetryCollector/Deployment: success with telemetryCollector.cloud env vars" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/telemetry-collector-deployment.yaml  \
+      --set 'global.cloud.enabled=false' \
+      --set 'telemetryCollector.enabled=true' \
+      --set 'telemetryCollector.image=bar' \
+      --set 'telemetryCollector.cloud.resourceId.secretName=client-resource-id-name' \
+      --set 'telemetryCollector.cloud.resourceId.secretKey=client-resource-id-key' \
+      --set 'telemetryCollector.cloud.clientSecret.secretName=client-secret-name' \
+      --set 'telemetryCollector.cloud.clientSecret.secretKey=client-secret-key' \
+      --set 'telemetryCollector.cloud.clientId.secretName=client-id-name' \
+      --set 'telemetryCollector.cloud.clientId.secretKey=client-id-key' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r 'map(select(.name == "HCP_RESOURCE_ID")) | .[0].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${actual}" = "client-resource-id-name" ]
+
+  local actual=$(echo $object |
+      yq -r 'map(select(.name == "HCP_RESOURCE_ID")) | .[0].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${actual}" = "client-resource-id-key" ]
+
+  local actual=$(echo $object |
+      yq -r 'map(select(.name == "HCP_CLIENT_ID")) | .[0].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${actual}" = "client-id-name" ]
+
+  local actual=$(echo $object |
+      yq -r 'map(select(.name == "HCP_CLIENT_ID")) | .[0].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${actual}" = "client-id-key" ]
+
+  local actual=$(echo $object |
+      yq -r 'map(select(.name == "HCP_CLIENT_SECRET")) | .[0].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${actual}" = "client-secret-name" ]
+
+  local actual=$(echo $object |
+      yq -r 'map(select(.name == "HCP_CLIENT_SECRET")) | .[0].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${actual}" = "client-secret-key" ]
 }
 
 @test "telemetryCollector/Deployment: fails when telemetryCollector.cloud.clientId is set and global.cloud.resourceId is not set or global.cloud.clientSecret.secretName is not set" {
@@ -776,14 +842,16 @@ load _helpers
       --set 'telemetryCollector.enabled=true' \
       --set 'telemetryCollector.image=bar' \
       --set 'telemetryCollector.cloud.clientId.secretName=client-id-name' \
-      --set 'telemetryCollector.clientSecret.secretName=client-secret-id-name' \
-      --set 'telemetryCollector.clientSecret.secretKey=client-secret-id-key' \
+      --set 'telemetryCollector.cloud.clientSecret.secretName=client-secret-id-name' \
+      --set 'telemetryCollector.cloud.clientSecret.secretKey=client-secret-id-key' \
       --set 'global.cloud.resourceId.secretName=resource-id-name' \
       --set 'global.cloud.resourceId.secretKey=resource-id-key' \
       .
   [ "$status" -eq 1 ]
 
-  [[ "$output" =~ "When telemetryCollector.cloud.clientId.secretName is set, telemetryCollector.cloud.clientSecret.secretName must also be set." ]]
+  echo "$output" > /dev/stderr
+
+  [[ "$output" =~ "When either telemetryCollector.cloud.clientId.secretName or telemetryCollector.cloud.clientId.secretKey is defined, both must be set." ]]
 }
 
 @test "telemetryCollector/Deployment: fails when telemetryCollector.cloud.clientId.secretKey is set but telemetryCollector.cloud.clientId.secretName is not set." {
@@ -794,13 +862,15 @@ load _helpers
       --set 'telemetryCollector.image=bar' \
       --set 'telemetryCollector.cloud.clientId.secretName=client-id-name' \
       --set 'telemetryCollector.cloud.clientId.secretKey=client-id-key' \
-      --set 'telemetryCollector.clientSecret.secretName=client-secret-id-name' \
+      --set 'telemetryCollector.cloud.clientSecret.secretName=client-secret-id-name' \
       --set 'global.cloud.resourceId.secretName=resource-id-name' \
       --set 'global.cloud.resourceId.secretKey=resource-id-key' \
       .
   [ "$status" -eq 1 ]
 
-  [[ "$output" =~ "When telemetryCollector.cloud.clientId.secretName is set, telemetryCollector.cloud.clientSecret.secretName must also be set." ]]
+  echo "$output" > /dev/stderr
+
+  [[ "$output" =~ "When either telemetryCollector.cloud.clientSecret.secretName or telemetryCollector.cloud.clientSecret.secretKey is defined, both must be set." ]]
 }
 
 @test "telemetryCollector/Deployment: fails when telemetryCollector.cloud.clientSecret.secretName is set but telemetryCollector.cloud.clientId.secretName is not set." {
@@ -809,16 +879,17 @@ load _helpers
       -s templates/telemetry-collector-deployment.yaml  \
       --set 'telemetryCollector.enabled=true' \
       --set 'telemetryCollector.image=bar' \
-      --set 'telemetryCollector.cloud.clientId.secretName=client-id-name' \
       --set 'telemetryCollector.cloud.clientId.secretKey=client-id-key' \
-      --set 'telemetryCollector.clientSecret.secretName=client-secret-id-name' \
-      --set 'telemetryCollector.clientSecret.secretKey=client-secret-key-name'  \
+      --set 'telemetryCollector.cloud.clientSecret.secretName=client-secret-id-name' \
+      --set 'telemetryCollector.cloud.clientSecret.secretKey=client-secret-key-name'  \
       --set 'global.cloud.resourceId.secretName=resource-id-name' \
       --set 'global.cloud.resourceId.secretKey=resource-id-key' \
       .
   [ "$status" -eq 1 ]
 
-  [[ "$output" =~ "When telemetryCollector.cloud.clientId.secretName is set, telemetryCollector.cloud.clientSecret.secretName must also be set." ]]
+  echo "$output" > /dev/stderr
+
+  [[ "$output" =~ "When telemetryCollector.cloud.clientSecret.secretName is set, telemetryCollector.cloud.clientId.secretName must also be set." ]]
 }
 
 @test "telemetryCollector/Deployment: fails when telemetryCollector.cloud.clientId.secretName is set but telemetry.cloud.clientId.secretKey is not set." {

--- a/charts/consul/test/unit/telemetry-collector-v2-deployment.bats
+++ b/charts/consul/test/unit/telemetry-collector-v2-deployment.bats
@@ -860,14 +860,16 @@ load _helpers
       --set 'telemetryCollector.enabled=true' \
       --set 'telemetryCollector.image=bar' \
       --set 'telemetryCollector.cloud.clientId.secretName=client-id-name' \
-      --set 'telemetryCollector.clientSecret.secretName=client-secret-id-name' \
-      --set 'telemetryCollector.clientSecret.secretKey=client-secret-id-key' \
-      --set 'global.resourceId.secretName=resource-id-name' \
-      --set 'global.resourceId.secretKey=resource-id-key' \
+      --set 'telemetryCollector.cloud.clientSecret.secretName=client-secret-id-name' \
+      --set 'telemetryCollector.cloud.clientSecret.secretKey=client-secret-id-key' \
+      --set 'global.cloud.resourceId.secretName=resource-id-name' \
+      --set 'global.cloud.resourceId.secretKey=resource-id-key' \
       .
   [ "$status" -eq 1 ]
 
-  [[ "$output" =~ "When telemetryCollector.cloud.clientId.secretName is set, global.cloud.resourceId.secretName, telemetryCollector.cloud.clientSecret.secretName must also be set." ]]
+  echo "$output" > /dev/stderr
+
+  [[ "$output" =~ "When either telemetryCollector.cloud.clientId.secretName or telemetryCollector.cloud.clientId.secretKey is defined, both must be set." ]]
 }
 
 @test "telemetryCollector/Deployment(V2):  fails when telemetryCollector.cloud.clientId.secretKey is set but telemetryCollector.cloud.clientId.secretName is not set." {
@@ -880,13 +882,15 @@ load _helpers
       --set 'telemetryCollector.image=bar' \
       --set 'telemetryCollector.cloud.clientId.secretName=client-id-name' \
       --set 'telemetryCollector.cloud.clientId.secretKey=client-id-key' \
-      --set 'telemetryCollector.clientSecret.secretName=client-secret-id-name' \
-      --set 'global.resourceId.secretName=resource-id-name' \
-      --set 'global.resourceId.secretKey=resource-id-key' \
+      --set 'telemetryCollector.cloud.clientSecret.secretName=client-secret-id-name' \
+      --set 'global.cloud.resourceId.secretName=resource-id-name' \
+      --set 'global.cloud.resourceId.secretKey=resource-id-key' \
       .
   [ "$status" -eq 1 ]
 
-  [[ "$output" =~ "When telemetryCollector.cloud.clientId.secretName is set, global.cloud.resourceId.secretName, telemetryCollector.cloud.clientSecret.secretName must also be set." ]]
+  echo "$output" > /dev/stderr
+
+  [[ "$output" =~ "When either telemetryCollector.cloud.clientSecret.secretName or telemetryCollector.cloud.clientSecret.secretKey is defined, both must be set." ]]
 }
 
 @test "telemetryCollector/Deployment(V2):  fails when telemetryCollector.cloud.clientSecret.secretName is set but telemetryCollector.cloud.clientId.secretName is not set." {
@@ -897,14 +901,17 @@ load _helpers
       --set 'global.experiments[0]=resource-apis' \
       --set 'telemetryCollector.enabled=true' \
       --set 'telemetryCollector.image=bar' \
-      --set 'telemetryCollector.cloud.clientId.secretName=client-id-name' \
       --set 'telemetryCollector.cloud.clientId.secretKey=client-id-key' \
-      --set 'telemetryCollector.clientSecret.secretName=client-secret-id-name' \
-      --set 'telemetryCollector.clientSecret.secretKey=client-secret-key-name'  \
+      --set 'telemetryCollector.cloud.clientSecret.secretName=client-secret-id-name' \
+      --set 'telemetryCollector.cloud.clientSecret.secretKey=client-secret-key-name'  \
+      --set 'global.cloud.resourceId.secretName=resource-id-name' \
+      --set 'global.cloud.resourceId.secretKey=resource-id-key' \
       .
   [ "$status" -eq 1 ]
 
-  [[ "$output" =~ "When telemetryCollector.cloud.clientId.secretName is set, global.cloud.resourceId.secretName, telemetryCollector.cloud.clientSecret.secretName must also be set." ]]
+  echo "$output" > /dev/stderr
+
+  [[ "$output" =~ "When telemetryCollector.cloud.clientSecret.secretName is set, telemetryCollector.cloud.clientId.secretName must also be set." ]]
 }
 
 @test "telemetryCollector/Deployment(V2):  fails when telemetryCollector.cloud.clientId.secretName is set but telemetry.cloud.clientId.secretKey is not set." {
@@ -958,7 +965,9 @@ load _helpers
       .
   [ "$status" -eq 1 ]
 
-  [[ "$output" =~ "When telemetryCollector has clientId and clientSecret .global.cloud.resourceId.secretKey must be set" ]]
+  echo "$output" > /dev/stderr
+
+  [[ "$output" =~ "When telemetryCollector has clientId and clientSecret, telemetryCollector.cloud.resourceId.secretKey or global.cloud.resourceId.secretKey must be set" ]]
 }
 
 #--------------------------------------------------------------------

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -652,10 +652,10 @@ global:
   # the API before cancelling the request.
   consulAPITimeout: 5s
 
-  # Enables installing an HCP Consul self-managed cluster.
+  # Enables installing an HCP Consul Central self-managed cluster.
   # Requires Consul v1.14+.
   cloud:
-    # If true, the Helm chart will enable the installation of an HCP Consul
+    # If true, the Helm chart will enable the installation of an HCP Consul Central
     # self-managed cluster.
     enabled: false
 
@@ -670,9 +670,8 @@ global:
       # @type: string
       secretKey: null
 
-    # The client id portion of a service principal with authorization to link the cluster
-    # in global.cloud.resourceId to HCP.
-    # https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals
+    # The client id portion of a [service principal](https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals) with authorization to link the cluster
+    # in global.cloud.resourceId to HCP Consul Central.
     clientId:
       # The name of the Kubernetes secret that holds the client id.
       # @type: string
@@ -681,9 +680,8 @@ global:
       # @type: string
       secretKey: null
 
-    # The client secret portion of a service principal with authorization to link the cluster
-    # in global.cloud.resourceId to HCP.
-    # https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals
+    # The client secret portion of a [service principal](https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals) with authorization to link the cluster
+    # in global.cloud.resourceId to HCP Consul Central.
     clientSecret:
       # The name of the Kubernetes secret that holds the client secret.
       # @type: string
@@ -692,7 +690,7 @@ global:
       # @type: string
       secretKey: null
 
-    # The API endpoint of HCP. This setting is used for internal testing and validation.
+    # The hostname of HCP's API. This setting is used for internal testing and validation.
     apiHost:
       # The name of the Kubernetes secret that holds the api hostname.
       # @type: string
@@ -701,7 +699,7 @@ global:
       # @type: string
       secretKey: null
 
-    # The URL of HCP auth API. This setting is used for internal testing and validation.
+    # The URL of HCP's auth API. This setting is used for internal testing and validation.
     authUrl:
       # The name of the Kubernetes secret that holds the authorization url.
       # @type: string
@@ -710,8 +708,7 @@ global:
       # @type: string
       secretKey: null
 
-    # The name of the Kubernetes secret that holds the HCP cloud scada address.
-    # This is optional when global.cloud.enabled is true.
+    # The address of HCP's scada service. This setting is used for internal testing and validation.
     scadaAddress:
       # The name of the Kubernetes secret that holds the scada address.
       # @type: string
@@ -3491,7 +3488,7 @@ telemetryCollector:
   customExporterConfig: null
 
   service:
-    # This value defines additional annotations for the server service account. This should be formatted as a multi-line
+    # This value defines additional annotations for the telemetry-collector's service account. This should be formatted as a multi-line
     # string.
     #
     # ```yaml
@@ -3517,12 +3514,11 @@ telemetryCollector:
     annotations: null
 
   cloud:
-    # The resource id of the HCP Consul cluster to push metrics for. Eg:
-    # organization/27109cd4-a309-4bf3-9986-e1d071914b18/project/fcef6c24-259d-4510-bb8d-1d812e120e34/hashicorp.consul.global-network-manager.cluster/consul-cluster
+    # The resource id of the HCP Consul Central cluster to push metrics for. Eg:
+    # `organization/27109cd4-a309-4bf3-9986-e1d071914b18/project/fcef6c24-259d-4510-bb8d-1d812e120e34/hashicorp.consul.global-network-manager.cluster/consul-cluster`
     #
-    # This is used for HCP Central clusters where global.cloud.resourceId is unset. For example:
-    #   - non-default admin partition
-    #   - externalServers.enabled where the external servers are HCP managed clusters
+    # This is used for HCP Consul Central-linked or managed clusters where global.cloud.resourceId is unset. For example, when using externalServers
+    # with HCP Consul-managed clusters or HCP Consul Central-linked clusters in a different admin partition.
     #
     # If global.cloud.resourceId is set, this should either be unset (defaulting to global.cloud.resourceId) or be the same as global.cloud.resourceId.
     #
@@ -3535,12 +3531,11 @@ telemetryCollector:
       # @type: string
       secretKey: null
 
-    # The client id portion of a service principal with authorization to push metrics to HCP
-    # https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals
+    # The client id portion of a [service principal](https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals) with authorization to push metrics to HCP
     #
     # This is set in two scenarios:
     #   - the service principal in global.cloud is unset
-    #   - the HCP UI provides a service principal with more scoped permissions that the service principal used in global.cloud
+    #   - the HCP UI provides a service principal with more narrowly scoped permissions that the service principal used in global.cloud
     #
     # @default: global.cloud.clientId
     clientId:
@@ -3551,12 +3546,11 @@ telemetryCollector:
       # @type: string
       secretKey: null
 
-    # The client secret portion of a service principal with authorization to push metrics to HCP.
-    # https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals
+    # The client secret portion of a [service principal](https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals) with authorization to push metrics to HCP.
     #
     # This is set in two scenarios:
     #   - the service principal in global.cloud is unset
-    #   - the HCP UI provides a service principal with more scoped permissions that the service principal used in global.cloud
+    #   - the HCP UI provides a service principal with more narrowly scoped permissions that the service principal used in global.cloud
     #
     # @default: global.cloud.clientSecret
     clientSecret:
@@ -3581,7 +3575,7 @@ telemetryCollector:
   # @type: string
   priorityClassName: ""
 
-  # A list of extra environment variables to set within the stateful set.
+  # A list of extra environment variables to set within the deployment.
   # These could be used to include proxy settings required for cloud auto-join
   # feature, in case kubernetes cluster is behind egress http proxies. Additionally,
   # it could be used to configure custom consul parameters.

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -3524,6 +3524,8 @@ telemetryCollector:
     #   - non-default admin partition
     #   - externalServers.enabled where the external servers are HCP managed clusters
     #
+    # If global.cloud.resourceId is set, this should either be unset (defaulting to global.cloud.resourceId) or be the same as global.cloud.resourceId.
+    #
     # @default: global.cloud.resourceId
     resourceId:
       # The name of the Kubernetes secret that holds the resource id.

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -672,6 +672,7 @@ global:
 
     # The client id portion of a [service principal](https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals) with authorization to link the cluster
     # in global.cloud.resourceId to HCP Consul Central.
+    # This is required when global.cloud.enabled is true.
     clientId:
       # The name of the Kubernetes secret that holds the client id.
       # @type: string
@@ -682,6 +683,7 @@ global:
 
     # The client secret portion of a [service principal](https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals) with authorization to link the cluster
     # in global.cloud.resourceId to HCP Consul Central.
+    # This is required when global.cloud.enabled is true.
     clientSecret:
       # The name of the Kubernetes secret that holds the client secret.
       # @type: string

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -114,7 +114,7 @@ global:
   # secretKey should be in the form of "key".
   secretsBackend:
     vault:
-      # Vault namespace (optional). This sets the Vault namespace for the `vault.hashicorp.com/namespace` 
+      # Vault namespace (optional). This sets the Vault namespace for the `vault.hashicorp.com/namespace`
       # agent annotation and [Vault Connect CA namespace](https://developer.hashicorp.com/consul/docs/connect/ca/vault#namespace).
       # To override one of these values individually, see `agentAnnotations` and `connectCA.additionalConfig`.
       vaultNamespace: ""
@@ -457,7 +457,7 @@ global:
       # @type: string
       secretKey: null
 
-    # The resource requests (CPU, memory, etc.) for the server-acl-init and server-acl-init-cleanup pods. 
+    # The resource requests (CPU, memory, etc.) for the server-acl-init and server-acl-init-cleanup pods.
     # This should be a YAML map corresponding to a Kubernetes
     # [`ResourceRequirements``](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core)
     # object.
@@ -558,7 +558,7 @@ global:
     # If enabled, this datacenter will be federation-capable. Only federation
     # via mesh gateways is supported.
     # Mesh gateways and servers will be configured to allow federation.
-    # Requires `global.tls.enabled`, `connectInject.enabled`, and one of 
+    # Requires `global.tls.enabled`, `connectInject.enabled`, and one of
     # `meshGateway.enabled` or `externalServers.enabled` to be true.
     # Requires Consul 1.8+.
     enabled: false
@@ -588,7 +588,7 @@ global:
     # from the one used by the Consul Service Mesh.
     # Please refer to the [Kubernetes Auth Method documentation](https://developer.hashicorp.com/consul/docs/security/acl/auth-methods/kubernetes).
     #
-    # If `externalServers.enabled` is set to true, `global.federation.k8sAuthMethodHost` and 
+    # If `externalServers.enabled` is set to true, `global.federation.k8sAuthMethodHost` and
     # `externalServers.k8sAuthMethodHost` should be set to the same value.
     #
     # You can retrieve this value from your `kubeconfig` by running:
@@ -659,7 +659,8 @@ global:
     # self-managed cluster.
     enabled: false
 
-    # The name of the Kubernetes secret that holds the HCP resource id.
+    # The resource id of the HCP Consul cluster to link to. Eg:
+    # organization/27109cd4-a309-4bf3-9986-e1d071914b18/project/fcef6c24-259d-4510-bb8d-1d812e120e34/hashicorp.consul.global-network-manager.cluster/consul-cluster
     # This is required when global.cloud.enabled is true.
     resourceId:
       # The name of the Kubernetes secret that holds the resource id.
@@ -669,8 +670,9 @@ global:
       # @type: string
       secretKey: null
 
-    # The name of the Kubernetes secret that holds the HCP cloud client id.
-    # This is required when global.cloud.enabled is true.
+    # The client id portion of a service principal with authorization to link the cluster
+    # in global.cloud.resourceId to HCP.
+    # https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals
     clientId:
       # The name of the Kubernetes secret that holds the client id.
       # @type: string
@@ -679,8 +681,9 @@ global:
       # @type: string
       secretKey: null
 
-    # The name of the Kubernetes secret that holds the HCP cloud client secret.
-    # This is required when global.cloud.enabled is true.
+    # The client secret portion of a service principal with authorization to link the cluster
+    # in global.cloud.resourceId to HCP.
+    # https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals
     clientSecret:
       # The name of the Kubernetes secret that holds the client secret.
       # @type: string
@@ -689,8 +692,7 @@ global:
       # @type: string
       secretKey: null
 
-    # The name of the Kubernetes secret that holds the HCP cloud client id.
-    # This is optional when global.cloud.enabled is true.
+    # The API endpoint of HCP. This setting is used for internal testing and validation.
     apiHost:
       # The name of the Kubernetes secret that holds the api hostname.
       # @type: string
@@ -699,8 +701,7 @@ global:
       # @type: string
       secretKey: null
 
-    # The name of the Kubernetes secret that holds the HCP cloud authorization url.
-    # This is optional when global.cloud.enabled is true.
+    # The URL of HCP auth API. This setting is used for internal testing and validation.
     authUrl:
       # The name of the Kubernetes secret that holds the authorization url.
       # @type: string
@@ -745,7 +746,7 @@ global:
   # ]
   # ```
   # @type: array<string>
-  trustedCAs: [ ]
+  trustedCAs: []
 
   # Consul feature flags that will be enabled across components.
   # Supported feature flags:
@@ -762,8 +763,7 @@ global:
   # experiments: [ "resource-apis" ]
   # ```
   # @type: array<string>
-  experiments: [ ]
-
+  experiments: []
 
 # Server, when enabled, configures a server cluster to run. This should
 # be disabled if you plan on connecting to a Consul cluster external to
@@ -884,9 +884,9 @@ server:
 
   # The [Persistent Volume Claim (PVC) retention policy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)
   # controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
-  # WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted, 
+  # WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted,
   # and WhenScaled specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is scaled down.
-  # 
+  #
   # Example:
   #
   # ```yaml
@@ -901,7 +901,7 @@ server:
   # _will not_ automatically secure pod communication, this
   # setting will only enable usage of the feature. Consul will automatically initialize
   # a new CA and set of certificates. Additional service mesh settings can be configured
-  # by setting the `server.extraConfig` value or by applying [configuration entries](https://developer.hashicorp.com/consul/docs/connect/config-entries). 
+  # by setting the `server.extraConfig` value or by applying [configuration entries](https://developer.hashicorp.com/consul/docs/connect/config-entries).
   connect: true
 
   serviceAccount:
@@ -1271,7 +1271,7 @@ server:
     # @type: string
     caCert: null
 
-  # [Enterprise Only] Added in Consul 1.8, the audit object allow users to enable auditing 
+  # [Enterprise Only] Added in Consul 1.8, the audit object allow users to enable auditing
   # and configure a sink and filters for their audit logs. Please refer to
   # [audit logs](https://developer.hashicorp.com/consul/docs/enterprise/audit-logging) documentation
   # for further information.
@@ -1280,7 +1280,7 @@ server:
     # global.acls.manageSystemACLs must be enabled to use this feature.
     enabled: false
 
-    # A single entry of the sink object provides configuration for the destination to which Consul 
+    # A single entry of the sink object provides configuration for the destination to which Consul
     # will log auditing events.
     #
     # Example:
@@ -1295,7 +1295,7 @@ server:
     #     rotate_duration: 24h
     #     rotate_max_files: 15
     #     rotate_bytes: 25165824
-    #     
+    #
     # ```
     #
     # The sink object supports the following keys:
@@ -1407,7 +1407,7 @@ externalServers:
   # This address must be reachable from the Consul servers.
   # Please refer to the [Kubernetes Auth Method documentation](https://developer.hashicorp.com/consul/docs/security/acl/auth-methods/kubernetes).
   #
-  # If `global.federation.enabled` is set to true, `global.federation.k8sAuthMethodHost` and 
+  # If `global.federation.enabled` is set to true, `global.federation.k8sAuthMethodHost` and
   # `externalServers.k8sAuthMethodHost` should be set to the same value.
   #
   # You could retrieve this value from your `kubeconfig` by running:
@@ -2200,7 +2200,7 @@ connectInject:
     # If this setting is false, you will need to install the Gateway API CRDs manually.
     manageExternalCRDs: true
 
-    # Enables Consul on Kubernets to manage only the non-standard CRDs used for Gateway API. If manageExternalCRDs is true 
+    # Enables Consul on Kubernets to manage only the non-standard CRDs used for Gateway API. If manageExternalCRDs is true
     # then all CRDs will be installed; otherwise, if manageNonStandardCRDs is true then only TCPRoute, GatewayClassConfig and MeshService
     # will be installed.
     manageNonStandardCRDs: false
@@ -2687,16 +2687,16 @@ connectInject:
     # - `consul.hashicorp.com/sidecar-proxy-lifecycle-graceful-shutdown-path`
     # @type: map
     lifecycle:
-        # @type: boolean
-        defaultEnabled: true
-        # @type: boolean
-        defaultEnableShutdownDrainListeners: true
-        # @type: integer
-        defaultShutdownGracePeriodSeconds: 30
-        # @type: integer
-        defaultGracefulPort: 20600
-        # @type: string
-        defaultGracefulShutdownPath: "/graceful_shutdown"
+      # @type: boolean
+      defaultEnabled: true
+      # @type: boolean
+      defaultEnableShutdownDrainListeners: true
+      # @type: integer
+      defaultShutdownGracePeriodSeconds: 30
+      # @type: integer
+      defaultGracefulPort: 20600
+      # @type: string
+      defaultGracefulShutdownPath: "/graceful_shutdown"
 
   # The resource settings for the Connect injected init container. If null, the resources
   # won't be set for the initContainer. The defaults are optimized for developer instances of
@@ -3096,8 +3096,8 @@ ingressGateways:
 
   # Gateways is a list of gateway objects. The only required field for
   # each is `name`, though they can also contain any of the fields in
-  # `defaults`. You must provide a unique name for each ingress gateway. These names 
-  # must be unique across different namespaces. 
+  # `defaults`. You must provide a unique name for each ingress gateway. These names
+  # must be unique across different namespaces.
   # Values defined here override the defaults, except in the case of annotations where both will be applied.
   # @type: array<map>
   gateways:
@@ -3517,11 +3517,52 @@ telemetryCollector:
     annotations: null
 
   cloud:
-    clientId:
+    # The resource id of the HCP Consul cluster to push metrics for. Eg:
+    # organization/27109cd4-a309-4bf3-9986-e1d071914b18/project/fcef6c24-259d-4510-bb8d-1d812e120e34/hashicorp.consul.global-network-manager.cluster/consul-cluster
+    #
+    # This is used for HCP Central clusters where global.cloud.resourceId is unset. For example:
+    #   - non-default admin partition
+    #   - externalServers.enabled where the external servers are HCP managed clusters
+    #
+    # @default: global.cloud.resourceId
+    resourceId:
+      # The name of the Kubernetes secret that holds the resource id.
+      # @type: string
       secretName: null
+      # The key within the Kubernetes secret that holds the resource id.
+      # @type: string
       secretKey: null
-    clientSecret:
+
+    # The client id portion of a service principal with authorization to push metrics to HCP
+    # https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals
+    #
+    # This is set in two scenarios:
+    #   - the service principal in global.cloud is unset
+    #   - the HCP UI provides a service principal with more scoped permissions that the service principal used in global.cloud
+    #
+    # @default: global.cloud.clientId
+    clientId:
+      # The name of the Kubernetes secret that holds the client id.
+      # @type: string
       secretName: null
+      # The key within the Kubernetes secret that holds the client id.
+      # @type: string
+      secretKey: null
+
+    # The client secret portion of a service principal with authorization to push metrics to HCP.
+    # https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals
+    #
+    # This is set in two scenarios:
+    #   - the service principal in global.cloud is unset
+    #   - the HCP UI provides a service principal with more scoped permissions that the service principal used in global.cloud
+    #
+    # @default: global.cloud.clientSecret
+    clientSecret:
+      # The name of the Kubernetes secret that holds the client secret.
+      # @type: string
+      secretName: null
+      # The key within the Kubernetes secret that holds the client secret.
+      # @type: string
       secretKey: null
 
   initContainer:
@@ -3543,4 +3584,4 @@ telemetryCollector:
   # feature, in case kubernetes cluster is behind egress http proxies. Additionally,
   # it could be used to configure custom consul parameters.
   # @type: map
-  extraEnvironmentVars: { }
+  extraEnvironmentVars: {}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -659,7 +659,7 @@ global:
     # self-managed cluster.
     enabled: false
 
-    # The resource id of the HCP Consul cluster to link to. Eg:
+    # The resource id of the HCP Consul Central cluster to link to. Eg:
     # organization/27109cd4-a309-4bf3-9986-e1d071914b18/project/fcef6c24-259d-4510-bb8d-1d812e120e34/hashicorp.consul.global-network-manager.cluster/consul-cluster
     # This is required when global.cloud.enabled is true.
     resourceId:


### PR DESCRIPTION
### Changes proposed in this PR:

@eddie-rowe reported that he was unable to deploy the Consul Telemetry Collector when `global.cloud.enabled` was false. This should be possible, but right now the telemetry-collector deployment pulls its resourceId out of `global.cloud.resourceId`, which may not be set even when a user is trying to use the collector.

For example, a user may link their cluster to HCP using `externalServers`, while `global.cloud` is empty (because there are no servers in the deployment), but then the `telemetryCollector` will fail to deploy for lack of `global.cloud.resourceId`

The change here is to add a new field, `telemetryCollector.cloud.resourceId` that's settable. If set, it's used in the consul-telemetry-collector deployment

JIRA: https://hashicorp.atlassian.net/browse/CC-6866

Time willing, in a follow up PR I'll add something to the `-preset cloud` to parse an `HCP_RESOURCE_ID` env var into a `global.cloud.resourceId` like we do already for client id and secret: https://github.com/hashicorp/consul-k8s/blob/fc70b0381677e1b3e2c94fc6d2c61baf2e886877/cli/preset/preset.go#L16

### How I've tested this PR:
- new bats tests, fixed old ones

### How I expect reviewers to test this PR:
- please let me know if anything is unclear and whether bats is sufficient

### Checklist:
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


