### PR TITLE
NET-9154: Update Kubernetes version

### DIFF
--- a/charts/consul/test/terraform/aks/variables.tf
+++ b/charts/consul/test/terraform/aks/variables.tf
@@ -7,7 +7,7 @@ variable "location" {
 }
 
 variable "kubernetes_version" {
-  default     = "1.26"
+  default     = "1.27"
   description = "Kubernetes version supported on AKS"
 }
 


### PR DESCRIPTION
### Changes proposed in this PR ###  
**Solution**: Update Kubernetes version from `1.26` -> `1.27`

**ISSUE**
❗ Acceptance-aks [CI](https://github.com/hashicorp/consul-k8s-workflows/actions/runs/8871366832/job/24354322593#step:17:345) tests is failing with error
```
Error: Code="AgentPoolK8sVersionNotSupported" Message="Version 1.26.12 is not supported in this region. 
```
[Link](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar)
![Screenshot 2024-04-30 at 3 51 30 PM](https://github.com/hashicorp/consul-k8s/assets/18365710/de94e606-662b-4bce-8c89-2528986d8bac)

### How I've tested this PR ###
Wait for nightly CI Tests to run

### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
