### PR TITLE
Removed namespace from cluster role

### DIFF
--- a/charts/consul/templates/server-clusterrole.yaml
+++ b/charts/consul/templates/server-clusterrole.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "consul.fullname" . }}-server
-  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Remove namespace declaration from the ClusterRole in the helm chart

### How I've tested this PR ###
- Locally using helm install

### How I expect reviewers to test this PR ###
- Deploying consul the same as they used to and noticed no changes

### Checklist ###
- [X] Not needed - Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
