### PR TITLE
Mw/net 6911 parallel cluster creation in acceptance test causes tests to hang on failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,11 +183,16 @@ kind-cni: kind-delete ## Helper target for doing local cni acceptance testing
 	make kind-cni-calico
 
 .PHONY: kind
-kind: kind-delete ## Helper target for doing local acceptance testing
+kind: kind-delete ## Helper target for doing local acceptance testing (works in all cases)
 	kind create cluster --name dc1 --image $(KIND_NODE_IMAGE)
 	kind create cluster --name dc2 --image $(KIND_NODE_IMAGE)
 	kind create cluster --name dc3 --image $(KIND_NODE_IMAGE)
 	kind create cluster --name dc4 --image $(KIND_NODE_IMAGE)
+
+.PHONY: kind-small
+kind-small: kind-delete ## Helper target for doing local acceptance testing (when you only need two clusters)
+	kind create cluster --name dc1 --image $(KIND_NODE_IMAGE)
+	kind create cluster --name dc2 --image $(KIND_NODE_IMAGE)
 
 .PHONY: kind-load
 kind-load: ## Helper target for loading local dev images (run with `DEV_IMAGE=...` to load non-k8s images)

--- a/acceptance/tests/partitions/partitions_connect_test.go
+++ b/acceptance/tests/partitions/partitions_connect_test.go
@@ -30,10 +30,10 @@ func TestPartitions_Connect(t *testing.T) {
 	env := suite.Environment()
 	cfg := suite.Config()
 
-	// Currently there is a bug which causes flakes when CNI is enabled
-	if cfg.EnableCNI {
-		t.Skipf("TODO(flaky): NET-5819")
-	}
+	// TODO: We are monitoring that NET-5819 is fixed, if this test is still flaking in CNI, re-enable this skip
+	//if cfg.EnableCNI {
+	//	t.Skipf("TODO(flaky): NET-5819")
+	//}
 
 	if !cfg.EnableEnterprise {
 		t.Skipf("skipping this test because -enable-enterprise is not set")

--- a/acceptance/tests/peering/peering_connect_namespaces_test.go
+++ b/acceptance/tests/peering/peering_connect_namespaces_test.go
@@ -123,6 +123,7 @@ func TestPeering_ConnectNamespaces(t *testing.T) {
 			var staticServerPeerCluster *consul.HelmCluster
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				staticServerPeerHelmValues := map[string]string{
 					"global.datacenter": staticServerPeer,
 				}
@@ -145,13 +146,12 @@ func TestPeering_ConnectNamespaces(t *testing.T) {
 				// Install the first peer where static-server will be deployed in the static-server kubernetes context.
 				staticServerPeerCluster = consul.NewHelmCluster(t, staticServerPeerHelmValues, staticServerPeerClusterContext, cfg, releaseName)
 				staticServerPeerCluster.Create(t)
-
-				wg.Done()
 			}()
 
 			var staticClientPeerCluster *consul.HelmCluster
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				staticClientPeerHelmValues := map[string]string{
 					"global.datacenter": staticClientPeer,
 				}
@@ -171,8 +171,6 @@ func TestPeering_ConnectNamespaces(t *testing.T) {
 				// Install the second peer where static-client will be deployed in the static-client kubernetes context.
 				staticClientPeerCluster = consul.NewHelmCluster(t, staticClientPeerHelmValues, staticClientPeerClusterContext, cfg, releaseName)
 				staticClientPeerCluster.Create(t)
-
-				wg.Done()
 			}()
 
 			// Wait for the clusters to start up

--- a/acceptance/tests/peering/peering_connect_test.go
+++ b/acceptance/tests/peering/peering_connect_test.go
@@ -86,6 +86,7 @@ func TestPeering_Connect(t *testing.T) {
 			var staticServerPeerCluster *consul.HelmCluster
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				staticServerPeerHelmValues := map[string]string{
 					"global.datacenter":                        staticServerPeer,
 					"terminatingGateways.enabled":              "true",
@@ -111,12 +112,12 @@ func TestPeering_Connect(t *testing.T) {
 				// Install the first peer where static-server will be deployed in the static-server kubernetes context.
 				staticServerPeerCluster = consul.NewHelmCluster(t, staticServerPeerHelmValues, staticServerPeerClusterContext, cfg, releaseName)
 				staticServerPeerCluster.Create(t)
-				wg.Done()
 			}()
 
 			var staticClientPeerCluster *consul.HelmCluster
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				// Create a second cluster to be peered with
 				staticClientPeerHelmValues := map[string]string{
 					"global.datacenter": staticClientPeer,
@@ -137,7 +138,6 @@ func TestPeering_Connect(t *testing.T) {
 				// Install the second peer where static-client will be deployed in the static-client kubernetes context.
 				staticClientPeerCluster = consul.NewHelmCluster(t, staticClientPeerHelmValues, staticClientPeerClusterContext, cfg, releaseName)
 				staticClientPeerCluster.Create(t)
-				wg.Done()
 			}()
 
 			// Wait for the clusters to start up

--- a/acceptance/tests/peering/peering_gateway_test.go
+++ b/acceptance/tests/peering/peering_gateway_test.go
@@ -70,6 +70,7 @@ func TestPeering_Gateway(t *testing.T) {
 	var staticServerPeerCluster *consul.HelmCluster
 	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		staticServerPeerHelmValues := map[string]string{
 			"global.datacenter": staticServerPeer,
 		}
@@ -92,12 +93,12 @@ func TestPeering_Gateway(t *testing.T) {
 		// Install the first peer where static-server will be deployed in the static-server kubernetes context.
 		staticServerPeerCluster = consul.NewHelmCluster(t, staticServerPeerHelmValues, staticServerPeerClusterContext, cfg, releaseName)
 		staticServerPeerCluster.Create(t)
-		wg.Done()
 	}()
 
 	var staticClientPeerCluster *consul.HelmCluster
 	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		staticClientPeerHelmValues := map[string]string{
 			"global.datacenter": staticClientPeer,
 		}
@@ -117,7 +118,6 @@ func TestPeering_Gateway(t *testing.T) {
 		// Install the second peer where static-client will be deployed in the static-client kubernetes context.
 		staticClientPeerCluster = consul.NewHelmCluster(t, staticClientPeerHelmValues, staticClientPeerClusterContext, cfg, releaseName)
 		staticClientPeerCluster.Create(t)
-		wg.Done()
 	}()
 
 	// Wait for the clusters to start up

--- a/acceptance/tests/sameness/sameness_test.go
+++ b/acceptance/tests/sameness/sameness_test.go
@@ -174,8 +174,6 @@ func TestFailover_Connect(t *testing.T) {
 
 				"global.adminPartitions.enabled": "true",
 
-				"global.logLevel": "warn",
-
 				"global.acls.manageSystemACLs": strconv.FormatBool(c.ACLsEnabled),
 
 				"connectInject.enabled":                       "true",

--- a/acceptance/tests/sameness/sameness_test.go
+++ b/acceptance/tests/sameness/sameness_test.go
@@ -196,6 +196,7 @@ func TestFailover_Connect(t *testing.T) {
 			// create in same routine as 01-b depends on 01-a being created first
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				// Create the cluster-01-a
 				defaultPartitionHelmValues := map[string]string{
 					"global.datacenter": cluster01Datacenter,
@@ -266,12 +267,12 @@ func TestFailover_Connect(t *testing.T) {
 
 				testClusters[keyCluster01b].helmCluster = consul.NewHelmCluster(t, secondaryPartitionHelmValues, testClusters[keyCluster01b].context, cfg, releaseName)
 				testClusters[keyCluster01b].helmCluster.Create(t)
-				wg.Done()
 			}()
 
 			// Create cluster-02-a Cluster.
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				PeerOneHelmValues := map[string]string{
 					"global.datacenter": cluster02Datacenter,
 				}
@@ -285,12 +286,12 @@ func TestFailover_Connect(t *testing.T) {
 
 				testClusters[keyCluster02a].helmCluster = consul.NewHelmCluster(t, PeerOneHelmValues, testClusters[keyCluster02a].context, cfg, releaseName)
 				testClusters[keyCluster02a].helmCluster.Create(t)
-				wg.Done()
 			}()
 
 			// Create cluster-03-a Cluster.
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				PeerTwoHelmValues := map[string]string{
 					"global.datacenter": cluster03Datacenter,
 				}
@@ -304,10 +305,10 @@ func TestFailover_Connect(t *testing.T) {
 
 				testClusters[keyCluster03a].helmCluster = consul.NewHelmCluster(t, PeerTwoHelmValues, testClusters[keyCluster03a].context, cfg, releaseName)
 				testClusters[keyCluster03a].helmCluster.Create(t)
-				wg.Done()
 			}()
 
 			// Wait for the clusters to start up
+			logger.Log(t, "waiting for clusters to start up . . .")
 			wg.Wait()
 
 			// Create a ProxyDefaults resource to configure services to use the mesh
@@ -870,7 +871,7 @@ func localityForRegion(r string) api.Locality {
 func deployCustomizeAsync(t *testing.T, opts *terratestk8s.KubectlOptions, noCleanupOnFailure bool, noCleanup bool, debugDirectory string, kustomizeDir string, wg *sync.WaitGroup) {
 	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		k8s.DeployKustomize(t, opts, noCleanupOnFailure, noCleanup, debugDirectory, kustomizeDir)
-		wg.Done()
 	}()
 }

--- a/control-plane/subcommand/get-consul-client-ca/command_test.go
+++ b/control-plane/subcommand/get-consul-client-ca/command_test.go
@@ -157,6 +157,7 @@ func TestRun_ConsulServerAvailableLater(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		// start the test server after 100ms
 		time.Sleep(100 * time.Millisecond)
 		a, err = testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
@@ -176,7 +177,6 @@ func TestRun_ConsulServerAvailableLater(t *testing.T) {
 			c.KeyFile = keyFile
 		})
 		require.NoError(t, err)
-		wg.Done()
 	}()
 	defer func() {
 		if a != nil {


### PR DESCRIPTION
### Changes proposed in this PR ###  

#### Fixes
- adds `defer wg.Done()` to avoid deadlock
- also attempts to fix NET-6909 with creation retry
- fixed an issue where the sameness test was logging at the warn log level
- disable the NET-5819 skip so that we can monitor if other changes to Consul since the issue was first logged may have fixed the issue

#### DevX
- added a make target for a smaller kind multi-cluster

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
