### PR TITLE
Dockerfile: backport #3418 to 1.1.x

### DIFF
--- a/.changelog/3418.txt
+++ b/.changelog/3418.txt
@@ -1,0 +1,3 @@
+```release-note:security
+ Upgrade to use `ubi-minimal:9.3` for OpenShift container images.
+ ```

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -117,7 +117,7 @@ CMD /bin/${BIN_NAME}
 # We don't rebuild the software because we want the exact checksums and
 # binary signatures to match the software and our builds aren't fully
 # reproducible currently.
-FROM registry.access.redhat.com/ubi9-minimal:9.2 as ubi
+FROM registry.access.redhat.com/ubi9-minimal:9.3 as ubi
 
 ARG PRODUCT_NAME
 ARG PRODUCT_VERSION


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Dockerfile: backport #3418 to 1.1.x

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


---

<details>
<summary> Overview of commits </summary>

  - 0c0c828534fe62f5e831fcc5051ccd83ed5c1305  - ccdb253121e3dd43e809734fd6df53cfd76a0794  - 7223f519f10966db9fcf105c507fe58b3a32a9ed  - 6b26bf347e81f3222364fda9f4983be8d7c358fc  - 40cbf0598bcd629e0ce2855610ca0d79f9230e5f 

</details>
