### PR TITLE
docs: update resource entry comments for CPU limits and production recs

### DIFF
--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1095,16 +1095,28 @@ server:
   #     cpu: '100m'
   # ```
   #
+  # -----------------------------------------------------------------------------------------
+  # Reference Architecture Recommendations (Production):
+  #
+  #   • Small clusters: 2–4 CPU cores, 8–16 GB RAM
+  #   • Large clusters: 8–16 CPU cores, 32–64 GB RAM
+  #
+  # The defaults below (200Mi memory, 100m CPU) remain suitable for demo or dev/test.
+  # For a production environment, size the requests/limits to align with the above guidelines.
+  # -----------------------------------------------------------------------------------------
   # @recurse: false
   # @type: map
   resources:
     requests:
+      # Recommended production default: 8Gi (Small) | 32Gi (Large)
       memory: "200Mi"
+      # Recommended production default: 2 - 4 (Small) | 8 - 16 (Large)
       cpu: "100m"
     limits:
+      # Recommended production default: 16Gi (Small) | 64Gi (Large)
       memory: "200Mi"
-      cpu: "100m"
-
+      # Recommended production default: null
+      cpu: null
   # The security context for the server pods. This should be a YAML map corresponding to a
   # Kubernetes [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) object.
   # By default, servers will run as non-root, with user ID `100` and group ID `1000`,
@@ -2510,11 +2522,15 @@ connectInject:
       # @type: map
       resources:
         requests:
+          # Recommended production default: 4Gi
           memory: "100Mi"
+          # Recommended production default: 2000m
           cpu: "100m"
         limits:
+          # Recommended production default: 2Gi
           memory: "100Mi"
-          cpu: "100m"
+          # Recommended production default: null
+          cpu: null
 
       # This value defines the number of pods to deploy for each Gateway as well as a min and max number of pods for all Gateways
       deployment:
@@ -2770,23 +2786,28 @@ connectInject:
     # @type: string
     annotations: null
 
-  # The resource settings for connect inject pods. The defaults, are optimized for getting started worklows on developer deployments. The settings should be tweaked for production deployments.
+  # The resource settings for connect inject pods. Defaults are minimal for dev/test.
+  # -----------------------------------------------------------------------------------------
+  # Production Note:
+  # It is recommended to leave CPU limits set to 'null' in production for better
+  # performance under load.
+  # -----------------------------------------------------------------------------------------
   # @type: map
   resources:
     requests:
-      # Recommended production default: 500Mi
+      # Recommended production default: 2Gi
       # @type: string
       memory: "200Mi"
-      # Recommended production default: 250m
+      # Recommended production default: 2000m
       # @type: string
       cpu: "50m"
     limits:
-      # Recommended production default: 500Mi
+      # Recommended production default: 4Gi
       # @type: string
       memory: "200Mi"
-      # Recommended production default: 250m
+      # Recommended production default: null
       # @type: string
-      cpu: "50m"
+      cpu: null
 
   # Sets the failurePolicy for the mutating webhook. By default this will cause pods not part of the consul installation to fail scheduling while the webhook
   # is offline. This prevents a pod from skipping mutation if the webhook were to be momentarily offline.
@@ -2954,17 +2975,17 @@ connectInject:
     # @type: map
     resources:
       requests:
-        # Recommended production default: 100Mi
+        # Recommended production default: 2Gi
         # @type: string
         memory: null
-        # Recommended production default: 100m
+        # Recommended production default: 2000m
         # @type: string
         cpu: null
       limits:
-        # Recommended production default: 100Mi
+        # Recommended production default: 4Gi
         # @type: string
         memory: null
-        # Recommended production default: 100m
+        # Recommended production default: null
         # @type: string
         cpu: null
     # Set default lifecycle management configuration for sidecar proxy.
@@ -3148,15 +3169,23 @@ meshGateway:
   # The resource settings for mesh gateway pods.
   # NOTE: The use of a YAML string is deprecated. Instead, set directly as a
   # YAML map.
+  # -----------------------------------------------------------------------------------------
+  # Production Note:
+  # It is recommended to set CPU limits to 'null' for better runtime flexibility under load.
+  # -----------------------------------------------------------------------------------------
   # @recurse: false
   # @type: map
   resources:
     requests:
+      # Recommended production default: 2Gi
       memory: "100Mi"
+      # Recommended production default: 2000m
       cpu: "100m"
     limits:
+      # Recommended production default: 4i
       memory: "100Mi"
-      cpu: "100m"
+      # Recommended production default: null
+      cpu: null
 
   # The resource settings for the `service-init` init container.
   # @recurse: false
@@ -3315,11 +3344,15 @@ ingressGateways:
     # @type: map
     resources:
       requests:
+        # Recommended production default: 2Gi
         memory: "100Mi"
+        # Recommended production default: 2000m
         cpu: "100m"
       limits:
+        # Recommended production default: 4Gi
         memory: "100Mi"
-        cpu: "100m"
+        # Recommended production default: null
+        cpu: null
 
     # This value defines the [affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
     # for ingress gateway pods. It defaults to `null` thereby allowing multiple gateway pods on each node. But if one would prefer
@@ -3450,11 +3483,15 @@ terminatingGateways:
     # @type: map
     resources:
       requests:
+        # Recommended production default: 2Gi
         memory: "100Mi"
+        # Recommended production default: 2000m
         cpu: "100m"
       limits:
+        # Recommended production default: 4Gi
         memory: "100Mi"
-        cpu: "100m"
+        # Recommended production default: null
+        cpu: null
 
     # This value defines the [affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
     # for terminating gateway pods. It defaults to `null` thereby allowing multiple gateway pods on each node. But if one would prefer
@@ -3594,11 +3631,15 @@ webhookCertManager:
   # @type: map
   resources:
     requests:
-      memory: "50Mi"
+      # Recommended production default: 200Mi
+      memory: "100Mi"
+      # Recommended production default: 100m
       cpu: "100m"
     limits:
-      memory: "50Mi"
-      cpu: "100m"
+      # Recommended production default: 1Gi
+      memory: "100Mi"
+      # Recommended production default: null
+      cpu: null
 
 # Configures a demo Prometheus installation.
 prometheus:


### PR DESCRIPTION
---
### Changes proposed in this PR
- Updates the **values.yaml** comment documentation to recommend setting CPU limits to `null` in production for service-mesh–related components (e.g., connectInject, meshGateway, terminatingGateway, API Gateway, etc.).
- Adds references to the recommended CPU and memory guidelines (Small vs. Large clusters) for Consul servers in production, as per the reference architecture.

### How I've tested this PR
- Verified that the **values.yaml** file retains all original data and keys, with no functional changes besides setting some default CPU limits to `null` for service mesh components.
- Ran a local Helm install to ensure the chart still loads successfully and that the comments render as expected in the generated ConfigMap.

### How I expect reviewers to test this PR
1. **Check the values.yaml diffs**: Confirm that all existing settings are untouched aside from the new doc blocks and `null` CPU limit changes for mesh components.
2. **Validate resource updates**: (Optional) Perform a `helm template` or local deployment to see the changes in resource definitions, ensuring the new CPU limit settings appear as commented.
3. **Review doc clarity**: Make sure the new references to recommended production sizing are clear, and that instructions about using `null` CPU limits for mesh components are understandable.

### Checklist
- [ ] Tests added (N/A or minimal since this is a doc-focused PR, but confirm if any Helm chart lint tests are relevant)
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
