### PR TITLE
[NET-10547] openshift: re-order SCC volume list for Argo sync

### DIFF
--- a/.changelog/4227.txt
+++ b/.changelog/4227.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+openshift: order SecurityContextConstraint volumes alphabetically to match OpenShift behavior.
+This ensures that diff detection tools like ArgoCD consider the source and reconciled resources to be identical.
+```

--- a/charts/consul/templates/client-securitycontextconstraints.yaml
+++ b/charts/consul/templates/client-securitycontextconstraints.yaml
@@ -13,6 +13,7 @@ metadata:
   annotations:
     kubernetes.io/description: {{ template "consul.fullname" . }}-client are the security context constraints required
       to run the consul client.
+# Iff. allowHostDirVolumePlugin is true, hostPath must be included in volumes (see below).
 {{- if .Values.client.dataDirectoryHostPath }}
 allowHostDirVolumePlugin: true
 {{- else }}
@@ -44,13 +45,17 @@ supplementalGroups:
   type: MustRunAs
 users: []
 volumes:
+# This list must be in alphabetical order to match the post-reconcile order enforced by OpenShift admission hooks.
+# Furthermore, hostPath must be included explicitly if allowHostDirVolumePlugin is true, as it will otherwise be
+# added by OpenShift. It must be excluded if allowHostDirVolumePlugin is false per OpenShift requirements.
+# This avoids false positives in change detection by third-party diff tools (e.g. ArgoCD) that respect list order.
 - configMap
 - downwardAPI
 - emptyDir
-- persistentVolumeClaim
-- projected
-- secret
 {{- if .Values.client.dataDirectoryHostPath }}
 - hostPath
 {{- end }}
+- persistentVolumeClaim
+- projected
+- secret
 {{- end}}

--- a/charts/consul/templates/cni-securitycontextconstraints.yaml
+++ b/charts/consul/templates/cni-securitycontextconstraints.yaml
@@ -13,6 +13,7 @@ metadata:
   annotations:
     kubernetes.io/description: {{ template "consul.fullname" . }}-cni are the security context constraints required
       to run consul-cni.
+# Iff. allowHostDirVolumePlugin is true, hostPath must be included in volumes (see below).
 allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: false
@@ -40,11 +41,15 @@ supplementalGroups:
   type: MustRunAs
 users: []
 volumes:
+# This list must be in alphabetical order to match the post-reconcile order enforced by OpenShift admission hooks.
+# Furthermore, hostPath must be included explicitly if allowHostDirVolumePlugin is true, as it will otherwise be
+# added by OpenShift. It must be excluded if allowHostDirVolumePlugin is false per OpenShift requirements.
+# This avoids false positives in change detection by third-party diff tools (e.g. ArgoCD) that respect list order.
 - configMap
 - downwardAPI
 - emptyDir
+- hostPath
 - persistentVolumeClaim
 - projected
 - secret
-- hostPath
 {{- end }}


### PR DESCRIPTION
Due to logic in OpenShift's admissions hook that force-reorders explicit and implicit entries in this list, our `SecurityContextConstraints` entries will never successfully sync via tools like ArgoCD, which expect an exact input and output match when diff'ing.

More details on the problem addressed by this change and potential future improvements to avoid it in the future can be found in https://github.com/hashicorp/consul-k8s/issues/4208 (see comments).

### Changes proposed in this PR ###  
- Reorder SCC `volumes` entries to match the post-reconciliation order persisted by OpenShift

### How I've tested this PR ###
- Spun up a local OpenShift CRC cluster w/ ArgoCD (GitOps Operator), deployed original and modified charts to verify fix results in a fully synced `consul-cni` SCC.
- Tested on Azure using community ArgoCD operator, same results.

### How I expect reviewers to test this PR ###
👀 

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
