### PR TITLE
[NET-9605] fix issue where gateway pods with TLS block thrash

### DIFF
--- a/control-plane/api-gateway/gatekeeper/volumes.go
+++ b/control-plane/api-gateway/gatekeeper/volumes.go
@@ -5,6 +5,9 @@ package gatekeeper
 
 import (
 	"fmt"
+	"slices"
+	"strings"
+
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
@@ -60,5 +63,15 @@ func volumesAndMounts(gateway v1beta1.Gateway) ([]corev1.Volume, []corev1.Volume
 		}
 	}
 
-	return maps.Values(volumes), maps.Values(mounts)
+	vols := maps.Values(volumes)
+	slices.SortFunc(vols, func(a, b corev1.Volume) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	mts := maps.Values(mounts)
+	slices.SortFunc(mts, func(a, b corev1.VolumeMount) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	return vols, mts
 }


### PR DESCRIPTION
### Changes proposed in this PR ###  
- when running a gateway with a TLS configuration on a listener the pods would consistently thrash due to inconsistent ordering of the volumes/mounts


### How I've tested this PR ###
- build the main branch of consul-k8s and of consul using `make dev-docker`
- clone the following gist: https://gist.github.com/jm96441n/b92a80c2251c7a54d1feada320c5eac6
- run the `start.sh` script
- open a tool like k9s and see the `gateway-2` pod thrash (you may have to delete the pod and re-apply the file as you can _occasionally_ get the same order of volumes/mounts on a re-reconcile)
- destroy that cluster
- build consul-k8s from this branch using `make dev-docker`
- run the `start.sh` script again
- open a tool like k9s and see the gateway pods not thrash (you can remove the second gateway multiple times to test this) 

### How I expect reviewers to test this PR ###
read the code

run the above steps

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
