### PR TITLE
feature: [syncCatalog] Add available Region and Zone Kubernetes Topology Metadata when Syncing Kubernetes Services

### DIFF
--- a/.changelog/3522.txt
+++ b/.changelog/3522.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-control-plane: Add Region and Zone Kubernetes Topology Metadata to Synced Node Port Services.
+control-plane: Add available Region and Zone Kubernetes Topology Metadata when Syncing Kubernetes Services.
 ```

--- a/.changelog/3522.txt
+++ b/.changelog/3522.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+control-plane: Add Region and Zone Kubernetes Topology Metadata to Synced Node Port Services.
+```

--- a/control-plane/catalog/to-consul/resource.go
+++ b/control-plane/catalog/to-consul/resource.go
@@ -756,6 +756,18 @@ func (t *ServiceResource) registerServiceInstance(
 			}
 			if subsetAddr.NodeName != nil {
 				r.Service.Meta[ConsulK8SNodeName] = *subsetAddr.NodeName
+				// Look up the node's ip address by getting node info
+				node, err := t.Client.CoreV1().Nodes().Get(t.Ctx, *subsetAddr.NodeName, metav1.GetOptions{})
+				if err != nil {
+					t.Log.Warn("error getting node info", "error", err)
+					continue
+				}
+				if region := node.Labels[corev1.LabelTopologyRegion]; region != "" {
+					r.Service.Meta[ConsulK8STopologyRegion] = region
+				}
+				if zone := node.Labels[corev1.LabelTopologyZone]; zone != "" {
+					r.Service.Meta[ConsulK8STopologyZone] = zone
+				}
 			}
 
 			r.Check = &consulapi.AgentCheck{

--- a/control-plane/catalog/to-consul/resource_test.go
+++ b/control-plane/catalog/to-consul/resource_test.go
@@ -796,6 +796,8 @@ func TestServiceResource_lbRegisterEndpoints(t *testing.T) {
 		require.Equal(r, "foo", actual[0].Service.Service)
 		require.Equal(r, "8.8.8.8", actual[0].Service.Address)
 		require.Equal(r, 8080, actual[0].Service.Port)
+		require.Equal(r, "us-east-2", actual[0].Service.Meta[ConsulK8STopologyRegion])
+		require.Equal(r, "us-east-2a", actual[0].Service.Meta[ConsulK8STopologyZone])
 		require.Equal(r, "k8s-sync", actual[0].Node)
 	})
 }
@@ -1131,6 +1133,9 @@ func TestServiceResource_clusterIP(t *testing.T) {
 	// Insert the endpoints
 	createEndpoints(t, client, "foo", metav1.NamespaceDefault)
 
+	// Insert the nodes
+	createNodes(t, client)
+
 	// Verify what we got
 	retry.Run(t, func(r *retry.R) {
 		syncer.Lock()
@@ -1140,6 +1145,8 @@ func TestServiceResource_clusterIP(t *testing.T) {
 		require.Equal(r, "foo", actual[0].Service.Service)
 		require.Equal(r, "1.1.1.1", actual[0].Service.Address)
 		require.Equal(r, 8080, actual[0].Service.Port)
+		require.Equal(r, "us-east-2", actual[0].Service.Meta[ConsulK8STopologyRegion])
+		require.Equal(r, "us-east-2a", actual[0].Service.Meta[ConsulK8STopologyZone])
 		require.Equal(r, "foo", actual[1].Service.Service)
 		require.Equal(r, "2.2.2.2", actual[1].Service.Address)
 		require.Equal(r, 8080, actual[1].Service.Port)
@@ -1166,6 +1173,9 @@ func TestServiceResource_clusterIP_healthCheck(t *testing.T) {
 
 	// Insert the endpoints
 	createEndpoints(t, client, "foo", metav1.NamespaceDefault)
+
+	// Insert the nodes
+	createNodes(t, client)
 
 	// Verify what we got
 	retry.Run(t, func(r *retry.R) {
@@ -1205,6 +1215,9 @@ func TestServiceResource_clusterIPPrefix(t *testing.T) {
 	// Insert the endpoints
 	createEndpoints(t, client, "foo", metav1.NamespaceDefault)
 
+	// Insert the nodes
+	createNodes(t, client)
+
 	// Verify what we got
 	retry.Run(t, func(r *retry.R) {
 		syncer.Lock()
@@ -1214,6 +1227,8 @@ func TestServiceResource_clusterIPPrefix(t *testing.T) {
 		require.Equal(r, "prefixfoo", actual[0].Service.Service)
 		require.Equal(r, "1.1.1.1", actual[0].Service.Address)
 		require.Equal(r, 8080, actual[0].Service.Port)
+		require.Equal(r, "us-east-2", actual[0].Service.Meta[ConsulK8STopologyRegion])
+		require.Equal(r, "us-east-2a", actual[0].Service.Meta[ConsulK8STopologyZone])
 		require.Equal(r, "prefixfoo", actual[1].Service.Service)
 		require.Equal(r, "2.2.2.2", actual[1].Service.Address)
 		require.Equal(r, 8080, actual[1].Service.Port)
@@ -1243,6 +1258,9 @@ func TestServiceResource_clusterIPAnnotatedPortName(t *testing.T) {
 	// Insert the endpoints
 	createEndpoints(t, client, "foo", metav1.NamespaceDefault)
 
+	// Insert the nodes
+	createNodes(t, client)
+
 	// Verify what we got
 	retry.Run(t, func(r *retry.R) {
 		syncer.Lock()
@@ -1252,6 +1270,8 @@ func TestServiceResource_clusterIPAnnotatedPortName(t *testing.T) {
 		require.Equal(r, "foo", actual[0].Service.Service)
 		require.Equal(r, "1.1.1.1", actual[0].Service.Address)
 		require.Equal(r, 2000, actual[0].Service.Port)
+		require.Equal(r, "us-east-2", actual[0].Service.Meta[ConsulK8STopologyRegion])
+		require.Equal(r, "us-east-2a", actual[0].Service.Meta[ConsulK8STopologyZone])
 		require.Equal(r, "foo", actual[1].Service.Service)
 		require.Equal(r, "2.2.2.2", actual[1].Service.Address)
 		require.Equal(r, 2000, actual[1].Service.Port)
@@ -1281,6 +1301,9 @@ func TestServiceResource_clusterIPAnnotatedPortNumber(t *testing.T) {
 	// Insert the endpoints
 	createEndpoints(t, client, "foo", metav1.NamespaceDefault)
 
+	// Insert the nodes
+	createNodes(t, client)
+
 	// Verify what we got
 	retry.Run(t, func(r *retry.R) {
 		syncer.Lock()
@@ -1290,6 +1313,8 @@ func TestServiceResource_clusterIPAnnotatedPortNumber(t *testing.T) {
 		require.Equal(r, "foo", actual[0].Service.Service)
 		require.Equal(r, "1.1.1.1", actual[0].Service.Address)
 		require.Equal(r, 4141, actual[0].Service.Port)
+		require.Equal(r, "us-east-2", actual[0].Service.Meta[ConsulK8STopologyRegion])
+		require.Equal(r, "us-east-2a", actual[0].Service.Meta[ConsulK8STopologyZone])
 		require.Equal(r, "foo", actual[1].Service.Service)
 		require.Equal(r, "2.2.2.2", actual[1].Service.Address)
 		require.Equal(r, 4141, actual[1].Service.Port)
@@ -1321,6 +1346,9 @@ func TestServiceResource_clusterIPUnnamedPorts(t *testing.T) {
 	// Insert the endpoints
 	createEndpoints(t, client, "foo", metav1.NamespaceDefault)
 
+	// Insert the nodes
+	createNodes(t, client)
+
 	// Verify what we got
 	retry.Run(t, func(r *retry.R) {
 		syncer.Lock()
@@ -1330,6 +1358,8 @@ func TestServiceResource_clusterIPUnnamedPorts(t *testing.T) {
 		require.Equal(r, "foo", actual[0].Service.Service)
 		require.Equal(r, "1.1.1.1", actual[0].Service.Address)
 		require.Equal(r, 8080, actual[0].Service.Port)
+		require.Equal(r, "us-east-2", actual[0].Service.Meta[ConsulK8STopologyRegion])
+		require.Equal(r, "us-east-2a", actual[0].Service.Meta[ConsulK8STopologyZone])
 		require.Equal(r, "foo", actual[1].Service.Service)
 		require.Equal(r, "2.2.2.2", actual[1].Service.Address)
 		require.Equal(r, 8080, actual[1].Service.Port)
@@ -1388,6 +1418,9 @@ func TestServiceResource_clusterIPAllNamespaces(t *testing.T) {
 	// Insert the endpoints
 	createEndpoints(t, client, "foo", testNamespace)
 
+	// Insert the nodes
+	createNodes(t, client)
+
 	// Verify what we got
 	retry.Run(t, func(r *retry.R) {
 		syncer.Lock()
@@ -1397,6 +1430,8 @@ func TestServiceResource_clusterIPAllNamespaces(t *testing.T) {
 		require.Equal(r, "foo", actual[0].Service.Service)
 		require.Equal(r, "1.1.1.1", actual[0].Service.Address)
 		require.Equal(r, 8080, actual[0].Service.Port)
+		require.Equal(r, "us-east-2", actual[0].Service.Meta[ConsulK8STopologyRegion])
+		require.Equal(r, "us-east-2a", actual[0].Service.Meta[ConsulK8STopologyZone])
 		require.Equal(r, "foo", actual[1].Service.Service)
 		require.Equal(r, "2.2.2.2", actual[1].Service.Address)
 		require.Equal(r, 8080, actual[1].Service.Port)
@@ -1429,6 +1464,9 @@ func TestServiceResource_clusterIPTargetPortNamed(t *testing.T) {
 	// Insert the endpoints
 	createEndpoints(t, client, "foo", metav1.NamespaceDefault)
 
+	// Insert the nodes
+	createNodes(t, client)
+
 	// Verify what we got
 	retry.Run(t, func(r *retry.R) {
 		syncer.Lock()
@@ -1438,6 +1476,8 @@ func TestServiceResource_clusterIPTargetPortNamed(t *testing.T) {
 		require.Equal(r, "foo", actual[0].Service.Service)
 		require.Equal(r, "1.1.1.1", actual[0].Service.Address)
 		require.Equal(r, 2000, actual[0].Service.Port)
+		require.Equal(r, "us-east-2", actual[0].Service.Meta[ConsulK8STopologyRegion])
+		require.Equal(r, "us-east-2a", actual[0].Service.Meta[ConsulK8STopologyZone])
 		require.Equal(r, "foo", actual[1].Service.Service)
 		require.Equal(r, "2.2.2.2", actual[1].Service.Address)
 		require.Equal(r, 2000, actual[1].Service.Port)
@@ -1464,6 +1504,9 @@ func TestServiceResource_targetRefInMeta(t *testing.T) {
 
 	// Insert the endpoints
 	createEndpoints(t, client, "foo", metav1.NamespaceDefault)
+
+	// Insert the nodes
+	createNodes(t, client)
 
 	// Verify what we got
 	retry.Run(t, func(r *retry.R) {
@@ -1950,6 +1993,7 @@ func TestServiceResource_addIngress(t *testing.T) {
 			_, err = client.NetworkingV1().Ingresses(metav1.NamespaceDefault).Create(context.Background(), test.ingress, metav1.CreateOptions{})
 			require.NoError(t, err)
 			createEndpoints(t, client, "test-service", metav1.NamespaceDefault)
+			createNodes(t, client)
 			// Verify that the service name annotation is preferred
 			retry.Run(t, func(r *retry.R) {
 				syncer.Lock()

--- a/control-plane/catalog/to-consul/resource_test.go
+++ b/control-plane/catalog/to-consul/resource_test.go
@@ -830,10 +830,14 @@ func TestServiceResource_nodePort(t *testing.T) {
 		require.Equal(r, "foo", actual[0].Service.Service)
 		require.Equal(r, "1.2.3.4", actual[0].Service.Address)
 		require.Equal(r, 30000, actual[0].Service.Port)
+		require.Equal(r, "us-east-2", actual[0].Service.Meta[ConsulK8STopologyRegion])
+		require.Equal(r, "us-east-2a", actual[0].Service.Meta[ConsulK8STopologyZone])
 		require.Equal(r, "k8s-sync", actual[0].Node)
 		require.Equal(r, "foo", actual[1].Service.Service)
 		require.Equal(r, "2.3.4.5", actual[1].Service.Address)
 		require.Equal(r, 30000, actual[1].Service.Port)
+		require.NotContains(r, actual[1].Service.Meta, ConsulK8STopologyRegion)
+		require.NotContains(r, actual[1].Service.Meta, ConsulK8STopologyZone)
 		require.Equal(r, "k8s-sync", actual[1].Node)
 		require.NotEqual(r, actual[0].Service.ID, actual[1].Service.ID)
 	})
@@ -2034,6 +2038,10 @@ func createNodes(t *testing.T, client *fake.Clientset) (*corev1.Node, *corev1.No
 	node1 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName1,
+			Labels: map[string]string{
+				corev1.LabelTopologyRegion: "us-east-2",
+				corev1.LabelTopologyZone:   "us-east-2a",
+			},
 		},
 
 		Status: corev1.NodeStatus{


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Add available Region and Zone Kubernetes Topology Metadata when Syncing Kubernetes Services

### How I've tested this PR ###
- Unit test
- Running locally compiled version on a production Kubernetes cluster and verified it worked (see attached screenshot)

<img width="935" alt="svc1" src="https://github.com/hashicorp/consul-k8s/assets/46899279/276b6722-94c5-44a2-a1c7-d0827f4f686b">
<img width="935" alt="svc2" src="https://github.com/hashicorp/consul-k8s/assets/46899279/d94da244-3885-4953-a5ab-949dc6827941">

### How I expect reviewers to test this PR ###
- Same as how I tested

### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
