### PR TITLE
Update MatchesConsul to normalize partitions during comparison.

### DIFF
--- a/.changelog/3284.txt
+++ b/.changelog/3284.txt
@@ -1,0 +1,3 @@
+```release-note:bug-fix
+control-plane: normalize the `partition` and `namespace` fields in V1 CRDs when comparing with saved version of the config-entry.
+```

--- a/control-plane/api/v1alpha1/exportedservices_types.go
+++ b/control-plane/api/v1alpha1/exportedservices_types.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	"github.com/hashicorp/consul/api"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
@@ -16,6 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 )
 
 const ExportedServicesKubeKind = "exportedservices"
@@ -189,8 +190,15 @@ func (in *ExportedServices) MatchesConsul(candidate api.ConfigEntry) bool {
 	if !ok {
 		return false
 	}
+
+	specialEquality := cmp.Options{
+		cmp.FilterPath(func(path cmp.Path) bool {
+			return path.String() == "Services.Consumers.Partition"
+		}, cmp.Transformer("NormalizePartition", normalizeEmptyToDefault)),
+	}
+
 	// No datacenter is passed to ToConsul as we ignore the Meta field when checking for equality.
-	return cmp.Equal(in.ToConsul(""), configEntry, cmpopts.IgnoreFields(capi.ExportedServicesConfigEntry{}, "Partition", "Meta", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
+	return cmp.Equal(in.ToConsul(""), configEntry, cmpopts.IgnoreFields(capi.ExportedServicesConfigEntry{}, "Partition", "Meta", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty(), specialEquality)
 
 }
 

--- a/control-plane/api/v1alpha1/exportedservices_types_test.go
+++ b/control-plane/api/v1alpha1/exportedservices_types_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 )
 
 // Test MatchesConsul for cases that should return true.
@@ -62,6 +63,7 @@ func TestExportedServices_MatchesConsul(t *testing.T) {
 								{
 									SamenessGroup: "sg1",
 								},
+								{},
 							},
 						},
 						{
@@ -103,6 +105,9 @@ func TestExportedServices_MatchesConsul(t *testing.T) {
 							},
 							{
 								SamenessGroup: "sg1",
+							},
+							{
+								Partition: "default",
 							},
 						},
 					},

--- a/control-plane/api/v1alpha1/exportedservices_types_test.go
+++ b/control-plane/api/v1alpha1/exportedservices_types_test.go
@@ -63,7 +63,6 @@ func TestExportedServices_MatchesConsul(t *testing.T) {
 								{
 									SamenessGroup: "sg1",
 								},
-								{},
 							},
 						},
 						{
@@ -105,9 +104,7 @@ func TestExportedServices_MatchesConsul(t *testing.T) {
 							},
 							{
 								SamenessGroup: "sg1",
-							},
-							{
-								Partition: "default",
+								Partition:     "default",
 							},
 						},
 					},

--- a/control-plane/api/v1alpha1/ingressgateway_types_test.go
+++ b/control-plane/api/v1alpha1/ingressgateway_types_test.go
@@ -8,12 +8,13 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 )
 
 func TestIngressGateway_MatchesConsul(t *testing.T) {
@@ -102,7 +103,6 @@ func TestIngressGateway_MatchesConsul(t *testing.T) {
 									Name:      "name1",
 									Hosts:     []string{"host1_1", "host1_2"},
 									Namespace: "ns1",
-									Partition: "default",
 									IngressServiceConfig: IngressServiceConfig{
 										MaxConnections:        &maxConnections,
 										MaxPendingRequests:    &maxPendingRequests,

--- a/control-plane/api/v1alpha1/samenessgroup_types_test.go
+++ b/control-plane/api/v1alpha1/samenessgroup_types_test.go
@@ -122,7 +122,9 @@ func TestSamenessGroups_MatchesConsul(t *testing.T) {
 						{
 							Partition: "p2",
 						},
-						{},
+						{
+							Peer: "test-peer",
+						},
 					},
 				},
 			},
@@ -143,6 +145,7 @@ func TestSamenessGroups_MatchesConsul(t *testing.T) {
 						Partition: "p2",
 					},
 					{
+						Peer:      "test-peer",
 						Partition: "default",
 					},
 				},

--- a/control-plane/api/v1alpha1/samenessgroup_types_test.go
+++ b/control-plane/api/v1alpha1/samenessgroup_types_test.go
@@ -4,13 +4,15 @@
 package v1alpha1
 
 import (
-	"github.com/hashicorp/consul-k8s/control-plane/api/common"
+	"testing"
+	"time"
+
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
-	"time"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 )
 
 func TestSamenessGroups_ToConsul(t *testing.T) {
@@ -120,6 +122,7 @@ func TestSamenessGroups_MatchesConsul(t *testing.T) {
 						{
 							Partition: "p2",
 						},
+						{},
 					},
 				},
 			},
@@ -138,6 +141,9 @@ func TestSamenessGroups_MatchesConsul(t *testing.T) {
 					},
 					{
 						Partition: "p2",
+					},
+					{
+						Partition: "default",
 					},
 				},
 			},

--- a/control-plane/api/v1alpha1/servicedefaults_types.go
+++ b/control-plane/api/v1alpha1/servicedefaults_types.go
@@ -703,9 +703,19 @@ func (in *ServiceDefaults) MatchesConsul(candidate capi.ConfigEntry) bool {
 	if !ok {
 		return false
 	}
+
+	specialEquality := cmp.Options{
+		cmp.FilterPath(func(path cmp.Path) bool {
+			return path.String() == "UpstreamConfig.Overrides.Namespace"
+		}, cmp.Transformer("NormalizeNamespace", normalizeEmptyToDefault)),
+		cmp.FilterPath(func(path cmp.Path) bool {
+			return path.String() == "UpstreamConfig.Overrides.Partition"
+		}, cmp.Transformer("NormalizePartition", normalizeEmptyToDefault)),
+		cmp.Comparer(transparentProxyConfigComparer),
+	}
+
 	// No datacenter is passed to ToConsul as we ignore the Meta field when checking for equality.
-	return cmp.Equal(in.ToConsul(""), configEntry, cmpopts.IgnoreFields(capi.ServiceConfigEntry{}, "Partition", "Namespace", "Meta", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty(),
-		cmp.Comparer(transparentProxyConfigComparer))
+	return cmp.Equal(in.ToConsul(""), configEntry, cmpopts.IgnoreFields(capi.ServiceConfigEntry{}, "Partition", "Namespace", "Meta", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty(), specialEquality)
 }
 
 func (in *ServiceDefaults) ConsulGlobalResource() bool {

--- a/control-plane/api/v1alpha1/servicedefaults_types_test.go
+++ b/control-plane/api/v1alpha1/servicedefaults_types_test.go
@@ -565,7 +565,6 @@ func TestServiceDefaults_MatchesConsul(t *testing.T) {
 							},
 							{
 								Name:              "upstream-default",
-								Namespace:         "ns",
 								EnvoyListenerJSON: `{"key": "value"}`,
 								EnvoyClusterJSON:  `{"key": "value"}`,
 								Protocol:          "http2",
@@ -707,7 +706,8 @@ func TestServiceDefaults_MatchesConsul(t *testing.T) {
 						},
 						{
 							Name:              "upstream-default",
-							Namespace:         "ns",
+							Namespace:         "default",
+							Partition:         "default",
 							EnvoyListenerJSON: `{"key": "value"}`,
 							EnvoyClusterJSON:  `{"key": "value"}`,
 							Protocol:          "http2",

--- a/control-plane/api/v1alpha1/serviceresolver_types_test.go
+++ b/control-plane/api/v1alpha1/serviceresolver_types_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 )
 
 func TestServiceResolver_MatchesConsul(t *testing.T) {
@@ -63,6 +64,7 @@ func TestServiceResolver_MatchesConsul(t *testing.T) {
 						Service:       "redirect",
 						ServiceSubset: "redirect_subset",
 						Namespace:     "redirect_namespace",
+						Partition:     "default",
 						Datacenter:    "redirect_datacenter",
 						Peer:          "redirect_peer",
 					},
@@ -96,6 +98,7 @@ func TestServiceResolver_MatchesConsul(t *testing.T) {
 							Targets: []ServiceResolverFailoverTarget{
 								{Peer: "failover_peer3"},
 								{Partition: "failover_partition3", Namespace: "failover_namespace3"},
+								{Partition: "default", Namespace: "default"},
 							},
 							Policy: &FailoverPolicy{
 								Mode:    "order-by-locality",
@@ -181,6 +184,7 @@ func TestServiceResolver_MatchesConsul(t *testing.T) {
 						Targets: []capi.ServiceResolverFailoverTarget{
 							{Peer: "failover_peer3"},
 							{Partition: "failover_partition3", Namespace: "failover_namespace3"},
+							{},
 						},
 						Policy: &capi.ServiceResolverFailoverPolicy{
 							Mode:    "order-by-locality",

--- a/control-plane/api/v1alpha1/serviceresolver_types_test.go
+++ b/control-plane/api/v1alpha1/serviceresolver_types_test.go
@@ -98,7 +98,7 @@ func TestServiceResolver_MatchesConsul(t *testing.T) {
 							Targets: []ServiceResolverFailoverTarget{
 								{Peer: "failover_peer3"},
 								{Partition: "failover_partition3", Namespace: "failover_namespace3"},
-								{Partition: "default", Namespace: "default"},
+								{Peer: "failover_peer4"},
 							},
 							Policy: &FailoverPolicy{
 								Mode:    "order-by-locality",
@@ -184,7 +184,7 @@ func TestServiceResolver_MatchesConsul(t *testing.T) {
 						Targets: []capi.ServiceResolverFailoverTarget{
 							{Peer: "failover_peer3"},
 							{Partition: "failover_partition3", Namespace: "failover_namespace3"},
-							{},
+							{Peer: "failover_peer4", Partition: "default", Namespace: "default"},
 						},
 						Policy: &capi.ServiceResolverFailoverPolicy{
 							Mode:    "order-by-locality",

--- a/control-plane/api/v1alpha1/servicerouter_types.go
+++ b/control-plane/api/v1alpha1/servicerouter_types.go
@@ -8,14 +8,15 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/consul-k8s/control-plane/api/common"
-	"github.com/hashicorp/consul-k8s/control-plane/namespaces"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/common"
+	"github.com/hashicorp/consul-k8s/control-plane/namespaces"
 )
 
 func init() {
@@ -253,8 +254,18 @@ func (in *ServiceRouter) MatchesConsul(candidate capi.ConfigEntry) bool {
 	if !ok {
 		return false
 	}
+
+	specialEquality := cmp.Options{
+		cmp.FilterPath(func(path cmp.Path) bool {
+			return path.String() == "Routes.Destination.Namespace"
+		}, cmp.Transformer("NormalizeNamespace", normalizeEmptyToDefault)),
+		cmp.FilterPath(func(path cmp.Path) bool {
+			return path.String() == "Routes.Destination.Partition"
+		}, cmp.Transformer("NormalizePartition", normalizeEmptyToDefault)),
+	}
+
 	// No datacenter is passed to ToConsul as we ignore the Meta field when checking for equality.
-	return cmp.Equal(in.ToConsul(""), configEntry, cmpopts.IgnoreFields(capi.ServiceRouterConfigEntry{}, "Partition", "Namespace", "Meta", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
+	return cmp.Equal(in.ToConsul(""), configEntry, cmpopts.IgnoreFields(capi.ServiceRouterConfigEntry{}, "Partition", "Namespace", "Meta", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty(), specialEquality)
 }
 
 func (in *ServiceRouter) Validate(consulMeta common.ConsulMeta) error {

--- a/control-plane/api/v1alpha1/servicerouter_types_test.go
+++ b/control-plane/api/v1alpha1/servicerouter_types_test.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 )
 
 // Test MatchesConsul.
@@ -158,6 +159,7 @@ func TestServiceRouter_MatchesConsul(t *testing.T) {
 							Service:               "service",
 							ServiceSubset:         "serviceSubset",
 							Namespace:             "namespace",
+							Partition:             "default",
 							PrefixRewrite:         "prefixRewrite",
 							IdleTimeout:           1 * time.Second,
 							RequestTimeout:        1 * time.Second,

--- a/control-plane/api/v1alpha1/servicesplitter_types.go
+++ b/control-plane/api/v1alpha1/servicesplitter_types.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	capi "github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 )
 
 func init() {
@@ -168,8 +169,18 @@ func (in *ServiceSplitter) MatchesConsul(candidate capi.ConfigEntry) bool {
 	if !ok {
 		return false
 	}
+
+	specialEquality := cmp.Options{
+		cmp.FilterPath(func(path cmp.Path) bool {
+			return path.String() == "Splits.Namespace"
+		}, cmp.Transformer("NormalizeNamespace", normalizeEmptyToDefault)),
+		cmp.FilterPath(func(path cmp.Path) bool {
+			return path.String() == "Splits.Partition"
+		}, cmp.Transformer("NormalizePartition", normalizeEmptyToDefault)),
+	}
+
 	// No datacenter is passed to ToConsul as we ignore the Meta field when checking for equality.
-	return cmp.Equal(in.ToConsul(""), configEntry, cmpopts.IgnoreFields(capi.ServiceSplitterConfigEntry{}, "Partition", "Namespace", "Meta", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
+	return cmp.Equal(in.ToConsul(""), configEntry, cmpopts.IgnoreFields(capi.ServiceSplitterConfigEntry{}, "Partition", "Namespace", "Meta", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty(), specialEquality)
 }
 
 func (in *ServiceSplitter) Validate(consulMeta common.ConsulMeta) error {

--- a/control-plane/api/v1alpha1/servicesplitter_types_test.go
+++ b/control-plane/api/v1alpha1/servicesplitter_types_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 )
 
 // Test MatchesConsul.
@@ -96,6 +97,7 @@ func TestServiceSplitter_MatchesConsul(t *testing.T) {
 						Service:       "foo",
 						ServiceSubset: "bar",
 						Namespace:     "baz",
+						Partition:     "default",
 						RequestHeaders: &capi.HTTPHeaderModifiers{
 							Add: map[string]string{
 								"foo":    "bar",


### PR DESCRIPTION
Changes proposed in this PR:

When setup as a secondary in WAN federation, Consul migrates config entries from the primary datacenter into the kubernetes secondaries. When the config entries are saved, the `partition` field in the spec of the config entries that have them, gets normalized to the value `default` if it was previously `""` in Consul Enterprise. CRDs for these resources then constantly re-sync themselves since the `MatchesConsul` method, which is responsible for identifying diffs, evaluates the match incorrectly.

To normalize this behavior, the comparison operation for the impacted CRDs has been updated so that when the Partition fields are compared, empty strings are normalized to the value `default`. This should ensure that those two values are considered symmetrical and hence should prevent the constant resync of the CRDs into Consul.

How I've tested this PR:
- Unit tests.
- [x] Tested on env where this behavior was previously observed and has now stopped occurring.

How I expect reviewers to test this PR:
- Kind eyes and a whimsical smile. Also, suggestions for additional test cases if you come across them.

Checklist:
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


