### PR TITLE
NET-6664 Specify cluster scope for MeshGateway CRD

### DIFF
--- a/charts/consul/templates/crd-meshgateways.yaml
+++ b/charts/consul/templates/crd-meshgateways.yaml
@@ -17,10 +17,8 @@ spec:
     kind: MeshGateway
     listKind: MeshGatewayList
     plural: meshgateways
-    shortNames:
-    - mesh-gateway
     singular: meshgateway
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - description: The sync status of the resource with Consul

--- a/control-plane/api/mesh/v2beta1/mesh_gateway_types.go
+++ b/control-plane/api/mesh/v2beta1/mesh_gateway_types.go
@@ -33,7 +33,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type==\"Synced\")].status",description="The sync status of the resource with Consul"
 // +kubebuilder:printcolumn:name="Last Synced",type="date",JSONPath=".status.lastSyncedTime",description="The last successful synced time of the resource with Consul"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
-// +kubebuilder:resource:shortName="mesh-gateway"
+// +kubebuilder:resource:scope="Cluster"
 type MeshGateway struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/control-plane/config/crd/bases/mesh.consul.hashicorp.com_meshgateways.yaml
+++ b/control-plane/config/crd/bases/mesh.consul.hashicorp.com_meshgateways.yaml
@@ -13,10 +13,8 @@ spec:
     kind: MeshGateway
     listKind: MeshGatewayList
     plural: meshgateways
-    shortNames:
-    - mesh-gateway
     singular: meshgateway
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - description: The sync status of the resource with Consul


### PR DESCRIPTION
**Changes proposed in this PR:**
- Change the scope of the `MeshGateway` CRD to `Cluster` due to the fact that the resource is partition-scoped in Consul and thus should not have a namespace

**How I've tested this PR:**
Using [this setup](https://github.com/nathancoleman/consul-lab/tree/main/k8s/mesh-gateway-v2)
```shell
$ helm upgrade --install consul <path_to_local_main_checkout>/charts/consul --values ./values.yaml
$ kubectl apply -f gateway.yaml
```

Instead of the namespace declaration error previously caused by the `Namespaced` scope, you'll see an error in the controller logs indicating that the create/update function is not yet implemented, which is expected.
```log
ERROR    Reconciler error    {"controller": "meshgateway", "controllerGroup": "mesh.consul.hashicorp.com", "controllerKind": "MeshGateway", "MeshGateway": {"name":"mesh-gateway"},  │
│ "namespace": "", "name": "mesh-gateway", "reconcileID": "c3917aab-878d-48c5-adbc-d701bab04c1b", "error": "onCreateUpdate not implemented"}
```

**How I expect reviewers to test this PR:**
See above

**Checklist:**
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


