### PR TITLE
Update acceptance test docs, add "WaitForInput" function

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -961,17 +961,23 @@ The tests are organized like this :
 ```shell
 demo $ tree -L 1 -d acceptance/tests
 acceptance/tests
+├── api-gateway
 ├── basic
 ├── cli
+├── cloud
 ├── config-entries
 ├── connect
 ├── consul-dns
+├── datadog
 ├── example
 ├── fixtures
 ├── ingress-gateway
 ├── metrics
 ├── partitions
 ├── peering
+├── sameness
+├── segments
+├── server
 ├── snapshot-agent
 ├── sync
 ├── terminating-gateway
@@ -1009,7 +1015,9 @@ $ kind create cluster --name=dc1 && kind create cluster --name=dc2
   `-consul-k8s-image=<your-custom-image>` && `-consul-image=<your-custom-image>`
 * You can set custom helm flags by modifying the test file directly in the respective directory.
 
-Finally, run the test like shown above:
+Finally, you have two options on how you can run your test:
+1. Take the following steps, this will run the test through to completion but not teardown any resources created by the test so you can inspect the state of the cluster
+at that point. You will be responsible for cleaning up the resources or deleting the cluster entirely when you're done.
 ```shell
 $ cd acceptance/tests
 $ go test -run Vault_WANFederationViaGateways ./vault/... -p 1 -timeout 2h -failfast -use-kind -no-cleanup-on-failure -kubecontext=kind-dc1 -secondary-kubecontext=kind-dc2 -enable-multi-cluster -debug-directory=/tmp/debug
@@ -1017,6 +1025,22 @@ $ go test -run Vault_WANFederationViaGateways ./vault/... -p 1 -timeout 2h -fail
 You can interact with the running kubernetes clusters now using `kubectl [COMMAND] --context=<kind-dc1/kind-dc2>`
 
 * `kind delete clusters --all` is helpful for cleanup!
+
+2. The other option is to use the helper method in the framework: `helpers.WaitForInput(t)` at the spot in your acceptance test where you would like to pause execution to inspect the cluster. This will pause the test execution until you execute a request to `localhost:8715` which tells the test to continue running, you can override the port value used by setting the `CONSUL_K8S_TEST_PAUSE_PORT` environment variable to a port of your choosing. When running the tests with the `-v` flag you will see a log output of the endpoint that the test is waiting on.
+
+```go
+
+import "github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
+
+func TestSomeTest(t *testing.T) {
+  // stuff to setup
+
+  // test execution will pause here until the endpoint is hit
+	helpers.WaitForInput(t)
+
+  // rest of test
+}
+```
 
 ### Example Debugging session using the acceptance test framework to bootstrap and debug a Vault backed federated Consul installation:
 This test utilizes the `consul-k8s` acceptance test framework, with a custom consul-k8s branch which:

--- a/acceptance/framework/helpers/helpers.go
+++ b/acceptance/framework/helpers/helpers.go
@@ -6,7 +6,9 @@ package helpers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -357,4 +359,49 @@ func createCmdArgs(options *k8s.KubectlOptions) []string {
 		cmdArgs = append(cmdArgs, "--namespace", options.Namespace)
 	}
 	return cmdArgs
+}
+
+const DEFAULT_PAUSE_PORT = ":8517"
+
+// WaitForInput starts a http server on a random port (which is output in the logs) and waits until you
+// issue a request to that endpoint to continue the tests. This is useful for debugging tests that require
+// inspecting the current state of a running cluster and you don't need to use long sleeps.
+func WaitForInput(t *testing.T) {
+	t.Helper()
+
+	envPort := os.Getenv("CONSUL_K8S_TEST_PAUSE_PORT")
+	listenerPort := DEFAULT_PAUSE_PORT
+
+	if envPort != "" {
+		listenerPort = ":" + envPort
+	}
+
+	mux := http.NewServeMux()
+	srv := &http.Server{
+		Addr:    listenerPort,
+		Handler: mux,
+	}
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			err := r.Body.Close()
+			if err != nil {
+				t.Logf("error closing request body: %v", err)
+			}
+		}()
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("input received\n"))
+		if err != nil {
+			t.Logf("writing body: %v", err)
+		}
+		err = srv.Shutdown(context.Background())
+		if err != nil {
+			t.Logf("error closing listener: %v", err)
+		}
+		t.Log("input received, continuing test")
+	})
+
+	t.Logf("Waiting for input on http://localhost%s", listenerPort)
+	if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Minor updates to acceptance tests documentation
- Adds `WaitForInput` function to pause test execution at points and check on status of cluster

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
