### PR TITLE
security: temporary triage for alpine base image

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -19,6 +19,17 @@ container {
   secrets {
     all = true
   }
+
+  triage {
+    suppress {
+      vulnerabilites = [
+        # 2024-05-21: temporary triage for alpine:3.18 base image (openssl)
+        "CVE-2024-0727",
+        "CVE-2023-6129",
+        "CVE-2023-5678"
+      ]
+    }
+  }
 }
 
 binary {


### PR DESCRIPTION
Temporarily triage openssl scanner results while we investigate base image pulls, which should have already addressed these vulnerabilities.

### Changes proposed in this PR ###  
- Add scanner triage

### How I've tested this PR ###
CI

### How I expect reviewers to test this PR ###
👀 

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
