### PR TITLE
[NET-6588] Remove abandoned virtual nodes from Consul Catalog

### DIFF
--- a/.changelog/3307.txt
+++ b/.changelog/3307.txt
@@ -1,0 +1,3 @@
+```release-note:bug-fix
+control-plane: Remove virtual nodes in the Consul Catalog when they do not have any services listed.
+```

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
@@ -3552,6 +3552,8 @@ func TestReconcileUpdateEndpoint(t *testing.T) {
 				}
 			})
 			consulClient := testClient.APIClient
+			// Wait so that bootstrap finishes
+			testClient.TestServer.WaitForActiveCARoot(t)
 
 			// Holds token accessorID for each service ID.
 			tokensForServices := make(map[string]string)
@@ -4203,7 +4205,8 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 				}
 			})
 			consulClient := testClient.APIClient
-			// TODO: stabilize this test by waiting for the ACL bootstrap
+			// Wait so that bootstrap finishes
+			testClient.TestServer.WaitForActiveCARoot(t)
 
 			// Register service and proxy in consul
 			var token *api.ACLToken


### PR DESCRIPTION
Changes proposed in this PR:
- When deregistering a service in Consul we would leave the virtual node sitting around
- This PR checks if a node has an empty service list and if so deletes 

How I've tested this PR:

- manually testing in kind to make sure nodes are cleaned up
- unit tests. The enpoints controller tests have a lot of coverage for service interactions.

How I expect reviewers to test this PR:

👀 

Checklist:
- [ ] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


