### PR TITLE
FLAKEY_TEST: Add retry to outbound request for ProxyLifecycleShutdown…

### DIFF
--- a/acceptance/tests/api-gateway/api_gateway_gatewayclassconfig_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_gatewayclassconfig_test.go
@@ -133,12 +133,14 @@ func TestAPIGateway_GatewayClassConfig(t *testing.T) {
 		k8sClient.DeleteAllOf(context.Background(), &gwv1beta1.Gateway{}, client.InNamespace(namespace))
 	})
 
+	
+
 	// Ensure it exists.
 	logger.Log(t, "checking that gateway is synchronized to Consul")
 	checkConsulExists(t, consulClient, api.APIGateway, gatewayName)
 
 	// Scenario: Gateway deployment should match the default instances defined on the gateway class config
-	logger.Log(t, "checking that gateway instances match defined gateway class config")
+	// checking that gateway instances match defined gateway class config
 	checkNumberOfInstances(t, k8sClient, consulClient, gateway.Name, gateway.Namespace, defaultInstances, gateway)
 
 	// Scenario: Updating the GatewayClassConfig should not affect gateways that have already been created
@@ -177,7 +179,7 @@ func scale(t *testing.T, client client.Client, name, namespace string, scaleTo *
 func checkNumberOfInstances(t *testing.T, k8client client.Client, consulClient *api.Client, name, namespace string, wantNumber *int32, gateway *gwv1beta1.Gateway) {
 	t.Helper()
 
-	retryCheckWithWait(t, 30, 10*time.Second, func(r *retry.R) {
+	retryCheckWithWait(t, 40, 10*time.Second, func(r *retry.R) {
 		logger.Log(t, "checking that gateway instances match defined gateway class config")
 		logger.Log(t, fmt.Sprintf("want: %d", *wantNumber))
 

--- a/acceptance/tests/api-gateway/api_gateway_gatewayclassconfig_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_gatewayclassconfig_test.go
@@ -133,8 +133,6 @@ func TestAPIGateway_GatewayClassConfig(t *testing.T) {
 		k8sClient.DeleteAllOf(context.Background(), &gwv1beta1.Gateway{}, client.InNamespace(namespace))
 	})
 
-	
-
 	// Ensure it exists.
 	logger.Log(t, "checking that gateway is synchronized to Consul")
 	checkConsulExists(t, consulClient, api.APIGateway, gatewayName)


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Test fails intermittently in CI (for some reason it only fails in cloud environment not kind clusters) see example [here](https://github.com/hashicorp/consul-k8s-workflows/actions/runs/9105828171/job/25032201606)
- Add retry to outbound API calls to improve chance of success.
   - if error occures, log the error and mark the current attempt as failed, trigger a retry.
   - If error does not exist, check if the output contains the specific error message. If the condition fails, log the error message and trigger a retry.

### How I've tested this PR ###
CI should pass


### How I expect reviewers to test this PR ###
CI should pass

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
