### PR TITLE
reconcile consul-k8s with changes made in Consul

### DIFF
--- a/charts/consul/templates/crd-apigateways.yaml
+++ b/charts/consul/templates/crd-apigateways.yaml
@@ -114,13 +114,6 @@ spec:
                                       provide the wildcard value \"*\" to list resources
                                       across all partitions."
                                     type: string
-                                  peerName:
-                                    description: "PeerName identifies which peer the
-                                      resource is imported from. https://developer.hashicorp.com/consul/docs/connect/cluster-peering
-                                      \n When using the List and WatchList endpoints,
-                                      provide the wildcard value \"*\" to list resources
-                                      across all peers."
-                                    type: string
                                 type: object
                               type:
                                 description: Type identifies the resource's type.

--- a/charts/consul/templates/crd-grpcroutes.yaml
+++ b/charts/consul/templates/crd-grpcroutes.yaml
@@ -72,9 +72,10 @@ spec:
                   description: 'NOTE: roughly equivalent to structs.ResourceReference'
                   properties:
                     port:
-                      description: For east/west this is the name of the Consul Service
+                      description: "For east/west this is the name of the Consul Service
                         port to direct traffic to or empty to imply all. For north/south
-                        this is TBD.
+                        this is TBD. \n For more details on potential values of this
+                        field, see documentation for Service.ServicePort."
                       type: string
                     ref:
                       description: For east/west configuration, this should point
@@ -105,13 +106,6 @@ spec:
                                 \n When using the List and WatchList endpoints, provide
                                 the wildcard value \"*\" to list resources across
                                 all partitions."
-                              type: string
-                            peerName:
-                              description: "PeerName identifies which peer the resource
-                                is imported from. https://developer.hashicorp.com/consul/docs/connect/cluster-peering
-                                \n When using the List and WatchList endpoints, provide
-                                the wildcard value \"*\" to list resources across
-                                all peers."
                               type: string
                           type: object
                         type:
@@ -166,7 +160,9 @@ spec:
                                 description: "For east/west this is the name of the
                                   Consul Service port to direct traffic to or empty
                                   to imply using the same value as the parent ref.
-                                  \n For north/south this is TBD."
+                                  For north/south this is TBD. \n For more details
+                                  on potential values of this field, see documentation
+                                  for Service.ServicePort."
                                 type: string
                               ref:
                                 description: For east/west configuration, this should
@@ -198,13 +194,6 @@ spec:
                                           \n When using the List and WatchList endpoints,
                                           provide the wildcard value \"*\" to list
                                           resources across all partitions."
-                                        type: string
-                                      peerName:
-                                        description: "PeerName identifies which peer
-                                          the resource is imported from. https://developer.hashicorp.com/consul/docs/connect/cluster-peering
-                                          \n When using the List and WatchList endpoints,
-                                          provide the wildcard value \"*\" to list
-                                          resources across all peers."
                                         type: string
                                     type: object
                                   type:

--- a/charts/consul/templates/crd-httproutes.yaml
+++ b/charts/consul/templates/crd-httproutes.yaml
@@ -72,9 +72,10 @@ spec:
                   description: 'NOTE: roughly equivalent to structs.ResourceReference'
                   properties:
                     port:
-                      description: For east/west this is the name of the Consul Service
+                      description: "For east/west this is the name of the Consul Service
                         port to direct traffic to or empty to imply all. For north/south
-                        this is TBD.
+                        this is TBD. \n For more details on potential values of this
+                        field, see documentation for Service.ServicePort."
                       type: string
                     ref:
                       description: For east/west configuration, this should point
@@ -105,13 +106,6 @@ spec:
                                 \n When using the List and WatchList endpoints, provide
                                 the wildcard value \"*\" to list resources across
                                 all partitions."
-                              type: string
-                            peerName:
-                              description: "PeerName identifies which peer the resource
-                                is imported from. https://developer.hashicorp.com/consul/docs/connect/cluster-peering
-                                \n When using the List and WatchList endpoints, provide
-                                the wildcard value \"*\" to list resources across
-                                all peers."
                               type: string
                           type: object
                         type:
@@ -169,7 +163,9 @@ spec:
                                 description: "For east/west this is the name of the
                                   Consul Service port to direct traffic to or empty
                                   to imply using the same value as the parent ref.
-                                  \n For north/south this is TBD."
+                                  For north/south this is TBD. \n For more details
+                                  on potential values of this field, see documentation
+                                  for Service.ServicePort."
                                 type: string
                               ref:
                                 description: For east/west configuration, this should
@@ -201,13 +197,6 @@ spec:
                                           \n When using the List and WatchList endpoints,
                                           provide the wildcard value \"*\" to list
                                           resources across all partitions."
-                                        type: string
-                                      peerName:
-                                        description: "PeerName identifies which peer
-                                          the resource is imported from. https://developer.hashicorp.com/consul/docs/connect/cluster-peering
-                                          \n When using the List and WatchList endpoints,
-                                          provide the wildcard value \"*\" to list
-                                          resources across all peers."
                                         type: string
                                     type: object
                                   type:

--- a/charts/consul/templates/crd-tcproutes.yaml
+++ b/charts/consul/templates/crd-tcproutes.yaml
@@ -66,9 +66,10 @@ spec:
                   description: 'NOTE: roughly equivalent to structs.ResourceReference'
                   properties:
                     port:
-                      description: For east/west this is the name of the Consul Service
+                      description: "For east/west this is the name of the Consul Service
                         port to direct traffic to or empty to imply all. For north/south
-                        this is TBD.
+                        this is TBD. \n For more details on potential values of this
+                        field, see documentation for Service.ServicePort."
                       type: string
                     ref:
                       description: For east/west configuration, this should point
@@ -99,13 +100,6 @@ spec:
                                 \n When using the List and WatchList endpoints, provide
                                 the wildcard value \"*\" to list resources across
                                 all partitions."
-                              type: string
-                            peerName:
-                              description: "PeerName identifies which peer the resource
-                                is imported from. https://developer.hashicorp.com/consul/docs/connect/cluster-peering
-                                \n When using the List and WatchList endpoints, provide
-                                the wildcard value \"*\" to list resources across
-                                all peers."
                               type: string
                           type: object
                         type:
@@ -151,7 +145,9 @@ spec:
                                 description: "For east/west this is the name of the
                                   Consul Service port to direct traffic to or empty
                                   to imply using the same value as the parent ref.
-                                  \n For north/south this is TBD."
+                                  For north/south this is TBD. \n For more details
+                                  on potential values of this field, see documentation
+                                  for Service.ServicePort."
                                 type: string
                               ref:
                                 description: For east/west configuration, this should
@@ -183,13 +179,6 @@ spec:
                                           \n When using the List and WatchList endpoints,
                                           provide the wildcard value \"*\" to list
                                           resources across all partitions."
-                                        type: string
-                                      peerName:
-                                        description: "PeerName identifies which peer
-                                          the resource is imported from. https://developer.hashicorp.com/consul/docs/connect/cluster-peering
-                                          \n When using the List and WatchList endpoints,
-                                          provide the wildcard value \"*\" to list
-                                          resources across all peers."
                                         type: string
                                     type: object
                                   type:

--- a/control-plane/api/auth/v2beta1/traffic_permissions_types.go
+++ b/control-plane/api/auth/v2beta1/traffic_permissions_types.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	inject "github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 )
 
 const (
@@ -62,10 +61,6 @@ func (in *TrafficPermissions) ResourceID(namespace, partition string) *pbresourc
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }

--- a/control-plane/api/auth/v2beta1/traffic_permissions_types_test.go
+++ b/control-plane/api/auth/v2beta1/traffic_permissions_types_test.go
@@ -317,10 +317,6 @@ func TestTrafficPermissions_MatchesConsul(t *testing.T) {
 					Tenancy: &pbresource.Tenancy{
 						Partition: constants.DefaultConsulNS,
 						Namespace: constants.DefaultConsulPartition,
-
-						// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-						// At a future point, this will move out of the Tenancy block.
-						PeerName: constants.DefaultConsulPeer,
 					},
 				},
 				Data:     inject.ToProtoAny(&pbmesh.ProxyConfiguration{}),
@@ -1021,10 +1017,6 @@ func constructTrafficPermissionResource(tp *pbauth.TrafficPermissions, name, nam
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 		Uid: "ABCD", // We add this to show it does not factor into the comparison
 	}

--- a/control-plane/api/mesh/v2beta1/api_gateway_types.go
+++ b/control-plane/api/mesh/v2beta1/api_gateway_types.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	inject "github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 )
 
 const (
@@ -76,10 +75,6 @@ func (in *APIGateway) ResourceID(namespace, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }

--- a/control-plane/api/mesh/v2beta1/gateway_class_types.go
+++ b/control-plane/api/mesh/v2beta1/gateway_class_types.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	inject "github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 )
 
 const (
@@ -58,10 +57,6 @@ func (in *GatewayClass) ResourceID(namespace, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }

--- a/control-plane/api/mesh/v2beta1/grpc_route_types.go
+++ b/control-plane/api/mesh/v2beta1/grpc_route_types.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	inject "github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 )
 
 const (
@@ -61,10 +60,6 @@ func (in *GRPCRoute) ResourceID(namespace, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }

--- a/control-plane/api/mesh/v2beta1/grpc_route_types_test.go
+++ b/control-plane/api/mesh/v2beta1/grpc_route_types_test.go
@@ -277,10 +277,6 @@ func TestGRPCRoute_MatchesConsul(t *testing.T) {
 					Tenancy: &pbresource.Tenancy{
 						Partition: constants.DefaultConsulNS,
 						Namespace: constants.DefaultConsulPartition,
-
-						// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-						// At a future point, this will move out of the Tenancy block.
-						PeerName: constants.DefaultConsulPeer,
 					},
 				},
 				Data:     inject.ToProtoAny(&pbmesh.ProxyConfiguration{}),
@@ -1174,10 +1170,6 @@ func constructGRPCRouteResource(tp *pbmesh.GRPCRoute, name, namespace, partition
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 		Uid: "ABCD", // We add this to show it does not factor into the comparison
 	}

--- a/control-plane/api/mesh/v2beta1/http_route_types.go
+++ b/control-plane/api/mesh/v2beta1/http_route_types.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	inject "github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 )
 
 const (
@@ -63,10 +62,6 @@ func (in *HTTPRoute) ResourceID(namespace, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }

--- a/control-plane/api/mesh/v2beta1/http_route_types_test.go
+++ b/control-plane/api/mesh/v2beta1/http_route_types_test.go
@@ -435,10 +435,6 @@ func TestHTTPRoute_MatchesConsul(t *testing.T) {
 					Tenancy: &pbresource.Tenancy{
 						Partition: constants.DefaultConsulNS,
 						Namespace: constants.DefaultConsulPartition,
-
-						// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-						// At a future point, this will move out of the Tenancy block.
-						PeerName: constants.DefaultConsulPeer,
 					},
 				},
 				Data:     inject.ToProtoAny(&pbmesh.ProxyConfiguration{}),
@@ -1311,10 +1307,6 @@ func constructHTTPRouteResource(tp *pbmesh.HTTPRoute, name, namespace, partition
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 		Uid: "ABCD", // We add this to show it does not factor into the comparison
 	}

--- a/control-plane/api/mesh/v2beta1/mesh_configuration_types.go
+++ b/control-plane/api/mesh/v2beta1/mesh_configuration_types.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	inject "github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v2beta1"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -57,10 +56,6 @@ func (in *MeshConfiguration) ResourceID(_, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			// we don't pass a namespace here because MeshConfiguration is partition-scoped
 			Partition: partition,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }

--- a/control-plane/api/mesh/v2beta1/mesh_gateway_types.go
+++ b/control-plane/api/mesh/v2beta1/mesh_gateway_types.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	inject "github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 )
 
 const (
@@ -58,10 +57,6 @@ func (in *MeshGateway) ResourceID(_, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: "", // Namespace is always unset because MeshGateway is partition-scoped
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }

--- a/control-plane/api/mesh/v2beta1/proxy_configuration_types.go
+++ b/control-plane/api/mesh/v2beta1/proxy_configuration_types.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	inject "github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 )
 
 const (
@@ -61,10 +60,6 @@ func (in *ProxyConfiguration) ResourceID(namespace, partition string) *pbresourc
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }

--- a/control-plane/api/mesh/v2beta1/proxy_configuration_types_test.go
+++ b/control-plane/api/mesh/v2beta1/proxy_configuration_types_test.go
@@ -220,10 +220,6 @@ func TestProxyConfiguration_MatchesConsul(t *testing.T) {
 					Tenancy: &pbresource.Tenancy{
 						Partition: constants.DefaultConsulNS,
 						Namespace: constants.DefaultConsulPartition,
-
-						// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-						// At a future point, this will move out of the Tenancy block.
-						PeerName: constants.DefaultConsulPeer,
 					},
 				},
 				Data:     inject.ToProtoAny(&pbmesh.ProxyConfiguration{}),
@@ -524,10 +520,6 @@ func constructProxyConfigurationResource(tp *pbmesh.ProxyConfiguration, name, na
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 		Uid: "ABCD", // We add this to show it does not factor into the comparison
 	}

--- a/control-plane/api/mesh/v2beta1/tcp_route_types.go
+++ b/control-plane/api/mesh/v2beta1/tcp_route_types.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	inject "github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 )
 
 const (
@@ -61,10 +60,6 @@ func (in *TCPRoute) ResourceID(namespace, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }

--- a/control-plane/api/mesh/v2beta1/tcp_route_types_test.go
+++ b/control-plane/api/mesh/v2beta1/tcp_route_types_test.go
@@ -83,7 +83,6 @@ func TestTCPRoute_MatchesConsul(t *testing.T) {
 											Type: pbmesh.ComputedRoutesType,
 											Tenancy: &pbresource.Tenancy{
 												Namespace: "another-namespace",
-												PeerName:  "another-peer",
 											},
 											Name:    "backend-name",
 											Section: "backend-section",
@@ -125,7 +124,6 @@ func TestTCPRoute_MatchesConsul(t *testing.T) {
 										Type: pbmesh.ComputedRoutesType,
 										Tenancy: &pbresource.Tenancy{
 											Namespace: "another-namespace",
-											PeerName:  "another-peer",
 										},
 										Name:    "backend-name",
 										Section: "backend-section",
@@ -157,10 +155,6 @@ func TestTCPRoute_MatchesConsul(t *testing.T) {
 					Tenancy: &pbresource.Tenancy{
 						Partition: constants.DefaultConsulNS,
 						Namespace: constants.DefaultConsulPartition,
-
-						// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-						// At a future point, this will move out of the Tenancy block.
-						PeerName: constants.DefaultConsulPeer,
 					},
 				},
 				Data:     inject.ToProtoAny(&pbmesh.ProxyConfiguration{}),
@@ -231,7 +225,6 @@ func TestTCPRoute_Resource(t *testing.T) {
 											Type: pbmesh.ComputedRoutesType,
 											Tenancy: &pbresource.Tenancy{
 												Namespace: "another-namespace",
-												PeerName:  "another-peer",
 											},
 											Name:    "backend-name",
 											Section: "backend-section",
@@ -273,7 +266,6 @@ func TestTCPRoute_Resource(t *testing.T) {
 										Type: pbmesh.ComputedRoutesType,
 										Tenancy: &pbresource.Tenancy{
 											Namespace: "another-namespace",
-											PeerName:  "another-peer",
 										},
 										Name:    "backend-name",
 										Section: "backend-section",
@@ -426,7 +418,6 @@ func TestTCPRoute_Validate(t *testing.T) {
 											Type: pbmesh.ComputedRoutesType,
 											Tenancy: &pbresource.Tenancy{
 												Namespace: "another-namespace",
-												PeerName:  "another-peer",
 											},
 											Name:    "backend-name",
 											Section: "backend-section",
@@ -550,10 +541,6 @@ func constructTCPRouteResource(tp *pbmesh.TCPRoute, name, namespace, partition s
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 		Uid: "ABCD", // We add this to show it does not factor into the comparison
 	}

--- a/control-plane/api/multicluster/v2beta1/exported_services_types.go
+++ b/control-plane/api/multicluster/v2beta1/exported_services_types.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	pbmulticluster "github.com/hashicorp/consul/proto-public/pbmulticluster/v2beta1"
+	pbmulticluster "github.com/hashicorp/consul/proto-public/pbmulticluster/v2"
 	"github.com/hashicorp/consul/proto-public/pbresource"
 	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
@@ -15,7 +15,6 @@ import (
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	inject "github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
-	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
 )
 
 const (
@@ -58,10 +57,6 @@ func (in *ExportedServices) ResourceID(_, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: "", // Namespace is always unset because ExportedServices is partition-scoped
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }

--- a/control-plane/config/crd/bases/mesh.consul.hashicorp.com_apigateways.yaml
+++ b/control-plane/config/crd/bases/mesh.consul.hashicorp.com_apigateways.yaml
@@ -110,13 +110,6 @@ spec:
                                       provide the wildcard value \"*\" to list resources
                                       across all partitions."
                                     type: string
-                                  peerName:
-                                    description: "PeerName identifies which peer the
-                                      resource is imported from. https://developer.hashicorp.com/consul/docs/connect/cluster-peering
-                                      \n When using the List and WatchList endpoints,
-                                      provide the wildcard value \"*\" to list resources
-                                      across all peers."
-                                    type: string
                                 type: object
                               type:
                                 description: Type identifies the resource's type.

--- a/control-plane/config/crd/bases/mesh.consul.hashicorp.com_grpcroutes.yaml
+++ b/control-plane/config/crd/bases/mesh.consul.hashicorp.com_grpcroutes.yaml
@@ -68,9 +68,10 @@ spec:
                   description: 'NOTE: roughly equivalent to structs.ResourceReference'
                   properties:
                     port:
-                      description: For east/west this is the name of the Consul Service
+                      description: "For east/west this is the name of the Consul Service
                         port to direct traffic to or empty to imply all. For north/south
-                        this is TBD.
+                        this is TBD. \n For more details on potential values of this
+                        field, see documentation for Service.ServicePort."
                       type: string
                     ref:
                       description: For east/west configuration, this should point
@@ -101,13 +102,6 @@ spec:
                                 \n When using the List and WatchList endpoints, provide
                                 the wildcard value \"*\" to list resources across
                                 all partitions."
-                              type: string
-                            peerName:
-                              description: "PeerName identifies which peer the resource
-                                is imported from. https://developer.hashicorp.com/consul/docs/connect/cluster-peering
-                                \n When using the List and WatchList endpoints, provide
-                                the wildcard value \"*\" to list resources across
-                                all peers."
                               type: string
                           type: object
                         type:
@@ -162,7 +156,9 @@ spec:
                                 description: "For east/west this is the name of the
                                   Consul Service port to direct traffic to or empty
                                   to imply using the same value as the parent ref.
-                                  \n For north/south this is TBD."
+                                  For north/south this is TBD. \n For more details
+                                  on potential values of this field, see documentation
+                                  for Service.ServicePort."
                                 type: string
                               ref:
                                 description: For east/west configuration, this should
@@ -194,13 +190,6 @@ spec:
                                           \n When using the List and WatchList endpoints,
                                           provide the wildcard value \"*\" to list
                                           resources across all partitions."
-                                        type: string
-                                      peerName:
-                                        description: "PeerName identifies which peer
-                                          the resource is imported from. https://developer.hashicorp.com/consul/docs/connect/cluster-peering
-                                          \n When using the List and WatchList endpoints,
-                                          provide the wildcard value \"*\" to list
-                                          resources across all peers."
                                         type: string
                                     type: object
                                   type:

--- a/control-plane/config/crd/bases/mesh.consul.hashicorp.com_httproutes.yaml
+++ b/control-plane/config/crd/bases/mesh.consul.hashicorp.com_httproutes.yaml
@@ -68,9 +68,10 @@ spec:
                   description: 'NOTE: roughly equivalent to structs.ResourceReference'
                   properties:
                     port:
-                      description: For east/west this is the name of the Consul Service
+                      description: "For east/west this is the name of the Consul Service
                         port to direct traffic to or empty to imply all. For north/south
-                        this is TBD.
+                        this is TBD. \n For more details on potential values of this
+                        field, see documentation for Service.ServicePort."
                       type: string
                     ref:
                       description: For east/west configuration, this should point
@@ -101,13 +102,6 @@ spec:
                                 \n When using the List and WatchList endpoints, provide
                                 the wildcard value \"*\" to list resources across
                                 all partitions."
-                              type: string
-                            peerName:
-                              description: "PeerName identifies which peer the resource
-                                is imported from. https://developer.hashicorp.com/consul/docs/connect/cluster-peering
-                                \n When using the List and WatchList endpoints, provide
-                                the wildcard value \"*\" to list resources across
-                                all peers."
                               type: string
                           type: object
                         type:
@@ -165,7 +159,9 @@ spec:
                                 description: "For east/west this is the name of the
                                   Consul Service port to direct traffic to or empty
                                   to imply using the same value as the parent ref.
-                                  \n For north/south this is TBD."
+                                  For north/south this is TBD. \n For more details
+                                  on potential values of this field, see documentation
+                                  for Service.ServicePort."
                                 type: string
                               ref:
                                 description: For east/west configuration, this should
@@ -197,13 +193,6 @@ spec:
                                           \n When using the List and WatchList endpoints,
                                           provide the wildcard value \"*\" to list
                                           resources across all partitions."
-                                        type: string
-                                      peerName:
-                                        description: "PeerName identifies which peer
-                                          the resource is imported from. https://developer.hashicorp.com/consul/docs/connect/cluster-peering
-                                          \n When using the List and WatchList endpoints,
-                                          provide the wildcard value \"*\" to list
-                                          resources across all peers."
                                         type: string
                                     type: object
                                   type:

--- a/control-plane/config/crd/bases/mesh.consul.hashicorp.com_tcproutes.yaml
+++ b/control-plane/config/crd/bases/mesh.consul.hashicorp.com_tcproutes.yaml
@@ -62,9 +62,10 @@ spec:
                   description: 'NOTE: roughly equivalent to structs.ResourceReference'
                   properties:
                     port:
-                      description: For east/west this is the name of the Consul Service
+                      description: "For east/west this is the name of the Consul Service
                         port to direct traffic to or empty to imply all. For north/south
-                        this is TBD.
+                        this is TBD. \n For more details on potential values of this
+                        field, see documentation for Service.ServicePort."
                       type: string
                     ref:
                       description: For east/west configuration, this should point
@@ -95,13 +96,6 @@ spec:
                                 \n When using the List and WatchList endpoints, provide
                                 the wildcard value \"*\" to list resources across
                                 all partitions."
-                              type: string
-                            peerName:
-                              description: "PeerName identifies which peer the resource
-                                is imported from. https://developer.hashicorp.com/consul/docs/connect/cluster-peering
-                                \n When using the List and WatchList endpoints, provide
-                                the wildcard value \"*\" to list resources across
-                                all peers."
                               type: string
                           type: object
                         type:
@@ -147,7 +141,9 @@ spec:
                                 description: "For east/west this is the name of the
                                   Consul Service port to direct traffic to or empty
                                   to imply using the same value as the parent ref.
-                                  \n For north/south this is TBD."
+                                  For north/south this is TBD. \n For more details
+                                  on potential values of this field, see documentation
+                                  for Service.ServicePort."
                                 type: string
                               ref:
                                 description: For east/west configuration, this should
@@ -179,13 +175,6 @@ spec:
                                           \n When using the List and WatchList endpoints,
                                           provide the wildcard value \"*\" to list
                                           resources across all partitions."
-                                        type: string
-                                      peerName:
-                                        description: "PeerName identifies which peer
-                                          the resource is imported from. https://developer.hashicorp.com/consul/docs/connect/cluster-peering
-                                          \n When using the List and WatchList endpoints,
-                                          provide the wildcard value \"*\" to list
-                                          resources across all peers."
                                         type: string
                                     type: object
                                   type:

--- a/control-plane/connect-inject/common/annotation_processor.go
+++ b/control-plane/connect-inject/common/annotation_processor.go
@@ -99,7 +99,7 @@ func processPodLabeledDestination(pod corev1.Pod, rawUpstream string, enablePart
 	service := parts[0]
 	pieces := strings.Split(service, ".")
 
-	var portName, datacenter, svcName, namespace, partition, peer string
+	var portName, datacenter, svcName, namespace, partition string
 	if enablePartitions || enableNamespaces {
 		switch len(pieces) {
 		case 8:
@@ -180,7 +180,6 @@ func processPodLabeledDestination(pod corev1.Pod, rawUpstream string, enablePart
 			Tenancy: &pbresource.Tenancy{
 				Partition: constants.GetNormalizedConsulPartition(partition),
 				Namespace: constants.GetNormalizedConsulNamespace(namespace),
-				PeerName:  constants.GetNormalizedConsulPeer(peer),
 			},
 			Name: svcName,
 		},
@@ -250,7 +249,6 @@ func processPodUnlabeledDestination(pod corev1.Pod, rawUpstream string, enablePa
 				Tenancy: &pbresource.Tenancy{
 					Partition: constants.GetNormalizedConsulPartition(partition),
 					Namespace: constants.GetNormalizedConsulNamespace(namespace),
-					PeerName:  constants.GetNormalizedConsulPeer(""),
 				},
 				Name: svcName,
 			},

--- a/control-plane/connect-inject/common/annotation_processor_test.go
+++ b/control-plane/connect-inject/common/annotation_processor_test.go
@@ -51,7 +51,6 @@ func TestProcessUpstreams(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: constants.GetNormalizedConsulPartition(""),
 								Namespace: constants.GetNormalizedConsulNamespace(""),
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream1",
 						},
@@ -88,7 +87,6 @@ func TestProcessUpstreams(t *testing.T) {
 			//				Tenancy: &pbresource.Tenancy{
 			//					Partition: constants.GetNormalizedConsulPartition(""),
 			//					Namespace: constants.GetNormalizedConsulNamespace(""),
-			//					PeerName: constants.GetNormalizedConsulPeer(""),
 			//				},
 			//				Name: "upstream1",
 			//			},
@@ -125,7 +123,6 @@ func TestProcessUpstreams(t *testing.T) {
 			//				Tenancy: &pbresource.Tenancy{
 			//					Partition: constants.GetNormalizedConsulPartition(""),
 			//					Namespace: constants.GetNormalizedConsulNamespace(""),
-			//					PeerName:  "peer1",
 			//				},
 			//				Name: "upstream1",
 			//			},
@@ -162,7 +159,6 @@ func TestProcessUpstreams(t *testing.T) {
 			//				Tenancy: &pbresource.Tenancy{
 			//					Partition: constants.GetNormalizedConsulPartition(""),
 			//					Namespace: "ns1",
-			//					PeerName:  "peer1",
 			//				},
 			//				Name: "upstream1",
 			//			},
@@ -197,7 +193,6 @@ func TestProcessUpstreams(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: "part1",
 								Namespace: "ns1",
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream1",
 						},
@@ -234,7 +229,6 @@ func TestProcessUpstreams(t *testing.T) {
 			//				Tenancy: &pbresource.Tenancy{
 			//					Partition: constants.GetNormalizedConsulPartition(""),
 			//					Namespace: "ns1",
-			//					PeerName: constants.GetNormalizedConsulPeer(""),
 			//				},
 			//				Name: "upstream1",
 			//			},
@@ -269,7 +263,6 @@ func TestProcessUpstreams(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: constants.GetNormalizedConsulPartition(""),
 								Namespace: "ns1",
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream1",
 						},
@@ -288,7 +281,6 @@ func TestProcessUpstreams(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: constants.GetNormalizedConsulPartition(""),
 								Namespace: constants.GetNormalizedConsulNamespace(""),
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream2",
 						},
@@ -307,7 +299,6 @@ func TestProcessUpstreams(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: "ap1",
 								Namespace: "ns1",
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream4",
 						},
@@ -344,7 +335,6 @@ func TestProcessUpstreams(t *testing.T) {
 			//				Tenancy: &pbresource.Tenancy{
 			//					Partition: constants.GetNormalizedConsulPartition(""),
 			//					Namespace: "ns1",
-			//					PeerName: constants.GetNormalizedConsulPeer(""),
 			//				},
 			//				Name: "upstream1",
 			//			},
@@ -363,7 +353,6 @@ func TestProcessUpstreams(t *testing.T) {
 			//				Tenancy: &pbresource.Tenancy{
 			//					Partition: constants.GetNormalizedConsulPartition(""),
 			//					Namespace: constants.GetNormalizedConsulNamespace(""),
-			//					PeerName: constants.GetNormalizedConsulPeer(""),
 			//				},
 			//				Name: "upstream2",
 			//			},
@@ -382,7 +371,6 @@ func TestProcessUpstreams(t *testing.T) {
 			//				Tenancy: &pbresource.Tenancy{
 			//					Partition: constants.GetNormalizedConsulPartition(""),
 			//					Namespace: "ns1",
-			//					PeerName: constants.GetNormalizedConsulPeer(""),
 			//				},
 			//				Name: "upstream3",
 			//			},
@@ -401,7 +389,6 @@ func TestProcessUpstreams(t *testing.T) {
 			//				Tenancy: &pbresource.Tenancy{
 			//					Partition: constants.GetNormalizedConsulPartition(""),
 			//					Namespace: "ns1",
-			//					PeerName:  "peer1",
 			//				},
 			//				Name: "upstream4",
 			//			},
@@ -586,7 +573,6 @@ func TestProcessUpstreams(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: constants.GetNormalizedConsulPartition(""),
 								Namespace: "ns1",
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream1",
 						},
@@ -605,7 +591,6 @@ func TestProcessUpstreams(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: constants.GetNormalizedConsulPartition(""),
 								Namespace: constants.GetNormalizedConsulNamespace(""),
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream2",
 						},
@@ -624,7 +609,6 @@ func TestProcessUpstreams(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: "ap1",
 								Namespace: "ns1",
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream4",
 						},
@@ -659,7 +643,6 @@ func TestProcessUpstreams(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: constants.GetNormalizedConsulPartition(""),
 								Namespace: constants.GetNormalizedConsulNamespace(""),
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream",
 						},
@@ -694,7 +677,6 @@ func TestProcessUpstreams(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: constants.GetNormalizedConsulPartition(""),
 								Namespace: "foo",
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream",
 						},
@@ -729,7 +711,6 @@ func TestProcessUpstreams(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: "bar",
 								Namespace: "foo",
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream",
 						},
@@ -764,7 +745,6 @@ func TestProcessUpstreams(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: constants.GetNormalizedConsulPartition(""),
 								Namespace: constants.GetNormalizedConsulNamespace(""),
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream1",
 						},
@@ -783,7 +763,6 @@ func TestProcessUpstreams(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: constants.GetNormalizedConsulPartition(""),
 								Namespace: constants.GetNormalizedConsulNamespace(""),
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream2",
 						},
@@ -826,7 +805,6 @@ func TestProcessUpstreams(t *testing.T) {
 			//				Tenancy: &pbresource.Tenancy{
 			//					Partition: constants.GetNormalizedConsulPartition(""),
 			//					Namespace: constants.GetNormalizedConsulNamespace(""),
-			//					PeerName: constants.GetNormalizedConsulPeer(""),
 			//				},
 			//				Name: "upstream1",
 			//			},
@@ -845,7 +823,6 @@ func TestProcessUpstreams(t *testing.T) {
 			//				Tenancy: &pbresource.Tenancy{
 			//					Partition: constants.GetNormalizedConsulPartition(""),
 			//					Namespace: "bar",
-			//					PeerName: constants.GetNormalizedConsulPeer(""),
 			//				},
 			//				Name: "upstream2",
 			//			},
@@ -864,7 +841,6 @@ func TestProcessUpstreams(t *testing.T) {
 			//				Tenancy: &pbresource.Tenancy{
 			//					Partition: "baz",
 			//					Namespace: "foo",
-			//					PeerName: constants.GetNormalizedConsulPeer(""),
 			//				},
 			//				Name: "upstream3",
 			//			},
@@ -907,7 +883,6 @@ func TestProcessUpstreams(t *testing.T) {
 			//				Tenancy: &pbresource.Tenancy{
 			//					Partition: constants.GetNormalizedConsulPartition(""),
 			//					Namespace: constants.GetNormalizedConsulNamespace(""),
-			//					PeerName: constants.GetNormalizedConsulPeer(""),
 			//				},
 			//				Name: "upstream1",
 			//			},
@@ -926,7 +901,6 @@ func TestProcessUpstreams(t *testing.T) {
 			//				Tenancy: &pbresource.Tenancy{
 			//					Partition: constants.GetNormalizedConsulPartition(""),
 			//					Namespace: "bar",
-			//					PeerName: constants.GetNormalizedConsulPeer(""),
 			//				},
 			//				Name: "upstream2",
 			//			},
@@ -945,7 +919,6 @@ func TestProcessUpstreams(t *testing.T) {
 			//				Tenancy: &pbresource.Tenancy{
 			//					Partition: constants.GetNormalizedConsulPartition(""),
 			//					Namespace: "foo",
-			//					PeerName: constants.GetNormalizedConsulPeer(""),
 			//				},
 			//				Name: "upstream3",
 			//			},

--- a/control-plane/connect-inject/common/common_test.go
+++ b/control-plane/connect-inject/common/common_test.go
@@ -575,10 +575,6 @@ func Test_ConsulNamespaceIsNotFound_ErrorMsg(t *testing.T) {
 		Tenancy: &pbresource.Tenancy{
 			Partition: constants.DefaultConsulPartition,
 			Namespace: "i-dont-exist-but-its-ok-we-will-meet-again-someday",
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 

--- a/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller.go
+++ b/control-plane/connect-inject/controllers/endpointsv2/endpoints_controller.go
@@ -375,7 +375,6 @@ func getServiceID(name, namespace, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-			PeerName:  constants.DefaultConsulPeer,
 		},
 	}
 }

--- a/control-plane/connect-inject/controllers/pod/pod_controller.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller.go
@@ -708,10 +708,6 @@ func getWorkloadID(name, namespace, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }
@@ -723,10 +719,6 @@ func getProxyConfigurationID(name, namespace, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }
@@ -738,10 +730,6 @@ func getHealthStatusID(name, namespace, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }
@@ -753,10 +741,6 @@ func getDestinationsID(name, namespace, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }

--- a/control-plane/connect-inject/controllers/pod/pod_controller_test.go
+++ b/control-plane/connect-inject/controllers/pod/pod_controller_test.go
@@ -793,7 +793,6 @@ func TestDestinationsWrite(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: constants.GetNormalizedConsulPartition(""),
 								Namespace: constants.GetNormalizedConsulNamespace(""),
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream1",
 						},
@@ -867,7 +866,6 @@ func TestDestinationsWrite(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: "part1",
 								Namespace: "ns1",
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream1",
 						},
@@ -914,7 +912,6 @@ func TestDestinationsWrite(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: constants.GetNormalizedConsulPartition(""),
 								Namespace: constants.GetNormalizedConsulNamespace(""),
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream",
 						},
@@ -950,7 +947,6 @@ func TestDestinationsWrite(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: "bar",
 								Namespace: "foo",
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream",
 						},
@@ -1033,7 +1029,6 @@ func TestDestinationsDelete(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: constants.GetNormalizedConsulPartition(""),
 								Namespace: constants.GetNormalizedConsulNamespace(""),
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "upstream1",
 						},
@@ -1577,7 +1572,6 @@ func TestReconcileUpdatePod(t *testing.T) {
 							Tenancy: &pbresource.Tenancy{
 								Partition: "ap1",
 								Namespace: "ns1",
-								PeerName:  constants.GetNormalizedConsulPeer(""),
 							},
 							Name: "mySVC3",
 						},
@@ -1980,7 +1974,6 @@ func createDestinations() *pbmesh.Destinations {
 					Tenancy: &pbresource.Tenancy{
 						Partition: constants.GetNormalizedConsulPartition(""),
 						Namespace: constants.GetNormalizedConsulNamespace(""),
-						PeerName:  constants.GetNormalizedConsulPeer(""),
 					},
 					Name: "mySVC",
 				},

--- a/control-plane/connect-inject/controllers/serviceaccount/serviceaccount_controller.go
+++ b/control-plane/connect-inject/controllers/serviceaccount/serviceaccount_controller.go
@@ -155,9 +155,6 @@ func getWorkloadIdentityID(name, namespace, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }

--- a/control-plane/consul/dataplane_client_test.go
+++ b/control-plane/consul/dataplane_client_test.go
@@ -116,7 +116,6 @@ func createWorkload(t *testing.T, watcher ServerConnectionManager, name string) 
 		Tenancy: &pbresource.Tenancy{
 			Partition: "default",
 			Namespace: "default",
-			PeerName:  "local",
 		},
 	}
 
@@ -157,7 +156,6 @@ func createProxyConfiguration(t *testing.T, watcher ServerConnectionManager, nam
 		Tenancy: &pbresource.Tenancy{
 			Partition: "default",
 			Namespace: "default",
-			PeerName:  "local",
 		},
 	}
 

--- a/control-plane/consul/resource_client_test.go
+++ b/control-plane/consul/resource_client_test.go
@@ -100,7 +100,6 @@ func createWriteRequest(t *testing.T, name string) *pbresource.WriteRequest {
 				Tenancy: &pbresource.Tenancy{
 					Namespace: constants.DefaultConsulNS,
 					Partition: constants.DefaultConsulPartition,
-					PeerName:  constants.DefaultConsulPeer,
 				},
 			},
 			Data: proto,

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -2,7 +2,7 @@ module github.com/hashicorp/consul-k8s/control-plane
 
 // TODO: Remove this when the next version of the submodule is released.
 // We need to use a replace directive instead of directly pinning because `api` requires version `0.5.1` and will clobber the pin, but not the replace directive.
-replace github.com/hashicorp/consul/proto-public => github.com/hashicorp/consul/proto-public v0.1.2-0.20240129174413-a2d50af1bdfb
+replace github.com/hashicorp/consul/proto-public => github.com/hashicorp/consul/proto-public v0.1.2-0.20240202204845-fb2b696c0e6b
 
 replace github.com/hashicorp/consul/sdk => github.com/hashicorp/consul/sdk v0.4.1-0.20231213150639-123bc95e1a3f
 

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -265,8 +265,8 @@ github.com/hashicorp/consul-server-connection-manager v0.1.6 h1:ktj8Fi+dRXn9hhM+
 github.com/hashicorp/consul-server-connection-manager v0.1.6/go.mod h1:HngMIv57MT+pqCVeRQMa1eTB5dqnyMm8uxjyv+Hn8cs=
 github.com/hashicorp/consul/api v1.10.1-0.20240122152324-758ddf84e9c9 h1:qaS6rE768dt5hGPl2y4DIABXF4eA23BNSmWFpEr3kWQ=
 github.com/hashicorp/consul/api v1.10.1-0.20240122152324-758ddf84e9c9/go.mod h1:gInwZGrnWlE1Vvq6rSD5pUf6qwNa69NTLLknbdwQRUk=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20240129174413-a2d50af1bdfb h1:4LCdNw3DTe5WRe3fJvY+hkRLNtRlunl/9PJuOlQmPa8=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20240129174413-a2d50af1bdfb/go.mod h1:ar/M/Gv31GeE7DxektZgAydwsCiOf6sBeJFcjQVTlVs=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20240202204845-fb2b696c0e6b h1:SQNk1hzihCm9jnbuJvtzUpNvYtum1NUxVeu9jwX9TgQ=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20240202204845-fb2b696c0e6b/go.mod h1:ar/M/Gv31GeE7DxektZgAydwsCiOf6sBeJFcjQVTlVs=
 github.com/hashicorp/consul/sdk v0.4.1-0.20231213150639-123bc95e1a3f h1:GKsa7bfoL7xgvCkzYJMF9eYYNfLWQyk8QuRZZl4nMTo=
 github.com/hashicorp/consul/sdk v0.4.1-0.20231213150639-123bc95e1a3f/go.mod h1:r/OmRRPbHOe0yxNahLw7G9x5WG17E1BIECMtCjcPSNo=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/control-plane/subcommand/mesh-init/command_test.go
+++ b/control-plane/subcommand/mesh-init/command_test.go
@@ -314,10 +314,6 @@ func getWorkloadID(name, namespace, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }
@@ -355,10 +351,6 @@ func getProxyConfigurationID(name, namespace, partition string) *pbresource.ID {
 		Tenancy: &pbresource.Tenancy{
 			Partition: partition,
 			Namespace: namespace,
-
-			// Because we are explicitly defining NS/partition, this will not default and must be explicit.
-			// At a future point, this will move out of the Tenancy block.
-			PeerName: constants.DefaultConsulPeer,
 		},
 	}
 }


### PR DESCRIPTION
### Changes proposed in this PR ###  
Reconcile changes in Consul with Consul-k8s
- Changed the multicluster group to from v2beta1 -> v2 https://github.com/hashicorp/consul/pull/20430
- `PeerName` field was removed from pbresource.Tenancy https://github.com/hashicorp/consul/pull/19865

### How I've tested this PR ###
Linter, unit and integration tests must pass


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
