### PR TITLE
Allowing ClusterIP when ExternalIPs slice has addresses

### DIFF
--- a/control-plane/catalog/to-consul/resource.go
+++ b/control-plane/catalog/to-consul/resource.go
@@ -312,7 +312,7 @@ func (t *ServiceResource) shouldSync(svc *corev1.Service) bool {
 	}
 
 	// Ignore ClusterIP services if ClusterIP sync is disabled
-	if svc.Spec.Type == corev1.ServiceTypeClusterIP && !t.ClusterIPSync {
+	if svc.Spec.Type == corev1.ServiceTypeClusterIP && !t.ClusterIPSync && len(svc.Spec.ExternalIPs) == 0 {
 		t.Log.Debug("[shouldSync] ignoring clusterip service", "svc.Namespace", svc.Namespace, "service", svc)
 		return false
 	}


### PR DESCRIPTION
Refactoring this PR: https://github.com/hashicorp/consul-k8s/pull/247 with the new code base.

The idea is to let ClusterIP type services be allowed even if the ClusterIPSync flag is false when there are addresses in the ExternalIPs slice. This is used in some scenarios, or as in our case, when using kube-router instead of a loadbalancer. We have a use case where this is needed.

Thanks

