### PR TITLE
NET-6394 Create/update/delete ServiceAccount on MeshGateway reconcile

### DIFF
--- a/control-plane/api/mesh/v2beta1/mesh_gateway_types.go
+++ b/control-plane/api/mesh/v2beta1/mesh_gateway_types.go
@@ -51,13 +51,13 @@ type MeshGatewayList struct {
 	Items           []*MeshGateway `json:"items"`
 }
 
-func (in *MeshGateway) ResourceID(namespace, partition string) *pbresource.ID {
+func (in *MeshGateway) ResourceID(_, partition string) *pbresource.ID {
 	return &pbresource.ID{
 		Name: in.Name,
 		Type: pbmesh.MeshGatewayType,
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
-			Namespace: namespace,
+			Namespace: "", // Namespace is always unset because MeshGateway is partition-scoped
 
 			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
 			// At a future point, this will move out of the Tenancy block.

--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
@@ -72,8 +72,6 @@ func (r *MeshGatewayController) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *MeshGatewayController) onCreateUpdate(ctx context.Context, req ctrl.Request, resource *meshv2beta1.MeshGateway) error {
-	// TODO NET-6392 NET-6393 NET-6394 NET-6395
-
 	builder := gateways.NewMeshGatewayBuilder(resource)
 
 	ifNew := func(ctx context.Context, object client.Object) error {
@@ -89,12 +87,12 @@ func (r *MeshGatewayController) onCreateUpdate(ctx context.Context, req ctrl.Req
 		return err
 	}
 
+	// TODO NET-6392 NET-6393 NET-6395
+
 	return nil
 }
 
 func (r *MeshGatewayController) onDelete(ctx context.Context, req ctrl.Request, resource *meshv2beta1.MeshGateway) error {
-	// TODO NET-6392 NET-6393 NET-6394 NET-6395
-
 	builder := gateways.NewMeshGatewayBuilder(resource)
 
 	ifExists := func(ctx context.Context, object client.Object) error {
@@ -105,6 +103,8 @@ func (r *MeshGatewayController) onDelete(ctx context.Context, req ctrl.Request, 
 	if err != nil {
 		return err
 	}
+
+	// TODO NET-6392 NET-6393 NET-6395
 
 	return nil
 }

--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
@@ -109,7 +109,7 @@ func (r *MeshGatewayController) onDelete(ctx context.Context, req ctrl.Request, 
 	return nil
 }
 
-// ownedObjectOp represent an operation that needs to be applied
+// ownedObjectOp represents an operation that needs to be applied
 // only if the newObject does not yet exist or if the existingObject
 // has an owner reference pointing to the MeshGateway being reconciled.
 //

--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
@@ -5,7 +5,6 @@ package controllersv2
 
 import (
 	"context"
-	"errors"
 
 	"github.com/go-logr/logr"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -15,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	meshv2beta1 "github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
+	"github.com/hashicorp/consul-k8s/control-plane/gateways"
 )
 
 // MeshGatewayController reconciles a MeshGateway object.
@@ -70,10 +70,14 @@ func (r *MeshGatewayController) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *MeshGatewayController) onCreateUpdate(ctx context.Context, req ctrl.Request, resource *meshv2beta1.MeshGateway) error {
 	// TODO NET-6392 NET-6393 NET-6394 NET-6395
-	return errors.New("onCreateUpdate not implemented")
+
+	serviceAccount := gateways.NewMeshGatewayServiceAccount(resource)
+	return r.Create(ctx, serviceAccount)
 }
 
 func (r *MeshGatewayController) onDelete(ctx context.Context, req ctrl.Request, resource *meshv2beta1.MeshGateway) error {
 	// TODO NET-6392 NET-6393 NET-6394 NET-6395
-	return errors.New("onDelete not implemented")
+
+	serviceAccount := gateways.NewMeshGatewayServiceAccount(resource)
+	return r.Delete(ctx, serviceAccount)
 }

--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
@@ -68,7 +68,10 @@ func (r *MeshGatewayController) UpdateStatus(ctx context.Context, obj client.Obj
 }
 
 func (r *MeshGatewayController) SetupWithManager(mgr ctrl.Manager) error {
-	return setupWithManager(mgr, &meshv2beta1.MeshGateway{}, r)
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&meshv2beta1.MeshGateway{}).
+		Owns(&corev1.ServiceAccount{}).
+		Complete(r)
 }
 
 func (r *MeshGatewayController) onCreateUpdate(ctx context.Context, req ctrl.Request, resource *meshv2beta1.MeshGateway) error {

--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
@@ -74,6 +74,14 @@ func (r *MeshGatewayController) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+// onCreateUpdate is responsible for creating/updating all K8s resources that
+// are required in order to run a meshv2beta1.MeshGateway. These are created/updated
+// in dependency order.
+//  1. ServiceAccount
+//  2. Deployment
+//  3. Service
+//  4. Role
+//  5. RoleBinding
 func (r *MeshGatewayController) onCreateUpdate(ctx context.Context, req ctrl.Request, resource *meshv2beta1.MeshGateway) error {
 	builder := gateways.NewMeshGatewayBuilder(resource)
 
@@ -92,20 +100,12 @@ func (r *MeshGatewayController) onCreateUpdate(ctx context.Context, req ctrl.Req
 	return nil
 }
 
+// onDelete is responsible for cleaning up any side effects of onCreateUpdate.
+// We only clean up side effects because all resources that we create explicitly
+// have an owner reference and will thus be cleaned up by the K8s garbage collector
+// once the owning meshv2beta1.MeshGateway is deleted.
 func (r *MeshGatewayController) onDelete(ctx context.Context, req ctrl.Request, resource *meshv2beta1.MeshGateway) error {
-	builder := gateways.NewMeshGatewayBuilder(resource)
-
-	deleteOp := func(ctx context.Context, _, object client.Object) error {
-		return r.Delete(ctx, object)
-	}
-
-	err := r.opIfNewOrOwned(ctx, resource, &corev1.ServiceAccount{}, builder.ServiceAccount(), deleteOp)
-	if err != nil {
-		return err
-	}
-
 	// TODO NET-6392 NET-6393 NET-6395
-
 	return nil
 }
 

--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
@@ -73,14 +73,27 @@ func (r *MeshGatewayController) SetupWithManager(mgr ctrl.Manager) error {
 func (r *MeshGatewayController) onCreateUpdate(ctx context.Context, req ctrl.Request, resource *meshv2beta1.MeshGateway) error {
 	// TODO NET-6392 NET-6393 NET-6394 NET-6395
 
-	return r.upsertIfNewOrOwned(ctx, resource, &corev1.ServiceAccount{}, gateways.NewMeshGatewayServiceAccount(resource))
+	builder := gateways.NewMeshGatewayBuilder(resource)
+
+	err := r.upsertIfNewOrOwned(ctx, resource, &corev1.ServiceAccount{}, builder.ServiceAccount())
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (r *MeshGatewayController) onDelete(ctx context.Context, req ctrl.Request, resource *meshv2beta1.MeshGateway) error {
 	// TODO NET-6392 NET-6393 NET-6394 NET-6395
 
-	serviceAccount := gateways.NewMeshGatewayServiceAccount(resource)
-	return r.Delete(ctx, serviceAccount)
+	builder := gateways.NewMeshGatewayBuilder(resource)
+
+	serviceAccount := builder.ServiceAccount()
+	if err := r.Delete(ctx, serviceAccount); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (r *MeshGatewayController) upsertIfNewOrOwned(ctx context.Context, gateway *meshv2beta1.MeshGateway, scanTarget, writeSource client.Object) error {

--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
@@ -115,7 +115,9 @@ type op func(context.Context, client.Object) error
 // resource that was not created by us. If this scenario is encountered, we error.
 func (r *MeshGatewayController) opIfNewOrOwned(ctx context.Context, gateway *meshv2beta1.MeshGateway, scanTarget, writeSource client.Object, ifNew, ifOwned op) error {
 	// Ensure owner reference is always set on objects that we write
-	ctrl.SetControllerReference(gateway, writeSource, r.Client.Scheme())
+	if err := ctrl.SetControllerReference(gateway, writeSource, r.Client.Scheme()); err != nil {
+		return err
+	}
 
 	key := client.ObjectKey{
 		Namespace: writeSource.GetNamespace(),

--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
@@ -55,8 +55,7 @@ func (r *MeshGatewayController) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
-	return ctrl.Result{}, nil
-	// return r.MeshConfigController.ReconcileEntry(ctx, r, req, &meshv2beta1.MeshGateway{})
+	return r.MeshConfigController.ReconcileEntry(ctx, r, req, &meshv2beta1.MeshGateway{})
 }
 
 func (r *MeshGatewayController) Logger(name types.NamespacedName) logr.Logger {

--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller_test.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller_test.go
@@ -10,10 +10,13 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
@@ -34,9 +37,11 @@ func TestMeshGatewayController_Reconcile(t *testing.T) {
 		expectedErr error
 		// expectedResult is the result we expect MeshGatewayController.Reconcile to return
 		expectedResult ctrl.Result
+		// postReconcile runs some set of assertions on the state of k8s after Reconcile is called
+		postReconcile func(*testing.T, client.Client)
 	}{
 		{
-			name: "onCreateUpdate",
+			name: "MeshGateway created with no existing ServiceAccount",
 			k8sObjects: []runtime.Object{
 				&v2beta1.MeshGateway{
 					ObjectMeta: metav1.ObjectMeta{
@@ -51,17 +56,26 @@ func TestMeshGatewayController_Reconcile(t *testing.T) {
 					Name:      "mesh-gateway",
 				},
 			},
-			expectedErr:    errors.New("onCreateUpdate not implemented"),
 			expectedResult: ctrl.Result{},
+			postReconcile: func(t *testing.T, c client.Client) {
+				// Verify ServiceAccount was created
+				key := client.ObjectKey{Namespace: "default", Name: "mesh-gateway"}
+				assert.NoError(t, c.Get(context.Background(), key, &corev1.ServiceAccount{}))
+			},
 		},
 		{
-			name: "onDelete",
+			name: "MeshGateway created with existing ServiceAccount not owned by gateway",
 			k8sObjects: []runtime.Object{
 				&v2beta1.MeshGateway{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace:         "default",
-						Name:              "mesh-gateway",
-						DeletionTimestamp: common.PointerTo(metav1.NewTime(time.Now())),
+						Namespace: "default",
+						Name:      "mesh-gateway",
+					},
+				},
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "mesh-gateway",
 					},
 				},
 			},
@@ -71,8 +85,109 @@ func TestMeshGatewayController_Reconcile(t *testing.T) {
 					Name:      "mesh-gateway",
 				},
 			},
-			expectedErr:    errors.New("onDelete not implemented"),
 			expectedResult: ctrl.Result{},
+			expectedErr:    errors.New("existing resource not owned by controller"),
+		},
+		{
+			name: "MeshGateway created with existing ServiceAccount owned by gateway",
+			k8sObjects: []runtime.Object{
+				&v2beta1.MeshGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "mesh-gateway",
+						UID:       "abc123",
+					},
+				},
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "mesh-gateway",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								UID:  "abc123",
+								Name: "mesh-gateway",
+							},
+						},
+					},
+				},
+			},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "default",
+					Name:      "mesh-gateway",
+				},
+			},
+			expectedResult: ctrl.Result{},
+			expectedErr:    nil, // The Reconcile should be a no-op
+		},
+		{
+			name: "MeshGateway deleted with existing ServiceAccount not owned by gateway",
+			k8sObjects: []runtime.Object{
+				&v2beta1.MeshGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         "default",
+						Name:              "mesh-gateway",
+						DeletionTimestamp: common.PointerTo(metav1.NewTime(time.Now())),
+					},
+				},
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "mesh-gateway",
+					},
+				},
+			},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "default",
+					Name:      "mesh-gateway",
+				},
+			},
+			expectedResult: ctrl.Result{},
+			expectedErr:    errors.New("existing resource not owned by controller"),
+			postReconcile: func(t *testing.T, c client.Client) {
+				// Verify ServiceAccount was not deleted
+				key := client.ObjectKey{Namespace: "default", Name: "mesh-gateway"}
+				assert.NoError(t, c.Get(context.Background(), key, &corev1.ServiceAccount{}))
+			},
+		},
+		{
+			name: "MeshGateway deleted with existing ServiceAccount owned by gateway",
+			k8sObjects: []runtime.Object{
+				&v2beta1.MeshGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         "default",
+						Name:              "mesh-gateway",
+						UID:               "abc123",
+						DeletionTimestamp: common.PointerTo(metav1.NewTime(time.Now())),
+					},
+				},
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "mesh-gateway",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								UID:  "abc123",
+								Name: "mesh-gateway",
+							},
+						},
+					},
+				},
+			},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "default",
+					Name:      "mesh-gateway",
+				},
+			},
+			expectedResult: ctrl.Result{},
+			postReconcile: func(t *testing.T, c client.Client) {
+				// Verify ServiceAccount was deleted
+				key := client.ObjectKey{Namespace: "default", Name: "mesh-gateway"}
+				err := c.Get(context.Background(), key, &corev1.ServiceAccount{})
+				assert.True(t, k8serr.IsNotFound(err))
+			},
 		},
 	}
 
@@ -83,6 +198,7 @@ func TestMeshGatewayController_Reconcile(t *testing.T) {
 			})
 
 			s := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(s))
 			s.AddKnownTypes(v2beta1.MeshGroupVersion, &v2beta1.MeshGateway{})
 			fakeClient := fake.NewClientBuilder().WithScheme(s).
 				WithRuntimeObjects(testCase.k8sObjects...).
@@ -105,6 +221,10 @@ func TestMeshGatewayController_Reconcile(t *testing.T) {
 				require.NoError(t, err)
 			}
 			assert.Equal(t, testCase.expectedResult, res)
+
+			if testCase.postReconcile != nil {
+				testCase.postReconcile(t, fakeClient)
+			}
 		})
 	}
 }

--- a/control-plane/gateways/builder.go
+++ b/control-plane/gateways/builder.go
@@ -1,0 +1,13 @@
+package gateways
+
+import meshv2beta1 "github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
+
+type meshGatewayBuilder struct {
+	gateway *meshv2beta1.MeshGateway
+}
+
+func NewMeshGatewayBuilder(gateway *meshv2beta1.MeshGateway) *meshGatewayBuilder {
+	return &meshGatewayBuilder{
+		gateway: gateway,
+	}
+}

--- a/control-plane/gateways/labels.go
+++ b/control-plane/gateways/labels.go
@@ -1,0 +1,7 @@
+package gateways
+
+func (b *meshGatewayBuilder) Labels() map[string]string {
+	return map[string]string{
+		"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+	}
+}

--- a/control-plane/gateways/serviceaccount.go
+++ b/control-plane/gateways/serviceaccount.go
@@ -3,16 +3,14 @@ package gateways
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
 )
 
-func NewMeshGatewayServiceAccount(gateway *v2beta1.MeshGateway) *corev1.ServiceAccount {
+func (b *meshGatewayBuilder) ServiceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      gateway.Name,
-			Namespace: gateway.Namespace,
-			Labels:    meshGatewayLabels(gateway),
+			Name:      b.gateway.Name,
+			Namespace: b.gateway.Namespace,
+			Labels:    b.Labels(),
 		},
 	}
 }

--- a/control-plane/gateways/serviceaccount.go
+++ b/control-plane/gateways/serviceaccount.go
@@ -1,0 +1,18 @@
+package gateways
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
+)
+
+func NewMeshGatewayServiceAccount(gateway *v2beta1.MeshGateway) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gateway.Name,
+			Namespace: gateway.Namespace,
+			Labels:    meshGatewayLabels(gateway),
+		},
+	}
+}

--- a/control-plane/gateways/serviceaccount_test.go
+++ b/control-plane/gateways/serviceaccount_test.go
@@ -1,0 +1,30 @@
+package gateways
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	meshv2beta1 "github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
+)
+
+func TestNewMeshGatewayBuilder_ServiceAccount(t *testing.T) {
+	b := NewMeshGatewayBuilder(&meshv2beta1.MeshGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "",
+			Name:      "mesh-gateway",
+		},
+	})
+
+	expected := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "",
+			Name:      "mesh-gateway",
+			Labels:    b.Labels(),
+		},
+	}
+
+	assert.Equal(t, expected, b.ServiceAccount())
+}


### PR DESCRIPTION
**Changes proposed in this PR:**
When reconciling a `MeshGateway` resource in the v2 API, create/update/delete a corresponding `ServiceAccount`.
Notably, we need to ensure we aren't updating or deleting resources that our controller didn't create simply because they have the expected name.

**How I've tested this PR:**
Added unit test coverage

**How I expect reviewers to test this PR:**
See above

**Checklist:**
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


