### PR TITLE
NET-6663 Set gateway-kind in Workload metadata when it represents a xGateway Pod

### DIFF
--- a/control-plane/connect-inject/constants/constants.go
+++ b/control-plane/connect-inject/constants/constants.go
@@ -27,6 +27,10 @@ const (
 	// ProxyDefaultHealthPort is the default HTTP health check port for the proxy.
 	ProxyDefaultHealthPort = 21000
 
+	// MetaGatewayKind is the meta key name for indicating which kind of gateway a Pod is for, if any.
+	// The value should be one of "mesh", "api", or "terminating".
+	MetaGatewayKind = "gateway-kind"
+
 	// MetaKeyManagedBy is the meta key name for indicating which Kubernetes controller manages a Consul resource.
 	MetaKeyManagedBy = "managed-by"
 

--- a/control-plane/connect-inject/controllers/pod/pod_controller.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller.go
@@ -664,10 +664,16 @@ func parseLocality(node corev1.Node) *pbcatalog.Locality {
 
 func metaFromPod(pod corev1.Pod) map[string]string {
 	// TODO: allow custom workload metadata
-	return map[string]string{
+	meta := map[string]string{
 		constants.MetaKeyKubeNS:    pod.GetNamespace(),
 		constants.MetaKeyManagedBy: constants.ManagedByPodValue,
 	}
+
+	if gatewayKind := pod.Annotations[constants.AnnotationGatewayKind]; gatewayKind != "" {
+		meta[constants.MetaGatewayKind] = gatewayKind
+	}
+
+	return meta
 }
 
 // getHealthStatusFromPod checks the Pod for a "Ready" condition that is true.

--- a/control-plane/gateways/deployment.go
+++ b/control-plane/gateways/deployment.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	globalDefaultInstances int32 = 1
+	globalDefaultInstances    int32 = 1
+	meshGatewayAnnotationKind       = "mesh-gateway"
 )
 
 func (b *meshGatewayBuilder) Deployment() (*appsv1.Deployment, error) {
@@ -69,8 +70,8 @@ func (b *meshGatewayBuilder) deploymentSpec() (*appsv1.DeploymentSpec, error) {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: b.Labels(),
 				Annotations: map[string]string{
-					"consul.hashicorp.com/mesh-inject": "false",
-					constants.AnnotationGatewayKind:    "mesh",
+					constants.AnnotationMeshInject:  "false",
+					constants.AnnotationGatewayKind: meshGatewayAnnotationKind,
 				},
 			},
 			Spec: corev1.PodSpec{

--- a/control-plane/gateways/deployment.go
+++ b/control-plane/gateways/deployment.go
@@ -12,6 +12,7 @@ import (
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
 
 	meshv2beta1 "github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 )
 
 const (
@@ -69,6 +70,7 @@ func (b *meshGatewayBuilder) deploymentSpec() (*appsv1.DeploymentSpec, error) {
 				Labels: b.Labels(),
 				Annotations: map[string]string{
 					"consul.hashicorp.com/mesh-inject": "false",
+					constants.AnnotationGatewayKind:    "mesh",
 				},
 			},
 			Spec: corev1.PodSpec{

--- a/control-plane/gateways/deployment_test.go
+++ b/control-plane/gateways/deployment_test.go
@@ -16,6 +16,7 @@ import (
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
 
 	meshv2beta1 "github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 )
 
 func Test_meshGatewayBuilder_Deployment(t *testing.T) {
@@ -72,7 +73,8 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 								"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
 							},
 							Annotations: map[string]string{
-								"consul.hashicorp.com/mesh-inject": "false",
+								constants.AnnotationMeshInject:  "false",
+								constants.AnnotationGatewayKind: meshGatewayAnnotationKind,
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -316,7 +318,8 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 								"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
 							},
 							Annotations: map[string]string{
-								"consul.hashicorp.com/mesh-inject": "false",
+								constants.AnnotationMeshInject:  "false",
+								constants.AnnotationGatewayKind: meshGatewayAnnotationKind,
 							},
 						},
 						Spec: corev1.PodSpec{


### PR DESCRIPTION
### Changes proposed in this PR ###  
By setting the gateway-kind annotation on the Pods for a MeshGateway, we indicate to the Pod controller in consul-k8s that the Pod represents a mesh gateway (or api/terminating in the future). The Pod controller then passes this along as metadata on the Workload that it creates in Consul.

The end result is that the sidecar and gateway proxy controllers can determine which Workloads they should generate ProxyStateTemplates for and which should be left to the other.

### How I've tested this PR ###
When combined with https://github.com/hashicorp/consul/pull/19902, the sidecar proxy controller should skip any Workloads created for a `MeshGateway` when `meshGateway.enabled=true` and `experiments: [resource-apis]` in values.yaml.

### How I expect reviewers to test this PR ###
See above

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
