### PR TITLE
Set cron jobs for release branches back to weekly

### DIFF
--- a/.github/workflows/weekly-acceptance-1-1-x.yml
+++ b/.github/workflows/weekly-acceptance-1-1-x.yml
@@ -5,8 +5,8 @@ name: weekly-acceptance-1-1-x
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    # Run weekly on Wednesday at 3AM UTC/11PM EST/8PM PST
-    - cron:  '0 3 * * 3'
+    # Run weekly on Monday at 3AM UTC/11PM EST/8PM PST
+    - cron:  '0 3 * * 1'
 
 
 # these should be the only settings that you will ever need to change

--- a/.github/workflows/weekly-acceptance-1-2-x.yml
+++ b/.github/workflows/weekly-acceptance-1-2-x.yml
@@ -5,9 +5,8 @@ name: weekly-acceptance-1-2-x
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    # Run weekly on Wednesday at 3AM UTC/11PM EST/8PM PST
-   # - cron:  '0 3 * * 3'
-    - cron:  '0 0 * * *' # Temporarily nightly until 1.2.0 GA
+    # Run weekly on Tuesday at 3AM UTC/11PM EST/8PM PST
+    - cron:  '0 3 * * 2'
 
 
 # these should be the only settings that you will ever need to change

--- a/.github/workflows/weekly-acceptance-1-3-x.yml
+++ b/.github/workflows/weekly-acceptance-1-3-x.yml
@@ -6,9 +6,7 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Run weekly on Wednesday at 3AM UTC/11PM EST/8PM PST
-   # - cron:  '0 3 * * 3'
-    - cron:  '0 0 * * *' # Temporarily nightly until 1.2.0 GA
-
+   - cron:  '0 3 * * 3'
 
 # these should be the only settings that you will ever need to change
 env:


### PR DESCRIPTION
Changes proposed in this PR:
- The 'weekly' jobs were changed to run nightly. Set them back to nightly.

How I've tested this PR:

👀 

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


