### PR TITLE
NET-6575- Add ConfigMap volume mount to gateway cleanup job

### DIFF
--- a/charts/consul/templates/gateway-cleanup-job.yaml
+++ b/charts/consul/templates/gateway-cleanup-job.yaml
@@ -56,4 +56,8 @@ spec:
       tolerations:
         {{ tpl .Values.global.acls.tolerations . | indent 8 | trim }}
       {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: { { template "consul.fullname" . } }-gateway-resources-config
 {{- end }}

--- a/charts/consul/templates/gateway-cleanup-job.yaml
+++ b/charts/consul/templates/gateway-cleanup-job.yaml
@@ -52,6 +52,10 @@ spec:
             limits:
               memory: "50Mi"
               cpu: "50m"
+            volumeMounts:
+              - name: config
+                mountPath: /consul/config
+                readOnly: true
       {{- if .Values.global.acls.tolerations }}
       tolerations:
         {{ tpl .Values.global.acls.tolerations . | indent 8 | trim }}
@@ -59,5 +63,5 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: { { template "consul.fullname" . } }-gateway-resources-config
+            name: {{ template "consul.fullname" . }}-gateway-resources-config
 {{- end }}


### PR DESCRIPTION
Changes proposed in this PR:
- Ran make lint to make sure the yaml file was formatted correctly with the new addition 

How I've tested this PR:
- Installed chart locally onto a kind cluster to ensure it still installs appropriately. 

How I expect reviewers to test this PR:
- BATs helm tests pass as expected
- If desired, reviewer can check out branch, and run the following commands to do a helm install locally

```
kind create cluster 
helm install consul $PATH_TO_CONSUL_K8s/charts/consul -n consul --create-namespace
```

Checklist:
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


