### PR TITLE
[NET-6705] Remove Secrets resource from partition-init Role

### DIFF
--- a/.changelog/4053.txt
+++ b/.changelog/4053.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ partition-init: Role no longer includes unnecessary access to Secrets resource.
+ ```

--- a/charts/consul/templates/partition-init-role.yaml
+++ b/charts/consul/templates/partition-init-role.yaml
@@ -15,12 +15,6 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
 rules:
-  - apiGroups: [""]
-    resources:
-      - secrets
-    verbs:
-      - create
-      - get
 {{- if .Values.connectInject.enabled }}
   - apiGroups: [""]
     resources:


### PR DESCRIPTION
### Changes proposed in this PR ###  
Remove `Secret` resource from partition-init `Role`

### How I've tested this PR ###
Deploy two k8s clusters with consul-k8s installed from this branch of the Helm chart. One should be a non-default partition utilizing the servers in the default partition cluster. The `partition-init` job should succeed.

<details>
<summary>Example</summary>

```yaml
# values-default.yaml (default partition)
global:
  name: consul
  datacenter: dc1
  peering:
    enabled: true
  tls:
    enabled: true
  acls:
    manageSystemACLs: true

  image: hashicorppreview/consul-enterprise:1.19-dev

  adminPartitions:
    enabled: true
    name: default  # required name for AP hosting consul-server

  enableConsulNamespaces: true

  enterpriseLicense:
    secretName: 'enterprise-license'
    secretKey: 'key'

connectInject:
  default: true
  transparentProxy:
    defaultEnabled: true

meshGateway:
  enabled: true

ui:
  enabled: true
  service:
    enabled: true
    type: LoadBalancer
```

```yaml
# values-other.yaml (non-default partition)
global:
  name: consul
  datacenter: dc1
  enabled: false
  peering:
    enabled: true
  tls:
    enabled: true
    caCert:
      secretName: consul-ca-cert # See step 6 from `Install Consul server cluster`
      secretKey: tls.crt
    caKey:
      secretName: consul-ca-key # See step 7 from `Install Consul server cluster`
      secretKey: tls.key
  acls:
    manageSystemACLs: true
    bootstrapToken:
      secretName: consul-partitions-acl-token # See step 8 from `Install Consul server cluster`
      secretKey: token
  
  image: hashicorppreview/consul-enterprise:1.19-dev

  adminPartitions:
    enabled: true
    name: other

  enableConsulNamespaces: true
  
  enterpriseLicense:
    secretName: 'enterprise-license'
    secretKey: 'key'

externalServers:
  enabled: true
  tlsServerName: server.dc1.consul
  hosts: ['34.73.166.251']
  k8sAuthMethodHost: 'https://35.231.108.47'
  
connectInject:
  default: true
  transparentProxy:
    defaultEnabled: true

meshGateway:
  enabled: true

ui:
  enabled: true
  service:
    enabled: true
    type: LoadBalancer
```

```log
$ kubectl get -w pod -A
consul        consul-partition-init-btg4x                           0/1     Pending             0             0s
consul        consul-partition-init-btg4x                           0/1     Pending             0             0s
consul        consul-partition-init-btg4x                           0/1     ContainerCreating   0             0s
consul        consul-partition-init-btg4x                           1/1     Running             0             4s
consul        consul-partition-init-btg4x                           0/1     Completed           0             6s
consul        consul-partition-init-btg4x                           0/1     Completed           0             7s
consul        consul-partition-init-btg4x                           0/1     Completed           0             8s
consul        consul-partition-init-btg4x                           0/1     Completed           0             8s
consul        consul-partition-init-btg4x                           0/1     Terminating         0             8s
consul        consul-partition-init-btg4x                           0/1     Terminating         0             8s
```

</details>


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
