### PR TITLE
Decoupling Consul's Role-Based Access Control (RBAC) from the core system.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.6.0 
+
+FEATURES:
+
+* helm: Add Support for global rbac flag to decouple Consul-RBAC installation.
+
 ## 1.5.1 (July 16, 2024)
 
 SECURITY:

--- a/charts/consul/templates/auth-method-clusterrole.yaml
+++ b/charts/consul/templates/auth-method-clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.acls.manageSystemACLs }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -15,4 +16,5 @@ rules:
   - serviceaccounts
   verbs:
   - get
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/auth-method-clusterrolebinding.yaml
+++ b/charts/consul/templates/auth-method-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.acls.manageSystemACLs }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -36,4 +37,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-auth-method
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/client-role.yaml
+++ b/charts/consul/templates/client-role.yaml
@@ -1,4 +1,5 @@
 {{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -39,5 +40,6 @@ rules:
 {{- end}}
 {{- else}}
 rules: []
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/client-rolebinding.yaml
+++ b/charts/consul/templates/client-rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -17,4 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-client
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/client-securitycontextconstraints.yaml
+++ b/charts/consul/templates/client-securitycontextconstraints.yaml
@@ -1,4 +1,5 @@
 {{- if (and .Values.global.openshift.enabled (or (and (ne (.Values.client.enabled | toString) "-") .Values.client.enabled) (and (eq (.Values.client.enabled | toString) "-") .Values.global.enabled))) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
@@ -54,3 +55,4 @@ volumes:
 - hostPath
 {{- end }}
 {{- end}}
+{{- end }}

--- a/charts/consul/templates/cni-clusterrole.yaml
+++ b/charts/consul/templates/cni-clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.connectInject.cni.enabled }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -34,5 +35,6 @@ rules:
   - {{ template "consul.fullname" . }}-cni
   verbs:
   - use
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/cni-clusterrolebinding.yaml
+++ b/charts/consul/templates/cni-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.connectInject.cni.enabled }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -17,4 +18,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-cni
   namespace: {{ default .Release.Namespace .Values.connectInject.cni.namespace }}
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/cni-securitycontextconstraints.yaml
+++ b/charts/consul/templates/cni-securitycontextconstraints.yaml
@@ -1,4 +1,5 @@
 {{- if (and (.Values.connectInject.cni.enabled) (.Values.global.openshift.enabled)) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
@@ -47,4 +48,5 @@ volumes:
 - projected
 - secret
 - hostPath
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/connect-inject-clusterrole.yaml
+++ b/charts/consul/templates/connect-inject-clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled) }}
+{{- if .Values.global.rbac.create }}
 # The ClusterRole to enable the Connect injector to get, list, watch and patch MutatingWebhookConfiguration.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -206,4 +207,5 @@ rules:
   verbs:
     - use
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/connect-inject-clusterrolebinding.yaml
+++ b/charts/consul/templates/connect-inject-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -17,4 +18,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-connect-injector
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/connect-inject-leader-election-role.yaml
+++ b/charts/consul/templates/connect-inject-leader-election-role.yaml
@@ -1,4 +1,5 @@
 {{- if or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -38,4 +39,5 @@ rules:
   verbs:
   - create
   - patch
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/connect-inject-leader-election-rolebinding.yaml
+++ b/charts/consul/templates/connect-inject-leader-election-rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if or (and (ne (.Values.connectInject.enabled | toString) "-") .Values.connectInject.enabled) (and (eq (.Values.connectInject.enabled | toString) "-") .Values.global.enabled) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -18,4 +19,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-connect-injector
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/create-federation-secret-role.yaml
+++ b/charts/consul/templates/create-federation-secret-role.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.federation.createFederationSecret }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -46,4 +47,5 @@ rules:
     resourceNames:
       - {{ template "consul.fullname" . }}-create-federation-secret
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/create-federation-secret-rolebinding.yaml
+++ b/charts/consul/templates/create-federation-secret-rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.federation.createFederationSecret }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -20,4 +21,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-create-federation-secret
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/datadog-agent-role.yaml
+++ b/charts/consul/templates/datadog-agent-role.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.metrics.datadog.enabled }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -34,5 +35,6 @@ rules:
     resourceNames:
       - {{ .Release.Namespace }}-datadog-agent-metrics-acl-token
     verbs: [ "get", "watch", "list" ]
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/datadog-agent-rolebinding.yaml
+++ b/charts/consul/templates/datadog-agent-rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.metrics.datadog.enabled }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -23,4 +24,5 @@ roleRef:
   kind: Role
   name: {{ template "consul.fullname" . }}-datadog-metrics
   apiGroup: ""
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/dns-proxy-clusterrole.yaml
+++ b/charts/consul/templates/dns-proxy-clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if (or (and (ne (.Values.dns.proxy.enabled | toString) "-") .Values.dns.proxy.enabled) (and (eq (.Values.dns.proxy.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -31,4 +32,5 @@ rules:
   {{- else }}
 rules: []
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/dns-proxy-clusterrolebinding.yaml
+++ b/charts/consul/templates/dns-proxy-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if (or (and (ne (.Values.dns.proxy.enabled | toString) "-") .Values.dns.proxy.enabled) (and (eq (.Values.dns.proxy.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -17,4 +18,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-dns-proxy
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/enterprise-license-role.yaml
+++ b/charts/consul/templates/enterprise-license-role.yaml
@@ -1,5 +1,6 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey (not .Values.global.enterpriseLicense.enableLicenseAutoload)) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -32,6 +33,7 @@ rules:
 {{- end }}
 {{- else }}
 rules: []
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/enterprise-license-rolebinding.yaml
+++ b/charts/consul/templates/enterprise-license-rolebinding.yaml
@@ -1,5 +1,6 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 {{- if (and .Values.global.enterpriseLicense.secretName .Values.global.enterpriseLicense.secretKey (not .Values.global.enterpriseLicense.enableLicenseAutoload)) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -18,5 +19,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-enterprise-license
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/gateway-cleanup-clusterrole.yaml
+++ b/charts/consul/templates/gateway-cleanup-clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.connectInject.enabled }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -31,5 +32,6 @@ rules:
       - {{ template "consul.fullname" . }}-gateway-cleanup
     verbs:
       - use
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/gateway-cleanup-clusterrolebinding.yaml
+++ b/charts/consul/templates/gateway-cleanup-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.connectInject.enabled }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -17,4 +18,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-gateway-cleanup
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/gateway-resources-clusterrole.yaml
+++ b/charts/consul/templates/gateway-resources-clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.connectInject.enabled }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -33,5 +34,6 @@ rules:
       - {{ template "consul.fullname" . }}-gateway-resources
     verbs:
       - use
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/gateway-resources-clusterrolebinding.yaml
+++ b/charts/consul/templates/gateway-resources-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.connectInject.enabled }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -17,4 +18,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-gateway-resources
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/gossip-encryption-autogenerate-role.yaml
+++ b/charts/consul/templates/gossip-encryption-autogenerate-role.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.gossipEncryption.autoGenerate }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -28,5 +29,6 @@ rules:
     - use
   resourceNames:
     - {{ template "consul.fullname" . }}-gossip-encryption-autogenerate
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/gossip-encryption-autogenerate-rolebinding.yaml
+++ b/charts/consul/templates/gossip-encryption-autogenerate-rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.gossipEncryption.autoGenerate }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -20,4 +21,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-gossip-encryption-autogenerate
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/ingress-gateways-role.yaml
+++ b/charts/consul/templates/ingress-gateways-role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingressGateways.enabled }}
-
+{{- if .Values.global.rbac.create }}
 {{- $root := . }}
 {{- $defaults := .Values.ingressGateways.defaults }}
 
@@ -42,5 +42,6 @@ rules:
       - get
 {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/ingress-gateways-rolebinding.yaml
+++ b/charts/consul/templates/ingress-gateways-rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ingressGateways.enabled }}
+{{- if .Values.global.rbac.create }}
 {{- $root := . }}
 {{- range .Values.ingressGateways.gateways }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -21,5 +22,6 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" $root }}-{{ .name }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/mesh-gateway-clusterrole.yaml
+++ b/charts/consul/templates/mesh-gateway-clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.meshGateway.enabled }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -30,5 +31,6 @@ rules:
   {{- end }}
 {{- else }}
 rules: []
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/mesh-gateway-clusterrolebinding.yaml
+++ b/charts/consul/templates/mesh-gateway-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.meshGateway.enabled }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -17,4 +18,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-mesh-gateway
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/partition-init-role.yaml
+++ b/charts/consul/templates/partition-init-role.yaml
@@ -1,5 +1,6 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (and .Values.global.adminPartitions.enabled (not $serverEnabled)) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -31,5 +32,6 @@ rules:
       - {{ template "consul.fullname" . }}-partition-init
     verbs:
       - use
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/partition-init-rolebinding.yaml
+++ b/charts/consul/templates/partition-init-rolebinding.yaml
@@ -1,5 +1,6 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (and .Values.global.adminPartitions.enabled (not $serverEnabled)) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -21,4 +22,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-partition-init
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/server-acl-init-cleanup-role.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-role.yaml
@@ -1,6 +1,7 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if .Values.global.acls.manageSystemACLs }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -23,6 +24,7 @@ rules:
       - {{ template "consul.fullname" . }}-server-acl-init-cleanup
     verbs:
       - use
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/server-acl-init-cleanup-rolebinding.yaml
+++ b/charts/consul/templates/server-acl-init-cleanup-rolebinding.yaml
@@ -1,6 +1,7 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if .Values.global.acls.manageSystemACLs }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -19,5 +20,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-server-acl-init-cleanup
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/server-acl-init-role.yaml
+++ b/charts/consul/templates/server-acl-init-role.yaml
@@ -1,6 +1,7 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if .Values.global.acls.manageSystemACLs }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -33,6 +34,7 @@ rules:
   - {{ template "consul.fullname" . }}-server-acl-init
   verbs:
   - use
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/server-acl-init-rolebinding.yaml
+++ b/charts/consul/templates/server-acl-init-rolebinding.yaml
@@ -1,6 +1,7 @@
 {{- $serverEnabled := (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) -}}
 {{- if (or $serverEnabled .Values.externalServers.enabled) }}
 {{- if .Values.global.acls.manageSystemACLs }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -19,5 +20,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-server-acl-init
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/server-clusterrole.yaml
+++ b/charts/consul/templates/server-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -14,3 +15,4 @@ rules:
   resources: ["nodes"]
   verbs:
   - get
+{{- end }}

--- a/charts/consul/templates/server-clusterrolebinding.yaml
+++ b/charts/consul/templates/server-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -16,3 +17,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-server
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/consul/templates/server-role.yaml
+++ b/charts/consul/templates/server-role.yaml
@@ -1,4 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -30,5 +31,6 @@ rules:
 {{- end }}
 {{- else}}
 rules: []
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/server-rolebinding.yaml
+++ b/charts/consul/templates/server-rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -17,4 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-server
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/server-securitycontextconstraints.yaml
+++ b/charts/consul/templates/server-securitycontextconstraints.yaml
@@ -1,4 +1,5 @@
 {{- if (and .Values.global.openshift.enabled .Values.server.exposeGossipAndRPCPorts (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled))) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
@@ -47,3 +48,4 @@ volumes:
 - projected
 - secret
 {{- end -}}
+{{- end }}

--- a/charts/consul/templates/sync-catalog-clusterrole.yaml
+++ b/charts/consul/templates/sync-catalog-clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- $syncEnabled := (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.rbac.create }}
 {{- if $syncEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -57,4 +58,6 @@ rules:
   - get
   - list
   - watch
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/sync-catalog-clusterrole.yaml
+++ b/charts/consul/templates/sync-catalog-clusterrole.yaml
@@ -60,4 +60,3 @@ rules:
   - watch
 {{- end }}
 {{- end }}
-{{- end }}

--- a/charts/consul/templates/sync-catalog-clusterrolebinding.yaml
+++ b/charts/consul/templates/sync-catalog-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- $syncEnabled := (or (and (ne (.Values.syncCatalog.enabled | toString) "-") .Values.syncCatalog.enabled) (and (eq (.Values.syncCatalog.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.rbac.create }}
 {{- if $syncEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -18,4 +19,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-sync-catalog
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/consul/templates/telemetry-collector-role.yaml
+++ b/charts/consul/templates/telemetry-collector-role.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.global.enablePodSecurityPolicies .Values.telemetryCollector.enabled }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -17,5 +18,6 @@ rules:
       - {{ template "consul.fullname" . }}-telemetry-collector
     verbs:
       - use
+{{- end }}
 {{- end }}
 

--- a/charts/consul/templates/telemetry-collector-rolebinding.yaml
+++ b/charts/consul/templates/telemetry-collector-rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.global.enablePodSecurityPolicies .Values.telemetryCollector.enabled }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -18,4 +19,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "consul.fullname" . }}-telemetry-collector
 {{- end }}
-
+{{- end }}

--- a/charts/consul/templates/terminating-gateways-role.yaml
+++ b/charts/consul/templates/terminating-gateways-role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.terminatingGateways.enabled }}
-
+{{- if .Values.global.rbac.create }}
 {{- $root := . }}
 {{- $defaults := .Values.terminatingGateways.defaults }}
 
@@ -28,5 +28,6 @@ rules:
 rules: []
 {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/terminating-gateways-rolebinding.yaml
+++ b/charts/consul/templates/terminating-gateways-rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.terminatingGateways.enabled }}
+{{- if .Values.global.rbac.create }}
 {{- $root := . }}
 {{- range .Values.terminatingGateways.gateways }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -22,5 +23,6 @@ subjects:
     name:  {{ template "consul.fullname" $root }}-{{ .name }}
     namespace: {{ $root.Release.Namespace }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/tls-init-cleanup-role.yaml
+++ b/charts/consul/templates/tls-init-cleanup-role.yaml
@@ -1,4 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.rbac.create }}
 {{- if (and .Values.global.tls.enabled (not .Values.server.serverCert.secretName)) }}
 {{- if not .Values.global.secretsBackend.vault.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,6 +36,7 @@ rules:
     - use
   resourceNames:
     - {{ template "consul.fullname" . }}-tls-init-cleanup
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/tls-init-cleanup-rolebinding.yaml
+++ b/charts/consul/templates/tls-init-cleanup-rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.rbac.create }}
 {{- if (and .Values.global.tls.enabled (not .Values.server.serverCert.secretName)) }}
 {{- if not .Values.global.secretsBackend.vault.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -22,6 +23,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-tls-init-cleanup
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/tls-init-role.yaml
+++ b/charts/consul/templates/tls-init-role.yaml
@@ -1,4 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.rbac.create }}
 {{- if (and .Values.global.tls.enabled (not .Values.server.serverCert.secretName)) }}
 {{- if not .Values.global.secretsBackend.vault.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -32,6 +33,7 @@ rules:
     - use
   resourceNames:
     - {{ template "consul.fullname" . }}-tls-init
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/tls-init-rolebinding.yaml
+++ b/charts/consul/templates/tls-init-rolebinding.yaml
@@ -26,4 +26,4 @@ subjects:
 {{- end }}
 {{- end }}
 {{- end }}
-{{ - end }}
+{{- end }}

--- a/charts/consul/templates/tls-init-rolebinding.yaml
+++ b/charts/consul/templates/tls-init-rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
+{{- if .Values.global.rbac.create }}
 {{- if (and .Values.global.tls.enabled (not .Values.server.serverCert.secretName)) }}
 {{- if not .Values.global.secretsBackend.vault.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -25,3 +26,4 @@ subjects:
 {{- end }}
 {{- end }}
 {{- end }}
+{{ - end }}

--- a/charts/consul/templates/webhook-cert-manager-clusterrole.yaml
+++ b/charts/consul/templates/webhook-cert-manager-clusterrole.yaml
@@ -1,5 +1,6 @@
 {{ $hasConfiguredWebhookCertsUsingVault := (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName) -}}
 {{- if (and .Values.connectInject.enabled (not $hasConfiguredWebhookCertsUsingVault)) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -50,5 +51,6 @@ rules:
   - {{ template "consul.fullname" . }}-webhook-cert-manager
   verbs:
   - use
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/consul/templates/webhook-cert-manager-clusterrolebinding.yaml
+++ b/charts/consul/templates/webhook-cert-manager-clusterrolebinding.yaml
@@ -1,5 +1,6 @@
 {{ $hasConfiguredWebhookCertsUsingVault := (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInjectRole .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName .Values.global.secretsBackend.vault.connectInject.caCert.secretName) -}}
 {{- if (and .Values.connectInject.enabled (not $hasConfiguredWebhookCertsUsingVault)) }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -18,4 +19,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-webhook-cert-manager
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/consul/test/unit/auth-method-clusterrole.bats
+++ b/charts/consul/test/unit/auth-method-clusterrole.bats
@@ -18,3 +18,12 @@ load _helpers
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "auth-method/ClusterRole: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/auth-method-clusterrole.yaml \
+        --set 'global.acls.manageSystemACLs=true' \
+        --set 'global.rbac.create=false' \
+        .
+}

--- a/charts/consul/test/unit/auth-method-clusterrolebinding.bats
+++ b/charts/consul/test/unit/auth-method-clusterrolebinding.bats
@@ -18,3 +18,12 @@ load _helpers
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "auth-method/ClusterRoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/auth-method-clusterrolebinding.yaml \
+        --set 'global.acls.manageSystemACLs=true' \
+        --set 'global.rbac.create=false' \
+        .
+}

--- a/charts/consul/test/unit/client-role.bats
+++ b/charts/consul/test/unit/client-role.bats
@@ -28,6 +28,16 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "client/Role: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/client-role.yaml  \
+        --set 'client.enabled=true' \
+        --set 'global.rbac.create=false' \
+        .
+
+}
+
 @test "client/Role: disabled with client.enabled=false" {
   cd `chart_dir`
   assert_empty helm template \

--- a/charts/consul/test/unit/client-rolebinding.bats
+++ b/charts/consul/test/unit/client-rolebinding.bats
@@ -9,7 +9,15 @@ load _helpers
       --set 'global.enabled=false' \
       .
 }
+@test "client/RoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/client-rolebinding.yaml  \
+        --set 'client.enabled=true' \
+        --set 'global.rbac.create=false' \
+        .
 
+}
 @test "client/RoleBinding: disabled with client disabled" {
   cd `chart_dir`
   assert_empty helm template \

--- a/charts/consul/test/unit/client-securitycontextconstraints.bats
+++ b/charts/consul/test/unit/client-securitycontextconstraints.bats
@@ -8,7 +8,15 @@ load _helpers
       -s templates/client-securitycontextconstraints.yaml  \
       .
 }
+@test "client/SecurityContextConstraints: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/client-securitycontextconstraints.yaml  \
+        --set 'client.enabled=true' \
+        --set 'global.rbac.create=false' \
+        .
 
+}
 @test "client/SecurityContextConstraints: disabled with client disabled and global.openshift.enabled=true" {
   cd `chart_dir`
   assert_empty helm template \

--- a/charts/consul/test/unit/cni-clusterrole.bats
+++ b/charts/consul/test/unit/cni-clusterrole.bats
@@ -8,7 +8,15 @@ load _helpers
       -s templates/cni-clusterrole.yaml  \
       .
 }
-
+@test "cni/ClusterRole: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/cni-clusterrole.yaml \
+        --set 'connectInject.cni.enabled=true' \
+        --set 'connectInject.enabled=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}
 @test "cni/ClusterRole: enabled with connectInject.cni.enabled=true and connectInject.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/cni-clusterrolebinding.bats
+++ b/charts/consul/test/unit/cni-clusterrolebinding.bats
@@ -8,7 +8,15 @@ load _helpers
       -s templates/cni-clusterrolebinding.yaml  \
       .
 }
-
+@test "cni/ClusterRoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/cni-clusterrolebinding.yaml \
+        --set 'connectInject.cni.enabled=true' \
+        --set 'connectInject.enabled=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}
 @test "cni/ClusterRoleBinding: enabled with connectInject.cni.enabled=true and connectInject.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/cni-securitycontextcontstraints.bats
+++ b/charts/consul/test/unit/cni-securitycontextcontstraints.bats
@@ -8,6 +8,15 @@ load _helpers
       -s templates/cni-securitycontextconstraints.yaml  \
       .
 }
+@test "cni/SecurityContextConstraints: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/cni-securitycontextconstraints.yaml \
+        --set 'connectInject.cni.enabled=true' \
+        --set 'connectInject.enabled=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}
 
 @test "cni/SecurityContextConstraints: disabled when cni disabled and global.openshift.enabled=true" {
   cd `chart_dir`

--- a/charts/consul/test/unit/connect-inject-clusterrole.bats
+++ b/charts/consul/test/unit/connect-inject-clusterrole.bats
@@ -11,6 +11,14 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "connectInject/ClusterRole: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/connect-inject-clusterrole.yaml \
+        --set 'global.rbac.create=false'  \
+        .
+}
+
 @test "connectInject/ClusterRole: enabled with global.enabled false" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/connect-inject-clusterrolebinding.bats
+++ b/charts/consul/test/unit/connect-inject-clusterrolebinding.bats
@@ -11,6 +11,14 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "connectInject/ClusterRoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/connect-inject-clusterrolebinding.yaml \
+        --set 'global.rbac.create=false'  \
+        .
+}
+
 @test "connectInject/ClusterRoleBinding: enabled with global.enabled false" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/create-federation-secret-role.bats
+++ b/charts/consul/test/unit/create-federation-secret-role.bats
@@ -9,6 +9,19 @@ load _helpers
       .
 }
 
+@test "createFederationSecret/Role: enabled with global.rbac.create false" {
+  cd `chart_dir`
+   assert_empty helm template \
+       -s templates/create-federation-secret-role.yaml \
+       --set 'global.federation.createFederationSecret=true' \
+       --set 'global.federation.enabled=true'  \
+       --set 'global.tls.enabled=true' \
+       --set 'meshGateway.enabled=true' \
+       --set 'connectInject.enabled=true'  \
+       --set 'global.rbac.create=false'  \
+       .
+}
+
 @test "createFederationSecret/Role: enabled with global.federation.createFederationSecret=true" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/create-federation-secret-rolebinding.bats
+++ b/charts/consul/test/unit/create-federation-secret-rolebinding.bats
@@ -8,6 +8,18 @@ load _helpers
       -s templates/create-federation-secret-rolebinding.yaml  \
       .
 }
+@test "createFederationSecret/RoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+   assert_empty helm template \
+       -s templates/create-federation-secret-rolebinding.yaml \
+       --set 'global.federation.createFederationSecret=true' \
+       --set 'global.federation.enabled=true'  \
+       --set 'global.tls.enabled=true' \
+       --set 'meshGateway.enabled=true' \
+       --set 'connectInject.enabled=true'  \
+       --set 'global.rbac.create=false'  \
+       .
+}
 
 @test "createFederationSecret/RoleBinding: enabled with global.createFederationSecret=true" {
   cd `chart_dir`

--- a/charts/consul/test/unit/dns-proxy-clusterrole.bats
+++ b/charts/consul/test/unit/dns-proxy-clusterrole.bats
@@ -8,7 +8,14 @@ load _helpers
     -s templates/dns-proxy-clusterrole.yaml  \
     .
 }
-
+@test "dnsProxy/ClusterRole: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/dns-proxy-clusterrole.yaml \
+        --set 'dns.proxy.enabled=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}
 @test "dnsProxy/ClusterRole: dns-proxy with global.enabled false" {
   cd `chart_dir`
     local actual=$(helm template \

--- a/charts/consul/test/unit/dns-proxy-clusterrolebinding.bats
+++ b/charts/consul/test/unit/dns-proxy-clusterrolebinding.bats
@@ -8,7 +8,14 @@ load _helpers
       -s templates/dns-proxy-clusterrolebinding.yaml  \
       .
 }
-
+@test "dnsProxy/ClusterRoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/dns-proxy-clusterrolebinding.yaml \
+        --set 'dns.proxy.enabled=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}
 @test "dnsProxy/ClusterRoleBinding: enabled with global.enabled false" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/enterprise-license-role.bats
+++ b/charts/consul/test/unit/enterprise-license-role.bats
@@ -8,7 +8,15 @@ load _helpers
       -s templates/enterprise-license-role.yaml  \
       .
 }
-
+@test "enterpriseLicense/Role: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/enterprise-license-role.yaml \
+        --set 'global.enterpriseLicense.secretName=foo' \
+        --set 'global.enterpriseLicense.secretKey=bar' \
+        --set 'global.rbac.create=false'  \
+        .
+}
 @test "enterpriseLicense/Role: disabled if autoload is true (default)" {
   cd `chart_dir`
   assert_empty helm template \

--- a/charts/consul/test/unit/enterprise-license-rolebinding.bats
+++ b/charts/consul/test/unit/enterprise-license-rolebinding.bats
@@ -9,6 +9,16 @@ load _helpers
       .
 }
 
+@test "enterpriseLicense/RoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/enterprise-license-rolebinding.yaml \
+        --set 'global.enterpriseLicense.secretName=foo' \
+        --set 'global.enterpriseLicense.secretKey=bar' \
+        --set 'global.rbac.create=false'  \
+        .
+}
+
 @test "enterpriseLicense/RoleBinding: disabled if autoload is true (default)" {
   cd `chart_dir`
   assert_empty helm template \

--- a/charts/consul/test/unit/gateway-cleanup-clusterrole.bats
+++ b/charts/consul/test/unit/gateway-cleanup-clusterrole.bats
@@ -20,7 +20,13 @@ target=templates/gateway-cleanup-clusterrole.yaml
         --set 'connectInject.enabled=false' \
         . 
 }
-
+@test "gatewaycleanup/ClusterRole: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s $target \
+        --set 'global.rbac.create=false'  \
+        .
+}
 @test "gatewaycleanup/ClusterRole: can use podsecuritypolicies with global.enablePodSecurityPolicy=true" {
     cd `chart_dir`
     local actual=$(helm template \

--- a/charts/consul/test/unit/gateway-cleanup-clusterrolebinding.bats
+++ b/charts/consul/test/unit/gateway-cleanup-clusterrolebinding.bats
@@ -20,4 +20,10 @@ target=templates/gateway-cleanup-clusterrolebinding.yaml
         --set 'connectInject.enabled=false' \
         . 
 }
-
+@test "gatewaycleanup/ClusterRoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s $target \
+        --set 'global.rbac.create=false'  \
+        .
+}

--- a/charts/consul/test/unit/gateway-resources-clusterrole.bats
+++ b/charts/consul/test/unit/gateway-resources-clusterrole.bats
@@ -13,6 +13,13 @@ target=templates/gateway-resources-clusterrole.yaml
     [ "$actual" = "true" ]
 }
 
+@test "gatewayresources/ClusterRole: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s $target \
+        --set 'global.rbac.create=false'  \
+        .
+}
 @test "gatewayresources/ClusterRole: disabled with connectInject.enabled=false" {
     cd `chart_dir`
     assert_empty helm template \

--- a/charts/consul/test/unit/gateway-resources-clusterrolebinding.bats
+++ b/charts/consul/test/unit/gateway-resources-clusterrolebinding.bats
@@ -13,6 +13,14 @@ target=templates/gateway-resources-clusterrolebinding.yaml
     [ "$actual" = "true" ]
 }
 
+@test "gatewayresources/ClusterRoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s $target \
+        --set 'global.rbac.create=false'  \
+        .
+}
+
 @test "gatewayresources/ClusterRoleBinding: disabled with connectInject.enabled=false" {
     cd `chart_dir`
     assert_empty helm template \

--- a/charts/consul/test/unit/gossip-encryption-autogenerate-role.bats
+++ b/charts/consul/test/unit/gossip-encryption-autogenerate-role.bats
@@ -26,3 +26,12 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "gossipEncryptionAutogenerate/Role: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/gossip-encryption-autogenerate-role.yaml  \
+        --set 'global.gossipEncryption.autoGenerate=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}

--- a/charts/consul/test/unit/gossip-encryption-autogenerate-rolebinding.bats
+++ b/charts/consul/test/unit/gossip-encryption-autogenerate-rolebinding.bats
@@ -27,3 +27,12 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "gossipEncryptionAutogenerate/RoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/gossip-encryption-autogenerate-rolebinding.yaml  \
+        --set 'global.gossipEncryption.autoGenerate=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}

--- a/charts/consul/test/unit/ingress-gateways-role.bats
+++ b/charts/consul/test/unit/ingress-gateways-role.bats
@@ -20,6 +20,16 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "ingressGateways/Role: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/ingress-gateways-role.yaml  \
+        --set 'ingressGateways.enabled=true' \
+        --set 'connectInject.enabled=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}
+
 @test "ingressGateways/Role: rules for PodSecurityPolicy" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/ingress-gateways-rolebinding.bats
+++ b/charts/consul/test/unit/ingress-gateways-rolebinding.bats
@@ -20,6 +20,15 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "ingressGateways/RoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/ingress-gateways-rolebinding.yaml  \
+        --set 'ingressGateways.enabled=true' \
+        --set 'connectInject.enabled=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}
 @test "ingressGateways/RoleBinding: multiple gateways" {
   cd `chart_dir`
   local object=$(helm template \

--- a/charts/consul/test/unit/mesh-gateway-clusterrole.bats
+++ b/charts/consul/test/unit/mesh-gateway-clusterrole.bats
@@ -20,6 +20,15 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "meshGateway/ClusterRole: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+      -s templates/mesh-gateway-clusterrole.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.rbac.create=false'  \
+        .
+}
 @test "meshGateway/ClusterRole: rules for PodSecurityPolicy" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/mesh-gateway-clusterrolebinding.bats
+++ b/charts/consul/test/unit/mesh-gateway-clusterrolebinding.bats
@@ -20,6 +20,16 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "meshGateway/ClusterRoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+      -s templates/mesh-gateway-clusterrolebinding.yaml  \
+      --set 'meshGateway.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.rbac.create=false'  \
+        .
+}
+
 @test "meshGateway/ClusterRoleBinding: subject name is correct" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/partition-init-role.bats
+++ b/charts/consul/test/unit/partition-init-role.bats
@@ -20,7 +20,16 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
-
+@test "partitionInit/Role: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/partition-init-role.yaml  \
+        --set 'global.adminPartitions.enabled=true' \
+        --set 'global.enableConsulNamespaces=true' \
+        --set 'server.enabled=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}
 @test "partitionInit/Role: disabled with global.adminPartitions.enabled=true and server.enabled=true" {
   cd `chart_dir`
   assert_empty helm template \

--- a/charts/consul/test/unit/partition-init-rolebinding.bats
+++ b/charts/consul/test/unit/partition-init-rolebinding.bats
@@ -21,6 +21,16 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "partitionInit/RoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/partition-init-rolebinding.yaml  \
+        --set 'global.adminPartitions.enabled=true' \
+        --set 'global.enableConsulNamespaces=true' \
+        --set 'server.enabled=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}
 @test "partitionInit/RoleBinding: disabled with global.adminPartitions.enabled=true and servers = true" {
   cd `chart_dir`
   assert_empty helm template \

--- a/charts/consul/test/unit/server-acl-init-cleanup-role.bats
+++ b/charts/consul/test/unit/server-acl-init-cleanup-role.bats
@@ -19,6 +19,15 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "serverACLInitCleanup/Role: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/server-acl-init-cleanup-role.yaml  \
+        --set 'global.acls.manageSystemACLs=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}
+
 @test "serverACLInitCleanup/Role: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   assert_empty helm template \

--- a/charts/consul/test/unit/server-acl-init-cleanup-rolebinding.bats
+++ b/charts/consul/test/unit/server-acl-init-cleanup-rolebinding.bats
@@ -19,6 +19,15 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "serverACLInitCleanup/RoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/server-acl-init-cleanup-rolebinding.yaml  \
+        --set 'global.acls.manageSystemACLs=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}
+
 @test "serverACLInitCleanup/RoleBinding: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   assert_empty helm template \

--- a/charts/consul/test/unit/server-acl-init-role.bats
+++ b/charts/consul/test/unit/server-acl-init-role.bats
@@ -19,6 +19,14 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "serverACLInit/Role: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/server-acl-init-role.yaml  \
+        --set 'global.acls.manageSystemACLs=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}
 @test "serverACLInit/Role: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   assert_empty helm template \

--- a/charts/consul/test/unit/server-acl-init-rolebinding.bats
+++ b/charts/consul/test/unit/server-acl-init-rolebinding.bats
@@ -19,6 +19,15 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "serverACLInit/RoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/server-acl-init-rolebinding.yaml  \
+        --set 'global.acls.manageSystemACLs=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}
+
 @test "serverACLInit/RoleBinding: disabled with server=false and global.acls.manageSystemACLs=true" {
   cd `chart_dir`
   assert_empty helm template \

--- a/charts/consul/test/unit/server-role.bats
+++ b/charts/consul/test/unit/server-role.bats
@@ -30,6 +30,13 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "server/Role: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/server-role.yaml  \
+        --set 'global.rbac.create=false'  \
+        .
+}
 @test "server/Role: disabled with server.enabled=false" {
   cd `chart_dir`
   assert_empty helm template \

--- a/charts/consul/test/unit/server-rolebinding.bats
+++ b/charts/consul/test/unit/server-rolebinding.bats
@@ -18,6 +18,13 @@ load _helpers
       --set 'global.enabled=false' \
       .
 }
+@test "server/RoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/server-rolebinding.yaml  \
+        --set 'global.rbac.create=false'  \
+        .
+}
 
 @test "server/RoleBinding: disabled with server disabled" {
   cd `chart_dir`

--- a/charts/consul/test/unit/server-securitycontextconstraints.bats
+++ b/charts/consul/test/unit/server-securitycontextconstraints.bats
@@ -28,3 +28,12 @@ load _helpers
       yq -s 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+@test "server/SecurityContextConstraints: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/server-securitycontextconstraints.yaml  \
+        --set 'global.openshift.enabled=true' \
+        --set 'server.exposeGossipAndRPCPorts=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}

--- a/charts/consul/test/unit/sync-catalog-clusterrole.bats
+++ b/charts/consul/test/unit/sync-catalog-clusterrole.bats
@@ -35,6 +35,14 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "syncCatalog/ClusterRole: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/sync-catalog-clusterrole.yaml  \
+        --set 'syncCatalog.enabled=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}
 @test "syncCatalog/ClusterRole: enabled with sync enabled and global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/sync-catalog-clusterrolebinding.bats
+++ b/charts/consul/test/unit/sync-catalog-clusterrolebinding.bats
@@ -35,6 +35,15 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "syncCatalog/ClusterRoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+        -s templates/sync-catalog-clusterrolebinding.yaml  \
+        --set 'syncCatalog.enabled=true' \
+        --set 'global.rbac.create=false'  \
+        .
+}
+
 @test "syncCatalog/ClusterRoleBinding: enabled with sync enabled and global.enabled=false" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/telemetry-collector-role.bats
+++ b/charts/consul/test/unit/telemetry-collector-role.bats
@@ -19,3 +19,13 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "telemetryCollector/Role: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+      -s templates/telemetry-collector-role.yaml  \
+      --set 'telemetryCollector.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'global.rbac.create=false'  \
+      .
+}

--- a/charts/consul/test/unit/telemetry-collector-rolebinding.bats
+++ b/charts/consul/test/unit/telemetry-collector-rolebinding.bats
@@ -19,3 +19,13 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "telemetryCollector/RoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+      -s templates/telemetry-collector-rolebinding.yaml  \
+      --set 'telemetryCollector.enabled=true' \
+      --set 'global.enablePodSecurityPolicies=true' \
+      --set 'global.rbac.create=false'  \
+      .
+}

--- a/charts/consul/test/unit/terminating-gateways-role.bats
+++ b/charts/consul/test/unit/terminating-gateways-role.bats
@@ -20,6 +20,16 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "terminatingGateways/Role: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+      -s templates/terminating-gateways-role.yaml   \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.rbac.create=false'  \
+      .
+}
+
 @test "terminatingGateways/Role: rules for PodSecurityPolicy" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/terminating-gateways-rolebinding.bats
+++ b/charts/consul/test/unit/terminating-gateways-rolebinding.bats
@@ -20,6 +20,16 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "terminatingGateways/RoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+      -s templates/terminating-gateways-rolebinding.yaml   \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.rbac.create=false'  \
+      .
+}
+
 @test "terminatingGateways/RoleBinding: multiple gateways" {
   cd `chart_dir`
   local object=$(helm template \

--- a/charts/consul/test/unit/tls-init-cleanup-role.bats
+++ b/charts/consul/test/unit/tls-init-cleanup-role.bats
@@ -49,6 +49,15 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "tlsInitCleanup/Role: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+      -s templates/tls-init-cleanup-role.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'server.enabled=true' \
+      --set 'global.rbac.create=false'  \
+      .
+}
 @test "tlsInitCleanup/Role: enabled with global.tls.enabled" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/tls-init-cleanup-rolebinding.bats
+++ b/charts/consul/test/unit/tls-init-cleanup-rolebinding.bats
@@ -59,6 +59,15 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "tlsInitCleanup/RoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+      -s templates/tls-init-cleanup-rolebinding.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'server.enabled=true' \
+      --set 'global.rbac.create=false'  \
+      .
+}
 #--------------------------------------------------------------------
 # Vault
 

--- a/charts/consul/test/unit/tls-init-role.bats
+++ b/charts/consul/test/unit/tls-init-role.bats
@@ -49,6 +49,15 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "tlsInit/Role: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+      -s templates/tls-init-role.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'server.enabled=true' \
+      --set 'global.rbac.create=false'  \
+      .
+}
 @test "tlsInit/Role: enabled with global.tls.enabled" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/tls-init-rolebinding.bats
+++ b/charts/consul/test/unit/tls-init-rolebinding.bats
@@ -39,6 +39,16 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "tlsInit/RoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+      -s templates/tls-init-rolebinding.yaml  \
+      --set 'global.tls.enabled=true' \
+      --set 'server.enabled=true' \
+      --set 'global.rbac.create=false'  \
+      .
+}
+
 @test "tlsInit/RoleBinding: disabled when server.enabled=false" {
   cd `chart_dir`
   assert_empty helm template \

--- a/charts/consul/test/unit/webhook-cert-manager-clusterrole.bats
+++ b/charts/consul/test/unit/webhook-cert-manager-clusterrole.bats
@@ -11,6 +11,13 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "webhookCertManager/ClusterRole: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+      -s templates/webhook-cert-manager-clusterrole.yaml  \
+      --set 'global.rbac.create=false'  \
+      .
+}
 @test "webhookCertManager/ClusterRole: enabled with connectInject.enabled=true" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/charts/consul/test/unit/webhook-cert-manager-clusterrolebinding.bats
+++ b/charts/consul/test/unit/webhook-cert-manager-clusterrolebinding.bats
@@ -20,7 +20,13 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
-
+@test "webhookCertManager/ClusterRoleBinding: enabled with global.rbac.create false" {
+  cd `chart_dir`
+    assert_empty helm template \
+      -s templates/webhook-cert-manager-clusterrolebinding.yaml  \
+      --set 'global.rbac.create=false'  \
+      .
+}
 #--------------------------------------------------------------------
 # Vault
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -27,6 +27,10 @@ global:
   # @type: string
   name: null
 
+  rbac:
+    # Create required ClusterRoles and ClusterRoleBindings for cert-manager
+    create: true
+
   # The domain Consul will answer DNS queries for
   # (Refer to [`-domain`](https://developer.hashicorp.com/consul/docs/agent/config/cli-flags#_domain)) and the domain services synced from
   # Consul into Kubernetes will have, e.g. `service-name.service.consul`.


### PR DESCRIPTION
### Changes proposed in this PR ###  
The goal of this requirement is to enhance the security architecture by decoupling Consul's Role-Based Access Control (RBAC) from the core system. This change is aimed at allowing Consul RBAC to be installed and configured as a prerequisite, ensuring that the permissions required to install the application and the cluster level RBAC can be managed independently. By implementing this solution, we will improve access management, reduce security risks, and streamline RBAC architecture.
**Goals:**

- Decoupling RBAC: Implement a mechanism that allows Consul RBAC to function independently of the Consul cluster, promoting a modular architecture.

- Minimizing Permissions: Ensure that users responsible for installing the RBAC and application operate with the least privilege principle, mitigating the risk posed by overly broad permissions.

- Improving Security Posture: Enhance the overall security of applications by limiting the attack surface exposed to potential threats.

**Benefits:**

- Enhanced Security: Reducing cluster-wide permissions decreases the risk of unauthorized access and potential vulnerabilities.

- Easier Compliance: By enabling granular access controls, organizations can more easily comply with security standards and regulations.

- Operational Efficiency: Streamlined RBAC permissions management leads to a more efficient development and deployment process, reducing friction between teams.

### How I've tested this PR ###

- Built the chart and deployed and tested with our Organization's product.
- Deployed Consul-RBAC as a separate chart maintained by us
- Tested  new RBAC components to validate individual functions and logic. This included  consul chart deployment along with other applications  and ensuring  normal functioning without any unexpected behaviors.

### How I expect reviewers to test this PR ###

- Deploy/Verify manifest of the consul chart with --set global.rbac.create=false value and ensure that this will not create any RBAC resources 
- Deploy with --set global.rbac.create=true value and ensure successful consul deployment along with RBAC resource creation.

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
