### PR TITLE
NET-8594: Disable TestSyncCatalog

### DIFF
--- a/acceptance/tests/sync/sync_catalog_test.go
+++ b/acceptance/tests/sync/sync_catalog_test.go
@@ -24,6 +24,8 @@ import (
 // The test will create a test service and a pod and will
 // wait for the service to be synced *to* consul.
 func TestSyncCatalog(t *testing.T) {
+	t.Skip("TODO(fails): NET-8594")
+
 	cfg := suite.Config()
 	if cfg.EnableCNI {
 		t.Skipf("skipping because -enable-cni is set and sync catalog is already tested with regular tproxy")


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Temporarily Disable `TestSyncCatalog` as it historically never passes in [CI](https://github.com/hashicorp/consul-k8s-workflows/actions/runs/8428680628/job/23081761926#step:20:928)  
- Follow up [ticket](https://hashicorp.atlassian.net/browse/NET-8594) 

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
