### PR TITLE
Net 9069/xw add license file to all bin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,8 +145,7 @@ jobs:
         working-directory: ${{ matrix.component }}
         run: |
           mkdir -p dist out
-          echo "Current working directory: $GITHUB_WORKSPACE"
-          cp LICENSE dist/LICENSE.txt
+          cp $GITHUB_WORKSPACE/LICENSE dist/LICENSE.txt
 
           export GIT_COMMIT=$(git rev-parse --short HEAD)
           export GIT_DIRTY=$(test -n "$(git status --porcelain)" && echo "+CHANGES")
@@ -167,7 +166,7 @@ jobs:
           LICENSE_DIR: ".release/linux/package/usr/share/doc/${{ env.PKG_NAME }}"
         run: |
           mkdir -p "$LICENSE_DIR"
-          cp LICENSE "$LICENSE_DIR/LICENSE.txt"
+          cp $GITHUB_WORKSPACE/LICENSE "$LICENSE_DIR/LICENSE.txt"
 
       - name: Package rpm and deb files
         if: matrix.goos == 'linux' && matrix.component == 'cli' && matrix.skip_packaging != 'true'
@@ -275,7 +274,7 @@ jobs:
           unzip -j *.zip
       - name: Copy LICENSE
         run:
-          cp LICENSE ./control-plane
+          cp $GITHUB_WORKSPACE/LICENSE $GITHUB_WORKSPACE/control-plane
 
       # This naming convention will be used ONLY for per-commit dev images
       - name: Set docker dev tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,7 @@ jobs:
         working-directory: ${{ matrix.component }}
         run: |
           mkdir -p dist out
+          echo "Current working directory: $GITHUB_WORKSPACE"
           cp LICENSE dist/LICENSE.txt
 
           export GIT_COMMIT=$(git rev-parse --short HEAD)


### PR DESCRIPTION
### Changes proposed in this PR ###  

The main branch failed when building the binaries, use abs path to copy files instead of relative.

Build is successful in this [branch](https://github.com/hashicorp/consul-k8s/actions/runs/8789758855).

