### PR TITLE
improve reliability of acceptance tests

### DIFF
--- a/acceptance/framework/helpers/helpers.go
+++ b/acceptance/framework/helpers/helpers.go
@@ -229,7 +229,7 @@ func RunCommand(t testutil.TestingTB, options *k8s.KubectlOptions, command Comma
 		}
 		return res.output, nil
 		// Sometimes this func runs for too long handle timeout if needed.
-	case <-time.After(400 * time.Second):
+	case <-time.After(320 * time.Second):
 		GetCRDRemoveFinalizers(t, options)
 		logger.Logf(t, "RunCommand timed out")
 		return "", nil

--- a/acceptance/framework/helpers/helpers.go
+++ b/acceptance/framework/helpers/helpers.go
@@ -223,9 +223,13 @@ func RunCommand(t testutil.TestingTB, options *k8s.KubectlOptions, command Comma
 
 	select {
 	case res := <-resultCh:
-		return res.output, res.err
+		if res.err != nil {
+			resErr := fmt.Errorf("error: %v\nOutput: %s", res.err, res.output)
+			return "", resErr
+		}
+		return res.output, nil
 		// Sometimes this func runs for too long handle timeout if needed.
-	case <-time.After(320 * time.Second):
+	case <-time.After(400 * time.Second):
 		GetCRDRemoveFinalizers(t, options)
 		logger.Logf(t, "RunCommand timed out")
 		return "", nil

--- a/acceptance/tests/api-gateway/api_gateway_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_test.go
@@ -107,11 +107,14 @@ func TestAPIGateway_Basic(t *testing.T) {
 			logger.Log(t, "creating static-client pod")
 			k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/bases/static-client")
 
+			k8s.RunKubectl(t, ctx.KubectlOptions(t), "wait", "--for=condition=available", "--timeout=5m", fmt.Sprintf("deploy/%s", "static-server"))
+
 			logger.Log(t, "patching route to target http server")
 			k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "httproute", "http-route", "-p", `{"spec":{"rules":[{"backendRefs":[{"name":"static-server","port":80}]}]}}`, "--type=merge")
 
 			logger.Log(t, "creating target tcp server")
 			k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/bases/static-server-tcp")
+			k8s.RunKubectl(t, ctx.KubectlOptions(t), "wait", "--for=condition=available", "--timeout=5m", fmt.Sprintf("deploy/%s", "static-server-tcp"))
 
 			logger.Log(t, "creating tcp-route")
 			k8s.RunKubectl(t, ctx.KubectlOptions(t), "apply", "-f", "../fixtures/cases/api-gateways/tcproute/route.yaml")


### PR DESCRIPTION
### Changes proposed in this PR ###  
- When are command fails to run with a error, include the output with the error code see [example](https://github.com/hashicorp/consul-k8s-workflows/actions/runs/8353236571/job/22864767746#step:20:2917)
- Wait for pods to rollout with timeout before moving on to next step of testing. 

### How I've tested this PR ###
CI should pass

### How I expect reviewers to test this PR ###
CI should pass

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
