### PR TITLE
Backport: [NET-9606] Use namespace-local Secret for mounting TLS certificates into api-gateway Pod

### DIFF
--- a/control-plane/api-gateway/common/translation.go
+++ b/control-plane/api-gateway/common/translation.go
@@ -536,8 +536,8 @@ func (t ResourceTranslator) ToFileSystemCertificate(secret corev1.Secret) *api.F
 		Name:        secret.Name,
 		Namespace:   t.Namespace(secret.Namespace),
 		Partition:   t.ConsulPartition,
-		Certificate: fmt.Sprintf("/consul/gateway-certificates/%s/%s/tls.crt", secret.Namespace, secret.Name),
-		PrivateKey:  fmt.Sprintf("/consul/gateway-certificates/%s/%s/tls.key", secret.Namespace, secret.Name),
+		Certificate: fmt.Sprintf("/consul/gateway-certificates/%s_%s_tls.crt", secret.Namespace, secret.Name),
+		PrivateKey:  fmt.Sprintf("/consul/gateway-certificates/%s_%s_tls.key", secret.Namespace, secret.Name),
 		Meta: t.addDatacenterToMeta(map[string]string{
 			constants.MetaKeyKubeNS:   secret.Namespace,
 			constants.MetaKeyKubeName: secret.Name,

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -359,10 +359,7 @@ func configEntriesTo[T api.ConfigEntry](entries []api.ConfigEntry) []T {
 
 func (r *GatewayController) deleteGatekeeperResources(ctx context.Context, log logr.Logger, gw *gwv1beta1.Gateway) error {
 	gk := gatekeeper.New(log, r.Client)
-	err := gk.Delete(ctx, types.NamespacedName{
-		Namespace: gw.Namespace,
-		Name:      gw.Name,
-	})
+	err := gk.Delete(ctx, *gw)
 	if err != nil {
 		return err
 	}

--- a/control-plane/api-gateway/gatekeeper/dataplane.go
+++ b/control-plane/api-gateway/gatekeeper/dataplane.go
@@ -24,6 +24,7 @@ const (
 	consulDataplaneDNSBindPort   = 8600
 	defaultEnvoyProxyConcurrency = 1
 	volumeNameForConnectInject   = "consul-connect-inject-data"
+	volumeNameForTLSCerts        = "consul-gateway-tls-certificates"
 )
 
 func consulDataplaneContainer(metrics common.MetricsConfig, config common.HelmConfig, gcc v1alpha1.GatewayClassConfig, name, namespace string, mounts []corev1.VolumeMount) (corev1.Container, error) {

--- a/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
@@ -95,6 +95,7 @@ type resources struct {
 	deployments     []*appsv1.Deployment
 	roles           []*rbac.Role
 	roleBindings    []*rbac.RoleBinding
+	secrets         []*corev1.Secret
 	services        []*corev1.Service
 	serviceAccounts []*corev1.ServiceAccount
 }
@@ -146,6 +147,7 @@ func TestUpsert(t *testing.T) {
 					configureDeployment(name, namespace, labels, 3, nil, nil, "", "1"),
 				},
 				roles:           []*rbac.Role{},
+				secrets:         []*corev1.Secret{},
 				services:        []*corev1.Service{},
 				serviceAccounts: []*corev1.ServiceAccount{},
 			},
@@ -195,6 +197,9 @@ func TestUpsert(t *testing.T) {
 					configureDeployment(name, namespace, labels, 3, nil, nil, "", "1"),
 				},
 				roles: []*rbac.Role{},
+				secrets: []*corev1.Secret{
+					configureSecret(name, namespace, labels, "1", nil),
+				},
 				services: []*corev1.Service{
 					configureService(name, namespace, labels, nil, (corev1.ServiceType)("NodePort"), []corev1.ServicePort{
 						{
@@ -247,6 +252,9 @@ func TestUpsert(t *testing.T) {
 					configureDeployment(name, namespace, labels, 3, nil, nil, "", "1"),
 				},
 				roles: []*rbac.Role{},
+				secrets: []*corev1.Secret{
+					configureSecret(name, namespace, labels, "1", nil),
+				},
 				services: []*corev1.Service{
 					configureService(name, namespace, labels, nil, (corev1.ServiceType)("NodePort"), []corev1.ServicePort{
 						{
@@ -305,6 +313,9 @@ func TestUpsert(t *testing.T) {
 				roleBindings: []*rbac.RoleBinding{
 					configureRoleBinding(name, namespace, labels, "1"),
 				},
+				secrets: []*corev1.Secret{
+					configureSecret(name, namespace, labels, "1", nil),
+				},
 				services: []*corev1.Service{
 					configureService(name, namespace, labels, nil, (corev1.ServiceType)("NodePort"), []corev1.ServicePort{
 						{
@@ -359,6 +370,7 @@ func TestUpsert(t *testing.T) {
 					configureDeployment(name, namespace, labels, 5, nil, nil, "", "1"),
 				},
 				roles:           []*rbac.Role{},
+				secrets:         []*corev1.Secret{},
 				services:        []*corev1.Service{},
 				serviceAccounts: []*corev1.ServiceAccount{},
 			},
@@ -396,6 +408,7 @@ func TestUpsert(t *testing.T) {
 					configureDeployment(name, namespace, labels, 2, nil, nil, "", "1"),
 				},
 				roles:           []*rbac.Role{},
+				secrets:         []*corev1.Secret{},
 				services:        []*corev1.Service{},
 				serviceAccounts: []*corev1.ServiceAccount{},
 			},
@@ -438,6 +451,9 @@ func TestUpsert(t *testing.T) {
 				roleBindings: []*rbac.RoleBinding{
 					configureRoleBinding(name, namespace, labels, "1"),
 				},
+				secrets: []*corev1.Secret{
+					configureSecret(name, namespace, labels, "1", nil),
+				},
 				services: []*corev1.Service{
 					configureService(name, namespace, labels, nil, (corev1.ServiceType)("NodePort"), []corev1.ServicePort{
 						{
@@ -460,6 +476,9 @@ func TestUpsert(t *testing.T) {
 				},
 				roleBindings: []*rbac.RoleBinding{
 					configureRoleBinding(name, namespace, labels, "1"),
+				},
+				secrets: []*corev1.Secret{
+					configureSecret(name, namespace, labels, "1", nil),
 				},
 				services: []*corev1.Service{
 					configureService(name, namespace, labels, nil, (corev1.ServiceType)("NodePort"), []corev1.ServicePort{
@@ -523,6 +542,9 @@ func TestUpsert(t *testing.T) {
 				roleBindings: []*rbac.RoleBinding{
 					configureRoleBinding(name, namespace, labels, "1"),
 				},
+				secrets: []*corev1.Secret{
+					configureSecret(name, namespace, labels, "1", nil),
+				},
 				services: []*corev1.Service{
 					configureService(name, namespace, labels, nil, (corev1.ServiceType)("NodePort"), []corev1.ServicePort{
 						{
@@ -550,6 +572,9 @@ func TestUpsert(t *testing.T) {
 				},
 				roleBindings: []*rbac.RoleBinding{
 					configureRoleBinding(name, namespace, labels, "1"),
+				},
+				secrets: []*corev1.Secret{
+					configureSecret(name, namespace, labels, "1", nil),
 				},
 				services: []*corev1.Service{
 					configureService(name, namespace, labels, nil, (corev1.ServiceType)("NodePort"), []corev1.ServicePort{
@@ -604,6 +629,7 @@ func TestUpsert(t *testing.T) {
 					configureDeployment(name, namespace, labels, 5, nil, nil, "", "1"),
 				},
 				roles:           []*rbac.Role{},
+				secrets:         []*corev1.Secret{},
 				services:        []*corev1.Service{},
 				serviceAccounts: []*corev1.ServiceAccount{},
 			},
@@ -657,6 +683,7 @@ func TestUpsert(t *testing.T) {
 			finalResources: resources{
 				deployments: []*appsv1.Deployment{},
 				roles:       []*rbac.Role{},
+				secrets:     []*corev1.Secret{},
 				services: []*corev1.Service{
 					configureService(name, namespace, labels, externalAndCopyAnnotations, (corev1.ServiceType)("NodePort"), []corev1.ServicePort{
 						{
@@ -726,6 +753,7 @@ func TestUpsert(t *testing.T) {
 			finalResources: resources{
 				deployments: []*appsv1.Deployment{},
 				roles:       []*rbac.Role{},
+				secrets:     []*corev1.Secret{},
 				services: []*corev1.Service{
 					configureService(name, namespace, labels, copyAnnotations, (corev1.ServiceType)("NodePort"), []corev1.ServicePort{
 						{
@@ -783,6 +811,7 @@ func TestUpsert(t *testing.T) {
 					configureDeployment(name, namespace, labels, 8, nil, nil, "", "1"),
 				},
 				roles:           []*rbac.Role{},
+				secrets:         []*corev1.Secret{},
 				services:        []*corev1.Service{},
 				serviceAccounts: []*corev1.ServiceAccount{},
 			},
@@ -824,6 +853,7 @@ func TestUpsert(t *testing.T) {
 					configureDeployment(name, namespace, labels, 2, nil, nil, "", "1"),
 				},
 				roles:           []*rbac.Role{},
+				secrets:         []*corev1.Secret{},
 				services:        []*corev1.Service{},
 				serviceAccounts: []*corev1.ServiceAccount{},
 			},
@@ -865,6 +895,7 @@ func TestUpsert(t *testing.T) {
 					configureDeployment(name, namespace, labels, 5, nil, nil, "", "1"),
 				},
 				roles:           []*rbac.Role{},
+				secrets:         []*corev1.Secret{},
 				services:        []*corev1.Service{},
 				serviceAccounts: []*corev1.ServiceAccount{},
 			},
@@ -908,10 +939,88 @@ func TestUpsert(t *testing.T) {
 				roleBindings: []*rbac.RoleBinding{
 					configureRoleBinding(name, namespace, labels, "1"),
 				},
+				secrets:  []*corev1.Secret{},
 				services: []*corev1.Service{},
 				serviceAccounts: []*corev1.ServiceAccount{
 					configureServiceAccount(name, namespace, labels, "1"),
 				},
+			},
+		},
+		"create a new gateway with TLS certificate reference": {
+			gateway: gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: gwv1beta1.GatewaySpec{
+					Listeners: []gwv1beta1.Listener{
+						{
+							Name:     "Listener 1",
+							Port:     443,
+							Protocol: "TCP",
+							TLS: &gwv1beta1.GatewayTLSConfig{
+								CertificateRefs: []gwv1beta1.SecretObjectReference{
+									{
+										Namespace: common.PointerTo(gwv1beta1.Namespace(namespace)),
+										Name:      "tls-cert",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			gatewayClassConfig: v1alpha1.GatewayClassConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "consul-gatewayclassconfig",
+				},
+				Spec: v1alpha1.GatewayClassConfigSpec{
+					DeploymentSpec: v1alpha1.DeploymentSpec{
+						DefaultInstances: common.PointerTo(int32(3)),
+						MaxInstances:     common.PointerTo(int32(3)),
+						MinInstances:     common.PointerTo(int32(1)),
+					},
+					CopyAnnotations:  v1alpha1.CopyAnnotationsSpec{},
+					OpenshiftSCCName: "test-api-gateway",
+				},
+			},
+			helmConfig: common.HelmConfig{
+				EnableOpenShift: false,
+				ImageDataplane:  "hashicorp/consul-dataplane",
+			},
+			initialResources: resources{
+				secrets: []*corev1.Secret{
+					{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "v1",
+							Kind:       "Secret",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "tls-cert",
+							Namespace: namespace,
+						},
+						Data: map[string][]byte{
+							corev1.TLSCertKey:       []byte("cert"),
+							corev1.TLSPrivateKeyKey: []byte("key"),
+						},
+						Type: corev1.SecretTypeTLS,
+					},
+				},
+			},
+			finalResources: resources{
+				deployments: []*appsv1.Deployment{
+					configureDeployment(name, namespace, labels, 3, nil, nil, "", "1"),
+				},
+				roles:        []*rbac.Role{},
+				roleBindings: []*rbac.RoleBinding{},
+				secrets: []*corev1.Secret{
+					configureSecret(name, namespace, labels, "1", map[string][]byte{
+						"default_tls-cert_tls.crt": []byte("cert"),
+						"default_tls-cert_tls.key": []byte("key"),
+					}),
+				},
+				services:        []*corev1.Service{},
+				serviceAccounts: []*corev1.ServiceAccount{},
 			},
 		},
 	}
@@ -1100,6 +1209,73 @@ func TestDelete(t *testing.T) {
 				serviceAccounts: []*corev1.ServiceAccount{},
 			},
 		},
+		"delete a gateway deployment with a Secret": {
+			gateway: gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: gwv1beta1.GatewaySpec{
+					Listeners: listeners,
+				},
+			},
+			gatewayClassConfig: v1alpha1.GatewayClassConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "consul-gatewayclassconfig",
+				},
+				Spec: v1alpha1.GatewayClassConfigSpec{
+					DeploymentSpec: v1alpha1.DeploymentSpec{
+						DefaultInstances: common.PointerTo(int32(3)),
+						MaxInstances:     common.PointerTo(int32(3)),
+						MinInstances:     common.PointerTo(int32(1)),
+					},
+					CopyAnnotations: v1alpha1.CopyAnnotationsSpec{},
+					ServiceType:     (*corev1.ServiceType)(common.PointerTo("NodePort")),
+				},
+			},
+			helmConfig: common.HelmConfig{
+				AuthMethod:     "method",
+				ImageDataplane: dataplaneImage,
+			},
+			initialResources: resources{
+				deployments: []*appsv1.Deployment{
+					configureDeployment(name, namespace, labels, 3, nil, nil, "", "1"),
+				},
+				roles: []*rbac.Role{
+					configureRole(name, namespace, labels, "1", false),
+				},
+				roleBindings: []*rbac.RoleBinding{
+					configureRoleBinding(name, namespace, labels, "1"),
+				},
+				secrets: []*corev1.Secret{
+					configureSecret(name, namespace, labels, "1", nil),
+				},
+				services: []*corev1.Service{
+					configureService(name, namespace, labels, nil, (corev1.ServiceType)("NodePort"), []corev1.ServicePort{
+						{
+							Name:     "Listener 1",
+							Protocol: "TCP",
+							Port:     8080,
+						},
+						{
+							Name:     "Listener 2",
+							Protocol: "TCP",
+							Port:     8081,
+						},
+					}, "1", true, false),
+				},
+				serviceAccounts: []*corev1.ServiceAccount{
+					configureServiceAccount(name, namespace, labels, "1"),
+				},
+			},
+			finalResources: resources{
+				deployments:     []*appsv1.Deployment{},
+				roles:           []*rbac.Role{},
+				secrets:         []*corev1.Secret{},
+				services:        []*corev1.Service{},
+				serviceAccounts: []*corev1.ServiceAccount{},
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -1118,10 +1294,7 @@ func TestDelete(t *testing.T) {
 
 			gatekeeper := New(log, client)
 
-			err := gatekeeper.Delete(context.Background(), types.NamespacedName{
-				Namespace: tc.gateway.Namespace,
-				Name:      tc.gateway.Name,
-			})
+			err := gatekeeper.Delete(context.Background(), tc.gateway)
 			require.NoError(t, err)
 			require.NoError(t, validateResourcesExist(t, client, tc.helmConfig, tc.finalResources, false))
 			require.NoError(t, validateResourcesAreDeleted(t, client, tc.initialResources))
@@ -1140,6 +1313,10 @@ func joinResources(resources resources) (objs []client.Object) {
 
 	for _, roleBinding := range resources.roleBindings {
 		objs = append(objs, roleBinding)
+	}
+
+	for _, secret := range resources.secrets {
+		objs = append(objs, secret)
 	}
 
 	for _, service := range resources.services {
@@ -1212,6 +1389,22 @@ func validateResourcesExist(t *testing.T, client client.Client, helmConfig commo
 			}
 		}
 		assert.True(t, hasDataplaneContainer)
+	}
+
+	for _, expected := range resources.secrets {
+		actual := &corev1.Secret{}
+		err := client.Get(context.Background(), types.NamespacedName{
+			Name:      expected.Name,
+			Namespace: expected.Namespace,
+		}, actual)
+		if err != nil {
+			return err
+		}
+
+		// Patch the createdAt label
+		actual.Labels[createdAtLabelKey] = createdAtLabelValue
+
+		require.Equal(t, expected, actual)
 	}
 
 	for _, expected := range resources.roles {
@@ -1409,6 +1602,31 @@ func configureDeployment(name, namespace string, labels map[string]string, repli
 				},
 			},
 		},
+	}
+}
+
+func configureSecret(name, namespace string, labels map[string]string, resourceVersion string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			Labels:          labels,
+			ResourceVersion: resourceVersion,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "gateway.networking.k8s.io/v1beta1",
+					Kind:               "Gateway",
+					Name:               name,
+					Controller:         common.PointerTo(true),
+					BlockOwnerDeletion: common.PointerTo(true),
+				},
+			},
+		},
+		Data: data,
 	}
 }
 

--- a/control-plane/api-gateway/gatekeeper/ownership.go
+++ b/control-plane/api-gateway/gatekeeper/ownership.go
@@ -1,0 +1,16 @@
+package gatekeeper
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+func isOwnedByGateway(o client.Object, gateway gwv1beta1.Gateway) bool {
+	for _, ref := range o.GetOwnerReferences() {
+		if ref.UID == gateway.GetUID() && ref.Name == gateway.GetName() {
+			// We found our gateway!
+			return true
+		}
+	}
+	return false
+}

--- a/control-plane/api-gateway/gatekeeper/secret.go
+++ b/control-plane/api-gateway/gatekeeper/secret.go
@@ -1,0 +1,129 @@
+package gatekeeper
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
+)
+
+func (g *Gatekeeper) upsertSecret(ctx context.Context, gateway gwv1beta1.Gateway) error {
+	desiredSecret, err := g.secret(ctx, gateway)
+	if err != nil {
+		return fmt.Errorf("failed to create certificate secret for gateway %s/%s: %w", gateway.Namespace, gateway.Name, err)
+	}
+
+	// If the Secret already exists, ensure that we own the Secret
+	existingSecret := &corev1.Secret{ObjectMeta: desiredSecret.ObjectMeta}
+	err = g.Client.Get(ctx, g.namespacedName(gateway), existingSecret)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("failed to fetch existing Secret %s/%s: %w", gateway.Namespace, gateway.Name, err)
+	} else if !k8serrors.IsNotFound(err) {
+		if !isOwnedByGateway(existingSecret, gateway) {
+			return fmt.Errorf("existing Secret %s/%s is not owned by Gateway %s/%s", existingSecret.Namespace, existingSecret.Name, gateway.Namespace, gateway.Name)
+		}
+	}
+
+	mutator := newSecretMutator(existingSecret, desiredSecret, gateway, g.Client.Scheme())
+
+	result, err := controllerruntime.CreateOrUpdate(ctx, g.Client, existingSecret, mutator)
+	if err != nil {
+		return err
+	}
+
+	switch result {
+	case controllerutil.OperationResultCreated:
+		g.Log.V(1).Info("Created Secret")
+	case controllerutil.OperationResultUpdated:
+		g.Log.V(1).Info("Updated Secret")
+	case controllerutil.OperationResultNone:
+		g.Log.V(1).Info("No change to Secret")
+	}
+
+	return nil
+}
+
+func (g *Gatekeeper) deleteSecret(ctx context.Context, gw gwv1beta1.Gateway) error {
+	secret := &corev1.Secret{}
+	if err := g.Client.Get(ctx, g.namespacedName(gw), secret); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if !isOwnedByGateway(secret, gw) {
+		return fmt.Errorf("existing Secret %s/%s is not owned by Gateway %s/%s", secret.Namespace, secret.Name, gw.Namespace, gw.Name)
+	}
+
+	if err := g.Client.Delete(ctx, secret); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (g *Gatekeeper) secret(ctx context.Context, gateway gwv1beta1.Gateway) (*corev1.Secret, error) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: gateway.Namespace,
+			Name:      gateway.Name,
+			Labels:    common.LabelsForGateway(&gateway),
+		},
+		Data: map[string][]byte{},
+		Type: corev1.SecretTypeOpaque,
+	}
+
+	for _, listener := range gateway.Spec.Listeners {
+		if listener.TLS == nil {
+			continue
+		}
+
+		for _, ref := range listener.TLS.CertificateRefs {
+			// Only take action on Secret references
+			if !common.NilOrEqual(ref.Group, "") || !common.NilOrEqual(ref.Kind, common.KindSecret) {
+				continue
+			}
+
+			key := types.NamespacedName{
+				Namespace: common.ValueOr(ref.Namespace, gateway.Namespace),
+				Name:      string(ref.Name),
+			}
+
+			referencedSecret := &corev1.Secret{}
+			if err := g.Client.Get(ctx, key, referencedSecret); err != nil && k8serrors.IsNotFound(err) {
+				// If the referenced Secret is not found, log a message and continue.
+				// The issue will be raised on the Gateway status by the validation process.
+				g.Log.V(1).Info(fmt.Sprintf("Referenced certificate secret %s/%s not found", key.Namespace, key.Name))
+			} else if err != nil {
+				return nil, fmt.Errorf("failed to fetch certificate secret %s/%s: %w", key.Namespace, key.Name, err)
+			}
+
+			prefix := fmt.Sprintf("%s_%s_", key.Namespace, key.Name)
+			for k, v := range referencedSecret.Data {
+				secret.Data[prefix+k] = v
+			}
+		}
+	}
+
+	return secret, nil
+}
+
+func newSecretMutator(existing, desired *corev1.Secret, gateway gwv1beta1.Gateway, scheme *runtime.Scheme) resourceMutator {
+	return func() error {
+		existing.Data = desired.Data
+		return controllerruntime.SetControllerReference(&gateway, existing, scheme)
+	}
+}

--- a/control-plane/api-gateway/gatekeeper/volumes.go
+++ b/control-plane/api-gateway/gatekeeper/volumes.go
@@ -4,61 +4,46 @@
 package gatekeeper
 
 import (
-	"fmt"
-	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
-	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 )
 
 // volumesAndMounts generates the list of volumes for the Deployment and the list of volume
-// mounts for the primary container in the Deployment. In addition to the "default" volume
-// containing connect-inject data, there will be one volume + mount per unique Secret
-// referenced in the Gateway's listener TLS configurations. The volume references the Secret
-// directly.
+// mounts for the primary container in the Deployment. There are two volumes that are created:
+// - one empty volume for holding connect-inject data
+// - one volume holding all TLS certificates referenced by the Gateway.
 func volumesAndMounts(gateway v1beta1.Gateway) ([]corev1.Volume, []corev1.VolumeMount) {
-	volumes := map[string]corev1.Volume{
-		volumeNameForConnectInject: {
+	volumes := []corev1.Volume{
+		{
 			Name: volumeNameForConnectInject,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory},
 			},
 		},
-	}
-	mounts := map[string]corev1.VolumeMount{
-		volumeNameForConnectInject: {
-			Name:      volumeNameForConnectInject,
-			MountPath: "/consul/connect-inject",
+		{
+			Name: volumeNameForTLSCerts,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  gateway.Name,
+					DefaultMode: common.PointerTo(int32(444)),
+					Optional:    common.PointerTo(false),
+				},
+			},
 		},
 	}
 
-	for i, listener := range gateway.Spec.Listeners {
-		if listener.TLS == nil {
-			continue
-		}
-
-		for j, ref := range listener.TLS.CertificateRefs {
-			refNamespace := common.ValueOr(ref.Namespace, gateway.Namespace)
-
-			volumeName := fmt.Sprintf("listener-%d-cert-%d-volume", i, j)
-
-			volumes[volumeName] = corev1.Volume{
-				Name: volumeName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName:  string(ref.Name),
-						DefaultMode: common.PointerTo(int32(444)),
-						Optional:    common.PointerTo(false),
-					},
-				},
-			}
-
-			mounts[volumeName] = corev1.VolumeMount{
-				Name:      volumeName,
-				MountPath: fmt.Sprintf("/consul/gateway-certificates/%s/%s", refNamespace, ref.Name),
-			}
-		}
+	mounts := []corev1.VolumeMount{
+		{
+			Name:      volumeNameForConnectInject,
+			MountPath: "/consul/connect-inject",
+		},
+		{
+			Name:      volumeNameForTLSCerts,
+			MountPath: "/consul/gateway-certificates",
+		},
 	}
 
-	return maps.Values(volumes), maps.Values(mounts)
+	return volumes, mounts
 }


### PR DESCRIPTION
> [!NOTE]
> This is a backport of #4100 targeting the consul-k8s 1.5.0 release

# Original PR Body

### Changes proposed in this PR ###  
In order to mount a volume from a `Secret` containing TLS certificates into the API gateway `Pod`, those `Secrets` must exist in the same namespace as the API gateway `Pod`. This centralizes all referenced TLS certificates into a `Secret` in the same namespace as the API gateway `Pod` to make that possible. This `Secret` is managed in the same way as other API gateway resources - such as `Role`, `Service`, etc. - in that it has an owner reference pointing to the `Gateway` that's consuming it. That owner reference is checked before any operations take place on the `Secret` to ensure that we aren't overwriting any pre-existing resources that we don't own.

### How I've tested this PR ###
Create a `Gateway` that references a TLS certificate `Secret` from a namespace _other than the one containing the `Gateway`._ Verify that the certificate is correctly consumed by the `Gateway`, and Envoy ends up serving up the secret in its config.

Configurations for this kind of setup is available [here](https://github.com/nathancoleman/consul-lab/tree/main/k8s/api-gateway/basic).

### How I expect reviewers to test this PR ###
See above

### Checklist ###
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
