### PR TITLE
Fix a panic in connect-inject when the provided upstreams list is malformed

### DIFF
--- a/.changelog/3956.txt
+++ b/.changelog/3956.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+control-plane: fix a panic when an upstream annotation is malformed.
+```
+
+```release-note:enhancement
+control-plane: support <space>, <comma> and <\n> as upstream separators.
+```

--- a/control-plane/connect-inject/webhook/container_env.go
+++ b/control-plane/connect-inject/webhook/container_env.go
@@ -22,6 +22,9 @@ func (w *MeshWebhook) containerEnvVars(pod corev1.Pod) []corev1.EnvVar {
 	var result []corev1.EnvVar
 	for _, raw := range strings.Split(raw, ",") {
 		parts := strings.SplitN(raw, ":", 3)
+		if len(parts) < 2 {
+			continue
+		}
 		port, _ := common.PortValue(pod, strings.TrimSpace(parts[1]))
 		if port > 0 {
 			name := strings.TrimSpace(parts[0])

--- a/control-plane/connect-inject/webhook/container_env.go
+++ b/control-plane/connect-inject/webhook/container_env.go
@@ -25,6 +25,7 @@ func (w *MeshWebhook) containerEnvVars(pod corev1.Pod) []corev1.EnvVar {
 	}) {
 		parts := strings.SplitN(raw, ":", 3)
 		if len(parts) < 2 {
+			w.Log.Error(fmt.Errorf("ustream URL is malformed, skipping it: %s", raw), "malformed upstream")
 			continue
 		}
 		port, _ := common.PortValue(pod, strings.TrimSpace(parts[1]))

--- a/control-plane/connect-inject/webhook/container_env.go
+++ b/control-plane/connect-inject/webhook/container_env.go
@@ -21,7 +21,7 @@ func (w *MeshWebhook) containerEnvVars(pod corev1.Pod) []corev1.EnvVar {
 
 	var result []corev1.EnvVar
 	for _, raw := range strings.FieldsFunc(raw, func(r rune) bool {
-		return r == ',' || r == ' ' // Split either comma separated or space separated
+		return r == ',' || r == ' ' || r == '\n' // Split either comma separated or space separated
 	}) {
 		parts := strings.SplitN(raw, ":", 3)
 		if len(parts) < 2 {

--- a/control-plane/connect-inject/webhook/container_env.go
+++ b/control-plane/connect-inject/webhook/container_env.go
@@ -20,7 +20,9 @@ func (w *MeshWebhook) containerEnvVars(pod corev1.Pod) []corev1.EnvVar {
 	}
 
 	var result []corev1.EnvVar
-	for _, raw := range strings.Split(raw, ",") {
+	for _, raw := range strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' // Split either comma separated or space separated
+	}) {
 		parts := strings.SplitN(raw, ":", 3)
 		if len(parts) < 2 {
 			continue

--- a/control-plane/connect-inject/webhook/container_env_test.go
+++ b/control-plane/connect-inject/webhook/container_env_test.go
@@ -125,7 +125,7 @@ func TestContainerEnvVars(t *testing.T) {
 			"Multiple upstreams comma separated and carriage return malformed upstream",
 			`static-server7890,
                        static-server2:7892
-                       static-server3:7893`,
+static-server3:7893`,
 			[]corev1.EnvVar{
 				{
 					Name:  "STATIC_SERVER2_CONNECT_SERVICE_HOST",

--- a/control-plane/connect-inject/webhook/container_env_test.go
+++ b/control-plane/connect-inject/webhook/container_env_test.go
@@ -17,14 +17,131 @@ func TestContainerEnvVars(t *testing.T) {
 	cases := []struct {
 		Name     string
 		Upstream string
+		required []corev1.EnvVar
 	}{
 		{
 			"Upstream with datacenter",
 			"static-server:7890:dc1",
+			[]corev1.EnvVar{
+				{
+					Name:  "STATIC_SERVER_CONNECT_SERVICE_HOST",
+					Value: "127.0.0.1",
+				}, {
+					Name:  "STATIC_SERVER_CONNECT_SERVICE_PORT",
+					Value: "7890",
+				},
+			},
 		},
 		{
 			"Upstream without datacenter",
 			"static-server:7890",
+			[]corev1.EnvVar{
+				{
+					Name:  "STATIC_SERVER_CONNECT_SERVICE_HOST",
+					Value: "127.0.0.1",
+				}, {
+					Name:  "STATIC_SERVER_CONNECT_SERVICE_PORT",
+					Value: "7890",
+				},
+			},
+		},
+		{
+			"Multiple upstreams comma separated",
+			"static-server:7890, static-server2:7892",
+			[]corev1.EnvVar{
+				{
+					Name:  "STATIC_SERVER_CONNECT_SERVICE_HOST",
+					Value: "127.0.0.1",
+				}, {
+					Name:  "STATIC_SERVER_CONNECT_SERVICE_PORT",
+					Value: "7890",
+				},
+				{
+					Name:  "STATIC_SERVER2_CONNECT_SERVICE_HOST",
+					Value: "127.0.0.1",
+				}, {
+					Name:  "STATIC_SERVER2_CONNECT_SERVICE_PORT",
+					Value: "7892",
+				},
+			},
+		},
+		{
+			"Multiple upstreams comma separated",
+			"static-server:7890, static-server2:7892 static-server3:7893",
+			[]corev1.EnvVar{
+				{
+					Name:  "STATIC_SERVER_CONNECT_SERVICE_HOST",
+					Value: "127.0.0.1",
+				}, {
+					Name:  "STATIC_SERVER_CONNECT_SERVICE_PORT",
+					Value: "7890",
+				},
+				{
+					Name:  "STATIC_SERVER2_CONNECT_SERVICE_HOST",
+					Value: "127.0.0.1",
+				}, {
+					Name:  "STATIC_SERVER2_CONNECT_SERVICE_PORT",
+					Value: "7892",
+				},
+				{
+					Name:  "STATIC_SERVER3_CONNECT_SERVICE_HOST",
+					Value: "127.0.0.1",
+				}, {
+					Name:  "STATIC_SERVER3_CONNECT_SERVICE_PORT",
+					Value: "7893",
+				},
+			},
+		},
+		{
+			"Multiple upstreams comma separated and carriage return",
+			`static-server:7890,
+                       static-server2:7892
+                       static-server3:7893`,
+			[]corev1.EnvVar{
+				{
+					Name:  "STATIC_SERVER_CONNECT_SERVICE_HOST",
+					Value: "127.0.0.1",
+				}, {
+					Name:  "STATIC_SERVER_CONNECT_SERVICE_PORT",
+					Value: "7890",
+				},
+				{
+					Name:  "STATIC_SERVER2_CONNECT_SERVICE_HOST",
+					Value: "127.0.0.1",
+				}, {
+					Name:  "STATIC_SERVER2_CONNECT_SERVICE_PORT",
+					Value: "7892",
+				},
+				{
+					Name:  "STATIC_SERVER3_CONNECT_SERVICE_HOST",
+					Value: "127.0.0.1",
+				}, {
+					Name:  "STATIC_SERVER3_CONNECT_SERVICE_PORT",
+					Value: "7893",
+				},
+			},
+		},
+		{
+			"Multiple upstreams comma separated and carriage return malformed upstream",
+			`static-server7890,
+                       static-server2:7892
+                       static-server3:7893`,
+			[]corev1.EnvVar{
+				{
+					Name:  "STATIC_SERVER2_CONNECT_SERVICE_HOST",
+					Value: "127.0.0.1",
+				}, {
+					Name:  "STATIC_SERVER2_CONNECT_SERVICE_PORT",
+					Value: "7892",
+				},
+				{
+					Name:  "STATIC_SERVER3_CONNECT_SERVICE_HOST",
+					Value: "127.0.0.1",
+				}, {
+					Name:  "STATIC_SERVER3_CONNECT_SERVICE_PORT",
+					Value: "7893",
+				},
+			},
 		},
 	}
 
@@ -42,15 +159,7 @@ func TestContainerEnvVars(t *testing.T) {
 				},
 			})
 
-			require.ElementsMatch(envVars, []corev1.EnvVar{
-				{
-					Name:  "STATIC_SERVER_CONNECT_SERVICE_HOST",
-					Value: "127.0.0.1",
-				}, {
-					Name:  "STATIC_SERVER_CONNECT_SERVICE_PORT",
-					Value: "7890",
-				},
-			})
+			require.ElementsMatch(envVars, tt.required)
 		})
 	}
 }


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Fix a panic when parsing a malformed upstream, now a malformed upstream will be ignored
- Support multiple separators between upstreams (<space>, <comma>, <return>).

### How I've tested this PR ###
Added unit tests to test multiple scenarios including malformed upstream lists

### How I expect reviewers to test this PR ###
N/A

### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
