### PR TITLE
[NET-6466] Remove secrets from termgw role

### DIFF
--- a/.changelog/3928.txt
+++ b/.changelog/3928.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+terminating-gateways: Remove unnecessary permissions from terminating gateways role
+```

--- a/charts/consul/templates/terminating-gateways-role.yaml
+++ b/charts/consul/templates/terminating-gateways-role.yaml
@@ -16,25 +16,14 @@ metadata:
     release: {{ $root.Release.Name }}
     component: terminating-gateway
     terminating-gateway-name: {{ template "consul.fullname" $root }}-{{ .name }}
-{{- if (or $root.Values.global.acls.manageSystemACLs $root.Values.global.enablePodSecurityPolicies) }}
-rules:
 {{- if $root.Values.global.enablePodSecurityPolicies }}
+rules:
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
     resourceNames:
       -  {{ template "consul.fullname" $root }}-{{ .name }}
     verbs:
       - use
-{{- end }}
-{{- if $root.Values.global.acls.manageSystemACLs }}
-  - apiGroups: [""]
-    resources:
-      - secrets
-    resourceNames:
-      -  {{ template "consul.fullname" $root }}-{{ .name }}-acl-token
-    verbs:
-      - get
-{{- end }}
 {{- else }}
 rules: []
 {{- end }}

--- a/charts/consul/test/unit/terminating-gateways-role.bats
+++ b/charts/consul/test/unit/terminating-gateways-role.bats
@@ -53,7 +53,7 @@ load _helpers
       --set 'global.enablePodSecurityPolicies=true' \
       . | tee /dev/stderr |
       yq -s -r '.[0].rules | length' | tee /dev/stderr)
-  [ "${actual}" = "2" ]
+  [ "${actual}" = "1" ]
 }
 
 @test "terminatingGateways/Role: rules for ACLs, PSPs with multiple gateways" {
@@ -76,10 +76,10 @@ load _helpers
   [ "${actual}" = "release-name-consul-gateway2" ]
 
   local actual=$(echo $object | yq '.[0].rules | length' | tee /dev/stderr)
-  [ "${actual}" = "2" ]
+  [ "${actual}" = "1" ]
 
   local actual=$(echo $object | yq '.[1].rules | length' | tee /dev/stderr)
-  [ "${actual}" = "2" ]
+  [ "${actual}" = "1" ]
 
   local actual=$(echo $object | yq '.[2] | length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]

--- a/charts/consul/test/unit/terminating-gateways-role.bats
+++ b/charts/consul/test/unit/terminating-gateways-role.bats
@@ -32,23 +32,6 @@ load _helpers
   [ "${actual}" = "podsecuritypolicies" ]
 }
 
-@test "terminatingGateways/Role: rules for global.acls.manageSystemACLs=true" {
-  cd `chart_dir`
-  local object=$(helm template \
-      -s templates/terminating-gateways-role.yaml  \
-      --set 'terminatingGateways.enabled=true' \
-      --set 'connectInject.enabled=true' \
-      --set 'global.acls.manageSystemACLs=true' \
-      . | tee /dev/stderr |
-      yq -s -r '.[0].rules[0]' | tee /dev/stderr)
-
-  local actual=$(echo $object | yq -r '.resources[0]' | tee /dev/stderr)
-  [ "${actual}" = "secrets" ]
-
-  local actual=$(echo $object | yq -r '.resourceNames[0]' | tee /dev/stderr)
-  [ "${actual}" = "release-name-consul-terminating-gateway-acl-token" ]
-}
-
 @test "terminatingGateways/Role: rules is empty if no ACLs, PSPs" {
   cd `chart_dir`
   local actual=$(helm template \


### PR DESCRIPTION
### Changes proposed in this PR ###  
- remove secrets access from terminating gateway as this is no longer needed

### How I've tested this PR ###
1. build a local version of the control plane by running `make dev-docker` from the root of this repo
1. clone the following gist https://gist.github.com/jm96441n/8671cc5e73bf950955c96f7cd3281694
2. checkout this branch in consul-k8s repo on your machine
3. in `start.sh` replace the value for `CONSUL_K8S_CHART_LOCATION` with the path to the helm charts in consul-k8s on your system
4. run `start.sh`
5. once all the services are up exec into the bender service using:
```
kubectl exec -i -t $(kubectl get pods --selector=app=bender -o jsonpath='{.items[*].metadata.name}') -c bender -- /bin/sh
```
6. install `curl` onto the container using `apk add curl`
7. contact the zoidberg service fronted by the termgw using `curl zoidberg.virtual.consul`

### How I expect reviewers to test this PR ###
Read the code, follow the above steps

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
