### PR TITLE
[NET-8174] security: add scan triage for CVE-2024-25620 (helm/v3)

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -13,19 +13,28 @@
 # See `security-scanner` docs or run with `--help` for scan target syntax.
 
 container {
-	dependencies = true
-	alpine_secdb = true
+  dependencies = true
+  alpine_secdb = true
 
-	secrets {
-		all = true
-	}
+  secrets {
+    all = true
+  }
 }
 
 binary {
-	go_modules   = true
-	osv          = true
+  go_modules   = true
+  osv          = true
 
-	secrets {
-		all = true
-	}
+  secrets {
+    all = true
+  }
+
+  triage {
+    suppress {
+      vulnerabilites = [
+        # NET-8174 (2024-02-20): Chart YAML path traversal (not impacted)
+        "GHSA-v53g-5gjp-272r", # alias CVE-2024-25620
+      ]
+    }
+  }
 }

--- a/scan.hcl
+++ b/scan.hcl
@@ -31,6 +31,10 @@ repository {
         "acceptance/*",
         "hack/*",
       ]
+      vulnerabilites = [
+        # NET-8174 (2024-02-20): Chart YAML path traversal (not impacted)
+		"GHSA-v53g-5gjp-272r", # alias CVE-2024-25620
+      ]
     }
   }
 }


### PR DESCRIPTION
Triage this scan result as `consul-k8s` should not be directly impacted and it is medium severity. Follow-up ticket filed for remediation.

### Changes proposed in this PR ###  
- Triage CVE-2024-25620 security scan result
- Improve formatting of scan config since this change will be backported.

### How I've tested this PR ###
Local scan has no further Go Modules OSV results when applied. Same with repository scan in CI (see checks below).

### How I expect reviewers to test this PR ###
👀 

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
