### PR TITLE
[NET-9097] Update service resolver webhook registration missed in previous backport

### DIFF
--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -800,12 +800,11 @@ func (c *Command) Run(args []string) int {
 		ConsulMeta: consulMeta,
 	}).SetupWithManager(mgr)
 
-	mgr.GetWebhookServer().Register("/mutate-v1alpha1-serviceresolver",
-		&ctrlRuntimeWebhook.Admission{Handler: &v1alpha1.ServiceResolverWebhook{
-			Client:     mgr.GetClient(),
-			Logger:     ctrl.Log.WithName("webhooks").WithName(apicommon.ServiceResolver),
-			ConsulMeta: consulMeta,
-		}})
+	(&v1alpha1.ServiceResolverWebhook{
+		Client:     mgr.GetClient(),
+		Logger:     ctrl.Log.WithName("webhooks").WithName(apicommon.ServiceResolver),
+		ConsulMeta: consulMeta,
+	}).SetupWithManager(mgr)
 
 	(&v1alpha1.ProxyDefaultsWebhook{
 		Client:     mgr.GetClient(),


### PR DESCRIPTION
### Changes proposed in this PR ###  
There was a slight oversight in #3967 in which the `ServiceResolver` webhook registration wasn't updated to use the new `SetupWithManager()` pattern like all of the other webhooks were. This PR updates it.

The result was that the manager would never have a decoder assigned to it. This was previously implicitly done by controller-runtime but was removed, thus the introduction of `SetupWithManager()` on all of the webhooks.

### How I've tested this PR ###
🤖 tests pass

### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
