### PR TITLE
[NET-6721] Replicas support for MeshGW v2 Deployments

### DIFF
--- a/control-plane/gateways/deployment.go
+++ b/control-plane/gateways/deployment.go
@@ -155,18 +155,18 @@ func compareDeployments(a, b *appsv1.Deployment) bool {
 
 func deploymentReplicaCount(replicas *meshv2beta1.GatewayClassReplicasConfig, currentReplicas *int32) *int32 {
 	// if we have the replicas config, use it
-	if replicas != nil && currentReplicas == nil {
+	if replicas != nil && replicas.Default != nil && currentReplicas == nil {
 		return replicas.Default
 	}
 
 	// if we have the replicas config and the current replicas, use the min/max to ensure
 	// the current replicas are within the min/max range
 	if replicas != nil && currentReplicas != nil {
-		if *currentReplicas > *replicas.Max {
+		if replicas.Max != nil && *currentReplicas > *replicas.Max {
 			return replicas.Max
 		}
 
-		if *currentReplicas < *replicas.Min {
+		if replicas.Min != nil && *currentReplicas < *replicas.Min {
 			return replicas.Min
 		}
 

--- a/control-plane/gateways/deployment.go
+++ b/control-plane/gateways/deployment.go
@@ -9,8 +9,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
-	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
-
 	meshv2beta1 "github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
 )
 
@@ -41,16 +39,15 @@ func (b *meshGatewayBuilder) deploymentSpec() (*appsv1.DeploymentSpec, error) {
 		nodeSelector     map[string]string
 		tolerations      []corev1.Toleration
 		deploymentConfig meshv2beta1.GatewayClassDeploymentConfig
+		replicas         *meshv2beta1.GatewayClassReplicasConfig
 	)
+
 	if b.gcc != nil {
 		containerConfig = b.gcc.Spec.Deployment.Container
 		deploymentConfig = b.gcc.Spec.Deployment
-
-		if b.gcc.Spec.Deployment.NodeSelector != nil {
-			nodeSelector = b.gcc.Spec.Deployment.NodeSelector
-		}
-
+		nodeSelector = b.gcc.Spec.Deployment.NodeSelector
 		tolerations = b.gcc.Spec.Deployment.Tolerations
+		replicas = b.gcc.Spec.Deployment.Replicas
 	}
 
 	container, err := consulDataplaneContainer(b.config, containerConfig, b.gateway.Name, b.gateway.Namespace)
@@ -60,7 +57,7 @@ func (b *meshGatewayBuilder) deploymentSpec() (*appsv1.DeploymentSpec, error) {
 
 	return &appsv1.DeploymentSpec{
 		// TODO NET-6721
-		Replicas: deploymentReplicaCount(nil, nil),
+		Replicas: deploymentReplicaCount(replicas, nil),
 		Selector: &metav1.LabelSelector{
 			MatchLabels: b.Labels(),
 		},
@@ -156,11 +153,31 @@ func compareDeployments(a, b *appsv1.Deployment) bool {
 	return *b.Spec.Replicas == *a.Spec.Replicas
 }
 
-func deploymentReplicaCount(deployment *pbmesh.Deployment, currentReplicas *int32) *int32 {
-	// TODO NET-6721 tamp replica count up and down based on min and max values
-	instanceValue := globalDefaultInstances
+func deploymentReplicaCount(replicas *meshv2beta1.GatewayClassReplicasConfig, currentReplicas *int32) *int32 {
+	// if we have the replicas config, use it
+	if replicas != nil && currentReplicas == nil {
+		return replicas.Default
+	}
+
+	// if we have the replicas config and the current replicas, use the min/max to ensure
+	// the current replicas are within the min/max range
+	if replicas != nil && currentReplicas != nil {
+		if *currentReplicas > *replicas.Max {
+			return replicas.Max
+		}
+
+		if *currentReplicas < *replicas.Min {
+			return replicas.Min
+		}
+
+		return currentReplicas
+	}
+
+	// if we don't have the replicas config, use the current replicas if we have them
 	if currentReplicas != nil {
 		return currentReplicas
 	}
-	return pointer.Int32(instanceValue)
+
+	// otherwise use the global default
+	return pointer.Int32(globalDefaultInstances)
 }

--- a/control-plane/subcommand/gateway-resources/command_test.go
+++ b/control-plane/subcommand/gateway-resources/command_test.go
@@ -372,6 +372,10 @@ var validGWConfigurationKitchenSink = `gatewayClassConfigs:
     name: consul-mesh-gateway
   spec:
     deployment:
+      replicas:
+        min: 3
+        default: 3
+        max: 3
       nodeSelector:
         beta.kubernetes.io/arch: amd64
         beta.kubernetes.io/os: linux
@@ -435,6 +439,7 @@ meshGateways:
 `
 
 func TestRun_loadGatewayConfigs(t *testing.T) {
+	var replicasCount int32 = 3
 	testCases := map[string]struct {
 		config             string
 		filename           string
@@ -447,6 +452,11 @@ func TestRun_loadGatewayConfigs(t *testing.T) {
 				NodeSelector: map[string]string{
 					"beta.kubernetes.io/arch": "amd64",
 					"beta.kubernetes.io/os":   "linux",
+				},
+				Replicas: &v2beta1.GatewayClassReplicasConfig{
+					Default: &replicasCount,
+					Min:     &replicasCount,
+					Max:     &replicasCount,
 				},
 				Tolerations: []corev1.Toleration{
 					{


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Add support for replicas config for meshgw v2 deployments
- currently draft because base branch https://github.com/hashicorp/consul-k8s/pull/3363 has an open PR


### How I've tested this PR ###
- :eye: 
- ran tests
- deployed kind cluster with replicas, saw them show up on deployment

### How I expect reviewers to test this PR ###
- :eye: 
- ran tests
- deployed kind cluster with replicas, saw them show up on deployment

### Checklist ###
- [X] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
