### PR TITLE
ci: Single source of truth for Go version in CI and Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ control-plane-dev-docker: ## Build consul-k8s-control-plane dev Docker image.
        --build-arg 'GIT_COMMIT=$(GIT_COMMIT)' \
        --build-arg 'GIT_DIRTY=$(GIT_DIRTY)' \
        --build-arg 'GIT_DESCRIBE=$(GIT_DESCRIBE)' \
+       --build-arg 'GOLANG_VERSION=$(GOLANG_VERSION)' \
        -f $(CURDIR)/control-plane/Dockerfile $(CURDIR)/control-plane
 
 .PHONY: control-plane-dev-skaffold
@@ -56,6 +57,7 @@ control-plane-dev-skaffold: ## Build consul-k8s-control-plane dev Docker image f
 	@$(SHELL) $(CURDIR)/control-plane/build-support/scripts/build-local.sh -o linux -a $(GOARCH)
 	@docker build -t '$(DEV_IMAGE)' \
        --build-arg 'TARGETARCH=$(GOARCH)' \
+       --build-arg 'GOLANG_VERSION=$(GOLANG_VERSION)' \
        -f $(CURDIR)/control-plane/Dockerfile.dev $(CURDIR)/control-plane
 
 .PHONY: check-remote-dev-image-env
@@ -73,6 +75,7 @@ control-plane-dev-docker-multi-arch: check-remote-dev-image-env ## Build consul-
        --build-arg 'GIT_COMMIT=$(GIT_COMMIT)' \
        --build-arg 'GIT_DIRTY=$(GIT_DIRTY)' \
        --build-arg 'GIT_DESCRIBE=$(GIT_DESCRIBE)' \
+       --build-arg 'GOLANG_VERSION=$(GOLANG_VERSION)' \
        --push \
        -f $(CURDIR)/control-plane/Dockerfile $(CURDIR)/control-plane
 
@@ -85,6 +88,7 @@ control-plane-fips-dev-docker: ## Build consul-k8s-control-plane FIPS dev Docker
        --build-arg 'GIT_COMMIT=$(GIT_COMMIT)' \
        --build-arg 'GIT_DIRTY=$(GIT_DIRTY)' \
        --build-arg 'GIT_DESCRIBE=$(GIT_DESCRIBE)' \
+       --build-arg 'GOLANG_VERSION=$(GOLANG_VERSION)' \
        --push \
        -f $(CURDIR)/control-plane/Dockerfile $(CURDIR)/control-plane
 
@@ -389,6 +393,9 @@ endif
 # ===========> Makefile config
 .DEFAULT_GOAL := help
 SHELL = bash
+# When changing the method of Go version detection, also update
+# version detection in CI workflows (build.yml).
+GOLANG_VERSION?=$(shell head -n 1 .go-version)
 GOOS?=$(shell go env GOOS)
 GOARCH?=$(shell go env GOARCH)
 DEV_IMAGE?=consul-k8s-control-plane-dev

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -16,7 +16,8 @@
 
 # go-discover builds the discover binary (which we don't currently publish
 # either).
-FROM golang:1.20.12-alpine as go-discover
+ARG GOLANG_VERSION
+FROM golang:${GOLANG_VERSION}-alpine as go-discover
 RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@214571b6a5309addf3db7775f4ee8cf4d264fd5f
 
 # dev copies the binary from a local build

--- a/control-plane/Makefile
+++ b/control-plane/Makefile
@@ -3,6 +3,10 @@ SHELL = bash
 ################
 # CI Variables #
 ################
+
+# When changing the method of Go version detection, also update
+# version detection in CI workflows (build.yml).
+GOLANG_VERSION?=$(shell head -n 1 ../.go-version)
 GIT_COMMIT?=$(shell git rev-parse --short HEAD)
 GIT_DIRTY?=$(shell test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 GIT_DESCRIBE?=$(shell git describe --tags --always)
@@ -33,6 +37,7 @@ ci.dev-docker:
 	@docker buildx build -t '$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT)' \
 	--platform linux/amd64,linux/arm64 \
 	--target=dev \
+	--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 	--push \
 	--label COMMIT_SHA=$(CIRCLE_SHA1) \
 	--label PULL_REQUEST=$(CIRCLE_PULL_REQUEST) \
@@ -43,6 +48,7 @@ ifeq ($(CIRCLE_BRANCH), main)
 	@docker buildx build -t '$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest' \
 	--platform linux/amd64,linux/arm64 \
 	--target=dev \
+	--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 	--push \
 	--label COMMIT_SHA=$(CIRCLE_SHA1) \
 	--label PULL_REQUEST=$(CIRCLE_PULL_REQUEST) \


### PR DESCRIPTION
Ensure Go version is determined consistently for CI and Docker builds rather than spread across several different files.

The intent is to eventually replace this with use of the `toolchain` directive in Go 1.21.

c.f. https://github.com/hashicorp/consul/pull/20058

### How I've tested this PR ###
CI continues to pass

### How I expect reviewers to test this PR ###
👀 

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
