### PR TITLE
[NET-9201] Validating webhook for registrations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -342,7 +342,7 @@ rebase the branch on main, fixing any conflicts along the way before the code ca
     ```go
       // +kubebuilder:webhook:verbs=create;update,path=/mutate-v1alpha1-ingressgateway,mutating=true,failurePolicy=fail,groups=consul.hashicorp.com,resources=ingressgateways,versions=v1alpha1,name=mutate-ingressgateway.consul.hashicorp.com,sideEffects=None,admissionReviewVersions=v1beta1;v1
     ```
-1. Ensure you update the path to match the annoataing in the `SetupWithManager` method:
+1. Ensure you update the path to match the annotation in the `SetupWithManager` method:
     ```go
     func (v *IngressGatewayWebhook) SetupWithManager(mgr ctrl.Manager) {
       v.decoder = admission.NewDecoder(mgr.GetScheme())

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -340,7 +340,14 @@ rebase the branch on main, fixing any conflicts along the way before the code ca
 1. Replace the names
 1. Ensure you've correctly replaced the names in the kubebuilder annotation, ensure the plurality is correct
     ```go
-    // +kubebuilder:webhook:verbs=create;update,path=/mutate-v1alpha1-ingressgateway,mutating=true,failurePolicy=fail,groups=consul.hashicorp.com,resources=ingressgateways,versions=v1alpha1,name=mutate-ingressgateway.consul.hashicorp.com,webhookVersions=v1beta1,sideEffects=None
+      // +kubebuilder:webhook:verbs=create;update,path=/mutate-v1alpha1-ingressgateway,mutating=true,failurePolicy=fail,groups=consul.hashicorp.com,resources=ingressgateways,versions=v1alpha1,name=mutate-ingressgateway.consul.hashicorp.com,sideEffects=None,admissionReviewVersions=v1beta1;v1
+    ```
+1. Ensure you update the path to match the annoataing in the `SetupWithManager` method:
+    ```go
+    func (v *IngressGatewayWebhook) SetupWithManager(mgr ctrl.Manager) {
+      v.decoder = admission.NewDecoder(mgr.GetScheme())
+      mgr.GetWebhookServer().Register("/mutate-v1alpha1-ingressgateway", &admission.Webhook{Handler: v})
+}
     ```
 
 ### Update command.go
@@ -362,16 +369,13 @@ rebase the branch on main, fixing any conflicts along the way before the code ca
         return 1
     }
     ```
-1. Update `control-plane/subcommand/inject-connect/command.go` and add your webhook (the path should match the kubebuilder annotation):
+1. Update `control-plane/subcommand/inject-connect/command.go` and add your webhook
     ```go
-    mgr.GetWebhookServer().Register("/mutate-v1alpha1-ingressgateway",
-        &webhook.Admission{Handler: &v1alpha1.IngressGatewayWebhook{
-            Client:                     mgr.GetClient(),
-            ConsulClient:               consulClient,
-            Logger:                     ctrl.Log.WithName("webhooks").WithName(common.IngressGateway),
-            EnableConsulNamespaces:     c.flagEnableNamespaces,
-            EnableNSMirroring:          c.flagEnableNSMirroring,
-        }})
+    (&v1alpha1.IngressGatewayWebhook
+      Client:     mgr.GetClient(),
+      Logger:     ctrl.Log.WithName("webhooks").WithName(common.IngressGateway),
+      ConsulMeta: consulMeta,
+    }).SetupWithManager(mgr)
     ```
 
 ### Generating YAML

--- a/charts/consul/templates/connect-inject-validatingwebhookconfiguration.yaml
+++ b/charts/consul/templates/connect-inject-validatingwebhookconfiguration.yaml
@@ -28,4 +28,20 @@ webhooks:
       name: {{ template "consul.fullname" . }}-connect-injector
       namespace: {{ .Release.Namespace }}
       path: /validate-v1alpha1-gatewaypolicy
+- name: validate-registration.consul.hashicorp.com
+  matchPolicy: Equivalent
+  rules:
+  - operations: [ "CREATE" , "UPDATE" ]
+    apiGroups: [ "consul.hashicorp.com" ]
+    apiVersions: [ "v1alpha1" ]
+    resources: [ "registrations" ]
+  failurePolicy: Fail
+  sideEffects: None
+  admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ template "consul.fullname" . }}-connect-injector
+      namespace: {{ .Release.Namespace }}
+      path: /validate-v1alpha1-registration
 {{- end }}

--- a/charts/consul/templates/crd-registrations.yaml
+++ b/charts/consul/templates/crd-registrations.yaml
@@ -86,9 +86,7 @@ spec:
                       udp:
                         type: string
                     required:
-                    - deregisterCriticalServiceAfterDuration
                     - intervalDuration
-                    - timeoutDuration
                     type: object
                   exposedPort:
                     type: integer
@@ -116,7 +114,6 @@ spec:
                 - checkId
                 - definition
                 - name
-                - node
                 - serviceId
                 - serviceName
                 - status

--- a/control-plane/api/v1alpha1/registration_types.go
+++ b/control-plane/api/v1alpha1/registration_types.go
@@ -301,3 +301,7 @@ func (r *Registration) SetSyncedCondition(status corev1.ConditionStatus, reason 
 		},
 	}
 }
+
+func (r *Registration) KubernetesName() string {
+	return r.ObjectMeta.Name
+}

--- a/control-plane/api/v1alpha1/registration_types.go
+++ b/control-plane/api/v1alpha1/registration_types.go
@@ -110,7 +110,7 @@ type Locality struct {
 
 // HealthCheck is used to represent a single check.
 type HealthCheck struct {
-	Node        string                `json:"node"`
+	Node        string                `json:"node,omitempty"`
 	CheckID     string                `json:"checkId"`
 	Name        string                `json:"name"`
 	Status      string                `json:"status"`
@@ -141,8 +141,8 @@ type HealthCheckDefinition struct {
 	OSService                              string              `json:"osService,omitempty"`
 	GRPCUseTLS                             bool                `json:"grpcUseTLS,omitempty"`
 	IntervalDuration                       string              `json:"intervalDuration"`
-	TimeoutDuration                        string              `json:"timeoutDuration"`
-	DeregisterCriticalServiceAfterDuration string              `json:"deregisterCriticalServiceAfterDuration"`
+	TimeoutDuration                        string              `json:"timeoutDuration,omitempty"`
+	DeregisterCriticalServiceAfterDuration string              `json:"deregisterCriticalServiceAfterDuration,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/control-plane/api/v1alpha1/registration_webhook.go
+++ b/control-plane/api/v1alpha1/registration_webhook.go
@@ -30,7 +30,7 @@ type RegistrationWebhook struct {
 	client.Client
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-v1alpha1-gatewaypolicy,mutating=false,failurePolicy=fail,groups=consul.hashicorp.com,resources=gatewaypolicies,versions=v1alpha1,name=validate-gatewaypolicy.consul.hashicorp.com,sideEffects=None,admissionReviewVersions=v1beta1;v1
+// +kubebuilder:webhook:verbs=create;update,path=/validate-v1alpha1-registration,mutating=false,failurePolicy=fail,groups=consul.hashicorp.com,resources=registrations,versions=v1alpha1,name=validate-registration.consul.hashicorp.com,sideEffects=None,admissionReviewVersions=v1beta1;v1
 
 func (v *RegistrationWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
 	resource := &Registration{}

--- a/control-plane/api/v1alpha1/registration_webhook.go
+++ b/control-plane/api/v1alpha1/registration_webhook.go
@@ -1,0 +1,122 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/common"
+)
+
+// +kubebuilder:object:generate=false
+
+type RegistrationWebhook struct {
+	Logger logr.Logger
+
+	// ConsulMeta contains metadata specific to the Consul installation.
+	ConsulMeta common.ConsulMeta
+
+	decoder *admission.Decoder
+	client.Client
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-v1alpha1-gatewaypolicy,mutating=false,failurePolicy=fail,groups=consul.hashicorp.com,resources=gatewaypolicies,versions=v1alpha1,name=validate-gatewaypolicy.consul.hashicorp.com,sideEffects=None,admissionReviewVersions=v1beta1;v1
+
+func (v *RegistrationWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
+	resource := &Registration{}
+	decodeErr := v.decoder.Decode(req, resource)
+	if decodeErr != nil {
+		return admission.Errored(http.StatusBadRequest, decodeErr)
+	}
+
+	var err error
+	err = errors.Join(err, validateRequiredFields(resource))
+	err = errors.Join(err, validateHealthChecks(resource))
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	return admission.Allowed("registration is valid")
+}
+
+func (v *RegistrationWebhook) SetupWithManager(mgr ctrl.Manager) {
+	v.decoder = admission.NewDecoder(mgr.GetScheme())
+	mgr.GetWebhookServer().Register("/validate-v1alpha1-registration", &admission.Webhook{Handler: v})
+}
+
+func validateRequiredFields(registration *Registration) error {
+	var err error
+	if registration.Spec.Node == "" {
+		err = errors.Join(err, errors.New("registration.Spec.Node is required"))
+	}
+	if registration.Spec.Service.Name == "" {
+		err = errors.Join(err, errors.New("registration.Spec.Service.Name is required"))
+	}
+	if registration.Spec.Address == "" {
+		err = errors.Join(err, errors.New("registration.Spec.Address is required"))
+	}
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+var validStatuses = map[string]struct{}{
+	"passing":  {},
+	"warning":  {},
+	"critical": {},
+}
+
+func validateHealthChecks(registration *Registration) error {
+	if registration.Spec.HealthCheck == nil {
+		return nil
+	}
+
+	var err error
+
+	if registration.Spec.HealthCheck.Name == "" {
+		err = errors.Join(err, errors.New("registration.Spec.HealthCheck.Name is required"))
+	}
+
+	// status must be one "passing", "warning", or "critical"
+	if _, ok := validStatuses[registration.Spec.HealthCheck.Status]; !ok {
+		err = errors.Join(err, fmt.Errorf("invalid registration.Spec.HealthCheck.Status value, must be 'passing', 'warning', or 'critical', actual: %q", registration.Spec.HealthCheck.Status))
+	}
+
+	// parse all durations and check for any errors
+	_, parseErr := time.ParseDuration(registration.Spec.HealthCheck.Definition.IntervalDuration)
+	if parseErr != nil {
+		err = errors.Join(err, fmt.Errorf("invalid registration.Spec.HealthCheck.Definition.IntervalDuration value: %q", registration.Spec.HealthCheck.Definition.IntervalDuration))
+	}
+
+	if registration.Spec.HealthCheck.Definition.TimeoutDuration != "" {
+		_, parseErr = time.ParseDuration(registration.Spec.HealthCheck.Definition.TimeoutDuration)
+		if parseErr != nil {
+			err = errors.Join(err, fmt.Errorf("invalid registration.Spec.HealthCheck.Definition.TimeoutDuration value: %q", registration.Spec.HealthCheck.Definition.TimeoutDuration))
+		}
+	}
+
+	if registration.Spec.HealthCheck.Definition.DeregisterCriticalServiceAfterDuration != "" {
+		_, parseErr = time.ParseDuration(registration.Spec.HealthCheck.Definition.DeregisterCriticalServiceAfterDuration)
+		if parseErr != nil {
+			err = errors.Join(err, fmt.Errorf("invalid registration.Spec.HealthCheck.Definition.DeregisterCriticalServiceAfterDuration value: %q", registration.Spec.HealthCheck.Definition.DeregisterCriticalServiceAfterDuration))
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/control-plane/api/v1alpha1/registration_webhook.go
+++ b/control-plane/api/v1alpha1/registration_webhook.go
@@ -39,8 +39,8 @@ func (v *RegistrationWebhook) Handle(ctx context.Context, req admission.Request)
 		return admission.Errored(http.StatusBadRequest, decodeErr)
 	}
 
-	v.Logger.Info("validating registration", "name", resource.Name, "timeout", resource.Spec.HealthCheck.Definition.TimeoutDuration)
 	var err error
+
 	err = errors.Join(err, validateRequiredFields(resource))
 	err = errors.Join(err, validateHealthChecks(resource))
 	if err != nil {

--- a/control-plane/api/v1alpha1/registration_webhook.go
+++ b/control-plane/api/v1alpha1/registration_webhook.go
@@ -39,6 +39,7 @@ func (v *RegistrationWebhook) Handle(ctx context.Context, req admission.Request)
 		return admission.Errored(http.StatusBadRequest, decodeErr)
 	}
 
+	v.Logger.Info("validating registration", "name", resource.Name, "timeout", resource.Spec.HealthCheck.Definition.TimeoutDuration)
 	var err error
 	err = errors.Join(err, validateRequiredFields(resource))
 	err = errors.Join(err, validateHealthChecks(resource))
@@ -50,6 +51,7 @@ func (v *RegistrationWebhook) Handle(ctx context.Context, req admission.Request)
 }
 
 func (v *RegistrationWebhook) SetupWithManager(mgr ctrl.Manager) {
+	v.Logger.Info("setting up registration webhook")
 	v.decoder = admission.NewDecoder(mgr.GetScheme())
 	mgr.GetWebhookServer().Register("/validate-v1alpha1-registration", &admission.Webhook{Handler: v})
 }
@@ -101,15 +103,15 @@ func validateHealthChecks(registration *Registration) error {
 	}
 
 	if registration.Spec.HealthCheck.Definition.TimeoutDuration != "" {
-		_, parseErr = time.ParseDuration(registration.Spec.HealthCheck.Definition.TimeoutDuration)
-		if parseErr != nil {
+		_, timeoutErr := time.ParseDuration(registration.Spec.HealthCheck.Definition.TimeoutDuration)
+		if timeoutErr != nil {
 			err = errors.Join(err, fmt.Errorf("invalid registration.Spec.HealthCheck.Definition.TimeoutDuration value: %q", registration.Spec.HealthCheck.Definition.TimeoutDuration))
 		}
 	}
 
 	if registration.Spec.HealthCheck.Definition.DeregisterCriticalServiceAfterDuration != "" {
-		_, parseErr = time.ParseDuration(registration.Spec.HealthCheck.Definition.DeregisterCriticalServiceAfterDuration)
-		if parseErr != nil {
+		_, deregCriticalErr := time.ParseDuration(registration.Spec.HealthCheck.Definition.DeregisterCriticalServiceAfterDuration)
+		if deregCriticalErr != nil {
 			err = errors.Join(err, fmt.Errorf("invalid registration.Spec.HealthCheck.Definition.DeregisterCriticalServiceAfterDuration value: %q", registration.Spec.HealthCheck.Definition.DeregisterCriticalServiceAfterDuration))
 		}
 	}

--- a/control-plane/api/v1alpha1/registration_webhook_test.go
+++ b/control-plane/api/v1alpha1/registration_webhook_test.go
@@ -1,0 +1,330 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	logrtest "github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestValidateRegistration(t *testing.T) {
+	cases := map[string]struct {
+		newResource   *Registration
+		expAllow      bool
+		expErrMessage string
+	}{
+		"valid with health check, status 'passing'": {
+			newResource: &Registration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-registration",
+				},
+				Spec: RegistrationSpec{
+					Node:    "node-virtual",
+					Address: "10.2.2.1",
+					Service: Service{Name: "test-service"},
+					HealthCheck: &HealthCheck{
+						Name:   "check name",
+						Status: "passing",
+						Definition: HealthCheckDefinition{
+							IntervalDuration: "10s",
+						},
+					},
+				},
+			},
+			expAllow: true,
+		},
+		"valid with health check, status 'warning'": {
+			newResource: &Registration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-registration",
+				},
+				Spec: RegistrationSpec{
+					Node:    "node-virtual",
+					Address: "10.2.2.1",
+					Service: Service{Name: "test-service"},
+					HealthCheck: &HealthCheck{
+						Name:   "check name",
+						Status: "warning",
+						Definition: HealthCheckDefinition{
+							IntervalDuration: "10s",
+						},
+					},
+				},
+			},
+			expAllow: true,
+		},
+		"valid with health check, status 'critical'": {
+			newResource: &Registration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-registration",
+				},
+				Spec: RegistrationSpec{
+					Node:    "node-virtual",
+					Address: "10.2.2.1",
+					Service: Service{Name: "test-service"},
+					HealthCheck: &HealthCheck{
+						Name:   "check name",
+						Status: "critical",
+						Definition: HealthCheckDefinition{
+							IntervalDuration: "10s",
+						},
+					},
+				},
+			},
+			expAllow: true,
+		},
+		"valid without health check": {
+			newResource: &Registration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-registration",
+				},
+				Spec: RegistrationSpec{
+					Node:        "node-virtual",
+					Address:     "10.2.2.1",
+					Service:     Service{Name: "test-service"},
+					HealthCheck: nil,
+				},
+			},
+			expAllow: true,
+		},
+		"invalid, missing node field": {
+			newResource: &Registration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-registration",
+				},
+				Spec: RegistrationSpec{
+					Node:        "",
+					Address:     "10.2.2.1",
+					Service:     Service{Name: "test-service"},
+					HealthCheck: nil,
+				},
+			},
+			expAllow:      false,
+			expErrMessage: "registration.Spec.Node is required",
+		},
+		"invalid, missing address field": {
+			newResource: &Registration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-registration",
+				},
+				Spec: RegistrationSpec{
+					Node:        "test-node",
+					Address:     "",
+					Service:     Service{Name: "test-service"},
+					HealthCheck: nil,
+				},
+			},
+			expAllow:      false,
+			expErrMessage: "registration.Spec.Address is required",
+		},
+		"invalid, missing service.name field": {
+			newResource: &Registration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-registration",
+				},
+				Spec: RegistrationSpec{
+					Node:        "test-node",
+					Address:     "10.2.2.1",
+					Service:     Service{Name: ""},
+					HealthCheck: nil,
+				},
+			},
+			expAllow:      false,
+			expErrMessage: "registration.Spec.Service.Name is required",
+		},
+		"invalid, health check is set and name is missing": {
+			newResource: &Registration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-registration",
+				},
+				Spec: RegistrationSpec{
+					Node:    "test-node",
+					Address: "10.2.2.1",
+					Service: Service{Name: "test-service"},
+					HealthCheck: &HealthCheck{
+						Name:   "",
+						Status: "passing",
+						Definition: HealthCheckDefinition{
+							IntervalDuration: "10s",
+						},
+					},
+				},
+			},
+			expAllow:      false,
+			expErrMessage: "registration.Spec.HealthCheck.Name is required",
+		},
+		"invalid, health check is set and intervalDuration is missing": {
+			newResource: &Registration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-registration",
+				},
+				Spec: RegistrationSpec{
+					Node:    "test-node",
+					Address: "10.2.2.1",
+					Service: Service{Name: "test-service"},
+					HealthCheck: &HealthCheck{
+						Name:   "check name",
+						Status: "passing",
+						Definition: HealthCheckDefinition{
+							IntervalDuration: "",
+						},
+					},
+				},
+			},
+			expAllow:      false,
+			expErrMessage: "invalid registration.Spec.HealthCheck.Definition.IntervalDuration value: \"\"",
+		},
+		"invalid, health check is set and intervalDuration is invalid duration type": {
+			newResource: &Registration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-registration",
+				},
+				Spec: RegistrationSpec{
+					Node:    "test-node",
+					Address: "10.2.2.1",
+					Service: Service{Name: "test-service"},
+					HealthCheck: &HealthCheck{
+						Name:   "check name",
+						Status: "passing",
+						Definition: HealthCheckDefinition{
+							IntervalDuration: "150",
+						},
+					},
+				},
+			},
+			expAllow:      false,
+			expErrMessage: "invalid registration.Spec.HealthCheck.Definition.IntervalDuration value: \"150\"",
+		},
+		"invalid, health check is set and timeoutDuration is invalid duration type": {
+			newResource: &Registration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-registration",
+				},
+				Spec: RegistrationSpec{
+					Node:    "test-node",
+					Address: "10.2.2.1",
+					Service: Service{Name: "test-service"},
+					HealthCheck: &HealthCheck{
+						Name:   "check name",
+						Status: "passing",
+						Definition: HealthCheckDefinition{
+							IntervalDuration: "10s",
+							TimeoutDuration:  "150",
+						},
+					},
+				},
+			},
+			expAllow:      false,
+			expErrMessage: "invalid registration.Spec.HealthCheck.Definition.TimeoutDuration value: \"150\"",
+		},
+		"invalid, health check is set and deregisterCriticalServiceAfterDuration is invalid duration type": {
+			newResource: &Registration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-registration",
+				},
+				Spec: RegistrationSpec{
+					Node:    "test-node",
+					Address: "10.2.2.1",
+					Service: Service{Name: "test-service"},
+					HealthCheck: &HealthCheck{
+						Name:   "check name",
+						Status: "passing",
+						Definition: HealthCheckDefinition{
+							IntervalDuration:                       "10s",
+							TimeoutDuration:                        "150s",
+							DeregisterCriticalServiceAfterDuration: "40",
+						},
+					},
+				},
+			},
+			expAllow:      false,
+			expErrMessage: "invalid registration.Spec.HealthCheck.Definition.DeregisterCriticalServiceAfterDuration value: \"40\"",
+		},
+		"invalid, health check is set and status is not 'passing', 'critical', or 'warning'": {
+			newResource: &Registration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-registration",
+				},
+				Spec: RegistrationSpec{
+					Node:    "test-node",
+					Address: "10.2.2.1",
+					Service: Service{Name: "test-service"},
+					HealthCheck: &HealthCheck{
+						Name:   "check name",
+						Status: "wrong",
+						Definition: HealthCheckDefinition{
+							IntervalDuration: "10s",
+						},
+					},
+				},
+			},
+			expAllow:      false,
+			expErrMessage: "invalid registration.Spec.HealthCheck.Status value, must be 'passing', 'warning', or 'critical', actual: \"wrong\"",
+		},
+		"everything that can go wrong has gone wrong": {
+			newResource: &Registration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-registration",
+				},
+				Spec: RegistrationSpec{
+					Node:    "",
+					Address: "",
+					Service: Service{Name: ""},
+					HealthCheck: &HealthCheck{
+						Name:   "",
+						Status: "wrong",
+						Definition: HealthCheckDefinition{
+							IntervalDuration:                       "10",
+							TimeoutDuration:                        "150",
+							DeregisterCriticalServiceAfterDuration: "40",
+						},
+					},
+				},
+			},
+			expAllow:      false,
+			expErrMessage: "registration.Spec.Node is required\nregistration.Spec.Service.Name is required\nregistration.Spec.Address is required\nregistration.Spec.HealthCheck.Name is required\ninvalid registration.Spec.HealthCheck.Status value, must be 'passing', 'warning', or 'critical', actual: \"wrong\"\ninvalid registration.Spec.HealthCheck.Definition.IntervalDuration value: \"10\"\ninvalid registration.Spec.HealthCheck.Definition.TimeoutDuration value: \"150\"\ninvalid registration.Spec.HealthCheck.Definition.DeregisterCriticalServiceAfterDuration value: \"40\"",
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			marshalledRequestObject, err := json.Marshal(c.newResource)
+			require.NoError(t, err)
+			s := runtime.NewScheme()
+			s.AddKnownTypes(GroupVersion, &Registration{}, &RegistrationList{})
+			client := fake.NewClientBuilder().WithScheme(s).Build()
+			decoder := admission.NewDecoder(s)
+
+			validator := &RegistrationWebhook{
+				Client:  client,
+				Logger:  logrtest.New(t),
+				decoder: decoder,
+			}
+			response := validator.Handle(ctx, admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      c.newResource.KubernetesName(),
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: marshalledRequestObject,
+					},
+				},
+			})
+
+			require.Equal(t, c.expAllow, response.Allowed)
+			if c.expErrMessage != "" {
+				require.Equal(t, c.expErrMessage, response.AdmissionResponse.Result.Message)
+			}
+		})
+	}
+}

--- a/control-plane/api/v1alpha1/registration_webhook_test.go
+++ b/control-plane/api/v1alpha1/registration_webhook_test.go
@@ -19,9 +19,9 @@ import (
 
 func TestValidateRegistration(t *testing.T) {
 	cases := map[string]struct {
-		newResource   *Registration
-		expAllow      bool
-		expErrMessage string
+		newResource        *Registration
+		expectedToAllow    bool
+		expectedErrMessage string
 	}{
 		"valid with health check, status 'passing'": {
 			newResource: &Registration{
@@ -41,7 +41,7 @@ func TestValidateRegistration(t *testing.T) {
 					},
 				},
 			},
-			expAllow: true,
+			expectedToAllow: true,
 		},
 		"valid with health check, status 'warning'": {
 			newResource: &Registration{
@@ -61,7 +61,7 @@ func TestValidateRegistration(t *testing.T) {
 					},
 				},
 			},
-			expAllow: true,
+			expectedToAllow: true,
 		},
 		"valid with health check, status 'critical'": {
 			newResource: &Registration{
@@ -81,7 +81,7 @@ func TestValidateRegistration(t *testing.T) {
 					},
 				},
 			},
-			expAllow: true,
+			expectedToAllow: true,
 		},
 		"valid without health check": {
 			newResource: &Registration{
@@ -95,7 +95,7 @@ func TestValidateRegistration(t *testing.T) {
 					HealthCheck: nil,
 				},
 			},
-			expAllow: true,
+			expectedToAllow: true,
 		},
 		"invalid, missing node field": {
 			newResource: &Registration{
@@ -109,8 +109,8 @@ func TestValidateRegistration(t *testing.T) {
 					HealthCheck: nil,
 				},
 			},
-			expAllow:      false,
-			expErrMessage: "registration.Spec.Node is required",
+			expectedToAllow:    false,
+			expectedErrMessage: "registration.Spec.Node is required",
 		},
 		"invalid, missing address field": {
 			newResource: &Registration{
@@ -124,8 +124,8 @@ func TestValidateRegistration(t *testing.T) {
 					HealthCheck: nil,
 				},
 			},
-			expAllow:      false,
-			expErrMessage: "registration.Spec.Address is required",
+			expectedToAllow:    false,
+			expectedErrMessage: "registration.Spec.Address is required",
 		},
 		"invalid, missing service.name field": {
 			newResource: &Registration{
@@ -139,8 +139,8 @@ func TestValidateRegistration(t *testing.T) {
 					HealthCheck: nil,
 				},
 			},
-			expAllow:      false,
-			expErrMessage: "registration.Spec.Service.Name is required",
+			expectedToAllow:    false,
+			expectedErrMessage: "registration.Spec.Service.Name is required",
 		},
 		"invalid, health check is set and name is missing": {
 			newResource: &Registration{
@@ -160,8 +160,8 @@ func TestValidateRegistration(t *testing.T) {
 					},
 				},
 			},
-			expAllow:      false,
-			expErrMessage: "registration.Spec.HealthCheck.Name is required",
+			expectedToAllow:    false,
+			expectedErrMessage: "registration.Spec.HealthCheck.Name is required",
 		},
 		"invalid, health check is set and intervalDuration is missing": {
 			newResource: &Registration{
@@ -181,8 +181,8 @@ func TestValidateRegistration(t *testing.T) {
 					},
 				},
 			},
-			expAllow:      false,
-			expErrMessage: "invalid registration.Spec.HealthCheck.Definition.IntervalDuration value: \"\"",
+			expectedToAllow:    false,
+			expectedErrMessage: "invalid registration.Spec.HealthCheck.Definition.IntervalDuration value: \"\"",
 		},
 		"invalid, health check is set and intervalDuration is invalid duration type": {
 			newResource: &Registration{
@@ -202,8 +202,8 @@ func TestValidateRegistration(t *testing.T) {
 					},
 				},
 			},
-			expAllow:      false,
-			expErrMessage: "invalid registration.Spec.HealthCheck.Definition.IntervalDuration value: \"150\"",
+			expectedToAllow:    false,
+			expectedErrMessage: "invalid registration.Spec.HealthCheck.Definition.IntervalDuration value: \"150\"",
 		},
 		"invalid, health check is set and timeoutDuration is invalid duration type": {
 			newResource: &Registration{
@@ -224,8 +224,8 @@ func TestValidateRegistration(t *testing.T) {
 					},
 				},
 			},
-			expAllow:      false,
-			expErrMessage: "invalid registration.Spec.HealthCheck.Definition.TimeoutDuration value: \"150\"",
+			expectedToAllow:    false,
+			expectedErrMessage: "invalid registration.Spec.HealthCheck.Definition.TimeoutDuration value: \"150\"",
 		},
 		"invalid, health check is set and deregisterCriticalServiceAfterDuration is invalid duration type": {
 			newResource: &Registration{
@@ -247,8 +247,8 @@ func TestValidateRegistration(t *testing.T) {
 					},
 				},
 			},
-			expAllow:      false,
-			expErrMessage: "invalid registration.Spec.HealthCheck.Definition.DeregisterCriticalServiceAfterDuration value: \"40\"",
+			expectedToAllow:    false,
+			expectedErrMessage: "invalid registration.Spec.HealthCheck.Definition.DeregisterCriticalServiceAfterDuration value: \"40\"",
 		},
 		"invalid, health check is set and status is not 'passing', 'critical', or 'warning'": {
 			newResource: &Registration{
@@ -268,8 +268,8 @@ func TestValidateRegistration(t *testing.T) {
 					},
 				},
 			},
-			expAllow:      false,
-			expErrMessage: "invalid registration.Spec.HealthCheck.Status value, must be 'passing', 'warning', or 'critical', actual: \"wrong\"",
+			expectedToAllow:    false,
+			expectedErrMessage: "invalid registration.Spec.HealthCheck.Status value, must be 'passing', 'warning', or 'critical', actual: \"wrong\"",
 		},
 		"everything that can go wrong has gone wrong": {
 			newResource: &Registration{
@@ -291,8 +291,8 @@ func TestValidateRegistration(t *testing.T) {
 					},
 				},
 			},
-			expAllow:      false,
-			expErrMessage: "registration.Spec.Node is required\nregistration.Spec.Service.Name is required\nregistration.Spec.Address is required\nregistration.Spec.HealthCheck.Name is required\ninvalid registration.Spec.HealthCheck.Status value, must be 'passing', 'warning', or 'critical', actual: \"wrong\"\ninvalid registration.Spec.HealthCheck.Definition.IntervalDuration value: \"10\"\ninvalid registration.Spec.HealthCheck.Definition.TimeoutDuration value: \"150\"\ninvalid registration.Spec.HealthCheck.Definition.DeregisterCriticalServiceAfterDuration value: \"40\"",
+			expectedToAllow:    false,
+			expectedErrMessage: "registration.Spec.Node is required\nregistration.Spec.Service.Name is required\nregistration.Spec.Address is required\nregistration.Spec.HealthCheck.Name is required\ninvalid registration.Spec.HealthCheck.Status value, must be 'passing', 'warning', or 'critical', actual: \"wrong\"\ninvalid registration.Spec.HealthCheck.Definition.IntervalDuration value: \"10\"\ninvalid registration.Spec.HealthCheck.Definition.TimeoutDuration value: \"150\"\ninvalid registration.Spec.HealthCheck.Definition.DeregisterCriticalServiceAfterDuration value: \"40\"",
 		},
 	}
 	for name, c := range cases {
@@ -321,9 +321,9 @@ func TestValidateRegistration(t *testing.T) {
 				},
 			})
 
-			require.Equal(t, c.expAllow, response.Allowed)
-			if c.expErrMessage != "" {
-				require.Equal(t, c.expErrMessage, response.AdmissionResponse.Result.Message)
+			require.Equal(t, c.expectedToAllow, response.Allowed)
+			if c.expectedErrMessage != "" {
+				require.Equal(t, c.expectedErrMessage, response.AdmissionResponse.Result.Message)
 			}
 		})
 	}

--- a/control-plane/config/crd/bases/consul.hashicorp.com_registrations.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_registrations.yaml
@@ -82,9 +82,7 @@ spec:
                       udp:
                         type: string
                     required:
-                    - deregisterCriticalServiceAfterDuration
                     - intervalDuration
-                    - timeoutDuration
                     type: object
                   exposedPort:
                     type: integer
@@ -112,7 +110,6 @@ spec:
                 - checkId
                 - definition
                 - name
-                - node
                 - serviceId
                 - serviceName
                 - status

--- a/control-plane/config/webhook/manifests.yaml
+++ b/control-plane/config/webhook/manifests.yaml
@@ -454,3 +454,24 @@ webhooks:
     resources:
     - gatewaypolicies
   sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-v1alpha1-registration
+  failurePolicy: Fail
+  name: validate-registration.consul.hashicorp.com
+  rules:
+  - apiGroups:
+    - consul.hashicorp.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - registrations
+  sideEffects: None

--- a/control-plane/config/webhook/manifests.yaml
+++ b/control-plane/config/webhook/manifests.yaml
@@ -473,5 +473,5 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - registrations
+    - registration
   sideEffects: None

--- a/control-plane/subcommand/inject-connect/v1controllers.go
+++ b/control-plane/subcommand/inject-connect/v1controllers.go
@@ -476,6 +476,12 @@ func (c *Command) configureV1Controllers(ctx context.Context, mgr manager.Manage
 		ConsulMeta: consulMeta,
 	}).SetupWithManager(mgr)
 
+	(&v1alpha1.RegistrationWebhook{
+		Client:     mgr.GetClient(),
+		Logger:     ctrl.Log.WithName("webhooks").WithName(apicommon.Registration),
+		ConsulMeta: consulMeta,
+	}).SetupWithManager(mgr)
+
 	if c.flagEnableWebhookCAUpdate {
 		err = c.updateWebhookCABundle(ctx)
 		if err != nil {


### PR DESCRIPTION
### Changes proposed in this PR ###  
- add validating webhook to catch configuration errors earlier

### How I've tested this PR ###
- requirements: `kubectl` and `yq` to be installed on your system, this branch checked out in consul-k8s
- set the following values in your shell, update the k8s chart location value to be the path to the consul-k8s charts on your machine
```
export CONSUL_K8S_CHARTS_LOCATION="$HOME/hashi/consul-k8s/charts/consul"
export CONSUL_HTTP_ADDR="127.0.0.1:8501"
export CONSUL_HTTP_SSL=true
export CONSUL_HTTP_SSL_VERIFY=false
```
- build from this branch `make docker-dev`
- from the following gist run the `start.sh` file, this will set up your cluster and register the service: https://gist.github.com/jm96441n/43e526387fc83f7079a10a555f739177
- open up the consul ui at `https://localhost:8501` (you'll have to allow insecure traffic over https here)
- see the `zoidberg` service registered
- make some modification to the `zoidberg` registration file at `registration.yaml` such as:
    1. remove the `node`, `address`, `service.name`, `healthCheck.Definition.IntervalDuration`,  and/or `healthCheck.CheckID` fields
    2. change any of the durations to an invalid duration
 - run `kubectl apply -f registration.yaml` and see the command error out

### How I expect reviewers to test this PR ###
run the above
read the code
run the tests


### Checklist ###
- [X] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
