### PR TITLE
Adds back manageNonStandardCRDs option to the helm chart

### DIFF
--- a/.changelog/4213.txt
+++ b/.changelog/4213.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixes install of Consul on GKE Autopilot where the option 'manageNonStandardCRDs' was not being used for the TCPRoute CRD.
+```

--- a/charts/consul/templates/crd-tcproutes-external.yaml
+++ b/charts/consul/templates/crd-tcproutes-external.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.connectInject.enabled .Values.connectInject.apiGateway.manageExternalCRDs }}
+{{- if and .Values.connectInject.enabled (or .Values.connectInject.apiGateway.manageExternalCRDs .Values.connectInject.apiGateway.manageNonStandardCRDs ) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/consul/test/unit/crd-tcproutes-external.bats
+++ b/charts/consul/test/unit/crd-tcproutes-external.bats
@@ -16,15 +16,18 @@ load _helpers
     assert_empty helm template \
         -s templates/crd-tcproutes-external.yaml \
         --set 'connectInject.enabled=false' \
-        . 
+        .
 }
 
-@test "tcproutes/CustomResourceDefinition: disabled with connectInject.apiGateway.manageExternalCRDs=false" {
+@test "tcproutes/CustomResourceDefinition: enabled with connectInject.apiGateway.manageExternalCRDs=true and connectInject.apiGateway.manageNonStandardCRDs=false" {
     cd `chart_dir`
-    assert_empty helm template \
+    local actual=$(helm template \
         -s templates/crd-tcproutes-external.yaml \
-        --set 'connectInject.apiGateway.manageExternalCRDs=false' \
-        . 
+        --set 'connectInject.apiGateway.manageExternalCRDs=true' \
+        --set 'connectInject.apiGateway.manageNonStandardCRDs=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
 }
 
 @test "tcproutes/CustomResourceDefinition: disabled with connectInject.apiGateway.manageExternalCRDs=false and connectInject.apiGateway.manageNonStandardCRDs=false" {
@@ -33,15 +36,16 @@ load _helpers
         -s templates/crd-tcproutes-external.yaml \
         --set 'connectInject.apiGateway.manageExternalCRDs=false' \
         --set 'connectInject.apiGateway.manageNonStandardCRDs=false' \
-        . 
+        .
 }
 
-@test "tcproutes/CustomResourceDefinition: enabled with connectInject.apiGateway.manageNonStandardCRDs=true" {
+@test "tcproutes/CustomResourceDefinition: enabled with connectInject.apiGateway.manageExternalCRDs=false and connectInject.apiGateway.manageNonStandardCRDs=true" {
     cd `chart_dir`
     local actual=$(helm template \
         -s templates/crd-tcproutes-external.yaml \
+        --set 'connectInject.apiGateway.manageExternalCRDs=false' \
         --set 'connectInject.apiGateway.manageNonStandardCRDs=true' \
       . | tee /dev/stderr |
-      yq -s 'length > 0' | tee /dev/stderr)
+      yq 'length > 0' | tee /dev/stderr)
     [ "${actual}" = "true" ]
 }


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Adds back the manageNonStandardCRDs option to the Helm chart. Somehow got removed from tcp-routes
- Fixes https://github.com/hashicorp/consul/issues/20909 

### How I've tested this PR ###
- Start a GKE Autopilot cluster
- Install with the following values, should have no errors
```
global:
  name: consul
connectInject:
  enabled: true
  apiGateway:
    manageExternalCRDs: false
    manageNonStandardCRDs: true
  cni:
    enabled: true
    logLevel: debug
    cniBinDir: "/home/kubernetes/bin"
    cniNetDir: "/etc/cni/net.d"
server:
  resources:
    requests:
      memory: "500Mi"
      cpu: "500m"
    limits:
      memory: "500Mi"
      cpu: "500m"
```

### How I expect reviewers to test this PR ###
Can test on another type of cluster, you just need to notice that flipping the value of `manageNonStandardCRDs` will determine whether the tcp-route CRD gets installed.

### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
