### PR TITLE
NET-5272/add docs team code owners to review helm values description

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Helm Docs Review
+
+/charts/consul/values.yaml @hashicorp/consul-docs


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Adds a CODEOWNERS file that would request a review from the docs team when helm values are changed. This review is non-blocking as we don't set the required review setting in the branch protection rules.

### How I've tested this PR ###
It should take effect in the next PR.

~### How I expect reviewers to test this PR ###~


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
