### PR TITLE
run weekly test on PR to validate changes.

### DIFF
--- a/.github/workflows/weekly-acceptance-1-1-x.yml
+++ b/.github/workflows/weekly-acceptance-1-1-x.yml
@@ -3,10 +3,7 @@
 # A separate file is needed for each release because the cron schedules are different for each release.
 name: weekly-acceptance-1-1-x
 on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    # Run weekly on Wednesday at 3AM UTC/11PM EST/8PM PST
-    - cron:  '0 3 * * 3'
+  pull_request:
 
 
 # these should be the only settings that you will ever need to change

--- a/acceptance/ci-inputs/kind-inputs.yaml
+++ b/acceptance/ci-inputs/kind-inputs.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 kindVersion: v0.19.0
-kindNodeImage: kindest/node:v1.26.4
+kindNodeImage: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
 kubectlVersion: v1.27.1


### PR DESCRIPTION
Changes proposed in this PR:
- Update kind-inputs to ensure weekly tests for 1.1.x run against kubernetes 1.27. This is with regards to ensuring LTS support for the 1.1.x version.

How I've tested this PR:
- enabling the weekly tests for 1.1.x to run against this PR

How I expect reviewers to test this PR:
- approve if pipelines go green

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


