### PR TITLE
Allow for Downward API Based Extra Environment Variables

### DIFF
--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -234,7 +234,12 @@ Inject extra environment vars in the format key:value, if populated
 {{- if .extraEnvironmentVars -}}
 {{- range $key, $value := .extraEnvironmentVars }}
 - name: {{ $key }}
+{{- if kindIs "map" $value }}
+  valueFrom:
+    {{- $value | toYaml | nindent 4 }}
+{{- else }}
   value: {{ $value | quote }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -1254,6 +1254,7 @@ load _helpers
       --set 'client.enabled=true' \
       --set 'client.extraEnvironmentVars.custom_proxy=fakeproxy' \
       --set 'client.extraEnvironmentVars.no_proxy=custom_no_proxy' \
+      --set "client.extraEnvironmentVars.from_annotations.fieldRef.fieldPath=metadata.annotations['foo']" \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
@@ -1264,6 +1265,10 @@ load _helpers
   local actual=$(echo $object |
       yq -r '.[] | select(.name=="no_proxy").value' | tee /dev/stderr)
   [ "${actual}" = "custom_no_proxy" ]
+
+  local actual=$(echo $object |
+      yq -r '.[] | select(.name=="from_annotations").valueFrom.fieldRef.fieldPath' | tee /dev/stderr)
+  [ "${actual}" = "metadata.annotations['foo']" ]
 }
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Update the `extraEnvironmentVars` helper to support map values that can be passed to the [`env.valueFrom (EnvVarSource)`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) key.

### How I've tested this PR ###
- Updated the existing `bats` unit test.
- We are currently running this change in our environment.

### How I expect reviewers to test this PR ###
- Pass a valid `valueFrom` definition 

### Checklist ###
- [X] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
