### PR TITLE
Backport of Fix consul-telemetry-collector deployments to non-default namespaces into release/1.3.x

### DIFF
--- a/.changelog/3215.txt
+++ b/.changelog/3215.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul-telemetry-collector: fix deployments to non-default namespaces when global.enableConsulNamespaces
+```

--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -3,6 +3,7 @@ module github.com/hashicorp/consul-k8s/acceptance
 go 1.20
 
 require (
+	github.com/google/uuid v1.3.0
 	github.com/gruntwork-io/terratest v0.31.2
 	github.com/hashicorp/consul-k8s/control-plane v0.0.0-20230609143603-198c4433d892
 	github.com/hashicorp/consul/api v1.10.1-0.20230906155245-56917eb4c968
@@ -13,6 +14,8 @@ require (
 	github.com/hashicorp/serf v0.10.1
 	github.com/hashicorp/vault/api v1.8.3
 	github.com/stretchr/testify v1.8.3
+	go.opentelemetry.io/proto/otlp v1.0.0
+	google.golang.org/protobuf v1.31.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
@@ -60,7 +63,7 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/gruntwork-io/gruntwork-cli v0.7.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.11 // indirect
@@ -123,7 +126,7 @@ require (
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/oauth2 v0.7.0 // indirect
+	golang.org/x/oauth2 v0.8.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/term v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
@@ -131,9 +134,9 @@ require (
 	golang.org/x/tools v0.7.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.3.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20230526203410-71b5a4ffd15e // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc // indirect
 	google.golang.org/grpc v1.56.3 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -299,6 +299,7 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -383,6 +384,8 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/gruntwork-io/gruntwork-cli v0.7.0 h1:YgSAmfCj9c61H+zuvHwKfYUwlMhu5arnQQLM4RH+CYs=
 github.com/gruntwork-io/gruntwork-cli v0.7.0/go.mod h1:jp6Z7NcLF2avpY8v71fBx6hds9eOFPELSuD/VPv7w00=
 github.com/gruntwork-io/terratest v0.31.2 h1:xvYHA80MUq5kx670dM18HInewOrrQrAN+XbVVtytUHg=
@@ -507,7 +510,7 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -765,6 +768,8 @@ go.opentelemetry.io/otel v1.11.1/go.mod h1:1nNhXBbWSD0nsL38H6btgnFN2k4i0sNLHNNMZ
 go.opentelemetry.io/otel/sdk v1.11.1 h1:F7KmQgoHljhUuJyA+9BiU+EkJfyX5nVVF4wyzWZpKxs=
 go.opentelemetry.io/otel/trace v1.11.1 h1:ofxdnzsNrGBYXbP7t7zpUK281+go5rF7dvdIZXF8gdQ=
 go.opentelemetry.io/otel/trace v1.11.1/go.mod h1:f/Q9G7vzk5u91PhbmKbg1Qn0rzH1LJ4vbPHFGkTPtOk=
+go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
+go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
@@ -884,8 +889,8 @@ golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
-golang.org/x/oauth2 v0.7.0 h1:qe6s0zUXlPX80/dITx3440hWZ7GwMwgDDyrSGTPJG/g=
-golang.org/x/oauth2 v0.7.0/go.mod h1:hPLQkd9LyjfXTiRohC/41GhcFqxisoUQ99sCUOHO9x4=
+golang.org/x/oauth2 v0.8.0 h1:6dkIjl3j3LtZ/O3sTgZTMsLKSftL/B8Zgq4huOIIUu8=
+golang.org/x/oauth2 v0.8.0/go.mod h1:yr7u4HXZRm1R1kBWqr/xKNqewf0plRYoB7sla+BCIXE=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1121,8 +1126,11 @@ google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20230526203410-71b5a4ffd15e h1:NumxXLPfHSndr3wBBdeKiVHjGVFzi9RX2HwwQke94iY=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20230526203410-71b5a4ffd15e/go.mod h1:66JfowdXAEgad5O9NnYcsNPLCPZJD++2L9X0PCMODrA=
+google.golang.org/genproto v0.0.0-20230526203410-71b5a4ffd15e h1:Ao9GzfUMPH3zjVfzXG5rlWlk+Q8MXWKwWpwVQE1MXfw=
+google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc h1:kVKPf/IiYSBWEWtkIn6wZXwWGCnLKcC8oWfZvXjsGnM=
+google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc/go.mod h1:vHYtlOoi6TsQ3Uk2yxR7NI5z8uoV+3pZtR4jmHIkRig=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc h1:XSJ8Vk1SWuNr8S18z1NZSziL0CPIXLCCMDOEFtHBOFc=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc/go.mod h1:66JfowdXAEgad5O9NnYcsNPLCPZJD++2L9X0PCMODrA=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -1151,8 +1159,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
-google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/acceptance/tests/cloud/basic_test.go
+++ b/acceptance/tests/cloud/basic_test.go
@@ -4,22 +4,19 @@
 package cloud
 
 import (
-	"crypto/tls"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	terratestk8s "github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
+	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/serf/testutil/retry"
 	"github.com/stretchr/testify/require"
 )
@@ -52,235 +49,260 @@ var (
 	scadaAddressSecretName     = "scadaaddress-sec-name"
 	scadaAddressSecretKey      = "scadaaddress-sec-key"
 	scadaAddressSecretKeyValue = "fake-server:443"
+
+	bootstrapTokenSecretName = "bootstrap-token"
+	bootstrapTokenSecretKey  = "token"
+	bootstrapToken           = uuid.NewString()
 )
 
-// The fake-server has a requestToken endpoint to retrieve the token.
-func requestToken(endpoint string) (string, error) {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-
-	client := &http.Client{Transport: tr}
-	url := fmt.Sprintf("https://%s/token", endpoint)
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		fmt.Println("Error creating request:", err)
-		return "", errors.New("error creating request")
-	}
-
-	// Perform the request
-	resp, err := client.Do(req)
-	if err != nil {
-		fmt.Println("Error sending request:", err)
-		return "", errors.New("error making request")
-	}
-	defer resp.Body.Close()
-
-	// Read the response body
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		fmt.Println("Error reading response:", err)
-		return "", errors.New("error reading body")
-	}
-
-	var tokenResponse TokenResponse
-	err = json.Unmarshal(body, &tokenResponse)
-	if err != nil {
-		fmt.Println("Error parsing response:", err)
-		return "", errors.New("error parsing body")
-	}
-
-	return tokenResponse.Token, nil
-
-}
-
-func TestBasicCloud(t *testing.T) {
-	ctx := suite.Environment().DefaultContext(t)
-
-	kubectlOptions := ctx.KubectlOptions(t)
-	ns := kubectlOptions.Namespace
-	k8sClient := environment.KubernetesClientFromOptions(t, kubectlOptions)
-
+func TestObservabilityCloud(t *testing.T) {
 	cfg := suite.Config()
 
 	if cfg.HCPResourceID != "" {
 		resourceSecretKeyValue = cfg.HCPResourceID
 	}
-	consul.CreateK8sSecret(t, k8sClient, cfg, ns, resourceSecretName, resourceSecretKey, resourceSecretKeyValue)
-	consul.CreateK8sSecret(t, k8sClient, cfg, ns, clientIDSecretName, clientIDSecretKey, clientIDSecretKeyValue)
-	consul.CreateK8sSecret(t, k8sClient, cfg, ns, clientSecretName, clientSecretKey, clientSecretKeyValue)
-	consul.CreateK8sSecret(t, k8sClient, cfg, ns, apiHostSecretName, apiHostSecretKey, apiHostSecretKeyValue)
-	consul.CreateK8sSecret(t, k8sClient, cfg, ns, authUrlSecretName, authUrlSecretKey, authUrlSecretKeyValue)
-	consul.CreateK8sSecret(t, k8sClient, cfg, ns, scadaAddressSecretName, scadaAddressSecretKey, scadaAddressSecretKeyValue)
 
-	k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/bases/cloud/hcp-mock")
-	podName, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "get", "pod", "-l", "app=fake-server", "-o", `jsonpath="{.items[0].metadata.name}"`)
-	podName = strings.ReplaceAll(podName, "\"", "")
-	if err != nil {
-		logger.Log(t, "error finding pod name")
-		return
-	}
-	logger.Log(t, "fake-server pod name:"+podName)
-	localPort := terratestk8s.GetAvailablePort(t)
-	tunnel := terratestk8s.NewTunnelWithLogger(
-		ctx.KubectlOptions(t),
-		terratestk8s.ResourceTypePod,
-		podName,
-		localPort,
-		443,
-		logger.TestLogger{})
-	defer tunnel.Close()
-	// Retry creating the port forward since it can fail occasionally.
-	retry.RunWith(&retry.Counter{Wait: 5 * time.Second, Count: 60}, t, func(r *retry.R) {
-		// NOTE: It's okay to pass in `t` to ForwardPortE despite being in a retry
-		// because we're using ForwardPortE (not ForwardPort) so the `t` won't
-		// get used to fail the test, just for logging.
-		require.NoError(r, tunnel.ForwardPortE(t))
-	})
-
-	logger.Log(t, "fake-server addr:"+tunnel.Endpoint())
-	consulToken, err := requestToken(tunnel.Endpoint())
-	if err != nil {
-		logger.Log(t, "error finding consul token")
-		return
+	cases := []struct {
+		name                      string
+		validateCloudInteractions bool
+		enableConsulNamespaces    bool
+		mirroringK8S              bool
+		adminPartitionsEnabled    bool
+		secure                    bool
+	}{
+		{
+			name:                      "default namespace and partition",
+			validateCloudInteractions: true,
+		},
+		{
+			name:   "default namespace and partition; secure",
+			secure: true,
+		},
+		{
+			name:                   "namespace mirroring; secure",
+			enableConsulNamespaces: true,
+			mirroringK8S:           true,
+			secure:                 true,
+		},
+		{
+			name:                   "admin partitions; secure",
+			enableConsulNamespaces: true,
+			mirroringK8S:           true,
+			adminPartitionsEnabled: true,
+			secure:                 true,
+		},
 	}
 
-	logger.Log(t, "consul test token :"+consulToken)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := suite.Environment().DefaultContext(t)
 
-	releaseName := helpers.RandomName()
+			if c.enableConsulNamespaces && !cfg.EnableEnterprise {
+				t.Skip("skipping this test because -enable-enterprise is not set")
+			}
 
-	helmValues := map[string]string{
-		"global.imagePullPolicy":             "IfNotPresent",
-		"global.cloud.enabled":               "true",
-		"global.cloud.resourceId.secretName": resourceSecretName,
-		"global.cloud.resourceId.secretKey":  resourceSecretKey,
+			options := &terratestk8s.KubectlOptions{
+				ContextName: ctx.KubectlOptions(t).ContextName,
+				ConfigPath:  ctx.KubectlOptions(t).ConfigPath,
+				Namespace:   ctx.KubectlOptions(t).Namespace,
+			}
+			ns := options.Namespace
 
-		"global.cloud.clientId.secretName": clientIDSecretName,
-		"global.cloud.clientId.secretKey":  clientIDSecretKey,
+			k8sClient := environment.KubernetesClientFromOptions(t, options)
 
-		"global.cloud.clientSecret.secretName": clientSecretName,
-		"global.cloud.clientSecret.secretKey":  clientSecretKey,
+			// Create cloud and telemetryCollector secrets.
+			consul.CreateK8sSecret(t, k8sClient, cfg, ns, resourceSecretName, resourceSecretKey, resourceSecretKeyValue)
+			consul.CreateK8sSecret(t, k8sClient, cfg, ns, clientIDSecretName, clientIDSecretKey, clientIDSecretKeyValue)
+			consul.CreateK8sSecret(t, k8sClient, cfg, ns, clientSecretName, clientSecretKey, clientSecretKeyValue)
+			consul.CreateK8sSecret(t, k8sClient, cfg, ns, apiHostSecretName, apiHostSecretKey, apiHostSecretKeyValue)
+			consul.CreateK8sSecret(t, k8sClient, cfg, ns, authUrlSecretName, authUrlSecretKey, authUrlSecretKeyValue)
+			consul.CreateK8sSecret(t, k8sClient, cfg, ns, scadaAddressSecretName, scadaAddressSecretKey, scadaAddressSecretKeyValue)
+			consul.CreateK8sSecret(t, k8sClient, cfg, ns, bootstrapTokenSecretName, bootstrapTokenSecretKey, bootstrapToken)
 
-		"global.cloud.apiHost.secretName": apiHostSecretName,
-		"global.cloud.apiHost.secretKey":  apiHostSecretKey,
+			k8s.DeployKustomize(t, options, cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/bases/cloud/hcp-mock")
+			podName, err := k8s.RunKubectlAndGetOutputE(t, options, "get", "pod", "-l", "app=fake-server", "-o", `jsonpath="{.items[0].metadata.name}"`)
+			podName = strings.ReplaceAll(podName, "\"", "")
+			if err != nil {
+				logger.Log(t, "error finding pod name")
+				return
+			}
+			logger.Log(t, "fake-server pod name:"+podName)
+			localPort := terratestk8s.GetAvailablePort(t)
+			tunnel := terratestk8s.NewTunnelWithLogger(
+				options,
+				terratestk8s.ResourceTypePod,
+				podName,
+				localPort,
+				443,
+				logger.TestLogger{})
+			defer tunnel.Close()
+			// Retry creating the port forward since it can fail occasionally.
+			retry.RunWith(&retry.Counter{Wait: 5 * time.Second, Count: 60}, t, func(r *retry.R) {
+				// NOTE: It's okay to pass in `t` to ForwardPortE despite being in a retry
+				// because we're using ForwardPortE (not ForwardPort) so the `t` won't
+				// get used to fail the test, just for logging.
+				require.NoError(r, tunnel.ForwardPortE(t))
+			})
 
-		"global.cloud.authUrl.secretName": authUrlSecretName,
-		"global.cloud.authUrl.secretKey":  authUrlSecretKey,
+			fsClient := newfakeServerClient(tunnel.Endpoint())
+			logger.Log(t, "fake-server addr:"+tunnel.Endpoint())
+			consulToken, err := fsClient.requestToken()
+			if err != nil {
+				logger.Log(t, "error finding consul token")
+				return
+			}
 
-		"global.cloud.scadaAddress.secretName": scadaAddressSecretName,
-		"global.cloud.scadaAddress.secretKey":  scadaAddressSecretKey,
-		"connectInject.default":                "true",
+			logger.Log(t, "consul test token :"+consulToken)
 
-		// TODO: Follow up with this bug
-		"global.acls.manageSystemACLs":         "false",
-		"global.gossipEncryption.autoGenerate": "false",
-		"global.tls.enabled":                   "true",
-		"global.tls.enableAutoEncrypt":         "true",
-		// TODO: Take this out
+			releaseName := helpers.RandomName()
 
-		"telemetryCollector.enabled":                   "true",
-		"telemetryCollector.image":                     cfg.ConsulCollectorImage,
-		"telemetryCollector.cloud.clientId.secretName": clientIDSecretName,
-		"telemetryCollector.cloud.clientId.secretKey":  clientIDSecretKey,
+			helmValues := map[string]string{
+				"global.imagePullPolicy": "IfNotPresent",
 
-		"telemetryCollector.cloud.clientSecret.secretName": clientSecretName,
-		"telemetryCollector.cloud.clientSecret.secretKey":  clientSecretKey,
-		// Either we set the global.trustedCAs (make sure it's idented exactly) or we
-		// set TLS to insecure
+				"global.acls.manageSystemACLs":   fmt.Sprint(c.secure),
+				"global.tls.enabled":             fmt.Sprint(c.secure),
+				"global.adminPartitions.enabled": fmt.Sprint(c.adminPartitionsEnabled),
 
-		"telemetryCollector.extraEnvironmentVars.HCP_API_TLS":       "insecure",
-		"telemetryCollector.extraEnvironmentVars.HCP_AUTH_TLS":      "insecure",
-		"telemetryCollector.extraEnvironmentVars.HCP_SCADA_TLS":     "insecure",
-		"telemetryCollector.extraEnvironmentVars.OTLP_EXPORTER_TLS": "insecure",
+				"global.enableConsulNamespaces":               fmt.Sprint(c.enableConsulNamespaces),
+				"connectInject.enabled":                       "true",
+				"connectInject.consulNamespaces.mirroringK8S": fmt.Sprint(c.mirroringK8S),
 
-		"server.extraEnvironmentVars.HCP_API_TLS":   "insecure",
-		"server.extraEnvironmentVars.HCP_AUTH_TLS":  "insecure",
-		"server.extraEnvironmentVars.HCP_SCADA_TLS": "insecure",
+				// TODO this doesn't appear to work because we just deploy to default using kubectl options from context.
+				// https://github.com/hashicorp/consul-k8s/blob/74097fe7b3023105ca755b45da9c72c716547f46/acceptance/framework/consul/helm_cluster.go#L107
+				// "connectInject.consulNamespaces.consulDestinationNamespace": c.destinationNamespace,
 
-		// This is pregenerated CA used for testing. It can be replaced at any time and isn't
-		// meant for anything other than testing
-		// 		"global.trustedCAs[0]": `-----BEGIN CERTIFICATE-----
-		// MIICrjCCAZYCCQD5LxMcnMY8rDANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDDA5m
-		// YWtlLXNlcnZlci1jYTAeFw0yMzA1MTkxMjIwMzhaFw0zMzA1MTYxMjIwMzhaMBkx
-		// FzAVBgNVBAMMDmZha2Utc2VydmVyLWNhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
-		// MIIBCgKCAQEAwhbiII7sMultedFzQVhVZz5Ti+9lWrpZb8y0ZR6NaNvoxDPX151t
-		// Adh5NegSeH/+351iDBGZHhmKECtBuk8FJgk88O7y8A7Yg+/lyeZd0SJTEeiYUe7d
-		// sSaBTYSmixyn6s15Y5MVp9gM7t2YXrocRkFxDtdhLMWf0zwzJEwDouFMMiFZw5II
-		// yDbI6UfwKyB8C8ln10+TcczbheaOMQ1jGn35YWAG/LEdutU6DO2Y/GZYQ41nyLF1
-		// klqh34USQPVQSQW7R7GiDxyhh1fGaDF6RAzH4RerzQSNvvTHmBXIGurB/Hnu1n3p
-		// CwWeatWMU5POy1es73S/EPM0NpWD5RabSwIDAQABMA0GCSqGSIb3DQEBCwUAA4IB
-		// AQBayoTltSW55PvKVp9cmqGOBMlkIMKPd6Ny4bCb/3UF+3bzQmIblh3O3kEt7WoY
-		// fA9vp+6cSRGVqgBfR2bi40RrerLNA79yywIZjfBMteNuRoul5VeD+mLyFCo4197r
-		// Atl2TEx2kl2V8rjCsEBcTqKqetVOMLYEZ2tbCeUt1A/K7OzaJfHgelEYcsVt68Q9
-		// /BLoo2UXfOpRrcsx7u7s5HPVbG3bx+1MvGJZ2C3i0B6agnkGDzEpoM4KZGxEefB9
-		// DOHIJfie9d9BQD52nZh3SGHz0b3vfJ430XrQmaNZ26fuIEyIYrpvyAhBXckj2iTD
-		// 1TXpqr/1D7EUbddktyhXTK9e
-		// -----END CERTIFICATE-----`,
+				"global.cloud.enabled":               "true",
+				"global.cloud.resourceId.secretName": resourceSecretName,
+				"global.cloud.resourceId.secretKey":  resourceSecretKey,
+
+				"global.cloud.clientId.secretName": clientIDSecretName,
+				"global.cloud.clientId.secretKey":  clientIDSecretKey,
+
+				"global.cloud.clientSecret.secretName": clientSecretName,
+				"global.cloud.clientSecret.secretKey":  clientSecretKey,
+
+				"global.cloud.apiHost.secretName": apiHostSecretName,
+				"global.cloud.apiHost.secretKey":  apiHostSecretKey,
+
+				"global.cloud.authUrl.secretName": authUrlSecretName,
+				"global.cloud.authUrl.secretKey":  authUrlSecretKey,
+
+				"global.cloud.scadaAddress.secretName": scadaAddressSecretName,
+				"global.cloud.scadaAddress.secretKey":  scadaAddressSecretKey,
+				"connectInject.default":                "true",
+
+				"telemetryCollector.enabled":                   "true",
+				"telemetryCollector.image":                     cfg.ConsulCollectorImage,
+				"telemetryCollector.cloud.clientId.secretName": clientIDSecretName,
+				"telemetryCollector.cloud.clientId.secretKey":  clientIDSecretKey,
+
+				"telemetryCollector.cloud.clientSecret.secretName": clientSecretName,
+				"telemetryCollector.cloud.clientSecret.secretKey":  clientSecretKey,
+
+				"telemetryCollector.extraEnvironmentVars.HCP_API_TLS":       "insecure",
+				"telemetryCollector.extraEnvironmentVars.HCP_AUTH_TLS":      "insecure",
+				"telemetryCollector.extraEnvironmentVars.HCP_SCADA_TLS":     "insecure",
+				"telemetryCollector.extraEnvironmentVars.OTLP_EXPORTER_TLS": "insecure",
+
+				"server.extraEnvironmentVars.HCP_API_TLS":   "insecure",
+				"server.extraEnvironmentVars.HCP_AUTH_TLS":  "insecure",
+				"server.extraEnvironmentVars.HCP_SCADA_TLS": "insecure",
+			}
+			if cfg.ConsulImage != "" {
+				helmValues["global.image"] = cfg.ConsulImage
+			}
+			if c.secure {
+				helmValues["global.acls.bootstrapToken.secretName"] = bootstrapTokenSecretName
+				helmValues["global.acls.bootstrapToken.secretKey"] = bootstrapTokenSecretKey
+			}
+
+			consulCluster := consul.NewHelmCluster(t, helmValues, ctx, cfg, releaseName)
+			consulCluster.ACLToken = bootstrapToken
+			consulCluster.Create(t)
+
+			logger.Log(t, "creating static-server deployment")
+			k8s.DeployKustomize(t, options, cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/bases/static-server")
+			t.Log("Finished deployment. Validating expected conditions now")
+
+			// Validate that the consul-telemetry-collector service was deployed to the expected namespace.
+			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
+			instances, _, err := consulClient.Catalog().Service("consul-telemetry-collector", "", &api.QueryOptions{Namespace: ns})
+			require.NoError(t, err)
+			require.Len(t, instances, 1)
+			require.Equal(t, "passing", instances[0].Checks.AggregatedStatus())
+
+			for name, tc := range map[string]struct {
+				refresh     *modifyTelemetryConfigBody
+				refreshTime int64
+				recordsPath string
+				timeout     time.Duration
+				wait        time.Duration
+				validations *metricValidations
+			}{
+				"collectorExportsMetrics": {
+					recordsPath: recordsPathCollector,
+					//  High timeout as Collector metrics scraped every 1 minute (https://github.com/hashicorp/consul-telemetry-collector/blob/dfdbf51b91d502a18f3b143a94ab4d50cdff10b8/internal/otel/config/helpers/receivers/prometheus_receiver.go#L54)
+					timeout: 5 * time.Minute,
+					wait:    1 * time.Second,
+					validations: &metricValidations{
+						expectedLabelKeys:    []string{"service_name", "service_instance_id"},
+						expectedMetricName:   "otelcol_receiver_accepted_metric_points",
+						disallowedMetricName: "server.memory_heap_size",
+					},
+				},
+				"consulPeriodicRefreshUpdateConfig": {
+					refresh: &modifyTelemetryConfigBody{
+						Filters: []string{"consul.state"},
+						Labels:  map[string]string{"new_label": "testLabel"},
+					},
+					recordsPath: recordsPathConsul,
+					//  High timeout as Consul server metrics exported every 1 minute (https://github.com/hashicorp/consul/blob/9776c10efb4472f196b47f88bc0db58b1bfa12ef/agent/hcp/telemetry/otel_sink.go#L27)
+					timeout: 3 * time.Minute,
+					wait:    1 * time.Second,
+					validations: &metricValidations{
+						expectedLabelKeys:    []string{"node_id", "node_name", "new_label"},
+						expectedMetricName:   "consul.state.services",
+						disallowedMetricName: "consul.fsm",
+					},
+				},
+				"consulPeriodicRefreshDisabled": {
+					refresh: &modifyTelemetryConfigBody{
+						Filters:  []string{"consul.state"},
+						Labels:   map[string]string{"new_label": "testLabel"},
+						Disabled: true,
+					},
+					recordsPath: recordsPathConsul,
+					// High timeout as Consul server metrics exported every 1 minute (https://github.com/hashicorp/consul/blob/9776c10efb4472f196b47f88bc0db58b1bfa12ef/agent/hcp/telemetry/otel_sink.go#L27)
+					timeout: 3 * time.Minute,
+					wait:    1 * time.Second,
+					validations: &metricValidations{
+						disabled: true,
+					},
+				},
+			} {
+				t.Run(name, func(t *testing.T) {
+					if !c.validateCloudInteractions {
+						t.Skip("skipping server metric and config validation")
+					}
+
+					// For a refresh test, we force a telemetry config update before validating metrics using fakeserver's /telemetry_config_modify endpoint.
+					if tc.refresh != nil {
+						refreshTime := time.Now()
+						err := fsClient.modifyTelemetryConfig(tc.refresh)
+						require.NoError(t, err)
+						// Add 10 seconds (2 * periodic refresh interval in fakeserver) to allow a periodic refresh from Consul side to take place.
+						tc.refreshTime = refreshTime.Add(10 * time.Second).UnixNano()
+					}
+
+					// Validate metrics are correct using fakeserver's /records endpoint to retrieve metric exports that occured from Consul/Collector to fakeserver.
+					// We use retry as we wait for Consul or the Collector to export metrics. This is the best we can do to avoid flakiness.
+					retry.RunWith(&retry.Timer{Timeout: tc.timeout, Wait: tc.wait}, t, func(r *retry.R) {
+						records, err := fsClient.getRecordsForPath(tc.recordsPath, tc.refreshTime)
+						require.NoError(r, err)
+						validateMetrics(r, records, tc.validations, tc.refreshTime)
+					})
+				})
+			}
+		})
 	}
-	if cfg.ConsulImage != "" {
-		helmValues["global.image"] = cfg.ConsulImage
-	}
-	if cfg.ConsulCollectorImage != "" {
-		helmValues["telemetryCollector.image"] = cfg.ConsulCollectorImage
-	}
-
-	consulCluster := consul.NewHelmCluster(t, helmValues, suite.Environment().DefaultContext(t), suite.Config(), releaseName)
-	consulCluster.Create(t)
-
-	logger.Log(t, "creating static-server deployment")
-
-	k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/bases/static-server")
-	t.Log("Finished deployment. Validating expected conditions now")
-	// Give some time for collector send metrics
-	time.Sleep(5 * time.Second)
-	err = validate(tunnel.Endpoint())
-	logger.Log(t, fmt.Sprintf("result: %v", err))
-	require.NoError(t, err)
-
-}
-
-func validate(endpoint string) error {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-
-	client := &http.Client{Transport: tr}
-	url := fmt.Sprintf("https://%s/validation", endpoint)
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		fmt.Println("Error creating request:", err)
-		return errors.New("error creating validation request")
-	}
-
-	// Perform the request
-	resp, err := client.Do(req)
-	if err != nil {
-		fmt.Println("Error sending request:", err)
-		return errors.New("error making  validation request")
-	}
-	if resp.StatusCode == http.StatusExpectationFailed {
-		// Read the response body
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			fmt.Println("Error reading response:", err)
-			return errors.New("error reading body")
-		}
-		var message errMsg
-		err = json.Unmarshal(body, &message)
-		if err != nil {
-			fmt.Println("Error parsing response:", err)
-			return errors.New("error parsing body")
-		}
-
-		return fmt.Errorf("Failed validation: %s", message)
-	} else if resp.StatusCode != http.StatusOK {
-		return errors.New("unexpected status code response from failure")
-	}
-
-	return nil
-
-}
-
-type errMsg struct {
-	Error string `json:"error"`
 }

--- a/acceptance/tests/cloud/fakeserver_client.go
+++ b/acceptance/tests/cloud/fakeserver_client.go
@@ -1,0 +1,158 @@
+package cloud
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+const (
+	// recordsPathConsul and recordsPathCollector distinguish metrics for consul vs. collector when fetching records.
+	recordsPathConsul    = "v1/metrics/consul"
+	recordsPathCollector = "v1/metrics/collector"
+)
+
+var (
+	errEncodingPayload = errors.New("failed to encode payload")
+	errCreatingRequest = errors.New("failed to create HTTP request")
+	errMakingRequest   = errors.New("failed to make request")
+	errReadingBody     = errors.New("failed to read body")
+	errClosingBody     = errors.New("failed to close body")
+	errParsingBody     = errors.New("failed to parse body")
+)
+
+// fakeServerClient provides an interface to communicate with the fakesever (a fake HCP Telemetry Gateway) via HTTP.
+type fakeServerClient struct {
+	client *http.Client
+	tunnel string
+}
+
+// modifyTelemetryConfigBody is a POST body that provides telemetry config changes to the fakeserver.
+type modifyTelemetryConfigBody struct {
+	Filters  []string          `json:"filters"`
+	Labels   map[string]string `json:"labels"`
+	Disabled bool              `json:"disabled"`
+}
+
+// TokenResponse is used to read a token response from the fakeserver.
+type TokenResponse struct {
+	Token string `json:"token"`
+}
+
+// RecordsResponse is used to read a /records response from the fakeserver.
+type RecordsResponse struct {
+	Records []*RequestRecord `json:"records"`
+}
+
+// RequestRecord holds info about a single request.
+type RequestRecord struct {
+	Method       string `json:"method"`
+	Path         string `json:"path"`
+	Body         []byte `json:"body"`
+	ValidRequest bool   `json:"validRequest"`
+	Timestamp    int64  `json:"timestamp"`
+}
+
+// newfakeServerClient returns a fakeServerClient to be used in tests to communicate with the fake Telemetry Gateway.
+func newfakeServerClient(tunnel string) *fakeServerClient {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	return &fakeServerClient{
+		client: &http.Client{Transport: tr},
+		tunnel: tunnel,
+	}
+}
+
+// requestToken retrieves a token from the fakeserver's token endpoint.
+func (f *fakeServerClient) requestToken() (string, error) {
+	url := fmt.Sprintf("https://%s/token", f.tunnel)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", errCreatingRequest, err)
+	}
+
+	resp, err := f.handleRequest(req)
+	if err != nil {
+		return "", err
+	}
+
+	tokenResponse := &TokenResponse{}
+	err = json.Unmarshal(resp, tokenResponse)
+	if err != nil {
+		return "", fmt.Errorf("%w : %w", errParsingBody, err)
+	}
+
+	return tokenResponse.Token, nil
+}
+
+// modifyTelemetryConfig can update the telemetry config returned by the fakeserver.
+// via the fakeserver's modify_telemetry_config endpoint.
+func (f *fakeServerClient) modifyTelemetryConfig(payload *modifyTelemetryConfigBody) error {
+	url := fmt.Sprintf("https://%s/modify_telemetry_config", f.tunnel)
+	payloadBuf := new(bytes.Buffer)
+
+	err := json.NewEncoder(payloadBuf).Encode(payload)
+	if err != nil {
+		return fmt.Errorf("%w:%w", errEncodingPayload, err)
+	}
+
+	req, err := http.NewRequest("POST", url, payloadBuf)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errCreatingRequest, err)
+	}
+
+	_, err = f.handleRequest(req)
+
+	return err
+}
+
+func (f *fakeServerClient) getRecordsForPath(path string, refreshTime int64) ([]*RequestRecord, error) {
+	url := fmt.Sprintf("https://%s/records/%s", f.tunnel, path)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errCreatingRequest, err)
+	}
+	if refreshTime > 0 {
+		q := req.URL.Query()
+		q.Add("since", strconv.FormatInt(refreshTime, 10))
+		req.URL.RawQuery = q.Encode()
+	}
+
+	resp, err := f.handleRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	recordsResponse := &RecordsResponse{}
+	err = json.Unmarshal(resp, recordsResponse)
+	if err != nil {
+		return nil, fmt.Errorf("%w : %w", errParsingBody, err)
+	}
+
+	return recordsResponse.Records, nil
+}
+
+// handleRequest returns the response body if the request is succesful.
+func (f *fakeServerClient) handleRequest(req *http.Request) ([]byte, error) {
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w : %w", errMakingRequest, err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	cErr := resp.Body.Close()
+	if cErr != nil {
+		return nil, fmt.Errorf("%w : %w", errClosingBody, err)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%w : %w", errReadingBody, err)
+	}
+
+	return body, nil
+}

--- a/acceptance/tests/cloud/metrics_validation.go
+++ b/acceptance/tests/cloud/metrics_validation.go
@@ -1,0 +1,114 @@
+package cloud
+
+import (
+	"strings"
+
+	"github.com/hashicorp/serf/testutil/retry"
+	"github.com/stretchr/testify/require"
+	otlpcolmetrics "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	otlpcommon "go.opentelemetry.io/proto/otlp/common/v1"
+	otlpmetrics "go.opentelemetry.io/proto/otlp/metrics/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+type metricValidations struct {
+	disabled             bool
+	expectedMetricName   string
+	disallowedMetricName string
+	expectedLabelKeys    []string
+}
+
+// validateMetrics ensure OTLP metrics as recorded by the Collector or Consul as expected.
+func validateMetrics(r *retry.R, records []*RequestRecord, validations *metricValidations, since int64) {
+	// If metrics are disabled, no metrics records should exist, and return early.
+	if validations.disabled {
+		require.Empty(r, records)
+		return
+	}
+
+	// If metrics are not disabled, records should not be empty.
+	require.NotEmpty(r, records)
+
+	for _, record := range records {
+		require.True(r, record.ValidRequest, "expected request to be valid")
+
+		req := &otlpcolmetrics.ExportMetricsServiceRequest{}
+		err := proto.Unmarshal(record.Body, req)
+		require.NoError(r, err, "failed to extract metrics from body")
+
+		// Basic validation that metrics are not empty.
+		require.NotEmpty(r, req.GetResourceMetrics())
+		require.NotEmpty(r, req.ResourceMetrics[0].GetScopeMetrics())
+		require.NotEmpty(r, req.ResourceMetrics[0].ScopeMetrics[0].GetMetrics())
+
+		// Verify expected key labels and metric names.
+		labels := externalLabels(req, since)
+		for _, key := range validations.expectedLabelKeys {
+			require.Contains(r, labels, key)
+		}
+		validateMetricName(r, req, validations)
+	}
+}
+
+// validateMetricName ensures an expected metric name has been recorded based on filters and disallowed metrics are not present.
+func validateMetricName(t *retry.R, request *otlpcolmetrics.ExportMetricsServiceRequest, validations *metricValidations) {
+	exists := false
+	for _, metric := range request.ResourceMetrics[0].ScopeMetrics[0].GetMetrics() {
+		require.NotContains(t, metric.Name, validations.disallowedMetricName)
+
+		if strings.Contains(metric.Name, validations.expectedMetricName) {
+			exists = true
+		}
+	}
+
+	require.True(t, exists)
+}
+
+// externalLabels converts OTLP labels to a map[string]string format.
+func externalLabels(request *otlpcolmetrics.ExportMetricsServiceRequest, since int64) map[string]string {
+	// For the Consul Telemetry Collector, labels are contained at the higher level scope.
+	attrs := request.ResourceMetrics[0].GetResource().GetAttributes()
+
+	// For Consul server metrics, labels are contained with individual metrics, and must be extracted.
+	if len(attrs) < 1 {
+		attrs = getMetricLabel(request.ResourceMetrics[0].GetScopeMetrics(), since)
+	}
+
+	labels := make(map[string]string, len(attrs))
+	for _, kv := range attrs {
+		k := strings.ReplaceAll(kv.GetKey(), ".", "_")
+		labels[k] = kv.GetValue().GetStringValue()
+	}
+
+	return labels
+}
+
+// getMetricLabel returns labels at each datapoint within a metric.
+func getMetricLabel(scopeMetrics []*otlpmetrics.ScopeMetrics, since int64) []*otlpcommon.KeyValue {
+	// The attributes field can only be accessed on the specific implementation (gauge, sum or hist).
+	for _, metric := range scopeMetrics[0].Metrics {
+		switch v := metric.Data.(type) {
+		case *otlpmetrics.Metric_Gauge:
+			for _, dp := range v.Gauge.GetDataPoints() {
+				// When a refresh has occured, filter time since last refresh as older data points may not have latest labels.
+				if dp.StartTimeUnixNano > uint64(since) {
+					return dp.Attributes
+				}
+			}
+		case *otlpmetrics.Metric_Histogram:
+			for _, dp := range v.Histogram.GetDataPoints() {
+				if dp.StartTimeUnixNano > uint64(since) {
+					return dp.Attributes
+				}
+			}
+		case *otlpmetrics.Metric_Sum:
+			for _, dp := range v.Sum.GetDataPoints() {
+				if dp.StartTimeUnixNano > uint64(since) {
+					return dp.Attributes
+				}
+			}
+		}
+	}
+
+	return []*otlpcommon.KeyValue{}
+}

--- a/acceptance/tests/cloud/observability_test.go
+++ b/acceptance/tests/cloud/observability_test.go
@@ -21,10 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type TokenResponse struct {
-	Token string `json:"token"`
-}
-
 var (
 	resourceSecretName     = "resource-sec-name"
 	resourceSecretKey      = "resource-sec-key"

--- a/charts/consul/templates/telemetry-collector-deployment.yaml
+++ b/charts/consul/templates/telemetry-collector-deployment.yaml
@@ -35,6 +35,8 @@ spec:
         # This annotation tells the endpoints controller that this pod was injected even though it wasn't. The
         # endpoints controller would then sync the endpoint into Consul
         "consul.hashicorp.com/connect-inject-status": "injected"
+        # Signals to the endpoints controller that we should force Consul NS creation, since we bypass the mesh webhook.
+        "consul.hashicorp.com/telemetry-collector": "true"
         # We aren't using tproxy and we don't have an original pod. This would be simpler if we made a path similar
         # to gateways
         "consul.hashicorp.com/connect-service-port": "metricsserver"
@@ -94,36 +96,51 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          {{- if .Values.global.acls.manageSystemACLs }}
-          - name: CONSUL_LOGIN_AUTH_METHOD
-            value: {{ template "consul.fullname" . }}-k8s-auth-method
-          - name: CONSUL_LOGIN_META
-            value: "component=consul-telemetry-collector,pod=$(NAMESPACE)/$(POD_NAME)"
-          {{- end }}
           - name: CONSUL_NODE_NAME
             value: $(NODE_NAME)-virtual
           {{- include "consul.consulK8sConsulServerEnvVars" . | nindent 10 }}
+          # acl login info
+          {{- if .Values.global.acls.manageSystemACLs }}
+          - name: CONSUL_LOGIN_AUTH_METHOD
+            value: {{ template "consul.fullname" . }}-k8s-auth-method
+          - name: CONSUL_LOGIN_DATACENTER
+            value: {{ .Values.global.datacenter }}
+          - name: CONSUL_LOGIN_META
+            value: "component=consul-telemetry-collector,pod=$(NAMESPACE)/$(POD_NAME)"
+          {{- end }}
+          # service and login namespace
+          # this is attempting to replicate the behavior of webhooks in calculating namespace
+          # https://github.com/hashicorp/consul-k8s/blob/b84339050bb2c4b62b60cec96275f74952b0ac9d/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go#L200 
           {{- if .Values.global.enableConsulNamespaces }}
+          {{- if .Values.connectInject.consulNamespaces.mirroringK8S }}
           - name: CONSUL_NAMESPACE
-            value: {{ .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }}
-          {{- if .Values.syncCatalog.consulNamespaces.mirroringK8S }}
+            value: {{ .Values.connectInject.consulNamespaces.mirroringK8SPrefix }}{{ .Release.Namespace }}
+          {{- else }}
+          - name: CONSUL_NAMESPACE
+            value: {{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
+          {{- end }}
+          {{- if .Values.global.acls.manageSystemACLs }}
+          {{- if .Values.connectInject.consulNamespaces.mirroringK8S }}
           - name: CONSUL_LOGIN_NAMESPACE
-            value: "default"
+            value: default
           {{- else }}
           - name: CONSUL_LOGIN_NAMESPACE
-            value: {{ .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }}
+            value: {{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
+          {{- end }} 
           {{- end }}
           {{- end }}
         command:
           - /bin/sh
           - -ec
           - |-
-            consul-k8s-control-plane connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
-              -log-level={{ default .Values.global.logLevel .Values.telemetryCollector.logLevel }} \
+            consul-k8s-control-plane connect-init \
               -log-json={{ .Values.global.logJSON }} \
+              -log-level={{ default .Values.global.logLevel .Values.telemetryCollector.logLevel }} \
+              -pod-name=${POD_NAME} \
+              -pod-namespace=${POD_NAMESPACE} \
+              -proxy-id-file="/consul/connect-inject/proxyid" \
               -service-account-name="consul-telemetry-collector" \
-              -service-name="" \
-              -proxy-id-file="/consul/connect-inject/proxyid"
+              -service-name=""
 
         image: {{ .Values.global.imageK8S }}
         imagePullPolicy: IfNotPresent
@@ -304,24 +321,30 @@ spec:
           - -credential-type=login
           - -login-bearer-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token
           - -login-auth-method={{ template "consul.fullname" . }}-k8s-auth-method
+          {{- end }}
+          # service and login namespace
           {{- if .Values.global.enableConsulNamespaces }}
-          {{- if .Values.syncCatalog.consulNamespaces.mirroringK8S }}
-          - -login-namespace="default"
+          {{- if .Values.connectInject.consulNamespaces.mirroringK8S }}
+          - -service-namespace={{ .Values.connectInject.consulNamespaces.mirroringK8SPrefix }}{{ .Release.Namespace }}
           {{- else }}
-          - -login-namespace={{ .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }}
+          - -service-namespace={{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
+          {{- end }}
+          {{- if .Values.global.acls.manageSystemACLs }}
+          {{- if .Values.connectInject.consulNamespaces.mirroringK8S }}
+          - -login-namespace=default
+          {{- else }}
+          - -login-namespace={{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
+          {{- end }} 
           {{- end }}
           {{- end }}
+          # service and login partition
           {{- if .Values.global.adminPartitions.enabled }}
-          - foo
+          - -service-partition={{ .Values.global.adminPartitions.name }}
+          {{- if .Values.global.acls.manageSystemACLs }}
           - -login-partition={{ .Values.global.adminPartitions.name }}
           {{- end }}
           {{- end }}
-          {{- if .Values.global.enableConsulNamespaces }}
-          - -service-namespace={{ .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }}
-          {{- end }}
-          {{- if .Values.global.adminPartitions.enabled }}
-          - -service-partition={{ .Values.global.adminPartitions.name }}
-          {{- end }}
+          # telemetry
           {{- if .Values.global.metrics.enabled }}
           - -telemetry-prom-scrape-path=/metrics
           {{- end }}

--- a/charts/consul/templates/telemetry-collector-v2-deployment.yaml
+++ b/charts/consul/templates/telemetry-collector-v2-deployment.yaml
@@ -88,22 +88,34 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          # acl login info
           {{- if .Values.global.acls.manageSystemACLs }}
           - name: CONSUL_LOGIN_AUTH_METHOD
             value: {{ template "consul.fullname" . }}-k8s-auth-method
+          - name: CONSUL_LOGIN_DATACENTER
+            value: {{ .Values.global.datacenter }}
           - name: CONSUL_LOGIN_META
             value: "component=consul-telemetry-collector,pod=$(NAMESPACE)/$(POD_NAME)"
           {{- end }}
-          {{- include "consul.consulK8sConsulServerEnvVars" . | nindent 10 }}
+          # service and login namespace
+          # this is attempting to replicate the behavior of webhooks in calculating namespace
+          # https://github.com/hashicorp/consul-k8s/blob/b84339050bb2c4b62b60cec96275f74952b0ac9d/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go#L200 
           {{- if .Values.global.enableConsulNamespaces }}
+          {{- if .Values.connectInject.consulNamespaces.mirroringK8S }}
           - name: CONSUL_NAMESPACE
-            value: {{ .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }}
-          {{- if .Values.syncCatalog.consulNamespaces.mirroringK8S }}
+            value: {{ .Values.connectInject.consulNamespaces.mirroringK8SPrefix }}{{ .Release.Namespace }}
+          {{- else }}
+          - name: CONSUL_NAMESPACE
+            value: {{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
+          {{- end }}
+          {{- if .Values.global.acls.manageSystemACLs }}
+          {{- if .Values.connectInject.consulNamespaces.mirroringK8S }}
           - name: CONSUL_LOGIN_NAMESPACE
             value: "default"
           {{- else }}
           - name: CONSUL_LOGIN_NAMESPACE
-            value: {{ .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }}
+            value: {{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
+          {{- end }} 
           {{- end }}
           {{- end }}
         command:
@@ -292,24 +304,30 @@ spec:
           - -credential-type=login
           - -login-bearer-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token
           - -login-auth-method={{ template "consul.fullname" . }}-k8s-auth-method
+          {{- end }}
+          # service and login namespace
           {{- if .Values.global.enableConsulNamespaces }}
-          {{- if .Values.syncCatalog.consulNamespaces.mirroringK8S }}
-          - -login-namespace="default"
+          {{- if .Values.connectInject.consulNamespaces.mirroringK8S }}
+          - -service-namespace={{ .Values.connectInject.consulNamespaces.mirroringK8SPrefix }}{{ .Release.Namespace }}
           {{- else }}
-          - -login-namespace={{ .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }}
+          - -service-namespace={{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
+          {{- end }}
+          {{- if .Values.global.acls.manageSystemACLs }}
+          {{- if .Values.connectInject.consulNamespaces.mirroringK8S }}
+          - -login-namespace=default
+          {{- else }}
+          - -login-namespace={{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
+          {{- end }} 
           {{- end }}
           {{- end }}
+          # service and login partition
           {{- if .Values.global.adminPartitions.enabled }}
-          - foo
+          - -service-partition={{ .Values.global.adminPartitions.name }}
+          {{- if .Values.global.acls.manageSystemACLs }}
           - -login-partition={{ .Values.global.adminPartitions.name }}
           {{- end }}
           {{- end }}
-          {{- if .Values.global.enableConsulNamespaces }}
-          - -service-namespace={{ .Values.syncCatalog.consulNamespaces.consulDestinationNamespace }}
-          {{- end }}
-          {{- if .Values.global.adminPartitions.enabled }}
-          - -service-partition={{ .Values.global.adminPartitions.name }}
-          {{- end }}
+          # telemetry
           {{- if .Values.global.metrics.enabled }}
           - -telemetry-prom-scrape-path=/metrics
           {{- end }}

--- a/charts/consul/test/unit/telemetry-collector-v2-deployment.bats
+++ b/charts/consul/test/unit/telemetry-collector-v2-deployment.bats
@@ -1357,3 +1357,50 @@ MIICFjCCAZsCCQCdwLtdjbzlYzAKBggqhkjOPQQDAjB0MQswCQYDVQQGEwJDQTEL' \
       --set 'telemetryCollector.image=bar' \
       .
 }
+
+#--------------------------------------------------------------------
+# Namespaces
+
+@test "telemetryCollector/Deployment(V2): namespace flags when mirroringK8S" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/telemetry-collector-v2-deployment.yaml   \
+      --set 'ui.enabled=false' \
+      --set 'global.experiments[0]=resource-apis' \
+      --set 'telemetryCollector.enabled=true' \
+      --set 'telemetryCollector.image=bar' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'connectInject.consulNamespaces.mirroringK8S=true' \
+      --namespace 'test-namespace' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec' | tee /dev/stderr)
+
+  local actual=$(echo $object | jq -r '.containers[1].args | any(contains("-login-namespace=default"))' | tee /dev/stderr)
+  [ "${actual}" = 'true' ]
+
+  local actual=$(echo $object | jq -r '.containers[1].args | any(contains("-service-namespace=test-namespace"))' | tee /dev/stderr)
+  [ "${actual}" = 'true' ]
+}
+
+@test "telemetryCollector/Deployment(V2): namespace flags when not mirroringK8S" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/telemetry-collector-v2-deployment.yaml   \
+      --set 'ui.enabled=false' \
+      --set 'global.experiments[0]=resource-apis' \
+      --set 'telemetryCollector.enabled=true' \
+      --set 'telemetryCollector.image=bar' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      --set 'connectInject.consulNamespaces.mirroringK8S=false' \
+      --set 'connectInject.consulNamespaces.consulDestinationNamespace=fakenamespace' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers' | tee /dev/stderr)
+
+  local actual=$(echo $object | jq -r '.[1].args | any(contains("-login-namespace=fakenamespace"))' | tee /dev/stderr)
+  [ "${actual}" = 'true' ]
+
+  local actual=$(echo $object | jq -r '.[1].args | any(contains("-service-namespace=fakenamespace"))' | tee /dev/stderr)
+  [ "${actual}" = 'true' ]
+}

--- a/control-plane/connect-inject/constants/annotations_and_labels.go
+++ b/control-plane/connect-inject/constants/annotations_and_labels.go
@@ -196,6 +196,11 @@ const (
 	// by the peering controllers.
 	LabelPeeringToken = "consul.hashicorp.com/peering-token"
 
+	// LabelTelemetryCollector is a label signaling the pod is associated with the deployment of a Consul Telemetry
+	// Collector. If this is set, during connect-inject, the endpoints-controller ensures the deployed Namespace exists in Consul and create it if it does not.
+	// This is only meant to be used by Deployment/consul-telemetry-collector.
+	LabelTelemetryCollector = "consul.hashicorp.com/telemetry-collector"
+
 	// Injected is used as the annotation value for keyInjectStatus and annotationInjected.
 	Injected = "injected"
 


### PR DESCRIPTION
This is a manual backport for the auto-gen one that failed

This backports this PR: https://github.com/hashicorp/consul-k8s/pull/3215

In a previous PR to consul-k8s the cloud observability tests were changed, but that wasn't backported. Because this backport includes acceptance test changes.. I'm also backporting those changes: https://github.com/hashicorp/consul-k8s/pull/2946