### PR TITLE
[NET-8174] security: add triage alias for GO-2024-2554

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -33,9 +33,12 @@ binary {
     suppress {
       vulnerabilites = [
         # NET-8174 (2024-02-20): Chart YAML path traversal (not impacted)
-        "GHSA-v53g-5gjp-272r", # alias CVE-2024-25620
+        "GHSA-v53g-5gjp-272r", 
+        "GO-2024-2554", # alias
+        "CVE-2024-25620", # alias
         # NET-8174 (2024-02-26): Missing YAML Content Leads To Panic (requires malicious plugin)
-        "GHSA-r53h-jv2g-vpx6", # alias CVE-2024-26147
+        "GHSA-r53h-jv2g-vpx6", 
+        "CVE-2024-26147", # alias
       ]
     }
   }

--- a/scan.hcl
+++ b/scan.hcl
@@ -33,9 +33,12 @@ repository {
       ]
       vulnerabilites = [
         # NET-8174 (2024-02-20): Chart YAML path traversal (not impacted)
-        "GHSA-v53g-5gjp-272r", # alias CVE-2024-25620
+        "GHSA-v53g-5gjp-272r", 
+        "GO-2024-2554", # alias
+        "CVE-2024-25620", # alias
         # NET-8174 (2024-02-26): Missing YAML Content Leads To Panic (requires malicious plugin)
-        "GHSA-r53h-jv2g-vpx6", # alias CVE-2024-26147
+        "GHSA-r53h-jv2g-vpx6", 
+        "CVE-2024-26147", # alias
       ]
     }
   }


### PR DESCRIPTION
This vulnerability was already triaged [via its GHSA alias](https://osv.dev/vulnerability/GO-2024-2554), but the scanner is flagging it under this name, so adding an explicit entry.

### How I've tested this PR ###
Scanner now passes locally.

### How I expect reviewers to test this PR ###
👀 

cc @picatz @dduzgun-security for awareness since I haven't seen aliases re-emerge weeks later before - maybe out of our control?