### PR TITLE
[DONOTMERGE] tmp: run acceptance tests targeting Envoy 1.26.7 via custom Dataplane

### DIFF
--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -17,7 +17,7 @@ annotations:
     - name: consul-k8s-control-plane
       image: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.1.9-dev
     - name: consul-dataplane
-      image: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.1-dev
+      image: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.1-dev-ec80631908d436f26f275418f563885691128e64
     - name: envoy
       image: envoyproxy/envoy:v1.25.11
   artifacthub.io/license: MPL-2.0

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -639,7 +639,7 @@ global:
   # The name (and tag) of the consul-dataplane Docker image used for the
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
   # @default: hashicorp/consul-dataplane:<latest supported version>
-  imageConsulDataplane: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.1-dev
+  imageConsulDataplane: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.1-dev-ec80631908d436f26f275418f563885691128e64
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.


### PR DESCRIPTION
To vet the Consul 1.15 / consul-k8s 1.1 upgrade from Envoy 1.25 to 1.26.7, run acceptance tests using these new versions.

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
