### PR TITLE
helm: allow configuration of container liveness and readiness probes

### DIFF
--- a/.changelog/4388.txt
+++ b/.changelog/4388.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+helm: add the ability to configure livenessProbe and readinesssProbe for consul-client daemonset.
+```

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -467,7 +467,14 @@ spec:
             - containerPort: 8600
               name: dns-udp
               protocol: "UDP"
+          {{- with .Values.client.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 14 }}
+          {{- end }}
           readinessProbe:
+          {{- if .Values.client.readinessProbe }}
+          {{- toYaml .Values.client.readinessProbe | nindent 14 }}
+          {{- else }}
             # NOTE(mitchellh): when our HTTP status endpoints support the
             # proper status codes, we should switch to that. This is temporary.
             exec:
@@ -483,6 +490,7 @@ spec:
                   curl http://127.0.0.1:8500/v1/status/leader \
                   {{- end }}
                   2>/dev/null | grep -E '".+"'
+          {{- end }}
           {{- if .Values.client.resources }}
           resources:
             {{- if eq (typeOf .Values.client.resources) "string" }}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1904,6 +1904,26 @@ client:
   # @type: string
   updateStrategy: null
 
+  # Override the default livenessProbe and readinessProbe for the DaemonSet consul-client container.
+  # Refer to the Kubernetes documentation on how to [Configure Liveness, Readiness and Startup Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+  #
+  # This should be a multi-line string
+  #
+  # Example:
+  #
+  # ```yaml
+  # readinessProbe:
+  #     exec:
+  #       command:
+  #       - /bin/sh
+  #       - -ec
+  #       - "curl http://127.0.0.1:8500/v1/status/leader 2>/dev/null | grep -E '\".+\"' \n"
+  # ```
+  #
+  # @type: string
+  livenessProbe: {}
+  readinessProbe: {}
+
 # Configuration for DNS configuration within the Kubernetes cluster.
 # This creates a service that routes to all agents (client or server)
 # for serving DNS requests. This DOES NOT automatically configure kube-dns


### PR DESCRIPTION
This is to pull community changes from #4388 into main.

### Changes proposed in this PR ###  
- Adds livenessProbe field to helm values - empty by default
- Adds readinessProbe field to helm values - defaults to existing readinessProbe

### How I've tested this PR ###
- Currently using a forked chart with this change
- `helm template . -f values.yaml` to compare diffs and none of the defaults are changed

### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

Fixes #4387