### PR TITLE
Prepare 1.4.0 release

### DIFF
--- a/.changelog/3625.txt
+++ b/.changelog/3625.txt
@@ -6,7 +6,7 @@ Upgrade `helm/v3` to 3.11.3. This resolves the following security vulnerabilitie
 [CVE-2022-23525](https://osv.dev/vulnerability/CVE-2022-23525)
 ```
 ```release-note:security
-security: upgrade containerd to 1.7.13 (latest) to resolve [GHSA-7ww5-4wqc-m92c](https://osv.dev/vulnerability/GO-2023-2412).
+Upgrade containerd to 1.7.13 (latest) to resolve [GHSA-7ww5-4wqc-m92c](https://osv.dev/vulnerability/GO-2023-2412).
 ```
 ```release-note:security
 Upgrade docker/docker to 25.0.3+incompatible (latest) to resolve [GHSA-jq35-85cj-fj4p](https://osv.dev/vulnerability/GHSA-jq35-85cj-fj4p).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,65 @@
+## 1.4.0 (February 29, 2024)
+
+> NOTE: Consul K8s 1.4.x is compatible with Consul 1.18.x and Consul Dataplane 1.4.x. Refer to our [compatibility matrix](https://developer.hashicorp.com/consul/docs/k8s/compatibility) for more info.
+BREAKING CHANGES:
+
+* server: set `autopilot.min_quorum` to the correct quorum value to ensure autopilot doesn't prune servers needed for quorum. Also set `autopilot. disable_upgrade_migration` to `true` as that setting is meant for blue/green deploys, not rolling deploys.
+
+This setting makes sense for most use-cases, however if you had a specific reason to use the old settings you can use the following config to keep them:
+
+    server:
+      extraConfig: |
+        {"autopilot": {"min_quorum": 0, "disable_upgrade_migration": false}} [[GH-3000](https://github.com/hashicorp/consul-k8s/issues/3000)]
+* server: set `leave_on_terminate` to `true` and set the server pod disruption budget `maxUnavailable` to `1`.
+
+This change makes server rollouts faster and more reliable. However, there is now a potential for reduced reliability if users accidentally
+scale the statefulset down. Now servers will leave the raft pool when they are stopped gracefully which reduces the fault
+tolerance. For example, with 5 servers, you can tolerate a loss of 2 servers' data as raft guarantees data is replicated to
+a majority of nodes (3). However, if you accidentally scale the statefulset down to 3, then the raft quorum will now be 2, and
+if you lose 2 servers, you may lose data. Before this change, the quorum would have remained at 3.
+
+During a regular rollout, the number of servers will be reduced by 1 at a time, which doesn't affect quorum when running
+an odd number of servers, e.g. quorum for 5 servers is 3, and quorum for 4 servers is also 3. That's why the pod disruption
+budget is being set to 1 now.
+
+If a server is stopped ungracefully, e.g. due to a node loss, it will not leave the raft pool, and so fault tolerance won't be affected.
+
+For the vast majority of users, this change will be beneficial, however if you wish to remain with the old settings you
+can set:
+
+    server:
+      extraConfig: |
+        {"leave_on_terminate": false}
+      disruptionBudget:
+        maxUnavailable: <previous setting> [[GH-3000](https://github.com/hashicorp/consul-k8s/issues/3000)]
+
+SECURITY:
+
+* Update Envoy version to 1.25.11 to address [CVE-2023-44487](https://github.com/envoyproxy/envoy/security/advisories/GHSA-jhv4-f7mr-xx76) [[GH-3116](https://github.com/hashicorp/consul-k8s/issues/3116)]
+* Upgrade `helm/v3` to 3.11.3. This resolves the following security vulnerabilities:
+[CVE-2023-25165](https://osv.dev/vulnerability/CVE-2023-25165)
+[CVE-2022-23524](https://osv.dev/vulnerability/CVE-2022-23524)
+[CVE-2022-23526](https://osv.dev/vulnerability/CVE-2022-23526)
+[CVE-2022-23525](https://osv.dev/vulnerability/CVE-2022-23525) [[GH-3625](https://github.com/hashicorp/consul-k8s/issues/3625)]
+* Upgrade docker/distribution to 2.8.3+incompatible (latest) to resolve [CVE-2023-2253](https://osv.dev/vulnerability/CVE-2023-2253). [[GH-3625](https://github.com/hashicorp/consul-k8s/issues/3625)]
+* Upgrade docker/docker to 25.0.3+incompatible (latest) to resolve [GHSA-jq35-85cj-fj4p](https://osv.dev/vulnerability/GHSA-jq35-85cj-fj4p). [[GH-3625](https://github.com/hashicorp/consul-k8s/issues/3625)]
+* Upgrade filepath-securejoin to 0.2.4 (latest) to resolve [GO-2023-2048](https://osv.dev/vulnerability/GO-2023-2048). [[GH-3625](https://github.com/hashicorp/consul-k8s/issues/3625)]
+* Upgrade containerd to 1.7.13 (latest) to resolve [GHSA-7ww5-4wqc-m92c](https://osv.dev/vulnerability/GO-2023-2412). [[GH-3625](https://github.com/hashicorp/consul-k8s/issues/3625)]
+
+IMPROVEMENTS:
+
+* control-plane: publish `consul-k8s-control-plane` and `consul-k8s-control-plane-fips` images to official HashiCorp AWS ECR. [[GH-3668](https://github.com/hashicorp/consul-k8s/issues/3668)]
+* helm: Kubernetes v1.29 is now supported. Minimum tested version of Kubernetes is now v1.26. [[GH-3675](https://github.com/hashicorp/consul-k8s/issues/3675)]
+
+BUG FIXES:
+
+* consul-telemetry-collector: fix args to consul-dataplane when global.acls.manageSystemACLs [[GH-3184](https://github.com/hashicorp/consul-k8s/issues/3184)]
+
+NOTES:
+
+* build: Releases will now also be available as Debian and RPM packages for the arm64 architecture, refer to the
+[Official Packaging Guide](https://www.hashicorp.com/official-packaging-guide) for more information. [[GH-3428](https://github.com/hashicorp/consul-k8s/issues/3428)]
+
 ## 1.3.1 (December 19, 2023)
 
 SECURITY:

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: consul
 version: 1.4.0
-appVersion: 1.18
+appVersion: 1.18.0
 kubeVersion: ">=1.22.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
@@ -13,14 +13,14 @@ sources:
   - https://github.com/hashicorp/consul
   - https://github.com/hashicorp/consul-k8s
 annotations:
-  artifacthub.io/prerelease: true
+  artifacthub.io/prerelease: false
   artifacthub.io/images: |
     - name: consul
-      image: docker.mirror.hashicorp.services/hashicorppreview/consul:1.18.0
+      image: hashicorp/consul:1.18.0
     - name: consul-k8s-control-plane
-      image: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.4.0
+      image: hashicorp/consul-k8s-control-plane:1.4.0
     - name: consul-dataplane
-      image: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.4.0
+      image: hashicorp/consul-dataplane:1.4.0
     - name: envoy
       image: envoyproxy/envoy:v1.25.11
   artifacthub.io/license: MPL-2.0

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -66,7 +66,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.10.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: docker.mirror.hashicorp.services/hashicorppreview/consul:1.18.0
+  image: hashicorp/consul:1.18.0
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.
@@ -86,7 +86,7 @@ global:
   # image that is used for functionality such as catalog sync.
   # This can be overridden per component.
   # @default: hashicorp/consul-k8s-control-plane:<latest version>
-  imageK8S: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.4.0
+  imageK8S: hashicorp/consul-k8s-control-plane:1.4.0
 
   # The name of the datacenter that the agents should
   # register as. This can't be changed once the Consul cluster is up and running
@@ -791,7 +791,7 @@ global:
   # The name (and tag) of the consul-dataplane Docker image used for the
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
   # @default: hashicorp/consul-dataplane:<latest supported version>
-  imageConsulDataplane: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.4.0
+  imageConsulDataplane: hashicorp/consul-dataplane:1.4.0
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Update versions for release
- Add `CHANGELOG` for 1.4.0
- Minor fix to changelog entry (will port to `main` and other branches)

Created by running `make prepare-release` w/ the following:
```shell
CONSUL_K8S_PRODUCT_VERSION=1.4.0
CONSUL_K8S_LAST_RELEASE_GIT_TAG=v1.3.3
CONSUL_K8S_RELEASE_VERSION=1.4.0
CONSUL_K8S_CONSUL_DATAPLANE_VERSION=1.4.0
CONSUL_K8S_RELEASE_BRANCH=release/1.4.0
CONSUL_K8S_CONSUL_VERSION=1.18.0
CONSUL_K8S_RELEASE_DATE=February 29, 2024
```