### PR TITLE
NET-6878: Remove finalizers from CRDs during test resource cleanup

### DIFF
--- a/acceptance/framework/helpers/helpers.go
+++ b/acceptance/framework/helpers/helpers.go
@@ -216,6 +216,7 @@ func RunCommand(t testutil.TestingTB, command Command) (string, error) {
 	return string(cmd), err
 }
 
+// getCRDRemoveFinalizers gets CRDs with finalizers and removes them.
 func getCRDRemoveFinalizers(t testutil.TestingTB) error {
 	t.Helper()
 	// Get CRD names with finalizers
@@ -233,7 +234,7 @@ func getCRDRemoveFinalizers(t testutil.TestingTB) error {
 	return nil
 }
 
-// CRD struct to parse CRD JSON output
+// CRD struct to parse CRD JSON output.
 type CRD struct {
 	Items []struct {
 		Metadata struct {
@@ -243,6 +244,7 @@ type CRD struct {
 	} `json:"items"`
 }
 
+// getCRDsWithFinalizers gets CRDs with finalizers.
 func getCRDsWithFinalizers() ([]string, error) {
 	cmd := exec.Command("kubectl", "get", "crd", "-o=json")
 
@@ -266,6 +268,7 @@ func getCRDsWithFinalizers() ([]string, error) {
 	return crdNames, nil
 }
 
+// removeFinalizers removes finalizers from CRDs.
 func removeFinalizers(crdNames []string) error {
 	for _, crd := range crdNames {
 		cmd := exec.Command("kubectl", "patch", "crd", crd, "--type=json", "-p=[{\"op\": \"remove\", \"path\": \"/metadata/finalizers\"}]")

--- a/acceptance/framework/k8s/deploy.go
+++ b/acceptance/framework/k8s/deploy.go
@@ -129,7 +129,10 @@ func CheckStaticServerConnectionMultipleFailureMessages(t *testing.T, options *k
 		expectedOutput = expectedSuccessOutput
 	}
 
-	retrier := &retry.Timer{Timeout: 320 * time.Second, Wait: 2 * time.Second}
+	retrier := &retry.Counter{
+		Count: 10,
+		Wait:  2 * time.Second,
+	}
 
 	args := []string{"exec", resourceType + sourceApp, "-c", sourceApp, "--", "curl", "-vvvsSf"}
 	args = append(args, curlArgs...)

--- a/acceptance/tests/peering/peering_gateway_test.go
+++ b/acceptance/tests/peering/peering_gateway_test.go
@@ -253,7 +253,7 @@ func TestPeering_Gateway(t *testing.T) {
 	// leader election so we may need to wait a long time for
 	// the reconcile loop to run (hence the 1m timeout here).
 	var gatewayAddress string
-	counter := &retry.Counter{Count: 600, Wait: 2 * time.Second}
+	counter := &retry.Counter{Count: 10, Wait: 2 * time.Second}
 	retry.RunWith(counter, t, func(r *retry.R) {
 		var gateway gwv1beta1.Gateway
 		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "gateway", Namespace: staticClientNamespace}, &gateway)


### PR DESCRIPTION
### Changes proposed in this PR ###  
At times, CRDs created as part of the test suite are not cleaned up properly causing the test to timeout and run for a really long time

- Switch from retrier based on time to a counter based retries for fast fail
- Add goroutine to the  remove finalizers, if "delete" resource command is called

### How I've tested this PR ###
CI should pass


### How I expect reviewers to test this PR ###
CI should pass

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
