### PR TITLE
Add new output format `archive` to proxy read command.

### DIFF
--- a/.changelog/4781.txt
+++ b/.changelog/4781.txt
@@ -1,3 +1,0 @@
-```release-note:feature
-cli: add new output format `archive` to proxy stats cmd, this will enable user to save the command output to a file.
-```

--- a/.changelog/4781.txt
+++ b/.changelog/4781.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+cli: add new output format `archive` to proxy stats cmd, this will enable user to save the command output to a file.
+```

--- a/.changelog/4789.txt
+++ b/.changelog/4789.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+cli: add new output format `archive` to proxy read cmd, this will enable user to save the command output to a json file.
+```

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -29,6 +29,13 @@ import (
 // defaultAdminPort is the port where the Envoy admin API is exposed.
 const defaultAdminPort int = 19000
 
+type OutputFormat struct {
+	Table   string
+	JSON    string
+	Raw     string
+	Archive string
+}
+
 const (
 	Table   = "table"
 	JSON    = "json"
@@ -581,7 +588,8 @@ func (c *ReadCommand) outputArchive(configs map[string]*envoy.EnvoyConfig) error
 	// Create file path and directory for storing proxy read data
 	// NOTE: currently it is writing data file in cwd /proxy dir only. Also, file contents will be overwritten if
 	// the command is run multiple times for the same pod name or if file already exists.
-	proxyReadFilePath := filepath.Join("proxy", "proxy-read-"+c.flagPodName+".json")
+	fileName := fmt.Sprintf("proxy-read-%s.json", c.flagPodName)
+	proxyReadFilePath := filepath.Join("proxy", fileName)
 	err = os.MkdirAll(filepath.Dir(proxyReadFilePath), 0755)
 	if err != nil {
 		fmt.Printf("error creating proxy read output directory: %v", err)

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -26,20 +26,21 @@ import (
 	"github.com/hashicorp/consul-k8s/cli/common/terminal"
 )
 
-// defaultAdminPort is the port where the Envoy admin API is exposed.
-const defaultAdminPort int = 19000
-
 const (
+	// defaultAdminPort is the port where the Envoy admin API is exposed.
+	defaultAdminPort int = 19000
+
+	// permissions for creating dir & file [before writing envoy config to a file].
 	filePerm = 0644
 	dirPerm  = 0755
-)
 
-const (
+	// Output formats
 	Table   = "table"
 	JSON    = "json"
 	Raw     = "raw"
 	Archive = "archive"
 
+	// Flag names
 	flagNameNamespace   = "namespace"
 	flagNameOutput      = "output"
 	flagNameClusters    = "clusters"

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -577,16 +577,15 @@ func (c *ReadCommand) outputArchive(configs map[string]*envoy.EnvoyConfig) error
 	fileName := fmt.Sprintf("proxy-read-%s.json", c.flagPodName)
 	proxyReadFilePath := filepath.Join("proxy", fileName)
 	err = os.MkdirAll(filepath.Dir(proxyReadFilePath), dirPerm)
-	c.UI.Output(proxyReadFilePath)
 	if err != nil {
-		c.UI.Output(fmt.Sprintf("error creating proxy read output directory: %v", err), terminal.WithErrorStyle())
+		return fmt.Errorf("error creating proxy read output directory: %v", err)
 	}
 	err = os.WriteFile(proxyReadFilePath, out, filePerm)
 	if err != nil {
 		// Note: Please do not delete the directory created above even if writing file fails.
 		// This (/proxy) directory is used by all proxy read, log, list, stats command, for storing their outputs as archive.
-		c.UI.Output(fmt.Sprintf("error writing proxy read output to json file '%s': %v", proxyReadFilePath, err), terminal.WithErrorStyle())
+		return fmt.Errorf("error writing proxy read output to json file '%s': %v", proxyReadFilePath, err)
 	}
-	c.UI.Output("proxy read '%s' output saved to '%s'", c.flagPodName, proxyReadFilePath, terminal.WithSuccessStyle())
+	c.UI.Output(fmt.Sprintf("proxy read '%s' output saved to '%s'", c.flagPodName, proxyReadFilePath), terminal.WithSuccessStyle())
 	return nil
 }

--- a/cli/cmd/proxy/read/command.go
+++ b/cli/cmd/proxy/read/command.go
@@ -29,13 +29,6 @@ import (
 // defaultAdminPort is the port where the Envoy admin API is exposed.
 const defaultAdminPort int = 19000
 
-type OutputFormat struct {
-	Table   string
-	JSON    string
-	Raw     string
-	Archive string
-}
-
 const (
 	Table   = "table"
 	JSON    = "json"

--- a/cli/cmd/proxy/read/command_test.go
+++ b/cli/cmd/proxy/read/command_test.go
@@ -189,7 +189,8 @@ func TestReadCommandOutputArchive(t *testing.T) {
 
 	require.Equal(t, 0, out)
 
-	expectedFilePath := filepath.Join(tempDir, "proxy", "proxy-read-"+podName+".json")
+	fileName := fmt.Sprintf("proxy-read-%s.json", podName)
+	expectedFilePath := filepath.Join(tempDir, "proxy", fileName)
 
 	_, err = os.Stat(expectedFilePath)
 	require.NoError(t, err, "expected output file to be created, but it was not")


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Added support for a new output format `archive` to the proxy read command. This will write the proxy read command output to a json file in current working dir.
- `consul-k8s proxy read <podname> read -o archive`