### PR TITLE
disable TestConnectInject_LocalRateLimiting for cloud provider tests

### DIFF
--- a/acceptance/tests/connect/local_rate_limit_test.go
+++ b/acceptance/tests/connect/local_rate_limit_test.go
@@ -25,6 +25,8 @@ func TestConnectInject_LocalRateLimiting(t *testing.T) {
 
 	if !cfg.EnableEnterprise {
 		t.Skipf("rate limiting is an enterprise only feature. -enable-enterprise must be set to run this test.")
+	} else if !cfg.UseKind {
+		t.Skipf("rate limiting tests are time sensitive and can be flaky on cloud providers. Only test on Kind.")
 	}
 
 	ctx := suite.Environment().DefaultContext(t)


### PR DESCRIPTION
### Changes proposed in this PR ###  
- This PR disables the local rate limiting tests for cloud providers. This test is time sensitive and was consistently flaking on cloud. This doesn't test any features specific to cloud, so I think it is safe to disable this in our nightlies.
-

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
