### PR TITLE
upgraded helm v3 to address GHSA-jw44-4f3j-q396

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -39,7 +39,8 @@ binary {
         # NET-8174 (2024-02-26): Missing YAML Content Leads To Panic (requires malicious plugin)
         "GHSA-r53h-jv2g-vpx6", 
         "CVE-2024-26147", # alias
-        "GHSA-jw44-4f3j-q396", # alias
+        "GHSA-jw44-4f3j-q396", # Tracked in NET-8174
+        "CVE-2019-25210" # alias
       ]
     }
   }

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -39,6 +39,7 @@ binary {
         # NET-8174 (2024-02-26): Missing YAML Content Leads To Panic (requires malicious plugin)
         "GHSA-r53h-jv2g-vpx6", 
         "CVE-2024-26147", # alias
+        "GHSA-jw44-4f3j-q396", # alias
       ]
     }
   }

--- a/scan.hcl
+++ b/scan.hcl
@@ -39,6 +39,7 @@ repository {
         # NET-8174 (2024-02-26): Missing YAML Content Leads To Panic (requires malicious plugin)
         "GHSA-r53h-jv2g-vpx6", 
         "CVE-2024-26147", # alias
+        "GHSA-jw44-4f3j-q396", # alias
       ]
     }
   }

--- a/scan.hcl
+++ b/scan.hcl
@@ -39,7 +39,8 @@ repository {
         # NET-8174 (2024-02-26): Missing YAML Content Leads To Panic (requires malicious plugin)
         "GHSA-r53h-jv2g-vpx6", 
         "CVE-2024-26147", # alias
-        "GHSA-jw44-4f3j-q396", # alias
+        "GHSA-jw44-4f3j-q396", # Tracked in NET-8174
+        "CVE-2019-25210" # alias
       ]
     }
   }


### PR DESCRIPTION
### Changes proposed in this PR ###  
- This PR addresses [CVE GHSA-jw44-4f3j-q396 ](https://github.com/advisories/GHSA-jw44-4f3j-q396). For now we will disable the scan to get the pipeline in order as there is currently no fix. `helm.sh/helm/v3` 3.14.4 will supposedly contain only bug fixes and will be released on April 10, 2024. So maybe it will be included with that.

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
