### PR TITLE
NET-10522 - consul-k8s - update test that makes it seem like global.enabled=false and client.enabled=true is required to enable dns proxy

### DIFF
--- a/charts/consul/test/unit/dns-proxy-deployment.bats
+++ b/charts/consul/test/unit/dns-proxy-deployment.bats
@@ -9,12 +9,10 @@ load _helpers
         .
 }
 
-@test "dnsProxy/Deployment: enable with global.enabled false, client.enabled true" {
+@test "dnsProxy/Deployment: enable with dns.proxy.enabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/dns-proxy-deployment.yaml  \
-      --set 'global.enabled=false' \
-      --set 'client.enabled=true' \
       --set 'dns.proxy.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)


### PR DESCRIPTION

### Changes proposed in this PR ###  
This is really a minor test change to set up and naming of the test so that it does not make readers think that in addition to setting `dns.proxy.enabled=true`, you also need to set `global.enabled=false` and `client.enabled=true`.

### How I've tested this PR ###
running locally and CI

### How I expect reviewers to test this PR ###
👀 

