### PR TITLE
Stop syncing GatewayClass + GatewayClassConfig into Consul

### DIFF
--- a/control-plane/config-entries/controllersv2/gateway_class_config_controller.go
+++ b/control-plane/config-entries/controllersv2/gateway_class_config_controller.go
@@ -27,7 +27,9 @@ type GatewayClassConfigController struct {
 // +kubebuilder:rbac:groups=mesh.consul.hashicorp.com,resources=gatewayclassconfig/status,verbs=get;update;patch
 
 func (r *GatewayClassConfigController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return r.Controller.ReconcileEntry(ctx, r, req, &meshv2beta1.GatewayClassConfig{})
+	// GatewayClassConfig is not synced into Consul because Consul has no use for it.
+	// Consul is only aware of the resource for the sake of Kubernetes CRD generation.
+	return ctrl.Result{}, nil
 }
 
 func (r *GatewayClassConfigController) Logger(name types.NamespacedName) logr.Logger {

--- a/control-plane/config-entries/controllersv2/gateway_class_controller.go
+++ b/control-plane/config-entries/controllersv2/gateway_class_controller.go
@@ -27,7 +27,9 @@ type GatewayClassController struct {
 // +kubebuilder:rbac:groups=mesh.consul.hashicorp.com,resources=gatewayclass/status,verbs=get;update;patch
 
 func (r *GatewayClassController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return r.Controller.ReconcileEntry(ctx, r, req, &meshv2beta1.GatewayClass{})
+	// GatewayClass is not synced into Consul because Consul has no use for it.
+	// Consul is only aware of the resource for the sake of Kubernetes CRD generation.
+	return ctrl.Result{}, nil
 }
 
 func (r *GatewayClassController) Logger(name types.NamespacedName) logr.Logger {

--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller_test.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller_test.go
@@ -73,7 +73,7 @@ func TestMeshGatewayController_Reconcile(t *testing.T) {
 					},
 				},
 				&corev1.ServiceAccount{
-					ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
 						Name:      "mesh-gateway",
 					},

--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller_test.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller_test.go
@@ -73,7 +73,7 @@ func TestMeshGatewayController_Reconcile(t *testing.T) {
 					},
 				},
 				&corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
 						Name:      "mesh-gateway",
 					},


### PR DESCRIPTION
**Changes proposed in this PR:**
Stop syncing `GatewayClass` and `GatewayClassConfig` into Consul, which has no use for them

**How I've tested this PR:**
- Create a `GatewayClass` and `GatewayClassConfig` resource in k8s, verify they're successfully reconciled

**How I expect reviewers to test this PR:**
See above

**Checklist:**
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


