### PR TITLE
Add tolerations to init job templates

### DIFF
--- a/charts/consul/templates/gossip-encryption-autogenerate-job.yaml
+++ b/charts/consul/templates/gossip-encryption-autogenerate-job.yaml
@@ -67,4 +67,12 @@ spec:
             limits:
               memory: "50Mi"
               cpu: "50m"
+      {{- if .Values.global.gossipEncryption.tolerations }}
+      tolerations:
+        {{ tpl .Values.global.gossipEncryption.tolerations . | indent 8 | trim }}
+      {{- end }}
+      {{- if .Values.global.gossipEncryption.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.global.gossipEncryption.nodeSelector . | indent 8 | trim }}
+      {{- end }}
 {{- end }}

--- a/charts/consul/templates/tls-init-cleanup-job.yaml
+++ b/charts/consul/templates/tls-init-cleanup-job.yaml
@@ -79,6 +79,14 @@ spec:
             limits:
               memory: "50Mi"
               cpu: "50m"
+      {{- if .Values.global.tls.tolerations }}
+      tolerations:
+        {{ tpl .Values.global.tls.tolerations . | indent 8 | trim }}
+      {{- end }}
+      {{- if .Values.global.tls.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.global.tls.nodeSelector . | indent 8 | trim }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/tls-init-job.yaml
+++ b/charts/consul/templates/tls-init-job.yaml
@@ -121,6 +121,14 @@ spec:
             limits:
               memory: "50Mi"
               cpu: "50m"
+      {{- if .Values.global.tls.tolerations }}
+      tolerations:
+        {{ tpl .Values.global.tls.tolerations . | indent 8 | trim }}
+      {{- end }}
+      {{- if .Values.global.tls.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.global.tls.nodeSelector . | indent 8 | trim }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/test/unit/gossip-encryption-autogenerate-job.bats
+++ b/charts/consul/test/unit/gossip-encryption-autogenerate-job.bats
@@ -135,3 +135,48 @@ load _helpers
     yq 'any(contains("-log-level=debug"))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# global.gossipEncryption.tolerations and global.gossipEncryption.nodeSelector
+
+@test "gossipEncryptionAutogenerate/Job: tolerations not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/gossip-encryption-autogenerate-job.yaml  \
+      --set 'global.gossipEncryption.autoGenerate=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.tolerations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "gossipEncryptionAutogenerate/Job: tolerations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/gossip-encryption-autogenerate-job.yaml  \
+      --set 'global.gossipEncryption.autoGenerate=true' \
+      --set 'global.gossipEncryption.tolerations=- key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.tolerations[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "gossipEncryptionAutogenerate/Job: nodeSelector not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/gossip-encryption-autogenerate-job.yaml  \
+      --set 'global.gossipEncryption.autoGenerate=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "gossipEncryptionAutogenerate/Job: nodeSelector can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/gossip-encryption-autogenerate-job.yaml  \
+      --set 'global.gossipEncryption.autoGenerate=true' \
+      --set 'global.gossipEncryption.nodeSelector=- key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}

--- a/charts/consul/test/unit/tls-init-cleanup-job.bats
+++ b/charts/consul/test/unit/tls-init-cleanup-job.bats
@@ -163,3 +163,48 @@ load _helpers
       yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 }
+
+#--------------------------------------------------------------------
+# global.tls.tolerations and global.tls.nodeSelector
+
+@test "tlsInitCleanup/Job: tolerations not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tls-init-cleanup-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.tolerations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "tlsInitCleanup/Job: tolerations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tls-init-cleanup-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.tolerations=- key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.tolerations[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "tlsInitCleanup/Job: nodeSelector not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tls-init-cleanup-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "tlsInitCleanup/Job: nodeSelector can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tls-init-cleanup-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.nodeSelector=- key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}

--- a/charts/consul/test/unit/tls-init-job.bats
+++ b/charts/consul/test/unit/tls-init-job.bats
@@ -280,3 +280,48 @@ load _helpers
       yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 }
+
+#--------------------------------------------------------------------
+# global.tls.tolerations and global.tls.nodeSelector
+
+@test "tlsInit/Job: tolerations not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tls-init-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.tolerations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "tlsInit/Job: tolerations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tls-init-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.tolerations=- key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.tolerations[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}
+
+@test "tlsInit/Job: nodeSelector not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tls-init-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "tlsInit/Job: nodeSelector can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/tls-init-job.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'global.tls.nodeSelector=- key: value' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector[0].key' | tee /dev/stderr)
+  [ "${actual}" = "value" ]
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -297,6 +297,24 @@ global:
     # @type: string
     logLevel: ""
 
+    # tolerations configures the taints and tolerations for the gossip-encryption-autogenerate job.
+    # This should be a multi-line string matching the
+    # [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) array in a Pod spec.
+    tolerations: ""
+
+    # This value defines [`nodeSelector`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
+    # labels for the gossip-encryption-autogenerate job pod assignment, formatted as a multi-line string.
+    #
+    # Example:
+    #
+    # ```yaml
+    # nodeSelector: |
+    #   beta.kubernetes.io/arch: amd64
+    # ```
+    #
+    # @type: string
+    nodeSelector: null
+
   # A list of addresses of upstream DNS servers that are used to recursively resolve DNS queries.
   # These values are given as `-recursor` flags to Consul servers and clients.
   # Refer to [`-recursor`](https://developer.hashicorp.com/consul/docs/agent/config/cli-flags#_recursor) for more details.
@@ -401,6 +419,24 @@ global:
     #
     # @type: string
     annotations: null
+
+    # tolerations configures the taints and tolerations for the tls-init
+    # and tls-init-cleanup jobs. This should be a multi-line string matching the
+    # [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) array in a Pod spec.
+    tolerations: ""
+
+    # This value defines [`nodeSelector`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
+    # labels for the tls-init and tls-init-cleanup jobs pod assignment, formatted as a multi-line string.
+    #
+    # Example:
+    #
+    # ```yaml
+    # nodeSelector: |
+    #   beta.kubernetes.io/arch: amd64
+    # ```
+    #
+    # @type: string
+    nodeSelector: null
 
   # [Enterprise Only] `enableConsulNamespaces` indicates that you are running
   # Consul Enterprise v1.7+ with a valid Consul Enterprise license and would


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Add the ability to specify tolerations for tls-init-job, tls-init-cleanup-job, and gossip-encryption-autogenerate-job.
- Add associated unit tests.
- Currently, these initialization jobs will get stuck in a 'Pending' state if all nodes in the default namespace have NoSchedule taints. Specifying tolerations allows the jobs to be scheduled.

### How I've tested this PR ###
- The template unit tests provided, and those added.
- Deployment against a private K8s cluster, verifying tolerations on init jobs.

### How I expect reviewers to test this PR ###
- Configure K8s test cluster with NoSchedule taints on all nodes. Deploy Consul with tls and gossipEncryption enabled, and tolerations defined for both. Inspect init jobs for expected tolerations and ensure they are not stuck in a 'Pending' state.

### Checklist ###
- [X] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
