### PR TITLE
Backport of PSA Acceptance Tests into release/1.7.x

### DIFF
--- a/acceptance/tests/api-gateway/api_gateway_external_servers_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_external_servers_test.go
@@ -120,7 +120,7 @@ func TestAPIGateway_ExternalServers(t *testing.T) {
 	})
 
 	k8sOptions := ctx.KubectlOptions(t)
-	targetAddress := fmt.Sprintf("http://%s/", gatewayAddress)
+	targetAddress := fmt.Sprintf("http://%s:8080/", gatewayAddress)
 
 	// check that intentions keep our connection from happening
 	k8s.CheckStaticServerHTTPConnectionFailing(t, k8sOptions, StaticClientName, targetAddress)

--- a/acceptance/tests/api-gateway/api_gateway_kitchen_sink_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_kitchen_sink_test.go
@@ -187,7 +187,7 @@ func TestAPIGateway_KitchenSink(t *testing.T) {
 
 	// finally we check that we can actually route to the service(s) via the gateway
 	k8sOptions := ctx.KubectlOptions(t)
-	targetHTTPAddress := fmt.Sprintf("http://%s/v1", gatewayAddress)
+	targetHTTPAddress := fmt.Sprintf("http://%s:8080/v1", gatewayAddress)
 
 	// Now we create the allow intention.
 	_, _, err = consulClient.ConfigEntries().Set(&api.ServiceIntentionsConfigEntry{

--- a/acceptance/tests/api-gateway/api_gateway_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_test.go
@@ -37,7 +37,8 @@ const (
 // Test that api gateway basic functionality works in a default installation and a secure installation.
 func TestAPIGateway_Basic(t *testing.T) {
 	cases := []struct {
-		secure bool
+		secure                   bool
+		restrictedPSAEnforcement bool
 	}{
 		{
 			secure: false,
@@ -45,12 +46,26 @@ func TestAPIGateway_Basic(t *testing.T) {
 		{
 			secure: true,
 		},
+		// There is an argument that all tests should be run in a restricted PSA namespace
+		// However we are on a time crunch and don't want to make sweeping changes to the test suite
+		{
+			secure:                   true,
+			restrictedPSAEnforcement: true,
+		},
+		{
+			secure:                   false,
+			restrictedPSAEnforcement: true,
+		},
 	}
 	for _, c := range cases {
-		name := fmt.Sprintf("secure: %t", c.secure)
+		name := fmt.Sprintf("secure: %t restrictedPSAEnforcement: %t", c.secure, c.restrictedPSAEnforcement)
 		t.Run(name, func(t *testing.T) {
 			ctx := suite.Environment().DefaultContext(t)
 			cfg := suite.Config()
+			if cfg.EnableTransparentProxy && c.restrictedPSAEnforcement && !cfg.EnableCNI {
+				t.Skipf("skipping because -enable-transparent-proxy is set and -enable-cni is not and tproxy cannot run in restrictedPSA without CNI enabled")
+			}
+
 			helmValues := map[string]string{
 				"connectInject.enabled":        "true",
 				"global.acls.manageSystemACLs": strconv.FormatBool(c.secure),
@@ -62,6 +77,30 @@ func TestAPIGateway_Basic(t *testing.T) {
 			consulCluster := consul.NewHelmCluster(t, helmValues, ctx, cfg, releaseName)
 
 			consulCluster.Create(t)
+
+			if c.restrictedPSAEnforcement {
+				//enable PSA enforcment for some tests
+				k8s.RunKubectl(t, ctx.KubectlOptions(t), "label", "--overwrite", "ns", ctx.KubectlOptions(t).Namespace,
+					"pod-security.kubernetes.io/enforce=restricted",
+				)
+
+				if cfg.EnableCNI {
+					helmValues["connectInject.cni.namespace"] = "cni-namespace"
+					//create namespace for CNI. CNI pods require NET_ADMIN so the need to run in a non PSA restricted namespace.
+					k8s.RunKubectl(t, ctx.KubectlOptions(t), "create", "namespace", "cni-namespace")
+				}
+			}
+			helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
+				if c.restrictedPSAEnforcement {
+					//reset namespace
+					k8s.RunKubectl(t, ctx.KubectlOptions(t), "label", "--overwrite", "ns", ctx.KubectlOptions(t).Namespace,
+						"pod-security.kubernetes.io/enforce=privileged",
+					)
+					if cfg.EnableCNI {
+						k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "namespace", "cni-namespace")
+					}
+				}
+			})
 
 			// Override the default proxy config settings for this test
 			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
@@ -208,6 +247,7 @@ func TestAPIGateway_Basic(t *testing.T) {
 			require.Len(t, tcpRoute.Status.Parents, 1)
 			require.EqualValues(t, gatewayClassControllerName, tcpRoute.Status.Parents[0].ControllerName)
 			require.EqualValues(t, "gateway", tcpRoute.Status.Parents[0].ParentRef.Name)
+
 			checkStatusCondition(t, tcpRoute.Status.Parents[0].Conditions, trueCondition("Accepted", "Accepted"))
 			checkStatusCondition(t, tcpRoute.Status.Parents[0].Conditions, trueCondition("ResolvedRefs", "ResolvedRefs"))
 			checkStatusCondition(t, tcpRoute.Status.Parents[0].Conditions, trueCondition("ConsulAccepted", "Accepted"))
@@ -239,9 +279,10 @@ func TestAPIGateway_Basic(t *testing.T) {
 
 			// finally we check that we can actually route to the service via the gateway
 			k8sOptions := ctx.KubectlOptions(t)
-			targetHTTPAddress := fmt.Sprintf("http://%s", gatewayAddress)
-			targetHTTPSAddress := fmt.Sprintf("https://%s", gatewayAddress)
-			targetTCPAddress := fmt.Sprintf("http://%s:81", gatewayAddress)
+			//we have to account for port mapping inside the cluster.
+			targetHTTPAddress := fmt.Sprintf("http://%s:8080", gatewayAddress)
+			targetHTTPSAddress := fmt.Sprintf("https://%s:8443", gatewayAddress)
+			targetTCPAddress := fmt.Sprintf("http://%s:8081", gatewayAddress)
 
 			if c.secure {
 				// check that intentions keep our connection from happening
@@ -543,13 +584,13 @@ func TestAPIGateway_JWTAuth_Basic(t *testing.T) {
 
 	// finally we check that we can actually route to the service(s) via the gateway
 	k8sOptions := ctx.KubectlOptions(t)
-	targetHTTPAddress := fmt.Sprintf("http://%s/v1", gatewayAddress)
-	targetHTTPAddressAdmin := fmt.Sprintf("http://%s:8081/admin", gatewayAddress)
-	targetHTTPAddressPet := fmt.Sprintf("http://%s:8081/pet", gatewayAddress)
-	targetHTTPAddressAdmin2 := fmt.Sprintf("http://%s:8081/admin-2", gatewayAddress)
-	targetHTTPAddressPet2 := fmt.Sprintf("http://%s:8081/pet-2", gatewayAddress)
-	targetHTTPAddressAdminNoAuthOnRoute := fmt.Sprintf("http://%s:8081/admin-no-auth", gatewayAddress)
-	targetHTTPAddressPetNotAuthOnRoute := fmt.Sprintf("http://%s:8081/pet-no-auth", gatewayAddress)
+	targetHTTPAddress := fmt.Sprintf("http://%s:8080/v1", gatewayAddress)
+	targetHTTPAddressAdmin := fmt.Sprintf("http://%s:8083/admin", gatewayAddress)
+	targetHTTPAddressPet := fmt.Sprintf("http://%s:8083/pet", gatewayAddress)
+	targetHTTPAddressAdmin2 := fmt.Sprintf("http://%s:8083/admin-2", gatewayAddress)
+	targetHTTPAddressPet2 := fmt.Sprintf("http://%s:8083/pet-2", gatewayAddress)
+	targetHTTPAddressAdminNoAuthOnRoute := fmt.Sprintf("http://%s:8083/admin-no-auth", gatewayAddress)
+	targetHTTPAddressPetNotAuthOnRoute := fmt.Sprintf("http://%s:8083/pet-no-auth", gatewayAddress)
 
 	// Now we create the allow intention.
 	_, _, err = consulClient.ConfigEntries().Set(&api.ServiceIntentionsConfigEntry{

--- a/acceptance/tests/fixtures/bases/api-gateway/gatewayclassconfig.yaml
+++ b/acceptance/tests/fixtures/bases/api-gateway/gatewayclassconfig.yaml
@@ -5,3 +5,6 @@ apiVersion: consul.hashicorp.com/v1alpha1
 kind: GatewayClassConfig
 metadata:
   name: gateway-class-config
+spec:
+  # In order for Gateways to work whether or not we're enforcing the "restricted" pod security policy, they must not used privileged ports
+  mapPrivilegedContainerPorts: 8000

--- a/acceptance/tests/fixtures/bases/static-client/deployment.yaml
+++ b/acceptance/tests/fixtures/bases/static-client/deployment.yaml
@@ -18,6 +18,17 @@ spec:
     spec:
       containers:
         - name: static-client
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              add:
+                - "NET_BIND_SERVICE"
+              drop:
+                - ALL
           image: docker.mirror.hashicorp.services/buildpack-deps:jammy-curl
           command: [ "/bin/sh", "-c", "--" ]
           args: [ "while true; do sleep 30; done;" ]

--- a/acceptance/tests/fixtures/bases/static-server-https/deployment.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-https/deployment.yaml
@@ -18,6 +18,17 @@ spec:
       containers:
         - name: caddy
           image: caddy:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              add:
+                - "NET_BIND_SERVICE"
+              drop:
+                - ALL
           ports:
             - name: https-port
               containerPort: 443

--- a/acceptance/tests/fixtures/bases/static-server-tcp/deployment.yaml
+++ b/acceptance/tests/fixtures/bases/static-server-tcp/deployment.yaml
@@ -22,6 +22,17 @@ spec:
       containers:
         - name: static-server
           image: docker.mirror.hashicorp.services/kschoche/http-echo:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              add:
+                - "NET_BIND_SERVICE"
+              drop:
+                - ALL
           args:
             - -text="hello world"
             - -listen=:8080

--- a/acceptance/tests/fixtures/bases/static-server/deployment.yaml
+++ b/acceptance/tests/fixtures/bases/static-server/deployment.yaml
@@ -21,6 +21,17 @@ spec:
           # Using alpine vs latest as there is a build issue with M1s. Also other tests in multiport-app reference
           # alpine so standardizing this.
           image: docker.mirror.hashicorp.services/hashicorp/http-echo:alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              add:
+                - "NET_BIND_SERVICE"
+              drop:
+                - ALL
           args:
             - -text="hello world"
             - -listen=:8080

--- a/acceptance/tests/fixtures/cases/api-gateways/jwt-auth/api-gateway.yaml
+++ b/acceptance/tests/fixtures/cases/api-gateways/jwt-auth/api-gateway.yaml
@@ -9,13 +9,13 @@ spec:
   gatewayClassName: gateway-class
   listeners:
   - protocol: HTTP
-    port: 8081
+    port: 83
     name: http-auth
     allowedRoutes:
       namespaces:
         from: "All"
   - protocol: HTTP
-    port: 8082
+    port: 84
     name: http-invalid-attach
     allowedRoutes:
       namespaces:

--- a/acceptance/tests/fixtures/cases/static-server-inject/patch.yaml
+++ b/acceptance/tests/fixtures/cases/static-server-inject/patch.yaml
@@ -14,6 +14,17 @@ spec:
       containers:
         - name: static-server
           image: docker.mirror.hashicorp.services/kschoche/http-echo:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              add:
+                - "NET_BIND_SERVICE"
+              drop:
+                - ALL
           args:
             - -text="hello world"
             - -listen=:8080

--- a/acceptance/tests/partitions/partitions_gateway_test.go
+++ b/acceptance/tests/partitions/partitions_gateway_test.go
@@ -259,7 +259,7 @@ func TestPartitions_Gateway(t *testing.T) {
 		gatewayAddress = gateway.Status.Addresses[0].Value
 	})
 
-	targetAddress := fmt.Sprintf("http://%s/", gatewayAddress)
+	targetAddress := fmt.Sprintf("http://%s:8080/", gatewayAddress)
 
 	// This section of the tests runs the in-partition networking tests.
 	t.Run("in-partition", func(t *testing.T) {

--- a/acceptance/tests/peering/peering_gateway_test.go
+++ b/acceptance/tests/peering/peering_gateway_test.go
@@ -276,7 +276,7 @@ func TestPeering_Gateway(t *testing.T) {
 		gatewayAddress = gateway.Status.Addresses[0].Value
 	})
 
-	targetAddress := fmt.Sprintf("http://%s/", gatewayAddress)
+	targetAddress := fmt.Sprintf("http://%s:8080/", gatewayAddress)
 
 	logger.Log(t, "creating local service resolver")
 	k8s.KubectlApplyK(t, staticClientOpts, "../fixtures/cases/api-gateways/peer-resolver")

--- a/acceptance/tests/wan-federation/wan_federation_gateway_test.go
+++ b/acceptance/tests/wan-federation/wan_federation_gateway_test.go
@@ -208,7 +208,7 @@ func checkConnectivity(t *testing.T, ctx environment.TestContext, client *api.Cl
 		gatewayAddress = gateway.Status.Addresses[0].Value
 	})
 
-	targetAddress := fmt.Sprintf("http://%s/", gatewayAddress)
+	targetAddress := fmt.Sprintf("http://%s:8080/", gatewayAddress)
 
 	logger.Log(t, "checking that the connection is not successful because there's no intention")
 	k8s.CheckStaticServerHTTPConnectionFailing(t, ctx.KubectlOptions(t), connhelper.StaticClientName, targetAddress)

--- a/control-plane/connect-inject/webhook/container_init.go
+++ b/control-plane/connect-inject/webhook/container_init.go
@@ -254,6 +254,9 @@ func (w *MeshWebhook) containerInit(namespace corev1.Namespace, pod corev1.Pod, 
 			}
 
 			container.SecurityContext = &corev1.SecurityContext{
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 				RunAsUser:    ptr.To(uid),
 				RunAsGroup:   ptr.To(group),
 				RunAsNonRoot: ptr.To(true),

--- a/control-plane/connect-inject/webhook/container_init_test.go
+++ b/control-plane/connect-inject/webhook/container_init_test.go
@@ -296,6 +296,9 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 			var expectedSecurityContext *corev1.SecurityContext
 			if c.cniEnabled && !c.openShiftEnabled {
 				expectedSecurityContext = &corev1.SecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
 					RunAsUser:    ptr.To(int64(initContainersUserAndGroupID)),
 					RunAsGroup:   ptr.To(int64(initContainersUserAndGroupID)),
 					RunAsNonRoot: ptr.To(true),
@@ -319,6 +322,9 @@ func TestHandlerContainerInit_transparentProxy(t *testing.T) {
 			} else if c.cniEnabled && c.openShiftEnabled {
 				// When cni + openShift
 				expectedSecurityContext = &corev1.SecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
 					RunAsUser:    ptr.To(int64(1000799999)),
 					RunAsGroup:   ptr.To(int64(1000799999)),
 					RunAsNonRoot: ptr.To(true),


### PR DESCRIPTION
The below text is copied from the body of the original PR.

---

### Changes proposed in this PR ###  
- Added acceptance test for running api gateway in PSA environment
- Added SecCompProfileUserType to connect inject container when CNI and TProxy are enabled
- Connect Inject will not run when tproxy is enabled because of additional permisions that are required 

### How I've tested this PR ###
- CI passes
- Local running of the acceptance tests

### How I expect reviewers to test this PR ###
CI Passes

### Checklist ###
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


---

<details>
<summary> Overview of commits </summary>

  - bd770c6076ad51d5ee15b4f8a8ec0afeae1c6641  - dd06d2268d3b6b50a3cbf4a73099d76b34bf7e1c  - 459ab518f5444e703a7b72826afa113f56e547f0  - c331e8521e17cc9610e804329e80c92ab3205f7f  - 7e44e0bf1a063009661e3902b39abcdd54d7a664  - 1a8fa75a49c0675d1e4b97ccd23830d7d345066f  - 038b15c8a433a01d39b891d1c31eefac544d4fa1  - b548bf687df1d98422275392cb8e826eaa258ed0  - 5113be981947baa543c97d4e456fd0d71b758867  - 52c54aff9865933d15645ceeddfbab16c8360cfb  - 9bb22e6b922d052165b7e89abd5963d5bebf2781  - 08016dfc17c27d2d04f1d258cf00642aa7cd844c  - d4670e8e3ab3c3f08faa291c975496400e7c621c  - e27f1a1a70e5331bb2979e77e9e61a74c8f142ab  - daab73a641c16844596bf288dccccc547a09281d  - 06c8a3afff504ccbf78b18b93c66235ba0d1fb69  - f6f8231de82759aae3f0b872807b3ec03c4153be  - 192383c104815939342588cc4e4a993e28b763d0  - 78a51c8dc34b3c41d33963f87ece50c961fea856  - 7ab629979d558a013755fabde46e72e9affa2d1c  - 6fcdf534105f668e322d1013fae64f4aaee76fe6  - 0432f87c17707a0db1dacfd0e76612de71bcd0b1  - 88b77127890470509bf4fdcc005475eb56bcbfbd  - 452b2e57885fec13f570defcd31c23cc122bab7b  - 613426ec1b692f6422d97d1b3ad19dc409f695f0  - 9158a8c75db7a419fc6c15fbf9def3db40507119  - 1c6ad113492ee05e548e21955fe0d378afea4446  - 66333401550ce51f2d2b5dc0d087948b2d042963  - e5a759532fad74ff238989a82cc6da3b21d410b9  - b42e03550b9560b073de87a291ca0bd8af4b1912  - 40c4edd1b5577c9fffedba8f023faed70594e356  - 456f6b96cb61dda96c2946f60d0d5b39e2535ae5  - 04a89f1b769a64b28050a45f9f9ae3d55dc14ed4  - 88044fe9fe1243bb309430a306bef0609e68f324  - e1b275c60b420594eb2dd8f29c12aa809303c3f1  - 7ad15bf575e766656e8223764a6433a6794c02c9  - 72c54581d51dbb1eca17a8c2dc874b0573900ea0  - 7bfab681d7ddb0adf67e9afce38e1064ecb30358  - d13a4c3313c1eb1042bcd71b8036c48e905c47c5  - 3eca28c374af9267f3d87de80a313cc1f95a3471  - 808fa4ebc5b65057a8075215fc6af61b2c1dba2b  - 80ab44ba4a87cded14967666b0df377344f72d5d  - f64b8da2cb84b689dceccda62ff9c3f01c2146a9  - 106bbfc893a2a5c6e6308dfc5eb34440a574f711  - b0fc82ee321e814ef62cf07c14c550ecdd8c6353  - a51644af047d953f5b6d0e3b6e5f683a905eaccf  - 4600a16e29b45d48c57f0b2fcb3ec51d605fa06d  - 7eb06d575f916723d2fda64bd2a35e446d553ee6  - 8b30527e6649f947da5e497150bb912161f7fc53  - cd7b90906ce23a2098f8f1382a856fe45c3b4ae4  - 41738d07fc7c923c7988e8177b6318340b2c7283  - a0d83e5c43e986a4986569d0eb6fba34fd2581ba  - c5eafb0876bfb950a440219d827e02de1bcda03c  - 61516c916ed52f30e94e068904e6c87294debeaf 

</details>