### PR TITLE
helmchart: add .Values.server.usePersistentVolume

### DIFF
--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -44,8 +44,10 @@ spec:
     rollingUpdate:
       partition: {{ .Values.server.updatePartition }}
   {{- end }}
+  {{- if .Values.server.usePersistentVolume }}
   {{- if and (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) (.Values.server.persistentVolumeClaimRetentionPolicy) }}
   persistentVolumeClaimRetentionPolicy: {{ toYaml .Values.server.persistentVolumeClaimRetentionPolicy | nindent 4 }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:
@@ -154,6 +156,10 @@ spec:
         {{- toYaml .Values.server.securityContext | nindent 8 }}
       {{- end }}
       volumes:
+        {{- if not .Values.server.usePersistentVolume }}
+        - name: data-empty-dir
+          emptyDir: {}
+        {{- end }}
         - name: config
           configMap:
             name: {{ template "consul.fullname" . }}-server-config
@@ -434,7 +440,11 @@ spec:
                 -hcl="experiments=[\"resource-apis\"]"
                 {{- end }}
           volumeMounts:
+            {{- if .Values.server.usePersistentVolume }}
             - name: data-{{ .Release.Namespace | trunc 58 | trimSuffix "-" }}
+            {{- else }}
+            - name: data-empty-dir
+            {{- end }}
               mountPath: /consul/data
             - name: config
               mountPath: /consul/config
@@ -642,6 +652,7 @@ spec:
       nodeSelector:
         {{ tpl .Values.server.nodeSelector . | indent 8 | trim }}
       {{- end }}
+  {{- if .Values.server.usePersistentVolume }}
   volumeClaimTemplates:
     - metadata:
         name: data-{{ .Release.Namespace | trunc 58 | trimSuffix "-" }}
@@ -654,4 +665,5 @@ spec:
         {{- if .Values.server.storageClass }}
         storageClassName: {{ .Values.server.storageClass }}
         {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -862,6 +862,9 @@ server:
     serflan:
       port: 8301
 
+  # Whether use persistent volume
+  usePersistentVolume: true
+
   # This defines the disk size for configuring the
   # servers' StatefulSet storage. For dynamically provisioned storage classes, this is the
   # desired size. For manually defined persistent volumes, this should be set to


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Add a flag to determine whether to use a persistent volume.
- In scenarios such as testing, it would be convenient to deploy Consul without a persistent volume for lightweight use.

### How I've tested this PR ###
TODO

### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
