### PR TITLE
Fix duplicate key in connect-inject ACL policy

### DIFF
--- a/.changelog/4434.txt
+++ b/.changelog/4434.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect-inject: fix issue where the ACL policy for the connect-injector included the `acl = "write"` rule twice when namespaces were not enabled.
+```

--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -310,11 +310,11 @@ partition "{{ .PartitionName }}" {
   }
 {{- if .EnableNamespaces }}
   namespace_prefix "" {
+    acl = "write"
 {{- end }}
 {{- if .EnablePartitions }}
     policy = "write"
 {{- end }}
-    acl = "write"
     service_prefix "" {
       policy = "write"
       intentions = "write"

--- a/control-plane/subcommand/server-acl-init/rules_test.go
+++ b/control-plane/subcommand/server-acl-init/rules_test.go
@@ -883,7 +883,6 @@ func TestInjectRules(t *testing.T) {
   node_prefix "" {
     policy = "write"
   }
-    acl = "write"
     service_prefix "" {
       policy = "write"
       intentions = "write"
@@ -929,7 +928,6 @@ partition "part-1" {
     policy = "write"
   }
     policy = "write"
-    acl = "write"
     service_prefix "" {
       policy = "write"
       intentions = "write"
@@ -952,7 +950,6 @@ partition "part-1" {
   node_prefix "" {
     policy = "write"
   }
-    acl = "write"
     service_prefix "" {
       policy = "write"
       intentions = "write"
@@ -975,8 +972,8 @@ partition "part-1" {
     policy = "write"
   }
   namespace_prefix "" {
-    policy = "write"
     acl = "write"
+    policy = "write"
     service_prefix "" {
       policy = "write"
       intentions = "write"
@@ -1026,7 +1023,6 @@ partition "part-1" {
     policy = "write"
   }
     policy = "write"
-    acl = "write"
     service_prefix "" {
       policy = "write"
       intentions = "write"
@@ -1051,8 +1047,8 @@ partition "part-1" {
     policy = "write"
   }
   namespace_prefix "" {
-    policy = "write"
     acl = "write"
+    policy = "write"
     service_prefix "" {
       policy = "write"
       intentions = "write"

--- a/control-plane/subcommand/server-acl-init/rules_test.go
+++ b/control-plane/subcommand/server-acl-init/rules_test.go
@@ -917,7 +917,31 @@ func TestInjectRules(t *testing.T) {
   }`,
 		},
 		{
-			EnableNamespaces: true,
+			EnableNamespaces: false,
+			EnablePartitions: true,
+			EnablePeering:    false,
+			PartitionName:    "part-1",
+			Expected: `
+partition "part-1" {
+  mesh = "write"
+  acl = "write"
+  node_prefix "" {
+    policy = "write"
+  }
+    policy = "write"
+    acl = "write"
+    service_prefix "" {
+      policy = "write"
+      intentions = "write"
+    }
+    identity_prefix "" {
+      policy = "write"
+      intentions = "write"
+    }
+}`,
+		},
+		{
+			EnableNamespaces: false,
 			EnablePartitions: false,
 			EnablePeering:    true,
 			Expected: `
@@ -928,7 +952,6 @@ func TestInjectRules(t *testing.T) {
   node_prefix "" {
     policy = "write"
   }
-  namespace_prefix "" {
     acl = "write"
     service_prefix "" {
       policy = "write"
@@ -937,8 +960,7 @@ func TestInjectRules(t *testing.T) {
     identity_prefix "" {
       policy = "write"
       intentions = "write"
-    }
-  }`,
+    }`,
 		},
 		{
 			EnableNamespaces: true,
@@ -964,6 +986,55 @@ partition "part-1" {
       intentions = "write"
     }
   }
+}`,
+		},
+		{
+			EnableNamespaces: true,
+			EnablePartitions: false,
+			EnablePeering:    true,
+			Expected: `
+  mesh = "write"
+  operator = "write"
+  acl = "write"
+  peering = "write"
+  node_prefix "" {
+    policy = "write"
+  }
+  namespace_prefix "" {
+    acl = "write"
+    service_prefix "" {
+      policy = "write"
+      intentions = "write"
+    }
+    identity_prefix "" {
+      policy = "write"
+      intentions = "write"
+    }
+  }`,
+		},
+		{
+			EnableNamespaces: false,
+			EnablePartitions: true,
+			EnablePeering:    true,
+			PartitionName:    "part-1",
+			Expected: `
+partition "part-1" {
+  mesh = "write"
+  acl = "write"
+  peering = "write"
+  node_prefix "" {
+    policy = "write"
+  }
+    policy = "write"
+    acl = "write"
+    service_prefix "" {
+      policy = "write"
+      intentions = "write"
+    }
+    identity_prefix "" {
+      policy = "write"
+      intentions = "write"
+    }
 }`,
 		},
 		{


### PR DESCRIPTION
### Changes proposed in this PR ###  
Stop including a duplicate `acl = "write"` rule at the root level of the connect-inject ACL policy when namespaces are not enabled. The security patch in https://github.com/hashicorp/consul/pull/21908 led to the connect-injector being unable to start up as its ACL policy is rejected by Consul.

### How I've tested this PR ###
1. Expanded the test matrix to cover all possible flag combinations w/ current policy output
2. Fixed policy generation
3. Updated the test assertions to account for the bug fix, verifying that `acl = "write"` never appears twice at the root level of the policy with any combination of flags

### How I expect reviewers to test this PR ###
Review commit-by-commit observing the above 

### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 