### PR TITLE
Use privileged dataplane entrypoint for consul-dataplane

### DIFF
--- a/.changelog/4745.txt
+++ b/.changelog/4745.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Consul-dataplane now includes both privileged and non-privileged binaries in the image. By default, all use cases use the non-privileged binaries (without NET_BIND_SERVICE). For Ingress, API, and Mesh Gateway use cases, if a privileged port is configured, the privileged binary (with NET_BIND_SERVICE capability) is automatically selected and used.
+```

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -682,3 +682,23 @@ Usage: {{ template "consul.imagePullPolicy" . }} TODO: melisa should we name thi
 {{fail "imagePullPolicy can only be IfNotPresent, Always, Never, or empty" }}
 {{ end }}
 {{- end -}}
+
+{{/*
+Checks if any of the ingress gateway ports are privileged (< 1024).
+This helper takes the ingress gateway configuration and checks both specific
+service ports and default service ports to determine if privileged ports are needed.
+
+Usage: {{ template "consul.ingressGatewayHasPrivilegedPorts" (dict "service" .service "defaults" $defaults) }}
+*/}}
+{{- define "consul.ingressGatewayHasPrivilegedPorts" -}}
+{{- $service := .service -}}
+{{- $defaults := .defaults -}}
+{{- $ports := (default $defaults.service.ports $service.ports) -}}
+{{- $hasPrivilegedPorts := false -}}
+{{- range $port := $ports -}}
+  {{- if lt (int $port.port) 1024 -}}
+    {{- $hasPrivilegedPorts = true -}}
+  {{- end -}}
+{{- end -}}
+{{- $hasPrivilegedPorts -}}
+{{- end -}}

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -23,8 +23,6 @@ securityContext:
   capabilities:
     drop:
     - ALL
-    add:
-    - NET_BIND_SERVICE
   runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -41,6 +41,33 @@ and consul-k8s-control-plane images.
 {{- end -}}
 {{- end -}}
 
+
+{{- define "consul.restrictedSecurityContextWithNetBindService" -}}
+{{- if not .Values.global.enablePodSecurityPolicies -}}
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    add:
+    - NET_BIND_SERVICE
+    drop:
+    - ALL
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+{{- if not .Values.global.openshift.enabled -}}
+{{/*
+We must set runAsUser or else the root user will be used in some cases and
+containers will fail to start due to runAsNonRoot above (e.g.
+tls-init-cleanup). On OpenShift, runAsUser is automatically. We pick user 100
+because it is a non-root user id that exists in the consul, consul-dataplane,
+and consul-k8s-control-plane images.
+*/}}
+  runAsUser: 100
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "consul.vaultSecretTemplate" -}}
  |
             {{ "{{" }}- with secret "{{ .secretName }}" -{{ "}}" }}

--- a/charts/consul/templates/dns-proxy-deployment.yaml
+++ b/charts/consul/templates/dns-proxy-deployment.yaml
@@ -81,6 +81,23 @@ spec:
       containers:
         - name: dns-proxy
           image: {{ .Values.global.imageConsulDataplane | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            {{- if lt (int .Values.dns.proxy.port) 1024 }}
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+            {{- else }}
+            capabilities:
+              drop:
+                - ALL
+            {{- end }}
           volumeMounts:
             - mountPath: /consul/service
               name: consul-service
@@ -123,9 +140,17 @@ spec:
                   name: {{ .Values.dns.proxy.aclToken.secretName }}
                   key: {{ .Values.dns.proxy.aclToken.secretKey }}
       {{- end }}
+          {{- if lt (int .Values.dns.proxy.port) 1024 }}
+          command:
+            - privileged-consul-dataplane
+          {{- else }}
           command:
             - consul-dataplane
+          {{- end }}
           args:
+            {{- if lt (int .Values.dns.proxy.port) 1024 }}
+            - -envoy-executable-path=/usr/local/bin/privileged-envoy
+            {{- end }}
             {{- if .Values.global.dualStack.defaultEnabled }}
             - -consul-dns-bind-addr="[::]"
             {{- else }}

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -291,9 +291,17 @@ spec:
           value: component=ingress-gateway
         - name: DP_SERVICE_NODE_NAME
           value: $(NODE_NAME)-virtual
+        {{- if $root.Values.ingressGateways.supportPrivilegedPorts }}
         command:
         - consul-dataplane
         args:
+<<<<<<< HEAD
+=======
+        - -envoy-executable-path=/usr/local/bin/privileged-envoy
+        {{- else }}
+        args:
+        {{- end }}
+>>>>>>> ece21310d (Allow ingress gateway users who do not bind to privileged ports to opt out of NET_BIND_SERVICE)
         - -envoy-ready-bind-port=21000
         {{- if $root.Values.externalServers.enabled }}
         - -addresses={{ $root.Values.externalServers.hosts | first }}

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -247,7 +247,7 @@ spec:
       - name: ingress-gateway
         image: {{ $root.Values.global.imageConsulDataplane | quote }}
         {{ template "consul.imagePullPolicy" $root }}
-        {{- include "consul.restrictedSecurityContext" $ | nindent 8 }}
+        {{- include "consul.restrictedSecurityContextWithNetBindService" $ | nindent 8 }}
         {{- if (default $defaults.resources .resources) }}
         resources: {{ toYaml (default $defaults.resources .resources) | nindent 10 }}
         {{- end }}

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -23,6 +23,7 @@
 {{- range .Values.ingressGateways.gateways }}
 
 {{- $service := .service }}
+{{- $needsPrivilegedPorts := eq "true" (include "consul.ingressGatewayHasPrivilegedPorts" (dict "service" $service "defaults" $defaults)) }}
 
 {{- if empty .name }}
 # Check that the gateway name is provided
@@ -247,7 +248,11 @@ spec:
       - name: ingress-gateway
         image: {{ $root.Values.global.imageConsulDataplane | quote }}
         {{ template "consul.imagePullPolicy" $root }}
+        {{- if $needsPrivilegedPorts }}
         {{- include "consul.restrictedSecurityContextWithNetBindService" $ | nindent 8 }}
+        {{- else }}
+        {{- include "consul.restrictedSecurityContext" $ | nindent 8 }}
+        {{- end }}
         {{- if (default $defaults.resources .resources) }}
         resources: {{ toYaml (default $defaults.resources .resources) | nindent 10 }}
         {{- end }}
@@ -291,7 +296,7 @@ spec:
           value: component=ingress-gateway
         - name: DP_SERVICE_NODE_NAME
           value: $(NODE_NAME)-virtual
-        {{- if $root.Values.ingressGateways.supportPrivilegedPorts }}
+        {{- if $needsPrivilegedPorts }}
         command:
         - privileged-consul-dataplane
         args:

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -293,7 +293,7 @@ spec:
           value: $(NODE_NAME)-virtual
         {{- if $root.Values.ingressGateways.supportPrivilegedPorts }}
         command:
-        - consul-dataplane
+        - privileged-consul-dataplane
         args:
         - -envoy-executable-path=/usr/local/bin/privileged-envoy
         {{- else }}

--- a/charts/consul/templates/ingress-gateways-deployment.yaml
+++ b/charts/consul/templates/ingress-gateways-deployment.yaml
@@ -295,13 +295,10 @@ spec:
         command:
         - consul-dataplane
         args:
-<<<<<<< HEAD
-=======
         - -envoy-executable-path=/usr/local/bin/privileged-envoy
         {{- else }}
         args:
         {{- end }}
->>>>>>> ece21310d (Allow ingress gateway users who do not bind to privileged ports to opt out of NET_BIND_SERVICE)
         - -envoy-ready-bind-port=21000
         {{- if $root.Values.externalServers.enabled }}
         - -addresses={{ $root.Values.externalServers.hosts | first }}

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -196,27 +196,23 @@ spec:
       - name: mesh-gateway
         image: {{ .Values.global.imageConsulDataplane | quote }}
         {{ template "consul.imagePullPolicy" . }}
-        {{ if not .Values.meshGateway.hostNetwork}}
         securityContext:
-          {{- if lt (int .Values.meshGateway.containerPort) 1024 }}
-          allowPrivilegeEscalation: true
-          runAsNonRoot: false
-          capabilities:
-            drop:
-              - ALL
-            add:
-              - NET_BIND_SERVICE
-          {{- else }}
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
-          capabilities:
-            drop:
-              - ALL
-          {{- end }}
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
-        {{- end }}
+          {{- if or (not .Values.meshGateway.hostNetwork) (lt (int .Values.meshGateway.containerPort) 1024) }}
+          capabilities:
+            {{- if not .Values.meshGateway.hostNetwork }}
+            drop:
+              - ALL
+            {{- end }}
+            {{- if lt (int .Values.meshGateway.containerPort) 1024 }}
+            add:
+              - NET_BIND_SERVICE
+            {{- end }}
+          {{- end }}
         {{- if .Values.meshGateway.resources }}
         resources:
             {{- if eq (typeOf .Values.meshGateway.resources) "string" }}

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -196,6 +196,7 @@ spec:
       - name: mesh-gateway
         image: {{ .Values.global.imageConsulDataplane | quote }}
         {{ template "consul.imagePullPolicy" . }}
+        {{ if not .Values.meshGateway.hostNetwork}}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -203,12 +204,9 @@ spec:
           seccompProfile:
             type: RuntimeDefault
           capabilities:
-            {{ if not .Values.meshGateway.hostNetwork}}
             drop:
               - ALL
-            {{- end }}
-            add:
-              - NET_BIND_SERVICE
+        {{- end }}
         {{- if .Values.meshGateway.resources }}
         resources:
             {{- if eq (typeOf .Values.meshGateway.resources) "string" }}

--- a/charts/consul/templates/mesh-gateway-deployment.yaml
+++ b/charts/consul/templates/mesh-gateway-deployment.yaml
@@ -198,14 +198,24 @@ spec:
         {{ template "consul.imagePullPolicy" . }}
         {{ if not .Values.meshGateway.hostNetwork}}
         securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
+          {{- if lt (int .Values.meshGateway.containerPort) 1024 }}
+          allowPrivilegeEscalation: true
+          runAsNonRoot: false
           capabilities:
             drop:
               - ALL
+            add:
+              - NET_BIND_SERVICE
+          {{- else }}
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
+          {{- end }}
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         {{- end }}
         {{- if .Values.meshGateway.resources }}
         resources:
@@ -249,9 +259,16 @@ spec:
           value: component=mesh-gateway
         - name: DP_SERVICE_NODE_NAME
           value: $(NODE_NAME)-virtual
+        {{- if lt (int .Values.meshGateway.containerPort) 1024 }}
+        command:
+        - privileged-consul-dataplane
+        args:
+        - -envoy-executable-path=/usr/local/bin/privileged-envoy
+        {{- else }}
         command:
         - consul-dataplane
         args:
+        {{- end }}
         {{- if .Values.externalServers.enabled }}
         - -addresses={{ .Values.externalServers.hosts | first }}
         {{- else }}

--- a/charts/consul/templates/mesh-gateway-podsecuritypolicy.yaml
+++ b/charts/consul/templates/mesh-gateway-podsecuritypolicy.yaml
@@ -18,7 +18,7 @@ spec:
   # but we can provide it for defense in depth.
   requiredDropCapabilities:
     - ALL
-  {{- if lt .Values.meshGateway.containerPort 1024 }}
+  {{- if lt (int .Values.meshGateway.containerPort) 1024 }}
   allowedCapabilities:
     - NET_BIND_SERVICE
   {{- end }}

--- a/charts/consul/templates/mesh-gateway-podsecuritypolicy.yaml
+++ b/charts/consul/templates/mesh-gateway-podsecuritypolicy.yaml
@@ -18,8 +18,6 @@ spec:
   # but we can provide it for defense in depth.
   requiredDropCapabilities:
     - ALL
-  defaultAddCapabilities:
-    - NET_BIND_SERVICE
   # Allow core volume types.
   volumes:
     - 'configMap'

--- a/charts/consul/templates/mesh-gateway-podsecuritypolicy.yaml
+++ b/charts/consul/templates/mesh-gateway-podsecuritypolicy.yaml
@@ -18,6 +18,10 @@ spec:
   # but we can provide it for defense in depth.
   requiredDropCapabilities:
     - ALL
+  {{- if lt .Values.meshGateway.containerPort 1024 }}
+  allowedCapabilities:
+    - NET_BIND_SERVICE
+  {{- end }}
   # Allow core volume types.
   volumes:
     - 'configMap'

--- a/charts/consul/templates/telemetry-collector-podsecuritypolicy.yaml
+++ b/charts/consul/templates/telemetry-collector-podsecuritypolicy.yaml
@@ -18,8 +18,6 @@ spec:
   # but we can provide it for defense in depth.
   requiredDropCapabilities:
     - ALL
-  defaultAddCapabilities:
-    - NET_BIND_SERVICE
   # Allow core volume types.
   volumes:
     - 'configMap'

--- a/charts/consul/templates/terminating-gateways-podsecuritypolicy.yaml
+++ b/charts/consul/templates/terminating-gateways-podsecuritypolicy.yaml
@@ -21,8 +21,6 @@ spec:
   # but we can provide it for defense in depth.
   requiredDropCapabilities:
     - ALL
-  defaultAddCapabilities:
-    - NET_BIND_SERVICE
   # Allow core volume types.
   volumes:
     - 'configMap'

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1382,7 +1382,7 @@ load _helpers
   local expected=$(echo '{
     "allowPrivilegeEscalation": false,
     "capabilities": {
-      "drop": ["ALL"],
+      "drop": ["ALL"]
     },
     "readOnlyRootFilesystem": true,
     "runAsNonRoot": true,
@@ -1414,7 +1414,7 @@ load _helpers
   local expected=$(echo '{
     "allowPrivilegeEscalation": false,
     "capabilities": {
-      "drop": ["ALL"],
+      "drop": ["ALL"]
     },
     "readOnlyRootFilesystem": true,
     "runAsNonRoot": true,

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -1383,7 +1383,6 @@ load _helpers
     "allowPrivilegeEscalation": false,
     "capabilities": {
       "drop": ["ALL"],
-      "add": ["NET_BIND_SERVICE"]
     },
     "readOnlyRootFilesystem": true,
     "runAsNonRoot": true,
@@ -1416,7 +1415,6 @@ load _helpers
     "allowPrivilegeEscalation": false,
     "capabilities": {
       "drop": ["ALL"],
-      "add": ["NET_BIND_SERVICE"]
     },
     "readOnlyRootFilesystem": true,
     "runAsNonRoot": true,

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -3292,6 +3292,11 @@ ingressGateways:
   # @type: string
   logLevel: ""
 
+  # When set, ingress-gateway containers use a privileged entrypoint in consul-dataplane which requires the
+  # NET_BIND_SERVICE capability at runtime. Disabling this setting will use the non-privileged entrypoint and
+  # drop the requirement for NET_BIND_SERVICE. Only disable this if you are *not* using privileged ports (< 1024).
+  supportPrivilegedPorts: true
+
   # Defaults sets default values for all gateway fields. With the exception
   # of annotations, defining any of these values in the `gateways` list
   # will override the default values provided here. Annotations will

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -3292,11 +3292,6 @@ ingressGateways:
   # @type: string
   logLevel: ""
 
-  # When set, ingress-gateway containers use a privileged entrypoint in consul-dataplane which requires the
-  # NET_BIND_SERVICE capability at runtime. Disabling this setting will use the non-privileged entrypoint and
-  # drop the requirement for NET_BIND_SERVICE. Only disable this if you are *not* using privileged ports (< 1024).
-  supportPrivilegedPorts: true
-
   # Defaults sets default values for all gateway fields. With the exception
   # of annotations, defining any of these values in the `gateways` list
   # will override the default values provided here. Annotations will

--- a/control-plane/api-gateway/gatekeeper/dataplane.go
+++ b/control-plane/api-gateway/gatekeeper/dataplane.go
@@ -20,7 +20,6 @@ import (
 
 const (
 	allCapabilities              = "ALL"
-	netBindCapability            = "NET_BIND_SERVICE"
 	consulDataplaneDNSBindHost   = "127.0.0.1"
 	consulDataplaneDNSBindPort   = 8600
 	defaultEnvoyProxyConcurrency = 1
@@ -124,17 +123,8 @@ func consulDataplaneContainer(metrics common.MetricsConfig, config common.HelmCo
 	}
 
 	container.SecurityContext = &corev1.SecurityContext{
-		AllowPrivilegeEscalation: ptr.To(usingPrivilegedPorts),
-		ReadOnlyRootFilesystem:   ptr.To(true),
-		RunAsNonRoot:             ptr.To(true),
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
-		// Drop any Linux capabilities you'd get as root other than NET_BIND_SERVICE.
-		// NET_BIND_SERVICE is a requirement for consul-dataplane, even though we don't
-		// bind to privileged ports.
+		ReadOnlyRootFilesystem: ptr.To(true),
 		Capabilities: &corev1.Capabilities{
-			Add:  []corev1.Capability{netBindCapability},
 			Drop: []corev1.Capability{allCapabilities},
 		},
 	}

--- a/control-plane/api-gateway/gatekeeper/dataplane_test.go
+++ b/control-plane/api-gateway/gatekeeper/dataplane_test.go
@@ -4,6 +4,7 @@
 package gatekeeper
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,6 +15,14 @@ import (
 
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+)
+
+const (
+	PrivilegedPort443     = 443
+	NonPrivilegedPort8080 = 8080
+	PrivilegedPortMapping = 8443
+	GRPCPort              = 8502
+	MetricsPort           = 9090
 )
 
 func TestConsulDataplaneContainer_PrivilegedPorts(t *testing.T) {
@@ -39,7 +48,7 @@ func TestConsulDataplaneContainer_PrivilegedPorts(t *testing.T) {
 					Listeners: []gwv1beta1.Listener{
 						{
 							Name: "https",
-							Port: 443, // Privileged port
+							Port: PrivilegedPort443, // Privileged port
 						},
 					},
 				},
@@ -65,14 +74,14 @@ func TestConsulDataplaneContainer_PrivilegedPorts(t *testing.T) {
 					Listeners: []gwv1beta1.Listener{
 						{
 							Name: "https",
-							Port: 443, // Privileged port
+							Port: PrivilegedPort443, // Privileged port
 						},
 					},
 				},
 			},
 			gcc: v1alpha1.GatewayClassConfig{
 				Spec: v1alpha1.GatewayClassConfigSpec{
-					MapPrivilegedContainerPorts: 8443, // Mapping enabled
+					MapPrivilegedContainerPorts: PrivilegedPortMapping, // Mapping enabled
 				},
 			},
 			expectedCommand:             nil, // No custom command
@@ -91,7 +100,7 @@ func TestConsulDataplaneContainer_PrivilegedPorts(t *testing.T) {
 					Listeners: []gwv1beta1.Listener{
 						{
 							Name: "http",
-							Port: 8080, // Non-privileged port
+							Port: NonPrivilegedPort8080, // Non-privileged port
 						},
 					},
 				},
@@ -117,11 +126,11 @@ func TestConsulDataplaneContainer_PrivilegedPorts(t *testing.T) {
 					Listeners: []gwv1beta1.Listener{
 						{
 							Name: "http",
-							Port: 8080, // Non-privileged port
+							Port: NonPrivilegedPort8080, // Non-privileged port
 						},
 						{
 							Name: "https",
-							Port: 443, // Privileged port
+							Port: PrivilegedPort443, // Privileged port
 						},
 					},
 				},
@@ -148,7 +157,7 @@ func TestConsulDataplaneContainer_PrivilegedPorts(t *testing.T) {
 				LogJSON:               false,
 				ConsulConfig: common.ConsulConfig{
 					Address:  "consul.default.svc.cluster.local",
-					GRPCPort: 8502,
+					GRPCPort: GRPCPort,
 				},
 			}
 
@@ -198,7 +207,7 @@ func TestConsulDataplaneContainer_SecurityContext(t *testing.T) {
 		LogJSON:               false,
 		ConsulConfig: common.ConsulConfig{
 			Address:  "consul.default.svc.cluster.local",
-			GRPCPort: 8502,
+			GRPCPort: GRPCPort,
 		},
 	}
 
@@ -211,7 +220,7 @@ func TestConsulDataplaneContainer_SecurityContext(t *testing.T) {
 			Listeners: []gwv1beta1.Listener{
 				{
 					Name: "http",
-					Port: 8080,
+					Port: NonPrivilegedPort8080,
 				},
 			},
 		},
@@ -246,7 +255,7 @@ func TestConsulDataplaneContainer_BasicFunctionality(t *testing.T) {
 
 	metrics := common.MetricsConfig{
 		Enabled: true,
-		Port:    9090,
+		Port:    MetricsPort,
 	}
 	config := common.HelmConfig{
 		ImageDataplane:        "consul-dataplane:test",
@@ -255,7 +264,7 @@ func TestConsulDataplaneContainer_BasicFunctionality(t *testing.T) {
 		LogJSON:               true,
 		ConsulConfig: common.ConsulConfig{
 			Address:  "consul.default.svc.cluster.local",
-			GRPCPort: 8502,
+			GRPCPort: GRPCPort,
 		},
 	}
 
@@ -268,7 +277,7 @@ func TestConsulDataplaneContainer_BasicFunctionality(t *testing.T) {
 			Listeners: []gwv1beta1.Listener{
 				{
 					Name: "http",
-					Port: 8080,
+					Port: NonPrivilegedPort8080,
 				},
 			},
 		},
@@ -337,7 +346,7 @@ func TestConsulDataplaneContainer_BasicFunctionality(t *testing.T) {
 		argsStr += arg + " "
 	}
 	require.Contains(t, argsStr, "-addresses")
-	require.Contains(t, argsStr, "-grpc-port=8502")
+	require.Contains(t, argsStr, fmt.Sprintf("-grpc-port=%d", GRPCPort))
 	require.Contains(t, argsStr, "-log-level=DEBUG")
 	require.Contains(t, argsStr, "-log-json=true")
 }

--- a/control-plane/api-gateway/gatekeeper/dataplane_test.go
+++ b/control-plane/api-gateway/gatekeeper/dataplane_test.go
@@ -238,7 +238,6 @@ func TestConsulDataplaneContainer_SecurityContext(t *testing.T) {
 
 	// Check capabilities for non-privileged case
 	require.NotNil(t, container.SecurityContext.Capabilities)
-	require.Equal(t, []corev1.Capability{"NET_BIND_SERVICE"}, container.SecurityContext.Capabilities.Add)
 	require.Equal(t, []corev1.Capability{"ALL"}, container.SecurityContext.Capabilities.Drop)
 }
 

--- a/control-plane/api-gateway/gatekeeper/dataplane_test.go
+++ b/control-plane/api-gateway/gatekeeper/dataplane_test.go
@@ -1,0 +1,344 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package gatekeeper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+)
+
+func TestConsulDataplaneContainer_PrivilegedPorts(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                        string
+		gateway                     gwv1beta1.Gateway
+		gcc                         v1alpha1.GatewayClassConfig
+		expectedCommand             []string
+		expectedHasEnvoyArg         bool
+		expectedCapabilities        []corev1.Capability
+		expectedPrivilegeEscalation bool
+	}{
+		{
+			name: "privileged port with mapping disabled",
+			gateway: gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gateway",
+					Namespace: "default",
+				},
+				Spec: gwv1beta1.GatewaySpec{
+					Listeners: []gwv1beta1.Listener{
+						{
+							Name: "https",
+							Port: 443, // Privileged port
+						},
+					},
+				},
+			},
+			gcc: v1alpha1.GatewayClassConfig{
+				Spec: v1alpha1.GatewayClassConfigSpec{
+					MapPrivilegedContainerPorts: 0, // Mapping disabled
+				},
+			},
+			expectedCommand:             []string{"privileged-consul-dataplane"},
+			expectedHasEnvoyArg:         true,
+			expectedCapabilities:        []corev1.Capability{"NET_BIND_SERVICE"},
+			expectedPrivilegeEscalation: true,
+		},
+		{
+			name: "privileged port with mapping enabled",
+			gateway: gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gateway",
+					Namespace: "default",
+				},
+				Spec: gwv1beta1.GatewaySpec{
+					Listeners: []gwv1beta1.Listener{
+						{
+							Name: "https",
+							Port: 443, // Privileged port
+						},
+					},
+				},
+			},
+			gcc: v1alpha1.GatewayClassConfig{
+				Spec: v1alpha1.GatewayClassConfigSpec{
+					MapPrivilegedContainerPorts: 8443, // Mapping enabled
+				},
+			},
+			expectedCommand:             nil, // No custom command
+			expectedHasEnvoyArg:         false,
+			expectedCapabilities:        []corev1.Capability{},
+			expectedPrivilegeEscalation: false,
+		},
+		{
+			name: "non-privileged port",
+			gateway: gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gateway",
+					Namespace: "default",
+				},
+				Spec: gwv1beta1.GatewaySpec{
+					Listeners: []gwv1beta1.Listener{
+						{
+							Name: "http",
+							Port: 8080, // Non-privileged port
+						},
+					},
+				},
+			},
+			gcc: v1alpha1.GatewayClassConfig{
+				Spec: v1alpha1.GatewayClassConfigSpec{
+					MapPrivilegedContainerPorts: 0, // Mapping disabled
+				},
+			},
+			expectedCommand:             nil, // No custom command
+			expectedHasEnvoyArg:         false,
+			expectedCapabilities:        []corev1.Capability{},
+			expectedPrivilegeEscalation: false,
+		},
+		{
+			name: "multiple listeners with one privileged",
+			gateway: gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gateway",
+					Namespace: "default",
+				},
+				Spec: gwv1beta1.GatewaySpec{
+					Listeners: []gwv1beta1.Listener{
+						{
+							Name: "http",
+							Port: 8080, // Non-privileged port
+						},
+						{
+							Name: "https",
+							Port: 443, // Privileged port
+						},
+					},
+				},
+			},
+			gcc: v1alpha1.GatewayClassConfig{
+				Spec: v1alpha1.GatewayClassConfigSpec{
+					MapPrivilegedContainerPorts: 0, // Mapping disabled
+				},
+			},
+			expectedCommand:             []string{"privileged-consul-dataplane"},
+			expectedHasEnvoyArg:         true,
+			expectedCapabilities:        []corev1.Capability{"NET_BIND_SERVICE"},
+			expectedPrivilegeEscalation: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			metrics := common.MetricsConfig{}
+			config := common.HelmConfig{
+				ImageDataplane:        "consul-dataplane:test",
+				GlobalImagePullPolicy: "IfNotPresent",
+				LogLevel:              "INFO",
+				LogJSON:               false,
+				ConsulConfig: common.ConsulConfig{
+					Address:  "consul.default.svc.cluster.local",
+					GRPCPort: 8502,
+				},
+			}
+
+			container, err := consulDataplaneContainer(metrics, config, tc.gcc, tc.gateway, []corev1.VolumeMount{})
+			require.NoError(t, err)
+
+			// Check command
+			if tc.expectedCommand != nil {
+				require.Equal(t, tc.expectedCommand, container.Command)
+			} else {
+				require.Nil(t, container.Command)
+			}
+
+			// Check for envoy executable path argument
+			hasEnvoyArg := false
+			for _, arg := range container.Args {
+				if arg == "-envoy-executable-path=/usr/local/bin/privileged-envoy" {
+					hasEnvoyArg = true
+					break
+				}
+			}
+			require.Equal(t, tc.expectedHasEnvoyArg, hasEnvoyArg)
+
+			// Check security context
+			require.NotNil(t, container.SecurityContext)
+			require.Equal(t, ptr.To(true), container.SecurityContext.ReadOnlyRootFilesystem)
+			require.Equal(t, ptr.To(tc.expectedPrivilegeEscalation), container.SecurityContext.AllowPrivilegeEscalation)
+
+			// Check capabilities
+			if len(tc.expectedCapabilities) > 0 {
+				require.NotNil(t, container.SecurityContext.Capabilities)
+				require.Equal(t, tc.expectedCapabilities, container.SecurityContext.Capabilities.Add)
+				require.Equal(t, []corev1.Capability{"ALL"}, container.SecurityContext.Capabilities.Drop)
+			}
+		})
+	}
+}
+
+func TestConsulDataplaneContainer_SecurityContext(t *testing.T) {
+	t.Parallel()
+
+	metrics := common.MetricsConfig{}
+	config := common.HelmConfig{
+		ImageDataplane:        "consul-dataplane:test",
+		GlobalImagePullPolicy: "IfNotPresent",
+		LogLevel:              "INFO",
+		LogJSON:               false,
+		ConsulConfig: common.ConsulConfig{
+			Address:  "consul.default.svc.cluster.local",
+			GRPCPort: 8502,
+		},
+	}
+
+	gateway := gwv1beta1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gateway",
+			Namespace: "default",
+		},
+		Spec: gwv1beta1.GatewaySpec{
+			Listeners: []gwv1beta1.Listener{
+				{
+					Name: "http",
+					Port: 8080,
+				},
+			},
+		},
+	}
+
+	gcc := v1alpha1.GatewayClassConfig{
+		Spec: v1alpha1.GatewayClassConfigSpec{
+			MapPrivilegedContainerPorts: 0,
+		},
+	}
+
+	container, err := consulDataplaneContainer(metrics, config, gcc, gateway, []corev1.VolumeMount{})
+	require.NoError(t, err)
+
+	// Verify all security context fields are set correctly
+	require.NotNil(t, container.SecurityContext)
+	require.Equal(t, ptr.To(true), container.SecurityContext.ReadOnlyRootFilesystem)
+	require.Equal(t, ptr.To(false), container.SecurityContext.AllowPrivilegeEscalation)
+	require.Equal(t, ptr.To(true), container.SecurityContext.RunAsNonRoot)
+
+	// Check seccomp profile
+	require.NotNil(t, container.SecurityContext.SeccompProfile)
+	require.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, container.SecurityContext.SeccompProfile.Type)
+
+	// Check capabilities for non-privileged case
+	require.NotNil(t, container.SecurityContext.Capabilities)
+	require.Equal(t, []corev1.Capability{"NET_BIND_SERVICE"}, container.SecurityContext.Capabilities.Add)
+	require.Equal(t, []corev1.Capability{"ALL"}, container.SecurityContext.Capabilities.Drop)
+}
+
+func TestConsulDataplaneContainer_BasicFunctionality(t *testing.T) {
+	t.Parallel()
+
+	metrics := common.MetricsConfig{
+		Enabled: true,
+		Port:    9090,
+	}
+	config := common.HelmConfig{
+		ImageDataplane:        "consul-dataplane:test",
+		GlobalImagePullPolicy: "IfNotPresent",
+		LogLevel:              "DEBUG",
+		LogJSON:               true,
+		ConsulConfig: common.ConsulConfig{
+			Address:  "consul.default.svc.cluster.local",
+			GRPCPort: 8502,
+		},
+	}
+
+	gateway := gwv1beta1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gateway",
+			Namespace: "default",
+		},
+		Spec: gwv1beta1.GatewaySpec{
+			Listeners: []gwv1beta1.Listener{
+				{
+					Name: "http",
+					Port: 8080,
+				},
+			},
+		},
+	}
+
+	gcc := v1alpha1.GatewayClassConfig{
+		Spec: v1alpha1.GatewayClassConfigSpec{
+			MapPrivilegedContainerPorts: 0,
+		},
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "test-volume",
+			MountPath: "/test",
+		},
+	}
+
+	container, err := consulDataplaneContainer(metrics, config, gcc, gateway, volumeMounts)
+	require.NoError(t, err)
+
+	// Basic container properties
+	require.Equal(t, gateway.Name, container.Name)
+	require.Equal(t, config.ImageDataplane, container.Image)
+	require.Equal(t, corev1.PullPolicy(config.GlobalImagePullPolicy), container.ImagePullPolicy)
+
+	// Volume mounts
+	require.Equal(t, volumeMounts, container.VolumeMounts)
+
+	// Environment variables
+	require.NotEmpty(t, container.Env)
+
+	// Check for required environment variables
+	envMap := make(map[string]string)
+	for _, env := range container.Env {
+		if env.Value != "" {
+			envMap[env.Name] = env.Value
+		}
+	}
+	require.Equal(t, "/consul/connect-inject", envMap["TMPDIR"])
+	require.Equal(t, "$(NODE_NAME)-virtual", envMap["DP_SERVICE_NODE_NAME"])
+
+	// Readiness probe
+	require.NotNil(t, container.ReadinessProbe)
+	require.NotNil(t, container.ReadinessProbe.HTTPGet)
+	require.Equal(t, "/ready", container.ReadinessProbe.HTTPGet.Path)
+
+	// Ports (should include prometheus port when metrics enabled)
+	require.NotEmpty(t, container.Ports)
+
+	var prometheusPortFound bool
+	for _, port := range container.Ports {
+		if port.Name == "prometheus" {
+			prometheusPortFound = true
+			require.Equal(t, int32(metrics.Port), port.ContainerPort)
+		}
+	}
+	require.True(t, prometheusPortFound, "Prometheus port should be configured when metrics are enabled")
+
+	// Args should contain expected dataplane arguments
+	require.NotEmpty(t, container.Args)
+
+	// Verify some key arguments are present
+	argsStr := ""
+	for _, arg := range container.Args {
+		argsStr += arg + " "
+	}
+	require.Contains(t, argsStr, "-addresses")
+	require.Contains(t, argsStr, "-grpc-port=8502")
+	require.Contains(t, argsStr, "-log-level=DEBUG")
+	require.Contains(t, argsStr, "-log-json=true")
+}

--- a/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper_test.go
@@ -1506,8 +1506,7 @@ func validateResourcesExist(t *testing.T, client client.Client, helmConfig commo
 		}
 		assert.True(t, hasInitContainer)
 
-		// Ensure there is a consul-dataplane container dropping ALL capabilities, adding
-		// back the NET_BIND_SERVICE capability, and establishing a read-only root filesystem
+		// Ensure there is a consul-dataplane container dropping ALL capabilities and establishing a read-only root filesystem
 		hasDataplaneContainer := false
 		for _, container := range actual.Spec.Template.Spec.Containers {
 			if container.Image == dataplaneImage {
@@ -1516,7 +1515,6 @@ func validateResourcesExist(t *testing.T, client client.Client, helmConfig commo
 				require.NotNil(t, container.SecurityContext.Capabilities)
 				require.NotNil(t, container.SecurityContext.ReadOnlyRootFilesystem)
 				assert.True(t, *container.SecurityContext.ReadOnlyRootFilesystem)
-				assert.Equal(t, []corev1.Capability{netBindCapability}, container.SecurityContext.Capabilities.Add)
 				assert.Equal(t, []corev1.Capability{allCapabilities}, container.SecurityContext.Capabilities.Drop)
 			}
 		}

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
@@ -265,15 +265,6 @@ func (w *MeshWebhook) consulDataplaneSidecar(namespace corev1.Namespace, pod cor
 		RunAsGroup:               ptr.To(group),
 		RunAsNonRoot:             ptr.To(true),
 		AllowPrivilegeEscalation: ptr.To(false),
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
-		// consul-dataplane requires the NET_BIND_SERVICE capability regardless of binding port #.
-		// See https://developer.hashicorp.com/consul/docs/connect/dataplane#technical-constraints
-		Capabilities: &corev1.Capabilities{
-			Add:  []corev1.Capability{"NET_BIND_SERVICE"},
-			Drop: []corev1.Capability{"ALL"},
-		},
 		ReadOnlyRootFilesystem: ptr.To(true),
 	}
 	enableConsulDataplaneAsSidecar, err := w.LifecycleConfig.EnableConsulDataplaneAsSidecar(pod)

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
@@ -268,6 +268,9 @@ func (w *MeshWebhook) consulDataplaneSidecar(namespace corev1.Namespace, pod cor
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
 		ReadOnlyRootFilesystem: ptr.To(true),
 	}
 	enableConsulDataplaneAsSidecar, err := w.LifecycleConfig.EnableConsulDataplaneAsSidecar(pod)

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
@@ -265,6 +265,9 @@ func (w *MeshWebhook) consulDataplaneSidecar(namespace corev1.Namespace, pod cor
 		RunAsGroup:               ptr.To(group),
 		RunAsNonRoot:             ptr.To(true),
 		AllowPrivilegeEscalation: ptr.To(false),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
 		ReadOnlyRootFilesystem: ptr.To(true),
 	}
 	enableConsulDataplaneAsSidecar, err := w.LifecycleConfig.EnableConsulDataplaneAsSidecar(pod)

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar_test.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar_test.go
@@ -807,6 +807,9 @@ func TestHandlerConsulDataplaneSidecar_withSecurityContext(t *testing.T) {
 				RunAsNonRoot:             ptr.To(true),
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 		},
 		"tproxy enabled; openshift disabled": {
@@ -818,6 +821,9 @@ func TestHandlerConsulDataplaneSidecar_withSecurityContext(t *testing.T) {
 				RunAsNonRoot:             ptr.To(true),
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 		},
 		"tproxy disabled; openshift enabled": {
@@ -829,6 +835,9 @@ func TestHandlerConsulDataplaneSidecar_withSecurityContext(t *testing.T) {
 				RunAsNonRoot:             ptr.To(true),
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 		},
 		"tproxy enabled; openshift enabled": {
@@ -840,6 +849,9 @@ func TestHandlerConsulDataplaneSidecar_withSecurityContext(t *testing.T) {
 				RunAsNonRoot:             ptr.To(true),
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 		},
 	}

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar_test.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar_test.go
@@ -807,6 +807,9 @@ func TestHandlerConsulDataplaneSidecar_withSecurityContext(t *testing.T) {
 				RunAsNonRoot:             ptr.To(true),
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
@@ -821,6 +824,9 @@ func TestHandlerConsulDataplaneSidecar_withSecurityContext(t *testing.T) {
 				RunAsNonRoot:             ptr.To(true),
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
@@ -835,6 +841,9 @@ func TestHandlerConsulDataplaneSidecar_withSecurityContext(t *testing.T) {
 				RunAsNonRoot:             ptr.To(true),
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
@@ -849,6 +858,9 @@ func TestHandlerConsulDataplaneSidecar_withSecurityContext(t *testing.T) {
 				RunAsNonRoot:             ptr.To(true),
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar_test.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar_test.go
@@ -807,13 +807,6 @@ func TestHandlerConsulDataplaneSidecar_withSecurityContext(t *testing.T) {
 				RunAsNonRoot:             ptr.To(true),
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
-				Capabilities: &corev1.Capabilities{
-					Add:  []corev1.Capability{"NET_BIND_SERVICE"},
-					Drop: []corev1.Capability{"ALL"},
-				},
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
 			},
 		},
 		"tproxy enabled; openshift disabled": {
@@ -825,13 +818,6 @@ func TestHandlerConsulDataplaneSidecar_withSecurityContext(t *testing.T) {
 				RunAsNonRoot:             ptr.To(true),
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
-				Capabilities: &corev1.Capabilities{
-					Add:  []corev1.Capability{"NET_BIND_SERVICE"},
-					Drop: []corev1.Capability{"ALL"},
-				},
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
 			},
 		},
 		"tproxy disabled; openshift enabled": {
@@ -843,13 +829,6 @@ func TestHandlerConsulDataplaneSidecar_withSecurityContext(t *testing.T) {
 				RunAsNonRoot:             ptr.To(true),
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
-				Capabilities: &corev1.Capabilities{
-					Add:  []corev1.Capability{"NET_BIND_SERVICE"},
-					Drop: []corev1.Capability{"ALL"},
-				},
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
 			},
 		},
 		"tproxy enabled; openshift enabled": {
@@ -861,13 +840,6 @@ func TestHandlerConsulDataplaneSidecar_withSecurityContext(t *testing.T) {
 				RunAsNonRoot:             ptr.To(true),
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
-				Capabilities: &corev1.Capabilities{
-					Add:  []corev1.Capability{"NET_BIND_SERVICE"},
-					Drop: []corev1.Capability{"ALL"},
-				},
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
 			},
 		},
 	}


### PR DESCRIPTION
> [!NOTE]
> This PR has a dependency on https://github.com/hashicorp/consul-dataplane/pull/652

### Changes proposed in this PR ### 

The current implementation enables NET_BIND_SERVICE for all the uses cases of data plane (envoy). We do not need this capability to be added to the pod when there privileged ports are not used.

We have generated the new data plane image as part of <PR-TODO> which can take the command to invoke the privileged envoy binary which can support the NET_BIND_SERVICE capability.

The current set of changes uses that, privileged, entry point when privileged ports are used for the use case. Although the most common use case is Ingress gateways which historically supported binding to privileged ports, for backward compatibility, the support is extended to other use cases: API Gateway and Mesh Gateway where user can configure the port.

All other use cases of data plane now use the "unprivileged", default, entry point which does not require the NET_BIND_SERVICE capability at runtime.

### How I've tested this PR ###

- Verified functionality for service mesh with ingress, API, and mesh gateways using both privileged and unprivileged ports to verify that it uses the appropriate entry point.
- Verified the function or service mesh with terminating gateway and regular service to service communication where unprivileged entry point.

### How I expect reviewers to test this PR ###

see above.

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
