### PR TITLE
chore:added workflow to delete stale branches

### DIFF
--- a/.github/workflows/stale-branches.yaml
+++ b/.github/workflows/stale-branches.yaml
@@ -1,0 +1,24 @@
+name: Stale Branches
+on:
+  schedule:
+    - cron: "0 6 * * 1-5"
+
+permissions:
+  issues: write
+  contents: write
+jobs:
+  stale_branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stale Branches
+        uses: crs-k/stale-branches@c6e09a3de1046d68b21eccdca23321d0ec277964 # v7.0.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          days-before-stale: 120
+          days-before-delete: 180
+          comment-updates: false
+          tag-committer: false
+          stale-branch-label: "stale branch 🗑️"
+          compare-branches: "info"
+          ignore-issue-interaction: true
+          pr-check: true


### PR DESCRIPTION
### Changes proposed in this PR ###  
The current backport assistant is failing and at times raising PRs with empty commit. The primarily reason observed for this is that when the PR is squashed and merged and then the source branch is deleted. Since the branch is deleted, it is not able to find the commits.

Permanent solution is to fix the backport assistant such that the PR is squashed, pick the commit from the main instead of the PR commits.

Temporary solution is to disable auto deletion of the source branch post PR merge and clearly them periodically using a workflow.

This PR adds the workflow to delete the stale PRs after 180 days when there are no open PRs associated with it.
### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
