### PR TITLE
[NET-8412] Fix order of APIGW ACL policy/role creation

### DIFF
--- a/.changelog/3779.txt
+++ b/.changelog/3779.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api-gateway: Fix order of initialization for creating ACL role/policy to avoid error logs in consul.
+```

--- a/control-plane/api-gateway/cache/consul.go
+++ b/control-plane/api-gateway/cache/consul.go
@@ -374,21 +374,21 @@ func (c *Cache) ensurePolicy(client *api.Client, gatewayName string) (string, er
 	}
 
 	cachedPolicy, found := c.gatewayNameToPolicy[gatewayName]
-	if found {
-		existing, _, err := client.ACL().PolicyReadByName(cachedPolicy.Name, &api.QueryOptions{})
-
-		if existing == nil {
-			return createPolicy()
-		}
-
-		if err != nil {
-			return "", err
-		}
-
-		return existing.ID, nil
+	if !found {
+		return createPolicy()
 	}
 
-	return createPolicy()
+	existing, _, err := client.ACL().PolicyReadByName(cachedPolicy.Name, &api.QueryOptions{})
+
+	if existing == nil {
+		return createPolicy()
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return existing.ID, nil
 }
 
 func (c *Cache) ensureRole(client *api.Client, gatewayName string) (string, error) {

--- a/control-plane/api-gateway/cache/consul.go
+++ b/control-plane/api-gateway/cache/consul.go
@@ -374,6 +374,7 @@ func (c *Cache) ensurePolicy(client *api.Client, gatewayName string) (string, er
 	}
 
 	cachedPolicy, found := c.gatewayNameToPolicy[gatewayName]
+
 	if !found {
 		return createPolicy()
 	}


### PR DESCRIPTION
### Changes proposed in this PR ###  
- cache role/policy for api-gateway so we know if we need to create so we avoid getting errors in consul around trying to create a role/policy that already exists

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
