### PR TITLE
NET-7179: Update MeshGateway to use new proto with workload selector

### DIFF
--- a/charts/consul/templates/crd-meshgateways.yaml
+++ b/charts/consul/templates/crd-meshgateways.yaml
@@ -73,6 +73,20 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+              workloads:
+                description: Selection of workloads to be configured as mesh gateways
+                properties:
+                  filter:
+                    type: string
+                  names:
+                    items:
+                      type: string
+                    type: array
+                  prefixes:
+                    items:
+                      type: string
+                    type: array
+                type: object
             type: object
           status:
             properties:

--- a/charts/consul/templates/gateway-resources-configmap.yaml
+++ b/charts/consul/templates/gateway-resources-configmap.yaml
@@ -125,5 +125,8 @@ data:
           - name: "wan"
             port: {{ .Values.meshGateway.service.port }}
             protocol: "TCP"
+          workloads:
+            prefixes: 
+              - "mesh-gateway"
   {{- end }}
 {{- end }}

--- a/control-plane/api/mesh/v2beta1/mesh_gateway_types.go
+++ b/control-plane/api/mesh/v2beta1/mesh_gateway_types.go
@@ -70,13 +70,7 @@ func (in *MeshGateway) ResourceID(_, partition string) *pbresource.ID {
 func (in *MeshGateway) Resource(namespace, partition string) *pbresource.Resource {
 	return &pbresource.Resource{
 		Id: in.ResourceID(namespace, partition),
-		Data: inject.ToProtoAny(&pbmesh.MeshGateway{
-			GatewayClassName: in.Spec.GatewayClassName,
-			Listeners:        in.Spec.Listeners,
-			Workloads: &pbcatalog.WorkloadSelector{
-				Prefixes: []string{in.Name},
-			},
-		}),
+		Data: inject.ToProtoAny(&in.Spec),
 		Metadata: meshConfigMeta(),
 	}
 }

--- a/control-plane/api/mesh/v2beta1/mesh_gateway_types.go
+++ b/control-plane/api/mesh/v2beta1/mesh_gateway_types.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	pbcatalog "github.com/hashicorp/consul/proto-public/pbcatalog/v2beta1"
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -69,8 +68,8 @@ func (in *MeshGateway) ResourceID(_, partition string) *pbresource.ID {
 
 func (in *MeshGateway) Resource(namespace, partition string) *pbresource.Resource {
 	return &pbresource.Resource{
-		Id: in.ResourceID(namespace, partition),
-		Data: inject.ToProtoAny(&in.Spec),
+		Id:       in.ResourceID(namespace, partition),
+		Data:     inject.ToProtoAny(&in.Spec),
 		Metadata: meshConfigMeta(),
 	}
 }

--- a/control-plane/api/mesh/v2beta1/mesh_gateway_types.go
+++ b/control-plane/api/mesh/v2beta1/mesh_gateway_types.go
@@ -67,9 +67,6 @@ func (in *MeshGateway) ResourceID(_, partition string) *pbresource.ID {
 	}
 }
 
-// Resource converts the `MeshGateway` CRD into the equivalent Consul resource.
-// This includes adding a pbcatalog.WorkloadSelector that will target the Pods created
-// for this MeshGateway.
 func (in *MeshGateway) Resource(namespace, partition string) *pbresource.Resource {
 	return &pbresource.Resource{
 		Id: in.ResourceID(namespace, partition),

--- a/control-plane/config/crd/bases/mesh.consul.hashicorp.com_meshgateways.yaml
+++ b/control-plane/config/crd/bases/mesh.consul.hashicorp.com_meshgateways.yaml
@@ -69,6 +69,20 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+              workloads:
+                description: Selection of workloads to be configured as mesh gateways
+                properties:
+                  filter:
+                    type: string
+                  names:
+                    items:
+                      type: string
+                    type: array
+                  prefixes:
+                    items:
+                      type: string
+                    type: array
+                type: object
             type: object
           status:
             properties:

--- a/control-plane/gateways/deployment_test.go
+++ b/control-plane/gateways/deployment_test.go
@@ -14,10 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 
-	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
-
 	meshv2beta1 "github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
 	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
 )
 
 const testCert = `-----BEGIN CERTIFICATE-----                                                                                                                              │

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -2,7 +2,7 @@ module github.com/hashicorp/consul-k8s/control-plane
 
 // TODO: Remove this when the next version of the submodule is released.
 // We need to use a replace directive instead of directly pinning because `api` requires version `0.5.1` and will clobber the pin, but not the replace directive.
-replace github.com/hashicorp/consul/proto-public => github.com/hashicorp/consul/proto-public v0.1.2-0.20240111191232-1e351e286e08
+replace github.com/hashicorp/consul/proto-public => github.com/hashicorp/consul/proto-public v0.1.2-0.20240116214818-6a8554317502
 
 replace github.com/hashicorp/consul/sdk => github.com/hashicorp/consul/sdk v0.4.1-0.20231213150639-123bc95e1a3f
 

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -265,8 +265,8 @@ github.com/hashicorp/consul-server-connection-manager v0.1.6 h1:ktj8Fi+dRXn9hhM+
 github.com/hashicorp/consul-server-connection-manager v0.1.6/go.mod h1:HngMIv57MT+pqCVeRQMa1eTB5dqnyMm8uxjyv+Hn8cs=
 github.com/hashicorp/consul/api v1.26.1 h1:5oSXOO5fboPZeW5SN+TdGFP/BILDgBm19OrPZ/pICIM=
 github.com/hashicorp/consul/api v1.26.1/go.mod h1:B4sQTeaSO16NtynqrAdwOlahJ7IUDZM9cj2420xYL8A=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20240111191232-1e351e286e08 h1:oYbCbKfscW83pWuI/BkVajKH93qCJ1tPzZzGAmj5Ivo=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20240111191232-1e351e286e08/go.mod h1:ar/M/Gv31GeE7DxektZgAydwsCiOf6sBeJFcjQVTlVs=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20240116214818-6a8554317502 h1:DeUPf9K/hAXVY6bTheu1mDsszkOzB3Dgz3hLVSUp8GA=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20240116214818-6a8554317502/go.mod h1:ar/M/Gv31GeE7DxektZgAydwsCiOf6sBeJFcjQVTlVs=
 github.com/hashicorp/consul/sdk v0.4.1-0.20231213150639-123bc95e1a3f h1:GKsa7bfoL7xgvCkzYJMF9eYYNfLWQyk8QuRZZl4nMTo=
 github.com/hashicorp/consul/sdk v0.4.1-0.20231213150639-123bc95e1a3f/go.mod h1:r/OmRRPbHOe0yxNahLw7G9x5WG17E1BIECMtCjcPSNo=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/control-plane/subcommand/gateway-resources/command_test.go
+++ b/control-plane/subcommand/gateway-resources/command_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
-	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
+	meshv2beta1 "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
 )
 
 func TestRun_flagValidation(t *testing.T) {
@@ -573,7 +573,7 @@ func TestRun_loadGatewayConfigs(t *testing.T) {
 					Name:      "mesh-gateway",
 					Namespace: "consul",
 				},
-				Spec: pbmesh.MeshGateway{
+				Spec: meshv2beta1.MeshGateway{
 					GatewayClassName: "consul-mesh-gateway",
 				},
 			}

--- a/control-plane/subcommand/gateway-resources/command_test.go
+++ b/control-plane/subcommand/gateway-resources/command_test.go
@@ -17,10 +17,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	meshv2beta1 "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
-
 	"github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
 )
 
 func TestRun_flagValidation(t *testing.T) {
@@ -574,7 +573,7 @@ func TestRun_loadGatewayConfigs(t *testing.T) {
 					Name:      "mesh-gateway",
 					Namespace: "consul",
 				},
-				Spec: meshv2beta1.MeshGateway{
+				Spec: pbmesh.MeshGateway{
 					GatewayClassName: "consul-mesh-gateway",
 				},
 			}


### PR DESCRIPTION
### Changes proposed in this PR ###  

- import the workload selector via go.mod  to be accessible in consul-k8s. See proto PR [here](https://github.com/hashicorp/consul/pull/20159) in Consul
- Ensure workloadSelector field is added to gateways CRD

### How I've tested this PR ###
local install and uninstall of Consul

### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
