### PR TITLE
CSL-11197: Fix rollout restart for API Gateway deployment to release 1.7.x

### DIFF
--- a/control-plane/api-gateway/gatekeeper/deployment.go
+++ b/control-plane/api-gateway/gatekeeper/deployment.go
@@ -222,9 +222,24 @@ func compareDeployments(a, b *appsv1.Deployment) bool {
 	return *b.Spec.Replicas == *a.Spec.Replicas
 }
 
-func newDeploymentMutator(deployment, mutated *appsv1.Deployment, gcc v1alpha1.GatewayClassConfig, gateway gwv1beta1.Gateway, scheme *runtime.Scheme) resourceMutator {
+func mergeAnnotation(b *appsv1.Deployment, annotations map[string]string) {
+	if b.Spec.Template.Annotations == nil {
+		b.Spec.Template.Annotations = make(map[string]string)
+	}
+	for k, v := range annotations {
+		if _, ok := b.Spec.Template.Annotations[k]; !ok {
+			b.Spec.Template.Annotations[k] = v
+		}
+	}
+
+}
+
+func newDeploymentMutator(deployment, mutated, existingDeployment *appsv1.Deployment, deploymentExists bool, gcc v1alpha1.GatewayClassConfig, gateway gwv1beta1.Gateway, scheme *runtime.Scheme) resourceMutator {
 	return func() error {
 		mutated = mergeDeployments(gcc, deployment, mutated)
+		if deploymentExists {
+			mergeAnnotation(mutated, existingDeployment.Spec.Template.Annotations)
+		}
 		return ctrl.SetControllerReference(&gateway, mutated, scheme)
 	}
 }


### PR DESCRIPTION
This PR resolves an issue where rollout restarts for the API Gateway deployment did not complete successfully. The gateway controller now correctly processes changes during a restart, ensuring reliable deployments. See[ CSL-11197](https://hashicorp.atlassian.net/browse/CSL-11197)