### PR TITLE
Net 7189 Consul k8s add protocol to listeners on the mesh gateway

### DIFF
--- a/charts/consul/templates/crd-meshgateways.yaml
+++ b/charts/consul/templates/crd-meshgateways.yaml
@@ -66,6 +66,10 @@ spec:
                       maximum: 65535
                       minimum: 0
                       type: integer
+                    protocol:
+                      enum:
+                      - TCP
+                      type: string
                   type: object
                 minItems: 1
                 type: array

--- a/charts/consul/templates/gateway-resources-configmap.yaml
+++ b/charts/consul/templates/gateway-resources-configmap.yaml
@@ -124,5 +124,6 @@ data:
           listeners: 
           - name: "wan"
             port: {{ .Values.meshGateway.service.port }}
+            protocol: "TCP"
   {{- end }}
 {{- end }}

--- a/control-plane/config/crd/bases/mesh.consul.hashicorp.com_meshgateways.yaml
+++ b/control-plane/config/crd/bases/mesh.consul.hashicorp.com_meshgateways.yaml
@@ -62,6 +62,10 @@ spec:
                       maximum: 65535
                       minimum: 0
                       type: integer
+                    protocol:
+                      enum:
+                      - TCP
+                      type: string
                   type: object
                 minItems: 1
                 type: array

--- a/control-plane/gateways/service.go
+++ b/control-plane/gateways/service.go
@@ -68,6 +68,7 @@ func (b *meshGatewayBuilder) Ports(portModifier int32) []corev1.ServicePort {
 			TargetPort: intstr.IntOrString{
 				IntVal: port + portModifier,
 			},
+			Protocol: corev1.Protocol(listener.Protocol),
 		})
 	}
 	return ports

--- a/control-plane/gateways/service_test.go
+++ b/control-plane/gateways/service_test.go
@@ -36,8 +36,9 @@ func Test_meshGatewayBuilder_Service(t *testing.T) {
 						GatewayClassName: "test-gateway-class",
 						Listeners: []*pbmesh.MeshGatewayListener{
 							{
-								Name: "wan",
-								Port: 443,
+								Name:     "wan",
+								Port:     443,
+								Protocol: "TCP",
 							},
 						},
 					},
@@ -93,6 +94,7 @@ func Test_meshGatewayBuilder_Service(t *testing.T) {
 							TargetPort: intstr.IntOrString{
 								IntVal: int32(8443),
 							},
+							Protocol: "TCP",
 						},
 					},
 				},
@@ -107,8 +109,9 @@ func Test_meshGatewayBuilder_Service(t *testing.T) {
 						GatewayClassName: "test-gateway-class",
 						Listeners: []*pbmesh.MeshGatewayListener{
 							{
-								Name: "wan",
-								Port: 443,
+								Name:     "wan",
+								Port:     443,
+								Protocol: "TCP",
 							},
 						},
 					},
@@ -131,6 +134,7 @@ func Test_meshGatewayBuilder_Service(t *testing.T) {
 							TargetPort: intstr.IntOrString{
 								IntVal: int32(443),
 							},
+							Protocol: "TCP",
 						},
 					},
 				},

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -2,7 +2,7 @@ module github.com/hashicorp/consul-k8s/control-plane
 
 // TODO: Remove this when the next version of the submodule is released.
 // We need to use a replace directive instead of directly pinning because `api` requires version `0.5.1` and will clobber the pin, but not the replace directive.
-replace github.com/hashicorp/consul/proto-public => github.com/hashicorp/consul/proto-public v0.1.2-0.20240110191229-7d92a5dfd601
+replace github.com/hashicorp/consul/proto-public => github.com/hashicorp/consul/proto-public v0.1.2-0.20240111191232-1e351e286e08
 
 replace github.com/hashicorp/consul/sdk => github.com/hashicorp/consul/sdk v0.4.1-0.20231213150639-123bc95e1a3f
 

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -265,8 +265,8 @@ github.com/hashicorp/consul-server-connection-manager v0.1.6 h1:ktj8Fi+dRXn9hhM+
 github.com/hashicorp/consul-server-connection-manager v0.1.6/go.mod h1:HngMIv57MT+pqCVeRQMa1eTB5dqnyMm8uxjyv+Hn8cs=
 github.com/hashicorp/consul/api v1.26.1 h1:5oSXOO5fboPZeW5SN+TdGFP/BILDgBm19OrPZ/pICIM=
 github.com/hashicorp/consul/api v1.26.1/go.mod h1:B4sQTeaSO16NtynqrAdwOlahJ7IUDZM9cj2420xYL8A=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20240110191229-7d92a5dfd601 h1:Y6tR3aGdKsh12oj80PWz2plRsyczJS8irZ++HdRJIB8=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20240110191229-7d92a5dfd601/go.mod h1:ar/M/Gv31GeE7DxektZgAydwsCiOf6sBeJFcjQVTlVs=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20240111191232-1e351e286e08 h1:oYbCbKfscW83pWuI/BkVajKH93qCJ1tPzZzGAmj5Ivo=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20240111191232-1e351e286e08/go.mod h1:ar/M/Gv31GeE7DxektZgAydwsCiOf6sBeJFcjQVTlVs=
 github.com/hashicorp/consul/sdk v0.4.1-0.20231213150639-123bc95e1a3f h1:GKsa7bfoL7xgvCkzYJMF9eYYNfLWQyk8QuRZZl4nMTo=
 github.com/hashicorp/consul/sdk v0.4.1-0.20231213150639-123bc95e1a3f/go.mod h1:r/OmRRPbHOe0yxNahLw7G9x5WG17E1BIECMtCjcPSNo=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Add protocol to listener config 

### How I've tested this PR ###
Spun up locally and ensured the mesh gateway service had the following values correctly set
```  ports:
  - name: wan
    nodePort: 31220
    port: 443
    protocol: TCP
    targetPort: 8443
```

### How I expect reviewers to test this PR ###
- Local install, look over 

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
