### PR TITLE
bump kubernetes version for AKS

### DIFF
--- a/charts/consul/test/terraform/aks/variables.tf
+++ b/charts/consul/test/terraform/aks/variables.tf
@@ -7,7 +7,7 @@ variable "location" {
 }
 
 variable "kubernetes_version" {
-  default     = "1.29"
+  default     = "1.28"
   description = "Kubernetes version supported on AKS"
 }
 

--- a/charts/consul/test/terraform/aks/variables.tf
+++ b/charts/consul/test/terraform/aks/variables.tf
@@ -7,7 +7,7 @@ variable "location" {
 }
 
 variable "kubernetes_version" {
-  default     = "1.27"
+  default     = "1.29"
   description = "Kubernetes version supported on AKS"
 }
 


### PR DESCRIPTION
### Changes proposed in this PR ###  
## PROBLEM
Nightly acceptance test on AKS is currently failing with error 
```Code="K8sVersionNotSupported" Message="Managed cluster consul-k8s-2814350665 is on version 1.27.16 which is not supported in this region``` due to [end of life support for Kubernetes version 1.27.](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli)
## SOLUTION
Upgraded AKS kubernetes version to 1.28

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
