### PR TITLE
Net 7238 - consul k8s modify gateway resources job to create apigw gatewayclass and gatewayclassconfig

### DIFF
--- a/charts/consul/templates/gateway-resources-configmap.yaml
+++ b/charts/consul/templates/gateway-resources-configmap.yaml
@@ -21,9 +21,10 @@ data:
   resources.json: |
     {{ toJson .Values.connectInject.apiGateway.managedGatewayClass.resources }}
   {{- end }}
-  {{- if and (mustHas "resource-apis" .Values.global.experiments) .Values.meshGateway.enabled }}
+  {{- if and (mustHas "resource-apis" .Values.global.experiments) (.Values.meshGateway.enabled or .Values.connectInject.apiGateway.managedGatewayClass }}
   config.yaml: |
     gatewayClassConfigs:
+      {{- if .Values.meshGateway.enabled  }}
       - apiVersion: mesh.consul.hashicorp.com/v2beta1
         metadata:
           name: consul-mesh-gateway
@@ -100,6 +101,42 @@ data:
             annotations:
               set: {{ toJson .Values.meshGateway.serviceAccount.annotations }}
           {{- end }}
+    {{- end }}
+    {{- if .Values.connectInject.apiGateway.managedGatewayClass  }}
+    - apiVersion: mesh.consul.hashicorp.com/v2beta1
+      metadata:
+        name: consul-api-gateway
+      kind: GatewayClassConfig
+      spec:
+        labels:
+          set:
+            app: {{ template "consul.name" . }}
+            chart: {{ template "consul.chart" . }}
+            heritage: {{ .Release.Service }}
+            release: {{ .Release.Name }}
+            component: api-gateway
+        annotations:
+          service: {{ .Values.connectInject.apiGateway.managedGatewayClass.copyAnnotations.service }}
+        deployment:
+          replicas:
+            default: {{ .Values.connectInject.apiGateway.managedGatewayClass.defaultInstances }}
+            min: {{ .Values.connectInject.apiGateway.managedGatewayClass.minInstances }}
+            max: {{ .Values.connectInject.apiGateway.managedGatewayClass.maxInstances }}
+          {{- if .Values.connectInject.apiGateway.managedGatewayClass.tolerations }}
+          tolerations: {{ fromYamlArray .Values.connectInject.apiGateway.managedGatewayClass.tolerations | toJson }}
+          {{- end }}
+        service:
+          {{- if .Values.connectInject.apiGateway.managedGatewayClass.service.annotations }}
+          annotations:
+            set: {{ toJson .Values.connectInject.apiGateway.managedGatewayClass.service.annotations }}
+          {{- end }}
+          type: {{ .Values.connectInject.apiGateway.managedGatewayClass.serviceType }}
+        {{- if .Values.connectInject.apiGateway.managedGatewayClass.serviceAccount.annotations }}
+        serviceAccount:
+          annotations:
+            set: {{ toJson .Values.connectInject.apiGateway.managedGatewayClass.serviceAccount.annotations }}
+    {{- end  }}
+    {{- if .Values.meshGateway.enabled  }}
     meshGateways:
       - apiVersion: mesh.consul.hashicorp.com/v2beta1
         kind: MeshGateway
@@ -128,5 +165,6 @@ data:
           workloads:
             prefixes: 
               - "mesh-gateway"
+    {{- end  }}
   {{- end }}
 {{- end }}

--- a/charts/consul/templates/gateway-resources-configmap.yaml
+++ b/charts/consul/templates/gateway-resources-configmap.yaml
@@ -105,7 +105,7 @@ data:
     {{- if .Values.connectInject.apiGateway.managedGatewayClass  }}
     - apiVersion: mesh.consul.hashicorp.com/v2beta1
       metadata:
-        name: consul-api-gateway22222
+        name: consul-api-gateway
       kind: GatewayClassConfig
       spec:
         labels:

--- a/charts/consul/templates/gateway-resources-configmap.yaml
+++ b/charts/consul/templates/gateway-resources-configmap.yaml
@@ -88,7 +88,8 @@ data:
               min: {{ .Values.meshGateway.replicas }}
               max: {{ .Values.meshGateway.replicas }}
             {{- if .Values.meshGateway.tolerations }}
-            tolerations: {{ fromYamlArray .Values.meshGateway.tolerations | toJson }}
+            tolerations:
+              {{ fromYamlArray .Values.meshGateway.tolerations | toJson }}
             {{- end }}
           service:
             {{- if .Values.meshGateway.service.annotations }}
@@ -103,42 +104,61 @@ data:
           {{- end }}
     {{- end }}
     {{- if .Values.connectInject.apiGateway.managedGatewayClass  }}
-    - apiVersion: mesh.consul.hashicorp.com/v2beta1
-      metadata:
-        name: consul-api-gateway
-      kind: GatewayClassConfig
-      spec:
-        labels:
-          set:
-            app: {{ template "consul.name" . }}
-            chart: {{ template "consul.chart" . }}
-            heritage: {{ .Release.Service }}
-            release: {{ .Release.Name }}
-            component: api-gateway
-        {{- if .Values.connectInject.apiGateway.managedGatewayClass.service }}
-        annotations:
-          service: {{ .Values.connectInject.apiGateway.managedGatewayClass.copyAnnotations.service }}
-        {{- end}}
-        deployment:
-          replicas:
-            default: {{ .Values.connectInject.apiGateway.managedGatewayClass.deployment.defaultInstances }}
-            min: {{ .Values.connectInject.apiGateway.managedGatewayClass.deployment.minInstances }}
-            max: {{ .Values.connectInject.apiGateway.managedGatewayClass.deployment.maxInstances }}
-          {{- if .Values.connectInject.apiGateway.managedGatewayClass.tolerations }}
-          tolerations: {{ fromYamlArray .Values.connectInject.apiGateway.managedGatewayClass.tolerations | toJson }}
-          {{- end }}
-        {{- if .Values.connectInject.apiGateway.managedGatewayClass.service }}
-        service:
+      - apiVersion: mesh.consul.hashicorp.com/v2beta1
+        metadata:
+          name: consul-api-gateway
+        kind: GatewayClassConfig
+        spec:
+          labels:
+            set:
+              app: {{ template "consul.name" . }}
+              chart: {{ template "consul.chart" . }}
+              heritage: {{ .Release.Service }}
+              release: {{ .Release.Name }}
+              component: api-gateway
+          {{- if .Values.connectInject.apiGateway.managedGatewayClass.copyAnnotations }}
           annotations:
-            set: {{ toJson .Values.connectInject.apiGateway.managedGatewayClass.service.annotations }}
-          {{- end }}
-          type: {{ .Values.connectInject.apiGateway.managedGatewayClass.serviceType }}
-        {{- if .Values.connectInject.apiGateway.managedGatewayClass.serviceAccount }}
-        serviceAccount:
-          annotations:
-            set: {{ toJson .Values.connectInject.apiGateway.managedGatewayClass.serviceAccount.annotations }}
-        {{- end  }}
-    {{- end }}
+            service: {{ .Values.connectInject.apiGateway.managedGatewayClass.copyAnnotations.service }}
+          {{- end}}
+          deployment:
+            {{- if .Values.connectInject.apiGateway.managedGatewayClass.nodeSelector }}
+            nodeSelector:
+              {{ fromYamlArray .Values.connectInject.apiGateway.managedGatewayClass.nodeSelector | toJson }}
+            {{- end }}
+            initContainer:
+              {{- if .Values.connectInject.apiGateway.managedGatewayClass.mapPrivilegedContainerPorts }}
+              portModifier: {{ .Values.connectInject.apiGateway.managedGatewayClass.mapPrivilegedContainerPorts }}
+              {{- end }}
+              consul:
+                logging:
+                  level: {{ .Values.global.logLevel }}
+            container:
+              {{- if .Values.connectInject.apiGateway.managedGatewayClass.mapPrivilegedContainerPorts }}
+              portModifier: {{ .Values.connectInject.apiGateway.managedGatewayClass.mapPrivilegedContainerPorts }}
+              {{- end }}
+              consul:
+                logging:
+                  level: {{ .Values.global.logLevel }}
+            replicas:
+              default: {{ .Values.connectInject.apiGateway.managedGatewayClass.deployment.defaultInstances }}
+              min: {{ .Values.connectInject.apiGateway.managedGatewayClass.deployment.minInstances }}
+              max: {{ .Values.connectInject.apiGateway.managedGatewayClass.deployment.maxInstances }}
+            {{- if .Values.connectInject.apiGateway.managedGatewayClass.tolerations }}
+            tolerations:
+              {{ fromYamlArray .Values.connectInject.apiGateway.managedGatewayClass.tolerations | toJson }}
+            {{- end }}
+          {{- if .Values.connectInject.apiGateway.managedGatewayClass.service }}
+          service:
+            annotations:
+              set: {{ toJson .Values.connectInject.apiGateway.managedGatewayClass.service.annotations }}
+            {{- end }}
+            type: {{ .Values.connectInject.apiGateway.managedGatewayClass.serviceType }}
+          {{- if .Values.connectInject.apiGateway.managedGatewayClass.serviceAccount }}
+          serviceAccount:
+            annotations:
+              set: {{ toJson .Values.connectInject.apiGateway.managedGatewayClass.serviceAccount.annotations }}
+          {{- end  }}
+      {{- end }}
     {{- if .Values.meshGateway.enabled  }}
     meshGateways:
       - apiVersion: mesh.consul.hashicorp.com/v2beta1
@@ -147,7 +167,6 @@ data:
           name: mesh-gateway
           namespace: {{ .Release.Namespace }}
           annotations: 
-            # TODO are these annotations even necessary?
             "consul.hashicorp.com/gateway-wan-address-source": {{ .Values.meshGateway.wanAddress.source | quote }}
             "consul.hashicorp.com/gateway-wan-address-static": {{ .Values.meshGateway.wanAddress.static | quote }}
             {{- if eq .Values.meshGateway.wanAddress.source "Service" }}

--- a/charts/consul/templates/gateway-resources-configmap.yaml
+++ b/charts/consul/templates/gateway-resources-configmap.yaml
@@ -21,7 +21,7 @@ data:
   resources.json: |
     {{ toJson .Values.connectInject.apiGateway.managedGatewayClass.resources }}
   {{- end }}
-  {{- if and (mustHas "resource-apis" .Values.global.experiments) (.Values.meshGateway.enabled or .Values.connectInject.apiGateway.managedGatewayClass }}
+  {{- if and (mustHas "resource-apis" .Values.global.experiments) (or .Values.meshGateway.enabled .Values.connectInject.apiGateway.managedGatewayClass) }}
   config.yaml: |
     gatewayClassConfigs:
       {{- if .Values.meshGateway.enabled  }}
@@ -105,7 +105,7 @@ data:
     {{- if .Values.connectInject.apiGateway.managedGatewayClass  }}
     - apiVersion: mesh.consul.hashicorp.com/v2beta1
       metadata:
-        name: consul-api-gateway
+        name: consul-api-gateway22222
       kind: GatewayClassConfig
       spec:
         labels:
@@ -115,27 +115,30 @@ data:
             heritage: {{ .Release.Service }}
             release: {{ .Release.Name }}
             component: api-gateway
+        {{- if .Values.connectInject.apiGateway.managedGatewayClass.service }}
         annotations:
           service: {{ .Values.connectInject.apiGateway.managedGatewayClass.copyAnnotations.service }}
+        {{- end}}
         deployment:
           replicas:
-            default: {{ .Values.connectInject.apiGateway.managedGatewayClass.defaultInstances }}
-            min: {{ .Values.connectInject.apiGateway.managedGatewayClass.minInstances }}
-            max: {{ .Values.connectInject.apiGateway.managedGatewayClass.maxInstances }}
+            default: {{ .Values.connectInject.apiGateway.managedGatewayClass.deployment.defaultInstances }}
+            min: {{ .Values.connectInject.apiGateway.managedGatewayClass.deployment.minInstances }}
+            max: {{ .Values.connectInject.apiGateway.managedGatewayClass.deployment.maxInstances }}
           {{- if .Values.connectInject.apiGateway.managedGatewayClass.tolerations }}
           tolerations: {{ fromYamlArray .Values.connectInject.apiGateway.managedGatewayClass.tolerations | toJson }}
           {{- end }}
+        {{- if .Values.connectInject.apiGateway.managedGatewayClass.service }}
         service:
-          {{- if .Values.connectInject.apiGateway.managedGatewayClass.service.annotations }}
           annotations:
             set: {{ toJson .Values.connectInject.apiGateway.managedGatewayClass.service.annotations }}
           {{- end }}
           type: {{ .Values.connectInject.apiGateway.managedGatewayClass.serviceType }}
-        {{- if .Values.connectInject.apiGateway.managedGatewayClass.serviceAccount.annotations }}
+        {{- if .Values.connectInject.apiGateway.managedGatewayClass.serviceAccount }}
         serviceAccount:
           annotations:
             set: {{ toJson .Values.connectInject.apiGateway.managedGatewayClass.serviceAccount.annotations }}
-    {{- end  }}
+        {{- end  }}
+    {{- end }}
     {{- if .Values.meshGateway.enabled  }}
     meshGateways:
       - apiVersion: mesh.consul.hashicorp.com/v2beta1

--- a/charts/consul/templates/gateway-resources-configmap.yaml
+++ b/charts/consul/templates/gateway-resources-configmap.yaml
@@ -117,13 +117,16 @@ data:
               release: {{ .Release.Name }}
               component: api-gateway
           {{- if .Values.connectInject.apiGateway.managedGatewayClass.copyAnnotations }}
+          {{- if .Values.connectInject.apiGateway.managedGatewayClass.copyAnnotations.service }}
           annotations:
-            service: {{ .Values.connectInject.apiGateway.managedGatewayClass.copyAnnotations.service }}
+            service:
+             {{ fromYamlArray .Values.connectInject.apiGateway.managedGatewayClass.copyAnnotations.service.annotations | toYaml }}
+          {{- end}}
           {{- end}}
           deployment:
             {{- if .Values.connectInject.apiGateway.managedGatewayClass.nodeSelector }}
             nodeSelector:
-              {{ fromYamlArray .Values.connectInject.apiGateway.managedGatewayClass.nodeSelector | toJson }}
+              {{ fromYamlArray .Values.connectInject.apiGateway.managedGatewayClass.nodeSelector | toYaml }}
             {{- end }}
             initContainer:
               {{- if .Values.connectInject.apiGateway.managedGatewayClass.mapPrivilegedContainerPorts }}
@@ -145,18 +148,18 @@ data:
               max: {{ .Values.connectInject.apiGateway.managedGatewayClass.deployment.maxInstances }}
             {{- if .Values.connectInject.apiGateway.managedGatewayClass.tolerations }}
             tolerations:
-              {{ fromYamlArray .Values.connectInject.apiGateway.managedGatewayClass.tolerations | toJson }}
+              {{ fromYamlArray .Values.connectInject.apiGateway.managedGatewayClass.tolerations | toYaml }}
             {{- end }}
           {{- if .Values.connectInject.apiGateway.managedGatewayClass.service }}
           service:
             annotations:
-              set: {{ toJson .Values.connectInject.apiGateway.managedGatewayClass.service.annotations }}
+              set: {{ toYaml .Values.connectInject.apiGateway.managedGatewayClass.service.annotations }}
             {{- end }}
             type: {{ .Values.connectInject.apiGateway.managedGatewayClass.serviceType }}
           {{- if .Values.connectInject.apiGateway.managedGatewayClass.serviceAccount }}
           serviceAccount:
             annotations:
-              set: {{ toJson .Values.connectInject.apiGateway.managedGatewayClass.serviceAccount.annotations }}
+              set: {{ toYaml .Values.connectInject.apiGateway.managedGatewayClass.serviceAccount.annotations }}
           {{- end  }}
       {{- end }}
     {{- if .Values.meshGateway.enabled  }}

--- a/charts/consul/test/unit/gateway-resources-configmap.bats
+++ b/charts/consul/test/unit/gateway-resources-configmap.bats
@@ -383,6 +383,8 @@ target=templates/gateway-resources-configmap.yaml
         yq -r '.data["config.yaml"]' | yq -r '.gatewayClassConfigs[0].spec.deployment' | tee /dev/stderr)
 
     local actual=$(echo "$config" | yq -r '.nodeSelector')
+    echo "${actual}"
+
     [ "${actual}" = '- key: value' ]
 }
 
@@ -415,6 +417,8 @@ target=templates/gateway-resources-configmap.yaml
         yq -r '.data["config.yaml"]' | yq -r '.gatewayClassConfigs[0].spec.deployment' | tee /dev/stderr)
 
     local actual=$(echo "$config" | yq -r '.tolerations')
+    echo "${actual}"
+
     [ "${actual}" = '- key: value' ]
 }
 
@@ -428,7 +432,7 @@ target=templates/gateway-resources-configmap.yaml
         . | tee /dev/stderr |
         yq -r '.data["config.yaml"]' | yq -r '.gatewayClassConfigs[0].spec.deployment' | tee /dev/stderr)
 
-    local actual=$(echo "$config" | yq -r '.nodeSelector')
+    local actual=$(echo "$config" | yq -r '.tolerations')
     [ "${actual}" = 'null' ]
 }
 
@@ -448,6 +452,7 @@ target=templates/gateway-resources-configmap.yaml
         yq -r '.data["config.yaml"]' | yq -r '.gatewayClassConfigs[0].spec.annotations' | tee /dev/stderr)
 
     local actual=$(echo "$config" | yq -r '.service')
+    echo "${actual}"
     [ "${actual}" = '- annotation.name' ]
 }
 
@@ -461,7 +466,7 @@ target=templates/gateway-resources-configmap.yaml
         . | tee /dev/stderr |
         yq -r '.data["config.yaml"]' | yq -r '.gatewayClassConfigs[0].spec.annotations' | tee /dev/stderr)
 
-    local actual=$(echo "$config" | yq -r '.service')
+    local actual=$(echo "$config" | jq -r '.service')
     [ "${actual}" = 'null' ]
 }
 

--- a/charts/consul/test/unit/gateway-resources-configmap.bats
+++ b/charts/consul/test/unit/gateway-resources-configmap.bats
@@ -385,7 +385,7 @@ target=templates/gateway-resources-configmap.yaml
     local actual=$(echo "$config" | yq -r '.nodeSelector')
     echo "${actual}"
 
-    [ "${actual}" = '- key: value' ]
+    [ "${actual}" = '{\n  [\n   \"annotation.name\"\n  ]\n}' ]
 }
 
 @test "gateway-resources/ConfigMap: API Gateway nodeSelector default {
@@ -416,10 +416,10 @@ target=templates/gateway-resources-configmap.yaml
         . | tee /dev/stderr |
         yq -r '.data["config.yaml"]' | yq -r '.gatewayClassConfigs[0].spec.deployment' | tee /dev/stderr)
 
-    local actual=$(echo "$config" | jq -r '.tolerations')
+    local actual=$(echo "$config" | yq -r '.tolerations')
     echo "${actual}"
 
-    [ "${actual}" = '- key: value' ]
+    [ "${actual}" = '{\n  [\n   \"annotation.name\"\n  ]\n}' ]
 }
 
 @test "gateway-resources/ConfigMap: API Gateway tolerations default {
@@ -453,7 +453,7 @@ target=templates/gateway-resources-configmap.yaml
 
     local actual=$(echo "$config" | yq -r '.service')
     echo "${actual}"
-    [ "${actual}" = '[\n \"annotation.name\"\n]'
+    [ "${actual}" = '{\n  [\n   \"annotation.name\"\n  ]\n}' ]
 }
 
 @test "gateway-resources/ConfigMap: API Gateway copyAnnotations default {

--- a/charts/consul/test/unit/gateway-resources-configmap.bats
+++ b/charts/consul/test/unit/gateway-resources-configmap.bats
@@ -385,7 +385,7 @@ target=templates/gateway-resources-configmap.yaml
     local actual=$(echo "$config" | yq -r '.nodeSelector')
     echo "${actual}"
 
-    [ "${actual}" = '{\n  [\n   "annotation.name"\n  ]\n}' ]
+    [ "${actual}" = '{\n  [\n   "key": "value"\n  ]\n}' ]
 }
 
 @test "gateway-resources/ConfigMap: API Gateway nodeSelector default {
@@ -419,7 +419,7 @@ target=templates/gateway-resources-configmap.yaml
     local actual=$(echo "$config" | yq -r '.tolerations')
     echo "${actual}"
 
-    [ "${actual}" = '{\n  [\n   "annotation.name"\n  ]\n}' ]
+    [ "${actual}" = '{\n  [\n   "key": "value"\n  ]\n}' ]
 }
 
 @test "gateway-resources/ConfigMap: API Gateway tolerations default {
@@ -453,7 +453,7 @@ target=templates/gateway-resources-configmap.yaml
 
     local actual=$(echo "$config" | yq -r '.service')
     echo "${actual}"
-    [ "${actual}" = '{\n  [\n   "annotation.name"\n  ]\n}' ]
+    [ "${actual}" = '{\n  "service": [\n   "annotation.name"\n  ]\n}' ]
 }
 
 @test "gateway-resources/ConfigMap: API Gateway copyAnnotations default {

--- a/charts/consul/test/unit/gateway-resources-configmap.bats
+++ b/charts/consul/test/unit/gateway-resources-configmap.bats
@@ -385,7 +385,7 @@ target=templates/gateway-resources-configmap.yaml
     local actual=$(echo "$config" | yq -r '.nodeSelector')
     echo "${actual}"
 
-    [ "${actual}" = '{\n  [\n   \"annotation.name\"\n  ]\n}' ]
+    [ "${actual}" = '{\n  [\n   "annotation.name"\n  ]\n}' ]
 }
 
 @test "gateway-resources/ConfigMap: API Gateway nodeSelector default {
@@ -419,7 +419,7 @@ target=templates/gateway-resources-configmap.yaml
     local actual=$(echo "$config" | yq -r '.tolerations')
     echo "${actual}"
 
-    [ "${actual}" = '{\n  [\n   \"annotation.name\"\n  ]\n}' ]
+    [ "${actual}" = '{\n  [\n   "annotation.name"\n  ]\n}' ]
 }
 
 @test "gateway-resources/ConfigMap: API Gateway tolerations default {
@@ -453,7 +453,7 @@ target=templates/gateway-resources-configmap.yaml
 
     local actual=$(echo "$config" | yq -r '.service')
     echo "${actual}"
-    [ "${actual}" = '{\n  [\n   \"annotation.name\"\n  ]\n}' ]
+    [ "${actual}" = '{\n  [\n   "annotation.name"\n  ]\n}' ]
 }
 
 @test "gateway-resources/ConfigMap: API Gateway copyAnnotations default {

--- a/charts/consul/test/unit/gateway-resources-configmap.bats
+++ b/charts/consul/test/unit/gateway-resources-configmap.bats
@@ -385,7 +385,7 @@ target=templates/gateway-resources-configmap.yaml
     local actual=$(echo "$config" | yq -r '.nodeSelector')
     echo "${actual}"
 
-    [ "${actual}" = '{\n  [\n   "key": "value"\n  ]\n}' ]
+    [ "${actual}" = '[\n  {\n    "key": "value"\n  }\n]' ]
 }
 
 @test "gateway-resources/ConfigMap: API Gateway nodeSelector default {
@@ -419,8 +419,10 @@ target=templates/gateway-resources-configmap.yaml
     local actual=$(echo "$config" | yq -r '.tolerations')
     echo "${actual}"
 
-    [ "${actual}" = '{\n  [\n   "key": "value"\n  ]\n}' ]
+    [ "${actual}" = '[\n  {\n    "key": "value"\n  }\n]' ]
 }
+
+
 
 @test "gateway-resources/ConfigMap: API Gateway tolerations default {
     cd `chart_dir`
@@ -453,7 +455,7 @@ target=templates/gateway-resources-configmap.yaml
 
     local actual=$(echo "$config" | yq -r '.service')
     echo "${actual}"
-    [ "${actual}" = '{\n  "service": [\n   "annotation.name"\n  ]\n}' ]
+    [ "${actual}" = '{\n  "service": [\n    "annotation.name"\n  ]\n}' ]
 }
 
 @test "gateway-resources/ConfigMap: API Gateway copyAnnotations default {

--- a/charts/consul/test/unit/gateway-resources-configmap.bats
+++ b/charts/consul/test/unit/gateway-resources-configmap.bats
@@ -382,13 +382,13 @@ target=templates/gateway-resources-configmap.yaml
         . | tee /dev/stderr |
         yq -r '.data["config.yaml"]' | yq -r '.gatewayClassConfigs[0].spec.deployment' | tee /dev/stderr)
 
-    local actual=$(echo "$config" | yq -r '.nodeSelector')
+    local actual=$(echo "$config" | yq -r '.nodeSelector[0].key')
     echo "actual"
     echo "${actual}"
     echo "expected"
     echo '[\n  {\n    "key": "value"\n  }\n]'
 
-    [ "${actual}" = '[\n  {\n    "key": "value"\n  }\n]' ]
+    [ "${actual}" = 'value']
 }
 
 @test "gateway-resources/ConfigMap: API Gateway nodeSelector default {
@@ -419,10 +419,10 @@ target=templates/gateway-resources-configmap.yaml
         . | tee /dev/stderr |
         yq -r '.data["config.yaml"]' | yq -r '.gatewayClassConfigs[0].spec.deployment' | tee /dev/stderr)
 
-    local actual=$(echo "$config" | yq -r '.tolerations')
+    local actual=$(echo "$config" | yq -r '.tolerations[0].key')
     echo "${actual}"
 
-    [ "${actual}" = '[\n  {\n    "key": "value"\n  }\n]' ]
+    [ "${actual}" = 'value' ]
 }
 
 
@@ -456,9 +456,9 @@ target=templates/gateway-resources-configmap.yaml
         . | tee /dev/stderr |
         yq -r '.data["config.yaml"]' | yq -r '.gatewayClassConfigs[0].spec.annotations' | tee /dev/stderr)
 
-    local actual=$(echo "$config" | yq -r '.service')
+    local actual=$(echo "$config" | yq -r '.service.service[0]')
     echo "${actual}"
-    [ "${actual}" = '{\n  "service": [\n    "annotation.name"\n  ]\n}' ]
+    [ "${actual}" = 'annotation.name' ]
 }
 
 @test "gateway-resources/ConfigMap: API Gateway copyAnnotations default {

--- a/charts/consul/test/unit/gateway-resources-configmap.bats
+++ b/charts/consul/test/unit/gateway-resources-configmap.bats
@@ -383,7 +383,10 @@ target=templates/gateway-resources-configmap.yaml
         yq -r '.data["config.yaml"]' | yq -r '.gatewayClassConfigs[0].spec.deployment' | tee /dev/stderr)
 
     local actual=$(echo "$config" | yq -r '.nodeSelector')
+    echo "actual"
     echo "${actual}"
+    echo "expected"
+    echo '[\n  {\n    "key": "value"\n  }\n]'
 
     [ "${actual}" = '[\n  {\n    "key": "value"\n  }\n]' ]
 }

--- a/charts/consul/test/unit/gateway-resources-configmap.bats
+++ b/charts/consul/test/unit/gateway-resources-configmap.bats
@@ -416,7 +416,7 @@ target=templates/gateway-resources-configmap.yaml
         . | tee /dev/stderr |
         yq -r '.data["config.yaml"]' | yq -r '.gatewayClassConfigs[0].spec.deployment' | tee /dev/stderr)
 
-    local actual=$(echo "$config" | yq -r '.tolerations')
+    local actual=$(echo "$config" | jq -r '.tolerations')
     echo "${actual}"
 
     [ "${actual}" = '- key: value' ]
@@ -453,7 +453,7 @@ target=templates/gateway-resources-configmap.yaml
 
     local actual=$(echo "$config" | yq -r '.service')
     echo "${actual}"
-    [ "${actual}" = '- annotation.name' ]
+    [ "${actual}" = '[\n \"annotation.name\"\n]'
 }
 
 @test "gateway-resources/ConfigMap: API Gateway copyAnnotations default {

--- a/charts/consul/test/unit/gateway-resources-configmap.bats
+++ b/charts/consul/test/unit/gateway-resources-configmap.bats
@@ -383,12 +383,9 @@ target=templates/gateway-resources-configmap.yaml
         yq -r '.data["config.yaml"]' | yq -r '.gatewayClassConfigs[0].spec.deployment' | tee /dev/stderr)
 
     local actual=$(echo "$config" | yq -r '.nodeSelector[0].key')
-    echo "actual"
-    echo "${actual}"
-    echo "expected"
-    echo '[\n  {\n    "key": "value"\n  }\n]'
+    echo ${actual}
 
-    [ "${actual}" = 'value']
+    [ "${actual}" = 'value' ]
 }
 
 @test "gateway-resources/ConfigMap: API Gateway nodeSelector default {
@@ -456,7 +453,7 @@ target=templates/gateway-resources-configmap.yaml
         . | tee /dev/stderr |
         yq -r '.data["config.yaml"]' | yq -r '.gatewayClassConfigs[0].spec.annotations' | tee /dev/stderr)
 
-    local actual=$(echo "$config" | yq -r '.service.service[0]')
+    local actual=$(echo "$config" | yq -r '.service[0]')
     echo "${actual}"
     [ "${actual}" = 'annotation.name' ]
 }

--- a/charts/consul/test/unit/gateway-resources-configmap.bats
+++ b/charts/consul/test/unit/gateway-resources-configmap.bats
@@ -448,7 +448,6 @@ target=templates/gateway-resources-configmap.yaml
         yq -r '.data["config.yaml"]' | yq -r '.gatewayClassConfigs[0].spec.annotations' | tee /dev/stderr)
 
     local actual=$(echo "$config" | yq -r '.service')
-    echo "${actual}"
     [ "${actual}" = '- annotation.name' ]
 }
 


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Modifed gatewayconfig map to respect apiGateway helm values
- Because the code created for meshgateway was generic enough so long as the gateway parses correctly, no further updates needed to be made

### How I've tested this PR ###
- Local install with the following minimal helm values
```
global:
  tls:
    enabled: true
  imageK8S: consul-k8s-control-plane-dev:gauntlet #or whatever you're tagging your local build image as
  logLevel: "debug"
  experiments:
    - "resource-apis"
server:
  replicas: 1
ui:
  enabled: false
apiGateway:
  managedGatewayClass:
    replicas:
      default: 1
```

### How I expect reviewers to test this PR ###
- Local install, look over

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
