### PR TITLE
[NET-11567] Update Helm Chart to allow snapshotagent to support extraVolumes and extraEnvionmentVars

### DIFF
--- a/.changelog/4471.txt
+++ b/.changelog/4471.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+helm: Add support for `server.snapshotAgent.extraVolumes` and `server.snapshotAgent.extraEnvironmentVars` so privileged credentials can be configured for the snapshot agent.
+```

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -315,6 +315,22 @@ spec:
             {{- end }}
             {{- end }}
         {{- end }}
+        {{- range .Values.server.snapshotAgent.extraVolumes }}
+        - name: userconfig-snapshot-{{ .name }}
+          {{ .type }}:
+            {{- if (eq .type "configMap") }}
+            name: {{ .name }}
+            {{- else if (eq .type "secret") }}
+            secretName: {{ .name }}
+            {{- end }}
+            {{- with .items }}
+            items:
+            {{- range . }}
+            - key: {{.key}}
+              path: {{.path}}
+            {{- end }}
+            {{- end }}
+        {{- end }}
       {{- if .Values.server.priorityClassName }}
       priorityClassName: {{ .Values.server.priorityClassName | quote }}
       {{- end }}
@@ -686,6 +702,7 @@ spec:
               value: /consul/license/{{ .Values.global.enterpriseLicense.secretKey }}
               {{- end }}
             {{- end }}
+            {{- include "consul.extraEnvironmentVars" .Values.server.snapshotAgent | nindent 12 }}
           command:
             - "/bin/sh"
             - "-ec"
@@ -732,6 +749,11 @@ spec:
             - name: consul-ca-cert
               mountPath: /consul/tls/ca
               readOnly: true
+            {{- end }}
+            {{- range .Values.server.snapshotAgent.extraVolumes }}
+            - name: userconfig-snapshot-{{ .name }}
+              readOnly: true
+              mountPath: /consul/userconfig/{{ .name }}
             {{- end }}
           {{- with .Values.server.snapshotAgent.resources }}
           resources:

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1438,6 +1438,35 @@ server:
     # @type: string
     caCert: null
 
+    # A list of extra environment variables to set on the snapshot agent specifically
+    # This could be used to configure credentials that the rest of the
+    # stateful set would not need access to, like GOOGLE_APPLICATION_CREDENTIALS
+    # @type: map
+    extraEnvironmentVars: { }
+
+    # A list of extra volumes to mount onto the snapshot agent. This
+    # is useful for bringing in extra data that only the snapshot agent needs access
+    # to. Like storage credentials. The value of this should be a list of objects.
+    #
+    # Example:
+    #
+    # ```yaml
+    # extraVolumes:
+    #   - type: secret
+    #     name: storage-credentials
+    # ```
+    #
+    # Each object supports the following keys:
+    #
+    # - `type` - Type of the volume, must be one of "configMap" or "secret". Case sensitive.
+    #
+    # - `name` - Name of the configMap or secret to be mounted. This also controls
+    #   the path that it is mounted to. The volume will be mounted to `/consul/userconfig/<name>`.
+    #
+    # The snapshot agent will not attempt to load any volumes passed in this stanza
+    # @type: array<map>
+    extraVolumes: [ ]
+
   # [Enterprise Only] Added in Consul 1.8, the audit object allow users to enable auditing
   # and configure a sink and filters for their audit logs. Please refer to
   # [audit logs](https://developer.hashicorp.com/consul/docs/enterprise/audit-logging) documentation


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Add support for server.snapshotAgent.extraEnvironment and server.snapshotAgent.extraVolume in the helm chart to allow for configuring google application credentials 

### How I've tested this PR ###
- Running locally against a kind cluster with the snapshot agent configured to point at a google bucket

Using the following config

Google application credentials loaded into cluster with the following secret name/secret key
```
   name: snapshot-agent-google-app-creds
   key: creds.json
```

configSecret
```
kubectl create secret generic snapshot-config --from-file=snapshot-agent=<path-to-config-below>/snapshotagentconfig.yaml
```

```
{
  "snapshot_agent": {
    "http_addr": "127.0.0.1:8500",
    "token": "",
    "datacenter": "",
    "ca_file": "",
    "ca_path": "",
    "cert_file": "",
    "key_file": "",
    "license_path": "",
    "tls_server_name": "",
    "login": {
      "auth_method": "",
      "bearer_token": "",
      "bearer_token_file": "",
      "meta": {}
    },
    "log": {
      "level": "INFO",
      "enable_syslog": false,
      "syslog_facility": "LOCAL0"
    },
    "snapshot": {
      "interval": "5m",
      "retain": 30,
      "stale": false,
      "service": "consul-snapshot",
      "deregister_after": "76h",
      "lock_key": "consul-snapshot/lock",
      "max_failures": 3,
      "local_scratch_path": "/home/consul"
    },
    "backup_destinations": {
      "google_storage": [
        {
          "bucket": "snapshot-test-bucket-2-4-2025"
        }
      ]
    }
  }
}
```

config.yaml 
```
---
global:
  image: 'hashicorp/consul-enterprise:1.20.0-ent'
  enterpriseLicense:
    secretName: 'consul-ent-license'
    secretKey: 'key'

server:
  snapshotAgent:
    enabled: true
    interval: "30s"
    fakevalue: false
    configSecret:
      secretName: snapshot-config
      secretKey: snapshot-agent
    extraEnvironmentVars:
      GOOGLE_APPLICATION_CREDENTIALS: /consul/userconfig/snapshot-agent-google-app-creds/creds.json
    extraVolumes:
      - type: secret
        name: snapshot-agent-google-app-creds
```

<img width="1201" alt="Screenshot 2025-02-04 at 3 22 34 PM" src="https://github.com/user-attachments/assets/651dae9a-35d4-4b84-bf3d-735dabdbc59f" />
<img width="883" alt="Screenshot 2025-02-04 at 3 22 51 PM" src="https://github.com/user-attachments/assets/eff26204-af41-4b63-9226-a5fa717c2fa8" />


### How I expect reviewers to test this PR ###
- Read and verify screenshots


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
