### PR TITLE
[NET-6938] Create workloads in Consul for mesh gateway pods

### DIFF
--- a/control-plane/connect-inject/common/common.go
+++ b/control-plane/connect-inject/common/common.go
@@ -192,6 +192,16 @@ func HasBeenMeshInjected(pod corev1.Pod) bool {
 	return false
 }
 
+func IsGateway(pod corev1.Pod) bool {
+	if pod.Annotations == nil {
+		return false
+	}
+	if anno, ok := pod.Annotations[constants.AnnotationGatewayKind]; ok && anno != "" {
+		return true
+	}
+	return false
+}
+
 // ConsulNamespaceIsNotFound checks the gRPC error code and message to determine
 // if a namespace does not exist. If the namespace exists this function returns false, true otherwise.
 func ConsulNamespaceIsNotFound(err error) bool {

--- a/control-plane/connect-inject/controllers/pod/pod_controller.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller.go
@@ -150,7 +150,7 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	r.Log.Info("retrieved", "name", pod.Name, "ns", pod.Namespace)
 
-	if inject.HasBeenMeshInjected(pod) {
+	if inject.HasBeenMeshInjected(pod) || inject.IsGateway(pod) {
 
 		// It is possible the pod was scheduled but doesn't have an allocated IP yet, so safely requeue
 		if pod.Status.PodIP == "" {

--- a/control-plane/connect-inject/controllers/pod/pod_controller.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller.go
@@ -336,9 +336,11 @@ func (r *Controller) writeWorkload(ctx context.Context, pod corev1.Pod) error {
 	}
 	data := inject.ToProtoAny(workload)
 
+	resourceID := getWorkloadID(pod.GetName(), r.getConsulNamespace(pod.Namespace), r.getPartition())
+	r.Log.Info("registering workload with Consul", getLogFieldsForResource(resourceID)...)
 	req := &pbresource.WriteRequest{
 		Resource: &pbresource.Resource{
-			Id:       getWorkloadID(pod.GetName(), r.getConsulNamespace(pod.Namespace), r.getPartition()),
+			Id:       resourceID,
 			Metadata: metaFromPod(pod),
 			Data:     data,
 		},
@@ -760,5 +762,13 @@ func getDestinationsID(name, namespace, partition string) *pbresource.ID {
 			// At a future point, this will move out of the Tenancy block.
 			PeerName: constants.DefaultConsulPeer,
 		},
+	}
+}
+
+func getLogFieldsForResource(id *pbresource.ID) []any {
+	return []any{
+		"name", id.Name,
+		"ns", id.Tenancy.Namespace,
+		"partition", id.Tenancy.Partition,
 	}
 }

--- a/control-plane/connect-inject/controllers/pod/pod_controller_ent_test.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller_ent_test.go
@@ -101,7 +101,7 @@ func TestReconcileCreatePodWithMirrorNamespaces(t *testing.T) {
 			expectedConsulNamespace:    constants.DefaultConsulNS,
 			expectedWorkload:           createWorkload(),
 			expectedHealthStatus:       createPassingHealthStatus(),
-			expectedProxyConfiguration: createProxyConfiguration(testPodName, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
+			expectedProxyConfiguration: createProxyConfiguration(testPodName, true, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
 		},
 		{
 			name:         "kitchen sink new pod, non-default ns and partition",
@@ -127,7 +127,7 @@ func TestReconcileCreatePodWithMirrorNamespaces(t *testing.T) {
 			expectedConsulNamespace:    "bar",
 			expectedWorkload:           createWorkload(),
 			expectedHealthStatus:       createPassingHealthStatus(),
-			expectedProxyConfiguration: createProxyConfiguration(testPodName, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
+			expectedProxyConfiguration: createProxyConfiguration(testPodName, true, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
 		},
 		{
 			name:         "new pod with namespace prefix",
@@ -194,7 +194,7 @@ func TestReconcileCreatePodWithMirrorNamespaces(t *testing.T) {
 			expectedConsulNamespace:    constants.DefaultConsulNS,
 			expectedWorkload:           createWorkload(),
 			expectedHealthStatus:       createPassingHealthStatus(),
-			expectedProxyConfiguration: createProxyConfiguration(testPodName, pbmesh.ProxyMode_PROXY_MODE_DEFAULT),
+			expectedProxyConfiguration: createProxyConfiguration(testPodName, true, pbmesh.ProxyMode_PROXY_MODE_DEFAULT),
 			expectedDestinations:       createDestinations(),
 		},
 		{
@@ -273,12 +273,12 @@ func TestReconcileUpdatePodWithMirrorNamespaces(t *testing.T) {
 			existingConsulNamespace:    "bar",
 			existingWorkload:           createWorkload(),
 			existingHealthStatus:       createPassingHealthStatus(),
-			existingProxyConfiguration: createProxyConfiguration(testPodName, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
+			existingProxyConfiguration: createProxyConfiguration(testPodName, true, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
 
 			expectedConsulNamespace:    "bar",
 			expectedWorkload:           createWorkload(),
 			expectedHealthStatus:       createPassingHealthStatus(),
-			expectedProxyConfiguration: createProxyConfiguration(testPodName, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
+			expectedProxyConfiguration: createProxyConfiguration(testPodName, true, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
 		},
 	}
 
@@ -311,7 +311,7 @@ func TestReconcileDeletePodWithMirrorNamespaces(t *testing.T) {
 			existingConsulNamespace:    "bar",
 			existingWorkload:           createWorkload(),
 			existingHealthStatus:       createPassingHealthStatus(),
-			existingProxyConfiguration: createProxyConfiguration(testPodName, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
+			existingProxyConfiguration: createProxyConfiguration(testPodName, true, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
 
 			expectedConsulNamespace: "bar",
 		},
@@ -330,7 +330,7 @@ func TestReconcileDeletePodWithMirrorNamespaces(t *testing.T) {
 			existingConsulNamespace:    "bar",
 			existingWorkload:           createWorkload(),
 			existingHealthStatus:       createPassingHealthStatus(),
-			existingProxyConfiguration: createProxyConfiguration(testPodName, pbmesh.ProxyMode_PROXY_MODE_DEFAULT),
+			existingProxyConfiguration: createProxyConfiguration(testPodName, true, pbmesh.ProxyMode_PROXY_MODE_DEFAULT),
 			existingDestinations:       createDestinations(),
 
 			expectedConsulNamespace: "bar",
@@ -415,7 +415,7 @@ func TestReconcileCreatePodWithDestinationNamespace(t *testing.T) {
 			expectedConsulNamespace:    constants.DefaultConsulNS,
 			expectedWorkload:           createWorkload(),
 			expectedHealthStatus:       createPassingHealthStatus(),
-			expectedProxyConfiguration: createProxyConfiguration(testPodName, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
+			expectedProxyConfiguration: createProxyConfiguration(testPodName, true, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
 		},
 		{
 			name:      "new pod with explicit destinations, ns and partition",
@@ -439,7 +439,7 @@ func TestReconcileCreatePodWithDestinationNamespace(t *testing.T) {
 			expectedConsulNamespace:    constants.DefaultConsulNS,
 			expectedWorkload:           createWorkload(),
 			expectedHealthStatus:       createPassingHealthStatus(),
-			expectedProxyConfiguration: createProxyConfiguration(testPodName, pbmesh.ProxyMode_PROXY_MODE_DEFAULT),
+			expectedProxyConfiguration: createProxyConfiguration(testPodName, true, pbmesh.ProxyMode_PROXY_MODE_DEFAULT),
 			expectedDestinations:       createDestinations(),
 		},
 		{
@@ -466,7 +466,7 @@ func TestReconcileCreatePodWithDestinationNamespace(t *testing.T) {
 			expectedConsulNamespace:    "a-penguin-walks-into-a-bar",
 			expectedWorkload:           createWorkload(),
 			expectedHealthStatus:       createPassingHealthStatus(),
-			expectedProxyConfiguration: createProxyConfiguration(testPodName, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
+			expectedProxyConfiguration: createProxyConfiguration(testPodName, true, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
 		},
 		{
 			name:         "namespace in Consul does not exist",
@@ -543,12 +543,12 @@ func TestReconcileUpdatePodWithDestinationNamespace(t *testing.T) {
 			existingConsulNamespace:    "a-penguin-walks-into-a-bar",
 			existingWorkload:           createWorkload(),
 			existingHealthStatus:       createPassingHealthStatus(),
-			existingProxyConfiguration: createProxyConfiguration(testPodName, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
+			existingProxyConfiguration: createProxyConfiguration(testPodName, true, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
 
 			expectedConsulNamespace:    "a-penguin-walks-into-a-bar",
 			expectedWorkload:           createWorkload(),
 			expectedHealthStatus:       createPassingHealthStatus(),
-			expectedProxyConfiguration: createProxyConfiguration(testPodName, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
+			expectedProxyConfiguration: createProxyConfiguration(testPodName, true, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
 		},
 	}
 
@@ -581,7 +581,7 @@ func TestReconcileDeletePodWithDestinationNamespace(t *testing.T) {
 			existingConsulNamespace:    "a-penguin-walks-into-a-bar",
 			existingWorkload:           createWorkload(),
 			existingHealthStatus:       createPassingHealthStatus(),
-			existingProxyConfiguration: createProxyConfiguration(testPodName, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
+			existingProxyConfiguration: createProxyConfiguration(testPodName, true, pbmesh.ProxyMode_PROXY_MODE_TRANSPARENT),
 
 			expectedConsulNamespace: "a-penguin-walks-into-a-bar",
 		},
@@ -600,7 +600,7 @@ func TestReconcileDeletePodWithDestinationNamespace(t *testing.T) {
 			existingConsulNamespace:    "a-penguin-walks-into-a-bar",
 			existingWorkload:           createWorkload(),
 			existingHealthStatus:       createPassingHealthStatus(),
-			existingProxyConfiguration: createProxyConfiguration(testPodName, pbmesh.ProxyMode_PROXY_MODE_DEFAULT),
+			existingProxyConfiguration: createProxyConfiguration(testPodName, true, pbmesh.ProxyMode_PROXY_MODE_DEFAULT),
 			existingDestinations:       createDestinations(),
 
 			expectedConsulNamespace: "a-penguin-walks-into-a-bar",

--- a/control-plane/gateways/deployment.go
+++ b/control-plane/gateways/deployment.go
@@ -63,8 +63,13 @@ func (b *meshGatewayBuilder) deploymentSpec() (*appsv1.DeploymentSpec, error) {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: b.Labels(),
 				Annotations: map[string]string{
-					constants.AnnotationMeshInject:  "false",
+					// Indicate that this pod is a mesh gateway pod so that the Pod controller,
+					// consul-k8s CLI, etc. can key off of it
 					constants.AnnotationGatewayKind: meshGatewayAnnotationKind,
+					// It's not logical to add a proxy sidecar since our workload is itself a proxy
+					constants.AnnotationMeshInject: "false",
+					// This functionality only applies when proxy sidecars are used
+					constants.AnnotationTransparentProxyOverwriteProbes: "false",
 				},
 			},
 			Spec: corev1.PodSpec{

--- a/control-plane/gateways/deployment_test.go
+++ b/control-plane/gateways/deployment_test.go
@@ -77,8 +77,9 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 								"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
 							},
 							Annotations: map[string]string{
-								constants.AnnotationMeshInject:  "false",
-								constants.AnnotationGatewayKind: meshGatewayAnnotationKind,
+								constants.AnnotationGatewayKind:                     meshGatewayAnnotationKind,
+								constants.AnnotationMeshInject:                      "false",
+								constants.AnnotationTransparentProxyOverwriteProbes: "false",
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -323,8 +324,9 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 								"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
 							},
 							Annotations: map[string]string{
-								constants.AnnotationMeshInject:  "false",
-								constants.AnnotationGatewayKind: meshGatewayAnnotationKind,
+								constants.AnnotationGatewayKind:                     meshGatewayAnnotationKind,
+								constants.AnnotationMeshInject:                      "false",
+								constants.AnnotationTransparentProxyOverwriteProbes: "false",
 							},
 						},
 						Spec: corev1.PodSpec{


### PR DESCRIPTION
### Changes proposed in this PR ###  
The `Pod` controller currently only creates `Workloads` in Consul for mesh-injected `Pods`.
`Pods` for xGateways are not mesh-injected because it doesn't make sense to add a proxy sidecar to a `Pod` that's already running a proxy as its primary workload; however, they still require `Workloads` to be registered in Consul so that we can generate `ProxyStateTemplates` for them (in a future PR).

This PR modifies the `Pod` controller to create `Workloads` in Consul for xGateway pods as well, relying on the fact that a known annotation specifying the `gateway-kind` is added to all v2 xGateway `Pods`.

Notably, this also results in a `ProxyConfiguration` being created for the mesh gateway workload, and I disabled the health endpoint override functionality by adding a predefined annotation to the gateway pods as it doesn't make sense for workloads that are not mesh-injected/don't have a sidecar.

### How I've tested this PR ###
`helm install` from `main` with this build for `global.imageK8S`, `meshGateway.enabled=true`, and `experiments=[resource-apis]`.

Verify that the `Workload` and `ProxyConfiguration` are created in Consul by shelling into consul-server and using the following commands:
<details>
<summary>Example commands + output</summary>

`Workload` resource:
```json
$ consul resource list catalog.v2beta1.Workload
{
    "resources": [
        {
            "data": {
                "addresses": [
                    {
                        "host": "10.60.2.11",
                        "ports": [
                            "proxy-health",
                            "wan",
                            "mesh"
                        ]
                    }
                ],
                "identity": "mesh-gateway",
                "locality": {
                    "region": "us-east1",
                    "zone": "us-east1-b"
                },
                "ports": {
                    "mesh": {
                        "port": 20000,
                        "protocol": "PROTOCOL_MESH"
                    },
                    "proxy-health": {
                        "port": 21000
                    },
                    "wan": {
                        "port": 8443
                    }
                }
            },
            "generation": "01HHQJDE6HA98NP5F6Y088XKJ7",
            "id": {
                "name": "mesh-gateway-6b4c5cd676-n5z2j",
                "tenancy": {
                    "namespace": "default",
                    "partition": "default",
                    "peerName": "local"
                },
                "type": {
                    "group": "catalog",
                    "groupVersion": "v2beta1",
                    "kind": "Workload"
                },
                "uid": "01HHQJDDCGD3XFGXP5ESRFHWYT"
            },
            "metadata": {
                "gateway-kind": "mesh-gateway",
                "k8s-namespace": "consul",
                "managed-by": "consul-k8s-pod-controller"
            },
            "status": {
                "consul.io/workload-health": {
                    "conditions": [
                        {
                            "message": "One or more workload health checks are not passing",
                            "reason": "HEALTH_CRITICAL",
                            "state": "STATE_FALSE",
                            "type": "healthy"
                        }
                    ],
                    "observedGeneration": "01HHQJDE6HA98NP5F6Y088XKJ7",
                    "updatedAt": "2023-12-15T20:24:17.881165934Z"
                }
            },
            "version": "715"
        }
    ]
}
```

`ProxyConfiguration` resource:
```json
$ consul resource list mesh.v2beta1.ProxyConfiguration
{
    "resources": [
        {
            "data": {
                "dynamicConfig": {
                    "mode": "PROXY_MODE_TRANSPARENT",
                    "transparentProxy": {
                        "outboundListenerPort": 15001
                    }
                },
                "workloads": {
                    "names": [
                        "mesh-gateway-6b4c5cd676-n5z2j"
                    ]
                }
            },
            "generation": "01HHQJDE6CNEE6QNNR4XG5PN45",
            "id": {
                "name": "mesh-gateway-6b4c5cd676-n5z2j",
                "tenancy": {
                    "namespace": "default",
                    "partition": "default",
                    "peerName": "local"
                },
                "type": {
                    "group": "mesh",
                    "groupVersion": "v2beta1",
                    "kind": "ProxyConfiguration"
                },
                "uid": "01HHQJDDCBWT3ZFD2ETDWYRJM3"
            },
            "metadata": {
                "gateway-kind": "mesh-gateway",
                "k8s-namespace": "consul",
                "managed-by": "consul-k8s-pod-controller"
            },
            "version": "712"
        }
    ]
}
```
</details>

### How I expect reviewers to test this PR ###
See above

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
