### PR TITLE
security: update alpine base image to 3.19

### DIFF
--- a/.changelog/4016.txt
+++ b/.changelog/4016.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Bump Dockerfile base image for `consul-k8s-control-plane` to `alpine:3.19` to address [CVE-2024-0727](https://nvd.nist.gov/vuln/detail/CVE-2024-0727)
+```

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@21457
 # dev copies the binary from a local build
 # -----------------------------------
 # BIN_NAME is a requirement in the hashicorp docker github action 
-FROM alpine:3.18 AS dev
+FROM alpine:3.19 AS dev
 
 # NAME and VERSION are the name of the software in releases.hashicorp.com
 # and the version to download. Example: NAME=consul VERSION=1.2.3.
@@ -79,7 +79,7 @@ CMD /bin/${BIN_NAME}
 # We don't rebuild the software because we want the exact checksums and
 # binary signatures to match the software and our builds aren't fully
 # reproducible currently.
-FROM alpine:3.18 AS release-default
+FROM alpine:3.19 AS release-default
 
 ARG BIN_NAME=consul-k8s-control-plane
 ARG CNI_BIN_NAME=consul-cni


### PR DESCRIPTION
Resolves CVE-2024-0727.

### Changes proposed in this PR ###  
- Update `alpine:3.18` where used to `alpine:3.19` (currently inconsistent)

### How I've tested this PR ###
CI

### How I expect reviewers to test this PR ###
👀 

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
