### PR TITLE
[NET-7156] Gateways Controllers Reusability

### DIFF
--- a/control-plane/api/mesh/v2beta1/api_gateway_types.go
+++ b/control-plane/api/mesh/v2beta1/api_gateway_types.go
@@ -12,6 +12,8 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	inject "github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
@@ -45,6 +47,20 @@ type APIGatewayStatus struct {
 	Status    `json:"status,omitempty"`
 	Addresses []GatewayAddress `json:"addresses"`
 	Listeners []ListenerStatus `json:"listeners"`
+}
+
+func (in *APIGatewayList) ReconcileRequests() []reconcile.Request {
+	requests := make([]reconcile.Request, 0, len(in.Items))
+
+	for _, item := range in.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      item.Name,
+				Namespace: item.Namespace,
+			},
+		})
+	}
+	return requests
 }
 
 type ListenerStatus struct {

--- a/control-plane/api/mesh/v2beta1/mesh_gateway_types.go
+++ b/control-plane/api/mesh/v2beta1/mesh_gateway_types.go
@@ -12,6 +12,8 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/common"
 	inject "github.com/hashicorp/consul-k8s/control-plane/connect-inject/common"
@@ -48,6 +50,20 @@ type MeshGatewayList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []*MeshGateway `json:"items"`
+}
+
+func (in *MeshGatewayList) ReconcileRequests() []reconcile.Request {
+	requests := make([]reconcile.Request, 0, len(in.Items))
+
+	for _, item := range in.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      item.Name,
+				Namespace: item.Namespace,
+			},
+		})
+	}
+	return requests
 }
 
 func (in *MeshGateway) ResourceID(_, partition string) *pbresource.ID {

--- a/control-plane/controllers/resources/api-gateway-controller.go
+++ b/control-plane/controllers/resources/api-gateway-controller.go
@@ -64,7 +64,7 @@ func (r *APIGatewayController) UpdateStatus(ctx context.Context, obj client.Obje
 }
 
 func (r *APIGatewayController) SetupWithManager(mgr ctrl.Manager) error {
-	return setupWithManager(mgr, &meshv2beta1.APIGateway{}, r)
+	return setupGatewayControllerWithManager[*meshv2beta1.APIGatewayList](mgr, &meshv2beta1.APIGateway{}, r.Client, r)
 }
 
 func (r *APIGatewayController) onCreateUpdate(ctx context.Context, req ctrl.Request, resource *meshv2beta1.APIGateway) error {

--- a/control-plane/controllers/resources/api-gateway-controller.go
+++ b/control-plane/controllers/resources/api-gateway-controller.go
@@ -64,7 +64,7 @@ func (r *APIGatewayController) UpdateStatus(ctx context.Context, obj client.Obje
 }
 
 func (r *APIGatewayController) SetupWithManager(mgr ctrl.Manager) error {
-	return setupGatewayControllerWithManager[*meshv2beta1.APIGatewayList](mgr, &meshv2beta1.APIGateway{}, r.Client, r)
+	return setupGatewayControllerWithManager[*meshv2beta1.APIGatewayList](mgr, &meshv2beta1.APIGateway{}, r.Client, r, APIGateway_GatewayClassIndex)
 }
 
 func (r *APIGatewayController) onCreateUpdate(ctx context.Context, req ctrl.Request, resource *meshv2beta1.APIGateway) error {

--- a/control-plane/controllers/resources/gateway_controller_setup.go
+++ b/control-plane/controllers/resources/gateway_controller_setup.go
@@ -124,7 +124,7 @@ func getGatewayClassesReferencingGatewayClassConfig(ctx context.Context, k8sClie
 }
 
 // getGatewaysReferencingGatewayClass queries all xGateway resources in the cluster
-// and returns any that reference the given GatewayClass.
+// and returns any that reference the given GatewayClass by name.
 func getGatewaysReferencingGatewayClass[T gatewayList](ctx context.Context, k8sClient client.Client, className string, index indexName) (T, error) {
 	var allGateways T
 	if err := k8sClient.List(ctx, allGateways, &client.ListOptions{

--- a/control-plane/controllers/resources/gateway_controller_setup.go
+++ b/control-plane/controllers/resources/gateway_controller_setup.go
@@ -8,7 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -22,7 +21,7 @@ type gatewayList interface {
 	ReconcileRequests() []reconcile.Request
 }
 
-func setupGatewayControllerWithManager[L gatewayList](mgr ctrl.Manager, obj client.Object, k8sClient client.Client, gwc reconcile.Reconciler) error {
+func setupGatewayControllerWithManager[L gatewayList](mgr ctrl.Manager, obj client.Object, k8sClient client.Client, gwc reconcile.Reconciler, index indexName) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(obj).
 		Owns(&appsv1.Deployment{}).
@@ -33,7 +32,12 @@ func setupGatewayControllerWithManager[L gatewayList](mgr ctrl.Manager, obj clie
 		Watches(
 			source.NewKindWithCache(&meshv2beta1.GatewayClass{}, mgr.GetCache()),
 			handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
-				gateways, err := getGatewaysReferencingGatewayClass[L](context.Background(), k8sClient, o.(*meshv2beta1.GatewayClass))
+				gc := o.(*meshv2beta1.GatewayClass)
+				if gc == nil {
+					return nil
+				}
+
+				gateways, err := getGatewaysReferencingGatewayClass[L](context.Background(), k8sClient, gc.Name, index)
 				if err != nil {
 					return nil
 				}
@@ -43,14 +47,23 @@ func setupGatewayControllerWithManager[L gatewayList](mgr ctrl.Manager, obj clie
 		Watches(
 			source.NewKindWithCache(&meshv2beta1.GatewayClassConfig{}, mgr.GetCache()),
 			handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
-				classes, err := getGatewayClassesReferencingGatewayClassConfig(context.Background(), k8sClient, o.(*meshv2beta1.GatewayClassConfig))
+				gcc := o.(*meshv2beta1.GatewayClassConfig)
+				if gcc == nil {
+					return nil
+				}
+
+				classes, err := getGatewayClassesByGatewayClassConfigName(context.Background(), k8sClient, gcc.Name)
 				if err != nil {
 					return nil
 				}
 
 				var requests []reconcile.Request
 				for _, class := range classes.Items {
-					gateways, err := getGatewaysReferencingGatewayClass[L](context.Background(), k8sClient, class)
+					if class == nil {
+						continue
+					}
+
+					gateways, err := getGatewaysReferencingGatewayClass[L](context.Background(), k8sClient, class.Name, index)
 					if err != nil {
 						continue
 					}
@@ -63,45 +76,46 @@ func setupGatewayControllerWithManager[L gatewayList](mgr ctrl.Manager, obj clie
 		Complete(gwc)
 }
 
-func getGatewayClassConfigForGatewayClass(ctx context.Context, k8sClient client.Client, gatewayClass *meshv2beta1.GatewayClass) (*meshv2beta1.GatewayClassConfig, error) {
-	if gatewayClass == nil {
-		// if we don't have a gateway class we can't fetch the corresponding config
-		return nil, nil
-	}
+// TODO: uncomment when moving the CRUD hooks from mesh gateway controller
+//func getGatewayClassConfigByGatewayClassName(ctx context.Context, k8sClient client.Client, className string) (*meshv2beta1.GatewayClassConfig, error) {
+//	gatewayClass, err := getGatewayClassByName(ctx, k8sClient, className)
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	if gatewayClass == nil {
+//		return nil, nil
+//	}
+//
+//	gatewayClassConfig := &meshv2beta1.GatewayClassConfig{}
+//	if ref := gatewayClass.Spec.ParametersRef; ref != nil {
+//		if ref.Group != meshv2beta1.MeshGroup || ref.Kind != v2beta1.KindGatewayClassConfig {
+//			// TODO @Gateway-Management additionally check for controller name when available
+//			return nil, nil
+//		}
+//
+//		if err := k8sClient.Get(ctx, types.NamespacedName{Name: ref.Name}, gatewayClassConfig); err != nil {
+//			return nil, client.IgnoreNotFound(err)
+//		}
+//	}
+//	return gatewayClassConfig, nil
+//}
+//
+//func getGatewayClassByName(ctx context.Context, k8sClient client.Client, className string) (*meshv2beta1.GatewayClass, error) {
+//var gatewayClass meshv2beta1.GatewayClass
+//
+//	if err := k8sClient.Get(ctx, types.NamespacedName{Name: className}, &gatewayClass); err != nil {
+//		return nil, client.IgnoreNotFound(err)
+//	}
+//	return &gatewayClass, nil
+//}
 
-	config := &meshv2beta1.GatewayClassConfig{}
-	if ref := gatewayClass.Spec.ParametersRef; ref != nil {
-		if ref.Group != meshv2beta1.MeshGroup || ref.Kind != "GatewayClassConfig" {
-			// TODO @Gateway-Management additionally check for controller name when available
-			return nil, nil
-		}
-
-		if err := k8sClient.Get(ctx, types.NamespacedName{Name: ref.Name}, config); err != nil {
-			return nil, client.IgnoreNotFound(err)
-		}
-	}
-	return config, nil
-}
-
-func getGatewayClassForGateway(ctx context.Context, k8sClient client.Client, className string) (*meshv2beta1.GatewayClass, error) {
-	var gatewayClass meshv2beta1.GatewayClass
-
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: className}, &gatewayClass); err != nil {
-		return nil, client.IgnoreNotFound(err)
-	}
-	return &gatewayClass, nil
-}
-
-// getGatewayClassesReferencingGatewayClassConfig queries all GatewayClass resources in the
+// getGatewayClassesByGatewayClassConfigName queries all GatewayClass resources in the
 // cluster and returns any that reference the given GatewayClassConfig.
-func getGatewayClassesReferencingGatewayClassConfig(ctx context.Context, k8sClient client.Client, config *meshv2beta1.GatewayClassConfig) (*meshv2beta1.GatewayClassList, error) {
-	if config == nil {
-		return nil, nil
-	}
-
+func getGatewayClassesByGatewayClassConfigName(ctx context.Context, k8sClient client.Client, configName string) (*meshv2beta1.GatewayClassList, error) {
 	allClasses := &meshv2beta1.GatewayClassList{}
 	if err := k8sClient.List(ctx, allClasses, &client.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector(GatewayClass_GatewayClassConfigIndex, config.Name),
+		FieldSelector: fields.OneTermEqualSelector(string(GatewayClass_GatewayClassConfigIndex), configName),
 	}); err != nil {
 		return nil, client.IgnoreNotFound(err)
 	}
@@ -111,31 +125,13 @@ func getGatewayClassesReferencingGatewayClassConfig(ctx context.Context, k8sClie
 
 // getGatewaysReferencingGatewayClass queries all MeshGateway resources in the cluster
 // and returns any that reference the given GatewayClass.
-func getGatewaysReferencingGatewayClass[T gatewayList](ctx context.Context, k8sClient client.Client, class *meshv2beta1.GatewayClass) (T, error) {
-	if class == nil {
-		return nil, nil
-	}
-
+func getGatewaysReferencingGatewayClass[T gatewayList](ctx context.Context, k8sClient client.Client, className string, index indexName) (T, error) {
 	var allGateways T
 	if err := k8sClient.List(ctx, allGateways, &client.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector(Gateway_GatewayClassIndex, class.Name),
+		FieldSelector: fields.OneTermEqualSelector(string(index), className),
 	}); err != nil {
 		return nil, client.IgnoreNotFound(err)
 	}
 
 	return allGateways, nil
-}
-
-func getGatewayClassConfigForGateway(ctx context.Context, k8sClient client.Client, className string) (*meshv2beta1.GatewayClassConfig, error) {
-	gatewayClass, err := getGatewayClassForGateway(ctx, k8sClient, className)
-	if err != nil {
-		return nil, err
-	}
-
-	gatewayClassConfig, err := getGatewayClassConfigForGatewayClass(ctx, k8sClient, gatewayClass)
-	if err != nil {
-		return nil, err
-	}
-
-	return gatewayClassConfig, nil
 }

--- a/control-plane/controllers/resources/gateway_controller_setup.go
+++ b/control-plane/controllers/resources/gateway_controller_setup.go
@@ -110,9 +110,9 @@ func setupGatewayControllerWithManager[L gatewayList](mgr ctrl.Manager, obj clie
 //	return &gatewayClass, nil
 //}
 
-// getGatewayClassesByGatewayClassConfigName queries all GatewayClass resources in the
-// cluster and returns any that reference the given GatewayClassConfig.
-func getGatewayClassesByGatewayClassConfigName(ctx context.Context, k8sClient client.Client, configName string) (*meshv2beta1.GatewayClassList, error) {
+// getGatewayClassesReferencingGatewayClassConfig queries all GatewayClass resources in the
+// cluster and returns any that reference the given GatewayClassConfig by name.
+func getGatewayClassesReferencingGatewayClassConfig(ctx context.Context, k8sClient client.Client, configName string) (*meshv2beta1.GatewayClassList, error) {
 	allClasses := &meshv2beta1.GatewayClassList{}
 	if err := k8sClient.List(ctx, allClasses, &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(string(GatewayClass_GatewayClassConfigIndex), configName),

--- a/control-plane/controllers/resources/gateway_controller_setup.go
+++ b/control-plane/controllers/resources/gateway_controller_setup.go
@@ -123,7 +123,7 @@ func getGatewayClassesByGatewayClassConfigName(ctx context.Context, k8sClient cl
 	return allClasses, nil
 }
 
-// getGatewaysReferencingGatewayClass queries all MeshGateway resources in the cluster
+// getGatewaysReferencingGatewayClass queries all xGateway resources in the cluster
 // and returns any that reference the given GatewayClass.
 func getGatewaysReferencingGatewayClass[T gatewayList](ctx context.Context, k8sClient client.Client, className string, index indexName) (T, error) {
 	var allGateways T

--- a/control-plane/controllers/resources/gateway_controller_setup.go
+++ b/control-plane/controllers/resources/gateway_controller_setup.go
@@ -52,7 +52,7 @@ func setupGatewayControllerWithManager[L gatewayList](mgr ctrl.Manager, obj clie
 					return nil
 				}
 
-				classes, err := getGatewayClassesByGatewayClassConfigName(context.Background(), k8sClient, gcc.Name)
+				classes, err := getGatewayClassesReferencingGatewayClassConfig(context.Background(), k8sClient, gcc.Name)
 				if err != nil {
 					return nil
 				}

--- a/control-plane/controllers/resources/gateway_controller_setup.go
+++ b/control-plane/controllers/resources/gateway_controller_setup.go
@@ -1,0 +1,141 @@
+package resources
+
+import (
+	"context"
+
+	meshv2beta1 "github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+type gatewayList interface {
+	*meshv2beta1.MeshGatewayList | *meshv2beta1.APIGatewayList
+	client.ObjectList
+	ReconcileRequests() []reconcile.Request
+}
+
+func setupGatewayControllerWithManager[L gatewayList](mgr ctrl.Manager, obj client.Object, k8sClient client.Client, gwc reconcile.Reconciler) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(obj).
+		Owns(&appsv1.Deployment{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.ServiceAccount{}).
+		Watches(
+			source.NewKindWithCache(&meshv2beta1.GatewayClass{}, mgr.GetCache()),
+			handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
+				gateways, err := getGatewaysReferencingGatewayClass[L](context.Background(), k8sClient, o.(*meshv2beta1.GatewayClass))
+				if err != nil {
+					return nil
+				}
+
+				return gateways.ReconcileRequests()
+			})).
+		Watches(
+			source.NewKindWithCache(&meshv2beta1.GatewayClassConfig{}, mgr.GetCache()),
+			handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
+				classes, err := getGatewayClassesReferencingGatewayClassConfig(context.Background(), k8sClient, o.(*meshv2beta1.GatewayClassConfig))
+				if err != nil {
+					return nil
+				}
+
+				var requests []reconcile.Request
+				for _, class := range classes.Items {
+					gateways, err := getGatewaysReferencingGatewayClass[L](context.Background(), k8sClient, class)
+					if err != nil {
+						continue
+					}
+
+					requests = append(requests, gateways.ReconcileRequests()...)
+				}
+
+				return requests
+			})).
+		Complete(gwc)
+}
+
+func getGatewayClassConfigForGatewayClass(ctx context.Context, k8sClient client.Client, gatewayClass *meshv2beta1.GatewayClass) (*meshv2beta1.GatewayClassConfig, error) {
+	if gatewayClass == nil {
+		// if we don't have a gateway class we can't fetch the corresponding config
+		return nil, nil
+	}
+
+	config := &meshv2beta1.GatewayClassConfig{}
+	if ref := gatewayClass.Spec.ParametersRef; ref != nil {
+		if ref.Group != meshv2beta1.MeshGroup || ref.Kind != "GatewayClassConfig" {
+			// TODO @Gateway-Management additionally check for controller name when available
+			return nil, nil
+		}
+
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: ref.Name}, config); err != nil {
+			return nil, client.IgnoreNotFound(err)
+		}
+	}
+	return config, nil
+}
+
+func getGatewayClassForGateway(ctx context.Context, k8sClient client.Client, className string) (*meshv2beta1.GatewayClass, error) {
+	var gatewayClass meshv2beta1.GatewayClass
+
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: className}, &gatewayClass); err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+	return &gatewayClass, nil
+}
+
+// getGatewayClassesReferencingGatewayClassConfig queries all GatewayClass resources in the
+// cluster and returns any that reference the given GatewayClassConfig.
+func getGatewayClassesReferencingGatewayClassConfig(ctx context.Context, k8sClient client.Client, config *meshv2beta1.GatewayClassConfig) (*meshv2beta1.GatewayClassList, error) {
+	if config == nil {
+		return nil, nil
+	}
+
+	allClasses := &meshv2beta1.GatewayClassList{}
+	if err := k8sClient.List(ctx, allClasses, &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(GatewayClass_GatewayClassConfigIndex, config.Name),
+	}); err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+
+	return allClasses, nil
+}
+
+// getGatewaysReferencingGatewayClass queries all MeshGateway resources in the cluster
+// and returns any that reference the given GatewayClass.
+func getGatewaysReferencingGatewayClass[T gatewayList](ctx context.Context, k8sClient client.Client, class *meshv2beta1.GatewayClass) (T, error) {
+	if class == nil {
+		return nil, nil
+	}
+
+	var allGateways T
+	if err := k8sClient.List(ctx, allGateways, &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(Gateway_GatewayClassIndex, class.Name),
+	}); err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+
+	return allGateways, nil
+}
+
+func getGatewayClassConfigForGateway(ctx context.Context, k8sClient client.Client, className string) (*meshv2beta1.GatewayClassConfig, error) {
+	gatewayClass, err := getGatewayClassForGateway(ctx, k8sClient, className)
+	if err != nil {
+		return nil, err
+	}
+
+	gatewayClassConfig, err := getGatewayClassConfigForGatewayClass(ctx, k8sClient, gatewayClass)
+	if err != nil {
+		return nil, err
+	}
+
+	return gatewayClassConfig, nil
+}

--- a/control-plane/controllers/resources/gateway_indices.go
+++ b/control-plane/controllers/resources/gateway_indices.go
@@ -8,16 +8,19 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	"github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
 	meshv2beta1 "github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
 )
 
+type indexName string
+
 const (
 	// Naming convention: TARGET_REFERENCE.
-	GatewayClass_GatewayClassConfigIndex = "__v2_gatewayclass_referencing_gatewayclassconfig"
+	GatewayClass_GatewayClassConfigIndex indexName = "__v2_gatewayclass_referencing_gatewayclassconfig"
 
-	Gateway_GatewayClassIndex = "__v2_gateway_referencing_gatewayclass"
+	APIGateway_GatewayClassIndex  indexName = "__v2_api_gateway_referencing_gatewayclass"
+	MeshGateway_GatewayClassIndex indexName = "__v2_mesh_gateway_referencing_gatewayclass"
 )
 
 // RegisterFieldIndexes registers all of the field indexes for the API gateway controllers.
@@ -25,7 +28,7 @@ const (
 // They allow us to quickly find objects based on a field value.
 func RegisterFieldIndexes(ctx context.Context, mgr ctrl.Manager) error {
 	for _, index := range indexes {
-		if err := mgr.GetFieldIndexer().IndexField(ctx, index.target, index.name, index.indexerFunc); err != nil {
+		if err := mgr.GetFieldIndexer().IndexField(ctx, index.target, string(index.name), index.indexerFunc); err != nil {
 			return err
 		}
 	}
@@ -33,38 +36,40 @@ func RegisterFieldIndexes(ctx context.Context, mgr ctrl.Manager) error {
 }
 
 type index struct {
-	name        string
+	name        indexName
 	target      client.Object
 	indexerFunc client.IndexerFunc
 }
 
 var indexes = []index{
 	{
-		name:        GatewayClass_GatewayClassConfigIndex,
-		target:      &meshv2beta1.GatewayClass{},
-		indexerFunc: gatewayClassConfigForGatewayClass,
+		name:   GatewayClass_GatewayClassConfigIndex,
+		target: &meshv2beta1.GatewayClass{},
+		indexerFunc: func(o client.Object) []string {
+			gc := o.(*meshv2beta1.GatewayClass)
+
+			pr := gc.Spec.ParametersRef
+			if pr != nil && pr.Kind == v2beta1.KindGatewayClassConfig {
+				return []string{pr.Name}
+			}
+
+			return []string{}
+		},
 	},
 	{
-		name:        Gateway_GatewayClassIndex,
-		target:      &gwv1beta1.Gateway{},
-		indexerFunc: gatewayClassForGateway,
+		name:   APIGateway_GatewayClassIndex,
+		target: &meshv2beta1.APIGateway{},
+		indexerFunc: func(o client.Object) []string {
+			g := o.(*meshv2beta1.APIGateway)
+			return []string{string(g.Spec.GatewayClassName)}
+		},
 	},
-}
-
-// gatewayClassConfigForGatewayClass creates an index of every GatewayClassConfig referenced by a GatewayClass.
-func gatewayClassConfigForGatewayClass(o client.Object) []string {
-	gc := o.(*meshv2beta1.GatewayClass)
-
-	pr := gc.Spec.ParametersRef
-	if pr != nil && pr.Kind == "GatewayClassConfig" {
-		return []string{pr.Name}
-	}
-
-	return []string{}
-}
-
-// gatewayClassForGateway creates an index of every GatewayClass referenced by a Gateway.
-func gatewayClassForGateway(o client.Object) []string {
-	g := o.(*meshv2beta1.APIGateway)
-	return []string{string(g.Spec.GatewayClassName)}
+	{
+		name:   MeshGateway_GatewayClassIndex,
+		target: &meshv2beta1.MeshGateway{},
+		indexerFunc: func(o client.Object) []string {
+			g := o.(*meshv2beta1.MeshGateway)
+			return []string{string(g.Spec.GatewayClassName)}
+		},
+	},
 }

--- a/control-plane/controllers/resources/gateway_indices.go
+++ b/control-plane/controllers/resources/gateway_indices.go
@@ -1,0 +1,70 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resources
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	meshv2beta1 "github.com/hashicorp/consul-k8s/control-plane/api/mesh/v2beta1"
+)
+
+const (
+	// Naming convention: TARGET_REFERENCE.
+	GatewayClass_GatewayClassConfigIndex = "__v2_gatewayclass_referencing_gatewayclassconfig"
+
+	Gateway_GatewayClassIndex = "__v2_gateway_referencing_gatewayclass"
+)
+
+// RegisterFieldIndexes registers all of the field indexes for the API gateway controllers.
+// These indexes are similar to indexes used in databases to speed up queries.
+// They allow us to quickly find objects based on a field value.
+func RegisterFieldIndexes(ctx context.Context, mgr ctrl.Manager) error {
+	for _, index := range indexes {
+		if err := mgr.GetFieldIndexer().IndexField(ctx, index.target, index.name, index.indexerFunc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type index struct {
+	name        string
+	target      client.Object
+	indexerFunc client.IndexerFunc
+}
+
+var indexes = []index{
+	{
+		name:        GatewayClass_GatewayClassConfigIndex,
+		target:      &meshv2beta1.GatewayClass{},
+		indexerFunc: gatewayClassConfigForGatewayClass,
+	},
+	{
+		name:        Gateway_GatewayClassIndex,
+		target:      &gwv1beta1.Gateway{},
+		indexerFunc: gatewayClassForGateway,
+	},
+}
+
+// gatewayClassConfigForGatewayClass creates an index of every GatewayClassConfig referenced by a GatewayClass.
+func gatewayClassConfigForGatewayClass(o client.Object) []string {
+	gc := o.(*meshv2beta1.GatewayClass)
+
+	pr := gc.Spec.ParametersRef
+	if pr != nil && pr.Kind == "GatewayClassConfig" {
+		return []string{pr.Name}
+	}
+
+	return []string{}
+}
+
+// gatewayClassForGateway creates an index of every GatewayClass referenced by a Gateway.
+func gatewayClassForGateway(o client.Object) []string {
+	g := o.(*meshv2beta1.APIGateway)
+	return []string{string(g.Spec.GatewayClassName)}
+}

--- a/control-plane/controllers/resources/gateway_indices.go
+++ b/control-plane/controllers/resources/gateway_indices.go
@@ -23,10 +23,10 @@ const (
 	MeshGateway_GatewayClassIndex indexName = "__v2_mesh_gateway_referencing_gatewayclass"
 )
 
-// RegisterFieldIndexes registers all of the field indexes for the API gateway controllers.
+// RegisterGatewayFieldIndexes registers all of the field indexes for the xGateway controllers.
 // These indexes are similar to indexes used in databases to speed up queries.
 // They allow us to quickly find objects based on a field value.
-func RegisterFieldIndexes(ctx context.Context, mgr ctrl.Manager) error {
+func RegisterGatewayFieldIndexes(ctx context.Context, mgr ctrl.Manager) error {
 	for _, index := range indexes {
 		if err := mgr.GetFieldIndexer().IndexField(ctx, index.target, string(index.name), index.indexerFunc); err != nil {
 			return err

--- a/control-plane/controllers/resources/mesh_gateway_controller.go
+++ b/control-plane/controllers/resources/mesh_gateway_controller.go
@@ -77,7 +77,7 @@ func (r *MeshGatewayController) UpdateStatus(ctx context.Context, obj client.Obj
 }
 
 func (r *MeshGatewayController) SetupWithManager(mgr ctrl.Manager) error {
-	return setupGatewayControllerWithManager[*meshv2beta1.MeshGatewayList](mgr, &meshv2beta1.MeshGateway{}, r.Client, r)
+	return setupGatewayControllerWithManager[*meshv2beta1.MeshGatewayList](mgr, &meshv2beta1.MeshGateway{}, r.Client, r, MeshGateway_GatewayClassIndex)
 }
 
 // onCreateUpdate is responsible for creating/updating all K8s resources that
@@ -279,46 +279,4 @@ func (r *MeshGatewayController) getGatewayClassForGateway(ctx context.Context, g
 		return nil, client.IgnoreNotFound(err)
 	}
 	return &gatewayClass, nil
-}
-
-// getGatewayClassesReferencingGatewayClassConfig queries all GatewayClass resources in the
-// cluster and returns any that reference the given GatewayClassConfig.
-func (r *MeshGatewayController) getGatewayClassesReferencingGatewayClassConfig(ctx context.Context, config *meshv2beta1.GatewayClassConfig) (*meshv2beta1.GatewayClassList, error) {
-	if config == nil {
-		return nil, nil
-	}
-
-	allClasses := &meshv2beta1.GatewayClassList{}
-	if err := r.Client.List(ctx, allClasses); err != nil {
-		return nil, client.IgnoreNotFound(err)
-	}
-
-	matchingClasses := &meshv2beta1.GatewayClassList{}
-	for _, class := range allClasses.Items {
-		if class.Spec.ParametersRef != nil && class.Spec.ParametersRef.Name == config.Name {
-			matchingClasses.Items = append(matchingClasses.Items, class)
-		}
-	}
-	return matchingClasses, nil
-}
-
-// getGatewaysReferencingGatewayClass queries all MeshGateway resources in the cluster
-// and returns any that reference the given GatewayClass.
-func (r *MeshGatewayController) getGatewaysReferencingGatewayClass(ctx context.Context, class *meshv2beta1.GatewayClass) (*meshv2beta1.MeshGatewayList, error) {
-	if class == nil {
-		return nil, nil
-	}
-
-	allGateways := &meshv2beta1.MeshGatewayList{}
-	if err := r.Client.List(ctx, allGateways); err != nil {
-		return nil, client.IgnoreNotFound(err)
-	}
-
-	matchingGateways := &meshv2beta1.MeshGatewayList{}
-	for _, gateway := range allGateways.Items {
-		if gateway.Spec.GatewayClassName == class.Name {
-			matchingGateways.Items = append(matchingGateways.Items, gateway)
-		}
-	}
-	return matchingGateways, nil
 }

--- a/control-plane/subcommand/inject-connect/v2controllers.go
+++ b/control-plane/subcommand/inject-connect/v2controllers.go
@@ -200,7 +200,7 @@ func (c *Command) configureV2Controllers(ctx context.Context, mgr manager.Manage
 		return err
 	}
 
-	if err := resourceControllers.RegisterFieldIndexes(ctx, mgr); err != nil {
+	if err := resourceControllers.RegisterGatewayFieldIndexes(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to register field indexes")
 		return err
 	}

--- a/control-plane/subcommand/inject-connect/v2controllers.go
+++ b/control-plane/subcommand/inject-connect/v2controllers.go
@@ -200,6 +200,11 @@ func (c *Command) configureV2Controllers(ctx context.Context, mgr manager.Manage
 		return err
 	}
 
+	if err := resourceControllers.RegisterFieldIndexes(ctx, mgr); err != nil {
+		setupLog.Error(err, "unable to register field indexes")
+		return err
+	}
+
 	if err := (&resourceControllers.MeshConfigurationController{
 		Controller: consulResourceController,
 		Client:     mgr.GetClient(),


### PR DESCRIPTION
### Changes proposed in this PR ###  
- adds indices onto the gateway resources in k8s for faster lookups as well as easier to read code
- makes the setup for a gateway controller generic so it can be reused across gateway types

### How I've tested this PR ###
- ran mesh gateways before and after, all works the same

### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
