### PR TITLE
chore: add compatibility note to .0 changelogs

### DIFF
--- a/control-plane/build-support/functions/10-util.sh
+++ b/control-plane/build-support/functions/10-util.sh
@@ -95,7 +95,7 @@ function have_gpg_key {
 
 function parse_version {
 	# Arguments:
-	#   $1 - Path to the top level Consul source
+	#   $1 - Path to the top level Consul K8s source
 	#   $2 - boolean value for whether the release version should be parsed from the source
 	#   $3 - boolean whether to use GIT_DESCRIBE and GIT_COMMIT environment variables
 	#   $4 - boolean whether to omit the version part of the version string. (optional)
@@ -190,7 +190,7 @@ function parse_version {
 
 function get_version {
 	# Arguments:
-	#   $1 - Path to the top level Consul source
+	#   $1 - Path to the top level Consul K8s source
 	#   $2 - Whether the release version should be parsed from source (optional)
 	#   $3 - Whether to use GIT_DESCRIBE and GIT_COMMIT environment variables
 	#
@@ -344,7 +344,7 @@ function normalize_git_url {
 
 function git_remote_url {
 	# Arguments:
-	#   $1 - Path to the top level Consul source
+	#   $1 - Path to the top level Consul K8s source
 	#   $2 - Remote name
 	#
 	# Returns:
@@ -380,7 +380,7 @@ function git_remote_url {
 
 function find_git_remote {
 	# Arguments:
-	#   $1 - Path to the top level Consul source
+	#   $1 - Path to the top level Consul K8s source
 	#
 	# Returns:
 	#   0 - success
@@ -482,7 +482,7 @@ function update_git_env {
 
 function git_push_ref {
 	# Arguments:
-	#   $1 - Path to the top level Consul source
+	#   $1 - Path to the top level Consul K8s source
 	#   $2 - Git ref (optional)
 	#   $3 - remote (optional - if not specified we will try to determine it)
 	#
@@ -659,7 +659,7 @@ function update_version_helm {
 
 function set_version {
 	# Arguments:
-	#   $1 - Path to top level Consul source
+	#   $1 - Path to top level Consul K8s source
 	#   $2 - The version of the release
 	#   $3 - The release date
 	#   $4 - The pre-release version
@@ -709,11 +709,13 @@ function set_version {
 
 function set_changelog {
 	# Arguments:
-	#   $1 - Path to top level Consul source
+	#   $1 - Path to top level Consul K8s source
 	#   $2 - Version
 	#   $3 - Release Date
 	#   $4 - The last git release tag
 	#   $5 - Pre-release version
+    #   $6 - The version of Consul corresponding to the release (only used for .0)
+    #   $7 - The version of Consul Dataplane corresponding to the release (only used for .0)
 	#
 	#
 	# Returns:
@@ -733,7 +735,13 @@ function set_changelog {
 		rel_date="$3"
 	fi
 	local last_release_date_git_tag=$4
-        local preReleaseVersion="-$5"
+
+	# Only set prerelease suffix if prerelease version is set
+    local preReleaseVersion="${5:+-${5}}"
+
+    local version_short="${version%\.*}"
+    local consul_version_short="${6%\.*}"
+    local consul_dataplane_version_short="${7%\.*}"
 
 	if test -z "${version}"; then
 		err "ERROR: Must specify a version to put into the changelog"
@@ -745,8 +753,18 @@ function set_changelog {
 		exit 1
 	fi
 
+	if [[ "${version}" =~ \.0$ ]]; then
+	    if [ -z "$version_short" ] || [ -z "$consul_version_short" ] || [ -z "$consul_dataplane_version_short" ]; then
+            echo "Error: Consul K8s, Consul or Consul Dataplane short version could not be detected."
+            exit 1
+        fi
+        compatibility_note="
+
+_Note: Consul K8s ${version_short} is compatible with Consul ${consul_version_short} and Consul Dataplane ${consul_dataplane_version_short}. Refer to our [compatibility matrix](https://developer.hashicorp.com/consul/docs/k8s/compatibility) for more info._"
+    fi
+
 	cat <<EOT | cat - "${curdir}"/CHANGELOG.MD >tmp && mv tmp "${curdir}"/CHANGELOG.MD
-## ${version}${preReleaseVersion} (${rel_date})
+## ${version}${preReleaseVersion} (${rel_date})${compatibility_note}
 $(changelog-build -last-release ${CONSUL_K8S_LAST_RELEASE_GIT_TAG} \
 		-entries-dir .changelog/ \
 		-changelog-template .changelog/changelog.tmpl \
@@ -758,13 +776,13 @@ EOT
 
 function prepare_release {
 	# Arguments:
-	#   $1 - Path to top level Consul source
+	#   $1 - Path to top level Consul K8s source
 	#   $2 - The version of the release
 	#   $3 - The release date
 	#   $4 - The last release git tag for this branch (eg. v1.1.0)
-  #   $5 - The consul version
+    #   $5 - The consul version
 	#   $6 - The consul-dataplane version
-  #   $7 - The pre-release version
+    #   $7 - The pre-release version
 	#
 	#
 	# Returns:
@@ -781,12 +799,12 @@ function prepare_release {
 
 	echo "prepare_release: dir:${curDir} consul-k8s:${version} consul:${consulVersion} consul-dataplane:${consulDataplaneVersion} date:"${releaseDate}" git tag:${lastGitTag}"
 	set_version "${curDir}" "${version}" "${releaseDate}" "${prereleaseVersion}" "hashicorp\/consul-k8s-control-plane:" "${consulVersion}" "hashicorp\/consul" "${consulDataplaneVersion}" "hashicorp\/consul-dataplane"
-	set_changelog "${curDir}" "${version}" "${releaseDate}" "${lastGitTag}" "${prereleaseVersion}"
+	set_changelog "${curDir}" "${version}" "${releaseDate}" "${lastGitTag}" "${prereleaseVersion}" "${consulVersion}" "${consulDataplaneVersion}"
 }
 
 function prepare_rc_branch {
   # Arguments:
-  #   $1 - Path to top level Consul source
+  #   $1 - Path to top level Consul K8s source
   #   $2 - The version of the release
   #   $3 - The release date
   #   $4 - The last release git tag for this branch (eg. v1.1.0)
@@ -813,7 +831,7 @@ function prepare_rc_branch {
 
 function prepare_dev {
 	# Arguments:
-	#   $1 - Path to top level Consul source
+	#   $1 - Path to top level Consul K8s source
 	#   $2 - The version of the release
 	#   $3 - The release date
 	#   $4 - The last release git tag for this branch (eg. v1.1.0) (Unused)
@@ -868,7 +886,7 @@ function git_staging_empty {
 
 function commit_dev_mode {
 	# Arguments:
-	#   $1 - Path to top level Consul source
+	#   $1 - Path to top level Consul K8s source
 	#
 	# Returns:
 	#   0 - success


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Add automation to generate a compatibility note in the changelog on `.0` releases
- Fix a minor bug with prerelease version in non-prerelease changelog entries

### How I've tested this PR ###

Results [here](https://github.com/hashicorp/consul-k8s/commit/ea6f2314a05c3c4c5310b2c38d29c98c901721f8#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR41) from running with `1.3.0` and then `1.3.1` env vars:
```shell
export CONSUL_K8S_RELEASE_VERSION=1.3.0
export CONSUL_K8S_PRODUCT_VERSION=1.3.0
export CONSUL_K8S_RELEASE_BRANCH=release/1.3.x
export CONSUL_K8S_RELEASE_DATE="December 20, 2099"
export CONSUL_K8S_LAST_RELEASE_GIT_TAG="v1.2.2"
export CONSUL_K8S_CONSUL_VERSION=1.17.0
export CONSUL_K8S_CONSUL_DATAPLANE_VERSION=1.3.0

make prepare-release

export CONSUL_K8S_RELEASE_VERSION=1.3.1
export CONSUL_K8S_PRODUCT_VERSION=1.3.1
export CONSUL_K8S_RELEASE_BRANCH=release/1.3.x
export CONSUL_K8S_RELEASE_DATE="December 19, 2023"
export CONSUL_K8S_LAST_RELEASE_GIT_TAG="v1.3.0"
export CONSUL_K8S_CONSUL_VERSION=1.17.1
export CONSUL_K8S_CONSUL_DATAPLANE_VERSION=1.3.1

make prepare-release
```

Compat note was only added on the `.0` release.

### How I expect reviewers to test this PR ###

👀 + 🤔 

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
