### PR TITLE
[NET-8174] security: add scan triage for CVE-2024-26147 (helm/v3)

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -34,6 +34,8 @@ binary {
       vulnerabilites = [
         # NET-8174 (2024-02-20): Chart YAML path traversal (not impacted)
         "GHSA-v53g-5gjp-272r", # alias CVE-2024-25620
+        # NET-8174 (2024-02-26): Missing YAML Content Leads To Panic (requires malicious plugin)
+        "GHSA-r53h-jv2g-vpx6", # alias CVE-2024-26147
       ]
     }
   }

--- a/scan.hcl
+++ b/scan.hcl
@@ -33,7 +33,9 @@ repository {
       ]
       vulnerabilites = [
         # NET-8174 (2024-02-20): Chart YAML path traversal (not impacted)
-		"GHSA-v53g-5gjp-272r", # alias CVE-2024-25620
+        "GHSA-v53g-5gjp-272r", # alias CVE-2024-25620
+        # NET-8174 (2024-02-26): Missing YAML Content Leads To Panic (requires malicious plugin)
+        "GHSA-r53h-jv2g-vpx6", # alias CVE-2024-26147
       ]
     }
   }


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Add scan triage for additional CVE, which can be addressed by the same follow-up work as the previous CVE

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
