### PR TITLE
Fix to support non-enterprise HCP observability testing 

### DIFF
--- a/acceptance/tests/cloud/observability_test.go
+++ b/acceptance/tests/cloud/observability_test.go
@@ -222,7 +222,11 @@ func TestObservabilityCloud(t *testing.T) {
 
 			// Validate that the consul-telemetry-collector service was deployed to the expected namespace.
 			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
-			instances, _, err := consulClient.Catalog().Service("consul-telemetry-collector", "", &api.QueryOptions{Namespace: ns})
+			q := &api.QueryOptions{}
+			if cfg.EnableEnterprise {
+				q.Namespace = ns
+			}
+			instances, _, err := consulClient.Catalog().Service("consul-telemetry-collector", "", q)
 			require.NoError(t, err)
 			require.Len(t, instances, 1)
 			require.Equal(t, "passing", instances[0].Checks.AggregatedStatus())


### PR DESCRIPTION

### Changes proposed in this PR ###  
- In the cloud observability tests, set the namespace in the query parameters only if enterprise is enabled.

### How I've tested this PR ###
Ran the tests with a Community Edition version of Consul and without `-enable-enterprise`:
```
--- PASS: TestObservabilityCloud (357.07s)
    --- PASS: TestObservabilityCloud/default_namespace_and_partition (230.08s)
        --- PASS: TestObservabilityCloud/default_namespace_and_partition/collectorExportsMetrics (109.46s)
        --- PASS: TestObservabilityCloud/default_namespace_and_partition/consulPeriodicRefreshUpdateConfig (28.12s)
        --- PASS: TestObservabilityCloud/default_namespace_and_partition/consulPeriodicRefreshDisabled (0.01s)
    --- PASS: TestObservabilityCloud/default_namespace_and_partition;_secure (126.99s)
        --- SKIP: TestObservabilityCloud/default_namespace_and_partition;_secure/consulPeriodicRefreshDisabled (0.00s)
        --- SKIP: TestObservabilityCloud/default_namespace_and_partition;_secure/collectorExportsMetrics (0.00s)
        --- SKIP: TestObservabilityCloud/default_namespace_and_partition;_secure/consulPeriodicRefreshUpdateConfig (0.00s)
    --- SKIP: TestObservabilityCloud/namespace_mirroring;_secure (0.00s)
    --- SKIP: TestObservabilityCloud/admin_partitions;_secure (0.00s)
PASS
ok  	github.com/hashicorp/consul-k8s/acceptance/tests/cloud	358.033s
```
Ran the tests with Consul Enterprise and with `-enable-enterprise`:
```
--- PASS: TestObservabilityCloud (596.74s)
    --- PASS: TestObservabilityCloud/default_namespace_and_partition (224.28s)
        --- PASS: TestObservabilityCloud/default_namespace_and_partition/collectorExportsMetrics (110.44s)
        --- PASS: TestObservabilityCloud/default_namespace_and_partition/consulPeriodicRefreshUpdateConfig (14.06s)
        --- PASS: TestObservabilityCloud/default_namespace_and_partition/consulPeriodicRefreshDisabled (0.01s)
    --- PASS: TestObservabilityCloud/default_namespace_and_partition;_secure (122.67s)
        --- SKIP: TestObservabilityCloud/default_namespace_and_partition;_secure/collectorExportsMetrics (0.00s)
        --- SKIP: TestObservabilityCloud/default_namespace_and_partition;_secure/consulPeriodicRefreshUpdateConfig (0.00s)
        --- SKIP: TestObservabilityCloud/default_namespace_and_partition;_secure/consulPeriodicRefreshDisabled (0.00s)
    --- PASS: TestObservabilityCloud/namespace_mirroring;_secure (124.69s)
        --- SKIP: TestObservabilityCloud/namespace_mirroring;_secure/collectorExportsMetrics (0.00s)
        --- SKIP: TestObservabilityCloud/namespace_mirroring;_secure/consulPeriodicRefreshUpdateConfig (0.00s)
        --- SKIP: TestObservabilityCloud/namespace_mirroring;_secure/consulPeriodicRefreshDisabled (0.00s)
    --- PASS: TestObservabilityCloud/admin_partitions;_secure (125.09s)
        --- SKIP: TestObservabilityCloud/admin_partitions;_secure/consulPeriodicRefreshUpdateConfig (0.00s)
        --- SKIP: TestObservabilityCloud/admin_partitions;_secure/consulPeriodicRefreshDisabled (0.00s)
        --- SKIP: TestObservabilityCloud/admin_partitions;_secure/collectorExportsMetrics (0.00s)
PASS
ok  	github.com/hashicorp/consul-k8s/acceptance/tests/cloud	597.577s
```

### How I expect reviewers to test this PR ###
Run the tests both with enterprise and without enterprise Consul images.

### Checklist ###
- [X] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
