### PR TITLE
NO-JIRA: cleanup iamRoles as part of nightly test cleanup

### DIFF
--- a/hack/aws-acceptance-test-cleanup/main.go
+++ b/hack/aws-acceptance-test-cleanup/main.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"strings"
@@ -782,7 +781,7 @@ func cleanupIAMRoles(ctx context.Context, iamClient *iam.IAM) error {
 		if aws.StringValue(role.RoleName)[:len(prefix)] == prefix {
 			err := detachRolePolicies(iamClient, role.RoleName)
 			if err != nil {
-				log.Printf("Failed to detach policies for role %s: %v", *role.RoleName, err)
+				fmt.Printf("Failed to detach policies for role %s: %v", *role.RoleName, err)
 				continue
 			}
 
@@ -791,9 +790,9 @@ func cleanupIAMRoles(ctx context.Context, iamClient *iam.IAM) error {
 				RoleName: role.RoleName,
 			})
 			if err != nil {
-				log.Printf("Failed to delete role %s: %v", *role.RoleName, err)
+				fmt.Printf("Failed to delete role %s: %v", *role.RoleName, err)
 			} else {
-				log.Printf("Deleted role: %s", *role.RoleName)
+				fmt.Printf("Deleted role: %s", *role.RoleName)
 			}
 		}
 	}
@@ -812,7 +811,7 @@ func detachRolePolicies(iamClient *iam.IAM, roleName *string) error {
 				PolicyArn: policy.PolicyArn,
 			})
 			if err != nil {
-				log.Printf("Failed to detach policy %s from role %s: %v", *policy.PolicyArn, *roleName, err)
+				fmt.Printf("Failed to detach policy %s from role %s: %v", *policy.PolicyArn, *roleName, err)
 			}
 		}
 		return !lastPage


### PR DESCRIPTION
### Changes proposed in this PR ###  
## PROBLEM
Acceptance test in CI are currently failing with error `LimitExceeded: Cannot exceed quota for RolesPerAccount: 1000`.

## SOLUTION
Update the `aws-acceptance-test-cleanup` script to include cleaning up iamroles created as part of test environment setup. 

### How I've tested this PR ###
Tested locally to ensure all exisiting iAMRoles created as part of previous acceptance test runs were cleaned up using this script

### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
