### PR TITLE
Net 6821 - Regenerate Terminating Gateway CRD with new field 

### DIFF
--- a/charts/consul/templates/crd-terminatinggateways.yaml
+++ b/charts/consul/templates/crd-terminatinggateways.yaml
@@ -73,6 +73,10 @@ spec:
                         to use for TLS connections from the gateway to the linked
                         service.
                       type: string
+                    disableAutoHostRewrite:
+                      description: DisableAutoHostRewrite disables terminating gateways
+                        auto host rewrite feature when set to true.
+                      type: boolean
                     keyFile:
                       description: KeyFile is the optional path to a private key to
                         use for TLS connections from the gateway to the linked service.

--- a/control-plane/api/v1alpha1/terminatinggateway_types.go
+++ b/control-plane/api/v1alpha1/terminatinggateway_types.go
@@ -79,6 +79,9 @@ type LinkedService struct {
 
 	// SNI is the optional name to specify during the TLS handshake with a linked service.
 	SNI string `json:"sni,omitempty"`
+
+	//DisableAutoHostRewrite disables terminating gateways auto host rewrite feature when set to true.
+	DisableAutoHostRewrite bool `json:",omitempty"`
 }
 
 func (in *TerminatingGateway) GetObjectMeta() metav1.ObjectMeta {
@@ -218,12 +221,13 @@ func (in *TerminatingGateway) DefaultNamespaceFields(consulMeta common.ConsulMet
 
 func (in LinkedService) toConsul() capi.LinkedService {
 	return capi.LinkedService{
-		Namespace: in.Namespace,
-		Name:      in.Name,
-		CAFile:    in.CAFile,
-		CertFile:  in.CertFile,
-		KeyFile:   in.KeyFile,
-		SNI:       in.SNI,
+		Namespace:              in.Namespace,
+		Name:                   in.Name,
+		CAFile:                 in.CAFile,
+		CertFile:               in.CertFile,
+		KeyFile:                in.KeyFile,
+		SNI:                    in.SNI,
+		DisableAutoHostRewrite: in.DisableAutoHostRewrite,
 	}
 }
 

--- a/control-plane/api/v1alpha1/terminatinggateway_types.go
+++ b/control-plane/api/v1alpha1/terminatinggateway_types.go
@@ -81,7 +81,7 @@ type LinkedService struct {
 	SNI string `json:"sni,omitempty"`
 
 	//DisableAutoHostRewrite disables terminating gateways auto host rewrite feature when set to true.
-	DisableAutoHostRewrite bool `json:",omitempty"`
+	DisableAutoHostRewrite bool `json:"disableAutoHostRewrite,omitempty"`
 }
 
 func (in *TerminatingGateway) GetObjectMeta() metav1.ObjectMeta {

--- a/control-plane/api/v1alpha1/terminatinggateway_types_test.go
+++ b/control-plane/api/v1alpha1/terminatinggateway_types_test.go
@@ -49,11 +49,12 @@ func TestTerminatingGateway_MatchesConsul(t *testing.T) {
 				Spec: TerminatingGatewaySpec{
 					Services: []LinkedService{
 						{
-							Name:     "name",
-							CAFile:   "caFile",
-							CertFile: "certFile",
-							KeyFile:  "keyFile",
-							SNI:      "sni",
+							Name:                   "name",
+							CAFile:                 "caFile",
+							CertFile:               "certFile",
+							KeyFile:                "keyFile",
+							SNI:                    "sni",
+							DisableAutoHostRewrite: true,
 						},
 						{
 							Name: "*",
@@ -71,11 +72,12 @@ func TestTerminatingGateway_MatchesConsul(t *testing.T) {
 				},
 				Services: []capi.LinkedService{
 					{
-						Name:     "name",
-						CAFile:   "caFile",
-						CertFile: "certFile",
-						KeyFile:  "keyFile",
-						SNI:      "sni",
+						Name:                   "name",
+						CAFile:                 "caFile",
+						CertFile:               "certFile",
+						KeyFile:                "keyFile",
+						SNI:                    "sni",
+						DisableAutoHostRewrite: true,
 					},
 					{
 						Name: "*",

--- a/control-plane/config/crd/bases/consul.hashicorp.com_terminatinggateways.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_terminatinggateways.yaml
@@ -69,6 +69,10 @@ spec:
                         to use for TLS connections from the gateway to the linked
                         service.
                       type: string
+                    disableAutoHostRewrite:
+                      description: DisableAutoHostRewrite disables terminating gateways
+                        auto host rewrite feature when set to true.
+                      type: boolean
                     keyFile:
                       description: KeyFile is the optional path to a private key to
                         use for TLS connections from the gateway to the linked service.

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -1,5 +1,7 @@
 module github.com/hashicorp/consul-k8s/control-plane
 
+replace github.com/hashicorp/consul/api => github.com/hashicorp/consul/api v1.10.1-0.20240312203720-262f4358003f
+
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/containernetworking/cni v1.1.2

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -273,8 +273,8 @@ github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20240226161840-f3842c41
 github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20240226161840-f3842c41cb2b/go.mod h1:9NKJHOcgmz/6P2y6MegNIOXhIKE/0ils/mHWd5sZgoU=
 github.com/hashicorp/consul-server-connection-manager v0.1.6 h1:ktj8Fi+dRXn9hhM+FXsfEJayhzzgTqfH08Ne5M6Fmug=
 github.com/hashicorp/consul-server-connection-manager v0.1.6/go.mod h1:HngMIv57MT+pqCVeRQMa1eTB5dqnyMm8uxjyv+Hn8cs=
-github.com/hashicorp/consul/api v1.28.2 h1:mXfkRHrpHN4YY3RqL09nXU1eHKLNiuAN4kHvDQ16k/8=
-github.com/hashicorp/consul/api v1.28.2/go.mod h1:KyzqzgMEya+IZPcD65YFoOVAgPpbfERu4I/tzG6/ueE=
+github.com/hashicorp/consul/api v1.10.1-0.20240312203720-262f4358003f h1:8clIrMnJtO5ab5Kd1qF19s9s581cyGYhQxfPLVRaFZs=
+github.com/hashicorp/consul/api v1.10.1-0.20240312203720-262f4358003f/go.mod h1:JnWx0qZd1Ffeoa42yVAxzv7/v7eaZyptkw0dG9F/gF4=
 github.com/hashicorp/consul/proto-public v0.6.0 h1:9qrBujmoTB5gQQ84kQO+YWvhjgYoYBNrOoHdo4cpHHM=
 github.com/hashicorp/consul/proto-public v0.6.0/go.mod h1:JF6983XNCzvw4wDNOLEwLqOq2IPw7iyT+pkswHSz08U=
 github.com/hashicorp/consul/sdk v0.16.0 h1:SE9m0W6DEfgIVCJX7xU+iv/hUl4m/nxqMTnCdMxDpJ8=


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Regenerated CRD as a follow up to https://github.com/hashicorp/consul/pull/20802

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
