### PR TITLE
Remove Duplicate UBI Tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -328,8 +328,8 @@ jobs:
             docker.io/hashicorppreview/${{ env.repo }}-control-plane-fips:${{ env.minor_dev_tag }}
             docker.io/hashicorppreview/${{ env.repo }}-control-plane-fips:${{ env.minor_dev_tag }}-${{ github.sha }}
 
-  build-docker-ubi-redhat-registry:
-    name: Docker ${{ matrix.arch }} ${{ matrix.fips }} UBI build for RedHat Registry
+  build-docker-ubi:
+    name: Docker ${{ matrix.arch }} ${{ matrix.fips }} UBI builds
     needs: [get-product-version, build]
     runs-on: ubuntu-latest
     strategy:
@@ -354,69 +354,6 @@ jobs:
           unzip -j *.zip
       - name: Copy LICENSE
         run:
-         cp LICENSE ./control-plane
-      - name: Docker Build (Action)
-        if: ${{ !matrix.fips }}
-        uses: hashicorp/actions-docker-build@v1
-        with:
-          smoke_test: |
-            TEST_VERSION="$(docker run "${IMAGE_NAME}" consul-k8s-control-plane version  | awk '{print $2}')"
-            if [ "${TEST_VERSION}" != "v${version}" ]; then
-              echo "Test FAILED"
-              exit 1
-            fi
-            echo "Test PASSED"
-          version: ${{ env.version }}
-          target: ubi
-          arch: ${{ matrix.arch }}
-          pkg_name: consul-k8s-control-plane_${{ env.version }}
-          bin_name: consul-k8s-control-plane
-          workdir: control-plane
-          redhat_tag: quay.io/redhat-isv-containers/611ca2f89a9b407267837100:${{env.version}}-ubi
-      - name: Docker FIPS Build (Action)
-        if: ${{ matrix.fips }}
-        uses: hashicorp/actions-docker-build@v1
-        with:
-          smoke_test: |
-            TEST_VERSION="$(docker run "${IMAGE_NAME}" consul-k8s-control-plane version  | awk '{print $2}')"
-            if [ "${TEST_VERSION}" != "v${version}" ]; then
-              echo "Test FAILED"
-              exit 1
-            fi
-            echo "Test PASSED"
-          version: ${{ env.version }}
-          target: ubi-fips # duplicate target to distinguish FIPS builds in CRT machinery
-          arch: ${{ matrix.arch }}
-          pkg_name: consul-k8s-control-plane_${{ env.version }}
-          bin_name: consul-k8s-control-plane
-          workdir: control-plane
-          redhat_tag: quay.io/redhat-isv-containers/6486b1beabfc4e51588c0416:${{env.version}}-ubi # this is different than the non-FIPS one
-
-  build-docker-ubi-dockerhub:
-    name: Docker ${{ matrix.arch }} ${{ matrix.fips }} UBI build for DockerHub
-    needs: [ get-product-version, build ]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ "amd64" ]
-        fips: [ "+fips1402", "" ]
-    env:
-      repo: ${{ github.event.repository.name }}
-      version: ${{ needs.get-product-version.outputs.product-version }}${{ matrix.fips }}
-    steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: consul-cni_${{ needs.get-product-version.outputs.product-version }}${{ matrix.fips }}_linux_${{ matrix.arch }}.zip
-          path: control-plane/dist/cni/linux/${{ matrix.arch }}
-      - name: extract consul-cni zip
-        env:
-          ZIP_LOCATION: control-plane/dist/cni/linux/${{ matrix.arch }}
-        run: |
-          cd ${ZIP_LOCATION}
-          unzip -j *.zip
-      - name: Copy LICENSE
-        run:
           cp LICENSE ./control-plane
 
       # This naming convention will be used ONLY for per-commit dev images
@@ -428,8 +365,8 @@ jobs:
           echo "minor_dev_tag=$(echo ${{ env.version }}| sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+(-[0-9a-zA-Z\+\.]+)?$/\1\2/')" >> $GITHUB_ENV
 
       - name: Docker Build (Action)
-        uses: hashicorp/actions-docker-build@v1
         if: ${{ !matrix.fips }}
+        uses: hashicorp/actions-docker-build@v1
         with:
           smoke_test: |
             TEST_VERSION="$(docker run "${IMAGE_NAME}" consul-k8s-control-plane version  | awk '{print $2}')"
@@ -451,10 +388,10 @@ jobs:
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.full_dev_tag }}-ubi-${{ github.sha }}
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.minor_dev_tag }}-ubi
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.minor_dev_tag }}-ubi-${{ github.sha }}
-
+          redhat_tag: quay.io/redhat-isv-containers/611ca2f89a9b407267837100:${{env.version}}-ubi
       - name: Docker FIPS Build (Action)
-        uses: hashicorp/actions-docker-build@v1
         if: ${{ matrix.fips }}
+        uses: hashicorp/actions-docker-build@v1
         with:
           smoke_test: |
             TEST_VERSION="$(docker run "${IMAGE_NAME}" consul-k8s-control-plane version  | awk '{print $2}')"
@@ -469,10 +406,4 @@ jobs:
           pkg_name: consul-k8s-control-plane_${{ env.version }}
           bin_name: consul-k8s-control-plane
           workdir: control-plane
-          tags: |
-            docker.io/hashicorp/${{ env.repo }}-control-plane-fips:${{ env.version }}-ubi
-          dev_tags: |
-            docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.full_dev_tag }}-ubi
-            docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.full_dev_tag }}-ubi-${{ github.sha }}
-            docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.minor_dev_tag }}-ubi
-            docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.minor_dev_tag }}-ubi-${{ github.sha }}
+          redhat_tag: quay.io/redhat-isv-containers/6486b1beabfc4e51588c0416:${{env.version}}-ubi # this is different than the non-FIPS one


### PR DESCRIPTION
This PR is intended to avoid a [production incident](https://github.com/hashicorp/releng-support/issues/123) where there are duplicate tags (auto-assigned) to UBI images. The entire issue is described [here](https://github.com/hashicorp/crt-workflows-common/pull/407#issue-1999804835), and can be avoided by building `UBI`s (intended for both `Dockerhub` and `Redhat`) in one step.

### PR Checklist

* [x] appropriate backport labels added
* [x] not a security concern
