### PR TITLE
ci: update security-scanner token

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,8 +40,7 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           repository: hashicorp/security-scanner
-          #TODO: replace w/ HASHIBOT_PRODSEC_GITHUB_TOKEN once provisioned
-          token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          token: ${{ secrets.HASHIBOT_PRODSEC_GITHUB_TOKEN }}
           path: security-scanner
           ref: main
 


### PR DESCRIPTION
replacing the `ELEVATED_GITHUB_TOKEN` with `HASHIBOT_PRODSEC_GITHUB_TOKEN`