### PR TITLE
Helm: fix hardcoded datadog ad url

### DIFF
--- a/.changelog/3876.txt
+++ b/.changelog/3876.txt
@@ -1,0 +1,3 @@
+```release-note:<bug>
+<helm>: fix the hardcoded server service name in the DataDog Auto-Discovery annotations
+```

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -154,12 +154,12 @@ spec:
               "instances": [
                 {
         {{- if .Values.global.tls.enabled }}
-                  "openmetrics_endpoint": "https://consul-server.{{ .Release.Namespace }}.svc:8501/v1/agent/metrics?format=prometheus",
+                  "openmetrics_endpoint": "https://{{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc:8501/v1/agent/metrics?format=prometheus",
                   "tls_cert": "/etc/datadog-agent/conf.d/consul.d/certs/tls.crt",
                   "tls_private_key": "/etc/datadog-agent/conf.d/consul.d/certs/tls.key",
                   "tls_ca_cert": "/etc/datadog-agent/conf.d/consul.d/ca/tls.crt",
         {{- else }}
-                  "openmetrics_endpoint": "http://consul-server.{{ .Release.Namespace }}.svc:8500/v1/agent/metrics?format=prometheus",
+                  "openmetrics_endpoint": "http://{{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc:8500/v1/agent/metrics?format=prometheus",
         {{- end }}
         {{- if ( .Values.global.acls.manageSystemACLs) }}
                   "headers": {
@@ -180,12 +180,12 @@ spec:
               "instances": [
                 {
         {{- if .Values.global.tls.enabled }}
-                  "url": "https://consul-server.{{ .Release.Namespace }}.svc:8501",
+                  "url": "https://{{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc:8501",
                   "tls_cert": "/etc/datadog-agent/conf.d/consul.d/certs/tls.crt",
                   "tls_private_key": "/etc/datadog-agent/conf.d/consul.d/certs/tls.key",
                   "tls_ca_cert": "/etc/datadog-agent/conf.d/consul.d/ca/tls.crt",
         {{- else }}
-                  "url": "http://consul-server.consul.svc:8500",
+                  "url": "http://{{ template "consul.fullname" . }}-server.consul.svc:8500",
         {{- end }}
                   "use_prometheus_endpoint": true,
         {{- if ( .Values.global.acls.manageSystemACLs) }}


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Address https://github.com/hashicorp/consul-k8s/issues/3876

### How I've tested this PR ###

Result can be checked in the test. Now the ad URL will always point to the correct server service name.


### How I expect reviewers to test this PR ###


### Checklist ###
- [X] Tests added
- [X] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
