### PR TITLE
docs: remove mulitport docs, add v1dns flag

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -907,25 +907,14 @@ global:
 
   # Consul feature flags that will be enabled across components.
   # Supported feature flags:
-  # - `resource-apis`:
-  #   _**Warning**_! This feature is under active development. It is not
-  #   recommended for production use. Setting this flag during an
-  #   upgrade could risk breaking your Consul cluster.
-  #   If this flag is set, Consul components will use the
-  #   V2 resources APIs for all operations.
-  # - `v2tenancy`:
-  #   _**Warning**_! This feature is under active development. It is not
-  #   recommended for production use. Setting this flag during an
-  #   upgrade could risk breaking your Consul cluster.
-  #   If this flag is set, Consul V2 resources (catalog, mesh, auth, etc)
-  #   will use V2 implementations for tenancy (partitions and namesapces)
-  #   instead of bridging to the existing V1 implementations. The
-  #   `resource-apis` feature flag must also be set.
+  # - `v1dns`:
+  #   When this flag is set, Consul agents use the legacy DNS implementation.
+  #   This setting exists in the case a DNS bug is found after the refactoring introduced in v1.19.0.
   #
   # Example:
   #
   # ```yaml
-  # experiments: [ "resource-apis" ]
+  # experiments: [ "v1dns" ]
   # ```
   # @type: array<string>
   experiments: []


### PR DESCRIPTION
### Changes proposed in this PR ###  
- This backports the change made in https://github.com/hashicorp/consul/pull/21278 to the source comments in k8s.