### PR TITLE
NET-10763 - Allow DNS Proxy to configured with an ACL token when manageSystemACLs is false

### DIFF
--- a/.changelog/4300.txt
+++ b/.changelog/4300.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+dns-proxy: add the ability to deploy a DNS proxy within the kubernetes cluster that forwards DNS requests to the consul server and can be configured with an ACL token and make partition aware DNS requests.
+```

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pkg/
 .vscode
 .bob/
 control-plane/cni/cni
+acceptance/tests/consul-dns/coredns-custom.yaml

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -114,6 +114,8 @@ func TestConsulDNS(t *testing.T) {
 				require.NoError(t, err)
 				logger.Log(t, "created DNS Proxy token", "token", dnsProxyToken)
 				secretName := "consul-dns-proxy-token"
+
+				// TODO: check for existence and update
 				_, err = ctx.KubernetesClient(t).CoreV1().Secrets(ctx.KubectlOptions(t).Namespace).Create(context.Background(), &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: secretName,
@@ -123,6 +125,9 @@ func TestConsulDNS(t *testing.T) {
 					},
 					Type: corev1.SecretTypeOpaque,
 				}, metav1.CreateOptions{})
+				t.Cleanup(func() {
+					require.NoError(t, ctx.KubernetesClient(t).CoreV1().Secrets(ctx.KubectlOptions(t).Namespace).Delete(context.Background(), secretName, metav1.DeleteOptions{}))
+				})
 
 				helmValues["dns.proxy.aclToken.secretName"] = secretName
 				helmValues["dns.proxy.aclToken.secretKey"] = common.ACLTokenSecretKey

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -6,7 +6,6 @@ package consuldns
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/consul-k8s/control-plane/subcommand/common"
 	"github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
 	"os"
@@ -108,7 +107,7 @@ func TestConsulDNS(t *testing.T) {
 						Name: secretName,
 					},
 					StringData: map[string]string{
-						common.ACLTokenSecretKey: dnsProxyToken.SecretID,
+						"token": dnsProxyToken.SecretID,
 					},
 					Type: corev1.SecretTypeOpaque,
 				}, metav1.CreateOptions{})
@@ -118,7 +117,7 @@ func TestConsulDNS(t *testing.T) {
 
 				// Update the helm values to include the secret name and key.
 				helmValues["dns.proxy.aclToken.secretName"] = secretName
-				helmValues["dns.proxy.aclToken.secretKey"] = common.ACLTokenSecretKey
+				helmValues["dns.proxy.aclToken.secretKey"] = "token"
 			}
 
 			// If DNS proxy is enabled, we need to set the enableDNSProxy flag in the helm values.

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -111,6 +111,8 @@ func TestConsulDNS(t *testing.T) {
 					},
 					Type: corev1.SecretTypeOpaque,
 				}, metav1.CreateOptions{})
+				require.NoError(t, err)
+
 				t.Cleanup(func() {
 					require.NoError(t, ctx.KubernetesClient(t).CoreV1().Secrets(ctx.KubectlOptions(t).Namespace).Delete(context.Background(), secretName, metav1.DeleteOptions{}))
 				})

--- a/charts/consul/templates/dns-proxy-deployment.yaml
+++ b/charts/consul/templates/dns-proxy-deployment.yaml
@@ -1,5 +1,4 @@
 {{- if (or (and (ne (.Values.dns.proxy.enabled | toString) "-") .Values.dns.proxy.enabled) (and (eq (.Values.dns.proxy.enabled | toString) "-") .Values.global.enabled)) }}
-{{- if not .Values.connectInject.enabled }}{{ fail "connectInject.enabled must be true" }}{{ end -}}
 {{ template "consul.validateRequiredCloudSecretsExist" . }}
 {{ template "consul.validateCloudSecretKeys" . }}
 
@@ -110,12 +109,20 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: DP_SERVICE_NODE_NAME
+              value: $(NODE_NAME)-virtual
+      {{- if .Values.global.acls.manageSystemACLs }}
             - name: DP_CREDENTIAL_LOGIN_META1
               value: pod=$(NAMESPACE)/$(POD_NAME)
             - name: DP_CREDENTIAL_LOGIN_META2
               value: component=dns-proxy
-            - name: DP_SERVICE_NODE_NAME
-              value: $(NODE_NAME)-virtual
+      {{- else if (and .Values.dns.proxy.aclToken.secretName .Values.dns.proxy.aclToken.secretKey) }}
+            - name: DP_CREDENTIAL_STATIC_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.dns.proxy.aclToken.secretName }}
+                  key: {{ .Values.dns.proxy.aclToken.secretKey }}
+      {{- end }}
           command:
             - consul-dataplane
           args:
@@ -159,6 +166,8 @@ spec:
         {{- if .Values.global.adminPartitions.enabled }}
             - -login-partition={{ .Values.global.adminPartitions.name }}
         {{- end }}
+        {{- else }}
+            - -credential-type=static
         {{- end }}
         {{- if .Values.global.adminPartitions.enabled }}
             - -service-partition={{ .Values.global.adminPartitions.name }}

--- a/charts/consul/test/unit/dns-proxy-deployment.bats
+++ b/charts/consul/test/unit/dns-proxy-deployment.bats
@@ -82,7 +82,30 @@ load _helpers
 
 
 #--------------------------------------------------------------------
-# authMethod
+# credentials
+
+@test "dnsProxy/Deployment: -credential-type is login by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/dns-proxy-deployment.yaml  \
+      --set 'dns.proxy.enabled=true' \
+      --set 'global.acls.manageSystemACLs=true' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0] | any(.args[]; . == "-credential-type=login")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "dnsProxy/Deployment: -credential-type is static when manageSystemACLs is false and dns.proxy.aclToken.secretName and dns.proxy.aclToken.secretKey are set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/dns-proxy-deployment.yaml  \
+      --set 'dns.proxy.enabled=true' \
+      --set 'dns.proxy.aclToken.secretName=foo' \
+      --set 'dns.proxy.aclToken.secretKey=bar' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0] | any(.args[]; . == "-credential-type=static")' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
 
 @test "dnsProxy/Deployment: -login-auth-method is not set by default" {
   cd `chart_dir`

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1925,6 +1925,17 @@ dns:
     # Port number to be used by DNS proxy
     port: 53
 
+    # Refers to a Kubernetes secret that you have created that contains
+    # an ACL token for your Consul cluster which allows the dns proxy the correct
+    # permissions. This is only needed if ACLs are managed manually within the Consul cluster, i.e. `global.acls.manageSystemACLs` is `false`.
+    aclToken:
+      # The name of the Kubernetes secret that holds the acl sync token.
+      # @type: string
+      secretName: null
+      # The key within the Kubernetes secret that holds the acl sync token.
+      # @type: string
+      secretKey: null
+
 # Values that configure the Consul UI.
 ui:
   # If true, the UI will be enabled. This will

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1922,12 +1922,18 @@ dns:
     # The number of deployment replicas.
     replicas: 1
 
-    # Port number to be used by DNS proxy
     port: 53
 
     # Refers to a Kubernetes secret that you have created that contains
     # an ACL token for your Consul cluster which allows the dns proxy the correct
     # permissions. This is only needed if ACLs are managed manually within the Consul cluster, i.e. `global.acls.manageSystemACLs` is `false`.
+    # The minimum permissions required for this token are:
+    # node_prefix "" {
+    #   policy = "read"
+    # }
+    # service_prefix "" {
+    #   policy = "read"
+    # }
     aclToken:
       # The name of the Kubernetes secret that holds the acl sync token.
       # @type: string

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1924,10 +1924,10 @@ dns:
 
     port: 53
 
-    # Refers to a Kubernetes secret that you have created that contains
-    # an ACL token for your Consul cluster which allows the dns proxy the correct
-    # permissions. This is only needed if ACLs are managed manually within the Consul cluster, i.e. `global.acls.manageSystemACLs` is `false`.
-    # The minimum permissions required for this token are:
+    # Refers to an existing Kubernetes secret that contains an ACL token
+    # for your Consul cluster. This token provides permissions for the DNS
+    # proxy. This field is required when `global.acls.manageSystemACLs` 
+    # is set to `false` to enable manual ACL management in a Consul cluster.
     # node_prefix "" {
     #   policy = "read"
     # }
@@ -1935,10 +1935,10 @@ dns:
     #   policy = "read"
     # }
     aclToken:
-      # The name of the Kubernetes secret that holds the acl sync token.
+      # The name of the Kubernetes secret that holds the ACL token.
       # @type: string
       secretName: null
-      # The key within the Kubernetes secret that holds the acl sync token.
+      # The key within the Kubernetes secret that holds the ACL token.
       # @type: string
       secretKey: null
 


### PR DESCRIPTION
### Changes proposed in this PR ###  
- add the ability for users to set the ACL token on dns-proxy similiar to how catalog sync exposes the ability to set the ACL token in a secret
-

### How I've tested this PR ###
CI & unit tests

### How I expect reviewers to test this PR ###
👀 

### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
