### PR TITLE
CSL-11197: Fix rollout restart for API Gateway deployment to release 1.8.x

### DIFF
--- a/.changelog/4773.txt
+++ b/.changelog/4773.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api-gateway: Fixed an issue where the gateway controller failed to detect annotation changes in deployments triggered by rollout restarts, preventing restarts from completing successfully.
+```


### PR DESCRIPTION
This PR resolves an issue where rollout restarts for the API Gateway deployment did not complete successfully. The gateway controller now correctly processes changes during a restart, ensuring reliable deployments. See[ CSL-11197](https://hashicorp.atlassian.net/browse/CSL-11197)

ref: https://github.com/hashicorp/consul-k8s/pull/4767