### PR TITLE
Backport of [NET-6465] Respect connectInject.initContainer.resources for v1 API gateways into release/1.2.x

### DIFF
--- a/.changelog/3531.txt
+++ b/.changelog/3531.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api-gateway: Apply `connectInject.initContainer.resources` to the init container for API gateway Pods.
+```

--- a/control-plane/api-gateway/common/helm_config.go
+++ b/control-plane/api-gateway/common/helm_config.go
@@ -6,6 +6,8 @@ package common
 import (
 	"strings"
 	"time"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 const componentAuthMethod = "k8s-component-auth-method"
@@ -40,6 +42,8 @@ type HelmConfig struct {
 	// MapPrivilegedServicePorts is the value which Consul will add to privileged container port values (ports < 1024)
 	// defined on a Gateway.
 	MapPrivilegedServicePorts int
+
+	InitContainerResources *v1.ResourceRequirements
 }
 
 type ConsulConfig struct {

--- a/control-plane/api-gateway/gatekeeper/deployment.go
+++ b/control-plane/api-gateway/gatekeeper/deployment.go
@@ -6,18 +6,19 @@ package gatekeeper
 import (
 	"context"
 
-	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
-	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
-	"k8s.io/apimachinery/pkg/types"
-
+	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 )
 
 const (
@@ -168,6 +169,14 @@ func compareDeployments(a, b *appsv1.Deployment) bool {
 	if len(b.Spec.Template.Spec.Containers) != len(a.Spec.Template.Spec.Containers) {
 		return false
 	}
+
+	for i, containerA := range a.Spec.Template.Spec.InitContainers {
+		containerB := b.Spec.Template.Spec.InitContainers[i]
+		if !cmp.Equal(containerA, containerB) {
+			return false
+		}
+	}
+
 	for i, container := range a.Spec.Template.Spec.Containers {
 		otherPorts := b.Spec.Template.Spec.Containers[i].Ports
 		if len(container.Ports) != len(otherPorts) {

--- a/control-plane/api-gateway/gatekeeper/init.go
+++ b/control-plane/api-gateway/gatekeeper/init.go
@@ -11,9 +11,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"k8s.io/utils/pointer"
+
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"github.com/hashicorp/consul-k8s/control-plane/namespaces"
-	"k8s.io/utils/pointer"
 )
 
 const (
@@ -166,6 +167,10 @@ func initContainer(config common.HelmConfig, name, namespace string) (corev1.Con
 				Name:  "CONSUL_PARTITION",
 				Value: config.ConsulPartition,
 			})
+	}
+
+	if config.InitContainerResources != nil {
+		container.Resources = *config.InitContainerResources
 	}
 
 	// Openshift Assigns the security context for us, do not enable if it is enabled.

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -537,6 +537,7 @@ func (c *Command) Run(args []string) int {
 			ConsulTLSServerName:        c.consul.TLSServerName,
 			ConsulPartition:            c.consul.Partition,
 			ConsulCACert:               string(caCertPem),
+			InitContainerResources:     &initResources,
 		},
 		AllowK8sNamespacesSet:   allowK8sNamespaces,
 		DenyK8sNamespacesSet:    denyK8sNamespaces,


### PR DESCRIPTION
## Backport

This PR is manually generated from #3531 to be assessed for backporting due to the inclusion of the label backport/1.2.x.

The below text is copied from the body of the original PR.

---

### Changes proposed in this PR ###  
Apply the existing `connectInject.initContainer.resources` value to the init container for API gateway `Pods`.

### How I've tested this PR ###
Create an API Gateway having installed Consul into Kubernetes w/ the above field set in your `values.yaml`.

### How I expect reviewers to test this PR ###
See above

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


---

<details>
<summary> Overview of commits </summary>

  - 9d89a7c101ca8550e6c68aeaf70f627d951bccb9  - 8a09d6e6ed88d3548ba402dc4e5ceb3c3b14d44f  - 0890d599bfc1f560196cdd9f0e93d47a7aab2d33 

</details>


