### PR TITLE
[net-8411] bug: fix premature token and service instance deletion due to pod fetch errors

### DIFF
--- a/.changelog/3758.txt
+++ b/.changelog/3758.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+control-plane: fix an issue where ACL token cleanup did not respect a pod's GracefulShutdownPeriodSeconds and
+tokens were invalidated immediately on pod entering Terminating state.
+```

--- a/.changelog/3758.txt
+++ b/.changelog/3758.txt
@@ -1,4 +1,4 @@
 ```release-note:bug
-control-plane: fix an issue where ACL token cleanup did not respect a pod's GracefulShutdownPeriodSeconds and
-tokens were invalidated immediately on pod entering Terminating state.
+control-plane: fix an issue where ACL tokens would prematurely be deleted and services would be deregistered if there
+was a K8s API error fetching the pod.
 ```

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
@@ -197,6 +197,7 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 					if k8serrors.IsNotFound(err) {
 						deregisterEndpointAddress[address.IP] = true
 					} else {
+						deregisterEndpointAddress[address.IP] = false
 						r.Log.Error(err, "failed to get pod", "name", address.TargetRef.Name)
 						errs = multierror.Append(errs, err)
 					}
@@ -1636,5 +1637,5 @@ func deregister(address string, deregisterEndpointAddress map[string]bool) bool 
 	if ok {
 		return deregister
 	}
-	return false
+	return true
 }

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
@@ -196,7 +196,10 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 					// If the pod doesn't exist anymore, set up the deregisterEndpointAddress map to deregister it.
 					if k8serrors.IsNotFound(err) {
 						deregisterEndpointAddress[address.IP] = true
+						r.Log.Info("pod not found", "name", address.TargetRef.Name)
 					} else {
+						// If there was a different error fetching the pod, then log the error but don't deregister it
+						// since this could be a K8s API blip and we don't want to prematurely deregister.
 						deregisterEndpointAddress[address.IP] = false
 						r.Log.Error(err, "failed to get pod", "name", address.TargetRef.Name)
 						errs = multierror.Append(errs, err)

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
@@ -1767,10 +1767,10 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 			},
 		},
 		{
-			// This test has 3 addresses, but only 2 are backed by pod resources. This will cause Reconcile to error
-			// on the invalid address but continue and process the other addresses. We check for error specific to
-			// pod3 being non-existant at the end, and validate the other 2 addresses have service instances.
-			name:          "Endpoints with multiple addresses but one is invalid",
+			// This test has 3 addresses, but only 2 are backed by pod resources. This will cause Reconcile to
+			// deregister the instance associated with the non-existent pod and continue and process the other
+			// addresses. We validate the other 2 addresses have service instances.
+			name:          "Endpoints with multiple addresses but one is deleted",
 			svcName:       "service-created",
 			consulSvcName: "service-created",
 			k8sObjects: func() []runtime.Object {
@@ -1897,7 +1897,6 @@ func TestReconcileCreateEndpoint(t *testing.T) {
 					Type:        constants.ConsulKubernetesCheckType,
 				},
 			},
-			expErr: "1 error occurred:\n\t* pods \"pod3\" not found\n\n",
 		},
 		{
 			name:          "Every configurable field set: port, different Consul service name, meta, tags, upstreams, metrics",


### PR DESCRIPTION
### Changes proposed in this PR ###  
- When a pod fetch fails, we used to not add it to the endpointAddressMap resulting in it getting deregistered and its token deleted. 
- This PR makes the cases we deregister in more explicit-- only if the pod does not exist, we will deregister the service instance and delete the token. This PR also switches endpointAddressMap to a map that marks endpoints explicitly for deregistration (or not). And only entries explicitly marked in the map for deregistration are deregistered. 

### How I've tested this PR ###

Unit tests, Manually testing by changing the code to simulate pod fetch errors and with the fix in this PR it doesn't deregister the instance and delete the token

### How I expect reviewers to test this PR ###


### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
