### PR TITLE
Use informer index instead of listing service EndpointSlices directly

### DIFF
--- a/control-plane/helper/controller/controller.go
+++ b/control-plane/helper/controller/controller.go
@@ -211,6 +211,15 @@ func (c *Controller) processSingle(
 	return true
 }
 
+// GetByIndex allows querying the informer's indexer to avoid extra calls to k8s
+func (c *Controller) GetByIndex(indexName, indexedValue string) ([]interface{}, error) {
+	if c.informer == nil {
+		return nil, nil
+	}
+
+	return c.informer.GetIndexer().ByIndex(indexName, indexedValue)
+}
+
 // informerDeleteHandler returns a function that implements
 // `DeleteFunc` from the `ResourceEventHandlerFuncs` interface.
 // It is split out as its own method to aid in testing.


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Use existing Informer cache for EndpointSlices instead of listing EndpointSlices directly from k8s.

We had a production issue where Kubernetes spuriously returned 1 of 5 EndpointSlices to a list request during k8s control-plane maintenance, causing a partial outage for that service until we could restart consul-k8s. Arguably k8s returning an incomplete list response is the bigger issue, but this PR will help make consul-k8s more resilient to k8s control-plane instability.

### How I've tested this PR ###
Ran unit tests, ran end-to-end test in a sandbox Kubernetes cluster.

### How I expect reviewers to test this PR ###
Run unit and end-to-end tests

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
