### PR TITLE
[net-7710] don't overwrite prometheus path annotation if it's already been specified

### DIFF
--- a/.changelog/3846.txt
+++ b/.changelog/3846.txt
@@ -1,0 +1,5 @@
+```release-note:improvement
+helm: only create the default Prometheus path annotation when it's not already specified within the component-specific
+annotations. For example if the `client.annotations` value sets prometheus.io/path annotation, don't overwrite it with
+the default value.
+```

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -93,7 +93,9 @@ spec:
         {{- end }}
         {{- if (and .Values.global.metrics.enabled .Values.global.metrics.enableAgentMetrics) }}
         "prometheus.io/scrape": "true"
+        {{- if not (hasKey (default "" .Values.client.annotations | fromYaml) "prometheus.io/path")}}
         "prometheus.io/path": "/v1/agent/metrics"
+        {{- end }}
         "prometheus.io/port": "8500"
         {{- end }}
     spec:

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -132,7 +132,9 @@ spec:
         {{- end }}
         {{- if (and $root.Values.global.metrics.enabled $root.Values.global.metrics.enableGatewayMetrics) }}
         "prometheus.io/scrape": "true"
+        {{- if not (hasKey (default "" $defaults.annotations | fromYaml) "prometheus.io/path")}}
         "prometheus.io/path": "/metrics"
+        {{- end }}
         "prometheus.io/port": "20200"
         {{- end }}
         {{- if $defaults.annotations }}

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -78,7 +78,9 @@ spec:
         {{- end }}
         {{- if (and .Values.global.metrics.enabled .Values.global.metrics.enableGatewayMetrics) }}
         "prometheus.io/scrape": "true"
+        {{- if not (hasKey (default "" .Values.meshGateway.annotations | fromYaml) "prometheus.io/path")}}
         "prometheus.io/path": "/metrics"
+        {{- end }}
         "prometheus.io/port": "20200"
         {{- end }}
         {{- if .Values.meshGateway.annotations }}

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -134,7 +134,9 @@ spec:
         {{- if (and .Values.global.metrics.enabled .Values.global.metrics.enableAgentMetrics) }}
         {{- if not .Values.global.metrics.datadog.openMetricsPrometheus.enabled }}
         "prometheus.io/scrape": "true"
+        {{- if not (hasKey (default "" .Values.server.annotations | fromYaml) "prometheus.io/path")}}
         "prometheus.io/path": "/v1/agent/metrics"
+        {{- end }}
         {{- if .Values.global.tls.enabled }}
         "prometheus.io/port": "8501"
         "prometheus.io/scheme": "https"

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -101,7 +101,9 @@ spec:
         {{- end }}
         {{- if (and $root.Values.global.metrics.enabled $root.Values.global.metrics.enableGatewayMetrics) }}
         "prometheus.io/scrape": "true"
+        {{- if not (hasKey (default "" $defaults.annotations | fromYaml) "prometheus.io/path")}}
         "prometheus.io/path": "/metrics"
+        {{- end }}
         "prometheus.io/port": "20200"
         {{- end }}
         {{- if $defaults.annotations }}

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -588,6 +588,19 @@ load _helpers
   [ "${actual}" = "/v1/agent/metrics" ]
 }
 
+@test "client/DaemonSet: when global.metrics.enableAgentMetrics=true, and client annotation for prometheus path is specified, it uses the client annotation rather than default." {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'client.enabled=true' \
+      --set 'global.metrics.enabled=true'  \
+      --set 'global.metrics.enableAgentMetrics=true'  \
+      --set 'client.annotations=prometheus.io/path: /anew/path' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations."prometheus.io/path"' | tee /dev/stderr)
+  [ "${actual}" = "/anew/path" ]
+}
+
 @test "client/DaemonSet: when global.metrics.enableAgentMetrics=true, sets telemetry flag" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/ingress-gateways-deployment.bats
+++ b/charts/consul/test/unit/ingress-gateways-deployment.bats
@@ -300,6 +300,19 @@ load _helpers
   [ "${actual}" = "/metrics" ]
 }
 
+@test "ingressGateways/Deployment: when global.metrics.enabled=true, and ingress gateways annotation for prometheus path is specified, it uses the specified annotation rather than default." {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/ingress-gateways-deployment.yaml  \
+      --set 'ingressGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.metrics.enabled=true'  \
+      --set 'ingressGateways.defaults.annotations=prometheus.io/path: /anew/path' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations."prometheus.io/path"' | tee /dev/stderr)
+  [ "${actual}" = "/anew/path" ]
+}
+
 @test "ingressGateways/Deployment: when global.metrics.enableGatewayMetrics=false, does not set proxy setting" {
   cd `chart_dir`
   local object=$(helm template \

--- a/charts/consul/test/unit/mesh-gateway-deployment.bats
+++ b/charts/consul/test/unit/mesh-gateway-deployment.bats
@@ -99,6 +99,19 @@ key2: value2' \
   [ "${actual}" = "/metrics" ]
 }
 
+@test "meshGateway/Deployment: when global.metrics.enabled=true, and mesh gateways annotation for prometheus path is specified, it uses the specified annotation rather than default." {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/mesh-gateway-deployment.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.metrics.enabled=true'  \
+      --set 'meshGateway.annotations=prometheus.io/path: /anew/path' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations."prometheus.io/path"' | tee /dev/stderr)
+  [ "${actual}" = "/anew/path" ]
+}
+
 @test "meshGateway/Deployment: when global.metrics.enableGatewayMetrics=false, does not set annotations" {
   cd `chart_dir`
   local object=$(helm template \

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -748,6 +748,19 @@ load _helpers
   [ "${actual}" = "/v1/agent/metrics" ]
 }
 
+@test "server/Statefulset: when global.metrics.enabled=true, and server annotation for prometheus path is specified, it uses the specified annotation rather than default." {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'global.metrics.enabled=true'  \
+      --set 'global.metrics.enableAgentMetrics=true'  \
+      --set 'server.annotations=prometheus.io/path: /anew/path' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations."prometheus.io/path"' | tee /dev/stderr)
+  [ "${actual}" = "/anew/path" ]
+}
+
+
 @test "server/StatefulSet: when global.metrics.enableAgentMetrics=true, adds prometheus scheme=http annotation" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -338,6 +338,19 @@ load _helpers
   [ "${actual}" = "/metrics" ]
 }
 
+@test "terminatingGateways/Deployment: when global.metrics.enabled=true, and terminating gateways annotation for prometheus path is specified, it uses the specified annotation rather than default." {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml  \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.metrics.enabled=true'  \
+      --set 'terminatingGateways.defaults.annotations=prometheus.io/path: /anew/path' \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations."prometheus.io/path"' | tee /dev/stderr)
+  [ "${actual}" = "/anew/path" ]
+}
+
 @test "terminatingGateways/Deployment: when global.metrics.enableGatewayMetrics=false, does not set prometheus annotations" {
   cd `chart_dir`
   local object=$(helm template \


### PR DESCRIPTION

### Changes proposed in this PR ###  
- Addresses https://github.com/hashicorp/consul-k8s/issues/1970 
- The issue specifically mentions client prometheus annotations, but I went ahead and made the change for all the places we have the prometheus path annotation. I only included the path annotation (rather than scrape and port) because the scrape and port annotations shouldn't change-- if metrics are enabled then scrape should be true and the port is hardcoded.

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
