### PR TITLE
Bugfix: Don't recreate servicemap for catalog sync

### DIFF
--- a/control-plane/catalog/to-consul/resource.go
+++ b/control-plane/catalog/to-consul/resource.go
@@ -878,21 +878,8 @@ func (t *serviceEndpointsResource) Upsert(endptKey string, raw interface{}) erro
 	svc.serviceLock.Lock()
 	defer svc.serviceLock.Unlock()
 
-	// Extract service name and format key
-	svcName := endpointSlice.Labels[discoveryv1.LabelServiceName]
+	// Extract service name and format the service key
 	svcKey := endpointSlice.Namespace + "/" + endpointSlice.Labels[discoveryv1.LabelServiceName]
-
-	if svc.serviceMap == nil {
-		svc.serviceMap = make(map[string]*corev1.Service)
-	}
-	var err error
-	if svc.serviceMap[svcKey] == nil {
-		svc.serviceMap[svcKey], err = t.Service.Client.CoreV1().Services(endpointSlice.Namespace).Get(t.Ctx, svcName, metav1.GetOptions{})
-		if err != nil {
-			t.Log.Error("issue getting service", "error", err)
-			return err
-		}
-	}
 
 	// Check if we care about endpoints for this service
 	if !svc.shouldTrackEndpoints(svcKey) {


### PR DESCRIPTION
### Changes proposed in this PR ###  
- I recently contributed https://github.com/hashicorp/consul-k8s/pull/3693 only to discover a bug that will add every service to the serviceMap and trigger a registration in consul. This removes that bug.

### How I've tested this PR ###
Existing tests and a manual build/deploy in my environment to confirm we don't register everything

### How I expect reviewers to test this PR ###
With my previous change, if spinning up consul catalog sync you'll see every k8s service become registered regardless of configuration. With this change you should only see intended services become registered.

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
