### PR TITLE
Fixing multiple flaky test failures due to timeout, version updates, …

### DIFF
--- a/acceptance/tests/api-gateway/api_gateway_kitchen_sink_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_kitchen_sink_test.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
 
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
@@ -90,8 +91,13 @@ func TestAPIGateway_KitchenSink(t *testing.T) {
 	if runWithEnterpriseOnlyFeatures {
 		fixturePath += "-ent"
 	}
-	out, err = k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "apply", "-k", fixturePath)
-	require.NoError(t, err, out)
+
+	counter := &retry.Counter{Count: 60, Wait: 10 * time.Second}
+	retry.RunWith(counter, t, func(r *retry.R) {
+		out, err = k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(r), "apply", "-k", fixturePath)
+		require.NoError(r, err, out)
+	})
+
 	helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
 		// Ignore errors here because if the test ran as expected
 		// the custom resources will have been deleted.
@@ -127,7 +133,7 @@ func TestAPIGateway_KitchenSink(t *testing.T) {
 		httpRoute      gwv1beta1.HTTPRoute
 	)
 
-	counter := &retry.Counter{Count: 60, Wait: 2 * time.Second}
+	counter = &retry.Counter{Count: 60, Wait: 2 * time.Second}
 	retry.RunWith(counter, t, func(r *retry.R) {
 		var gateway gwv1beta1.Gateway
 		err = k8sClient.Get(context.Background(), types.NamespacedName{Name: "gateway", Namespace: "default"}, &gateway)
@@ -143,8 +149,11 @@ func TestAPIGateway_KitchenSink(t *testing.T) {
 		require.Len(r, gateway.Status.Listeners, 2)
 
 		// http route checks
-		err = k8sClient.Get(context.Background(), types.NamespacedName{Name: "http-route", Namespace: "default"}, &httpRoute)
-		require.NoError(r, err)
+		counter = &retry.Counter{Count: 60, Wait: 10 * time.Second}
+		retry.RunWith(counter, t, func(r *retry.R) {
+			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: "http-route", Namespace: "default"}, &httpRoute)
+			require.NoError(r, err)
+		})
 
 		require.EqualValues(r, int32(1), gateway.Status.Listeners[0].AttachedRoutes)
 		checkStatusCondition(r, gateway.Status.Listeners[0].Conditions, trueCondition("Accepted", "Accepted"))

--- a/acceptance/tests/api-gateway/api_gateway_lifecycle_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_lifecycle_test.go
@@ -6,8 +6,6 @@ package apigateway
 import (
 	"context"
 	"fmt"
-	"testing"
-
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
@@ -21,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	"testing"
 )
 
 func TestAPIGateway_Lifecycle(t *testing.T) {
@@ -376,12 +375,13 @@ func checkRouteBound(t *testing.T, client client.Client, name, namespace, parent
 
 func updateKubernetes[T client.Object](t *testing.T, k8sClient client.Client, o T, fn func(o T)) {
 	t.Helper()
-
-	err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(o), o)
-	require.NoError(t, err)
-	fn(o)
-	err = k8sClient.Update(context.Background(), o)
-	require.NoError(t, err)
+	retryCheck(t, 200, func(r *retry.R) {
+		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(o), o)
+		require.NoError(t, err)
+		fn(o)
+		err = k8sClient.Update(context.Background(), o)
+		require.NoError(t, err)
+	})
 }
 
 func createRoute(t *testing.T, client client.Client, name, namespace, parent, target string) *gwv1beta1.HTTPRoute {

--- a/acceptance/tests/api-gateway/api_gateway_tenancy_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_tenancy_test.go
@@ -131,7 +131,7 @@ func TestAPIGateway_Tenancy(t *testing.T) {
 			k8sClient := ctx.ControllerRuntimeClient(t)
 			consulClient, _ := consulCluster.SetupConsulClient(t, c.secure)
 
-			retryCheck(t, 120, func(r *retry.R) {
+			retryCheck(t, 200, func(r *retry.R) {
 				var gateway gwv1beta1.Gateway
 				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "gateway", Namespace: gatewayNamespace}, &gateway)
 				require.NoError(r, err)

--- a/acceptance/tests/connect/connect_proxy_lifecycle_test.go
+++ b/acceptance/tests/connect/connect_proxy_lifecycle_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -126,17 +128,21 @@ func TestConnectInject_ProxyLifecycleShutdown(t *testing.T) {
 			}
 
 			connHelper.TestConnectionSuccess(t, connhelper.ConnHelperOpts{})
-
-			// Get static-client pod name
-			ns := ctx.KubectlOptions(t).Namespace
-			pods, err := ctx.KubernetesClient(t).CoreV1().Pods(ns).List(
-				context.Background(),
-				metav1.ListOptions{
-					LabelSelector: "app=static-client",
-				},
-			)
-			require.NoError(t, err)
-			require.Len(t, pods.Items, 1)
+			var pods *corev1.PodList
+			var ns string
+			var err error
+			retry.Run(t, func(r *retry.R) {
+				// Get static-client pod name
+				ns = ctx.KubectlOptions(r).Namespace
+				pods, err = ctx.KubernetesClient(r).CoreV1().Pods(ns).List(
+					context.Background(),
+					metav1.ListOptions{
+						LabelSelector: "app=static-client",
+					},
+				)
+				require.NoError(r, err)
+				require.Len(r, pods.Items, 1)
+			})
 			clientPodName := pods.Items[0].Name
 
 			// We should terminate the pods shortly after envoy gracefully shuts down in our 5s test cases.

--- a/acceptance/tests/sameness/sameness_test.go
+++ b/acceptance/tests/sameness/sameness_test.go
@@ -58,7 +58,7 @@ const (
 	cluster02Region = "us-west-1"
 	cluster03Region = "us-east-2"
 
-	retryTimeout = 5 * time.Minute
+	retryTimeout = 50 * time.Minute
 )
 
 func TestFailover_Connect(t *testing.T) {

--- a/charts/consul/test/terraform/aks/main.tf
+++ b/charts/consul/test/terraform/aks/main.tf
@@ -4,7 +4,11 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "3.40.0"
+      version = "~> 4.27.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5.0"
     }
   }
 }
@@ -36,8 +40,8 @@ resource "azurerm_virtual_network" "default" {
   address_space       = ["192.${count.index + 168}.0.0/16"]
 
   subnet {
-    name           = "consul-k8s-${random_id.suffix[count.index].dec}-subnet"
-    address_prefix = "192.${count.index + 168}.1.0/24"
+    name             = "consul-k8s-${random_id.suffix[count.index].dec}-subnet"
+    address_prefixes = ["192.${count.index + 168}.1.0/24"]
   }
 }
 
@@ -68,11 +72,10 @@ resource "azurerm_kubernetes_cluster" "default" {
   // communication is tested, the connections goes through the appropriate gateway
   // rather than directly from pod to pod.
   network_profile {
-    network_plugin     = "kubenet"
-    service_cidr       = "10.0.0.0/16"
-    dns_service_ip     = "10.0.0.10"
-    pod_cidr           = "10.244.0.0/16"
-    docker_bridge_cidr = "172.17.0.1/16"
+    network_plugin = "kubenet"
+    service_cidr   = "10.0.0.0/16"
+    dns_service_ip = "10.0.0.10"
+    pod_cidr       = "10.244.0.0/16"
   }
 
   default_node_pool {

--- a/charts/consul/test/terraform/aks/variables.tf
+++ b/charts/consul/test/terraform/aks/variables.tf
@@ -7,7 +7,7 @@ variable "location" {
 }
 
 variable "kubernetes_version" {
-  default     = "1.31"
+  default     = "1.32"
   description = "Kubernetes version supported on AKS"
 }
 

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -68,7 +68,7 @@ module "eks" {
   kubeconfig_api_version = "client.authentication.k8s.io/v1beta1"
 
   cluster_name    = "consul-k8s-${random_id.suffix[count.index].dec}"
-  cluster_version = "1.31"
+  cluster_version = var.kubernetes_version
   subnets         = module.vpc[count.index].private_subnets
   enable_irsa     = true
 
@@ -124,10 +124,10 @@ resource "aws_iam_role_policy_attachment" "csi" {
 }
 
 resource "aws_eks_addon" "csi-driver" {
-  count                       = var.cluster_count
-  cluster_name                = module.eks[count.index].cluster_id
-  addon_name                  = "aws-ebs-csi-driver"
-  addon_version               = "v1.15.0-eksbuild.1"
+  count        = var.cluster_count
+  cluster_name = module.eks[count.index].cluster_id
+  addon_name   = "aws-ebs-csi-driver"
+  # addon_version               = "v1.15.0-eksbuild.1"
   service_account_role_arn    = aws_iam_role.csi-driver-role[count.index].arn
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"

--- a/charts/consul/test/terraform/eks/variables.tf
+++ b/charts/consul/test/terraform/eks/variables.tf
@@ -28,3 +28,8 @@ variable "tags" {
   default     = {}
   description = "Tags to attach to the created resources."
 }
+
+variable "kubernetes_version" {
+  default     = "1.32"
+  description = "Kubernetes version supported on EKS"
+}

--- a/charts/consul/test/terraform/gke/main.tf
+++ b/charts/consul/test/terraform/gke/main.tf
@@ -21,7 +21,7 @@ resource "random_id" "suffix" {
 
 data "google_container_engine_versions" "main" {
   location       = var.zone
-  version_prefix = "1.31."
+  version_prefix = var.kubernetes_version_prefix
 }
 
 # We assume that the subnets are already created to save time.

--- a/charts/consul/test/terraform/gke/variables.tf
+++ b/charts/consul/test/terraform/gke/variables.tf
@@ -43,3 +43,8 @@ variable "subnet" {
   default     = "default"
   description = "Subnet to create the cluster in. Currently all clusters use the default subnet and we are running out of IPs"
 }
+
+variable "kubernetes_version_prefix" {
+  default     = "1.32."
+  description = "Kubernetes version supported on EKS"
+}


### PR DESCRIPTION
…script changes (#4576)

* Increasing retry count from 120 to 200 for TestAPIGateway_Tenancy testcase

* addition of test logs

* Setting empty string for ResourceVersionField

* Updating terraform scripts and versions

* Testing sending nil in resourceVersion

* Using SetResourceVersion to set ResourceVersion value

* Setting resourceVersion to nil

* Removing unwanted print statement

* Addition of retry for update failure

* Removal of setting resource version

* Using retryCheck for retrying updateKubernetes

* Adding retry for apply command

* Fixing used retry object

* Fixing no new variable

---------

### Changes proposed in this PR ###  
-
-

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
