### PR TITLE
Backport of CRT build failing for Go into release/1.1.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
 
   build-docker:
     name: Docker ${{ matrix.arch }} default release build
-    needs: [get-product-version, build]
+    needs: [get-product-version, get-go-version, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -242,7 +242,7 @@ jobs:
           echo "minor_dev_tag=$(echo ${{ env.version }}| sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+(-[0-9a-zA-Z\+\.]+)?$/\1\2/')" >> $GITHUB_ENV
 
       - name: Docker Build (Action)
-        uses: hashicorp/actions-docker-build@v1
+        uses: hashicorp/actions-docker-build@76d2fc91532d816ca2660d8f3139e432ac3700fd
         with:
           smoke_test: |
             TEST_VERSION="$(docker run "${IMAGE_NAME}" consul-k8s-control-plane version  | awk '{print $2}')"
@@ -264,10 +264,12 @@ jobs:
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.full_dev_tag }}-${{ github.sha }}
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.minor_dev_tag }}
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.minor_dev_tag }}-${{ github.sha }}
+          extra_build_args: |
+            GOLANG_VERSION=${{ needs.get-go-version.outputs.go-version }}
 
   build-docker-ubi-redhat-registry:
     name: Docker ${{ matrix.arch }} UBI build for RedHat Registry
-    needs: [get-product-version, build]
+    needs: [get-product-version, get-go-version, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -290,7 +292,7 @@ jobs:
       - name: Copy LICENSE
         run:
          cp LICENSE ./control-plane
-      - uses: hashicorp/actions-docker-build@v1
+      - uses: hashicorp/actions-docker-build@76d2fc91532d816ca2660d8f3139e432ac3700fd
         with:
           smoke_test: |
             TEST_VERSION="$(docker run "${IMAGE_NAME}" consul-k8s-control-plane version  | awk '{print $2}')"
@@ -306,10 +308,12 @@ jobs:
           bin_name: consul-k8s-control-plane
           workdir: control-plane
           redhat_tag: quay.io/redhat-isv-containers/611ca2f89a9b407267837100:${{env.version}}-ubi
+          extra_build_args: |
+            GOLANG_VERSION=${{ needs.get-go-version.outputs.go-version }}
 
   build-docker-ubi-dockerhub:
     name: Docker ${{ matrix.arch }} UBI build for DockerHub
-    needs: [ get-product-version, build ]
+    needs: [get-product-version, get-go-version, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -342,7 +346,7 @@ jobs:
           echo "minor_dev_tag=$(echo ${{ env.version }}| sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+(-[0-9a-zA-Z\+\.]+)?$/\1\2/')" >> $GITHUB_ENV
 
       - name: Docker Build (Action)
-        uses: hashicorp/actions-docker-build@v1
+        uses: hashicorp/actions-docker-build@76d2fc91532d816ca2660d8f3139e432ac3700fd
         with:
           smoke_test: |
             TEST_VERSION="$(docker run "${IMAGE_NAME}" consul-k8s-control-plane version  | awk '{print $2}')"
@@ -364,3 +368,5 @@ jobs:
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.full_dev_tag }}-ubi-${{ github.sha }}
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.minor_dev_tag }}-ubi
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.minor_dev_tag }}-ubi-${{ github.sha }}
+          extra_build_args: |
+            GOLANG_VERSION=${{ needs.get-go-version.outputs.go-version }}

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -14,7 +14,7 @@
 # go-discover builds the discover binary (which we don't currently publish
 # either).
 ARG GOLANG_VERSION
-FROM golang:${GOLANG_VERSION} as go-discover
+FROM golang:${GOLANG_VERSION}-alpine as go-discover
 RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@214571b6a5309addf3db7775f4ee8cf4d264fd5f
 
 # dev copies the binary from a local build


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Manual backport of #3490 into release/1.1.x
- added in a dockerfile change that was breaking CRT on main instead of doing a separate PR.

### How I've tested this PR ###

CI

### How I expect reviewers to test this PR ###

:eyes:

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
