### PR TITLE
NET-10526 - consul-k8s - add test to ensure that the regular dns service is not deployed when dns proxy is enabled

### DIFF
--- a/charts/consul/test/unit/dns-service.bats
+++ b/charts/consul/test/unit/dns-service.bats
@@ -38,6 +38,15 @@ load _helpers
       .
 }
 
+@test "dns/Service: disable with dns.proxy.enabled set to true" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/dns-service.yaml  \
+      --set 'dns.enabled=true' \
+      --set 'dns.proxy.enabled=true' \
+      .
+}
+
 #--------------------------------------------------------------------
 # annotations
 


### PR DESCRIPTION
### Changes proposed in this PR ###  
- add test to ensure that the regular dns service is not deployed when dns proxy is enabled
-

### How I've tested this PR ###
locally and CI

### How I expect reviewers to test this PR ###
👀 

### Checklist ###
- [x] Tests added
