### PR TITLE
[NET-7657] Consume version of proto-public with GatewayClass[Config] removed

### DIFF
--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -2,7 +2,7 @@ module github.com/hashicorp/consul-k8s/control-plane
 
 // TODO: Remove this when the next version of the submodule is released.
 // We need to use a replace directive instead of directly pinning because `api` requires version `0.5.1` and will clobber the pin, but not the replace directive.
-replace github.com/hashicorp/consul/proto-public => github.com/hashicorp/consul/proto-public v0.1.2-0.20240202204845-fb2b696c0e6b
+replace github.com/hashicorp/consul/proto-public => github.com/hashicorp/consul/proto-public v0.1.2-0.20240207215339-2456fe5148bd
 
 replace github.com/hashicorp/consul/sdk => github.com/hashicorp/consul/sdk v0.4.1-0.20231213150639-123bc95e1a3f
 

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -265,8 +265,8 @@ github.com/hashicorp/consul-server-connection-manager v0.1.6 h1:ktj8Fi+dRXn9hhM+
 github.com/hashicorp/consul-server-connection-manager v0.1.6/go.mod h1:HngMIv57MT+pqCVeRQMa1eTB5dqnyMm8uxjyv+Hn8cs=
 github.com/hashicorp/consul/api v1.10.1-0.20240122152324-758ddf84e9c9 h1:qaS6rE768dt5hGPl2y4DIABXF4eA23BNSmWFpEr3kWQ=
 github.com/hashicorp/consul/api v1.10.1-0.20240122152324-758ddf84e9c9/go.mod h1:gInwZGrnWlE1Vvq6rSD5pUf6qwNa69NTLLknbdwQRUk=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20240202204845-fb2b696c0e6b h1:SQNk1hzihCm9jnbuJvtzUpNvYtum1NUxVeu9jwX9TgQ=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20240202204845-fb2b696c0e6b/go.mod h1:ar/M/Gv31GeE7DxektZgAydwsCiOf6sBeJFcjQVTlVs=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20240207215339-2456fe5148bd h1:xNTNL7j7qNNhH68bxHabcsS3GKL6T1OEMYDbbxJ42qI=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20240207215339-2456fe5148bd/go.mod h1:JF6983XNCzvw4wDNOLEwLqOq2IPw7iyT+pkswHSz08U=
 github.com/hashicorp/consul/sdk v0.4.1-0.20231213150639-123bc95e1a3f h1:GKsa7bfoL7xgvCkzYJMF9eYYNfLWQyk8QuRZZl4nMTo=
 github.com/hashicorp/consul/sdk v0.4.1-0.20231213150639-123bc95e1a3f/go.mod h1:r/OmRRPbHOe0yxNahLw7G9x5WG17E1BIECMtCjcPSNo=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
### Changes proposed in this PR ###  
This is a followup to #3559 and https://github.com/hashicorp/consul/pull/20523 which removed the usage of and the model of `GatewayClass` and `GatewayClassConfig`, respectively.

### How I've tested this PR ###
🤖 tests pass

### How I expect reviewers to test this PR ###
See above

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
