### PR TITLE
Backport of Add telemetryCollector.cloud.resourceId field that works even when global.cloud.enabled is false into release/1.1.x

### DIFF
--- a/.changelog/3219.txt
+++ b/.changelog/3219.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul-telemetry-collector: add telemetryCollector.cloud.resourceId that works even when not global.cloud.enabled
+```

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -431,7 +431,7 @@ Usage: {{ template "consul.validateCloudSecretKeys" . }}
 
 
 {{/*
-Fails if temeletryCollector.clientId or telemetryCollector.clientSecret exist and one of other secrets is nil or empty.
+Fails if telemetryCollector.clientId or telemetryCollector.clientSecret exist and one of other secrets is nil or empty.
 - telemetryCollector.cloud.clientId.secretName
 - telemetryCollector.cloud.clientSecret.secretName
 - global.cloud.resourceId.secretName
@@ -440,11 +440,11 @@ Usage: {{ template "consul.validateTelemetryCollectorCloud" . }}
 
 */}}
 {{- define "consul.validateTelemetryCollectorCloud" -}}
-{{- if (and .Values.telemetryCollector.cloud.clientId.secretName (or (not .Values.global.cloud.resourceId.secretName) (not .Values.telemetryCollector.cloud.clientSecret.secretName))) }}
-{{fail "When telemetryCollector.cloud.clientId.secretName is set, global.cloud.resourceId.secretName, telemetryCollector.cloud.clientSecret.secretName must also be set."}}
+{{- if (and .Values.telemetryCollector.cloud.clientId.secretName (and (not .Values.global.cloud.clientSecret.secretName) (not .Values.telemetryCollector.cloud.clientSecret.secretName))) }}
+{{fail "When telemetryCollector.cloud.clientId.secretName is set, telemetryCollector.cloud.clientSecret.secretName must also be set."}}
 {{- end }}
-{{- if (and .Values.telemetryCollector.cloud.clientSecret.secretName (or (not .Values.global.cloud.resourceId.secretName) (not .Values.telemetryCollector.cloud.clientSecret.secretName))) }}
-{{fail "When telemetryCollector.cloud.clientSecret.secretName is set, global.cloud.resourceId.secretName,telemetryCollector.cloud.clientId.secretName must also be set."}}
+{{- if (and .Values.telemetryCollector.cloud.clientSecret.secretName (and (not .Values.global.cloud.clientId.secretName) (not .Values.telemetryCollector.cloud.clientId.secretName))) }}
+{{fail "When telemetryCollector.cloud.clientSecret.secretName is set, telemetryCollector.cloud.clientId.secretName must also be set."}}
 {{- end }}
 {{- end }}
 
@@ -457,10 +457,29 @@ Usage: {{ template "consul.validateTelemetryCollectorCloud" . }}
 {{- if or (and .Values.telemetryCollector.cloud.clientSecret.secretName (not .Values.telemetryCollector.cloud.clientSecret.secretKey)) (and .Values.telemetryCollector.cloud.clientSecret.secretKey (not .Values.telemetryCollector.cloud.clientSecret.secretName)) }}
 {{fail "When either telemetryCollector.cloud.clientSecret.secretName or telemetryCollector.cloud.clientSecret.secretKey is defined, both must be set."}}
 {{- end }}
-{{- if or (and .Values.telemetryCollector.cloud.clientSecret.secretName .Values.telemetryCollector.cloud.clientSecret.secretKey .Values.telemetryCollector.cloud.clientId.secretName .Values.telemetryCollector.cloud.clientId.secretKey (not .Values.global.cloud.resourceId.secretName)) }}
-{{fail "When telemetryCollector has clientId and clientSecret global.cloud.resourceId.secretName must be set"}}
+{{- if or (and .Values.telemetryCollector.cloud.clientSecret.secretName .Values.telemetryCollector.cloud.clientSecret.secretKey .Values.telemetryCollector.cloud.clientId.secretName .Values.telemetryCollector.cloud.clientId.secretKey (not (or .Values.telemetryCollector.cloud.resourceId.secretName .Values.global.cloud.resourceId.secretName))) }}
+{{fail "When telemetryCollector has clientId and clientSecret, telemetryCollector.cloud.resourceId.secretName or global.cloud.resourceId.secretName must be set"}}
 {{- end }}
-{{- if or (and .Values.telemetryCollector.cloud.clientSecret.secretName .Values.telemetryCollector.cloud.clientSecret.secretKey .Values.telemetryCollector.cloud.clientId.secretName .Values.telemetryCollector.cloud.clientId.secretKey (not .Values.global.cloud.resourceId.secretKey)) }}
-{{fail "When telemetryCollector has clientId and clientSecret .global.cloud.resourceId.secretKey must be set"}}
+{{- if or (and .Values.telemetryCollector.cloud.clientSecret.secretName .Values.telemetryCollector.cloud.clientSecret.secretKey .Values.telemetryCollector.cloud.clientId.secretName .Values.telemetryCollector.cloud.clientId.secretKey (not (or .Values.telemetryCollector.cloud.resourceId.secretKey .Values.global.cloud.resourceId.secretKey))) }}
+{{fail "When telemetryCollector has clientId and clientSecret, telemetryCollector.cloud.resourceId.secretKey or global.cloud.resourceId.secretKey must be set"}}
 {{- end }}
 {{- end -}}
+
+{{/*
+Fails if telemetryCollector.cloud.resourceId is set but differs from global.cloud.resourceId. This should never happen. Either one or both are set, but they should never differ.
+If they differ, that implies we're configuring servers for one HCP Consul cluster but pushing envoy metrics for a different HCP Consul cluster. A user could set the same value
+in two secrets (it's questionable whether resourceId should be a secret at all) but we won't know at this point, so we just check secret name+key.
+
+Usage: {{ template "consul.validateTelemetryCollectorResourceId" . }}
+
+*/}}
+{{- define "consul.validateTelemetryCollectorResourceId" -}}
+{{- if and (and .Values.telemetryCollector.cloud.resourceId.secretName .Values.global.cloud.resourceId.secretName) (not (eq .Values.telemetryCollector.cloud.resourceId.secretName .Values.global.cloud.resourceId.secretName)) }}
+{{fail "When both global.cloud.resourceId.secretName and telemetryCollector.cloud.resourceId.secretName are set, they should be the same."}}
+{{- end }}
+{{- if and (and .Values.telemetryCollector.cloud.resourceId.secretKey .Values.global.cloud.resourceId.secretKey) (not (eq .Values.telemetryCollector.cloud.resourceId.secretKey .Values.global.cloud.resourceId.secretKey)) }}
+{{fail "When both global.cloud.resourceId.secretKey and telemetryCollector.cloud.resourceId.secretKey are set, they should be the same."}}
+{{- end }}
+{{- end }}
+
+{{/**/}}

--- a/charts/consul/templates/telemetry-collector-deployment.yaml
+++ b/charts/consul/templates/telemetry-collector-deployment.yaml
@@ -5,6 +5,7 @@
 {{ template "consul.validateCloudSecretKeys" . }}
 {{ template "consul.validateTelemetryCollectorCloud" . }}
 {{ template "consul.validateTelemetryCollectorCloudSecretKeys" . }}
+{{ template "consul.validateTelemetryCollectorResourceId" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -165,13 +166,32 @@ spec:
             # These are mounted as secrets so that the telemetry-collector can use them when cloud is enabled.
             # - the hcp-go-sdk in consul agent will already look for HCP_CLIENT_ID, HCP_CLIENT_SECRET, HCP_AUTH_URL,
             #   HCP_SCADA_ADDRESS, and HCP_API_HOST.  so nothing more needs to be done.
-            # - HCP_RESOURCE_ID is created for use in the global cloud section but we will share it here
+            # - HCP_RESOURCE_ID is created either in the global cloud section or in telemetryCollector.cloud
+            {{- if .Values.telemetryCollector.cloud.resourceId.secretName }}
+            - name: HCP_RESOURCE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.telemetryCollector.cloud.resourceId.secretName }}
+                  key: {{ .Values.telemetryCollector.cloud.resourceId.secretKey }}
+            {{- else if .Values.global.cloud.resourceId.secretName }}
+            - name: HCP_RESOURCE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.cloud.resourceId.secretName }}
+                  key: {{ .Values.global.cloud.resourceId.secretKey }}
+            {{- end }}
             {{- if .Values.telemetryCollector.cloud.clientId.secretName }}
             - name: HCP_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.telemetryCollector.cloud.clientId.secretName }}
                   key: {{ .Values.telemetryCollector.cloud.clientId.secretKey }}
+            {{- else if .Values.global.cloud.clientId.secretName }}
+            - name: HCP_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.cloud.clientId.secretName }}
+                  key: {{ .Values.global.cloud.clientId.secretKey }}
             {{- end }}
             {{- if .Values.telemetryCollector.cloud.clientSecret.secretName }}
             - name: HCP_CLIENT_SECRET
@@ -179,14 +199,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.telemetryCollector.cloud.clientSecret.secretName }}
                   key: {{ .Values.telemetryCollector.cloud.clientSecret.secretKey }}
-            {{- end}}
-            {{- if .Values.global.cloud.resourceId.secretName }}
-            - name: HCP_RESOURCE_ID
+            {{- else if .Values.global.cloud.clientSecret.secretName }}
+            - name: HCP_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.cloud.resourceId.secretName }}
-                  key: {{ .Values.global.cloud.resourceId.secretKey }}
-            {{- end }}
+                  name: {{ .Values.global.cloud.clientSecret.secretName }}
+                  key: {{ .Values.global.cloud.clientSecret.secretKey }}
+            {{- end}}
             {{- if .Values.global.cloud.authUrl.secretName }}
             - name: HCP_AUTH_URL
               valueFrom:
@@ -227,7 +246,7 @@ spec:
 
           consul-telemetry-collector agent \
           {{- if .Values.telemetryCollector.customExporterConfig }}
-          -config-file-path /consul/config/config.json \
+            -config-file-path /consul/config/config.json \
           {{ end }}
         volumeMounts:
           {{- if .Values.telemetryCollector.customExporterConfig }}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -114,7 +114,7 @@ global:
   # secretKey should be in the form of "key".
   secretsBackend:
     vault:
-      # Vault namespace (optional). This sets the Vault namespace for the `vault.hashicorp.com/namespace` 
+      # Vault namespace (optional). This sets the Vault namespace for the `vault.hashicorp.com/namespace`
       # agent annotation and [Vault Connect CA namespace](https://developer.hashicorp.com/consul/docs/connect/ca/vault#namespace).
       # To override one of these values individually, see `agentAnnotations` and `connectCA.additionalConfig`.
       vaultNamespace: ""
@@ -558,7 +558,7 @@ global:
     # If enabled, this datacenter will be federation-capable. Only federation
     # via mesh gateways is supported.
     # Mesh gateways and servers will be configured to allow federation.
-    # Requires `global.tls.enabled`, `connectInject.enabled`, and one of 
+    # Requires `global.tls.enabled`, `connectInject.enabled`, and one of
     # `meshGateway.enabled` or `externalServers.enabled` to be true.
     # Requires Consul 1.8+.
     enabled: false
@@ -588,7 +588,7 @@ global:
     # from the one used by the Consul Service Mesh.
     # Please refer to the [Kubernetes Auth Method documentation](https://developer.hashicorp.com/consul/docs/security/acl/auth-methods/kubernetes).
     #
-    # If `externalServers.enabled` is set to true, `global.federation.k8sAuthMethodHost` and 
+    # If `externalServers.enabled` is set to true, `global.federation.k8sAuthMethodHost` and
     # `externalServers.k8sAuthMethodHost` should be set to the same value.
     #
     # You can retrieve this value from your `kubeconfig` by running:
@@ -652,14 +652,15 @@ global:
   # the API before cancelling the request.
   consulAPITimeout: 5s
 
-  # Enables installing an HCP Consul self-managed cluster.
+  # Enables installing an HCP Consul Central self-managed cluster.
   # Requires Consul v1.14+.
   cloud:
-    # If true, the Helm chart will enable the installation of an HCP Consul
+    # If true, the Helm chart will enable the installation of an HCP Consul Central
     # self-managed cluster.
     enabled: false
 
-    # The name of the Kubernetes secret that holds the HCP resource id.
+    # The resource id of the HCP Consul Central cluster to link to. Eg:
+    # organization/27109cd4-a309-4bf3-9986-e1d071914b18/project/fcef6c24-259d-4510-bb8d-1d812e120e34/hashicorp.consul.global-network-manager.cluster/consul-cluster
     # This is required when global.cloud.enabled is true.
     resourceId:
       # The name of the Kubernetes secret that holds the resource id.
@@ -669,7 +670,8 @@ global:
       # @type: string
       secretKey: null
 
-    # The name of the Kubernetes secret that holds the HCP cloud client id.
+    # The client id portion of a [service principal](https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals) with authorization to link the cluster
+    # in global.cloud.resourceId to HCP Consul Central.
     # This is required when global.cloud.enabled is true.
     clientId:
       # The name of the Kubernetes secret that holds the client id.
@@ -679,7 +681,8 @@ global:
       # @type: string
       secretKey: null
 
-    # The name of the Kubernetes secret that holds the HCP cloud client secret.
+    # The client secret portion of a [service principal](https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals) with authorization to link the cluster
+    # in global.cloud.resourceId to HCP Consul Central.
     # This is required when global.cloud.enabled is true.
     clientSecret:
       # The name of the Kubernetes secret that holds the client secret.
@@ -689,8 +692,7 @@ global:
       # @type: string
       secretKey: null
 
-    # The name of the Kubernetes secret that holds the HCP cloud client id.
-    # This is optional when global.cloud.enabled is true.
+    # The hostname of HCP's API. This setting is used for internal testing and validation.
     apiHost:
       # The name of the Kubernetes secret that holds the api hostname.
       # @type: string
@@ -699,8 +701,7 @@ global:
       # @type: string
       secretKey: null
 
-    # The name of the Kubernetes secret that holds the HCP cloud authorization url.
-    # This is optional when global.cloud.enabled is true.
+    # The URL of HCP's auth API. This setting is used for internal testing and validation.
     authUrl:
       # The name of the Kubernetes secret that holds the authorization url.
       # @type: string
@@ -709,8 +710,7 @@ global:
       # @type: string
       secretKey: null
 
-    # The name of the Kubernetes secret that holds the HCP cloud scada address.
-    # This is optional when global.cloud.enabled is true.
+    # The address of HCP's scada service. This setting is used for internal testing and validation.
     scadaAddress:
       # The name of the Kubernetes secret that holds the scada address.
       # @type: string
@@ -866,9 +866,9 @@ server:
 
   # The [Persistent Volume Claim (PVC) retention policy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)
   # controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
-  # WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted, 
+  # WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted,
   # and WhenScaled specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is scaled down.
-  # 
+  #
   # Example:
   #
   # ```yaml
@@ -883,7 +883,7 @@ server:
   # _will not_ automatically secure pod communication, this
   # setting will only enable usage of the feature. Consul will automatically initialize
   # a new CA and set of certificates. Additional service mesh settings can be configured
-  # by setting the `server.extraConfig` value or by applying [configuration entries](https://developer.hashicorp.com/consul/docs/connect/config-entries). 
+  # by setting the `server.extraConfig` value or by applying [configuration entries](https://developer.hashicorp.com/consul/docs/connect/config-entries).
   connect: true
 
   serviceAccount:
@@ -1352,7 +1352,7 @@ externalServers:
   # This address must be reachable from the Consul servers.
   # Please refer to the [Kubernetes Auth Method documentation](https://developer.hashicorp.com/consul/docs/security/acl/auth-methods/kubernetes).
   #
-  # If `global.federation.enabled` is set to true, `global.federation.k8sAuthMethodHost` and 
+  # If `global.federation.enabled` is set to true, `global.federation.k8sAuthMethodHost` and
   # `externalServers.k8sAuthMethodHost` should be set to the same value.
   #
   # You could retrieve this value from your `kubeconfig` by running:
@@ -2947,8 +2947,8 @@ ingressGateways:
 
   # Gateways is a list of gateway objects. The only required field for
   # each is `name`, though they can also contain any of the fields in
-  # `defaults`. You must provide a unique name for each ingress gateway. These names 
-  # must be unique across different namespaces. 
+  # `defaults`. You must provide a unique name for each ingress gateway. These names
+  # must be unique across different namespaces.
   # Values defined here override the defaults, except in the case of annotations where both will be applied.
   # @type: array<map>
   gateways:
@@ -3342,7 +3342,7 @@ telemetryCollector:
   customExporterConfig: null
 
   service:
-    # This value defines additional annotations for the server service account. This should be formatted as a multi-line
+    # This value defines additional annotations for the telemetry-collector's service account. This should be formatted as a multi-line
     # string.
     #
     # ```yaml
@@ -3368,11 +3368,51 @@ telemetryCollector:
     annotations: null
 
   cloud:
-    clientId:
+    # The resource id of the HCP Consul Central cluster to push metrics for. Eg:
+    # `organization/27109cd4-a309-4bf3-9986-e1d071914b18/project/fcef6c24-259d-4510-bb8d-1d812e120e34/hashicorp.consul.global-network-manager.cluster/consul-cluster`
+    #
+    # This is used for HCP Consul Central-linked or managed clusters where global.cloud.resourceId is unset. For example, when using externalServers
+    # with HCP Consul-managed clusters or HCP Consul Central-linked clusters in a different admin partition.
+    #
+    # If global.cloud.resourceId is set, this should either be unset (defaulting to global.cloud.resourceId) or be the same as global.cloud.resourceId.
+    #
+    # @default: global.cloud.resourceId
+    resourceId:
+      # The name of the Kubernetes secret that holds the resource id.
+      # @type: string
       secretName: null
+      # The key within the Kubernetes secret that holds the resource id.
+      # @type: string
       secretKey: null
-    clientSecret:
+
+    # The client id portion of a [service principal](https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals) with authorization to push metrics to HCP
+    #
+    # This is set in two scenarios:
+    #   - the service principal in global.cloud is unset
+    #   - the HCP UI provides a service principal with more narrowly scoped permissions that the service principal used in global.cloud
+    #
+    # @default: global.cloud.clientId
+    clientId:
+      # The name of the Kubernetes secret that holds the client id.
+      # @type: string
       secretName: null
+      # The key within the Kubernetes secret that holds the client id.
+      # @type: string
+      secretKey: null
+
+    # The client secret portion of a [service principal](https://developer.hashicorp.com/hcp/docs/hcp/admin/iam/service-principals#service-principals) with authorization to push metrics to HCP.
+    #
+    # This is set in two scenarios:
+    #   - the service principal in global.cloud is unset
+    #   - the HCP UI provides a service principal with more narrowly scoped permissions that the service principal used in global.cloud
+    #
+    # @default: global.cloud.clientSecret
+    clientSecret:
+      # The name of the Kubernetes secret that holds the client secret.
+      # @type: string
+      secretName: null
+      # The key within the Kubernetes secret that holds the client secret.
+      # @type: string
       secretKey: null
 
   initContainer:
@@ -3389,7 +3429,7 @@ telemetryCollector:
   # @type: string
   priorityClassName: ""
 
-  # A list of extra environment variables to set within the stateful set.
+  # A list of extra environment variables to set within the deployment.
   # These could be used to include proxy settings required for cloud auto-join
   # feature, in case kubernetes cluster is behind egress http proxies. Additionally,
   # it could be used to configure custom consul parameters.


### PR DESCRIPTION
This is a cherry-picked backport since the automatically generated one failed (I changed files in that PR that don't exist in 1.1.x release branch): https://github.com/hashicorp/consul-k8s/pull/3238

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


