### PR TITLE
 [NET-9376] Fix Issue with multiple APIGW's roles/policy

### DIFF
--- a/.changelog/4002.txt
+++ b/.changelog/4002.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api-gateway: fix bug where multiple logical APIGateways would share the same ACL policy.
+```

--- a/control-plane/api-gateway/cache/consul.go
+++ b/control-plane/api-gateway/cache/consul.go
@@ -412,9 +412,27 @@ func (c *Cache) ensureRole(client *api.Client, gatewayName string) (string, erro
 		}
 
 		_, _, err = client.ACL().RoleCreate(role, &api.WriteOptions{})
-		if err != nil {
+		if err != nil && !isRoleExistsErr(err, aclRoleName) {
+			// don't error out in the case that the role already exists.
 			return "", err
 		}
+
+		if err != nil && isRoleExistsErr(err, aclRoleName) {
+			role, _, err := client.ACL().RoleReadByName(role.Name, &api.QueryOptions{})
+			if err != nil {
+				return "", err
+			}
+
+			role.Policies = []*api.ACLLink{{ID: policyID}}
+			role, _, err = client.ACL().RoleUpdate(role, &api.WriteOptions{})
+			if err != nil {
+				return "", err
+			}
+
+			c.gatewayNameToRole[gatewayName] = role
+			return aclRoleName, err
+		}
+
 		c.gatewayNameToRole[gatewayName] = role
 		return aclRoleName, err
 	}
@@ -450,7 +468,7 @@ func (c *Cache) gatewayPolicy(gatewayName string) api.ACLPolicy {
 	}
 
 	return api.ACLPolicy{
-		Name:        "api-gateway-token-policy",
+		Name:        fmt.Sprint("api-gateway-policy-for-", gatewayName),
 		Description: "API Gateway token Policy",
 		Rules:       data.String(),
 	}
@@ -586,10 +604,21 @@ func ignoreACLsDisabled(err error) error {
 	return err
 }
 
+// isExistsErr returns true if err is due to trying to call an API for a given type and it already exists.
+func isExistsErr(err error, typeName, name string) bool {
+	return err != nil &&
+		strings.Contains(err.Error(), "Unexpected response code: 500") &&
+		strings.Contains(err.Error(), fmt.Sprintf("Invalid %s: A %s with Name %q already exists", typeName, typeName, name))
+}
+
+// isRoleExistsErr returns true if err is due to trying to call the
+// role create API when the role already exists.
+func isRoleExistsErr(err error, roleName string) bool {
+	return isExistsErr(err, "Role", roleName)
+}
+
 // isPolicyExistsErr returns true if err is due to trying to call the
 // policy create API when the policy already exists.
 func isPolicyExistsErr(err error, policyName string) bool {
-	return err != nil &&
-		strings.Contains(err.Error(), "Unexpected response code: 500") &&
-		strings.Contains(err.Error(), fmt.Sprintf("Invalid Policy: A Policy with Name %q already exists", policyName))
+	return isExistsErr(err, "Policy", policyName)
 }


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Update role with correct policy when creating a new gateway
- this works on upgrade process

### How I've tested this PR ###
- have `kubectl` on your system

1. clone the following gist: https://gist.github.com/jm96441n/c0645d345c4a92f8b5ea6af272a19d63
1. set the `imageK8s` field in the `consul_values.yaml` file to be `hashicorp/consul-k8s-control-plane:1.3`
1. run the `start.sh` script
1. run the following in your terminal 
```
export CONSUL_HTTP_ADDR="127.0.0.1:8501"
export CONSUL_HTTP_SSL=true
export CONSUL_HTTP_SSL_VERIFY=false
export CONSUL_HTTP_TOKEN=$(kubectl get --namespace consul secrets/consul-consul-bootstrap-acl-token --template={{.data.token}} | base64 -d)
```
1. in a tool like k9s see that `api-gateway-2` is in an error state
1. open consul at `https://localhost:8501` (you'll need to allow the insecure traffic to bypass the warning)
1. copy the value of `CONSUL_HTTP_TOKEN` to your clipboard and use that to login to the UI
1. go to the `roles` tab and view the role for the `api-gateway-2` and see the policy it is using is the `api-gateway-token-policy` which grants write access to the first gateway created
1. on this branch run `make docker-dev`
1. update the `imageK8s` field to be `consul-k8s-control-plane:local`
1. in your terminal run: `helm upgrade --install consul hashicorp/consul -f ./consul/consul_values.yaml -n consul --create-namespace --wait`
1. once that finishes in a tool like k9s you should see all the api-gateways spin up correctly
1. run `kubectl port-forward service/consul-consul-ui 8501:443 -n consul &` in your terminal to re-establish the port-forward to the consul ui
1. repeat steps 2/3/4 to open the consul ui and view the role for `api-gateway-2` then you should see it is using the specific policy for this gateway that grants it write access to itself

### How I expect reviewers to test this PR ###
read the code
run the above steps

### Checklist ###
- [ ] Tests added
- [X] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
