### PR TITLE
Revert "Add validation that externalServers.hosts is not set to HCP-managed cluster's addresses when global.cloud.enabled"

### DIFF
--- a/.changelog/3218.txt
+++ b/.changelog/3218.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-helm: add validation that global.cloud.enabled is not set with externalServers.hosts set to HCP-managed clusters
-```

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -1,7 +1,6 @@
 {{- if and .Values.global.peering.enabled (not .Values.connectInject.enabled) }}{{ fail "setting global.peering.enabled to true requires connectInject.enabled to be true" }}{{ end }}
 {{- if and .Values.global.peering.enabled (not .Values.global.tls.enabled) }}{{ fail "setting global.peering.enabled to true requires global.tls.enabled to be true" }}{{ end }}
 {{- if and .Values.global.peering.enabled (not .Values.meshGateway.enabled) }}{{ fail "setting global.peering.enabled to true requires meshGateway.enabled to be true" }}{{ end }}
-{{- if and .Values.externalServers.enabled .Values.global.cloud.enabled (gt (len .Values.externalServers.hosts) 0) (regexMatch ".+.hashicorp.cloud$" ( first .Values.externalServers.hosts )) }}{{fail "global.cloud.enabled cannot be used in combination with an HCP-managed cluster address in externalServers.hosts. global.cloud.enabled is for linked self-managed clusters."}}{{- end }}
 {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if and .Values.global.adminPartitions.enabled (not .Values.global.enableConsulNamespaces) }}{{ fail "global.enableConsulNamespaces must be true if global.adminPartitions.enabled=true" }}{{ end }}
 {{ template "consul.validateVaultWebhookCertConfiguration" . }}

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -2639,30 +2639,6 @@ reservedNameTest() {
   [ "${actual}" = "true" ]
 }
 
-@test "connectInject/Deployment: validates that externalServers.hosts is not set with an HCP-managed cluster's address" {
-  cd `chart_dir`
-  run helm template \
-      -s templates/connect-inject-deployment.yaml  \
-      --set 'global.enabled=false' \
-      --set 'connectInject.enabled=true' \
-      --set 'global.tls.enabled=true' \
-      --set 'global.tls.enableAutoEncrypt=true' \
-      --set 'externalServers.enabled=true' \
-      --set 'externalServers.hosts[0]=abc.aws.hashicorp.cloud' \
-      --set 'global.cloud.enabled=true' \
-      --set 'global.cloud.clientId.secretName=client-id-name' \
-      --set 'global.cloud.clientId.secretKey=client-id-key' \
-      --set 'global.cloud.clientSecret.secretName=client-secret-id-name' \
-      --set 'global.cloud.clientSecret.secretKey=client-secret-id-key' \
-      --set 'global.cloud.resourceId.secretName=resource-id-name' \
-      --set 'global.cloud.resourceId.secretKey=resource-id-key' \
-     . > /dev/stderr
-
-  [ "$status" -eq 1 ]
-
-  [[ "$output" =~ "global.cloud.enabled cannot be used in combination with an HCP-managed cluster address in externalServers.hosts. global.cloud.enabled is for linked self-managed clusters." ]]
-}
-
 @test "connectInject/Deployment: can provide a TLS server name for the sidecar-injector when global.cloud.enabled is set" {
   cd `chart_dir`
   local env=$(helm template \

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -655,12 +655,8 @@ global:
   # Enables installing an HCP Consul Central self-managed cluster.
   # Requires Consul v1.14+.
   cloud:
-    # If true, the Helm chart will link a [self-managed cluster to HCP](https://developer.hashicorp.com/hcp/docs/consul/self-managed).
-    # This can either be used to [configure a new cluster](https://developer.hashicorp.com/hcp/docs/consul/self-managed/new)
-    # or [link an existing one](https://developer.hashicorp.com/hcp/docs/consul/self-managed/existing).
-    #
-    # Note: this setting should not be enabled for [HashiCorp-managed clusters](https://developer.hashicorp.com/hcp/docs/consul/hcp-managed).
-    # It is strictly for linking self-managed clusters.
+    # If true, the Helm chart will enable the installation of an HCP Consul Central
+    # self-managed cluster.
     enabled: false
 
     # The resource id of the HCP Consul Central cluster to link to. Eg:


### PR DESCRIPTION
Reverts hashicorp/consul-k8s#3218