### PR TITLE
Add validation that externalServers.hosts is not set to HCP-managed cluster's addresses when global.cloud.enabled

### DIFF
--- a/.changelog/3315.txt
+++ b/.changelog/3315.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+helm: add validation that global.cloud.enabled is not set with externalServers.hosts set to HCP-managed clusters
+```

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -1,6 +1,7 @@
 {{- if and .Values.global.peering.enabled (not .Values.connectInject.enabled) }}{{ fail "setting global.peering.enabled to true requires connectInject.enabled to be true" }}{{ end }}
 {{- if and .Values.global.peering.enabled (not .Values.global.tls.enabled) }}{{ fail "setting global.peering.enabled to true requires global.tls.enabled to be true" }}{{ end }}
 {{- if and .Values.global.peering.enabled (not .Values.meshGateway.enabled) }}{{ fail "setting global.peering.enabled to true requires meshGateway.enabled to be true" }}{{ end }}
+{{- if and .Values.externalServers.enabled .Values.global.cloud.enabled (gt (len .Values.externalServers.hosts) 0) (regexMatch ".+.hashicorp.cloud$" ( first .Values.externalServers.hosts )) }}{{fail "global.cloud.enabled cannot be used in combination with an HCP-managed cluster address in externalServers.hosts. global.cloud.enabled is for linked self-managed clusters."}}{{- end }}
 {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if and .Values.global.adminPartitions.enabled (not .Values.global.enableConsulNamespaces) }}{{ fail "global.enableConsulNamespaces must be true if global.adminPartitions.enabled=true" }}{{ end }}
 {{ template "consul.validateVaultWebhookCertConfiguration" . }}

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -1,12 +1,14 @@
 {{- if and .Values.global.peering.enabled (not .Values.connectInject.enabled) }}{{ fail "setting global.peering.enabled to true requires connectInject.enabled to be true" }}{{ end }}
 {{- if and .Values.global.peering.enabled (not .Values.global.tls.enabled) }}{{ fail "setting global.peering.enabled to true requires global.tls.enabled to be true" }}{{ end }}
 {{- if and .Values.global.peering.enabled (not .Values.meshGateway.enabled) }}{{ fail "setting global.peering.enabled to true requires meshGateway.enabled to be true" }}{{ end }}
-{{- if and .Values.externalServers.enabled .Values.global.cloud.enabled (gt (len .Values.externalServers.hosts) 0) (regexMatch ".+.hashicorp.cloud$" ( first .Values.externalServers.hosts )) }}{{fail "global.cloud.enabled cannot be used in combination with an HCP-managed cluster address in externalServers.hosts. global.cloud.enabled is for linked self-managed clusters."}}{{- end }}
 {{- if (or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if and .Values.global.adminPartitions.enabled (not .Values.global.enableConsulNamespaces) }}{{ fail "global.enableConsulNamespaces must be true if global.adminPartitions.enabled=true" }}{{ end }}
 {{ template "consul.validateVaultWebhookCertConfiguration" . }}
 {{- template "consul.reservedNamesFailer" (list .Values.connectInject.consulNamespaces.consulDestinationNamespace "connectInject.consulNamespaces.consulDestinationNamespace") }}
 {{- if and .Values.externalServers.enabled (not .Values.externalServers.hosts) }}{{ fail "externalServers.hosts must be set if externalServers.enabled is true" }}{{ end -}}
+{{- if and .Values.externalServers.enabled .Values.global.cloud.enabled }}
+  {{- if and (gt (len .Values.externalServers.hosts) 0) (regexMatch ".+.hashicorp.cloud$" ( first .Values.externalServers.hosts )) }}{{fail "global.cloud.enabled cannot be used in combination with an HCP-managed cluster address in externalServers.hosts. global.cloud.enabled is for linked self-managed clusters."}}{{- end }}
+{{- end }}
 {{- if and .Values.externalServers.skipServerWatch (not .Values.externalServers.enabled) }}{{ fail "externalServers.enabled must be set if externalServers.skipServerWatch is true" }}{{ end -}}
 {{- $dnsEnabled := (or (and (ne (.Values.dns.enabled | toString) "-") .Values.dns.enabled) (and (eq (.Values.dns.enabled | toString) "-") .Values.connectInject.transparentProxy.defaultEnabled)) -}}
 {{- $dnsRedirectionEnabled := (or (and (ne (.Values.dns.enableRedirection | toString) "-") .Values.dns.enableRedirection) (and (eq (.Values.dns.enableRedirection | toString) "-") .Values.connectInject.transparentProxy.defaultEnabled)) -}}

--- a/charts/consul/test/unit/connect-inject-deployment.bats
+++ b/charts/consul/test/unit/connect-inject-deployment.bats
@@ -2639,6 +2639,30 @@ reservedNameTest() {
   [ "${actual}" = "true" ]
 }
 
+@test "connectInject/Deployment: validates that externalServers.hosts is not set with an HCP-managed cluster's address" {
+  cd `chart_dir`
+  run helm template \
+      -s templates/connect-inject-deployment.yaml  \
+      --set 'global.enabled=false' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.enableAutoEncrypt=true' \
+      --set 'externalServers.enabled=true' \
+      --set 'externalServers.hosts[0]=abc.aws.hashicorp.cloud' \
+      --set 'global.cloud.enabled=true' \
+      --set 'global.cloud.clientId.secretName=client-id-name' \
+      --set 'global.cloud.clientId.secretKey=client-id-key' \
+      --set 'global.cloud.clientSecret.secretName=client-secret-id-name' \
+      --set 'global.cloud.clientSecret.secretKey=client-secret-id-key' \
+      --set 'global.cloud.resourceId.secretName=resource-id-name' \
+      --set 'global.cloud.resourceId.secretKey=resource-id-key' \
+     . > /dev/stderr
+
+  [ "$status" -eq 1 ]
+
+  [[ "$output" =~ "global.cloud.enabled cannot be used in combination with an HCP-managed cluster address in externalServers.hosts. global.cloud.enabled is for linked self-managed clusters." ]]
+}
+
 @test "connectInject/Deployment: can provide a TLS server name for the sidecar-injector when global.cloud.enabled is set" {
   cd `chart_dir`
   local env=$(helm template \

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -655,8 +655,12 @@ global:
   # Enables installing an HCP Consul Central self-managed cluster.
   # Requires Consul v1.14+.
   cloud:
-    # If true, the Helm chart will enable the installation of an HCP Consul Central
-    # self-managed cluster.
+    # If true, the Helm chart will link a [self-managed cluster to HCP](https://developer.hashicorp.com/hcp/docs/consul/self-managed).
+    # This can either be used to [configure a new cluster](https://developer.hashicorp.com/hcp/docs/consul/self-managed/new)
+    # or [link an existing one](https://developer.hashicorp.com/hcp/docs/consul/self-managed/existing).
+    #
+    # Note: this setting should not be enabled for [HashiCorp-managed clusters](https://developer.hashicorp.com/hcp/docs/consul/hcp-managed).
+    # It is strictly for linking self-managed clusters.
     enabled: false
 
     # The resource id of the HCP Consul Central cluster to link to. Eg:


### PR DESCRIPTION
This reintroduces #3218 with an additional small change to ensure Helm template validation is applied with necessary short-circuits. I've added the fix as a separate commit to simplify review based on the original.

Original PR description below:

---------------------------------

### Overview

If we set `externalServers.hosts` to the public or private address of an HCP-manged cluster, we run into the following because we're hardcoding `-tls-server-name` to `server.{{ .Values.global.datacenter}}.{{ .Values.global.domain}}`:

> 2023-11-10T01:32:31.386Z [ERROR] consul-server-connection-manager: connection error: error="rpc error: code = Unavailable desc = connection error: desc = \"transport: authentication handshake failed: tls: failed to verify certificate: x509: certificate is valid for 517429dd-fcab-4fe6-bc4a-57750f69df7e.aws.hashicorp.cloud, consul-cluster.consul.e4065767-bd61-4f00-8b2b-81f631f7d4d1.aws.hashicorp.cloud, consul-cluster.private.consul.e4065767-bd61-4f00-8b2b-81f631f7d4d1.aws.hashicorp.cloud, not server.consul-cluster.consul\”"

We [hard-code `-tls-server-name` in many places](https://github.com/search?q=repo%3Ahashicorp%2Fconsul-k8s%20%22-tls-server-name%3Dserver.%7B%7B%20.Values.global.datacenter%7D%7D.%7B%7B%20.Values.global.domain%7D%7D%22&type=code) like:

https://github.com/hashicorp/consul-k8s/blob/4d7a1873b2c6049efc9769e3a03406db1a8f1380/charts/consul/templates/_helpers.tpl#L229-L231

### Changes proposed in this PR:
- Add validation that users don't set `global.cloud.enabled` while also using `externalServers.hosts` that point at an HCP-managed cluster (any address that has the suffix ".hashicorp.cloud")
- Add note to `values.yaml` describing how `global.cloud` is really for _linking_ clusters, not for HCP-managed cloud clusters.

### How I've tested this PR:
- bats, new bats test, ran it locally

### How I expect reviewers to test this PR:


### Checklist:
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


