### PR TITLE
Support WAN Address Annotations

### DIFF
--- a/charts/consul/templates/gateway-resources-configmap.yaml
+++ b/charts/consul/templates/gateway-resources-configmap.yaml
@@ -1,4 +1,9 @@
 {{- if .Values.connectInject.enabled }}
+
+# Validation
+# For meshGateway.wanAddress, static must be set if source is "Static"
+{{if (and (eq .Values.meshGateway.wanAddress.source "Static") (eq .Values.meshGateway.wanAddress.static ""))}}{{fail ".meshGateway.wanAddress.static must be set to a value if .meshGateway.wanAddress.source is Static"}}{{ end }}
+
 # Configuration of Gateway Resources Job which creates managed Gateway configuration.
 apiVersion: v1
 kind: ConfigMap
@@ -104,5 +109,9 @@ data:
           namespace: {{ .Release.Namespace }}
         spec:
           gatewayClassName: consul-mesh-gateway
+          wanAddress:
+            source: {{ .Values.meshGateway.wanAddress.source }}
+            port: {{ .Values.meshGateway.wanAddress.port }}
+            static: {{ .Values.meshGateway.wanAddress.static }}
   {{- end }}
 {{- end }}

--- a/charts/consul/templates/gateway-resources-configmap.yaml
+++ b/charts/consul/templates/gateway-resources-configmap.yaml
@@ -107,11 +107,20 @@ data:
         metadata:
           name: mesh-gateway
           namespace: {{ .Release.Namespace }}
+          annotations: 
+            # TODO are these annotations even necessary?
+            "consul.hashicorp.com/gateway-wan-address-source": {{ .Values.meshGateway.wanAddress.source | quote }}
+            "consul.hashicorp.com/gateway-wan-address-static": {{ .Values.meshGateway.wanAddress.static | quote }}
+            {{- if eq .Values.meshGateway.wanAddress.source "Service" }}
+            {{- if eq .Values.meshGateway.service.type "NodePort" }}
+            "consul.hashicorp.com/gateway-wan-port": {{ .Values.meshGateway.service.nodePort | quote  }}
+            {{- else }}
+            "consul.hashicorp.com/gateway-wan-port": {{ .Values.meshGateway.service.port | quote }}
+            {{- end }}
+            {{- else }}
+            "consul.hashicorp.com/gateway-wan-port": {{ .Values.meshGateway.wanAddress.port | quote }}
+            {{- end }}
         spec:
           gatewayClassName: consul-mesh-gateway
-          wanAddress:
-            source: {{ .Values.meshGateway.wanAddress.source }}
-            port: {{ .Values.meshGateway.wanAddress.port }}
-            static: {{ .Values.meshGateway.wanAddress.static }}
   {{- end }}
 {{- end }}

--- a/charts/consul/test/unit/gateway-resources-configmap.bats
+++ b/charts/consul/test/unit/gateway-resources-configmap.bats
@@ -77,30 +77,30 @@ target=templates/gateway-resources-configmap.yaml
 #--------------------------------------------------------------------
 # Mesh Gateway WAN Address configuration
 
-@test "gatewayresources/ConfigMap: Mesh Gateway WAN Address default annotations" {
+@test "gateway-resources/ConfigMap: Mesh Gateway WAN Address default annotations" {
     cd `chart_dir`
-    local actual=$(helm template \
+    local annotations=$(helm template \
         -s $target \
         --set 'connectInject.enabled=true' \
         --set 'meshGateway.enabled=true' \
         --set 'global.experiments[0]=resource-apis' \
         --set 'ui.enabled=false' \
         . | tee /dev/stderr |
-        yq '.data["config.yaml"]' | yq -r -j '.meshGateways[0].metadata.annotations' | tee /dev/stderr)
+        yq -r '.data["config.yaml"]' | yq -r '.meshGateways[0].metadata.annotations' | tee /dev/stderr)
 
-    local expected=$(echo '{
-        "consul.hashicorp.com/gateway-wan-address-source": "Service",
-        "consul.hashicorp.com/gateway-wan-port": "443",
-        "consul.hashicorp.com/gateway-wan-address-static": ""
-    }' | tee /dev/stderr)
+    local actual=$(echo "$annotations" | jq -r '.["consul.hashicorp.com/gateway-wan-address-source"]')
+    [ "${actual}" = 'Service' ]
 
-    local equal=$(jq -n --argjson a "$actual" --argjson b "$expected" '$a == $b')
-    [ "${equal}" = 'true' ]
+    local actual=$(echo "$annotations" | jq -r '.["consul.hashicorp.com/gateway-wan-port"]')
+    [ "${actual}" = '443' ]
+
+    local actual=$(echo "$annotations" | jq -r '.["consul.hashicorp.com/gateway-wan-address-static"]')
+    [ "${actual}" = '' ]
 }
 
-@test "gatewayresources/ConfigMap: Mesh Gateway WAN Address NodePort annotations" {
+@test "gateway-resources/ConfigMap: Mesh Gateway WAN Address NodePort annotations" {
     cd `chart_dir`
-    local actual=$(helm template \
+    local annotations=$(helm template \
         -s $target \
         --set 'connectInject.enabled=true' \
         --set 'meshGateway.enabled=true' \
@@ -110,21 +110,21 @@ target=templates/gateway-resources-configmap.yaml
         --set 'meshGateway.service.type=NodePort' \
         --set 'meshGateway.service.nodePort=30000' \
         . | tee /dev/stderr |
-        yq '.data["config.yaml"]' | yq -r -j '.meshGateways[0].metadata.annotations' | tee /dev/stderr)
+        yq -r '.data["config.yaml"]' | yq -r '.meshGateways[0].metadata.annotations' | tee /dev/stderr)
 
-    local expected=$(echo '{
-        "consul.hashicorp.com/gateway-wan-address-source": "Service",
-        "consul.hashicorp.com/gateway-wan-port": "30000",
-        "consul.hashicorp.com/gateway-wan-address-static": ""
-    }' | tee /dev/stderr)
+    local actual=$(echo "$annotations" | jq -r '.["consul.hashicorp.com/gateway-wan-address-source"]')
+    [ "${actual}" = 'Service' ]
 
-    local equal=$(jq -n --argjson a "$actual" --argjson b "$expected" '$a == $b')
-    [ "${equal}" = 'true' ]
+    local actual=$(echo "$annotations" | jq -r '.["consul.hashicorp.com/gateway-wan-port"]')
+    [ "${actual}" = '30000' ]
+
+    local actual=$(echo "$annotations" | jq -r '.["consul.hashicorp.com/gateway-wan-address-static"]')
+    [ "${actual}" = '' ]
 }
 
-@test "gatewayresources/ConfigMap: Mesh Gateway WAN Address static configuration" {
+@test "gateway-resources/ConfigMap: Mesh Gateway WAN Address static configuration" {
     cd `chart_dir`
-    local actual=$(helm template \
+    local annotations=$(helm template \
         -s $target \
         --set 'connectInject.enabled=true' \
         --set 'meshGateway.enabled=true' \
@@ -133,15 +133,15 @@ target=templates/gateway-resources-configmap.yaml
         --set 'meshGateway.wanAddress.source=Static' \
         --set 'meshGateway.wanAddress.static=127.0.0.1' \
         . | tee /dev/stderr |
-        yq '.data["config.yaml"]' | yq -r -j '.meshGateways[0].metadata.annotations' | tee /dev/stderr)
+        yq -r '.data["config.yaml"]' | yq -r '.meshGateways[0].metadata.annotations' | tee /dev/stderr)
 
-    local expected=$(echo '{
-        "consul.hashicorp.com/gateway-wan-address-source": "Static",
-        "consul.hashicorp.com/gateway-wan-port": "443",
-        "consul.hashicorp.com/gateway-wan-address-static": "127.0.0.1"
-    }' | tee /dev/stderr)
+    local actual=$(echo "$annotations" | jq -r '.["consul.hashicorp.com/gateway-wan-address-source"]')
+    [ "${actual}" = 'Static' ]
 
-    local equal=$(jq -n --argjson a "$actual" --argjson b "$expected" '$a == $b')
-    [ "${equal}" = 'true' ]
+    local actual=$(echo "$annotations" | jq -r '.["consul.hashicorp.com/gateway-wan-port"]')
+    [ "${actual}" = '443' ]
+
+    local actual=$(echo "$annotations" | jq -r '.["consul.hashicorp.com/gateway-wan-address-static"]')
+    [ "${actual}" = '127.0.0.1' ]
 }
 

--- a/charts/consul/test/unit/gateway-resources-configmap.bats
+++ b/charts/consul/test/unit/gateway-resources-configmap.bats
@@ -79,28 +79,28 @@ target=templates/gateway-resources-configmap.yaml
 
 @test "gatewayresources/ConfigMap: Mesh Gateway WAN Address default annotations" {
     cd `chart_dir`
-    local spec=$(helm template \
+    local actual=$(helm template \
         -s $target \
         --set 'connectInject.enabled=true' \
         --set 'meshGateway.enabled=true' \
         --set 'global.experiments[0]=resource-apis' \
         --set 'ui.enabled=false' \
         . | tee /dev/stderr |
-        yq '.data["config.yaml"]' | yq '.meshGateways[0].metadata.annotations' | tee /dev/stderr)
+        yq '.data["config.yaml"]' | yq -r -j '.meshGateways[0].metadata.annotations' | tee /dev/stderr)
 
-    local actual=$(echo "$spec" | yq '.["consul.hashicorp.com/gateway-wan-address-source"]')
-    [ "${actual}" = 'Service' ]
+    local expected=$(echo '{
+        "consul.hashicorp.com/gateway-wan-address-source": "Service",
+        "consul.hashicorp.com/gateway-wan-port": "443",
+        "consul.hashicorp.com/gateway-wan-address-static": ""
+    }' | tee /dev/stderr)
 
-    local actual=$(echo "$spec" | yq '.["consul.hashicorp.com/gateway-wan-port"]')
-    [ "${actual}" = '443' ]
-
-    local actual=$(echo "$spec" | yq '.["consul.hashicorp.com/gateway-wan-address-static"]')
-    [ "${actual}" = '' ]
+    local equal=$(jq -n --argjson a "$actual" --argjson b "$expected" '$a == $b')
+    [ "${equal}" = 'true' ]
 }
 
 @test "gatewayresources/ConfigMap: Mesh Gateway WAN Address NodePort annotations" {
     cd `chart_dir`
-    local spec=$(helm template \
+    local actual=$(helm template \
         -s $target \
         --set 'connectInject.enabled=true' \
         --set 'meshGateway.enabled=true' \
@@ -110,21 +110,21 @@ target=templates/gateway-resources-configmap.yaml
         --set 'meshGateway.service.type=NodePort' \
         --set 'meshGateway.service.nodePort=30000' \
         . | tee /dev/stderr |
-        yq '.data["config.yaml"]' | yq '.meshGateways[0].metadata.annotations' | tee /dev/stderr)
+        yq '.data["config.yaml"]' | yq -r -j '.meshGateways[0].metadata.annotations' | tee /dev/stderr)
 
-    local actual=$(echo "$spec" | yq '.["consul.hashicorp.com/gateway-wan-address-source"]')
-    [ "${actual}" = 'Service' ]
+    local expected=$(echo '{
+        "consul.hashicorp.com/gateway-wan-address-source": "Service",
+        "consul.hashicorp.com/gateway-wan-port": "30000",
+        "consul.hashicorp.com/gateway-wan-address-static": ""
+    }' | tee /dev/stderr)
 
-    local actual=$(echo "$spec" | yq '.["consul.hashicorp.com/gateway-wan-port"]')
-    [ "${actual}" = '30000' ]
-
-    local actual=$(echo "$spec" | yq '.["consul.hashicorp.com/gateway-wan-address-static"]')
-    [ "${actual}" = '' ]
+    local equal=$(jq -n --argjson a "$actual" --argjson b "$expected" '$a == $b')
+    [ "${equal}" = 'true' ]
 }
 
 @test "gatewayresources/ConfigMap: Mesh Gateway WAN Address static configuration" {
     cd `chart_dir`
-    local spec=$(helm template \
+    local actual=$(helm template \
         -s $target \
         --set 'connectInject.enabled=true' \
         --set 'meshGateway.enabled=true' \
@@ -133,15 +133,15 @@ target=templates/gateway-resources-configmap.yaml
         --set 'meshGateway.wanAddress.source=Static' \
         --set 'meshGateway.wanAddress.static=127.0.0.1' \
         . | tee /dev/stderr |
-        yq '.data["config.yaml"]' | yq '.meshGateways[0].metadata.annotations' | tee /dev/stderr)
+        yq '.data["config.yaml"]' | yq -r -j '.meshGateways[0].metadata.annotations' | tee /dev/stderr)
 
-    local actual=$(echo "$spec" | yq '.["consul.hashicorp.com/gateway-wan-address-source"]')
-    [ "${actual}" = 'Static' ]
+    local expected=$(echo '{
+        "consul.hashicorp.com/gateway-wan-address-source": "Static",
+        "consul.hashicorp.com/gateway-wan-port": "443",
+        "consul.hashicorp.com/gateway-wan-address-static": "127.0.0.1"
+    }' | tee /dev/stderr)
 
-    local actual=$(echo "$spec" | yq '.["consul.hashicorp.com/gateway-wan-port"]')
-    [ "${actual}" = '443' ]
-
-    local actual=$(echo "$spec" | yq '.["consul.hashicorp.com/gateway-wan-address-static"]')
-    [ "${actual}" = '127.0.0.1' ]
+    local equal=$(jq -n --argjson a "$actual" --argjson b "$expected" '$a == $b')
+    [ "${equal}" = 'true' ]
 }
 

--- a/charts/consul/test/unit/gateway-resources-configmap.bats
+++ b/charts/consul/test/unit/gateway-resources-configmap.bats
@@ -77,7 +77,7 @@ target=templates/gateway-resources-configmap.yaml
 #--------------------------------------------------------------------
 # Mesh Gateway WAN Address configuration
 
-@test "gatewayresources/Job: Mesh Gateway WAN Address default annotations" {
+@test "gatewayresources/ConfigMap: Mesh Gateway WAN Address default annotations" {
     cd `chart_dir`
     local spec=$(helm template \
         -s $target \
@@ -98,7 +98,7 @@ target=templates/gateway-resources-configmap.yaml
     [ "${actual}" = '' ]
 }
 
-@test "gatewayresources/Job: Mesh Gateway WAN Address NodePort annotations" {
+@test "gatewayresources/ConfigMap: Mesh Gateway WAN Address NodePort annotations" {
     cd `chart_dir`
     local spec=$(helm template \
         -s $target \
@@ -122,7 +122,7 @@ target=templates/gateway-resources-configmap.yaml
     [ "${actual}" = '' ]
 }
 
-@test "gatewayresources/Job: Mesh Gateway WAN Address static configuration" {
+@test "gatewayresources/ConfigMap: Mesh Gateway WAN Address static configuration" {
     cd `chart_dir`
     local spec=$(helm template \
         -s $target \

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2763,7 +2763,7 @@ meshGateway:
     #   are routable from other datacenters.
     #
     # - `Static` - Use the address hardcoded in `meshGateway.wanAddress.static`.
-    source: "Service"
+    source: Service
 
     # Port that gets registered for WAN traffic.
     # If source is set to "Service" then this setting will have no effect.

--- a/control-plane/gateways/deployment.go
+++ b/control-plane/gateways/deployment.go
@@ -70,6 +70,13 @@ func (b *meshGatewayBuilder) deploymentSpec() (*appsv1.DeploymentSpec, error) {
 					constants.AnnotationMeshInject: "false",
 					// This functionality only applies when proxy sidecars are used
 					constants.AnnotationTransparentProxyOverwriteProbes: "false",
+					// This annotation determines which source to use to set the
+					// WAN address and WAN port for the Mesh Gateway service registration.
+					constants.AnnotationGatewayWANSource: b.gateway.Annotations[constants.AnnotationGatewayWANSource],
+					// This annotation determines the WAN port for the Mesh Gateway service registration.
+					constants.AnnotationGatewayWANPort: b.gateway.Annotations[constants.AnnotationGatewayWANPort],
+					// This annotation determines the address for the gateway when the source annotation is "Static".
+					constants.AnnotationGatewayWANAddress: b.gateway.Annotations[constants.AnnotationGatewayWANAddress],
 				},
 			},
 			Spec: corev1.PodSpec{

--- a/control-plane/gateways/deployment_test.go
+++ b/control-plane/gateways/deployment_test.go
@@ -35,6 +35,13 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 			name: "happy path",
 			fields: fields{
 				gateway: &meshv2beta1.MeshGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							constants.AnnotationGatewayWANSource:  "Service",
+							constants.AnnotationGatewayWANPort:    "443",
+							constants.AnnotationGatewayWANAddress: "",
+						},
+					},
 					Spec: pbmesh.MeshGateway{
 						GatewayClassName: "test-gateway-class",
 					},
@@ -133,6 +140,9 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 								constants.AnnotationGatewayKind:                     meshGatewayAnnotationKind,
 								constants.AnnotationMeshInject:                      "false",
 								constants.AnnotationTransparentProxyOverwriteProbes: "false",
+								constants.AnnotationGatewayWANSource:                "Service",
+								constants.AnnotationGatewayWANPort:                  "443",
+								constants.AnnotationGatewayWANAddress:               "",
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -389,6 +399,13 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 			name: "nil gatewayclassconfig - (notfound)",
 			fields: fields{
 				gateway: &meshv2beta1.MeshGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							constants.AnnotationGatewayWANSource:  "Service",
+							constants.AnnotationGatewayWANPort:    "443",
+							constants.AnnotationGatewayWANAddress: "",
+						},
+					},
 					Spec: pbmesh.MeshGateway{
 						GatewayClassName: "test-gateway-class",
 					},
@@ -413,6 +430,9 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 								constants.AnnotationGatewayKind:                     meshGatewayAnnotationKind,
 								constants.AnnotationMeshInject:                      "false",
 								constants.AnnotationTransparentProxyOverwriteProbes: "false",
+								constants.AnnotationGatewayWANSource:                "Service",
+								constants.AnnotationGatewayWANPort:                  "443",
+								constants.AnnotationGatewayWANAddress:               "",
 							},
 						},
 						Spec: corev1.PodSpec{


### PR DESCRIPTION
### Changes proposed in this PR ###  

- Add wanAddress configuration to the configmap
- Set the annotations on the mesh gateway CRD
- Patch through the annotations from the Mesh Gateway

### How I've tested this PR ###

I added BATs and I ran a deployment with the following configuration:

```yaml
global:
  imageK8S: consul-k8s-control-plane:local
  experiments:
    - resource-apis

meshGateway:
  enabled: true

ui:
  enabled: false
```

Which produced a mesh gateway with the correct configuration.

<img width="633" alt="Screenshot 2023-12-21 at 1 44 17 PM" src="https://github.com/hashicorp/consul-k8s/assets/29112081/22fd3763-15e2-4a45-be0d-8fea3d4c6e7e">

### How I expect reviewers to test this PR ###


### Checklist ###
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
