### PR TITLE
[NET-9153] Handle Terminating Gateway ACL Setup 

### DIFF
--- a/control-plane/controllers/configentries/registrations_controller.go
+++ b/control-plane/controllers/configentries/registrations_controller.go
@@ -92,9 +92,10 @@ func (r *RegistrationsController) Reconcile(ctx context.Context, req ctrl.Reques
 	// the acl setup
 	if r.ConsulClientConfig.APIClientConfig.Token != "" || r.ConsulClientConfig.APIClientConfig.TokenFile != "" {
 		err = r.updateTermGWACLRole(log, client, registration)
-	}
-	if err != nil {
-		return ctrl.Result{}, err
+		if err != nil {
+			r.updateStatusError(ctx, registration, "ConsulErrorACL", err)
+			return ctrl.Result{}, err
+		}
 	}
 
 	err = r.updateStatus(ctx, req.NamespacedName)

--- a/control-plane/controllers/configentries/registrations_controller_test.go
+++ b/control-plane/controllers/configentries/registrations_controller_test.go
@@ -5,6 +5,8 @@ package configentries_test
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -24,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	capi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-uuid"
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	"github.com/hashicorp/consul-k8s/control-plane/consul"
@@ -31,11 +34,17 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 )
 
+type serverResponseConfig struct {
+	registering bool
+	aclEnabled  bool
+}
+
 func TestReconcile_Success(tt *testing.T) {
 	deletionTime := metav1.Now()
 	cases := map[string]struct {
-		registration       *v1alpha1.Registration
-		expectedConditions []v1alpha1.Condition
+		registration         *v1alpha1.Registration
+		serverResponseConfig serverResponseConfig
+		expectedConditions   []v1alpha1.Condition
 	}{
 		"success on registration": {
 			registration: &v1alpha1.Registration{
@@ -59,6 +68,41 @@ func TestReconcile_Success(tt *testing.T) {
 						Address: "127.0.0.1",
 					},
 				},
+			},
+			serverResponseConfig: serverResponseConfig{registering: true},
+			expectedConditions: []v1alpha1.Condition{{
+				Type:    "Synced",
+				Status:  v1.ConditionTrue,
+				Reason:  "",
+				Message: "",
+			}},
+		},
+		"success on registration -- ACLs enabled": {
+			registration: &v1alpha1.Registration{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Registration",
+					APIVersion: "consul.hashicorp.com/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-registration",
+					Finalizers: []string{configentries.RegistrationFinalizer},
+				},
+				Spec: v1alpha1.RegistrationSpec{
+					ID:         "node-id",
+					Node:       "virtual-node",
+					Address:    "127.0.0.1",
+					Datacenter: "dc1",
+					Service: v1alpha1.Service{
+						ID:      "service-id",
+						Name:    "service-name",
+						Port:    8080,
+						Address: "127.0.0.1",
+					},
+				},
+			},
+			serverResponseConfig: serverResponseConfig{
+				registering: true,
+				aclEnabled:  true,
 			},
 			expectedConditions: []v1alpha1.Condition{{
 				Type:    "Synced",
@@ -91,6 +135,40 @@ func TestReconcile_Success(tt *testing.T) {
 					},
 				},
 			},
+			serverResponseConfig: serverResponseConfig{
+				registering: false,
+				aclEnabled:  false,
+			},
+			expectedConditions: []v1alpha1.Condition{},
+		},
+		"success on deregistration - ACLs enabled": {
+			registration: &v1alpha1.Registration{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Registration",
+					APIVersion: "consul.hashicorp.com/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-registration",
+					Finalizers:        []string{configentries.RegistrationFinalizer},
+					DeletionTimestamp: &deletionTime,
+				},
+				Spec: v1alpha1.RegistrationSpec{
+					ID:         "node-id",
+					Node:       "virtual-node",
+					Address:    "127.0.0.1",
+					Datacenter: "dc1",
+					Service: v1alpha1.Service{
+						ID:      "service-id",
+						Name:    "service-name",
+						Port:    8080,
+						Address: "127.0.0.1",
+					},
+				},
+			},
+			serverResponseConfig: serverResponseConfig{
+				registering: false,
+				aclEnabled:  true,
+			},
 			expectedConditions: []v1alpha1.Condition{},
 		},
 	}
@@ -103,22 +181,8 @@ func TestReconcile_Success(tt *testing.T) {
 			s.AddKnownTypes(v1alpha1.GroupVersion, &v1alpha1.Registration{})
 			ctx := context.Background()
 
-			consulServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(200)
-			}))
+			consulServer, testClient := fakeConsulServer(t, tc.serverResponseConfig, tc.registration.Spec.Service.Name)
 			defer consulServer.Close()
-
-			parsedURL, err := url.Parse(consulServer.URL)
-			require.NoError(t, err)
-			host := strings.Split(parsedURL.Host, ":")[0]
-
-			port, err := strconv.Atoi(parsedURL.Port())
-			require.NoError(t, err)
-
-			testClient := &test.TestServerClient{
-				Cfg:     &consul.Config{APIClientConfig: &capi.Config{Address: host}, HTTPPort: port},
-				Watcher: test.MockConnMgrForIPAndPort(t, host, port, false),
-			}
 
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(s).
@@ -134,7 +198,7 @@ func TestReconcile_Success(tt *testing.T) {
 				ConsulServerConnMgr: testClient.Watcher,
 			}
 
-			_, err = controller.Reconcile(ctx, ctrl.Request{
+			_, err := controller.Reconcile(ctx, ctrl.Request{
 				NamespacedName: types.NamespacedName{Name: tc.registration.Name, Namespace: tc.registration.Namespace},
 			})
 			require.NoError(t, err)
@@ -278,4 +342,132 @@ func TestReconcile_Failure(tt *testing.T) {
 			}
 		})
 	}
+}
+
+func fakeConsulServer(t *testing.T, serverResponseConfig serverResponseConfig, serviceName string) (*httptest.Server, *test.TestServerClient) {
+	t.Helper()
+	mux := buildMux(t, serverResponseConfig, serviceName)
+	consulServer := httptest.NewServer(mux)
+
+	parsedURL, err := url.Parse(consulServer.URL)
+	require.NoError(t, err)
+	host := strings.Split(parsedURL.Host, ":")[0]
+
+	port, err := strconv.Atoi(parsedURL.Port())
+	require.NoError(t, err)
+
+	cfg := &consul.Config{APIClientConfig: &capi.Config{Address: host}, HTTPPort: port}
+	if serverResponseConfig.aclEnabled {
+		cfg.APIClientConfig.Token = "test-token"
+	}
+
+	testClient := &test.TestServerClient{
+		Cfg:     cfg,
+		Watcher: test.MockConnMgrForIPAndPort(t, host, port, false),
+	}
+
+	return consulServer, testClient
+}
+
+func buildMux(t *testing.T, cfg serverResponseConfig, serviceName string) http.Handler {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/catalog/register", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+
+	mux.HandleFunc("/v1/catalog/deregister", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+
+	policyID, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+
+	mux.HandleFunc("/v1/acl/roles", func(w http.ResponseWriter, r *http.Request) {
+		termGWPolicies := []*capi.ACLLink{
+			{
+				ID:   "b7e377d9-5e2b-b99c-3f06-139584cf47f8",
+				Name: "terminating-gateway-policy",
+			},
+		}
+
+		if !cfg.registering {
+			termGWPolicies = append(termGWPolicies, &capi.ACLLink{
+				ID:   policyID,
+				Name: fmt.Sprintf("%s-write-policy", serviceName),
+			})
+		}
+
+		entries := []*capi.ACLRole{
+			{
+				ID:          "754a8717-46e9-9f18-7f76-28dc0afafd19",
+				Name:        "consul-consul-connect-inject-acl-role",
+				Description: "ACL Role for consul-consul-connect-injector",
+				Policies: []*capi.ACLLink{
+					{
+						ID:   "38511a9f-a309-11e2-7f67-7fea12056e7c",
+						Name: "connect-inject-policy",
+					},
+				},
+			},
+			{
+				ID:          "61fc5051-96e9-7b67-69b5-98f7f6682563",
+				Name:        "consul-consul-terminating-gateway-acl-role",
+				Description: "ACL Role for consul-consul-terminating-gateway",
+				Policies:    termGWPolicies,
+			},
+		}
+		val, err := json.Marshal(entries)
+		if err != nil {
+			w.WriteHeader(500)
+			return
+		}
+		w.WriteHeader(200)
+		w.Write(val)
+	})
+
+	mux.HandleFunc("/v1/acl/role/", func(w http.ResponseWriter, r *http.Request) {
+		role := &capi.ACLRole{
+			ID:          "61fc5051-96e9-7b67-69b5-98f7f6682563",
+			Name:        "consul-consul-terminating-gateway-acl-role",
+			Description: "ACL Role for consul-consul-terminating-gateway",
+			Policies: []*capi.ACLLink{
+				{
+					ID:   "b7e377d9-5e2b-b99c-3f06-139584cf47f8",
+					Name: "terminating-gateway-policy",
+				},
+				{
+					ID:   policyID,
+					Name: fmt.Sprintf("%s-write-policy", serviceName),
+				},
+			},
+		}
+		val, err := json.Marshal(role)
+		if err != nil {
+			w.WriteHeader(500)
+			return
+		}
+		w.WriteHeader(200)
+		w.Write(val)
+	})
+
+	mux.HandleFunc("/v1/acl/policy/name/", func(w http.ResponseWriter, r *http.Request) {
+		policy := &capi.ACLPolicy{
+			ID:   policyID,
+			Name: fmt.Sprintf("%s-write-policy", serviceName),
+		}
+		val, err := json.Marshal(policy)
+		if err != nil {
+			w.WriteHeader(500)
+			return
+		}
+		w.WriteHeader(200)
+		w.Write(val)
+	})
+
+	mux.HandleFunc("/v1/acl/policy/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+
+	return mux
 }


### PR DESCRIPTION
### Changes proposed in this PR ###  
- modify term gateway acl role when registering/deregistering services

### How I've tested this PR ###
- requirements: `kubectl` and `yq` to be installed on your system, this branch checked out in consul-k8s
- set the following values in your shell, update the k8s chart location value to be the path to the consul-k8s charts on your machine
```
export CONSUL_K8S_CHARTS_LOCATION="$HOME/hashi/consul-k8s/charts/consul"
export CONSUL_HTTP_ADDR="127.0.0.1:8501"
export CONSUL_HTTP_SSL=true
export CONSUL_HTTP_SSL_VERIFY=false
```
- build from this branch `make docker-dev`
- from the following gist run the `start.sh` file, this will set up your cluster and register the service: https://gist.github.com/jm96441n/43e526387fc83f7079a10a555f739177
- open up the consul ui at `https://localhost:8501` (you'll have to allow insecure traffic over https here)
- see the `zoidberg` service registered
- run `consul acl role list` and you should see the terminating gateway acl role including the `zoidberg` write policy
- run `consul acl policy list` and you should see the zoidberg write policy
- delete the registration by running `kubectl delete -f ./registration.yaml`
- now in the UI the registration should be gone
- run `consul acl role list` and you should see the terminating gateway acl role no longer include the `zoidberg` write policy
- run `consul acl policy list` and you should no longer see the zoidberg write policy

### How I expect reviewers to test this PR ###
run the above
read the code
run the tests


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
