### PR TITLE
NET-10548 Adds image pull secrets to the gateway cleanup and gateway resources job service account

### DIFF
--- a/.changelog/4210.txt
+++ b/.changelog/4210.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+helm: adds imagePullSecret to the gateway-resources job and the gateway-cleanup job, would fail before if the image was in a private registry
+```

--- a/charts/consul/templates/gateway-cleanup-serviceaccount.yaml
+++ b/charts/consul/templates/gateway-cleanup-serviceaccount.yaml
@@ -10,4 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: gateway-cleanup
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/gateway-resources-serviceaccount.yaml
+++ b/charts/consul/templates/gateway-resources-serviceaccount.yaml
@@ -10,4 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: gateway-resources
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range . }}
+  - name: {{ .name }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/consul/test/unit/gateway-cleanup-serviceaccount.bats
+++ b/charts/consul/test/unit/gateway-cleanup-serviceaccount.bats
@@ -21,3 +21,25 @@ target=templates/gateway-cleanup-serviceaccount.yaml
         . 
 }
 
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "gatewaycleanup/ServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/gateway-cleanup-serviceaccount.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}
+
+

--- a/charts/consul/test/unit/gateway-resources-serviceaccount.bats
+++ b/charts/consul/test/unit/gateway-resources-serviceaccount.bats
@@ -21,3 +21,23 @@ target=templates/gateway-resources-serviceaccount.yaml
         . 
 }
 
+#--------------------------------------------------------------------
+# global.imagePullSecrets
+
+@test "gatewayresources/ServiceAccount: can set image pull secrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/gateway-resources-serviceaccount.yaml  \
+      --set 'connectInject.enabled=true' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      --set 'global.imagePullSecrets[1].name=my-secret2' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+
+  local actual=$(echo "$object" |
+      yq -r '.imagePullSecrets[1].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret2" ]
+}


### PR DESCRIPTION
This fixes https://github.com/hashicorp/consul-k8s/issues/3862. When installing consul-k8s with a private image registry, the 'gateway-resources' and 'gateway-cleanup jobs could not pull the images as thier service accounts did not include the imagePull secrets


### How I've tested this PR ###
- Added bats test
- Manually tested with the following values and a private registry set up
*Do a helm install with the local chart from this branch*. If the jobs didn't have the required pull secrets, they would never spin up.
Also do a helm uninstall to see the cleanup-job run.
```
global:
  name: consul
  imageK8S: my-private-registry/consul-k8s-control-plane:latest
  imagePullSecrets:
  - name: consul-pull-secret
    namespace: consul
# This is useful to make sure it is always pulling the image, and not just getting it from another container on the cluster
  imagePullPolicy: "Always" 
```

### How I expect reviewers to test this PR ###
Test on your own cluster with a private registry using the above values.

### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
