### PR TITLE
build.yml: Add ECR images back

### DIFF
--- a/.changelog/3668.txt
+++ b/.changelog/3668.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+control-plane: publish `consul-k8s-controlplane` and `consul-k8s-control-plane-fips` images to official HashiCorp AWS ECR. 
+```

--- a/.changelog/3668.txt
+++ b/.changelog/3668.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-control-plane: publish `consul-k8s-controlplane` and `consul-k8s-control-plane-fips` images to official HashiCorp AWS ECR. 
+control-plane: publish `consul-k8s-control-plane` and `consul-k8s-control-plane-fips` images to official HashiCorp AWS ECR. 
 ```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,6 +291,7 @@ jobs:
           workdir: control-plane
           tags: |
             docker.io/hashicorp/${{ env.repo }}-control-plane:${{ env.version }}
+            public.ecr.aws/hashicorp/${{ env.repo }}-control-plane:${{ env.version }}
           dev_tags: |
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.full_dev_tag }}
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.full_dev_tag }}-${{ github.sha }}
@@ -318,6 +319,7 @@ jobs:
           workdir: control-plane
           tags: |
             docker.io/hashicorp/${{ env.repo }}-control-plane-fips:${{ env.version }}
+            public.ecr.aws/hashicorp/${{ env.repo }}-control-plane-fips:${{ env.version }}
           dev_tags: |
             docker.io/hashicorppreview/${{ env.repo }}-control-plane-fips:${{ env.full_dev_tag }}
             docker.io/hashicorppreview/${{ env.repo }}-control-plane-fips:${{ env.full_dev_tag }}-${{ github.sha }}
@@ -381,6 +383,7 @@ jobs:
           workdir: control-plane
           tags: |
             docker.io/hashicorp/${{ env.repo }}-control-plane:${{ env.version }}-ubi
+            public.ecr.aws/hashicorp/${{ env.repo }}-control-plane:${{ env.version }}-ubi
           dev_tags: |
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.full_dev_tag }}-ubi
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.full_dev_tag }}-ubi-${{ github.sha }}
@@ -407,6 +410,8 @@ jobs:
           pkg_name: consul-k8s-control-plane_${{ env.version }}
           bin_name: consul-k8s-control-plane
           workdir: control-plane
+          tags: 
+            public.ecr.aws/hashicorp/${{ env.repo }}-control-plane-fips:${{ env.version }}-ubi
           redhat_tag: quay.io/redhat-isv-containers/6486b1beabfc4e51588c0416:${{env.version}}-ubi # this is different than the non-FIPS one
           extra_build_args: |
             GOLANG_VERSION=${{ needs.get-go-version.outputs.go-version }}


### PR DESCRIPTION
### Changes proposed in this PR ###  

Some customers and practitioners would like AWS ECR images due the reduced cost of pulling images onto their EKS clusters. This PR makes puts back the publishing of the k8s images. 

- Previous builds were removed by https://github.com/hashicorp/consul-k8s/pull/1364/files
- Closes https://github.com/hashicorp/consul-k8s/issues/3091 

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
