### PR TITLE
Add `prepare-release-dev` make command to `release/1.1.x`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,25 @@ ifndef CONSUL_K8S_NEXT_CONSUL_DATAPLANE_VERSION
 endif
 	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_dev $(CURDIR) $(CONSUL_K8S_RELEASE_VERSION) "$(CONSUL_K8S_RELEASE_DATE)" "" $(CONSUL_K8S_NEXT_RELEASE_VERSION) $(CONSUL_K8S_NEXT_CONSUL_VERSION) $(CONSUL_K8S_NEXT_CONSUL_DATAPLANE_VERSION)
 
+.PHONY: prepare-release-dev
+prepare-release-dev: ## prepare release dev
+ifndef CONSUL_K8S_RELEASE_VERSION
+	$(error CONSUL_K8S_RELEASE_VERSION is required)
+endif
+ifndef CONSUL_K8S_RELEASE_DATE
+	$(error CONSUL_K8S_RELEASE_DATE is required, use format <Month> <Day>, <Year> (ex. October 4, 2022))
+endif
+ifndef CONSUL_K8S_NEXT_RELEASE_VERSION
+	$(error CONSUL_K8S_RELEASE_VERSION is required)
+endif
+ifndef CONSUL_K8S_CONSUL_VERSION
+	$(error CONSUL_K8S_CONSUL_VERSION is required)
+endif
+ifndef CONSUL_K8S_CONSUL_DATAPLANE_VERSION
+	$(error CONSUL_K8S_CONSUL_DATAPLANE_VERSION is required)
+endif
+	source $(CURDIR)/control-plane/build-support/scripts/functions.sh; prepare_dev $(CURDIR) $(CONSUL_K8S_RELEASE_VERSION) "$(CONSUL_K8S_RELEASE_DATE)" "" $(CONSUL_K8S_NEXT_RELEASE_VERSION) $(CONSUL_K8S_CONSUL_VERSION) $(CONSUL_K8S_CONSUL_DATAPLANE_VERSION)
+
 # ===========> Makefile config
 .DEFAULT_GOAL := help
 SHELL = bash


### PR DESCRIPTION
This make command did not get backported to `release/1.1.x`. I need to add it to reset the branch for dev.