### PR TITLE
NET-10193 - add acceptance test for DNS proxy work

### DIFF
--- a/acceptance/framework/flags/flags.go
+++ b/acceptance/framework/flags/flags.go
@@ -228,7 +228,7 @@ func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 		HelmChartVersion:       t.flagHelmChartVersion,
 		ConsulImage:            t.flagConsulImage,
 		ConsulK8SImage:         t.flagConsulK8sImage,
-		ConsulDataplaneImage:   "jmurrethc/consul-dataplane-dev:1.2", // t.flagConsulDataplaneImage,
+		ConsulDataplaneImage:   "jmurrethc/consul-dataplane-dev:1.2-amd", // t.flagConsulDataplaneImage,
 		ConsulVersion:          consulVersion,
 		ConsulDataplaneVersion: consulDataplaneVersion,
 		EnvoyImage:             t.flagEnvoyImage,

--- a/acceptance/framework/flags/flags.go
+++ b/acceptance/framework/flags/flags.go
@@ -228,7 +228,7 @@ func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 		HelmChartVersion:       t.flagHelmChartVersion,
 		ConsulImage:            t.flagConsulImage,
 		ConsulK8SImage:         t.flagConsulK8sImage,
-		ConsulDataplaneImage:   "jmurrethc/consul-dataplane-dev:1.2-amd", // t.flagConsulDataplaneImage,
+		ConsulDataplaneImage:   t.flagConsulDataplaneImage,
 		ConsulVersion:          consulVersion,
 		ConsulDataplaneVersion: consulDataplaneVersion,
 		EnvoyImage:             t.flagEnvoyImage,

--- a/acceptance/framework/flags/flags.go
+++ b/acceptance/framework/flags/flags.go
@@ -228,7 +228,7 @@ func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
 		HelmChartVersion:       t.flagHelmChartVersion,
 		ConsulImage:            t.flagConsulImage,
 		ConsulK8SImage:         t.flagConsulK8sImage,
-		ConsulDataplaneImage:   t.flagConsulDataplaneImage,
+		ConsulDataplaneImage:   "jmurrethc/consul-dataplane-dev:1.2", // t.flagConsulDataplaneImage,
 		ConsulVersion:          consulVersion,
 		ConsulDataplaneVersion: consulDataplaneVersion,
 		EnvoyImage:             t.flagEnvoyImage,

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -34,9 +34,9 @@ func TestConsulDNS(t *testing.T) {
 		secure         bool
 		enableDNSProxy bool
 	}{
-		//{secure: false, enableDNSProxy: false},
+		{secure: false, enableDNSProxy: false},
 		{secure: false, enableDNSProxy: true},
-		//{secure: true, enableDNSProxy: false},
+		{secure: true, enableDNSProxy: false},
 		{secure: true, enableDNSProxy: true},
 	}
 	for _, c := range cases {

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -6,12 +6,15 @@ package consuldns
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,74 +30,110 @@ func TestConsulDNS(t *testing.T) {
 		t.Skipf("skipping because -use-aks is set")
 	}
 
-	for _, secure := range []bool{false, true} {
-		name := fmt.Sprintf("secure: %t", secure)
+	cases := []struct {
+		secure         bool
+		enableDNSProxy bool
+	}{
+		//{secure: false, enableDNSProxy: false},
+		{secure: false, enableDNSProxy: true},
+		//{secure: true, enableDNSProxy: false},
+		{secure: true, enableDNSProxy: true},
+	}
+	for _, c := range cases {
+		name := fmt.Sprintf("secure: %t / enableDNSProxy: %t", c.secure, c.enableDNSProxy)
 		t.Run(name, func(t *testing.T) {
 			env := suite.Environment()
 			ctx := env.DefaultContext(t)
 			releaseName := helpers.RandomName()
-
 			helmValues := map[string]string{
 				"dns.enabled":                  "true",
-				"global.tls.enabled":           strconv.FormatBool(secure),
-				"global.acls.manageSystemACLs": strconv.FormatBool(secure),
+				"global.tls.enabled":           strconv.FormatBool(c.secure),
+				"global.acls.manageSystemACLs": strconv.FormatBool(c.secure),
+				"dns.proxy.enabled":            strconv.FormatBool(c.enableDNSProxy),
 			}
 			cluster := consul.NewHelmCluster(t, helmValues, ctx, suite.Config(), releaseName)
 			cluster.Create(t)
 
-			k8sClient := ctx.KubernetesClient(t)
 			contextNamespace := ctx.KubectlOptions(t).Namespace
 
-			dnsService, err := k8sClient.CoreV1().Services(contextNamespace).Get(context.Background(), fmt.Sprintf("%s-%s", releaseName, "consul-dns"), metav1.GetOptions{})
-			require.NoError(t, err)
+			verifyDNS(t, releaseName, c.enableDNSProxy, contextNamespace, ctx, ctx, "app=consul,component=server",
+				"consul.service.consul", true, 0)
 
-			dnsIP := dnsService.Spec.ClusterIP
-
-			consulServerList, err := k8sClient.CoreV1().Pods(contextNamespace).List(context.Background(), metav1.ListOptions{
-				LabelSelector: "app=consul,component=server",
-			})
-			require.NoError(t, err)
-
-			serverIPs := make([]string, len(consulServerList.Items))
-			for _, serverPod := range consulServerList.Items {
-				serverIPs = append(serverIPs, serverPod.Status.PodIP)
-			}
-
-			dnsPodName := fmt.Sprintf("%s-dns-pod", releaseName)
-			dnsTestPodArgs := []string{
-				"run", "-it", dnsPodName, "--restart", "Never", "--image", "anubhavmishra/tiny-tools", "--", "dig", fmt.Sprintf("@%s-consul-dns", releaseName), "consul.service.consul",
-			}
-
-			helpers.Cleanup(t, suite.Config().NoCleanupOnFailure, suite.Config().NoCleanup, func() {
-				// Note: this delete command won't wait for pods to be fully terminated.
-				// This shouldn't cause any test pollution because the underlying
-				// objects are deployments, and so when other tests create these
-				// they should have different pod names.
-				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "pod", dnsPodName)
-			})
-
-			retry.Run(t, func(r *retry.R) {
-				logs, err := k8s.RunKubectlAndGetOutputE(r, ctx.KubectlOptions(r), dnsTestPodArgs...)
-				require.NoError(r, err)
-
-				// When the `dig` request is successful, a section of it's response looks like the following:
-				//
-				// ;; ANSWER SECTION:
-				// consul.service.consul.	0	IN	A	<consul-server-pod-ip>
-				//
-				// ;; Query time: 2 msec
-				// ;; SERVER: <dns-ip>#<dns-port>(<dns-ip>)
-				// ;; WHEN: Mon Aug 10 15:02:40 UTC 2020
-				// ;; MSG SIZE  rcvd: 98
-				//
-				// We assert on the existence of the ANSWER SECTION, The consul-server IPs being present in the ANSWER SECTION and the the DNS IP mentioned in the SERVER: field
-
-				require.Contains(r, logs, fmt.Sprintf("SERVER: %s", dnsIP))
-				require.Contains(r, logs, "ANSWER SECTION:")
-				for _, ip := range serverIPs {
-					require.Contains(r, logs, fmt.Sprintf("consul.service.consul.\t0\tIN\tA\t%s", ip))
-				}
-			})
 		})
 	}
+}
+
+func verifyDNS(t *testing.T, releaseName string, enableDNSProxy bool, svcNamespace string, requestingCtx, svcContext environment.TestContext,
+	podLabelSelector, svcName string, shouldResolveDNSRecord bool, dnsUtilsPodIndex int) {
+	logger.Log(t, "get the in cluster dns service or proxy.")
+	dnsSvcName := fmt.Sprintf("%s-consul-dns", releaseName)
+	if enableDNSProxy {
+		dnsSvcName += "-proxy"
+	}
+	dnsService, err := requestingCtx.KubernetesClient(t).CoreV1().Services(requestingCtx.KubectlOptions(t).Namespace).Get(context.Background(), dnsSvcName, metav1.GetOptions{})
+	require.NoError(t, err)
+	dnsIP := dnsService.Spec.ClusterIP
+
+	podList, err := svcContext.KubernetesClient(t).CoreV1().Pods(svcNamespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: podLabelSelector,
+	})
+	require.NoError(t, err)
+
+	servicePodIPs := make([]string, len(podList.Items))
+	for _, serverPod := range podList.Items {
+		servicePodIPs = append(servicePodIPs, serverPod.Status.PodIP)
+	}
+
+	logger.Log(t, "launch a pod to test the dns resolution.")
+	dnsUtilsPod := fmt.Sprintf("%s-dns-utils-pod-%d", releaseName, dnsUtilsPodIndex)
+	dnsTestPodArgs := []string{
+		"run", "-it", dnsUtilsPod, "--restart", "Never", "--image", "anubhavmishra/tiny-tools", "--", "dig", fmt.Sprintf("@%s", dnsSvcName), svcName,
+	}
+
+	helpers.Cleanup(t, suite.Config().NoCleanupOnFailure, suite.Config().NoCleanup, func() {
+		// Note: this delete command won't wait for pods to be fully terminated.
+		// This shouldn't cause any test pollution because the underlying
+		// objects are deployments, and so when other tests create these
+		// they should have different pod names.
+		k8s.RunKubectl(t, requestingCtx.KubectlOptions(t), "delete", "pod", dnsUtilsPod)
+	})
+
+	retry.Run(t, func(r *retry.R) {
+		logger.Log(t, "run the dns utilize pod and query DNS for the service.")
+		logs, err := k8s.RunKubectlAndGetOutputE(r, requestingCtx.KubectlOptions(r), dnsTestPodArgs...)
+		require.NoError(r, err)
+
+		// When the `dig` request is successful, a section of it's response looks like the following:
+		//
+		// ;; ANSWER SECTION:
+		// consul.service.consul.	0	IN	A	<consul-server-pod-ip>
+		//
+		// ;; Query time: 2 msec
+		// ;; SERVER: <dns-ip>#<dns-port>(<dns-ip>)
+		// ;; WHEN: Mon Aug 10 15:02:40 UTC 2020
+		// ;; MSG SIZE  rcvd: 98
+		//
+		// We assert on the existence of the ANSWER SECTION, The consul-server IPs being present in the ANSWER SECTION and the the DNS IP mentioned in the SERVER: field
+
+		logger.Log(t, "verify the DNS results.")
+		require.Contains(r, logs, fmt.Sprintf("SERVER: %s", dnsIP))
+		// strip logs of tabs, newlines and spaces to make it easier to assert on the content when there is a DNS match
+		strippedLogs := strings.Replace(logs, "\t", "", -1)
+		strippedLogs = strings.Replace(strippedLogs, "\n", "", -1)
+		strippedLogs = strings.Replace(strippedLogs, " ", "", -1)
+		for _, ip := range servicePodIPs {
+			if ip != "" {
+				aRecordPattern := "%s.0INA%s"
+				if shouldResolveDNSRecord {
+					require.Contains(r, logs, "ANSWER SECTION:")
+					require.Contains(r, strippedLogs, fmt.Sprintf(aRecordPattern, svcName, ip))
+				} else {
+					require.NotContains(r, logs, "ANSWER SECTION:")
+					require.NotContains(r, strippedLogs, fmt.Sprintf(aRecordPattern, svcName, ip))
+					require.Contains(r, logs, "status: NXDOMAIN")
+					require.Contains(r, logs, "AUTHORITY SECTION:\nconsul.\t\t\t0\tIN\tSOA\tns.consul. hostmaster.consul.")
+				}
+			}
+		}
+	})
 }

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -39,6 +39,7 @@ func TestConsulDNS(t *testing.T) {
 		{secure: true, enableDNSProxy: false},
 		{secure: true, enableDNSProxy: true},
 	}
+
 	for _, c := range cases {
 		name := fmt.Sprintf("secure: %t / enableDNSProxy: %t", c.secure, c.enableDNSProxy)
 		t.Run(name, func(t *testing.T) {

--- a/charts/consul/templates/dns-proxy-deployment.yaml
+++ b/charts/consul/templates/dns-proxy-deployment.yaml
@@ -60,7 +60,9 @@ spec:
         {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
-      serviceAccountName: {{ template "consul.fullname" . }}-dns-proxy
+      # serviceAccountName: {{ template "consul.fullname" . }}-dns-proxy
+      # TODO(jmurret): fix the service account for dns-proxy
+      serviceAccountName: {{ template "consul.fullname" . }}-connect-injector
       volumes:
         - name: consul-service
           emptyDir:


### PR DESCRIPTION
### Changes proposed in this PR ###  
- run consul-dns temporarily with connect injector service account so that it can get an ACL token.  (A follow up PR will map the appropriate service account)
- add test cases for `TestConsulDNS` for dnsproxy deployments

### How I've tested this PR ###
- acceptance test

### How I expect reviewers to test this PR ###
👀 

### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
