### PR TITLE
go-discover version upgrade

### DIFF
--- a/.changelog/4684.txt
+++ b/.changelog/4684.txt
@@ -1,0 +1,3 @@
+```release-note:security
+go: upgrade go version to 40c38fd658f0fd07ce74f2ee51b8abd3bfed01b3
+```

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -18,7 +18,7 @@
 # either).
 ARG GOLANG_VERSION
 FROM golang:${GOLANG_VERSION}-alpine3.22 AS go-discover
-RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@275a71457aa412bf20df9f9b77c380667164a5e6
+RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@40c38fd658f0fd07ce74f2ee51b8abd3bfed01b3
 
 # dev copies the binary from a local build
 # -----------------------------------


### PR DESCRIPTION
### Changes proposed in this PR ###  
- go discover version upgrade to 40c38fd658f0fd07ce74f2ee51b8abd3bfed01b3 as part of CVE(CVE-2024-45337 &

CVE-2025-22869)
-

### How I've tested this PR ###
- Ran Trivy scan to verify CVE fixed

### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
