### PR TITLE
Create role and role binding for mesh gateways

### DIFF
--- a/control-plane/gateways/role.go
+++ b/control-plane/gateways/role.go
@@ -1,0 +1,30 @@
+package gateways
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (b *meshGatewayBuilder) Role() *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      b.gateway.Name,
+			Namespace: b.gateway.Namespace,
+			Labels:    b.Labels(),
+		},
+		Rules: []rbacv1.PolicyRule{},
+	}
+}
+
+func (b *meshGatewayBuilder) RoleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      b.gateway.Name,
+			Namespace: b.gateway.Namespace,
+			Labels:    b.Labels(),
+		},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.ServiceAccountKind, Name: b.gateway.Name, Namespace: b.gateway.Namespace},
+		},
+	}
+}

--- a/control-plane/gateways/role.go
+++ b/control-plane/gateways/role.go
@@ -24,7 +24,11 @@ func (b *meshGatewayBuilder) RoleBinding() *rbacv1.RoleBinding {
 			Labels:    b.Labels(),
 		},
 		Subjects: []rbacv1.Subject{
-			{Kind: rbacv1.ServiceAccountKind, Name: b.gateway.Name, Namespace: b.gateway.Namespace},
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      b.gateway.Name,
+				Namespace: b.gateway.Namespace,
+			},
 		},
 	}
 }


### PR DESCRIPTION
Changes proposed in this PR:

This creates proper k8s roles and role-bindings for mesh gateways. ~It does raise a question about how we're modeling mesh gateway CRDs though. Specifically in the `v1` implementation we were creating cluster-scoped roles rather than namespace-scoped. Presumably this is because a mesh gateway should be associated with a installation rather than having the ability to run per-namespace. I know that we've changed the modeling around registered gateway "instances" from v1 to the resource api "workloads", but just wondering if said mesh gateway "workloads" are considered "partition-scoped" or still allow for carrying namespace information.~

~If they allow for namespace information, then we're good on the Role/RoleBinding approach, otherwise, I think most of these resources should likely move to use cluster-scoped CRDs where appropriate and create deployments solely in the k8s namespace that the helm install happens in.~

Synced up offline with Nate. We modified the `MeshGateway` model to allow for workloads to be run in alternative namespaces inentionally, so we're good to go with `Role` and `RoleBinding` rather than their cluster-scoped equivalents.

How I've tested this PR:

Unit tests.

Checklist:
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


