### PR TITLE
NET-8391: fix cleanup script - remove network interface(s)

### DIFF
--- a/.github/workflows/nightly-cleanup.yml
+++ b/.github/workflows/nightly-cleanup.yml
@@ -1,14 +1,10 @@
 # Dispatch to the consul-k8s-workflows with a nightly cron
 name: nightly-cleanup
 on:
-  push:
-    branches:
-      # REMOVE MEEEEE - Testing only
-      - "NET-8391_fix_eks_cleanup_2"
-  # schedule:
-  #   # * is a special character in YAML so you have to quote this string
-  #   # Run nightly at 12PM UTC/8AM EST/5AM PST
-  #   - cron: '0 12 * * *'
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run nightly at 12PM UTC/8AM EST/5AM PST
+    - cron: '0 12 * * *'
 
 # these should be the only settings that you will ever need to change
 env:

--- a/.github/workflows/nightly-cleanup.yml
+++ b/.github/workflows/nightly-cleanup.yml
@@ -1,10 +1,14 @@
 # Dispatch to the consul-k8s-workflows with a nightly cron
 name: nightly-cleanup
 on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    # Run nightly at 12PM UTC/8AM EST/5AM PST
-    - cron: '0 12 * * *'
+  push:
+    branches:
+      # REMOVE MEEEEE - Testing only
+      - "NET-8391_fix_eks_cleanup_2"
+  # schedule:
+  #   # * is a special character in YAML so you have to quote this string
+  #   # Run nightly at 12PM UTC/8AM EST/5AM PST
+  #   - cron: '0 12 * * *'
 
 # these should be the only settings that you will ever need to change
 env:


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Consul-K8s EKS cleanup tests fail regularly, see [here](https://github.com/hashicorp/consul-k8s-workflows/actions/runs/7861808199/job/21450617885)

**ISSUE**
This error was caused as a result of the network interface used as part of the cluster setup for testing to not be automatically cleaned up. 

**FIX**
Add a network interface cleanup step

### How I've tested this PR ###
✅  CI triggered by this PR automatically cleaning up attached network interface resource [here](https://github.com/hashicorp/consul-k8s-workflows/actions/runs/8237526039/job/22526542345#step:8:21)


### How I expect reviewers to test this PR ###
See CI examples above


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
