### PR TITLE
[NET-6702] HTTPRoute not being deleted from consul bug

### DIFF
--- a/.changelog/3440.txt
+++ b/.changelog/3440.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api-gateway: fix issue where deleting an http-route in a non-default namespace would not remove the route from Consul.
+```

--- a/control-plane/api-gateway/cache/consul.go
+++ b/control-plane/api-gateway/cache/consul.go
@@ -434,9 +434,12 @@ func (c *Cache) Delete(ctx context.Context, ref api.ResourceReference) error {
 		return err
 	}
 
-	options := &api.WriteOptions{}
+	options := &api.WriteOptions{Namespace: ref.Namespace, Partition: ref.Partition}
 
 	_, err = client.ConfigEntries().Delete(ref.Kind, ref.Name, options.WithContext(ctx))
+	if err != nil {
+		c.logger.Info("delete error", "err", err)
+	}
 	return err
 }
 


### PR DESCRIPTION
### Changes proposed in this PR ###  
- include namespace/partition on request context when deleting resources from consul

### How I've tested this PR ###
Ran examples here https://github.com/jm96441n/consul-experiments/tree/main/k8s/http-route-bug


### How I expect reviewers to test this PR ###
1. make a build of the main branch of this repo by running `make control-plane-dev-docker`
1. clone down this repo https://github.com/jm96441n/consul-experiments/tree/main/k8s/http-route-bug 
1. run the `start` script in the repo
1. once resources finish spinning up check that the route exists by running ` consul config read -kind http-route -name backend-route-default -namespace=app`
1. delete the route by running `kubectl delete -f ./resources/route.yaml`
1. run ` consul config read -kind http-route -name backend-route-default -namespace=app` again to see the route still exists
1. tear down the kind cluster
1. make a new build of the control plane by checking out this branch and running `make control-plane-dev-docker`
1. re-run the start script from the example
once resources finish spinning up check that the route exists by running ` consul config read -kind http-route -name backend-route-default -namespace=app`
1. delete the route by running `kubectl delete -f ./resources/route.yaml`
1. run ` consul config read -kind http-route -name backend-route-default -namespace=app` again to see the route is now deleted


### Checklist ###
- [X] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
