### PR TITLE
[NET-6787] HostNetwork support for meshgw deployments

### DIFF
--- a/charts/consul/templates/crd-gatewayclassconfigs.yaml
+++ b/charts/consul/templates/crd-gatewayclassconfigs.yaml
@@ -164,6 +164,10 @@ spec:
                             type: object
                         type: object
                     type: object
+                  hostNetwork:
+                    description: HostNetwork specifies whether the gateway pods should
+                      run on the host network
+                    type: boolean
                   initContainer:
                     description: InitContainer contains config specific to the created
                       Deployment's init container

--- a/charts/consul/templates/gateway-resources-configmap.yaml
+++ b/charts/consul/templates/gateway-resources-configmap.yaml
@@ -60,6 +60,9 @@ data:
             {{- with .Values.meshGateway.nodeSelector }}
             nodeSelector: {{ fromYaml . | toJson }}
             {{- end }}
+            {{- with .Values.meshGateway.hostNetwork }}
+            hostNetwork: {{ . }}
+            {{- end }}
             priorityClassName: {{ toJson .Values.meshGateway.priorityClassName }}
             replicas:
               default: {{ .Values.meshGateway.replicas }}

--- a/control-plane/api/mesh/v2beta1/gateway_class_config_types.go
+++ b/control-plane/api/mesh/v2beta1/gateway_class_config_types.go
@@ -67,6 +67,8 @@ type GatewayClassDeploymentConfig struct {
 	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 	// Tolerations specifies the tolerations to use on the created Deployment
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+	// HostNetwork specifies whether the gateway pods should run on the host network
+	HostNetwork bool `json:"hostNetwork,omitempty"`
 }
 
 type GatewayClassReplicasConfig struct {

--- a/control-plane/config/crd/bases/mesh.consul.hashicorp.com_gatewayclassconfigs.yaml
+++ b/control-plane/config/crd/bases/mesh.consul.hashicorp.com_gatewayclassconfigs.yaml
@@ -160,6 +160,10 @@ spec:
                             type: object
                         type: object
                     type: object
+                  hostNetwork:
+                    description: HostNetwork specifies whether the gateway pods should
+                      run on the host network
+                    type: boolean
                   initContainer:
                     description: InitContainer contains config specific to the created
                       Deployment's init container

--- a/control-plane/subcommand/gateway-resources/command_test.go
+++ b/control-plane/subcommand/gateway-resources/command_test.go
@@ -372,6 +372,7 @@ var validGWConfigurationKitchenSink = `gatewayClassConfigs:
     name: consul-mesh-gateway
   spec:
     deployment:
+      hostNetwork: true
       replicas:
         min: 3
         default: 3
@@ -449,6 +450,7 @@ func TestRun_loadGatewayConfigs(t *testing.T) {
 			config:   validGWConfigurationKitchenSink,
 			filename: "kitchenSinkConfig.yaml",
 			expectedDeployment: v2beta1.GatewayClassDeploymentConfig{
+				HostNetwork: true,
 				NodeSelector: map[string]string{
 					"beta.kubernetes.io/arch": "amd64",
 					"beta.kubernetes.io/os":   "linux",


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Adds host network support for v2 mesh gw deployments
-

### How I've tested this PR ###
- ran local kind cluster with hostNetwork enabled
- tests


### How I expect reviewers to test this PR ###
- :eye: 
- run tests

### Checklist ###
- [X] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
