### PR TITLE
Helm: support sync-lb-services-endpoints for sync catalog

### DIFF
--- a/.changelog/3905.txt
+++ b/.changelog/3905.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+helm: support sync-lb-services-endpoints flag for syncCatalog
+```

--- a/charts/consul/templates/sync-catalog-deployment.yaml
+++ b/charts/consul/templates/sync-catalog-deployment.yaml
@@ -191,9 +191,9 @@ spec:
             {{- if .Values.syncCatalog.ingress.loadBalancerIPs }}
             -loadBalancer-ips=true \
             {{- end }}
+            {{- end }}
             {{- if .Values.syncCatalog.syncLoadBalancerEndpoints }}
             -sync-lb-services-endpoints=true \
-            {{- end }}
             {{- end }}
         livenessProbe:
           httpGet:

--- a/charts/consul/templates/sync-catalog-deployment.yaml
+++ b/charts/consul/templates/sync-catalog-deployment.yaml
@@ -191,6 +191,9 @@ spec:
             {{- if .Values.syncCatalog.ingress.loadBalancerIPs }}
             -loadBalancer-ips=true \
             {{- end }}
+            {{- if .Values.syncCatalog.syncLoadBalancerEndpoints }}
+            -sync-lb-services-endpoints=true \
+            {{- end }}
             {{- end }}
         livenessProbe:
           httpGet:

--- a/charts/consul/test/unit/sync-catalog-deployment.bats
+++ b/charts/consul/test/unit/sync-catalog-deployment.bats
@@ -414,6 +414,29 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# syncLoadBalancerEndpoints
+
+@test "syncCatalog/Deployment: enable LB endpoints sync flag not passed when disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-sync-lb-services-endpoints=true"))' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+@test "syncCatalog/Deployment: enable LB endpoints sync flag passed when enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/sync-catalog-deployment.yaml  \
+      --set 'syncCatalog.enabled=true' \
+      --set 'syncCatalog.syncLoadBalancerEndpoints=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].command | any(contains("-sync-lb-services-endpoints=true"))' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 # affinity
 
 @test "syncCatalog/Deployment: affinity not set by default" {

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2193,6 +2193,10 @@ syncCatalog:
   # Set this to false to skip syncing ClusterIP services.
   syncClusterIPServices: true
 
+  # If true, LoadBalancer service endpoints instead of ingress addresses will be synced to Consul. 
+  # If false, LoadBalancer endpoints are not synced to Consul.
+  syncLoadBalancerEndpoints: false
+
   ingress:
     # Syncs the hostname from a Kubernetes Ingress resource to service registrations
     # when a rule matched a service. Currently only supports host based routing and


### PR DESCRIPTION
This PR adds a test and fixes a minor issue in the original https://github.com/hashicorp/consul-k8s/pull/3875, plus runs privileged tests required to merge.

I intend to backport this change to all active versions as it exposes a feature that's existed in `consul-k8s` since well before those releases.

---------

### Changes proposed in this PR ###  
- syncCatalog: add support for `sync-lb-services-endpoints` startup flag

### How I've tested this PR ###
helm template

### How I expect reviewers to test this PR ###
Validate that if the helm value is set to true that it's correctly rendered in the deployment manifest

### Checklist ###
- [ ] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

fixes #3899 