### PR TITLE
NET-10871 Remove unnecessary resource permissions in connect-inject ClusterRole

### DIFF
--- a/.changelog/4307.txt
+++ b/.changelog/4307.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect-inject: remove unnecessary resource permissions from connect-inject ClusterRole
+```

--- a/charts/consul/templates/connect-inject-clusterrole.yaml
+++ b/charts/consul/templates/connect-inject-clusterrole.yaml
@@ -74,15 +74,21 @@ rules:
   - get
   - patch
   - update
-- apiGroups: [ "" ]
-  resources: [ "secrets", "serviceaccounts", "endpoints", "services", "namespaces", "nodes" ]
+- apiGroups: [""]
+  resources: ["secrets", "serviceaccounts", "services"]
   verbs:
-  - create
+    - get
+    - list
+    - watch
+    - delete
+    - create
+    - update
+- apiGroups: [ "" ]
+  resources: ["endpoints", "namespaces", "nodes"]
+  verbs:
   - get
   - list
   - watch
-  - delete
-  - update
 - apiGroups: [ "rbac.authorization.k8s.io" ]
   resources: [ "roles", "rolebindings" ]
   verbs:

--- a/charts/consul/test/unit/connect-inject-clusterrole.bats
+++ b/charts/consul/test/unit/connect-inject-clusterrole.bats
@@ -265,7 +265,7 @@ load _helpers
       -s templates/connect-inject-clusterrole.yaml  \
       --set 'global.openshift.enabled=true' \
       . | tee /dev/stderr |
-      yq '.rules[13].resourceNames | index("restricted-v2")' | tee /dev/stderr)
+      yq '.rules[14].resourceNames | index("restricted-v2")' | tee /dev/stderr)
   [ "${object}" == 0 ]
 }
 
@@ -276,6 +276,6 @@ load _helpers
       --set 'global.openshift.enabled=true' \
       --set 'connectInject.apiGateway.managedGatewayClass.openshiftSCCName=fakescc' \
       . | tee /dev/stderr |
-       yq '.rules[13].resourceNames | index("fakescc")' | tee /dev/stderr)
+       yq '.rules[14].resourceNames | index("fakescc")' | tee /dev/stderr)
    [ "${object}" == 0 ]
 }

--- a/charts/consul/test/unit/connect-inject-clusterrole.bats
+++ b/charts/consul/test/unit/connect-inject-clusterrole.bats
@@ -115,7 +115,7 @@ load _helpers
       --set 'client.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
-      yq -r '.rules[4]' | tee /dev/stderr)
+      yq -r '.rules[5]' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.resources[| index("pods")' | tee /dev/stderr)
   [ "${actual}" != null ]
@@ -144,7 +144,7 @@ load _helpers
       --set 'client.enabled=true' \
       --set 'connectInject.enabled=true' \
       . | tee /dev/stderr |
-      yq -r '.rules[5]' | tee /dev/stderr)
+      yq -r '.rules[6]' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.resources[| index("leases")' | tee /dev/stderr)
   [ "${actual}" != null ]

--- a/charts/consul/test/unit/connect-inject-clusterrole.bats
+++ b/charts/consul/test/unit/connect-inject-clusterrole.bats
@@ -34,7 +34,7 @@ load _helpers
 #--------------------------------------------------------------------
 # rules
 
-@test "connectInject/ClusterRole: sets get, list, and watch access to endpoints, services, namespaces and nodes in all api groups" {
+@test "connectInject/ClusterRole: sets get, list, watch, delete, create, and update access to secrets, serviceaccounts and services in core api group" {
   cd `chart_dir`
   local object=$(helm template \
       -s templates/connect-inject-clusterrole.yaml  \
@@ -44,10 +44,48 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.rules[2]' | tee /dev/stderr)
 
-  local actual=$(echo $object | yq -r '.resources[| index("endpoints")' | tee /dev/stderr)
+  local actual=$(echo $object | yq -r '.resources[| index("secrets")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  local actual=$(echo $object | yq -r '.resources[| index("serviceaccounts")' | tee /dev/stderr)
   [ "${actual}" != null ]
 
   local actual=$(echo $object | yq -r '.resources[| index("services")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  local actual=$(echo $object | yq -r '.apiGroups[0]' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+
+  local actual=$(echo $object | yq -r '.verbs | index("get")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  local actual=$(echo $object | yq -r '.verbs | index("list")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  local actual=$(echo $object | yq -r '.verbs | index("watch")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  local actual=$(echo $object | yq -r '.verbs | index("delete")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  local actual=$(echo $object | yq -r '.verbs | index("create")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+
+  local actual=$(echo $object | yq -r '.verbs | index("update")' | tee /dev/stderr)
+  [ "${actual}" != null ]
+}
+
+@test "connectInject/ClusterRole: sets get, list, and watch access to endpoints, namespaces and nodes in core api group" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/connect-inject-clusterrole.yaml  \
+      --set 'global.enabled=false' \
+      --set 'client.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.rules[3]' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.resources[| index("endpoints")' | tee /dev/stderr)
   [ "${actual}" != null ]
 
   local actual=$(echo $object | yq -r '.resources[| index("namespaces")' | tee /dev/stderr)

--- a/charts/consul/test/unit/connect-inject-clusterrole.bats
+++ b/charts/consul/test/unit/connect-inject-clusterrole.bats
@@ -235,7 +235,7 @@ load _helpers
       --set 'global.secretsBackend.vault.consulServerRole=bar' \
       --set 'global.secretsBackend.vault.consulCARole=test2' \
       . | tee /dev/stderr |
-      yq -r '.rules[6]' | tee /dev/stderr)
+      yq -r '.rules[7]' | tee /dev/stderr)
 
   local actual=$(echo $object | yq -r '.resources[0]' | tee /dev/stderr)
   [ "${actual}" = "mutatingwebhookconfigurations" ]


### PR DESCRIPTION
### Changes proposed in this PR ###  
Remove unnecessary permissions for `Namespace` and `Node` resources in the connect-inject controller's `ClusterRole`

### How I've tested this PR ###
- 🤖 tests pass
- Manual smoke test running a Consul installation with service mesh and API gateways enabled

### How I expect reviewers to test this PR ###
- Validate against your mental model of Consul
- (See above)

### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
