### PR TITLE
[NET-9932] Always add NET_BIND_SERVICE capability to injected sidecar container

### DIFF
--- a/.changelog/4066.txt
+++ b/.changelog/4066.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect-inject: add NET_BIND_SERVICE capability when injecting consul-dataplane sidecar
+```

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
@@ -234,7 +234,20 @@ func (w *MeshWebhook) consulDataplaneSidecar(namespace corev1.Namespace, pod cor
 			RunAsGroup:               pointer.Int64(sidecarUserAndGroupID),
 			RunAsNonRoot:             pointer.Bool(true),
 			AllowPrivilegeEscalation: pointer.Bool(false),
-			ReadOnlyRootFilesystem:   pointer.Bool(true),
+			// consul-dataplane requires the NET_BIND_SERVICE capability regardless of binding port #.
+			// See https://developer.hashicorp.com/consul/docs/connect/dataplane#technical-constraints
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{"NET_BIND_SERVICE"},
+			},
+			ReadOnlyRootFilesystem: pointer.Bool(true),
+		}
+	} else {
+		// consul-dataplane requires the NET_BIND_SERVICE capability regardless of binding port #.
+		// See https://developer.hashicorp.com/consul/docs/connect/dataplane#technical-constraints
+		container.SecurityContext = &corev1.SecurityContext{
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{"NET_BIND_SERVICE"},
+			},
 		}
 	}
 

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar_test.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar_test.go
@@ -808,6 +808,9 @@ func TestHandlerConsulDataplaneSidecar_withSecurityContext(t *testing.T) {
 				RunAsNonRoot:             pointer.Bool(true),
 				ReadOnlyRootFilesystem:   pointer.Bool(true),
 				AllowPrivilegeEscalation: pointer.Bool(false),
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{"NET_BIND_SERVICE"},
+				},
 			},
 		},
 		"tproxy enabled; openshift disabled": {
@@ -819,12 +822,19 @@ func TestHandlerConsulDataplaneSidecar_withSecurityContext(t *testing.T) {
 				RunAsNonRoot:             pointer.Bool(true),
 				ReadOnlyRootFilesystem:   pointer.Bool(true),
 				AllowPrivilegeEscalation: pointer.Bool(false),
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{"NET_BIND_SERVICE"},
+				},
 			},
 		},
 		"tproxy disabled; openshift enabled": {
-			tproxyEnabled:      false,
-			openShiftEnabled:   true,
-			expSecurityContext: nil,
+			tproxyEnabled:    false,
+			openShiftEnabled: true,
+			expSecurityContext: &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{"NET_BIND_SERVICE"},
+				},
+			},
 		},
 		"tproxy enabled; openshift enabled": {
 			tproxyEnabled:    true,
@@ -835,6 +845,9 @@ func TestHandlerConsulDataplaneSidecar_withSecurityContext(t *testing.T) {
 				RunAsNonRoot:             pointer.Bool(true),
 				ReadOnlyRootFilesystem:   pointer.Bool(true),
 				AllowPrivilegeEscalation: pointer.Bool(false),
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{"NET_BIND_SERVICE"},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
### Changes proposed in this PR ###  
Consul-dataplane always requires the `NET_BIND_SERVICE` capability ([docs](https://developer.hashicorp.com/consul/docs/connect/dataplane#technical-constraints)). This is explicitly allowed under the `restricted-v2` `SecurityContextConstraints` (SCC) that ships with OpenShift 4.11+; however, the container needs to _request_ the capability in order for it to be granted. This change does that.

### How I've tested this PR ###
Worked w/ @natemollica-nm to verify that this fix allows the application sidecar running the `consul-dataplane` image to spin up successfully under the `restricted-v2` SCC where it would have previously logged the following error on startup.
```log
Defaulted container "consul-dataplane" out of: consul-dataplane, backend, consul-connect-inject-init (init)
[dumb-init] /usr/local/bin/consul-dataplane: Operation not permitted
```

Application sidecars should now be fully functional on OpenShift without creating a custom SCC.
The `Pod` containing the injected sidecar should get an annotation from OpenShift indicating that it's using the `restricted-v2` SCC.

### How I expect reviewers to test this PR ###
See above

### Checklist ###
- [ ] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
