### PR TITLE
[NET-7137] Include gateway-kind and gateway-consul-service-name labels on Deployment

### DIFF
--- a/control-plane/gateways/metadata.go
+++ b/control-plane/gateways/metadata.go
@@ -7,11 +7,12 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
+	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 )
 
 const labelManagedBy = "mesh.consul.hashicorp.com/managed-by"
 
-var defaultLabels = map[string]string{labelManagedBy: "consul-k8s"}
+var defaultLabels = map[string]string{labelManagedBy: "consul-k8s-gateways-controller-v2"}
 
 func (b *meshGatewayBuilder) annotationsForDeployment() map[string]string {
 	if b.gcc == nil {
@@ -49,6 +50,10 @@ func (b *meshGatewayBuilder) annotationsForServiceAccount() map[string]string {
 }
 
 func (b *meshGatewayBuilder) labelsForDeployment() map[string]string {
+	defaultLabels := defaultLabels
+	defaultLabels[constants.AnnotationGatewayConsulServiceName] = b.Service().Name
+	defaultLabels[constants.AnnotationGatewayKind] = "mesh-gateway"
+
 	if b.gcc == nil {
 		return defaultLabels
 	}


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Include `gateway-kind` and `.../gateway-consul-service-name` annotations on `Deployment`

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
