### PR TITLE
Respect the configuration when configuring the GRPC port.

### DIFF
--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -443,9 +443,11 @@ spec:
               hostPort: 8501
               name: https
             {{- end }}
+            {{- if .Values.client.grpc }}
             - containerPort: 8502
               hostPort: 8502
               name: grpc
+            {{- end }}
             - containerPort: 8301
               {{- if .Values.client.exposeGossipPorts }}
               hostPort: 8301

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -914,6 +914,28 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "client/DaemonSet: GRPC port 8502 is not configured when GRPC is disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.grpc=false' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].ports[] | select (.containerPort == 8502)' | tee /dev/stderr)
+  [ "${actual}" == "" ]
+}
+
+@test "client/DaemonSet: GRPC port 8502 is configured when GRPC is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.grpc=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].ports[] | select (.containerPort == 8502)' | tee /dev/stderr)
+  [ "${actual}" != "" ]
+}
+
 @test "client/DaemonSet: init container is created when global.tls.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \


### PR DESCRIPTION
### Changes proposed in this PR ###  
- The helm template client-daemonsets.yaml respects the client.grpc configuration when configuring and exposing the GRPC port 8502 for the consul client container. 


### How I've tested this PR ###
- Tests happened manually by deploying the server-statefulset and client-daemonset onto the same Kubernetes nodes. I confirmed that the clients were able to start without port collisions while the server.exposeGossipAndRPCPorts flag was enabled and the client.grpc flag was disabled. 

### How I expect reviewers to test this PR ###
- Confirm that use cases I currently do not see are covered and still functional. 

### Checklist ###
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
