### PR TITLE
Fix ArgoCD hooks annotation location

### DIFF
--- a/.changelog/3989.txt
+++ b/.changelog/3989.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+helm: Fix ArgoCD hooks related annotation on init Job, they must be added at Job definition and not tempalte level.
+```

--- a/.changelog/3989.txt
+++ b/.changelog/3989.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-helm: Fix ArgoCD hooks related annotation on init Job, they must be added at Job definition and not tempalte level.
+helm: Fix ArgoCD hooks related annotations on server-acl-init Job, they must be added at Job definition and not template level.
 ```

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -32,6 +32,11 @@ metadata:
     {{- if .Values.global.extraLabels }}
       {{- toYaml .Values.global.extraLabels | nindent 4 }}
     {{- end }}
+  {{- if .Values.global.argocd.enabled }}
+  annotations:
+    "argocd.argoproj.io/hook": "Sync"
+    "argocd.argoproj.io/hook-delete-policy": "HookSucceeded"
+  {{- end }}
 spec:
   template:
     metadata:
@@ -50,12 +55,7 @@ spec:
         {{- if .Values.global.acls.annotations }}
           {{- tpl .Values.global.acls.annotations . | nindent 8 }}
         {{- end }}
-        {{- if .Values.global.argocd.enabled }}
-        "argocd.argoproj.io/hook": "Sync"
-        "argocd.argoproj.io/hook-delete-policy": "HookSucceeded"
-        {{- end }}
         {{- if .Values.global.secretsBackend.vault.enabled }}
-
         {{- /* Run the Vault agent as both an init container and sidecar.
         The Vault agent sidecar is needed when server-acl-init bootstraps ACLs
         and writes the bootstrap token back to Vault.

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -2383,14 +2383,14 @@ load _helpers
      --set 'global.acls.manageSystemACLs=true' \
      --set 'global.argocd.enabled=true' \
      . | tee /dev/stderr |
-     yq -r '.spec.template.metadata.annotations["argocd.argoproj.io/hook"]' | tee /dev/stderr)
+     yq -r '.metadata.annotations["argocd.argoproj.io/hook"]' | tee /dev/stderr)
   [ "${actual}" = "Sync" ]
   local actual=$(helm template \
      -s templates/server-acl-init-job.yaml \
      --set 'global.acls.manageSystemACLs=true' \
      --set 'global.argocd.enabled=true' \
      . | tee /dev/stderr |
-     yq -r '.spec.template.metadata.annotations["argocd.argoproj.io/hook-delete-policy"]' | tee /dev/stderr)
+     yq -r '.metadata.annotations["argocd.argoproj.io/hook-delete-policy"]' | tee /dev/stderr)
   [ "${actual}" = "HookSucceeded" ]
 }
 
@@ -2401,14 +2401,14 @@ load _helpers
      --set 'global.acls.manageSystemACLs=true' \
      --set 'global.argocd.enabled=false' \
      . | tee /dev/stderr |
-     yq -r '.spec.template.metadata.annotations["argocd.argoproj.io/hook"]' | tee /dev/stderr)
+     yq -r '.metadata.annotations["argocd.argoproj.io/hook"]' | tee /dev/stderr)
   [ "${actual}" = null ]
   local actual=$(helm template \
      -s templates/server-acl-init-job.yaml \
      --set 'global.acls.manageSystemACLs=true' \
      --set 'global.argocd.enabled=false' \
      . | tee /dev/stderr |
-     yq -r '.spec.template.metadata.annotations["argocd.argoproj.io/hook-delete-policy"]' | tee /dev/stderr)
+     yq -r '.metadata.annotations["argocd.argoproj.io/hook-delete-policy"]' | tee /dev/stderr)
   [ "${actual}" = null ]
 }
 


### PR DESCRIPTION
### Changes proposed in this PR ###  

ArgoCD hooks to be set to Job annotations and not at Job template spec level -> https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#usage 

If set at current Job template spec level when Job is finished ArgoCD detects back again diff entering into a loop, if ArgoCD AutoSync is enabled this will be a loop of init jobs running forever.

fix: #3831 

### How I've tested this PR ###

* Ran helm bats tests successfully.

### How I expect reviewers to test this PR ###

* Deploy this chart using ArgoCD Application. Without the fix after the sync it will enter in a diff sync loop. 

### Checklist ###
- [x] Tests added (Not needed)
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
