### PR TITLE
add linting back

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,68 @@
+# Dispatch to the consul-k8s-workflows when a PR is created and on merges to main/release*
+name: lint
+on:
+  pull_request:
+
+jobs:
+    get-go-version:
+      runs-on: ubuntu-latest
+      outputs:
+        go-version: ${{ steps.get-go-version.outputs.go-version }}
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+        - name: Determine Go version
+          id: get-go-version
+          # We use .go-version as our source of truth for current Go
+          # version, because "goenv" can react to it automatically.
+          run: |
+            echo "Building with Go $(cat .go-version)"
+            echo "go-version=$(cat .go-version)" >> "${GITHUB_OUTPUT}"
+
+    linting:
+      name: golangci-lint
+      needs:
+        - get-go-version
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+        - name: Setup go
+          uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+          with:
+            go-version: ${{ needs.get-go-version.outputs.go-version }}
+            cache: false
+
+        - name: Setup GOROOT  # Need to set GOROOT because an older version of go-critic used GOROOT to find rules
+          run: echo "GOROOT=$(go env GOROOT)" >> "${GITHUB_ENV}"
+
+        - name: golangci-lint-helm-gen
+          uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
+          with:
+            version: "v1.55.2"
+            working-directory: hack/helm-reference-gen
+            skip-cache: true  # We have seen sticky timeout bugs crop up with caching enabled, so disabling for now
+            args: "--no-config --disable-all --enable gofmt,govet"
+
+        - name: golangci-lint-control-plane
+          uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
+          with:
+            version: "v1.55.2"
+            working-directory: control-plane
+            skip-cache: true  # We have seen sticky timeout bugs crop up with caching enabled, so disabling for now
+
+        - name: golangci-lint-acceptance
+          uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
+          with:
+            version: "v1.55.2"
+            working-directory: acceptance
+            skip-cache: true  # We have seen sticky timeout bugs crop up with caching enabled, so disabling for now
+
+        - name: golangci-lint-cli
+          uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
+          with:
+            version: "v1.55.2"
+            working-directory: acceptance
+            skip-cache: true  # We have seen sticky timeout bugs crop up with caching enabled, so disabling for now


### PR DESCRIPTION
### Changes proposed in this PR ###  
- This PR adds linting back to the source repo. This has some advantages as it allows for the linting workflow to mark errors in the `files changed`

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
