### PR TITLE
[NET-9446] chore: disable CE tests for Consul 1.18

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -28,4 +28,4 @@ jobs:
         ref: main
         token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
         # set "test-ce" to false when a new minor version is released
-        inputs: '{ "test-ce": true, "context":"${{ env.CONTEXT }}", "actor":"${{ github.actor }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'
+        inputs: '{ "test-ce": false, "context":"${{ env.CONTEXT }}", "actor":"${{ github.actor }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,4 +22,4 @@ jobs:
         ref: main
         token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
         # set "test-ce" to false when a new minor version is released
-        inputs: '{ "test-ce": true, "context":"${{ env.CONTEXT }}", "actor":"${{ github.actor }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'
+        inputs: '{ "test-ce": false, "context":"${{ env.CONTEXT }}", "actor":"${{ github.actor }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'


### PR DESCRIPTION
With the release of 1.19, this version is now Ent-only.
