### PR TITLE
chore: remove workstream from JIRA sync

### DIFF
--- a/.github/workflows/jira-issues.yaml
+++ b/.github/workflows/jira-issues.yaml
@@ -46,9 +46,7 @@ jobs:
           description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created in GitHub by ${{ github.actor }}._"
           # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve)
           extraFields: '{ "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}",
-                          "customfield_10371": { "value": "GitHub" },
-                          "customfield_10535": [{ "value": "Service Mesh" }],
-                          "components": [{ "name": "${{ github.event.repository.name }}" }],
+                          "customfield_10371": { "value": "GitHub" }],
                           "labels": ${{ steps.set-ticket-labels.outputs.LABELS }} }'
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}

--- a/.github/workflows/jira-pr.yaml
+++ b/.github/workflows/jira-pr.yaml
@@ -60,9 +60,7 @@ jobs:
           description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created in GitHub by ${{ github.actor }}._"
           # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve)
           extraFields: '{ "customfield_10089": "${{ github.event.pull_request.html_url }}",
-                          "customfield_10371": { "value": "GitHub" },     
-                          "customfield_10535": [{ "value": "Service Mesh" }],
-                          "components": [{ "name": "${{ github.event.repository.name }}" }],
+                          "customfield_10371": { "value": "GitHub" }],
                           "labels": ${{ steps.set-ticket-labels.outputs.LABELS }} }'
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}


### PR DESCRIPTION
### Description
Removing the workstream from this integration so we can triage teams appropriately.

*edit: 
I also removed the component because I think that's creating issues with this integration - I believe they were deleted in JIRA when we consolidated recently. You can see it fail in this PR.
