### PR TITLE
Dockerfile: update to ubi-minimal:9.3

### DIFF
--- a/.changelog/3418.txt
+++ b/.changelog/3418.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-Upgrade OpenShift container images to use `ubi-minimal:9.3` as the base image.
+Upgrade OpenShift container images to use `ubi9-minimal:9.3` as the base image.
 ```

--- a/.changelog/3418.txt
+++ b/.changelog/3418.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Upgrade to use `ubi-minimal:9.3` for OpenShift container images.
+```

--- a/.changelog/3418.txt
+++ b/.changelog/3418.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-Upgrade to use `ubi-minimal:9.3` for OpenShift container images.
+Upgrade OpenShift container images to use `ubi-minimal:9.3` as the base image.
 ```

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -127,7 +127,7 @@ FROM release-default AS release-default-fips
 # We don't rebuild the software because we want the exact checksums and
 # binary signatures to match the software and our builds aren't fully
 # reproducible currently.
-FROM registry.access.redhat.com/ubi9-minimal:9.2 as ubi
+FROM registry.access.redhat.com/ubi9-minimal:9.3 as ubi
 
 ARG PRODUCT_NAME
 ARG PRODUCT_VERSION


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Dockerfile: bump up to `ubi-minimal:9.3` to remediate vulnerabilities. The current `ubi-minimal:9.2` image is not actively maintained and CVEs fixes are not backported.

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
