### PR TITLE
fix: deregistration should not do graceful shutdown if there is a new pod

### DIFF
--- a/.changelog/4059.txt
+++ b/.changelog/4059.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+endpoints-controller: graceful shutdown logic should not run on a new pod with the same name. Fixes a case where statefulset rollouts could get stuck in graceful shutdown when the new pods come up.
+```

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
@@ -4389,6 +4389,63 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 			enableACLs: true,
 		},
 		{
+			name:          "When pod is part of statefulset and comes up with new node, the old service instance should be deleted",
+			consulSvcName: "service-deleted",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "default",
+					UID:       "123",
+					Annotations: map[string]string{
+						constants.AnnotationEnableSidecarProxyLifecycle:                     "true",
+						constants.AnnotationSidecarProxyLifecycleShutdownGracePeriodSeconds: "5",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: nodeName + "-different", // new node name
+					// We don't need any other fields for this test
+				},
+			},
+			consulPodUid:              "123",
+			expectServicesToBeDeleted: true,
+			initialConsulSvcs: []*api.AgentService{
+				{
+					ID:      "pod1-service-deleted",
+					Service: "service-deleted",
+					Port:    80,
+					Address: "1.2.3.4",
+					Meta: map[string]string{
+						metaKeyKubeServiceName:   "service-deleted",
+						constants.MetaKeyKubeNS:  "default",
+						metaKeyManagedBy:         constants.ManagedByValue,
+						metaKeySyntheticNode:     "true",
+						constants.MetaKeyPodName: "pod1",
+						constants.MetaKeyPodUID:  "123",
+					},
+				},
+				{
+					Kind:    api.ServiceKindConnectProxy,
+					ID:      "pod1-service-deleted-sidecar-proxy",
+					Service: "service-deleted-sidecar-proxy",
+					Port:    20000,
+					Address: "1.2.3.4",
+					Proxy: &api.AgentServiceConnectProxyConfig{
+						DestinationServiceName: "service-deleted",
+						DestinationServiceID:   "pod1-service-deleted",
+					},
+					Meta: map[string]string{
+						metaKeyKubeServiceName:   "service-deleted",
+						constants.MetaKeyKubeNS:  "default",
+						metaKeyManagedBy:         constants.ManagedByValue,
+						metaKeySyntheticNode:     "true",
+						constants.MetaKeyPodName: "pod1",
+						constants.MetaKeyPodUID:  "123",
+					},
+				},
+			},
+			enableACLs: true,
+		},
+		{
 			name:                      "Mesh Gateway",
 			consulSvcName:             "service-deleted",
 			expectServicesToBeDeleted: true,

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
@@ -4332,6 +4332,63 @@ func TestReconcileDeleteEndpoint(t *testing.T) {
 			enableACLs:   true,
 		},
 		{
+			name:          "When pod is part of statefulset and comes up with new uid, the old service instance should be deleted",
+			consulSvcName: "service-deleted",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "default",
+					UID:       "new-pod-uid", // different from the original uid the initial instances were registered with
+					Annotations: map[string]string{
+						constants.AnnotationEnableSidecarProxyLifecycle:                     "true",
+						constants.AnnotationSidecarProxyLifecycleShutdownGracePeriodSeconds: "5",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: nodeName,
+					// We don't need any other fields for this test
+				},
+			},
+			consulPodUid:              "123",
+			expectServicesToBeDeleted: true,
+			initialConsulSvcs: []*api.AgentService{
+				{
+					ID:      "pod1-service-deleted",
+					Service: "service-deleted",
+					Port:    80,
+					Address: "1.2.3.4",
+					Meta: map[string]string{
+						metaKeyKubeServiceName:   "service-deleted",
+						constants.MetaKeyKubeNS:  "default",
+						metaKeyManagedBy:         constants.ManagedByValue,
+						metaKeySyntheticNode:     "true",
+						constants.MetaKeyPodName: "pod1",
+						constants.MetaKeyPodUID:  "123",
+					},
+				},
+				{
+					Kind:    api.ServiceKindConnectProxy,
+					ID:      "pod1-service-deleted-sidecar-proxy",
+					Service: "service-deleted-sidecar-proxy",
+					Port:    20000,
+					Address: "1.2.3.4",
+					Proxy: &api.AgentServiceConnectProxyConfig{
+						DestinationServiceName: "service-deleted",
+						DestinationServiceID:   "pod1-service-deleted",
+					},
+					Meta: map[string]string{
+						metaKeyKubeServiceName:   "service-deleted",
+						constants.MetaKeyKubeNS:  "default",
+						metaKeyManagedBy:         constants.ManagedByValue,
+						metaKeySyntheticNode:     "true",
+						constants.MetaKeyPodName: "pod1",
+						constants.MetaKeyPodUID:  "123",
+					},
+				},
+			},
+			enableACLs: true,
+		},
+		{
 			name:                      "Mesh Gateway",
 			consulSvcName:             "service-deleted",
 			expectServicesToBeDeleted: true,


### PR DESCRIPTION
### Changes proposed in this PR ###  
The existing graceful shutdown logic checks for the pod with the same name and looks at its graceful shutdown time to mark the service instance as unhealthy in consul and delay its deletion. In the case of a statefulset rollout, a pod will go down and a new pod with the same name will come up, so we could run into a race condition where we try to mark the service instance as unhealthy thinking that the pod is terminating, but it's actually the new running pod, not the old terminating pod.

This change is to check whether the service instance we're proposing to deregister in consul should go through graceful shutdown or not. If the pod has a different UID from the pod UID used to register that service instance, then the service instance should be deregistered. 

### How I've tested this PR ###
- Unit tests
- I was not able to reproduce the race condition locally.

### How I expect reviewers to test this PR ###
👀 

### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
