### PR TITLE
Manual Backport of update: upgrade alpine version to 3.21 in Dockerfile into release/1.7.x

### DIFF
--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@275a7
 # dev copies the binary from a local build
 # -----------------------------------
 # BIN_NAME is a requirement in the hashicorp docker github action 
-FROM alpine:3.19 AS dev
+FROM alpine:3.21 AS dev
 
 # NAME and VERSION are the name of the software in releases.hashicorp.com
 # and the version to download. Example: NAME=consul VERSION=1.2.3.
@@ -79,7 +79,7 @@ CMD /bin/${BIN_NAME}
 # We don't rebuild the software because we want the exact checksums and
 # binary signatures to match the software and our builds aren't fully
 # reproducible currently.
-FROM alpine:3.19 AS release-default
+FROM alpine:3.21 AS release-default
 
 ARG BIN_NAME=consul-k8s-control-plane
 ARG CNI_BIN_NAME=consul-cni


### PR DESCRIPTION
### Changes proposed in this PR ###  
- update: upgrade alpine version from 3.19 to 3.21 in Dockerfile

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 
