### PR TITLE
Net 6575- Modify Gateways Cleanup Job to cleanup v2 resources

### DIFF
--- a/charts/consul/templates/gateway-cleanup-clusterrole.yaml
+++ b/charts/consul/templates/gateway-cleanup-clusterrole.yaml
@@ -24,6 +24,15 @@ rules:
     verbs:
     - get
     - delete
+  - apiGroups:
+    - mesh.consul.hashicorp.com
+    resources:
+    - gatewayclassconfigs
+    - gatewayclasses
+    - meshgateways
+    verbs:
+    - get
+    - delete
 {{- if .Values.global.enablePodSecurityPolicies }}
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]

--- a/charts/consul/templates/gateway-cleanup-job.yaml
+++ b/charts/consul/templates/gateway-cleanup-job.yaml
@@ -52,10 +52,10 @@ spec:
             limits:
               memory: "50Mi"
               cpu: "50m"
-            volumeMounts:
-              - name: config
-                mountPath: /consul/config
-                readOnly: true
+          volumeMounts:
+            - name: config
+              mountPath: /consul/config
+              readOnly: true
       {{- if .Values.global.acls.tolerations }}
       tolerations:
         {{ tpl .Values.global.acls.tolerations . | indent 8 | trim }}

--- a/control-plane/subcommand/gateway-cleanup/command.go
+++ b/control-plane/subcommand/gateway-cleanup/command.go
@@ -8,6 +8,9 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+
+	"io"
+	"os"
 	"sync"
 	"time"
 
@@ -19,10 +22,17 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	k8syaml "sigs.k8s.io/yaml"
 
+	"github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand"
 	"github.com/hashicorp/consul-k8s/control-plane/subcommand/flags"
+)
+
+const (
+	gatewayConfigFilename  = "/consul/config/config.yaml"
+	resourceConfigFilename = "/consul/config/resources.json"
 )
 
 type Command struct {
@@ -31,15 +41,23 @@ type Command struct {
 	flags *flag.FlagSet
 	k8s   *flags.K8SFlags
 
-	flagGatewayClassName       string
-	flagGatewayClassConfigName string
+	flagGatewayClassName           string
+	flagGatewayClassConfigName     string
+	flagGatewayConfigLocation      string
+	flagResourceConfigFileLocation string
 
 	k8sClient client.Client
 
 	once sync.Once
 	help string
 
+	gatewayConfig gatewayConfig
+
 	ctx context.Context
+}
+
+type gatewayConfig struct {
+	GatewayClassConfigs []*v2beta1.GatewayClassConfig `yaml:"gatewayClassConfigs"`
 }
 
 func (c *Command) init() {
@@ -49,6 +67,12 @@ func (c *Command) init() {
 		"Name of Kubernetes GatewayClass to delete.")
 	c.flags.StringVar(&c.flagGatewayClassConfigName, "gateway-class-config-name", "",
 		"Name of Kubernetes GatewayClassConfig to delete.")
+
+	c.flags.StringVar(&c.flagGatewayConfigLocation, "gateway-config-file-location", gatewayConfigFilename,
+		"specify a different location for where the gateway config file is")
+
+	c.flags.StringVar(&c.flagResourceConfigFileLocation, "resource-config-file-location", resourceConfigFilename,
+		"specify a different location for where the gateway resource config file is")
 
 	c.k8s = &flags.K8SFlags{}
 	flags.Merge(c.flags, c.k8s.Flags())
@@ -93,6 +117,11 @@ func (c *Command) Run(args []string) int {
 			return 1
 		}
 
+		if err := v2beta1.AddMeshToScheme(s); err != nil {
+			c.UI.Error(fmt.Sprintf("Could not add consul-k8s schema: %s", err))
+			return 1
+		}
+
 		c.k8sClient, err = client.New(config, client.Options{Scheme: s})
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error initializing Kubernetes client: %s", err))
@@ -101,6 +130,8 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// do the cleanup
+
+	//V1 Cleanup
 
 	// find the class config and mark it for deletion first so that we
 	// can do an early return if the gateway class isn't found
@@ -152,6 +183,18 @@ func (c *Command) Run(args []string) int {
 		// since we don't want to block someone from uninstallation
 	}
 
+	//V2 Cleanup
+	err = c.loadGatewayConfigs()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+	err = c.deleteV2GatewayClassAndClassConfigs()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
 	return 0
 }
 
@@ -191,4 +234,90 @@ func exponentialBackoffWithMaxIntervalAndTime() *backoff.ExponentialBackOff {
 	backoff.MaxInterval = 1 * time.Second
 	backoff.Reset()
 	return backoff
+}
+
+// loadGatewayConfigs reads and loads the configs from `/consul/config/config.yaml`, if this file does not exist nothing is done.
+func (c *Command) loadGatewayConfigs() error {
+	file, err := os.Open(c.flagGatewayConfigLocation)
+	if err != nil {
+		if os.IsNotExist(err) {
+			c.UI.Warn(fmt.Sprintf("gateway configuration file not found, skipping gateway configuration, filename: %s", c.flagGatewayConfigLocation))
+			return nil
+		}
+		c.UI.Error(fmt.Sprintf("Error opening gateway configuration file %s: %s", c.flagGatewayConfigLocation, err))
+		return err
+	}
+
+	config, err := io.ReadAll(file)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error reading gateway configuration file %s: %s", c.flagGatewayConfigLocation, err))
+		return err
+	}
+
+	err = k8syaml.Unmarshal(config, &c.gatewayConfig)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error decoding gateway config file: %s", err))
+		return err
+	}
+
+	if err := file.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Command) deleteV2GatewayClassAndClassConfigs() error {
+	for _, gcc := range c.gatewayConfig.GatewayClassConfigs {
+
+		// find the class config and mark it for deletion first so that we
+		// can do an early return if the gateway class isn't found
+		config := &v2beta1.GatewayClassConfig{}
+		err := c.k8sClient.Get(context.Background(), types.NamespacedName{Name: gcc.Name, Namespace: gcc.Namespace}, config)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				// no gateway class config, just ignore and return
+				return nil
+			}
+			return err
+		}
+
+		// ignore any returned errors
+		_ = c.k8sClient.Delete(context.Background(), config)
+
+		// find the gateway class
+		gatewayClass := &v2beta1.GatewayClass{}
+		//TODO is the correct name for the gatewayclass?
+		err = c.k8sClient.Get(context.Background(), types.NamespacedName{Name: gcc.Name, Namespace: gcc.Namespace}, gatewayClass)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				// no gateway class, just ignore and return
+				return nil
+			}
+			return err
+		}
+
+		// ignore any returned errors
+		_ = c.k8sClient.Delete(context.Background(), gatewayClass)
+
+		// make sure they're gone
+		if err := backoff.Retry(func() error {
+			err = c.k8sClient.Get(context.Background(), types.NamespacedName{Name: gcc.Name, Namespace: gcc.Namespace}, config)
+			if err == nil || !k8serrors.IsNotFound(err) {
+				return errors.New("gateway class config still exists")
+			}
+
+			err = c.k8sClient.Get(context.Background(), types.NamespacedName{Name: gcc.Name, Namespace: gcc.Namespace}, gatewayClass)
+			if err == nil || !k8serrors.IsNotFound(err) {
+				return errors.New("gateway class still exists")
+			}
+
+			return nil
+		}, exponentialBackoffWithMaxIntervalAndTime()); err != nil {
+			c.UI.Error(err.Error())
+			// if we failed, return 0 anyway after logging the error
+			// since we don't want to block someone from uninstallation
+		}
+	}
+
+	return nil
 }

--- a/control-plane/subcommand/gateway-cleanup/command.go
+++ b/control-plane/subcommand/gateway-cleanup/command.go
@@ -138,6 +138,7 @@ func (c *Command) Run(args []string) int {
 	config := &v1alpha1.GatewayClassConfig{}
 	err = c.k8sClient.Get(context.Background(), types.NamespacedName{Name: c.flagGatewayClassConfigName}, config)
 	if err != nil {
+
 		if k8serrors.IsNotFound(err) {
 			// no gateway class config, just ignore and return
 			return 0
@@ -150,6 +151,7 @@ func (c *Command) Run(args []string) int {
 	_ = c.k8sClient.Delete(context.Background(), config)
 
 	// find the gateway class
+
 	gatewayClass := &gwv1beta1.GatewayClass{}
 	err = c.k8sClient.Get(context.Background(), types.NamespacedName{Name: c.flagGatewayClassName}, gatewayClass)
 	if err != nil {
@@ -186,12 +188,14 @@ func (c *Command) Run(args []string) int {
 	//V2 Cleanup
 	err = c.loadGatewayConfigs()
 	if err != nil {
+
 		c.UI.Error(err.Error())
 		return 1
 	}
 	err = c.deleteV2GatewayClassAndClassConfigs()
 	if err != nil {
 		c.UI.Error(err.Error())
+
 		return 1
 	}
 

--- a/control-plane/subcommand/gateway-cleanup/command.go
+++ b/control-plane/subcommand/gateway-cleanup/command.go
@@ -253,7 +253,6 @@ func (c *Command) loadGatewayConfigs() error {
 	file, err := os.Open(c.flagGatewayConfigLocation)
 	if err != nil {
 		if os.IsNotExist(err) {
-			panic(err)
 			c.UI.Warn(fmt.Sprintf("gateway configuration file not found, skipping gateway configuration, filename: %s", c.flagGatewayConfigLocation))
 			return nil
 		}

--- a/control-plane/subcommand/gateway-cleanup/command.go
+++ b/control-plane/subcommand/gateway-cleanup/command.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-
 	"io"
 	"os"
 	"sync"

--- a/control-plane/subcommand/gateway-cleanup/command.go
+++ b/control-plane/subcommand/gateway-cleanup/command.go
@@ -299,7 +299,7 @@ func (c *Command) deleteV2GatewayClassAndClassConfigs() error {
 
 		// find the gateway class
 		gatewayClass := &v2beta1.GatewayClass{}
-		//TODO is the correct name for the gatewayclass?
+		//TODO: NET-6838 To pull the GatewayClassName from the Configmap
 		err = c.k8sClient.Get(context.Background(), types.NamespacedName{Name: gcc.Name, Namespace: gcc.Namespace}, gatewayClass)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {

--- a/control-plane/subcommand/gateway-cleanup/command_test.go
+++ b/control-plane/subcommand/gateway-cleanup/command_test.go
@@ -4,6 +4,9 @@
 package gatewaycleanup
 
 import (
+	"github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
+	corev1 "k8s.io/api/core/v1"
+	"os"
 	"testing"
 
 	"github.com/mitchellh/cli"
@@ -52,6 +55,7 @@ func TestRun(t *testing.T) {
 			s := runtime.NewScheme()
 			require.NoError(t, gwv1beta1.Install(s))
 			require.NoError(t, v1alpha1.AddToScheme(s))
+			require.NoError(t, v2beta1.AddMeshToScheme(s))
 
 			objs := []client.Object{}
 			if tt.gatewayClass != nil {
@@ -81,4 +85,115 @@ func TestRun(t *testing.T) {
 			require.Equal(t, 0, code)
 		})
 	}
+}
+
+func TestRunV2Resources(t *testing.T) {
+	t.Parallel()
+
+	for name, tt := range map[string]struct {
+		gatewayClassConfig []*v2beta1.GatewayClassConfig
+		gatewayClass       []*v2beta1.GatewayClass
+		configMapData      string
+	}{
+
+		"v2 resources exists": {
+			gatewayClassConfig: []*v2beta1.GatewayClassConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-gateway",
+					},
+				},
+			},
+			gatewayClass: []*v2beta1.GatewayClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-gateway",
+					},
+				},
+			},
+			configMapData: `gatewayClassConfigs:
+- apiVersion: mesh.consul.hashicorp.com/v2beta1
+  kind: GatewayClassConfig
+  metadata:
+    name: test-gateway
+  spec:
+    deployment:
+      container:
+        resources:
+          requests:
+            cpu: 200m
+            memory: 200Mi
+          limits:
+            cpu: 200m
+            memory: 200Mi
+`,
+		},
+		"v2 emptyconfigmap": {
+			configMapData: "",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tt := tt
+
+			t.Parallel()
+
+			s := runtime.NewScheme()
+			require.NoError(t, gwv1beta1.Install(s))
+			require.NoError(t, v2beta1.AddMeshToScheme(s))
+			require.NoError(t, corev1.AddToScheme(s))
+			require.NoError(t, v1alpha1.AddToScheme(s))
+
+			objs := []client.Object{}
+			for _, gatewayClass := range tt.gatewayClass {
+				objs = append(objs, gatewayClass)
+			}
+			for _, gatewayClassConfig := range tt.gatewayClassConfig {
+				objs = append(objs, gatewayClassConfig)
+			}
+
+			configMap := &corev1.ConfigMap{
+				Data: map[string]string{
+					"config.yaml": tt.configMapData,
+				},
+			}
+
+			objs = append(objs, configMap)
+
+			client := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+
+			ui := cli.NewMockUi()
+			cmd := Command{
+				UI:                         ui,
+				k8sClient:                  client,
+				flagGatewayClassName:       "gateway-class",
+				flagGatewayClassConfigName: "gateway-class-config",
+			}
+
+			code := cmd.Run([]string{
+				"-gateway-class-config-name", "gateway-class-config",
+				"-gateway-class-name", "gateway-class",
+			})
+
+			require.Equal(t, 0, code)
+		})
+	}
+}
+
+func createGatewayConfigFile(t *testing.T, fileContent, filename string) string {
+	t.Helper()
+
+	// create a temp file to store configuration yaml
+	tmpdir := t.TempDir()
+	file, err := os.CreateTemp(tmpdir, filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(fileContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return file.Name()
 }


### PR DESCRIPTION
Changes proposed in this PR:
- Add v2 resources to gateway cleanup job

How I've tested this PR:
- Local kind helm install/uninstall while running
```kubectl logs job/consul-consul-gateway-cleanup -n consul```
In order to make sure the cleanup job didn't actually error.
- Updated unit test to cover v2 config map method

How I expect reviewers to test this PR:
- Local kind helm install/uninstall from this branch
- CI passes

Checklist:
- [ X ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


