### PR TITLE
Add support for Nomad transparent proxy

### DIFF
--- a/control-plane/cni/main.go
+++ b/control-plane/cni/main.go
@@ -72,6 +72,10 @@ type CNIArgs struct {
 	K8S_POD_NAMESPACE types.UnmarshallableString
 	// K8S_POD_INFRA_CONTAINER_ID is the runtime container ID that the pod runs under.
 	K8S_POD_INFRA_CONTAINER_ID types.UnmarshallableString
+
+	// IPTABLES_CONFIG is the runtime iptables configuration passed by
+	// orchestrator (ex. the Nomad client agent)
+	IPTABLES_CONFIG types.UnmarshallableString
 }
 
 // PluginConf is is the configuration used by the plugin.
@@ -95,9 +99,8 @@ type PluginConf struct {
 	Multus bool `json:"multus"`
 	// Kubeconfig file name. Can be set as a cli flag.
 	Kubeconfig string `json:"kubeconfig"`
-	// LogLevl is the logging level. Can be set as a cli flag.
+	// LogLevel is the logging level. Can be set as a cli flag.
 	LogLevel string `json:"log_level"`
-	//
 }
 
 // parseConfig parses the supplied CNI configuration (and prevResult) from stdin.
@@ -132,9 +135,11 @@ func (c *Command) cmdAdd(args *skel.CmdArgs) error {
 
 	podNamespace := string(cniArgs.K8S_POD_NAMESPACE)
 	podName := string(cniArgs.K8S_POD_NAME)
+	cniArgsIPTablesCfg := string(cniArgs.IPTABLES_CONFIG)
 
-	// We should never encounter this unless there has been an error in the kubelet. A good safeguard.
-	if podNamespace == "" || podName == "" {
+	// We should never encounter this unless there has been an error in the
+	// kubelet. A good safeguard.
+	if (podNamespace == "" || podName == "") && cniArgsIPTablesCfg == "" {
 		return fmt.Errorf("not running in a pod, namespace and pod should have values")
 	}
 
@@ -167,49 +172,54 @@ func (c *Command) cmdAdd(args *skel.CmdArgs) error {
 		result = prevResult
 	}
 
-	ctx := context.Background()
-	if c.client == nil {
+	var iptablesCfg iptables.Config
 
-		// Connect to kubernetes.
-		restConfig, err := clientcmd.BuildConfigFromFlags("", filepath.Join(cfg.CNINetDir, cfg.Kubeconfig))
+	if cniArgsIPTablesCfg != "" {
+		var err error
+		iptablesCfg, err = parseIPTablesFromCNIArgs(cniArgsIPTablesCfg)
 		if err != nil {
-			return fmt.Errorf("could not get rest config from kubernetes api: %s", err)
+			return err
+		}
+	} else {
+		if c.client == nil {
+			if err := c.createK8sClient(cfg); err != nil {
+				return err
+			}
 		}
 
-		c.client, err = kubernetes.NewForConfig(restConfig)
+		ctx := context.Background()
+		pod, err := c.client.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("error initializing Kubernetes client: %s", err)
+			return fmt.Errorf("error retrieving pod: %s", err)
 		}
-	}
 
-	pod, err := c.client.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("error retrieving pod: %s", err)
-	}
+		// Skip traffic redirection if the correct annotations are not on the pod.
+		if skipTrafficRedirection(*pod) {
+			logger.Debug("skipping traffic redirection because the pod is either not injected or transparent proxy is disabled: %s", pod.Name)
+			return types.PrintResult(result, cfg.CNIVersion)
+		}
 
-	// Skip traffic redirection if the correct annotations are not on the pod.
-	if skipTrafficRedirection(*pod) {
-		logger.Debug("skipping traffic redirection because the pod is either not injected or transparent proxy is disabled: %s", pod.Name)
-		return types.PrintResult(result, cfg.CNIVersion)
-	}
+		// We do not throw an error here because kubernetes will often throw a
+		// benign error where the pod has been updated in between the get and
+		// update of the annotation. Eventually kubernetes will update the
+		// annotation
+		ok := c.updateTransparentProxyStatusAnnotation(podName, podNamespace, waiting)
+		if !ok {
+			logger.Info("unable to update %s pod annotation to waiting", keyTransparentProxyStatus)
+		}
 
-	// We do not throw an error here because kubernetes will often throw a benign error where the pod has been
-	// updated in between the get and update of the annotation. Eventually kubernetes will update the annotation
-	ok := c.updateTransparentProxyStatusAnnotation(podName, podNamespace, waiting)
-	if !ok {
-		logger.Info("unable to update %s pod annotation to waiting", keyTransparentProxyStatus)
-	}
-
-	// Parse the cni-proxy-config annotation into an iptables.Config object.
-	iptablesCfg, err := parseAnnotation(*pod, annotationRedirectTraffic)
-	if err != nil {
-		return err
+		// Parse the cni-proxy-config annotation into an iptables.Config object.
+		iptablesCfg, err = parseAnnotation(*pod, annotationRedirectTraffic)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Set NetNS passed through the CNI.
 	iptablesCfg.NetNS = args.Netns
 
-	// Set the provider to a fake provider in testing, otherwise use the default iptables.Provider
+	// Set the provider to a fake provider in testing, otherwise use the default
+	// iptables.Provider
 	if c.iptablesProvider != nil {
 		iptablesCfg.IptablesProvider = c.iptablesProvider
 	}
@@ -220,15 +230,21 @@ func (c *Command) cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("could not apply iptables setup: %v", err)
 	}
 
-	// We do not throw an error here because kubernetes will often throw a benign error where the pod has been
-	// updated in between the get and update of the annotation. Eventually kubernetes will update the annotation
-	ok = c.updateTransparentProxyStatusAnnotation(podName, podNamespace, complete)
-	if !ok {
-		logger.Info("unable to update %s pod annotation to complete", keyTransparentProxyStatus)
+	if cniArgsIPTablesCfg != "" {
+
+		// We do not throw an error here because kubernetes will often throw a
+		// benign error where the pod has been updated in between the get and update
+		// of the annotation. Eventually kubernetes will update the annotation
+		ok := c.updateTransparentProxyStatusAnnotation(podName, podNamespace, complete)
+		if !ok {
+			logger.Info("unable to update %s pod annotation to complete", keyTransparentProxyStatus)
+		}
 	}
 
-	logger.Debug("traffic redirect rules applied to pod: %s", pod.Name)
-	// Pass through the result for the next plugin even though we are the final plugin in the chain.
+	logger.Debug("traffic redirect rules applied to pod: %s", podName)
+
+	// Pass through the result for the next plugin even if we are the final
+	// plugin in the chain.
 	return types.PrintResult(result, cfg.CNIVersion)
 }
 
@@ -249,6 +265,21 @@ func main() {
 	skel.PluginMain(c.cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("consul-cni"))
 }
 
+// createK8sClient configures the command's Kubernetes API client if it doesn't
+// already exist
+func (c *Command) createK8sClient(cfg *PluginConf) error {
+	restConfig, err := clientcmd.BuildConfigFromFlags("", filepath.Join(cfg.CNINetDir, cfg.Kubeconfig))
+	if err != nil {
+		return fmt.Errorf("could not get rest config from kubernetes api: %s", err)
+	}
+
+	c.client, err = kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("error initializing Kubernetes client: %s", err)
+	}
+	return nil
+}
+
 // skipTrafficRedirection looks for annotations on the pod and determines if it should skip traffic redirection.
 // The absence of the annotations is the equivalent of "disabled" because it means that the connect-inject mutating
 // webhook did not run against the pod.
@@ -265,6 +296,15 @@ func skipTrafficRedirection(pod corev1.Pod) bool {
 		return true
 	}
 	return false
+}
+
+func parseIPTablesFromCNIArgs(args string) (iptables.Config, error) {
+	cfg := iptables.Config{}
+	err := json.Unmarshal([]byte(args), &cfg)
+	if err != nil {
+		return cfg, fmt.Errorf("could not unmarshal CNI args: %w", err)
+	}
+	return cfg, nil
 }
 
 // parseAnnotation parses the cni-proxy-config annotation into an iptables.Config object.

--- a/control-plane/cni/main_test.go
+++ b/control-plane/cni/main_test.go
@@ -67,22 +67,6 @@ func Test_cmdAdd(t *testing.T) {
 			expectedRules: false, // Rules won't be applied because the command will throw an error first
 		},
 		{
-			name: "Missing prevResult in stdin data, should throw error",
-			cmd: &Command{
-				client: fake.NewSimpleClientset(),
-			},
-			podName:   "missing-prev-result",
-			stdInData: missingPrevResultStdinData,
-			configuredPod: func(pod *corev1.Pod, cmd *Command) *corev1.Pod {
-				_, err := cmd.client.CoreV1().Pods(defaultNamespace).Create(context.Background(), pod, metav1.CreateOptions{})
-				require.NoError(t, err)
-
-				return pod
-			},
-			expectedErr:   fmt.Errorf("must be called as final chained plugin"),
-			expectedRules: false, // Rules won't be applied because the command will throw an error first
-		},
-		{
 			name: "Missing IPs in prevResult in stdin data, should throw error",
 			cmd: &Command{
 				client: fake.NewSimpleClientset(),
@@ -326,31 +310,6 @@ const goodStdinData = `{
         ],
         "routes": []
 
-    },
-    "cni_bin_dir": "/opt/cni/bin",
-    "cni_net_dir": "/etc/cni/net.d",
-    "kubeconfig": "ZZZ-consul-cni-kubeconfig",
-    "log_level": "info",
-    "multus": false,
-    "name": "consul-cni",
-    "type": "consul-cni"
-}`
-
-const missingPrevResultStdinData = `{
-    "cniVersion": "0.3.1",
-	"name": "kindnet",
-	"type": "kindnet",
-    "capabilities": {
-        "testCapability": false
-    },
-    "ipam": {
-        "type": "host-local"
-    },
-    "dns": {
-        "nameservers": ["nameserver"],
-        "domain": "domain",
-        "search": ["search"],
-        "options": ["option"]
     },
     "cni_bin_dir": "/opt/cni/bin",
     "cni_net_dir": "/etc/cni/net.d",


### PR DESCRIPTION
_Work-in-progress, see https://github.com/hashicorp/nomad/issues/10628_

Nomad will implement support for Connect transparent proxy. Unlike in K8s, the
CNI plugin can't contact the Nomad API to read allocation metadata (pod labels)
to get the iptables configuration, and doesn't use the rest of the Consul-K8s
control plane to inject that metadata. Instead, Nomad will pass the iptables
configuration JSON-serialized in the CNI arguments.

This changeset implements the behavior switch by detecting the `IPTABLES_CONFIG`
argument in the CNI arguments. This hypothetically allows for non-Nomad
workflows to use the same code path, if desired.

Ref: https://github.com/hashicorp/nomad/issues/10628

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
