### PR TITLE
ci: fix CI skip script hole

### DIFF
--- a/.github/scripts/check_skip_ci.sh
+++ b/.github/scripts/check_skip_ci.sh
@@ -24,10 +24,11 @@ function contains() {
 #
 # ... `git merge-base origin/$SKIP_CHECK_BRANCH HEAD` would return commit `D`
 # `...HEAD` specifies from the common ancestor to the latest commit on the current branch (HEAD)..
-files_to_check=$(git diff --name-only "$(git merge-base origin/$SKIP_CHECK_BRANCH HEAD~)"...HEAD)
+skip_check_branch=${SKIP_CHECK_BRANCH:?SKIP_CHECK_BRANCH is required}
+files_to_check=$(git diff --name-only "$(git merge-base origin/$skip_check_branch HEAD~)"...HEAD)
 
 # Define the directories to check
-skipped_directories=("assets" ".changelog/", "version")
+skipped_directories=("assets" ".changelog" "version")
 
 files_to_skip=("LICENSE" ".copywrite.hcl" ".gitignore")
 
@@ -43,7 +44,7 @@ for file_to_check in "${files_to_check_array[@]}"; do
   # - Markdown files
   for dir in "${skipped_directories[@]}"; do
     if [[ "$file_to_check" == */check_skip_ci.sh ]] ||
-      [[ "$file_to_check" == "$dir"* ]] ||
+      [[ "$file_to_check" == "$dir/"* ]] ||
       [[ "$file_to_check" == *.md ]] ||
       contains "${files_to_skip[*]}" "$file_to_check"; then
       file_is_skipped=true


### PR DESCRIPTION
In some environments, the script will not fail despite `SKIP_CHECK_BRANCH` being unset, leading to the script explicitly skipping CI when it should fail fast.

Prevent this by explicitly checking for the env var.

Also fix a small bug where we're incorrectly requiring ',' in the .changelog directory name, which means we'll never skip changelog entries.

This change is a port of https://github.com/hashicorp/consul/pull/21741.

## Testing

```shell
❯ ./.github/scripts/check_skip_ci.sh
./.github/scripts/check_skip_ci.sh: line 27: SKIP_CHECK_BRANCH: SKIP_CHECK_BRANCH is required

❯ export SKIP_CHECK_BRANCH=net-10843-cannot-add-tolerations-to-apigateway
❯ ./.github/scripts/check_skip_ci.sh
checking file: .changelog/4313.txt
checking file: .github/scripts/check_skip_ci.sh
checking file: .go-version
non-skippable file changed: .go-version
Changes detected in non-documentation files - will not skip tests and build
```