### PR TITLE
Specify required RoleRef on RoleBinding

### DIFF
--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller_test.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller_test.go
@@ -109,7 +109,7 @@ func TestMeshGatewayController_Reconcile(t *testing.T) {
 			},
 			expectedResult: ctrl.Result{},
 			postReconcile: func(t *testing.T, c client.Client) {
-				// Verify ClusterRole was created
+				// Verify Role was created
 				key := client.ObjectKey{Namespace: "consul", Name: "mesh-gateway"}
 				assert.NoError(t, c.Get(context.Background(), key, &rbacv1.Role{}))
 			},
@@ -190,7 +190,7 @@ func TestMeshGatewayController_Reconcile(t *testing.T) {
 			},
 			expectedResult: ctrl.Result{},
 			postReconcile: func(t *testing.T, c client.Client) {
-				// Verify ClusterRole was created
+				// Verify RoleBinding was created
 				key := client.ObjectKey{Namespace: "consul", Name: "mesh-gateway"}
 				assert.NoError(t, c.Get(context.Background(), key, &rbacv1.RoleBinding{}))
 			},

--- a/control-plane/gateways/role.go
+++ b/control-plane/gateways/role.go
@@ -25,10 +25,16 @@ func (b *meshGatewayBuilder) RoleBinding() *rbacv1.RoleBinding {
 		},
 		Subjects: []rbacv1.Subject{
 			{
+				APIGroup:  "",
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      b.gateway.Name,
 				Namespace: b.gateway.Namespace,
 			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     b.Role().Name,
 		},
 	}
 }


### PR DESCRIPTION
**Changes proposed in this PR:**
The `RoleRef` field must be set on the `RoleBinding`. Since we don't currently set this, K8s returns an error when the reconciler attempts to create the `RoleBinding`.

```log
Reconciler error    {"controller": "meshgateway", "controllerGroup": "mesh.consul.hashicorp.com", "controllerKind": "MeshGateway", "MeshGateway": {"name":"mesh-gateway","namespace":"consul"}, "na │
│ mespace": "consul", "name": "mesh-gateway", "reconcileID": "80c9985f-28ed-4872-b330-7fcf87dffcde", "error": "unable to create role binding: unsupported role reference kind: \"\""}
```

**How I've tested this PR:**
`helm upgrade --install` from this branch, then verify that the expected `RoleBinding` was created:
```shell
$ kubectl get rolebinding -A
```

**How I expect reviewers to test this PR:**
See above

**Checklist:**
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


