### PR TITLE
Update file skip logic and simplify CODEOWNERS config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,1 @@
 * @hashicorp/consul-selfmanage-maintainers
-
-# Helm Docs Review
-
-/charts/consul/values.yaml @hashicorp/consul-docs

--- a/.github/workflows/reusable-conditional-skip.yml
+++ b/.github/workflows/reusable-conditional-skip.yml
@@ -51,6 +51,7 @@ jobs:
             **.md
             assets/**
             .changelog/**
+            .github/CODEOWNERS
       - name: Print changed files
         env:
           SKIPPABLE_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
Added `.github/CODEOWNERS` to the list of skippable files in the workflow configuration to prevent unnecessary workflow runs. Simplified CODEOWNERS file by removing redundant entries related to Helm Docs Review.

### Changes proposed in this PR ###  
-
-

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
