### PR TITLE
NET-9173: tcp acceptance tests

### DIFF
--- a/acceptance/framework/helpers/helpers.go
+++ b/acceptance/framework/helpers/helpers.go
@@ -209,6 +209,12 @@ func RunCommand(t testutil.TestingTB, options *k8s.KubectlOptions, command Comma
 
 	go func() {
 		output, err := exec.Command(command.Command, command.Args...).CombinedOutput()
+		for _, v := range command.Args {
+			if strings.Contains(v, "-vvvsSf") {
+				fmt.Printf("%s%s\n", command.Command, command.Args)
+				fmt.Println(string(output))
+			}
+		}
 		resultCh <- &cmdResult{output: string(output), err: err}
 	}()
 

--- a/acceptance/framework/k8s/deploy.go
+++ b/acceptance/framework/k8s/deploy.go
@@ -180,6 +180,7 @@ func CheckStaticServerConnectionFailing(t *testing.T, options *k8s.KubectlOption
 		"curl: (52) Empty reply from server",
 		"curl: (7) Failed to connect",
 		"curl: (56) Recv failure: Connection reset by peer",
+		"curl: (35) OpenSSL SSL_connect: Connection reset by peer",
 	}, "", curlArgs...)
 }
 

--- a/acceptance/tests/fixtures/bases/static-server-test-tcp/configmap.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-test-tcp/configmap.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: static-server-config
+data:
+  config: |
+    {
+      local_certs
+      skip_install_trust
+      auto_https disable_redirects
+    }
+    static-server-hostname.virtual.server.consul {
+      log
+      respond  "hello world"
+    }
+    :80 {
+      log
+      respond  "hello world"
+    }

--- a/acceptance/tests/fixtures/bases/static-server-test-tcp/deployment.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-test-tcp/deployment.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: static-server
+  template:
+    metadata:
+      labels:
+        app: static-server
+    spec:
+      containers:
+        - name: caddy
+          image: caddy:latest
+          ports:
+            - name: https-port
+              containerPort: 443
+            - name: http-port
+              containerPort: 80
+          volumeMounts:
+            - name: data
+              mountPath: "/data"
+            - name: config
+              mountPath: /etc/caddy/
+              readOnly: true
+      serviceAccountName: static-server
+      volumes:
+        - name: data
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: static-server-config
+            items:
+              - key: "config"
+                path: "Caddyfile"

--- a/acceptance/tests/fixtures/bases/static-server-test-tcp/kustomization.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-test-tcp/kustomization.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resources:
+  - deployment.yaml
+  - configmap.yaml
+  - service.yaml
+  - serviceaccount.yaml
+  - psp-rolebinding.yaml
+  - privileged-scc-rolebinding.yaml

--- a/acceptance/tests/fixtures/bases/static-server-test-tcp/privileged-scc-rolebinding.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-test-tcp/privileged-scc-rolebinding.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: static-server-openshift-privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+  - kind: ServiceAccount
+    name: static-server

--- a/acceptance/tests/fixtures/bases/static-server-test-tcp/psp-rolebinding.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-test-tcp/psp-rolebinding.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: static-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-psp
+subjects:
+  - kind: ServiceAccount
+    name: static-server

--- a/acceptance/tests/fixtures/bases/static-server-test-tcp/service.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-test-tcp/service.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: static-server
+  labels:
+    app: static-server
+spec:
+  ports:
+    - name: https-port
+      port: 443
+      targetPort: https-port
+      protocol: TCP
+    - name: http-port
+      port: 80
+      targetPort: http-port
+      protocol: TCP
+  selector:
+    app: static-server

--- a/acceptance/tests/fixtures/bases/static-server-test-tcp/serviceaccount.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-test-tcp/serviceaccount.yaml
@@ -1,0 +1,7 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: static-server


### PR DESCRIPTION
### Changes proposed in this PR ###  
❗ ADDED TEST IS FAILING ❗ 
- Follow up acceptance test for this [PR](https://github.com/hashicorp/consul-enterprise/pull/9199)
- We have existing acceptance test coverage for `http` external services accessible over a peering connection [here](https://github.com/hashicorp/consul-k8s/blob/95ee1569b743de7c2bcc82429fdef6116bad3693/acceptance/tests/peering/peering_connect_test.go#L34-L386); 

This PR adds acceptance test coverage for tcp external services in the same setup. External service was updated to a TCP / HTTP port enabled service. 

### How I've tested this PR ###
CI should pass

### How I expect reviewers to test this PR ###
CI should pass

### Checklist ###
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
