### PR TITLE
chore: fix previous changelog for alpine upgrade

### DIFF
--- a/.changelog/4016.txt
+++ b/.changelog/4016.txt
@@ -1,3 +1,3 @@
-```release-note:security
-Bump Dockerfile base image for `consul-k8s-control-plane` to `alpine:3.19` to address [CVE-2024-0727](https://nvd.nist.gov/vuln/detail/CVE-2024-0727)
+```release-note:improvement
+Bump Dockerfile base image for `consul-k8s-control-plane` to `alpine:3.19`.
 ```


### PR DESCRIPTION
The original change was made as a security fix, which was later determined to be unnecessary (both `alpine` 3.18 and 3.19 received the CVE fix in question). Recategorizing this as an improvement for the final changelog. The `alpine` upgrade is still worth doing, as is aligning all the base images in the Dockerfile on a single version.

I'll follow up w/ the same change on backports of https://github.com/hashicorp/consul-k8s/pull/4016.
