### PR TITLE
Net 6742 - consul k8s mgw deployment priority class name support

### DIFF
--- a/charts/consul/templates/gateway-resources-configmap.yaml
+++ b/charts/consul/templates/gateway-resources-configmap.yaml
@@ -32,6 +32,9 @@ data:
               release: {{ .Release.Name }}
               component: mesh-gateway
           deployment:
+            {{- if .Values.meshGateway.priorityClassName }}
+            priorityClassName: {{ .Values.meshGateway.priorityClassName | quote }}
+            {{- end }}
             {{- if .Values.meshGateway.affinity }}
             affinity: {{ toJson (default "{}" .Values.meshGateway.affinity) }}
             {{- end }}

--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
@@ -229,7 +229,7 @@ func (r *MeshGatewayController) getGatewayClassConfigForGateway(ctx context.Cont
 		return nil, err
 	}
 
-	gatewayClassConfig, err := r.getConfigForGatewayClass(ctx, gatewayClass)
+	gatewayClassConfig, err := r.getGatewayClassForGatewayClassConfig(ctx, gatewayClass)
 	if err != nil {
 		return nil, err
 	}
@@ -237,14 +237,14 @@ func (r *MeshGatewayController) getGatewayClassConfigForGateway(ctx context.Cont
 	return gatewayClassConfig, nil
 }
 
-func (r *MeshGatewayController) getConfigForGatewayClass(ctx context.Context, gatewayClass *meshv2beta1.GatewayClass) (*meshv2beta1.GatewayClassConfig, error) {
-	if gatewayClass == nil {
+func (r *MeshGatewayController) getGatewayClassForGatewayClassConfig(ctx context.Context, gatewayClassConfig *meshv2beta1.GatewayClass) (*meshv2beta1.GatewayClassConfig, error) {
+	if gatewayClassConfig == nil {
 		// if we don't have a gateway class we can't fetch the corresponding config
 		return nil, nil
 	}
 
 	config := &meshv2beta1.GatewayClassConfig{}
-	if ref := gatewayClass.Spec.ParametersRef; ref != nil {
+	if ref := gatewayClassConfig.Spec.ParametersRef; ref != nil {
 		if ref.Group != meshv2beta1.MeshGroup || ref.Kind != "GatewayClassConfig" {
 			// TODO @Gateway-Management additionally check for controller name when available
 			return nil, nil

--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller.go
@@ -229,7 +229,7 @@ func (r *MeshGatewayController) getGatewayClassConfigForGateway(ctx context.Cont
 		return nil, err
 	}
 
-	gatewayClassConfig, err := r.getGatewayClassForGatewayClassConfig(ctx, gatewayClass)
+	gatewayClassConfig, err := r.getGatewayClassConfigForGatewayClass(ctx, gatewayClass)
 	if err != nil {
 		return nil, err
 	}
@@ -237,14 +237,14 @@ func (r *MeshGatewayController) getGatewayClassConfigForGateway(ctx context.Cont
 	return gatewayClassConfig, nil
 }
 
-func (r *MeshGatewayController) getGatewayClassForGatewayClassConfig(ctx context.Context, gatewayClassConfig *meshv2beta1.GatewayClass) (*meshv2beta1.GatewayClassConfig, error) {
-	if gatewayClassConfig == nil {
+func (r *MeshGatewayController) getGatewayClassConfigForGatewayClass(ctx context.Context, gatewayClass *meshv2beta1.GatewayClass) (*meshv2beta1.GatewayClassConfig, error) {
+	if gatewayClass == nil {
 		// if we don't have a gateway class we can't fetch the corresponding config
 		return nil, nil
 	}
 
 	config := &meshv2beta1.GatewayClassConfig{}
-	if ref := gatewayClassConfig.Spec.ParametersRef; ref != nil {
+	if ref := gatewayClass.Spec.ParametersRef; ref != nil {
 		if ref.Group != meshv2beta1.MeshGroup || ref.Kind != "GatewayClassConfig" {
 			// TODO @Gateway-Management additionally check for controller name when available
 			return nil, nil

--- a/control-plane/config-entries/controllersv2/mesh_gateway_controller_test.go
+++ b/control-plane/config-entries/controllersv2/mesh_gateway_controller_test.go
@@ -345,6 +345,7 @@ func TestMeshGatewayController_Reconcile(t *testing.T) {
 			require.NoError(t, corev1.AddToScheme(s))
 			require.NoError(t, appsv1.AddToScheme(s))
 			require.NoError(t, rbacv1.AddToScheme(s))
+			require.NoError(t, v2beta1.AddMeshToScheme(s))
 			s.AddKnownTypes(v2beta1.MeshGroupVersion, &v2beta1.MeshGateway{}, &v2beta1.GatewayClass{}, &v2beta1.GatewayClassConfig{})
 			fakeClient := fake.NewClientBuilder().WithScheme(s).
 				WithRuntimeObjects(testCase.k8sObjects...).

--- a/control-plane/gateways/deployment.go
+++ b/control-plane/gateways/deployment.go
@@ -38,6 +38,7 @@ func (b *meshGatewayBuilder) deploymentSpec() (*appsv1.DeploymentSpec, error) {
 
 	var containerConfig *meshv2beta1.GatewayClassContainerConfig
 	var deploymentConfig meshv2beta1.GatewayClassDeploymentConfig
+	
 	if b.gcc != nil {
 		containerConfig = b.gcc.Spec.Deployment.Container
 		deploymentConfig = b.gcc.Spec.Deployment

--- a/control-plane/gateways/deployment.go
+++ b/control-plane/gateways/deployment.go
@@ -37,8 +37,10 @@ func (b *meshGatewayBuilder) deploymentSpec() (*appsv1.DeploymentSpec, error) {
 	}
 
 	var containerConfig *meshv2beta1.GatewayClassContainerConfig
+	var deploymentConfig meshv2beta1.GatewayClassDeploymentConfig
 	if b.gcc != nil {
 		containerConfig = b.gcc.Spec.Deployment.Container
+		deploymentConfig = b.gcc.Spec.Deployment
 	}
 
 	container, err := consulDataplaneContainer(b.config, containerConfig, b.gateway.Name, b.gateway.Namespace)
@@ -96,6 +98,7 @@ func (b *meshGatewayBuilder) deploymentSpec() (*appsv1.DeploymentSpec, error) {
 					},
 				},
 				NodeSelector:       nodeSelector,
+				PriorityClassName:  deploymentConfig.PriorityClassName,
 				Tolerations:        nil,
 				ServiceAccountName: b.serviceAccountName(),
 			},

--- a/control-plane/gateways/deployment.go
+++ b/control-plane/gateways/deployment.go
@@ -38,7 +38,7 @@ func (b *meshGatewayBuilder) deploymentSpec() (*appsv1.DeploymentSpec, error) {
 
 	var containerConfig *meshv2beta1.GatewayClassContainerConfig
 	var deploymentConfig meshv2beta1.GatewayClassDeploymentConfig
-	
+
 	if b.gcc != nil {
 		containerConfig = b.gcc.Spec.Deployment.Container
 		deploymentConfig = b.gcc.Spec.Deployment

--- a/control-plane/gateways/deployment_test.go
+++ b/control-plane/gateways/deployment_test.go
@@ -48,6 +48,7 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 								Min:     pointer.Int32(1),
 								Max:     pointer.Int32(8),
 							},
+							PriorityClassName: "priorityclassname",
 						},
 					},
 				},
@@ -252,7 +253,8 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 									TTY:       false,
 								},
 							},
-							NodeSelector: map[string]string{"beta.kubernetes.io/arch": "amd64"},
+							NodeSelector:      map[string]string{"beta.kubernetes.io/arch": "amd64"},
+							PriorityClassName: "priorityclassname",
 							Affinity: &corev1.Affinity{
 								NodeAffinity: nil,
 								PodAffinity:  nil,


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Add support for priorityClassName to deployment generation

### How I've tested this PR ###

Ran a local install with the following consul values set on the helm.
```
global:
  tls:
    enabled: true
  imageK8S: consul-k8s-control-plane-dev:gauntlet #or whatever you're tagging your local build image as
  logLevel: "debug"
  experiments:
    - "resource-apis"
server:
  replicas: 1
ui:
  enabled: false
meshGateway:
  enabled: true
  priorityClassName: "hellotest"
```

Ran

 ```kubectl get deployments mesh-gateway -n consul -o yaml```

  ```apiVersion: apps/v1
       kind: Deployment
... <removed for brevity> 
          priorityClassName: hellotest
```
### How I expect reviewers to test this PR ###
- Local install
- Looking over
- CI passes

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
