### PR TITLE
Pass gateway init resources from config to the container

### DIFF
--- a/control-plane/gateways/deployment.go
+++ b/control-plane/gateways/deployment.go
@@ -46,7 +46,7 @@ func (b *meshGatewayBuilder) deploymentSpec() (*appsv1.DeploymentSpec, error) {
 		}
 	}
 
-	initContainer, err := b.initContainer(b.config, b.gateway.Name, b.gateway.Namespace)
+	initContainer, err := b.initContainer()
 	if err != nil {
 		return nil, err
 	}

--- a/control-plane/gateways/deployment.go
+++ b/control-plane/gateways/deployment.go
@@ -32,21 +32,23 @@ func (b *meshGatewayBuilder) Deployment() (*appsv1.Deployment, error) {
 }
 
 func (b *meshGatewayBuilder) deploymentSpec() (*appsv1.DeploymentSpec, error) {
-	initContainer, err := b.initContainer(b.config, b.gateway.Name, b.gateway.Namespace)
-	if err != nil {
-		return nil, err
-	}
-
 	var (
-		containerConfig  meshv2beta1.GatewayClassContainerConfig
 		deploymentConfig meshv2beta1.GatewayClassDeploymentConfig
+		containerConfig  meshv2beta1.GatewayClassContainerConfig
 	)
 
+	// If GatewayClassConfig is not nil, use it to override the defaults for
+	// the deployment and container configs.
 	if b.gcc != nil {
 		deploymentConfig = b.gcc.Spec.Deployment
 		if deploymentConfig.Container != nil {
 			containerConfig = *b.gcc.Spec.Deployment.Container
 		}
+	}
+
+	initContainer, err := b.initContainer(b.config, b.gateway.Name, b.gateway.Namespace)
+	if err != nil {
+		return nil, err
 	}
 
 	container, err := consulDataplaneContainer(b.config, containerConfig, b.gateway.Name, b.gateway.Namespace)

--- a/control-plane/gateways/deployment.go
+++ b/control-plane/gateways/deployment.go
@@ -32,7 +32,7 @@ func (b *meshGatewayBuilder) Deployment() (*appsv1.Deployment, error) {
 }
 
 func (b *meshGatewayBuilder) deploymentSpec() (*appsv1.DeploymentSpec, error) {
-	initContainer, err := initContainer(b.config, b.gateway.Name, b.gateway.Namespace)
+	initContainer, err := b.initContainer(b.config, b.gateway.Name, b.gateway.Namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/control-plane/gateways/deployment_init_container.go
+++ b/control-plane/gateways/deployment_init_container.go
@@ -146,7 +146,7 @@ func (b *meshGatewayBuilder) initContainer() (corev1.Container, error) {
 			Value: consulNamespace,
 		})
 
-	if config.TLSEnabled {
+	if b.config.TLSEnabled {
 		container.Env = append(container.Env,
 			corev1.EnvVar{
 				Name:  constants.UseTLSEnvVar,
@@ -154,11 +154,11 @@ func (b *meshGatewayBuilder) initContainer() (corev1.Container, error) {
 			},
 			corev1.EnvVar{
 				Name:  constants.CACertPEMEnvVar,
-				Value: config.ConsulCACert,
+				Value: b.config.ConsulCACert,
 			},
 			corev1.EnvVar{
 				Name:  constants.TLSServerNameEnvVar,
-				Value: config.ConsulTLSServerName,
+				Value: b.config.ConsulTLSServerName,
 			})
 	}
 

--- a/control-plane/gateways/deployment_init_container.go
+++ b/control-plane/gateways/deployment_init_container.go
@@ -40,7 +40,7 @@ func (b *meshGatewayBuilder) initContainer() (corev1.Container, error) {
 		LogLevel:           b.config.LogLevel,
 		LogJSON:            b.config.LogJSON,
 		ServiceName:        b.gateway.Name,
-		ServiceAccountName: b.gateway.Name,
+		ServiceAccountName: b.serviceAccountName(),
 	}
 
 	// Create expected volume mounts

--- a/control-plane/gateways/deployment_init_container.go
+++ b/control-plane/gateways/deployment_init_container.go
@@ -30,9 +30,9 @@ type initContainerCommandData struct {
 	LogJSON  bool
 }
 
-// containerInit returns the init container spec for connect-init that polls for the service and the connect proxy service to be registered
+// initContainer returns the init container spec for connect-init that polls for the service and the connect proxy service to be registered
 // so that it can save the proxy service id to the shared volume and boostrap Envoy with the proxy-id.
-func initContainer(config GatewayConfig, name, namespace string) (corev1.Container, error) {
+func (b *meshGatewayBuilder) initContainer(config GatewayConfig, name, namespace string) (corev1.Container, error) {
 	data := initContainerCommandData{
 		AuthMethod:         config.AuthMethod,
 		LogLevel:           config.LogLevel,
@@ -113,6 +113,7 @@ func initContainer(config GatewayConfig, name, namespace string) (corev1.Contain
 		},
 		VolumeMounts: volMounts,
 		Command:      []string{"/bin/sh", "-ec", buf.String()},
+		Resources:    corev1.ResourceRequirements{},
 	}
 
 	if config.AuthMethod != "" {

--- a/control-plane/gateways/deployment_test.go
+++ b/control-plane/gateways/deployment_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
@@ -118,6 +119,18 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 									MaxSkew:           1,
 									TopologyKey:       "key",
 									WhenUnsatisfiable: "DoNotSchedule",
+								},
+							},
+							InitContainer: &meshv2beta1.GatewayClassInitContainerConfig{
+								Resources: &corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"cpu":    resource.MustParse("100m"),
+										"memory": resource.MustParse("128Mi"),
+									},
+									Limits: corev1.ResourceList{
+										"cpu":    resource.MustParse("200m"),
+										"memory": resource.MustParse("228Mi"),
+									},
 								},
 							},
 						},
@@ -241,7 +254,16 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 											Value: "",
 										},
 									},
-									Resources: corev1.ResourceRequirements{},
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"cpu":    resource.MustParse("100m"),
+											"memory": resource.MustParse("128Mi"),
+										},
+										Limits: corev1.ResourceList{
+											"cpu":    resource.MustParse("200m"),
+											"memory": resource.MustParse("228Mi"),
+										},
+									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "consul-mesh-inject-data",


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Make initConfig an associated function to the builder
- Pass in init container resources if they are set
- Use values from the builder now that initContainer is associated with it

### How I've tested this PR ###

Updated the happy path unit test to exercise the resource setting.

### How I expect reviewers to test this PR ###


### Checklist ###
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
