### PR TITLE
Net 12039 terminating gateway acl policy fix

### DIFF
--- a/.changelog/4468.txt
+++ b/.changelog/4468.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-control-plane: Fixed bug in TerminatingGateway controller workflow for handling AdminPartition enabled cluster ACL policies for associated TerminatingGateway services ([NET-12039](https://hashicorp.atlassian.net/browse/NET-12039)).
+control-plane: Fixed bug in TerminatingGateway controller workflow for handling AdminPartition enabled cluster ACL policies for associated TerminatingGateway services.
 ```

--- a/.changelog/4468.txt
+++ b/.changelog/4468.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+control-plane: Fixed bug in TerminatingGateway controller workflow for handling AdminPartition enabled cluster ACL policies for associated TerminatingGateway services ([NET-12039](https://hashicorp.atlassian.net/browse/NET-12039)).
+```

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1458,10 +1458,10 @@ server:
     #
     # Each object supports the following keys:
     #
-    # - `type` - Type of the volume, must be one of "configMap" or "secret". Case sensitive.
+    # - `type` - Type of the volume. Must be one of `configMap` or `secret`. Case sensitive.
     #
-    # - `name` - Name of the configMap or secret to be mounted. This also controls
-    #   the path that it is mounted to. The volume will be mounted to `/consul/userconfig/<name>`.
+    # - `name` - Name of the configMap or secret to mount. This specification also controls
+    #   the path it mounts to. The volume will be mounted to `/consul/userconfig/<name>`.
     #
     # The snapshot agent will not attempt to load any volumes passed in this stanza
     # @type: array<map>

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1438,9 +1438,9 @@ server:
     # @type: string
     caCert: null
 
-    # A list of extra environment variables to set on the snapshot agent specifically
-    # This could be used to configure credentials that the rest of the
-    # stateful set would not need access to, like GOOGLE_APPLICATION_CREDENTIALS
+    # A list of extra environment variables to set on the snapshot agent specifically.
+    # Use this parameter to configure credentials that the rest of the
+    # stateful set would not need access to, like `GOOGLE_APPLICATION_CREDENTIALS`.
     # @type: map
     extraEnvironmentVars: { }
 

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1444,9 +1444,9 @@ server:
     # @type: map
     extraEnvironmentVars: { }
 
-    # A list of extra volumes to mount onto the snapshot agent. This
-    # is useful for bringing in extra data that only the snapshot agent needs access
-    # to. Like storage credentials. The value of this should be a list of objects.
+    # A list of extra volumes to mount onto the snapshot agent. Use this block
+    # to include extra data that only the snapshot agent needs access
+    # to, such as storage credentials. This value should be a list of objects.
     #
     # Example:
     #

--- a/control-plane/controllers/configentries/configentry_controller.go
+++ b/control-plane/controllers/configentries/configentry_controller.go
@@ -90,6 +90,10 @@ type ConfigEntryController struct {
 	// `k8s-default` namespace.
 	NSMirroringPrefix string
 
+	// ConsulPartition indicates the Consul Admin Partition name the controller is
+	// operating in. Adds this value as metadata on managed resources.
+	ConsulPartition string
+
 	// CrossNSACLPolicy is the name of the ACL policy to attach to
 	// any created Consul namespaces to allow cross namespace service discovery.
 	// Only necessary if ACLs are enabled.

--- a/control-plane/controllers/configentries/configentry_controller.go
+++ b/control-plane/controllers/configentries/configentry_controller.go
@@ -90,8 +90,8 @@ type ConfigEntryController struct {
 	// `k8s-default` namespace.
 	NSMirroringPrefix string
 
-	// ConsulPartition indicates the Consul Admin Partition name the controller is
-	// operating in. Adds this value as metadata on managed resources.
+	// ConsulPartition specifies the name of the Consul admin partition the controller
+	// operates in. Adds this value as metadata on managed resources.
 	ConsulPartition string
 
 	// CrossNSACLPolicy is the name of the ACL policy to attach to

--- a/control-plane/controllers/configentries/configentry_controller_test.go
+++ b/control-plane/controllers/configentries/configentry_controller_test.go
@@ -32,7 +32,10 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 )
 
-const datacenterName = "datacenter"
+const (
+	partitionName  = "default"
+	datacenterName = "datacenter"
+)
 
 type testReconciler interface {
 	Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error)
@@ -73,6 +76,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
+						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -107,6 +111,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
+						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -138,6 +143,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
+						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -169,6 +175,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
+						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -213,6 +220,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
+						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -253,6 +261,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
+						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -332,6 +341,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
+						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -381,6 +391,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
+						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -421,6 +432,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
+						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -460,6 +472,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
+						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -513,6 +526,7 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
+						ConsulPartition:     partitionName,
 					},
 				}
 			},

--- a/control-plane/controllers/configentries/configentry_controller_test.go
+++ b/control-plane/controllers/configentries/configentry_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
 	"testing"
 	"time"
 
@@ -33,10 +32,7 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 )
 
-const (
-	partitionName  = "default"
-	datacenterName = "datacenter"
-)
+const datacenterName = "datacenter"
 
 type testReconciler interface {
 	Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error)
@@ -77,7 +73,6 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
-						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -112,7 +107,6 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
-						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -144,7 +138,6 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
-						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -176,7 +169,6 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
-						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -221,7 +213,6 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
-						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -262,7 +253,6 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
-						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -342,7 +332,6 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
-						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -392,7 +381,6 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
-						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -433,7 +421,6 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
-						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -473,7 +460,6 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
-						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -527,7 +513,6 @@ func TestConfigEntryControllers_createsConfigEntry(t *testing.T) {
 						ConsulClientConfig:  cfg,
 						ConsulServerConnMgr: watcher,
 						DatacenterName:      datacenterName,
-						ConsulPartition:     partitionName,
 					},
 				}
 			},
@@ -1626,9 +1611,9 @@ func TestConfigEntryControllers_errorUpdatesSyncStatus(t *testing.T) {
 	})
 	req.Error(err)
 
-	expErr := fmt.Sprintf("Get \"http://127.0.0.1:%d/v1/config/%s/%s.*\": dial tcp 127.0.0.1:%d: connect: connection refused",
+	expErr := fmt.Sprintf("Get \"http://127.0.0.1:%d/v1/config/%s/%s\": dial tcp 127.0.0.1:%d: connect: connection refused",
 		testClient.Cfg.HTTPPort, capi.ServiceDefaults, svcDefaults.ConsulName(), testClient.Cfg.HTTPPort)
-	req.Regexp(regexp.MustCompile(expErr), err.Error())
+	req.Contains(err.Error(), expErr)
 	req.False(resp.Requeue)
 
 	// Check that the status is "synced=false".
@@ -1637,7 +1622,7 @@ func TestConfigEntryControllers_errorUpdatesSyncStatus(t *testing.T) {
 	status, reason, errMsg := svcDefaults.SyncedCondition()
 	req.Equal(corev1.ConditionFalse, status)
 	req.Equal("ConsulAgentError", reason)
-	req.Regexp(regexp.MustCompile(expErr), errMsg)
+	req.Contains(errMsg, expErr)
 }
 
 // Test that if the config entry hasn't changed in Consul but our resource

--- a/control-plane/controllers/configentries/terminatinggateway_controller.go
+++ b/control-plane/controllers/configentries/terminatinggateway_controller.go
@@ -61,6 +61,7 @@ var (
 	servicePolicyRulesTpl = `
 {{- if .EnablePartitions }}
 partition "{{.Partition}}" {
+{{- end }}
 {{- if .EnableNamespaces }}
   namespace "{{.Namespace}}" {
 {{- end }}
@@ -71,6 +72,7 @@ partition "{{.Partition}}" {
 {{- if .EnableNamespaces }}
   }
 {{- end }}
+{{- if .EnablePartitions }}
 }
 {{- end }}
 `
@@ -79,6 +81,7 @@ partition "{{.Partition}}" {
 	wildcardPolicyRulesTpl = `
 {{- if .EnablePartitions }}
 partition "{{.Partition}}" {
+{{- end }}
 {{- if .EnableNamespaces }}
   namespace "{{.Namespace}}" {
 {{- end }}
@@ -89,6 +92,7 @@ partition "{{.Partition}}" {
 {{- if .EnableNamespaces }}
   }
 {{- end }}
+{{- if .EnablePartitions }}
 }
 {{- end }}
 `

--- a/control-plane/subcommand/inject-connect/v1controllers.go
+++ b/control-plane/subcommand/inject-connect/v1controllers.go
@@ -187,6 +187,7 @@ func (c *Command) configureControllers(ctx context.Context, mgr manager.Manager,
 		ConsulDestinationNamespace: c.flagConsulDestinationNamespace,
 		EnableNSMirroring:          c.flagEnableK8SNSMirroring,
 		NSMirroringPrefix:          c.flagK8SNSMirroringPrefix,
+		ConsulPartition:            c.consul.Partition,
 		CrossNSACLPolicy:           c.flagCrossNamespaceACLPolicy,
 	}
 	if err := (&controllers.ServiceDefaultsController{
@@ -275,6 +276,7 @@ func (c *Command) configureControllers(ctx context.Context, mgr manager.Manager,
 		Client:                mgr.GetClient(),
 		Log:                   ctrl.Log.WithName("controller").WithName(apicommon.TerminatingGateway),
 		NamespacesEnabled:     c.flagEnableNamespaces,
+		PartitionsEnabled:     c.flagEnablePartitions,
 		Scheme:                mgr.GetScheme(),
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", apicommon.TerminatingGateway)


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Introduce handling of Consul AdminPartition ACL policy rules when `global.adminPartitions.enabled: true`

Current workflow requires end users to manually update the Terminating Gateway policies applied by the TerminatingGateway resource controller when AdminPartitions are enabled from:

```hcl
namespace "default" {
  service_prefix "" {
    policy = "write"
  }
}
```

to

```hcl
partition "default" {
  namespace "default" {
    service_prefix "" {
      policy    = "write"
      intention = "read"
    }
  }
}
```

### How I've tested this PR ###
- Clone [consul-k8s](https://github.com/hashicorp/consul-k8s.git) repository to $HOME/HashiCorp/consul-k8s
- Apply this branch's commits to locally cloned repo.
- Using https://github.com/hashicorp-support/consul-k3d-multicluster 
  - From this repo, run `make install-dev` to deploy dev image with changes
- Verify the desired results of Consul ACL TerminatingGateway generated policies:

# Test Matrix for ACL Policies and Admin Partitions with Terminating Gateway

| **Test Case**                     | **Admin Partitions Enabled** | **Partition Name** | **Service Type**     | **Expected ACL Policy**                                                                                                   |
|-----------------------------------|------------------------------|---------------------|-----------------------|--------------------------------------------------------------------------------------------------------------------------|
| Default Partition, Wildcard       | Yes                          | default             | Wildcard (`*`)        | `partition "default" { namespace "default" { service_prefix "" { policy = "write"; intention = "read"; } } }`            |
| Default Partition, Specific       | Yes                          | default             | Specific (`static-server`) | `partition "default" { namespace "default" { service "static-server" { policy = "write"; intention = "read"; } } }`      |
| Non-Default Partition, Wildcard   | Yes                          | dev                 | Wildcard (`*`)        | `partition "dev" { namespace "default" { service_prefix "" { policy = "write"; intention = "read"; } } }`                |
| Non-Default Partition, Specific   | Yes                          | dev                 | Specific (`static-server`) | `partition "dev" { namespace "default" { service "static-server" { policy = "write"; intention = "read"; } } }`          |
| No Partition, Wildcard            | No                           | N/A                 | Wildcard (`*`)        | `namespace "default" { service_prefix "" { policy = "write"; intention = "read"; } }`                                    |
| No Partition, Specific            | No                           | N/A                 | Specific (`static-server`) | `namespace "default" { service "static-server" { policy = "write"; intention = "read"; } }`                              |



### How I expect reviewers to test this PR ###
👀 


### Checklist ###
- [] Tests added
- [X] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
