### PR TITLE
[NET-6809] Add chart related labels for mesh gateway deployments

### DIFF
--- a/control-plane/gateways/deployment_test.go
+++ b/control-plane/gateways/deployment_test.go
@@ -42,6 +42,16 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 				config: GatewayConfig{},
 				gcc: &meshv2beta1.GatewayClassConfig{
 					Spec: meshv2beta1.GatewayClassConfigSpec{
+						GatewayClassAnnotationsAndLabels: meshv2beta1.GatewayClassAnnotationsAndLabels{
+							Labels: meshv2beta1.GatewayClassAnnotationsLabelsConfig{
+								Set: map[string]string{
+									"app":      "consul",
+									"chart":    "consul-helm",
+									"heritage": "Helm",
+									"release":  "consul",
+								},
+							},
+						},
 						Deployment: meshv2beta1.GatewayClassDeploymentConfig{
 							Container: &meshv2beta1.GatewayClassContainerConfig{
 								HostPort:     8080,
@@ -67,17 +77,59 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 			},
 			want: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
+<<<<<<< HEAD
 					Labels:      defaultLabels,
 					Annotations: map[string]string{},
+||||||| parent of bb907131 (use set labels for setting labels on deployments)
+					Labels: map[string]string{
+						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+					},
+=======
+					Labels: map[string]string{
+						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+						"mesh.consul.hashicorp.com/app":        "consul",
+						"mesh.consul.hashicorp.com/chart":      "consul-helm",
+						"mesh.consul.hashicorp.com/heritage":   "Helm",
+						"mesh.consul.hashicorp.com/release":    "consul",
+					},
+>>>>>>> bb907131 (use set labels for setting labels on deployments)
 				},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: pointer.Int32(1),
 					Selector: &metav1.LabelSelector{
+<<<<<<< HEAD
 						MatchLabels: defaultLabels,
+||||||| parent of bb907131 (use set labels for setting labels on deployments)
+						MatchLabels: map[string]string{
+							"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+						},
+=======
+						MatchLabels: map[string]string{
+							"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+							"mesh.consul.hashicorp.com/app":        "consul",
+							"mesh.consul.hashicorp.com/chart":      "consul-helm",
+							"mesh.consul.hashicorp.com/heritage":   "Helm",
+							"mesh.consul.hashicorp.com/release":    "consul",
+						},
+>>>>>>> bb907131 (use set labels for setting labels on deployments)
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
+<<<<<<< HEAD
 							Labels: defaultLabels,
+||||||| parent of bb907131 (use set labels for setting labels on deployments)
+							Labels: map[string]string{
+								"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+							},
+=======
+							Labels: map[string]string{
+								"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+								"mesh.consul.hashicorp.com/app":        "consul",
+								"mesh.consul.hashicorp.com/chart":      "consul-helm",
+								"mesh.consul.hashicorp.com/heritage":   "Helm",
+								"mesh.consul.hashicorp.com/release":    "consul",
+							},
+>>>>>>> bb907131 (use set labels for setting labels on deployments)
 							Annotations: map[string]string{
 								constants.AnnotationGatewayKind:                     meshGatewayAnnotationKind,
 								constants.AnnotationMeshInject:                      "false",
@@ -281,7 +333,21 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 											Weight: 1,
 											PodAffinityTerm: corev1.PodAffinityTerm{
 												LabelSelector: &metav1.LabelSelector{
+<<<<<<< HEAD
 													MatchLabels: defaultLabels,
+||||||| parent of bb907131 (use set labels for setting labels on deployments)
+													MatchLabels: map[string]string{
+														"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+													},
+=======
+													MatchLabels: map[string]string{
+														"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+														"mesh.consul.hashicorp.com/app":        "consul",
+														"mesh.consul.hashicorp.com/chart":      "consul-helm",
+														"mesh.consul.hashicorp.com/heritage":   "Helm",
+														"mesh.consul.hashicorp.com/release":    "consul",
+													},
+>>>>>>> bb907131 (use set labels for setting labels on deployments)
 												},
 												TopologyKey: "kubernetes.io/hostname",
 											},

--- a/control-plane/gateways/deployment_test.go
+++ b/control-plane/gateways/deployment_test.go
@@ -77,59 +77,37 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 			},
 			want: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-<<<<<<< HEAD
-					Labels:      defaultLabels,
+					Labels: map[string]string{
+						labelManagedBy: "consul-k8s",
+						"app":          "consul",
+						"chart":        "consul-helm",
+						"heritage":     "Helm",
+						"release":      "consul",
+					},
+
 					Annotations: map[string]string{},
-||||||| parent of bb907131 (use set labels for setting labels on deployments)
-					Labels: map[string]string{
-						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
-					},
-=======
-					Labels: map[string]string{
-						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
-						"mesh.consul.hashicorp.com/app":        "consul",
-						"mesh.consul.hashicorp.com/chart":      "consul-helm",
-						"mesh.consul.hashicorp.com/heritage":   "Helm",
-						"mesh.consul.hashicorp.com/release":    "consul",
-					},
->>>>>>> bb907131 (use set labels for setting labels on deployments)
 				},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: pointer.Int32(1),
 					Selector: &metav1.LabelSelector{
-<<<<<<< HEAD
-						MatchLabels: defaultLabels,
-||||||| parent of bb907131 (use set labels for setting labels on deployments)
 						MatchLabels: map[string]string{
-							"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+							labelManagedBy: "consul-k8s",
+							"app":          "consul",
+							"chart":        "consul-helm",
+							"heritage":     "Helm",
+							"release":      "consul",
 						},
-=======
-						MatchLabels: map[string]string{
-							"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
-							"mesh.consul.hashicorp.com/app":        "consul",
-							"mesh.consul.hashicorp.com/chart":      "consul-helm",
-							"mesh.consul.hashicorp.com/heritage":   "Helm",
-							"mesh.consul.hashicorp.com/release":    "consul",
-						},
->>>>>>> bb907131 (use set labels for setting labels on deployments)
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-<<<<<<< HEAD
-							Labels: defaultLabels,
-||||||| parent of bb907131 (use set labels for setting labels on deployments)
 							Labels: map[string]string{
-								"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+								labelManagedBy: "consul-k8s",
+								"app":          "consul",
+								"chart":        "consul-helm",
+								"heritage":     "Helm",
+								"release":      "consul",
 							},
-=======
-							Labels: map[string]string{
-								"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
-								"mesh.consul.hashicorp.com/app":        "consul",
-								"mesh.consul.hashicorp.com/chart":      "consul-helm",
-								"mesh.consul.hashicorp.com/heritage":   "Helm",
-								"mesh.consul.hashicorp.com/release":    "consul",
-							},
->>>>>>> bb907131 (use set labels for setting labels on deployments)
+
 							Annotations: map[string]string{
 								constants.AnnotationGatewayKind:                     meshGatewayAnnotationKind,
 								constants.AnnotationMeshInject:                      "false",
@@ -333,21 +311,13 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 											Weight: 1,
 											PodAffinityTerm: corev1.PodAffinityTerm{
 												LabelSelector: &metav1.LabelSelector{
-<<<<<<< HEAD
-													MatchLabels: defaultLabels,
-||||||| parent of bb907131 (use set labels for setting labels on deployments)
 													MatchLabels: map[string]string{
-														"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+														labelManagedBy: "consul-k8s",
+														"app":          "consul",
+														"chart":        "consul-helm",
+														"heritage":     "Helm",
+														"release":      "consul",
 													},
-=======
-													MatchLabels: map[string]string{
-														"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
-														"mesh.consul.hashicorp.com/app":        "consul",
-														"mesh.consul.hashicorp.com/chart":      "consul-helm",
-														"mesh.consul.hashicorp.com/heritage":   "Helm",
-														"mesh.consul.hashicorp.com/release":    "consul",
-													},
->>>>>>> bb907131 (use set labels for setting labels on deployments)
 												},
 												TopologyKey: "kubernetes.io/hostname",
 											},

--- a/control-plane/gateways/service_test.go
+++ b/control-plane/gateways/service_test.go
@@ -62,42 +62,24 @@ func Test_meshGatewayBuilder_Service(t *testing.T) {
 			},
 			want: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-<<<<<<< HEAD
-					Labels:      defaultLabels,
-||||||| parent of bb907131 (use set labels for setting labels on deployments)
 					Labels: map[string]string{
-						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+						labelManagedBy: "consul-k8s",
+						"app":          "consul",
+						"chart":        "consul-helm",
+						"heritage":     "Helm",
+						"release":      "consul",
 					},
-=======
-					Labels: map[string]string{
-						"mesh.consul.hashicorp.com/app":        "consul",
-						"mesh.consul.hashicorp.com/chart":      "consul-helm",
-						"mesh.consul.hashicorp.com/heritage":   "Helm",
-						"mesh.consul.hashicorp.com/release":    "consul",
-						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
-					},
->>>>>>> bb907131 (use set labels for setting labels on deployments)
 					Annotations: map[string]string{},
 				},
 				Spec: corev1.ServiceSpec{
-<<<<<<< HEAD
-					Selector: defaultLabels,
-					Type:     corev1.ServiceTypeLoadBalancer,
-||||||| parent of bb907131 (use set labels for setting labels on deployments)
 					Selector: map[string]string{
-						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+						labelManagedBy: "consul-k8s",
+						"app":          "consul",
+						"chart":        "consul-helm",
+						"heritage":     "Helm",
+						"release":      "consul",
 					},
 					Type: corev1.ServiceTypeLoadBalancer,
-=======
-					Selector: map[string]string{
-						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
-						"mesh.consul.hashicorp.com/app":        "consul",
-						"mesh.consul.hashicorp.com/chart":      "consul-helm",
-						"mesh.consul.hashicorp.com/heritage":   "Helm",
-						"mesh.consul.hashicorp.com/release":    "consul",
-					},
-					Type: corev1.ServiceTypeLoadBalancer,
->>>>>>> bb907131 (use set labels for setting labels on deployments)
 					Ports: []corev1.ServicePort{
 						{
 							Name: "wan",

--- a/control-plane/gateways/service_test.go
+++ b/control-plane/gateways/service_test.go
@@ -39,6 +39,16 @@ func Test_meshGatewayBuilder_Service(t *testing.T) {
 				config: GatewayConfig{},
 				gcc: &meshv2beta1.GatewayClassConfig{
 					Spec: meshv2beta1.GatewayClassConfigSpec{
+						GatewayClassAnnotationsAndLabels: meshv2beta1.GatewayClassAnnotationsAndLabels{
+							Labels: meshv2beta1.GatewayClassAnnotationsLabelsConfig{
+								Set: map[string]string{
+									"app":      "consul",
+									"chart":    "consul-helm",
+									"heritage": "Helm",
+									"release":  "consul",
+								},
+							},
+						},
 						Deployment: meshv2beta1.GatewayClassDeploymentConfig{
 							Container: &meshv2beta1.GatewayClassContainerConfig{
 								PortModifier: 8000,
@@ -52,12 +62,42 @@ func Test_meshGatewayBuilder_Service(t *testing.T) {
 			},
 			want: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
+<<<<<<< HEAD
 					Labels:      defaultLabels,
+||||||| parent of bb907131 (use set labels for setting labels on deployments)
+					Labels: map[string]string{
+						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+					},
+=======
+					Labels: map[string]string{
+						"mesh.consul.hashicorp.com/app":        "consul",
+						"mesh.consul.hashicorp.com/chart":      "consul-helm",
+						"mesh.consul.hashicorp.com/heritage":   "Helm",
+						"mesh.consul.hashicorp.com/release":    "consul",
+						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+					},
+>>>>>>> bb907131 (use set labels for setting labels on deployments)
 					Annotations: map[string]string{},
 				},
 				Spec: corev1.ServiceSpec{
+<<<<<<< HEAD
 					Selector: defaultLabels,
 					Type:     corev1.ServiceTypeLoadBalancer,
+||||||| parent of bb907131 (use set labels for setting labels on deployments)
+					Selector: map[string]string{
+						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+					},
+					Type: corev1.ServiceTypeLoadBalancer,
+=======
+					Selector: map[string]string{
+						"mesh.consul.hashicorp.com/managed-by": "consul-k8s",
+						"mesh.consul.hashicorp.com/app":        "consul",
+						"mesh.consul.hashicorp.com/chart":      "consul-helm",
+						"mesh.consul.hashicorp.com/heritage":   "Helm",
+						"mesh.consul.hashicorp.com/release":    "consul",
+					},
+					Type: corev1.ServiceTypeLoadBalancer,
+>>>>>>> bb907131 (use set labels for setting labels on deployments)
 					Ports: []corev1.ServicePort{
 						{
 							Name: "wan",


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Adds chart related labels for mesh gateway deployments
-

### How I've tested this PR ###
- ran tests
- ran local kind cluster and checked config

### How I expect reviewers to test this PR ###
- :eye: 
- run tests
- run local kind cluster and checked config

### Checklist ###
- [X] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
