### PR TITLE
[1.2.7] Remove Duplicate UBI Tags (#3265)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -328,9 +328,9 @@ jobs:
           extra_build_args: |
             GOLANG_VERSION=${{ needs.get-go-version.outputs.go-version }}
 
-  build-docker-ubi-redhat-registry:
-    name: Docker ${{ matrix.arch }} ${{ matrix.fips }} UBI build for RedHat Registry
-    needs: [get-product-version, get-go-version, build]
+  build-docker-ubi:
+    name: Docker ${{ matrix.arch }} ${{ matrix.fips }} UBI builds
+    needs: [get-product-version, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -351,78 +351,6 @@ jobs:
           ZIP_LOCATION: control-plane/dist/cni/linux/${{ matrix.arch }}
         run: |
           cd "${ZIP_LOCATION}"
-          unzip -j *.zip
-      - name: Copy LICENSE
-        run:
-         cp LICENSE ./control-plane
-      - name: Docker Build (Action)
-        if: ${{ !matrix.fips }}
-        uses: hashicorp/actions-docker-build@76d2fc91532d816ca2660d8f3139e432ac3700fd
-        with:
-          smoke_test: |
-            TEST_VERSION="$(docker run "${IMAGE_NAME}" consul-k8s-control-plane version  | awk '{print $2}')"
-            if [ "${TEST_VERSION}" != "v${version}" ]; then
-              echo "Test FAILED"
-              exit 1
-            fi
-            echo "Test PASSED"
-          version: ${{ env.version }}
-          target: ubi
-          arch: ${{ matrix.arch }}
-          pkg_name: consul-k8s-control-plane_${{ env.version }}
-          bin_name: consul-k8s-control-plane
-          workdir: control-plane
-          tags: |
-            public.ecr.aws/hashicorp/${{ env.repo }}-control-plane:${{ env.version }}-ubi
-          redhat_tag: quay.io/redhat-isv-containers/611ca2f89a9b407267837100:${{env.version}}-ubi
-          extra_build_args: |
-            GOLANG_VERSION=${{ needs.get-go-version.outputs.go-version }}
-
-      - name: Docker FIPS Build (Action)
-        if: ${{ matrix.fips }}
-        uses: hashicorp/actions-docker-build@76d2fc91532d816ca2660d8f3139e432ac3700fd
-        with:
-          smoke_test: |
-            TEST_VERSION="$(docker run "${IMAGE_NAME}" consul-k8s-control-plane version  | awk '{print $2}')"
-            if [ "${TEST_VERSION}" != "v${version}" ]; then
-              echo "Test FAILED"
-              exit 1
-            fi
-            echo "Test PASSED"
-          version: ${{ env.version }}
-          target: ubi-fips # duplicate target to distinguish FIPS builds in CRT machinery
-          arch: ${{ matrix.arch }}
-          pkg_name: consul-k8s-control-plane_${{ env.version }}
-          bin_name: consul-k8s-control-plane
-          workdir: control-plane
-          tags: |
-            public.ecr.aws/hashicorp/${{ env.repo }}-control-plane-fips:${{ env.version }}-ubi
-          redhat_tag: quay.io/redhat-isv-containers/6486b1beabfc4e51588c0416:${{env.version}}-ubi # this is different than the non-FIPS one
-          extra_build_args: |
-            GOLANG_VERSION=${{ needs.get-go-version.outputs.go-version }}
-
-  build-docker-ubi-dockerhub:
-    name: Docker ${{ matrix.arch }} ${{ matrix.fips }} UBI build for DockerHub
-    needs: [ get-product-version, get-go-version, build ]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ "amd64" ]
-        fips: [ "+fips1402", "" ]
-    env:
-      repo: ${{ github.event.repository.name }}
-      version: ${{ needs.get-product-version.outputs.product-version }}${{ matrix.fips }}
-    steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: consul-cni_${{ needs.get-product-version.outputs.product-version }}${{ matrix.fips }}_linux_${{ matrix.arch }}.zip
-          path: control-plane/dist/cni/linux/${{ matrix.arch }}
-      - name: extract consul-cni zip
-        env:
-          ZIP_LOCATION: control-plane/dist/cni/linux/${{ matrix.arch }}
-        run: |
-          cd ${ZIP_LOCATION}
           unzip -j *.zip
       - name: Copy LICENSE
         run:
@@ -460,12 +388,12 @@ jobs:
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.full_dev_tag }}-ubi-${{ github.sha }}
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.minor_dev_tag }}-ubi
             docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.minor_dev_tag }}-ubi-${{ github.sha }}
+          redhat_tag: quay.io/redhat-isv-containers/611ca2f89a9b407267837100:${{env.version}}-ubi
           extra_build_args: |
             GOLANG_VERSION=${{ needs.get-go-version.outputs.go-version }}
-
       - name: Docker FIPS Build (Action)
-        uses: hashicorp/actions-docker-build@76d2fc91532d816ca2660d8f3139e432ac3700fd
         if: ${{ matrix.fips }}
+        uses: hashicorp/actions-docker-build@76d2fc91532d816ca2660d8f3139e432ac3700fd
         with:
           smoke_test: |
             TEST_VERSION="$(docker run "${IMAGE_NAME}" consul-k8s-control-plane version  | awk '{print $2}')"
@@ -480,12 +408,6 @@ jobs:
           pkg_name: consul-k8s-control-plane_${{ env.version }}
           bin_name: consul-k8s-control-plane
           workdir: control-plane
-          tags: |
-            docker.io/hashicorp/${{ env.repo }}-control-plane-fips:${{ env.version }}-ubi
-          dev_tags: |
-            docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.full_dev_tag }}-ubi
-            docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.full_dev_tag }}-ubi-${{ github.sha }}
-            docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.minor_dev_tag }}-ubi
-            docker.io/hashicorppreview/${{ env.repo }}-control-plane:${{ env.minor_dev_tag }}-ubi-${{ github.sha }}
           extra_build_args: |
             GOLANG_VERSION=${{ needs.get-go-version.outputs.go-version }}
+          redhat_tag: quay.io/redhat-isv-containers/6486b1beabfc4e51588c0416:${{env.version}}-ubi # this is different than the non-FIPS one


### PR DESCRIPTION
- Amalgamate UBI with Dockerhub and Redhat tags into one step
- Avoids a production incident that errors on duplicate tags: hashicorp/releng-support#123

### Changes proposed in this PR ###  
-
-

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
