### PR TITLE
ci: pass required consul-k8s-workflows checks on CI skip

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,3 +27,27 @@ jobs:
         ref: main
         token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
         inputs: '{ "context":"${{ env.CONTEXT }}", "actor":"${{ github.actor }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'
+
+  pass-required-checks-on-skip:
+    needs: [ conditional-skip ]
+    if: needs.conditional-skip.outputs.skip-ci == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # The required checks that should be "passed" when the CI is skipped
+          - check-name: acceptance
+          - check-name: acceptance-cni
+          - check-name: acceptance-tproxy
+    steps:
+    - name: Update final status
+      uses: docker://ghcr.io/curtbushko/commit-status-action:e1d661c757934ab35c74210b4b70c44099ec747a
+      env:
+        INPUT_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+        INPUT_REPOSITORY: ${{ github.repository }}
+        INPUT_CONTEXT: ${{ matrix.check-name }}
+        INPUT_STATE: success
+        INPUT_DESCRIPTION: "Skipped due to conditional-skip check"
+        INPUT_SHA: ${{ env.SHA }}
+        INPUT_DETAILS_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        INPUT_OWNER: "hashicorp"


### PR DESCRIPTION
Unlike local job checks, these will not automatically be considered passing when skipped.

Follow-up to https://github.com/hashicorp/consul-k8s/pull/4127 after enabling required checks for acceptance tests.

### Changes proposed in this PR ###  
- Skip newly required acceptance test checks (set by `consul-k8s-workflows`) when skipping CI due to docs-only changes

### How I've tested this PR ###
https://github.com/hashicorp/consul-k8s/pull/4146 (PR based on this branch, with skipping always on regardless of changed files, since this PR changes files that will not be skipped):
![image](https://github.com/hashicorp/consul-k8s/assets/2141941/4b570eb2-236c-43aa-ac87-8007e5f11e9d)


### How I expect reviewers to test this PR ###
👀 

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
