### PR TITLE
Add json tags to api-gateway types

### DIFF
--- a/charts/consul/templates/crd-apigateways.yaml
+++ b/charts/consul/templates/crd-apigateways.yaml
@@ -196,41 +196,113 @@ spec:
             type: object
           status:
             properties:
-              conditions:
-                description: Conditions indicate the latest available observations
-                  of a resource's current state.
+              addresses:
                 items:
-                  description: 'Conditions define a readiness condition for a Consul
-                    resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                   properties:
-                    lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition
-                        transitioned from one status to another.
-                      format: date-time
-                      type: string
-                    message:
-                      description: A human readable message indicating details about
-                        the transition.
-                      type: string
-                    reason:
-                      description: The reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      type: string
                     type:
-                      description: Type of condition.
+                      default: IPAddress
+                      type: string
+                    value:
                       type: string
                   required:
-                  - status
                   - type
+                  - value
                   type: object
                 type: array
-              lastSyncedTime:
-                description: LastSyncedTime is the last time the resource successfully
-                  synced with Consul.
-                format: date-time
-                type: string
+              listeners:
+                items:
+                  properties:
+                    attachedRoutes:
+                      format: int32
+                      type: integer
+                    name:
+                      type: string
+                    status:
+                      properties:
+                        conditions:
+                          description: Conditions indicate the latest available observations
+                            of a resource's current state.
+                          items:
+                            description: 'Conditions define a readiness condition
+                              for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                            properties:
+                              lastTransitionTime:
+                                description: LastTransitionTime is the last time the
+                                  condition transitioned from one status to another.
+                                format: date-time
+                                type: string
+                              message:
+                                description: A human readable message indicating details
+                                  about the transition.
+                                type: string
+                              reason:
+                                description: The reason for the condition's last transition.
+                                type: string
+                              status:
+                                description: Status of the condition, one of True,
+                                  False, Unknown.
+                                type: string
+                              type:
+                                description: Type of condition.
+                                type: string
+                            required:
+                            - status
+                            - type
+                            type: object
+                          type: array
+                        lastSyncedTime:
+                          description: LastSyncedTime is the last time the resource
+                            successfully synced with Consul.
+                          format: date-time
+                          type: string
+                      type: object
+                  required:
+                  - attachedRoutes
+                  - name
+                  type: object
+                type: array
+              status:
+                properties:
+                  conditions:
+                    description: Conditions indicate the latest available observations
+                      of a resource's current state.
+                    items:
+                      description: 'Conditions define a readiness condition for a
+                        Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                      properties:
+                        lastTransitionTime:
+                          description: LastTransitionTime is the last time the condition
+                            transitioned from one status to another.
+                          format: date-time
+                          type: string
+                        message:
+                          description: A human readable message indicating details
+                            about the transition.
+                          type: string
+                        reason:
+                          description: The reason for the condition's last transition.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False,
+                            Unknown.
+                          type: string
+                        type:
+                          description: Type of condition.
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  lastSyncedTime:
+                    description: LastSyncedTime is the last time the resource successfully
+                      synced with Consul.
+                    format: date-time
+                    type: string
+                type: object
+            required:
+            - addresses
+            - listeners
             type: object
         type: object
     served: true

--- a/charts/consul/templates/crd-trafficpermissions.yaml
+++ b/charts/consul/templates/crd-trafficpermissions.yaml
@@ -101,23 +101,25 @@ spec:
                               when evaluating rules for the incoming connection.
                             items:
                               properties:
-                                header:
-                                  properties:
-                                    exact:
-                                      type: string
-                                    invert:
-                                      type: boolean
-                                    name:
-                                      type: string
-                                    prefix:
-                                      type: string
-                                    present:
-                                      type: boolean
-                                    regex:
-                                      type: string
-                                    suffix:
-                                      type: string
-                                  type: object
+                                headers:
+                                  items:
+                                    properties:
+                                      exact:
+                                        type: string
+                                      invert:
+                                        type: boolean
+                                      name:
+                                        type: string
+                                      prefix:
+                                        type: string
+                                      present:
+                                        type: boolean
+                                      regex:
+                                        type: string
+                                      suffix:
+                                        type: string
+                                    type: object
+                                  type: array
                                 methods:
                                   description: Methods is the list of HTTP methods.
                                   items:
@@ -138,23 +140,25 @@ spec:
                                   type: array
                               type: object
                             type: array
-                          header:
-                            properties:
-                              exact:
-                                type: string
-                              invert:
-                                type: boolean
-                              name:
-                                type: string
-                              prefix:
-                                type: string
-                              present:
-                                type: boolean
-                              regex:
-                                type: string
-                              suffix:
-                                type: string
-                            type: object
+                          headers:
+                            items:
+                              properties:
+                                exact:
+                                  type: string
+                                invert:
+                                  type: boolean
+                                name:
+                                  type: string
+                                prefix:
+                                  type: string
+                                present:
+                                  type: boolean
+                                regex:
+                                  type: string
+                                suffix:
+                                  type: string
+                              type: object
+                            type: array
                           methods:
                             description: Methods is the list of HTTP methods. If no
                               methods are specified, this rule will apply to all methods.

--- a/control-plane/api/mesh/v2beta1/api_gateway_types.go
+++ b/control-plane/api/mesh/v2beta1/api_gateway_types.go
@@ -43,13 +43,13 @@ type APIGateway struct {
 }
 
 type APIGatewayStatus struct {
-	Status
-	Addresses []GatewayAddress
-	Listeners []ListenerStatus
+	Status    `json:"status,omitempty"`
+	Addresses []GatewayAddress `json:"addresses"`
+	Listeners []ListenerStatus `json:"listeners"`
 }
 
 type ListenerStatus struct {
-	Status
+	Status         `json:"status,omitempty"`
 	Name           string `json:"name"`
 	AttachedRoutes int32  `json:"attachedRoutes"`
 }

--- a/control-plane/config/crd/bases/auth.consul.hashicorp.com_trafficpermissions.yaml
+++ b/control-plane/config/crd/bases/auth.consul.hashicorp.com_trafficpermissions.yaml
@@ -97,23 +97,25 @@ spec:
                               when evaluating rules for the incoming connection.
                             items:
                               properties:
-                                header:
-                                  properties:
-                                    exact:
-                                      type: string
-                                    invert:
-                                      type: boolean
-                                    name:
-                                      type: string
-                                    prefix:
-                                      type: string
-                                    present:
-                                      type: boolean
-                                    regex:
-                                      type: string
-                                    suffix:
-                                      type: string
-                                  type: object
+                                headers:
+                                  items:
+                                    properties:
+                                      exact:
+                                        type: string
+                                      invert:
+                                        type: boolean
+                                      name:
+                                        type: string
+                                      prefix:
+                                        type: string
+                                      present:
+                                        type: boolean
+                                      regex:
+                                        type: string
+                                      suffix:
+                                        type: string
+                                    type: object
+                                  type: array
                                 methods:
                                   description: Methods is the list of HTTP methods.
                                   items:
@@ -134,23 +136,25 @@ spec:
                                   type: array
                               type: object
                             type: array
-                          header:
-                            properties:
-                              exact:
-                                type: string
-                              invert:
-                                type: boolean
-                              name:
-                                type: string
-                              prefix:
-                                type: string
-                              present:
-                                type: boolean
-                              regex:
-                                type: string
-                              suffix:
-                                type: string
-                            type: object
+                          headers:
+                            items:
+                              properties:
+                                exact:
+                                  type: string
+                                invert:
+                                  type: boolean
+                                name:
+                                  type: string
+                                prefix:
+                                  type: string
+                                present:
+                                  type: boolean
+                                regex:
+                                  type: string
+                                suffix:
+                                  type: string
+                              type: object
+                            type: array
                           methods:
                             description: Methods is the list of HTTP methods. If no
                               methods are specified, this rule will apply to all methods.

--- a/control-plane/config/crd/bases/mesh.consul.hashicorp.com_apigateways.yaml
+++ b/control-plane/config/crd/bases/mesh.consul.hashicorp.com_apigateways.yaml
@@ -192,41 +192,113 @@ spec:
             type: object
           status:
             properties:
-              conditions:
-                description: Conditions indicate the latest available observations
-                  of a resource's current state.
+              addresses:
                 items:
-                  description: 'Conditions define a readiness condition for a Consul
-                    resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                   properties:
-                    lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition
-                        transitioned from one status to another.
-                      format: date-time
-                      type: string
-                    message:
-                      description: A human readable message indicating details about
-                        the transition.
-                      type: string
-                    reason:
-                      description: The reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      type: string
                     type:
-                      description: Type of condition.
+                      default: IPAddress
+                      type: string
+                    value:
                       type: string
                   required:
-                  - status
                   - type
+                  - value
                   type: object
                 type: array
-              lastSyncedTime:
-                description: LastSyncedTime is the last time the resource successfully
-                  synced with Consul.
-                format: date-time
-                type: string
+              listeners:
+                items:
+                  properties:
+                    attachedRoutes:
+                      format: int32
+                      type: integer
+                    name:
+                      type: string
+                    status:
+                      properties:
+                        conditions:
+                          description: Conditions indicate the latest available observations
+                            of a resource's current state.
+                          items:
+                            description: 'Conditions define a readiness condition
+                              for a Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                            properties:
+                              lastTransitionTime:
+                                description: LastTransitionTime is the last time the
+                                  condition transitioned from one status to another.
+                                format: date-time
+                                type: string
+                              message:
+                                description: A human readable message indicating details
+                                  about the transition.
+                                type: string
+                              reason:
+                                description: The reason for the condition's last transition.
+                                type: string
+                              status:
+                                description: Status of the condition, one of True,
+                                  False, Unknown.
+                                type: string
+                              type:
+                                description: Type of condition.
+                                type: string
+                            required:
+                            - status
+                            - type
+                            type: object
+                          type: array
+                        lastSyncedTime:
+                          description: LastSyncedTime is the last time the resource
+                            successfully synced with Consul.
+                          format: date-time
+                          type: string
+                      type: object
+                  required:
+                  - attachedRoutes
+                  - name
+                  type: object
+                type: array
+              status:
+                properties:
+                  conditions:
+                    description: Conditions indicate the latest available observations
+                      of a resource's current state.
+                    items:
+                      description: 'Conditions define a readiness condition for a
+                        Consul resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                      properties:
+                        lastTransitionTime:
+                          description: LastTransitionTime is the last time the condition
+                            transitioned from one status to another.
+                          format: date-time
+                          type: string
+                        message:
+                          description: A human readable message indicating details
+                            about the transition.
+                          type: string
+                        reason:
+                          description: The reason for the condition's last transition.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False,
+                            Unknown.
+                          type: string
+                        type:
+                          description: Type of condition.
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  lastSyncedTime:
+                    description: LastSyncedTime is the last time the resource successfully
+                      synced with Consul.
+                    format: date-time
+                    type: string
+                type: object
+            required:
+            - addresses
+            - listeners
             type: object
         type: object
     served: true


### PR DESCRIPTION
### Changes proposed in this PR ###  
Running `make ctrl-manifests` returns the following error on `main` branch
```     
make ensure-controller-gen-version
Found correct version: Version: v0.12.1
cd control-plane; /Users/anitaakaeze/go/bin/controller-gen "crd:ignoreUnexportedFields=true,allowDangerousTypes=true" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/Users/anitaakaeze/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1/api_gateway_types.go:46:2: encountered struct field "" without JSON tag in type "APIGatewayStatus"
/Users/anitaakaeze/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1/api_gateway_types.go:47:2: encountered struct field "Addresses" without JSON tag in type "APIGatewayStatus"
/Users/anitaakaeze/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1/api_gateway_types.go:48:2: encountered struct field "Listeners" without JSON tag in type "APIGatewayStatus"
Error: not all generators ran successfully
run `controller-gen crd:ignoreUnexportedFields=true,allowDangerousTypes=true rbac:roleName=manager-role webhook paths=./... output:crd:artifacts:config=config/crd/bases -w` to see all available markers, or `controller-gen crd:ignoreUnexportedFields=true,allowDangerousTypes=true rbac:roleName=manager-role webhook paths=./... output:crd:artifacts:config=config/crd/bases -h` for usage
make: *** [ctrl-manifests] Error 1
```
This solution adds the required JSON tags to ensure CRD can be generated 

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
