### PR TITLE
update ubuntu version for build workflow as 20.04 is deprecated in GH

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
 
   build:
     needs: [get-go-version, get-product-version]
-    runs-on: ubuntu-20.04 # the GLIBC is too high on 22.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Updated ubuntu version for build workflow
- 20.04 has been deprecated by GitHub
- The change is already present in `release/1.7.x` and `release/1.5.x` and will only need backport for `release/1.6.x`

### How I've tested this PR ###
- The change is already tested in 1.7.0 release

### How I expect reviewers to test this PR ###
- Build should create necessary artifacts

### Checklist ###
- [ ] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
