### PR TITLE
NET-6393: Create/update/delete Service on MeshGateway reconcile

### DIFF
--- a/control-plane/api/mesh/v2beta1/gateway_class_config_types.go
+++ b/control-plane/api/mesh/v2beta1/gateway_class_config_types.go
@@ -113,6 +113,7 @@ type GatewayClassServiceConfig struct {
 	GatewayClassAnnotationsAndLabels `json:",inline"`
 
 	// Type specifies the type of Service to use (LoadBalancer, ClusterIP, etc.)
+	// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer
 	Type *corev1.ServiceType `json:"type,omitempty"`
 }
 

--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
@@ -289,7 +289,7 @@ func (r *MeshGatewayController) getGatewayClassForGateway(ctx context.Context, g
 }
 
 func areServicesEqual(a, b *corev1.Service) bool {
-
+	// If either service "a" or "b" is nil, don't want to try and merge the nil service
 	if a == nil || b == nil {
 		return true
 	}

--- a/control-plane/gateways/annotations.go
+++ b/control-plane/gateways/annotations.go
@@ -1,0 +1,26 @@
+package gateways
+
+func (b *meshGatewayBuilder) Annotations() map[string]string {
+
+	var (
+		annotationNamesToCopy = []string{}
+		annotationNamesToAdd  = map[string]string{}
+	)
+
+	if b.gcc != nil {
+		annotationNamesToCopy = b.gcc.Spec.Service.Annotations.InheritFromGateway
+		annotationNamesToAdd = b.gcc.Spec.Service.Annotations.Set
+	}
+
+	out := map[string]string{}
+
+	for _, v := range annotationNamesToCopy {
+		out[v] = b.gateway.Annotations[v]
+	}
+
+	for k, v := range annotationNamesToAdd {
+		out[k] = v
+	}
+
+	return out
+}

--- a/control-plane/gateways/service.go
+++ b/control-plane/gateways/service.go
@@ -1,0 +1,50 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package gateways
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	meshv2beta1 "github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
+)
+
+const port = 443
+
+func (b *meshGatewayBuilder) Service() *corev1.Service {
+	var (
+		containerConfig *meshv2beta1.GatewayClassContainerConfig
+		portModifier    = 0
+		serviceType     = corev1.ServiceType("")
+	)
+
+	if b.gcc != nil {
+		containerConfig = b.gcc.Spec.Deployment.Container
+		portModifier = containerConfig.PortModifier
+		serviceType = *b.gcc.Spec.Service.Type
+	}
+
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        b.gateway.Name,
+			Namespace:   b.gateway.Namespace,
+			Labels:      b.Labels(),
+			Annotations: b.Annotations(),
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: b.Labels(),
+			Type:     serviceType,
+			Ports: []corev1.ServicePort{
+				{
+					Name: "wan",
+					Port: port,
+					TargetPort: intstr.IntOrString{
+						IntVal: int32(port + portModifier),
+					},
+				},
+			},
+		},
+	}
+}

--- a/control-plane/gateways/service_test.go
+++ b/control-plane/gateways/service_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package gateways
+
+import (
+	"testing"
+
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	meshv2beta1 "github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
+)
+
+func Test_meshGatewayBuilder_Service(t *testing.T) {
+	lbType := corev1.ServiceTypeLoadBalancer
+
+	type fields struct {
+		gateway *meshv2beta1.MeshGateway
+		config  GatewayConfig
+		gcc     *meshv2beta1.GatewayClassConfig
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   *corev1.Service
+	}{
+		{
+			name: "service resource crd created - happy path",
+			fields: fields{
+				gateway: &meshv2beta1.MeshGateway{
+					Spec: pbmesh.MeshGateway{
+						GatewayClassName: "test-gateway-class",
+					},
+				},
+				config: GatewayConfig{},
+				gcc: &meshv2beta1.GatewayClassConfig{
+					Spec: meshv2beta1.GatewayClassConfigSpec{
+						Deployment: meshv2beta1.GatewayClassDeploymentConfig{
+							Container: &meshv2beta1.GatewayClassContainerConfig{
+								PortModifier: 8000,
+							},
+						},
+						Service: meshv2beta1.GatewayClassServiceConfig{
+							Type: &lbType,
+						},
+					},
+				},
+			},
+			want: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+					},
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+					},
+					Type: corev1.ServiceTypeLoadBalancer,
+					Ports: []corev1.ServicePort{
+						{
+							Name: "wan",
+							Port: int32(443),
+							TargetPort: intstr.IntOrString{
+								IntVal: int32(8443),
+							},
+						},
+					},
+				},
+				Status: corev1.ServiceStatus{},
+			},
+		},
+		{
+			name: "create service resource crd - gcc is nil",
+			fields: fields{
+				gateway: &meshv2beta1.MeshGateway{
+					Spec: pbmesh.MeshGateway{
+						GatewayClassName: "test-gateway-class",
+					},
+				},
+				config: GatewayConfig{},
+				gcc:    nil,
+			},
+			want: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+					},
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+					},
+					Type: "",
+					Ports: []corev1.ServicePort{
+						{
+							Name: "wan",
+							Port: int32(443),
+							TargetPort: intstr.IntOrString{
+								IntVal: int32(443),
+							},
+						},
+					},
+				},
+				Status: corev1.ServiceStatus{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &meshGatewayBuilder{
+				gateway: tt.fields.gateway,
+				config:  tt.fields.config,
+				gcc:     tt.fields.gcc,
+			}
+			result := b.Service()
+			assert.Equalf(t, tt.want, result, "Service()")
+		})
+	}
+}

--- a/control-plane/subcommand/gateway-resources/command.go
+++ b/control-plane/subcommand/gateway-resources/command.go
@@ -436,6 +436,7 @@ func (c *Command) createV2GatewayClassAndClassConfigs(ctx context.Context, compo
 			return err
 		}
 
+		// TODO: NET-6934 remove hardcoded values;
 		class := &v2beta1.GatewayClass{
 			ObjectMeta: metav1.ObjectMeta{Name: cfg.Name, Labels: labels},
 			TypeMeta:   metav1.TypeMeta{Kind: "GatewayClass"},

--- a/control-plane/subcommand/gateway-resources/command.go
+++ b/control-plane/subcommand/gateway-resources/command.go
@@ -436,7 +436,7 @@ func (c *Command) createV2GatewayClassAndClassConfigs(ctx context.Context, compo
 			return err
 		}
 
-		// TODO: NET-6934 remove hardcoded values;
+		// TODO: NET-6934 remove hardcoded values
 		class := &v2beta1.GatewayClass{
 			ObjectMeta: metav1.ObjectMeta{Name: cfg.Name, Labels: labels},
 			TypeMeta:   metav1.TypeMeta{Kind: "GatewayClass"},


### PR DESCRIPTION
### Changes proposed in this PR ###  
When reconciling a MeshGateway resource in the v2 API, create/update/delete a corresponding Service.

### How I've tested this PR ###

- Unit Test in code for review

**Manual Test Steps Below**
- Checkout and build consul-k8s using this branch;
- Run `make control-plane-dev-docker` to ensure you're using a `local` control-plane-dev image with changes
- [If required] Update consul values.yaml with ` imageK8S: consul-k8s-control-plane-dev:local`
- Then do a local kind helm install/uninstall of Consul
- Add `v2beta1` gateway resource

**RESULT**
```
$ k get gatewayclass.mesh -A
gateway-class2                               32m
```
Then get the gatewayclass.mesh resource yaml output
```
apiVersion: mesh.consul.hashicorp.com/v2beta1
kind: GatewayClass
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"mesh.consul.hashicorp.com/v2beta1","kind":"GatewayClass","metadata":{"annotations":{},"name":"gateway-class2"},"spec":{"parametersRef":{"group":"mesh.consul.hashicorp.com","kind":"GatewayClassConfig","name":"gateway-class-config2"}}}
  creationTimestamp: "2023-12-13T02:21:02Z"
  generation: 1
  name: gateway-class2
  resourceVersion: "1658"
  uid: e17be12f-2afa-4e57-bc65-86733ef075ae
spec:
  parametersRef:
    group: mesh.consul.hashicorp.com
    kind: GatewayClassConfig
    name: gateway-class-config2
```
Next, validate service was deployed
```
$ k get service -n consul
mesh-gateway              LoadBalancer   10.96.67.159   <pending>     443:32130/TCP  
```
Then get the yaml output
```
$ k get service mesh-gateway -o yaml -n consul
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: "2023-12-11T20:39:52Z"
  labels:
    mesh.consul.hashicorp.com/managed-by: consul-k8s
  name: mesh-gateway
  namespace: consul
  ownerReferences:
  - apiVersion: mesh.consul.hashicorp.com/v2beta1
    blockOwnerDeletion: true
    controller: true
    kind: MeshGateway
    name: mesh-gateway
    uid: 369c3fe7-4db7-4b20-ba4d-82da2f1b9b96
  resourceVersion: "1086"
  uid: 35706f9f-ba96-440f-8746-4984f711f483
spec:
  allocateLoadBalancerNodePorts: true
  clusterIP: 10.96.9.244
  clusterIPs:
  - 10.96.9.244
  externalTrafficPolicy: Cluster
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv4
  ipFamilyPolicy: SingleStack
  ports:
  - name: wan
    nodePort: 30271
    port: 443
    protocol: TCP
    targetPort: 8443
  selector:
    mesh.consul.hashicorp.com/managed-by: consul-k8s
  sessionAffinity: None
  type: LoadBalancer
status:
  loadBalancer: {}
```
### How I expect reviewers to test this PR ###
Follow testing steps above

### Checklist ###
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
