### PR TITLE
release: Update 10-util.sh to adjust formatting

### DIFF
--- a/control-plane/build-support/functions/10-util.sh
+++ b/control-plane/build-support/functions/10-util.sh
@@ -761,7 +761,7 @@ function set_changelog {
         fi
         compatibility_note="
 
-_Note: Consul K8s ${version_short} is compatible with Consul ${consul_version_short} and Consul Dataplane ${consul_dataplane_version_short}. Refer to our [compatibility matrix](https://developer.hashicorp.com/consul/docs/k8s/compatibility) for more info._"
+> NOTE: Consul K8s ${version_short}.x is compatible with Consul ${consul_version_short}.x and Consul Dataplane ${consul_dataplane_version_short}.x. Refer to our [compatibility matrix](https://developer.hashicorp.com/consul/docs/k8s/compatibility) for more info."
     fi
 
 	cat <<EOT | cat - "${curdir}"/CHANGELOG.MD >tmp && mv tmp "${curdir}"/CHANGELOG.MD


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Previous formatting (example), was not being rendered correctly 

    _ Note: Consul K8s 1.4 is compatible with Consul 1.18 and Consul Dataplane 1.4. Refer to our [compatibility matrix](https://developer.hashicorp.com/consul/docs/k8s/compatibility) for more info._

- New formatting (example) 

    > NOTE: Consul K8s 1.4.x is compatible with Consul 1.18.x and Consul Dataplane 1.4.x. Refer to our [compatibility matrix](https://developer.hashicorp.com/consul/docs/k8s/compatibility) for more info.

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
