### PR TITLE
Use golang -alpine image when building go-discover

### DIFF
--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -17,7 +17,7 @@
 # go-discover builds the discover binary (which we don't currently publish
 # either).
 ARG GOLANG_VERSION
-FROM golang:${GOLANG_VERSION} as go-discover
+FROM golang:${GOLANG_VERSION}-alpine as go-discover
 RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@214571b6a5309addf3db7775f4ee8cf4d264fd5f
 
 # dev copies the binary from a local build


### PR DESCRIPTION
### Changes proposed in this PR ###  
- armv6 was deprecated from the base golang docker images for 1.21.x so force golang:<version>-alpine tag instead
- consul-dataplane already uses the -alpine image.

### How I've tested this PR ###

👀 

### How I expect reviewers to test this PR ###

:eyes:

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
