### PR TITLE
[NET-10985] Fix bug where imagePullSecrets were not set up for Gateways

### DIFF
--- a/.changelog/4316.txt
+++ b/.changelog/4316.txt
@@ -1,3 +1,5 @@
 ```release-note:bug
-api-gateway: `global.imagePullSecrets` are now configured on the `ServiceAccount` for `Gateways`
+api-gateway: `global.imagePullSecrets` are now configured on the `ServiceAccount` for `Gateways`.
+
+Note: the referenced image pull Secrets must be present in any namespace that the `Gateway` is deployed to.
 ```

--- a/.changelog/4316.txt
+++ b/.changelog/4316.txt
@@ -1,5 +1,5 @@
 ```release-note:bug
 api-gateway: `global.imagePullSecrets` are now configured on the `ServiceAccount` for `Gateways`.
 
-Note: the referenced image pull Secret(s) must be present in any namespace that the `Gateway` is deployed to.
+Note: the referenced image pull Secret(s) must be present in the same namespace the `Gateway` is deployed to.
 ```

--- a/.changelog/4316.txt
+++ b/.changelog/4316.txt
@@ -1,5 +1,5 @@
 ```release-note:bug
 api-gateway: `global.imagePullSecrets` are now configured on the `ServiceAccount` for `Gateways`.
 
-Note: the referenced image pull Secrets must be present in any namespace that the `Gateway` is deployed to.
+Note: the referenced image pull Secret(s) must be present in any namespace that the `Gateway` is deployed to.
 ```

--- a/.changelog/4316.txt
+++ b/.changelog/4316.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api-gateway: `global.imagePullSecrets` are now configured on the `ServiceAccount` for `Gateways`
+```

--- a/charts/consul/templates/connect-inject-configmap.yaml
+++ b/charts/consul/templates/connect-inject-configmap.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.connectInject.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "consul.fullname" . }}-connect-inject-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "consul.name" . }}
+    chart: {{ template "consul.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: connect-injector
+data:
+  config.json: |
+    {
+      "image_pull_secrets": {{ .Values.global.imagePullSecrets | toJson }}
+    }
+{{- end }}

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -311,6 +311,9 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
           volumeMounts:
+            - name: config
+              mountPath: /consul/config
+              readOnly: true
           {{- if not (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName) }}
             - name: certs
               mountPath: /etc/connect-injector/certs
@@ -326,6 +329,9 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
+        - name: config
+          configMap:
+            name: {{ template "consul.fullname" . }}-connect-inject-config
       {{- if not (and .Values.global.secretsBackend.vault.enabled .Values.global.secretsBackend.vault.connectInject.tlsCert.secretName) }}
         - name: certs
           secret:

--- a/charts/consul/templates/connect-inject-deployment.yaml
+++ b/charts/consul/templates/connect-inject-deployment.yaml
@@ -141,6 +141,7 @@ spec:
             - "-ec"
             - |
               exec consul-k8s-control-plane inject-connect \
+                -config-file=/consul/config/config.json \
                 {{- if .Values.global.federation.enabled }}
                 -enable-federation \
                 {{- end }}

--- a/control-plane/api-gateway/common/helm_config.go
+++ b/control-plane/api-gateway/common/helm_config.go
@@ -18,7 +18,8 @@ type HelmConfig struct {
 	// ImageDataplane is the Consul Dataplane image to use in gateway deployments.
 	ImageDataplane string
 	// ImageConsulK8S is the Consul Kubernetes Control Plane image to use in gateway deployments.
-	ImageConsulK8S   string
+	ImageConsulK8S string
+	// ImagePullSecrets reference one or more Secret(s) that contain the credentials to pull images from private image repos.
 	ImagePullSecrets []v1.LocalObjectReference
 	// GlobalImagePullPolicy is the pull policy to use for all images used in gateway deployments.
 	GlobalImagePullPolicy      string

--- a/control-plane/api-gateway/common/helm_config.go
+++ b/control-plane/api-gateway/common/helm_config.go
@@ -18,7 +18,8 @@ type HelmConfig struct {
 	// ImageDataplane is the Consul Dataplane image to use in gateway deployments.
 	ImageDataplane string
 	// ImageConsulK8S is the Consul Kubernetes Control Plane image to use in gateway deployments.
-	ImageConsulK8S string
+	ImageConsulK8S   string
+	ImagePullSecrets []v1.LocalObjectReference
 	// GlobalImagePullPolicy is the pull policy to use for all images used in gateway deployments.
 	GlobalImagePullPolicy      string
 	ConsulDestinationNamespace string

--- a/control-plane/api-gateway/gatekeeper/gatekeeper.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper.go
@@ -106,7 +106,7 @@ func (g *Gatekeeper) namespacedName(gateway gwv1beta1.Gateway) types.NamespacedN
 }
 
 func (g *Gatekeeper) serviceAccountName(gateway gwv1beta1.Gateway, config common.HelmConfig) string {
-	if config.AuthMethod == "" && !config.EnableOpenShift {
+	if config.AuthMethod == "" && !config.EnableOpenShift && len(config.ImagePullSecrets) == 0 {
 		return ""
 	}
 	return gateway.Name

--- a/control-plane/api-gateway/gatekeeper/gatekeeper.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper.go
@@ -106,6 +106,8 @@ func (g *Gatekeeper) namespacedName(gateway gwv1beta1.Gateway) types.NamespacedN
 }
 
 func (g *Gatekeeper) serviceAccountName(gateway gwv1beta1.Gateway, config common.HelmConfig) string {
+	// We only create a ServiceAccount if it's needed for RBAC or image pull secrets;
+	// otherwise, we clean up if one was previously created.
 	if config.AuthMethod == "" && !config.EnableOpenShift && len(config.ImagePullSecrets) == 0 {
 		return ""
 	}

--- a/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
@@ -197,7 +197,8 @@ func TestUpsert(t *testing.T) {
 				},
 			},
 			helmConfig: common.HelmConfig{
-				ImageDataplane: dataplaneImage,
+				ImageDataplane:   dataplaneImage,
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "my-secret"}},
 			},
 			initialResources: resources{},
 			finalResources: resources{
@@ -224,7 +225,9 @@ func TestUpsert(t *testing.T) {
 						},
 					}, "1", false, false),
 				},
-				serviceAccounts: []*corev1.ServiceAccount{},
+				serviceAccounts: []*corev1.ServiceAccount{
+					configureServiceAccount(name, namespace, labels, "1", []corev1.LocalObjectReference{{Name: "my-secret"}}),
+				},
 			},
 		},
 		"create a new gateway deployment with managed Service": {
@@ -279,7 +282,6 @@ func TestUpsert(t *testing.T) {
 						},
 					}, "1", false, false),
 				},
-				serviceAccounts: []*corev1.ServiceAccount{},
 			},
 		},
 		"create a new gateway deployment with managed Service and ACLs": {
@@ -307,8 +309,9 @@ func TestUpsert(t *testing.T) {
 				},
 			},
 			helmConfig: common.HelmConfig{
-				AuthMethod:     "method",
-				ImageDataplane: dataplaneImage,
+				AuthMethod:       "method",
+				ImageDataplane:   dataplaneImage,
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "my-secret"}},
 			},
 			initialResources: resources{},
 			finalResources: resources{
@@ -341,7 +344,7 @@ func TestUpsert(t *testing.T) {
 					}, "1", false, false),
 				},
 				serviceAccounts: []*corev1.ServiceAccount{
-					configureServiceAccount(name, namespace, labels, "1"),
+					configureServiceAccount(name, namespace, labels, "1", []corev1.LocalObjectReference{{Name: "my-secret"}}),
 				},
 			},
 		},
@@ -472,7 +475,7 @@ func TestUpsert(t *testing.T) {
 					}, "1", true, false),
 				},
 				serviceAccounts: []*corev1.ServiceAccount{
-					configureServiceAccount(name, namespace, labels, "1"),
+					configureServiceAccount(name, namespace, labels, "1", nil),
 				},
 			},
 			finalResources: resources{
@@ -505,7 +508,7 @@ func TestUpsert(t *testing.T) {
 					}, "2", false, false),
 				},
 				serviceAccounts: []*corev1.ServiceAccount{
-					configureServiceAccount(name, namespace, labels, "1"),
+					configureServiceAccount(name, namespace, labels, "1", nil),
 				},
 			},
 			ignoreTimestampOnService: true,
@@ -568,7 +571,7 @@ func TestUpsert(t *testing.T) {
 					}, "1", true, false),
 				},
 				serviceAccounts: []*corev1.ServiceAccount{
-					configureServiceAccount(name, namespace, labels, "1"),
+					configureServiceAccount(name, namespace, labels, "1", nil),
 				},
 			},
 			finalResources: resources{
@@ -595,7 +598,7 @@ func TestUpsert(t *testing.T) {
 					}, "2", false, false),
 				},
 				serviceAccounts: []*corev1.ServiceAccount{
-					configureServiceAccount(name, namespace, labels, "1"),
+					configureServiceAccount(name, namespace, labels, "1", nil),
 				},
 			},
 			ignoreTimestampOnService: true,
@@ -966,7 +969,7 @@ func TestUpsert(t *testing.T) {
 				secrets:  []*corev1.Secret{},
 				services: []*corev1.Service{},
 				serviceAccounts: []*corev1.ServiceAccount{
-					configureServiceAccount(name, namespace, labels, "1"),
+					configureServiceAccount(name, namespace, labels, "1", nil),
 				},
 			},
 		},
@@ -1311,7 +1314,7 @@ func TestDelete(t *testing.T) {
 					}, "1", true, false),
 				},
 				serviceAccounts: []*corev1.ServiceAccount{
-					configureServiceAccount(name, namespace, labels, "1"),
+					configureServiceAccount(name, namespace, labels, "1", nil),
 				},
 			},
 			finalResources: resources{
@@ -1377,7 +1380,7 @@ func TestDelete(t *testing.T) {
 					}, "1", true, false),
 				},
 				serviceAccounts: []*corev1.ServiceAccount{
-					configureServiceAccount(name, namespace, labels, "1"),
+					configureServiceAccount(name, namespace, labels, "1", nil),
 				},
 			},
 			finalResources: resources{
@@ -1886,7 +1889,7 @@ func configureService(name, namespace string, labels, annotations map[string]str
 	return &service
 }
 
-func configureServiceAccount(name, namespace string, labels map[string]string, resourceVersion string) *corev1.ServiceAccount {
+func configureServiceAccount(name, namespace string, labels map[string]string, resourceVersion string, pullSecrets []corev1.LocalObjectReference) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -1907,6 +1910,7 @@ func configureServiceAccount(name, namespace string, labels map[string]string, r
 				},
 			},
 		},
+		ImagePullSecrets: pullSecrets,
 	}
 }
 

--- a/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
@@ -203,7 +203,7 @@ func TestUpsert(t *testing.T) {
 			initialResources: resources{},
 			finalResources: resources{
 				deployments: []*appsv1.Deployment{
-					configureDeployment(name, namespace, labels, 3, nil, nil, "", "1"),
+					configureDeployment(name, namespace, labels, 3, nil, nil, name, "1"),
 				},
 				roles: []*rbac.Role{},
 				secrets: []*corev1.Secret{
@@ -316,7 +316,7 @@ func TestUpsert(t *testing.T) {
 			initialResources: resources{},
 			finalResources: resources{
 				deployments: []*appsv1.Deployment{
-					configureDeployment(name, namespace, labels, 3, nil, nil, "", "1"),
+					configureDeployment(name, namespace, labels, 3, nil, nil, name, "1"),
 				},
 				roles: []*rbac.Role{
 					configureRole(name, namespace, labels, "1", false),
@@ -454,7 +454,7 @@ func TestUpsert(t *testing.T) {
 			},
 			initialResources: resources{
 				deployments: []*appsv1.Deployment{
-					configureDeployment(name, namespace, labels, 3, nil, nil, "", "1"),
+					configureDeployment(name, namespace, labels, 3, nil, nil, name, "1"),
 				},
 				roles: []*rbac.Role{
 					configureRole(name, namespace, labels, "1", false),
@@ -480,7 +480,7 @@ func TestUpsert(t *testing.T) {
 			},
 			finalResources: resources{
 				deployments: []*appsv1.Deployment{
-					configureDeployment(name, namespace, labels, 3, nil, nil, "", "2"),
+					configureDeployment(name, namespace, labels, 3, nil, nil, name, "2"),
 				},
 				roles: []*rbac.Role{
 					configureRole(name, namespace, labels, "1", false),
@@ -545,7 +545,7 @@ func TestUpsert(t *testing.T) {
 			},
 			initialResources: resources{
 				deployments: []*appsv1.Deployment{
-					configureDeployment(name, namespace, labels, 3, nil, nil, "", "1"),
+					configureDeployment(name, namespace, labels, 3, nil, nil, name, "1"),
 				},
 				roles: []*rbac.Role{
 					configureRole(name, namespace, labels, "1", false),
@@ -576,7 +576,7 @@ func TestUpsert(t *testing.T) {
 			},
 			finalResources: resources{
 				deployments: []*appsv1.Deployment{
-					configureDeployment(name, namespace, labels, 3, nil, nil, "", "2"),
+					configureDeployment(name, namespace, labels, 3, nil, nil, name, "2"),
 				},
 				roles: []*rbac.Role{
 					configureRole(name, namespace, labels, "1", false),
@@ -958,7 +958,7 @@ func TestUpsert(t *testing.T) {
 			},
 			finalResources: resources{
 				deployments: []*appsv1.Deployment{
-					configureDeployment(name, namespace, labels, 3, nil, nil, "", "1"),
+					configureDeployment(name, namespace, labels, 3, nil, nil, name, "1"),
 				},
 				roles: []*rbac.Role{
 					configureRole(name, namespace, labels, "1", true),
@@ -1478,6 +1478,9 @@ func validateResourcesExist(t *testing.T, client client.Client, helmConfig commo
 		require.Equal(t, expected.Spec.Template.ObjectMeta.Annotations, actual.Spec.Template.ObjectMeta.Annotations)
 		require.Equal(t, expected.Spec.Template.ObjectMeta.Labels, actual.Spec.Template.Labels)
 
+		// Ensure the service account is assigned
+		require.Equal(t, expected.Spec.Template.Spec.ServiceAccountName, actual.Spec.Template.Spec.ServiceAccountName)
+
 		// Ensure there is an init container
 		hasInitContainer := false
 		for _, container := range actual.Spec.Template.Spec.InitContainers {
@@ -1687,7 +1690,7 @@ func validateResourcesAreDeleted(t *testing.T, k8sClient client.Client, resource
 	return nil
 }
 
-func configureDeployment(name, namespace string, labels map[string]string, replicas int32, nodeSelector map[string]string, tolerations []corev1.Toleration, serviceAccoutName, resourceVersion string) *appsv1.Deployment {
+func configureDeployment(name, namespace string, labels map[string]string, replicas int32, nodeSelector map[string]string, tolerations []corev1.Toleration, serviceAccountName, resourceVersion string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -1740,7 +1743,7 @@ func configureDeployment(name, namespace string, labels map[string]string, repli
 					},
 					NodeSelector:       nodeSelector,
 					Tolerations:        tolerations,
-					ServiceAccountName: serviceAccoutName,
+					ServiceAccountName: serviceAccountName,
 				},
 			},
 		},

--- a/control-plane/api-gateway/gatekeeper/init.go
+++ b/control-plane/api-gateway/gatekeeper/init.go
@@ -7,12 +7,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"k8s.io/utils/ptr"
 	"strconv"
 	"strings"
 	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
@@ -36,9 +36,9 @@ type initContainerCommandData struct {
 	LogJSON  bool
 }
 
-// containerInit returns the init container spec for connect-init that polls for the service and the connect proxy service to be registered
+// initContainer returns the init container spec for connect-init that polls for the service and the connect proxy service to be registered
 // so that it can save the proxy service id to the shared volume and boostrap Envoy with the proxy-id.
-func (g Gatekeeper) initContainer(config common.HelmConfig, name, namespace string) (corev1.Container, error) {
+func (g *Gatekeeper) initContainer(config common.HelmConfig, name, namespace string) (corev1.Container, error) {
 	data := initContainerCommandData{
 		AuthMethod:         config.AuthMethod,
 		LogLevel:           config.LogLevel,

--- a/control-plane/api-gateway/gatekeeper/rolebinding.go
+++ b/control-plane/api-gateway/gatekeeper/rolebinding.go
@@ -10,12 +10,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
-	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	rbac "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 )
 
 func (g *Gatekeeper) upsertRoleBinding(ctx context.Context, gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config common.HelmConfig) error {
@@ -65,7 +66,7 @@ func (g *Gatekeeper) deleteRoleBinding(ctx context.Context, gwName types.Namespa
 
 func (g *Gatekeeper) roleBinding(gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config common.HelmConfig) *rbac.RoleBinding {
 	// Create resources for reference. This avoids bugs if naming patterns change.
-	serviceAccount := g.serviceAccount(gateway)
+	serviceAccount := g.serviceAccount(gateway, config)
 	role := g.role(gateway, gcc, config)
 
 	return &rbac.RoleBinding{

--- a/control-plane/api-gateway/gatekeeper/serviceaccount.go
+++ b/control-plane/api-gateway/gatekeeper/serviceaccount.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (g *Gatekeeper) upsertServiceAccount(ctx context.Context, gateway gwv1beta1.Gateway, config common.HelmConfig) error {
-	if config.AuthMethod == "" && !config.EnableOpenShift {
+	if config.AuthMethod == "" && !config.EnableOpenShift && len(config.ImagePullSecrets) == 0 {
 		return g.deleteServiceAccount(ctx, types.NamespacedName{Namespace: gateway.Namespace, Name: gateway.Name})
 	}
 

--- a/control-plane/api-gateway/gatekeeper/serviceaccount.go
+++ b/control-plane/api-gateway/gatekeeper/serviceaccount.go
@@ -7,14 +7,14 @@ import (
 	"context"
 	"errors"
 
-	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
-	"k8s.io/apimachinery/pkg/types"
-	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
-
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 )
 
 func (g *Gatekeeper) upsertServiceAccount(ctx context.Context, gateway gwv1beta1.Gateway, config common.HelmConfig) error {
@@ -47,7 +47,7 @@ func (g *Gatekeeper) upsertServiceAccount(ctx context.Context, gateway gwv1beta1
 	}
 
 	// Create the ServiceAccount.
-	serviceAccount = g.serviceAccount(gateway)
+	serviceAccount = g.serviceAccount(gateway, config)
 	if err := ctrl.SetControllerReference(&gateway, serviceAccount, g.Client.Scheme()); err != nil {
 		return err
 	}
@@ -69,12 +69,13 @@ func (g *Gatekeeper) deleteServiceAccount(ctx context.Context, gwName types.Name
 	return nil
 }
 
-func (g *Gatekeeper) serviceAccount(gateway gwv1beta1.Gateway) *corev1.ServiceAccount {
+func (g *Gatekeeper) serviceAccount(gateway gwv1beta1.Gateway, config common.HelmConfig) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gateway.Name,
 			Namespace: gateway.Namespace,
 			Labels:    common.LabelsForGateway(&gateway),
 		},
+		ImagePullSecrets: config.ImagePullSecrets,
 	}
 }

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -48,6 +48,7 @@ type Command struct {
 	flagListen                string
 	flagCertDir               string // Directory with TLS certs for listening (PEM)
 	flagDefaultInject         bool   // True to inject by default
+	flagConfigFile            string // Path to a config file in JSON format
 	flagConsulImage           string // Docker image for Consul
 	flagConsulDataplaneImage  string // Docker image for Envoy
 	flagConsulK8sImage        string // Docker image for consul-k8s
@@ -174,6 +175,7 @@ func init() {
 func (c *Command) init() {
 	c.flagSet = flag.NewFlagSet("", flag.ContinueOnError)
 	c.flagSet.StringVar(&c.flagListen, "listen", ":8080", "Address to bind listener to.")
+	c.flagSet.StringVar(&c.flagConfigFile, "config-file", "", "Path to a JSON config file.")
 	c.flagSet.Var((*flags.FlagMapValue)(&c.flagNodeMeta), "node-meta",
 		"Metadata to set on the node, formatted as key=value. This flag may be specified multiple times to set multiple meta fields.")
 	c.flagSet.BoolVar(&c.flagDefaultInject, "default-inject", true, "Inject by default.")

--- a/control-plane/subcommand/inject-connect/v1controllers.go
+++ b/control-plane/subcommand/inject-connect/v1controllers.go
@@ -38,13 +38,15 @@ func (c *Command) configureControllers(ctx context.Context, mgr manager.Manager,
 	}
 
 	var cfgFile FileConfig
-	if file, err := os.ReadFile("/consul/config/config.json"); err != nil {
-		setupLog.Info("Failed to read config file, may not be present", "error", err)
-	} else {
-		if err := json.Unmarshal(file, &cfgFile); err != nil {
-			setupLog.Error(err, "Config file present but could not be deserialized, will use defaults")
+	if c.flagConfigFile != "" {
+		if file, err := os.ReadFile(c.flagConfigFile); err != nil {
+			setupLog.Info("Failed to read specified -config-file", "file", c.flagConfigFile, "error", err)
 		} else {
-			setupLog.Info("Config file present and deserialized", "config", cfgFile)
+			if err := json.Unmarshal(file, &cfgFile); err != nil {
+				setupLog.Error(err, "Config file present but could not be deserialized, will use defaults", "file", c.flagConfigFile)
+			} else {
+				setupLog.Info("Config file present and deserialized", "file", c.flagConfigFile, "config", cfgFile)
+			}
 		}
 	}
 

--- a/control-plane/subcommand/inject-connect/v1controllers.go
+++ b/control-plane/subcommand/inject-connect/v1controllers.go
@@ -5,10 +5,12 @@ package connectinject
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/hashicorp/consul-server-connection-manager/discovery"
+	v1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -30,6 +32,21 @@ import (
 func (c *Command) configureControllers(ctx context.Context, mgr manager.Manager, watcher *discovery.Watcher) error {
 	// Create Consul API config object.
 	consulConfig := c.consul.ConsulClientConfig()
+
+	type FileConfig struct {
+		ImagePullSecrets []v1.LocalObjectReference `json:"image_pull_secrets"`
+	}
+
+	var cfgFile FileConfig
+	if file, err := os.ReadFile("/consul/config/config.json"); err != nil {
+		setupLog.Info("Failed to read config file, may not be present", "error", err)
+	} else {
+		if err := json.Unmarshal(file, &cfgFile); err != nil {
+			setupLog.Error(err, "Config file present but could not be deserialized, will use defaults")
+		} else {
+			setupLog.Info("Config file present and deserialized", "config", cfgFile)
+		}
+	}
 
 	// Convert allow/deny lists to sets.
 	allowK8sNamespaces := flags.ToSet(c.flagAllowK8sNamespacesList)
@@ -118,6 +135,7 @@ func (c *Command) configureControllers(ctx context.Context, mgr manager.Manager,
 			},
 			ImageDataplane:              c.flagConsulDataplaneImage,
 			ImageConsulK8S:              c.flagConsulK8sImage,
+			ImagePullSecrets:            cfgFile.ImagePullSecrets,
 			GlobalImagePullPolicy:       c.flagGlobalImagePullPolicy,
 			ConsulDestinationNamespace:  c.flagConsulDestinationNamespace,
 			NamespaceMirroringPrefix:    c.flagK8SNSMirroringPrefix,


### PR DESCRIPTION
Fixes #4312

> [!NOTE]
> In order for the pull secrets to work for a `Gateway`, they must be available in any namespace that a `Gateway` is deployed to. This is already the case with injected mesh sidecars if you, for example, consume consul-dataplane from a private image registry, so I have not made any special accomadations for `Gateways`.

### Changes proposed in this PR ###  
Plumb `global.imagePullSecrets` onto the `ServiceAccount` created for each `Gateway`

### How I've tested this PR ###
1. Created a private registry on DockerHub for consul-dataplane, which is used by the gateway's `Deployment`
    ```shell
    docker pull hashicorp/consul-dataplane:1.5.3
    docker tag hashicorp/consul-dataplane:1.5.3 <your_dockerhub_username>/consul-dataplane:1.5.3
    docker login
    docker push <your_dockerhub_username>/consul-dataplane:1.5.3
    ```
1. [Created an image pull secret for DockerHub in my K8s cluster](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line)
1. Set `global.imageConsulDataplane` to the private registry version
1. Install using this version of the Helm chart and this build of consul-k8s-control-plane
    <details>
    <summary>values.yaml</summary>

    ```yaml
    global:
      name: consul
      datacenter: dc1
      imageConsulDataplane: docker.io/<your_dockerhub_username>/consul-dataplane:1.5.3
      imageK8S: consul-k8s-control-plane:local
      imagePullSecrets:
      - name: regcred
      tls:
        enabled: true
        enableAutoEncrypt: true
      acls:
        manageSystemACLs: true
    connectInject:
      enabled: true
    ```
    </details>

    ```shell
    kind create cluster
    make dev-docker && kind load docker-image consul-k8s-control-plane:local
    helm upgrade --install consul /path/to/consul-k8s/charts/consul --namespace consul --create-namespace --values ./values.yaml
    ```

### How I expect reviewers to test this PR ###
See above

### Checklist ###
- [ ] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
