### PR TITLE
[NET-7492, NET-7495] Support -server-watch-disabled, use -proxy-* args instead of -service-*

### DIFF
--- a/control-plane/gateways/constants.go
+++ b/control-plane/gateways/constants.go
@@ -13,7 +13,6 @@ const (
 	// Dataplane Configuration Environment variables.
 	envDPProxyId             = "DP_PROXY_ID"
 	envDPCredentialLoginMeta = "DP_CREDENTIAL_LOGIN_META"
-	envDPServiceNodeName     = "DP_SERVICE_NODE_NAME"
 
 	// Init Container Configuration Environment variables.
 	envConsulAddresses            = "CONSUL_ADDRESSES"

--- a/control-plane/gateways/deployment_dataplane_container.go
+++ b/control-plane/gateways/deployment_dataplane_container.go
@@ -93,10 +93,6 @@ func (b *meshGatewayBuilder) consulDataplaneContainer(containerConfig v2beta1.Ga
 				Name:  envDPCredentialLoginMeta,
 				Value: "pod=$(POD_NAMESPACE)/$(DP_PROXY_ID)",
 			},
-			{
-				Name:  envDPServiceNodeName,
-				Value: "$(NODE_NAME)-virtual",
-			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -175,11 +171,14 @@ func (b *meshGatewayBuilder) dataplaneArgs(bearerTokenFile string) ([]string, er
 			args = append(args, "-login-partition="+b.config.ConsulTenancyConfig.ConsulPartition)
 		}
 	}
+	if b.config.SkipServerWatch {
+		args = append(args, "-server-watch-disabled=true")
+	}
 	if b.config.ConsulTenancyConfig.EnableConsulNamespaces {
-		args = append(args, "-service-namespace="+consulNamespace)
+		args = append(args, "-proxy-namespace="+consulNamespace)
 	}
 	if b.config.ConsulTenancyConfig.ConsulPartition != "" {
-		args = append(args, "-service-partition="+b.config.ConsulTenancyConfig.ConsulPartition)
+		args = append(args, "-proxy-partition="+b.config.ConsulTenancyConfig.ConsulPartition)
 	}
 
 	args = append(args, buildTLSArgs(b.config)...)

--- a/control-plane/gateways/deployment_test.go
+++ b/control-plane/gateways/deployment_test.go
@@ -367,10 +367,6 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 											Value: "pod=$(POD_NAMESPACE)/$(DP_PROXY_ID)",
 										},
 										{
-											Name:  "DP_SERVICE_NODE_NAME",
-											Value: "$(NODE_NAME)-virtual",
-										},
-										{
 											Name:  "DP_ENVOY_READY_BIND_ADDRESS",
 											Value: "",
 											ValueFrom: &corev1.EnvVarSource{
@@ -772,10 +768,6 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 											Value: "pod=$(POD_NAMESPACE)/$(DP_PROXY_ID)",
 										},
 										{
-											Name:  "DP_SERVICE_NODE_NAME",
-											Value: "$(NODE_NAME)-virtual",
-										},
-										{
 											Name:  "DP_ENVOY_READY_BIND_ADDRESS",
 											Value: "",
 											ValueFrom: &corev1.EnvVarSource{
@@ -1055,10 +1047,6 @@ func Test_meshGatewayBuilder_Deployment(t *testing.T) {
 										{
 											Name:  "DP_CREDENTIAL_LOGIN_META",
 											Value: "pod=$(POD_NAMESPACE)/$(DP_PROXY_ID)",
-										},
-										{
-											Name:  "DP_SERVICE_NODE_NAME",
-											Value: "$(NODE_NAME)-virtual",
 										},
 										{
 											Name:  "DP_ENVOY_READY_BIND_ADDRESS",

--- a/control-plane/gateways/gateway_config.go
+++ b/control-plane/gateways/gateway_config.go
@@ -41,6 +41,9 @@ type GatewayConfig struct {
 	// MapPrivilegedServicePorts is the value which Consul will add to privileged container port values (ports < 1024)
 	// defined on a Gateway.
 	MapPrivilegedServicePorts int
+
+	// TODO(nathancoleman) Add doc
+	SkipServerWatch bool
 }
 
 // GatewayResources is a collection of Kubernetes resources for a Gateway.

--- a/control-plane/subcommand/inject-connect/v2controllers.go
+++ b/control-plane/subcommand/inject-connect/v2controllers.go
@@ -233,7 +233,7 @@ func (c *Command) configureV2Controllers(ctx context.Context, mgr manager.Manage
 			TLSEnabled:          c.consul.UseTLS,
 			ConsulTLSServerName: c.consul.TLSServerName,
 			ConsulCACert:        string(c.caCertPem),
-			SkipServerWatch: c.consul.SkipServerWatch,
+			SkipServerWatch:     c.consul.SkipServerWatch,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", common.MeshGateway)

--- a/control-plane/subcommand/inject-connect/v2controllers.go
+++ b/control-plane/subcommand/inject-connect/v2controllers.go
@@ -233,6 +233,7 @@ func (c *Command) configureV2Controllers(ctx context.Context, mgr manager.Manage
 			TLSEnabled:          c.consul.UseTLS,
 			ConsulTLSServerName: c.consul.TLSServerName,
 			ConsulCACert:        string(c.caCertPem),
+			SkipServerWatch: c.consul.SkipServerWatch,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", common.MeshGateway)


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Adjust envars for consul-dataplane to use the `-proxy-` args instead of the deprecated `-service-` args. This is important because it's either-or in consul-dataplane [here](https://github.com/hashicorp/consul-dataplane/blob/b80f2bf4a4876789ae0b524275b8201e692b7177/cmd/consul-dataplane/config.go#L270-L288) which is biting us because we set the `-proxy-id` arg today which pushes into the initial `if` case and ignores our `-service-*` flags.
- Add support for disabling server watch, which is used the the consul-servers are behind a load balancer, such as when a second admin partition communicates via the `expose-consul-servers` K8s `Service`.

### How I've tested this PR ###
Deploy a second admin partition with `externalServers.skipServerWatch: true` in your `values.yaml`. Verify that the arg is set on the mesh gateway's dataplane container and that the dataplane container is only trying to connect to the public IP of the `expose-consul-servers` K8s `Service (via logs).

### How I expect reviewers to test this PR ###
See above

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
