### PR TITLE
NET-6768: Set port on MeshGateway

### DIFF
--- a/charts/consul/templates/gateway-resources-configmap.yaml
+++ b/charts/consul/templates/gateway-resources-configmap.yaml
@@ -95,6 +95,7 @@ data:
               set: {{ toJson .Values.meshGateway.service.annotations }}
             {{- end }}
             type: {{ .Values.meshGateway.service.type }}
+            port: {{ .Values.meshGateway.service.port }}
           {{- if .Values.meshGateway.serviceAccount.annotations }}
           serviceAccount:
             annotations:

--- a/control-plane/api/mesh/v2beta1/gateway_class_config_types.go
+++ b/control-plane/api/mesh/v2beta1/gateway_class_config_types.go
@@ -125,6 +125,9 @@ type GatewayClassServiceConfig struct {
 	// Type specifies the type of Service to use (LoadBalancer, ClusterIP, etc.)
 	// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer
 	Type *corev1.ServiceType `json:"type,omitempty"`
+
+	// Port specifies the WAN port for the mesh-gateway service registration
+	Port int32 `json:"port,omitempty"`
 }
 
 type GatewayClassServiceAccountConfig struct {

--- a/control-plane/gateways/service.go
+++ b/control-plane/gateways/service.go
@@ -4,6 +4,8 @@
 package gateways
 
 import (
+	"fmt"
+
 	meshv2beta1 "github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,10 +21,14 @@ func (b *meshGatewayBuilder) Service() *corev1.Service {
 	)
 
 	if b.gcc != nil {
+		fmt.Println("PORT", b.gcc.Spec.Service.Port)
+
+		if b.gcc.Spec.Service.Port != int32(0) {
+			port = b.gcc.Spec.Service.Port
+		}
 		containerConfig = b.gcc.Spec.Deployment.Container
 		portModifier = containerConfig.PortModifier
 		serviceType = *b.gcc.Spec.Service.Type
-		port = b.gcc.Spec.Service.Port
 	}
 
 	return &corev1.Service{

--- a/control-plane/gateways/service.go
+++ b/control-plane/gateways/service.go
@@ -4,26 +4,25 @@
 package gateways
 
 import (
+	meshv2beta1 "github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-
-	meshv2beta1 "github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
 )
-
-const port = int32(443)
 
 func (b *meshGatewayBuilder) Service() *corev1.Service {
 	var (
-		containerConfig *meshv2beta1.GatewayClassContainerConfig
 		portModifier    = int32(0)
+		port            = int32(443)
 		serviceType     = corev1.ServiceType("")
+		containerConfig *meshv2beta1.GatewayClassContainerConfig
 	)
 
 	if b.gcc != nil {
 		containerConfig = b.gcc.Spec.Deployment.Container
 		portModifier = containerConfig.PortModifier
 		serviceType = *b.gcc.Spec.Service.Type
+		port = b.gcc.Spec.Service.Port
 	}
 
 	return &corev1.Service{

--- a/control-plane/gateways/service.go
+++ b/control-plane/gateways/service.go
@@ -23,7 +23,7 @@ func (b *meshGatewayBuilder) Service() *corev1.Service {
 	if b.gcc != nil {
 		fmt.Println("PORT", b.gcc.Spec.Service.Port)
 
-		if b.gcc.Spec.Service.Port != int32(0) {
+		if b.gcc.Spec.Service.Port != 0 {
 			port = b.gcc.Spec.Service.Port
 		}
 		containerConfig = b.gcc.Spec.Deployment.Container

--- a/control-plane/gateways/service_test.go
+++ b/control-plane/gateways/service_test.go
@@ -56,7 +56,7 @@ func Test_meshGatewayBuilder_Service(t *testing.T) {
 						},
 						Service: meshv2beta1.GatewayClassServiceConfig{
 							Type: &lbType,
-							Port: int32(443),
+							Port: int32(8081),
 						},
 					},
 				},
@@ -84,9 +84,9 @@ func Test_meshGatewayBuilder_Service(t *testing.T) {
 					Ports: []corev1.ServicePort{
 						{
 							Name: "wan",
-							Port: int32(443),
+							Port: int32(8081),
 							TargetPort: intstr.IntOrString{
-								IntVal: int32(8443),
+								IntVal: int32(16081),
 							},
 						},
 					},

--- a/control-plane/gateways/service_test.go
+++ b/control-plane/gateways/service_test.go
@@ -95,6 +95,71 @@ func Test_meshGatewayBuilder_Service(t *testing.T) {
 			},
 		},
 		{
+			name: "service resource crd created -- no service port set",
+			fields: fields{
+				gateway: &meshv2beta1.MeshGateway{
+					Spec: pbmesh.MeshGateway{
+						GatewayClassName: "test-gateway-class",
+					},
+				},
+				config: GatewayConfig{},
+				gcc: &meshv2beta1.GatewayClassConfig{
+					Spec: meshv2beta1.GatewayClassConfigSpec{
+						GatewayClassAnnotationsAndLabels: meshv2beta1.GatewayClassAnnotationsAndLabels{
+							Labels: meshv2beta1.GatewayClassAnnotationsLabelsConfig{
+								Set: map[string]string{
+									"app":      "consul",
+									"chart":    "consul-helm",
+									"heritage": "Helm",
+									"release":  "consul",
+								},
+							},
+						},
+						Deployment: meshv2beta1.GatewayClassDeploymentConfig{
+							Container: &meshv2beta1.GatewayClassContainerConfig{
+								PortModifier: 8000,
+							},
+						},
+						Service: meshv2beta1.GatewayClassServiceConfig{
+							Type: &lbType,
+						},
+					},
+				},
+			},
+			want: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						labelManagedBy: "consul-k8s",
+						"app":          "consul",
+						"chart":        "consul-helm",
+						"heritage":     "Helm",
+						"release":      "consul",
+					},
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						labelManagedBy: "consul-k8s",
+						"app":          "consul",
+						"chart":        "consul-helm",
+						"heritage":     "Helm",
+						"release":      "consul",
+					},
+					Type: corev1.ServiceTypeLoadBalancer,
+					Ports: []corev1.ServicePort{
+						{
+							Name: "wan",
+							Port: int32(443),
+							TargetPort: intstr.IntOrString{
+								IntVal: int32(8443),
+							},
+						},
+					},
+				},
+				Status: corev1.ServiceStatus{},
+			},
+		},
+		{
 			name: "create service resource crd - gcc is nil",
 			fields: fields{
 				gateway: &meshv2beta1.MeshGateway{

--- a/control-plane/gateways/service_test.go
+++ b/control-plane/gateways/service_test.go
@@ -56,6 +56,7 @@ func Test_meshGatewayBuilder_Service(t *testing.T) {
 						},
 						Service: meshv2beta1.GatewayClassServiceConfig{
 							Type: &lbType,
+							Port: int32(443),
 						},
 					},
 				},


### PR DESCRIPTION
### Changes proposed in this PR ### 
Add support for .Values.meshGateway.service.port in service

- Update `GatewayClassServiceConfig` to store the port value
- Update `service` in configmap.yaml

### How I've tested this PR ###
- unit test passes

MANUAL TEST FAILING SO FAR
1. Install consul with custom meshGateway service port in values.yaml
```
meshGateway:
  enabled: true
  service:
    port: 8182
```
**RESULT:** 
1. Get logs from connect-inject pod to ensure no nil pointer errors
```
PORT 0 <= should be whatever custom value is set in values.yaml (8182)
```
2.  Get meshgateway service.yaml logs
```
apiVersion: v1
kind: Service
...
spec:
 ...
  ports:
  - name: wan
    nodePort: 31432
    port: 443 <= INCORRECT should be 8182
    protocol: TCP
    targetPort: 704 <= INCORRECT should be 8182 + 8000
...
```

### How I expect reviewers to test this PR ###
- Same as above
- Run unit test for [service.go](gateways/service_test.go)

### Checklist ###
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
