### PR TITLE
add make target script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,6 +309,14 @@ eks-test-packages: ## eks test packages
 aks-test-packages: ## aks test packages
 	@./control-plane/build-support/scripts/set_test_package_matrix.sh "acceptance/ci-inputs/aks_acceptance_test_packages.yaml"
 
+.PHONY: go-mod-tidy
+go-mod-tidy: ## Recursively run go mod tidy on all subdirectories
+	@./control-plane/build-support/scripts/mod_tidy.sh
+
+.PHONY: check-mod-tidy
+check-mod-tidy: ## Recursively run go mod tidy on all subdirectories and check if there are any changes
+	@./control-plane/build-support/scripts/mod_tidy.sh --check
+
 ##@ Release Targets
 
 .PHONY: check-env

--- a/control-plane/build-support/scripts/mod_tidy.sh
+++ b/control-plane/build-support/scripts/mod_tidy.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+CHECK=false
+
+# Check if the --check argument is passed
+for arg in "$@"
+do
+    if [ "$arg" == "--check" ]
+    then
+        CHECK=true
+    fi
+done
+
+# Find directories containing a go.mod file
+for dir in $(find . -type f -name go.mod -exec dirname {} \;); do
+    # Change into the directory
+    cd "$dir" || exit
+
+    # Run go mod tidy
+    echo "Running go mod tidy in $dir"
+    go mod tidy
+
+    # Change back to the original directory
+    cd - || exit
+done
+
+# Check for differences if the --check argument was passed
+if [ "$CHECK" = true ]; then
+    if [[ -n "$(git status --porcelain)" ]]; then
+        echo "differences were found in go.mod or go.sum, run go mod tidy to fix them"
+        exit 1
+    fi
+fi


### PR DESCRIPTION
### Changes proposed in this PR ###  
This adds a script and a make target for running `go mod tidy` recursively. It also adds a new target that reports back an error if go mod tidy needs to be run. This is useful for CI.

### How I've tested this PR ###
I committed a change locally of an incorrect `go.mod` file then ran the script with and without the check. Verified check behaviour returns an error.

### How I expect reviewers to test this PR ###
👀 

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
