### PR TITLE
Increase timeout for running commands in acceptance test

### DIFF
--- a/acceptance/framework/helpers/helpers.go
+++ b/acceptance/framework/helpers/helpers.go
@@ -225,7 +225,7 @@ func RunCommand(t testutil.TestingTB, options *k8s.KubectlOptions, command Comma
 	case res := <-resultCh:
 		return res.output, res.err
 		// Sometimes this func runs for too long handle timeout if needed.
-	case <-time.After(30 * time.Second):
+	case <-time.After(320 * time.Second):
 		GetCRDRemoveFinalizers(t, options)
 		logger.Logf(t, "RunCommand timed out")
 		return "", nil


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Increase timeout before returning errors in [tests](https://github.com/hashicorp/consul-k8s/pull/3784) 

### How I've tested this PR ###
CI should pass

### How I expect reviewers to test this PR ###
CI should pass

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
