### PR TITLE
Datadog Unix Socket Path Custom Path fix

### DIFF
--- a/.changelog/3635.txt
+++ b/.changelog/3635.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-helm: updated `server-statefulset.yaml` templating to handle custom Unix Domain Socket paths.
+helm: (datadog integration) updated `server-statefulset.yaml` templating to handle custom Unix Domain Socket paths.
 ```

--- a/.changelog/3635.txt
+++ b/.changelog/3635.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+helm: updated `server-statefulset.yaml` templating to handle custom Unix Domain Socket paths.
+```

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -292,7 +292,7 @@ spec:
         {{- if and .Values.global.metrics.datadog.enabled .Values.global.metrics.datadog.dogstatsd.enabled (eq .Values.global.metrics.datadog.dogstatsd.socketTransportType "UDS" ) }}
         - name: dsdsocket
           hostPath:
-            path: /var/run/datadog
+            path: {{ dir .Values.global.metrics.datadog.dogstatsd.dogstatsdAddr | trimAll "\"" }}
             type: DirectoryOrCreate
         {{- end }}
         {{- range .Values.server.extraVolumes }}
@@ -542,7 +542,7 @@ spec:
             {{- end }}
             {{- if and .Values.global.metrics.datadog.enabled .Values.global.metrics.datadog.dogstatsd.enabled (eq .Values.global.metrics.datadog.dogstatsd.socketTransportType "UDS" ) }}
             - name: dsdsocket
-              mountPath: /var/run/datadog
+              mountPath: {{ dir .Values.global.metrics.datadog.dogstatsd.dogstatsdAddr | trimAll "\"" }}
               readOnly: true
             {{- end }}
             {{- range .Values.server.extraVolumes }}

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1070,6 +1070,37 @@ load _helpers
   [ "${actual}" = "consul-server" ]
 }
 
+@test "server/StatefulSet: datadog unix socket path name rendering for hostPath volume and volumeMount using default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml \
+      --set 'global.metrics.enabled=true'  \
+      --set 'telemetryCollector.enabled=true' \
+      --set 'global.metrics.enableAgentMetrics=true'  \
+      --set 'global.metrics.datadog.enabled=true' \
+      --set 'global.metrics.datadog.dogstatsd.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.volumes[] | select(.name=="dsdsocket") | .hostPath.path' | tee /dev/stderr)
+
+  [ "${actual}" = "/var/run/datadog" ]
+}
+
+@test "server/StatefulSet: datadog unix socket path name rendering for hostPath volume and volumeMount using non default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml \
+      --set 'global.metrics.enabled=true'  \
+      --set 'telemetryCollector.enabled=true' \
+      --set 'global.metrics.enableAgentMetrics=true'  \
+      --set 'global.metrics.datadog.enabled=true' \
+      --set 'global.metrics.datadog.dogstatsd.enabled=true' \
+      --set 'global.metrics.datadog.dogstatsd.dogstatsdAddr="/this/otherpath/datadog/dsd.socket"' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.volumes[] | select(.name=="dsdsocket") | .hostPath.path' | tee /dev/stderr)
+
+  [ "${actual}" = "/this/otherpath/datadog" ]
+}
+
 #--------------------------------------------------------------------
 # config-configmap
 


### PR DESCRIPTION
### Changes proposed in this PR ###  

Initial integration hard-coded Unix Domain Socket `hostPath` for the consul-server statefulset, making the Helm override `global.metrics.datadog.dogstatsd.dogstatsdAddr` not useful if users wanted/needed a custom UDS socket path beyond the default value of `/var/run/datadog`.

```yaml
# server-statefulset.yaml
...
        volumes:
            - name: dsdsocket
              hostPath:
                  path: /var/run/datadog
                  type: DirectoryOrCreate
```

This PR updates this to use the helm override as intended for custom UDS paths

```yaml
# server-statefulset.yaml
...
        volumes:
            - name: dsdsocket
              hostPath:
                  path: {{ dir .Values.global.metrics.datadog.dogstatsd.dogstatsdAddr | trimAll "\"" }}
                  type: DirectoryOrCreate
```

### How I've tested this PR ###

Updated `server-statefulset.bats` with the following tests for default and non-default paths:

- `"server/StatefulSet: datadog unix socket path name rendering for hostPath volume and volumeMount using default"`
- `"server/StatefulSet: datadog unix socket path name rendering for hostPath volume and volumeMount using non default"`

Tested locally running a k3d cluster with latest build. [Repo](https://github.com/hashicorp-support/consul-k3d-multicluster.git)

### How I expect reviewers to test this PR ###

👀 Acceptance test results

### Checklist ###
- [X] Tests added
- [X] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
