### PR TITLE
Backport: CNI enhancements for tests, race conditions, upgrades, artifact cleanups #4757

### DIFF
--- a/.changelog/4757.txt
+++ b/.changelog/4757.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+cni: fixed race conditions with older versions where no cleanup was done for binary
+cni: cleanup of cni binary on previous pod deletion to improve security posture
+```

--- a/.github/workflows/pr-cloud-acceptance.yml
+++ b/.github/workflows/pr-cloud-acceptance.yml
@@ -29,4 +29,4 @@ jobs:
           repo: hashicorp/consul-k8s-workflows
           ref: main
           token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-          inputs: '{ "context":"${{ env.CONTEXT }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ github.sha }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'
+          inputs: '{"context":"${{ env.CONTEXT }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ github.sha }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'

--- a/charts/consul/templates/cni-daemonset.yaml
+++ b/charts/consul/templates/cni-daemonset.yaml
@@ -66,6 +66,11 @@ spec:
           {{ template "consul.imagePullPolicy" . }}
           securityContext:
             privileged: true
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
           command:
             - consul-k8s-control-plane
             - install-cni
@@ -73,6 +78,7 @@ spec:
             - -cni-bin-dir={{ .Values.connectInject.cni.cniBinDir }}
             - -cni-net-dir={{ .Values.connectInject.cni.cniNetDir }}
             - -multus={{ .Values.connectInject.cni.multus }}
+            - -installation-id=$(POD_UID)
             {{- if .Values.connectInject.cni.autorotateToken }}
             - -autorotate-token={{ .Values.connectInject.cni.autorotateToken }}
             {{- end }}

--- a/control-plane/subcommand/install-cni/cniconfig_test.go
+++ b/control-plane/subcommand/install-cni/cniconfig_test.go
@@ -304,7 +304,6 @@ func TestRemoveCNIConfig(t *testing.T) {
 			// get the config file name in the tempdir
 			filename := filepath.Base(c.goldenFile)
 			tempDestFile := filepath.Join(tempDir, filename)
-
 			err = removeCNIConfig(tempDestFile)
 			if err != nil {
 				t.Fatal(err)

--- a/control-plane/subcommand/install-cni/command.go
+++ b/control-plane/subcommand/install-cni/command.go
@@ -28,6 +28,7 @@ const (
 	defaultCNIBinSourceDir = "/bin"
 	consulCNIName          = "consul-cni" // Name of the plugin and binary. They must be the same as per the CNI spec.
 	defaultLogJSON         = false
+	gracePeriodTimeout     = 100 * time.Second
 )
 
 // Command flags and structure.
@@ -51,6 +52,10 @@ type Command struct {
 	flagLogJSON bool
 	// flagMultus is a boolean flag for multus support.
 	flagMultus bool
+	// flagInstallationID is a unique identifier for this installation instance.
+	flagInstallationID string
+	// flagCNITokenPath is the path to the CNI token file for testing purposes.
+	flagCNITokenPath string
 
 	flagSet *flag.FlagSet
 
@@ -72,6 +77,8 @@ func (c *Command) init() {
 	c.flagSet.BoolVar(&c.flagK8sAutorotateToken, "autorotate-token", config.DefaultAutorotateToken, "Enable or disable token autorotate feature.")
 	c.flagSet.BoolVar(&c.flagLogJSON, "log-json", defaultLogJSON, "Enable or disable JSON output format for logging.")
 	c.flagSet.BoolVar(&c.flagMultus, "multus", config.DefaultMultus, "If the plugin is a multus plugin (default = false)")
+	c.flagSet.StringVar(&c.flagInstallationID, "installation-id", "", "Unique identifier for this installation instance (auto-generated if not provided)")
+	c.flagSet.StringVar(&c.flagCNITokenPath, "cni-token-path", "", "Path to the CNI token file for testing purposes.")
 
 	c.help = flags.Usage(help, c.flagSet)
 
@@ -87,7 +94,6 @@ func (c *Command) init() {
 // Run runs the command.
 func (c *Command) Run(args []string) int {
 	c.once.Do(c.init)
-
 	if err := c.flagSet.Parse(args); err != nil {
 		return 1
 	}
@@ -102,22 +108,35 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
-	uid := fmt.Sprintf("%d", time.Now().UnixNano())
+	// Generate or use provided installation ID
+	var installationID string
+	if c.flagInstallationID != "" {
+		installationID = c.flagInstallationID
+	} else {
+		installationID = fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+
 	// Create the CNI Config from command flags.
 	cfg := &config.CNIConfig{
-		Name:         config.DefaultPluginName,
-		Type:         config.DefaultPluginType,
-		CNITokenPath: config.DefaultCNITokenDir + "/" + config.DefaultCNITokenFilename,
+		Name: config.DefaultPluginName,
+		Type: config.DefaultPluginType,
+		CNITokenPath: func() string {
+			dir := c.flagCNITokenPath
+			if dir == "" {
+				dir = config.DefaultCNITokenDir
+			}
+			return filepath.Join(dir, config.DefaultCNITokenFilename)
+		}(),
 		CNIHostTokenPath: func() string {
 			if c.flagK8sAutorotateToken {
-				return c.flagCNINetDir + "/" + config.DefaultCNIHostTokenFilename + "-" + uid
+				return filepath.Join(c.flagCNINetDir, config.DefaultCNIHostTokenFilename+"-"+installationID)
 			}
 			return ""
 		}(),
 		AutorotateToken: c.flagK8sAutorotateToken,
 		CNIBinDir:       c.flagCNIBinDir,
 		CNINetDir:       c.flagCNINetDir,
-		Kubeconfig:      c.flagKubeconfig,
+		Kubeconfig:      config.DefaultKubeconfig + "-" + installationID,
 		LogLevel:        c.flagLogLevel,
 		Multus:          c.flagMultus,
 	}
@@ -141,9 +160,9 @@ func (c *Command) Run(args []string) int {
 	// Copy the consul-cni binary from the installer container to the host.
 	c.logger.Info("Copying consul-cni binary", "destination", cfg.CNIBinDir)
 	srcFile := filepath.Join(c.flagCNIBinSourceDir, consulCNIName)
-	err := copyFile(srcFile, cfg.CNIBinDir)
-	if err != nil {
-		c.logger.Error("could not copy consul-cni binary", "error", err)
+	// Watch for changes in the binary file and copy it to the destination when updates occur.
+	if err := c.binWatcher(ctx, srcFile, cfg.CNIBinDir, cfg.Type); err != nil {
+		c.logger.Error("Binary watcher failed", "error", err)
 		return 1
 	}
 
@@ -193,44 +212,164 @@ func (c *Command) Run(args []string) int {
 		// annotation during connect inject so that multus knows to run the consul-cni plugin.
 		c.logger.Info("Multus enabled, using multus NetworkAttachementDefinition for configuration")
 	}
+
+	errCh := make(chan error, 2)
+	var wg sync.WaitGroup
 	// watch for changes in the default cni serviceaccount token directory
 	if cfg.AutorotateToken {
 		// if autorotate-token is enabled, we need to watch the token file for changes and copy it to the host
 		// as newly rotated projected tokens are only available in the cni-pod and not on the host
 		sourceTokenPath := cfg.CNITokenPath
 		hostTokenPath := cfg.CNIHostTokenPath
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			if err := c.tokenFileWatcher(ctx, sourceTokenPath, hostTokenPath); err != nil {
 				c.logger.Error("Token file watcher failed", "error", err)
+				errCh <- err
 			}
 		}()
 	}
 
-	// Watch for changes in the cniNetDir directory and fix/install the config file if need be.
-	err = c.directoryWatcher(ctx, cfg, cfg.CNINetDir, cfgFile)
-	if err != nil {
-		c.logger.Error("error with directory watcher", "error", err)
-		return 1
+	// Watch for changes in the cniNetDir directory and fix/install the config files if need be.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := c.directoryWatcher(ctx, cfg, cfg.CNINetDir, cfgFile); err != nil {
+			c.logger.Error("error with directory watcher", "error", err)
+			errCh <- err
+		}
+	}()
+
+	// Wait for either a shutdown signal or an error from watchers
+	var responseCode = 0
+	select {
+	case sig := <-c.sigCh:
+		c.logger.Info("Received shutdown signal", "signal", sig)
+
+	case err := <-errCh:
+		c.logger.Error("Received error from watcher", "error", err)
+		responseCode = 1
 	}
-	return 0
+	cancel()
+	wg.Wait()
+	// wait for watchers to finish as they regenerate pluginconfs/tokens/kubeconfigs
+	c.cleanup(cfg, cfgFile)
+	return responseCode
+}
+
+// binWatcher watches for changes in the source CNI binary file and re-copies it to the destination when updates occur.
+// This is useful for scenarios where the CNI binary might be updated during runtime.
+func (c *Command) binWatcher(ctx context.Context, sourceBinPath, destBinDir, destBinName string) error {
+	destBinWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("could not create sourceBinWatcher: %w", err)
+	}
+	defer func() {
+		_ = destBinWatcher.Close()
+	}()
+
+	destBinPath := filepath.Join(destBinDir, destBinName)
+	c.logger.Info("Creating destBinWatcher for", "file", destBinPath)
+	for i := 1; i <= 5; i++ {
+		if _, err := os.Stat(destBinPath); err != nil && os.IsNotExist(err) {
+			// previous pod might have cleaned it up
+			err = copyFileWithName(sourceBinPath, destBinDir, destBinName)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+		err = destBinWatcher.Add(destBinPath)
+		if err != nil {
+			//probably the file is not present as previous pod deleted it after fileCheck as race condition
+			c.logger.Error("could not watch binary file %s: %w", sourceBinPath, err)
+			time.Sleep(time.Second * time.Duration(i))
+		} else {
+			break
+		}
+		c.logger.Info("Created destBinWatcher for", "file", destBinPath)
+	}
+	//older pods who dont cleanup so wont fire remove event for race conditions if
+	// we added the bin watcher for older binary
+	gracePeriodAlarm := time.NewTimer(gracePeriodTimeout)
+	defer gracePeriodAlarm.Stop()
+	// post this watcher is created, but it might be that previous pod removes it later
+	// so we listen to remove events and copy once and end watching
+
+	for {
+		select {
+		case event, ok := <-destBinWatcher.Events:
+			if !ok {
+				c.logger.Error("Binary destBinWatcher event is not ok", "event", event)
+				break
+			}
+
+			// Only handle events for the specific binary file
+			c.logger.Info("Received binary file event",
+				"event_type", event.Op.String(),
+				"file", event.Name)
+
+			// Handle Remove event that might indicate binary removal
+			if event.Op&(fsnotify.Remove) != 0 {
+				// Re-copy the binary file
+				if err := copyFileWithName(sourceBinPath, destBinDir, destBinName); err != nil {
+					c.logger.Error("Failed to copy binary after update", "error", err)
+					return err
+				} else {
+					c.logger.Info("Successfully copied updated binary from source")
+				}
+				return nil
+			}
+		case <-gracePeriodAlarm.C:
+			c.logger.Info("Grace period timeout reached, older pod may not have cleaned up binary, proceeding with copy")
+			// Copy the binary and proceed since older pod didn't clean up within grace period
+			if err := copyFileWithName(sourceBinPath, destBinDir, destBinName); err != nil {
+				c.logger.Error("Failed to copy binary after grace period timeout", "error", err)
+				return err
+			} else {
+				c.logger.Info("Successfully copied binary after grace period timeout")
+			}
+			return nil
+		case err, ok := <-destBinWatcher.Errors:
+			if !ok {
+				c.logger.Error("SourceBinWatcher error channel closed")
+				return nil
+			}
+			c.logger.Error("SourceBinWatcher error", "error", err)
+
+		case <-ctx.Done():
+			return nil
+		}
+	}
 }
 
 // cleanup removes the consul-cni configuration, kubeconfig and cni-host-token-<uid> file from cniNetDir and cniBinDir.
 func (c *Command) cleanup(cfg *config.CNIConfig, cfgFile string) {
 	var err error
 	c.logger.Info("Shutdown received, cleaning up")
+	// Its important to cleanup in this order as plugin conf binds cni in the workflow
 	if cfgFile != "" {
 		err = removeCNIConfig(cfgFile)
+		c.logger.Info("Removed CNI Config", "file", cfgFile)
 		if err != nil {
 			c.logger.Error("Unable to cleanup CNI Config: %w", err)
 		}
 	}
-	c.logger.Info("Removing file", "file", cfg.CNIHostTokenPath)
 
+	cniBinaryPath := filepath.Join(cfg.CNIBinDir, cfg.Type)
+	c.logger.Info("Removing file", "file", cniBinaryPath)
+	err = removeFile(cniBinaryPath)
+	if err != nil {
+		c.logger.Error("Unable to remove %s file: %w", cniBinaryPath, err)
+	}
+
+	c.logger.Info("Removing file", "file", cfg.CNIHostTokenPath)
 	err = removeFile(cfg.CNIHostTokenPath)
 	if err != nil {
 		c.logger.Error("Unable to remove %s file: %w", cfg.CNIHostTokenPath, err)
 	}
+
 	kubeconfig := filepath.Join(cfg.CNINetDir, cfg.Kubeconfig)
 	c.logger.Info("Removing file", "file", kubeconfig)
 
@@ -246,9 +385,8 @@ func (c *Command) cleanup(cfg *config.CNIConfig, cfgFile string) {
 func (c *Command) directoryWatcher(ctx context.Context, cfg *config.CNIConfig, dir, cfgFile string) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return fmt.Errorf("could not create watcher: %w", err)
+		return fmt.Errorf("could not create dirwatcher: %w", err)
 	}
-
 	c.logger.Info("Creating directory watcher for", "directory", dir)
 	err = watcher.Add(dir)
 	if err != nil {
@@ -256,13 +394,12 @@ func (c *Command) directoryWatcher(ctx context.Context, cfg *config.CNIConfig, d
 	}
 	defer func() {
 		_ = watcher.Close()
-		c.cleanup(cfg, cfgFile)
 	}()
 
 	// Generate the initial kubeconfig file that will be used by the plugin to communicate with the kubernetes api.
 	c.logger.Info("Creating kubeconfig", "file", cfg.Kubeconfig)
-	kubeConfigFile := filepath.Join(cfg.CNINetDir, cfg.Kubeconfig)
-	err = createKubeConfig(cfg)
+	kubeConfigFile := filepath.Join(dir, cfg.Kubeconfig)
+	err = createKubeConfig(dir, cfg)
 	if err != nil {
 		c.logger.Error("could not create kube config", "error", err)
 	}
@@ -278,25 +415,26 @@ func (c *Command) directoryWatcher(ctx context.Context, cfg *config.CNIConfig, d
 			// created before other CNI plugins were installed.
 			if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Remove) != 0 {
 				// Separate tokenFileWatcher updates the token file in the host path
-				// This directory watcher doesn't need to handle anything related to token
-				if strings.Contains(event.Name, config.DefaultCNIHostTokenFilename) {
-					c.logger.Info("Skipping event for host token path. Nothing to do.", "event_path", event.Name)
+				// older daemonset can delete this token on SIGTERM as cleanup
+				if event.Name == cfg.CNIHostTokenPath {
+					c.logger.Info("Token file updated", "file", event.Name)
 					break
 				}
-
 				// older daemonset can delete this kubeconfig on SIGTERM as cleanup
 				// new pod should listen to remove and regenerate it.
+				// currently this is not unit-testable as createKubeConfig is not mockable
 				if event.Name == kubeConfigFile {
 					if event.Op&fsnotify.Remove != 0 {
 						c.logger.Info("Creating kubeconfig", "file", cfg.Kubeconfig)
-						err := createKubeConfig(cfg)
+						err := createKubeConfig(dir, cfg)
 						if err != nil {
 							c.logger.Error("could not create kube config", "error", err)
-							break
+							return err
 						}
 					}
 					break
 				}
+
 				// Only repair things if this is a non-multus setup. Multus config is handled differently
 				// than chained plugins
 				if !cfg.Multus {
@@ -306,14 +444,14 @@ func (c *Command) directoryWatcher(ctx context.Context, cfg *config.CNIConfig, d
 					cfgFile, err = defaultCNIConfigFile(dir)
 					if err != nil {
 						c.logger.Error("Unable get default config file", "error", err)
-						break
+						return err
 					}
 
 					if strings.HasSuffix(cfgFile, ".conf") {
 						cfgFile, err = confListFileFromConfFile(cfgFile)
 						if err != nil {
 							c.logger.Error("could convert .conf file to .conflist file", "error", err)
-							break
+							return err
 						}
 					}
 
@@ -331,18 +469,16 @@ func (c *Command) directoryWatcher(ctx context.Context, cfg *config.CNIConfig, d
 							}
 						} else {
 							c.logger.Info("Valid config file detected, nothing to do")
-							break
 						}
 					}
 				}
 			}
+
 		case err, ok := <-watcher.Errors:
 			if !ok {
 				c.logger.Error("Event watcher event is not ok", "error", err)
 			}
 		case <-ctx.Done():
-			return nil
-		case <-c.sigCh:
 			return nil
 		}
 	}
@@ -351,35 +487,32 @@ func (c *Command) directoryWatcher(ctx context.Context, cfg *config.CNIConfig, d
 // In case of autorotate-token, we are using projected tokens which doesn't support hostpath mount,
 // we need to watch the token file for changes and copy it to the host.
 func (c *Command) tokenFileWatcher(ctx context.Context, sourceTokenPath, hostTokenPath string) error {
-	watcher, err := fsnotify.NewWatcher()
+	sourceTokenWatcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return fmt.Errorf("could not create token watcher: %w", err)
+		return fmt.Errorf("could not create sourcetokenWatcher: %w", err)
 	}
-
+	if err != nil {
+		return fmt.Errorf("could not create desttokenWatcher: %w", err)
+	}
 	defer func() {
-		_ = watcher.Close()
+		_ = sourceTokenWatcher.Close()
 	}()
 
-	// Watch the directory containing the token instead of the symlink
-	c.logger.Info("Creating token watcher for", "file", sourceTokenPath)
-	if err := watcher.Add(sourceTokenPath); err != nil {
+	c.logger.Info("Creating sourceTokenWatcher for", "file", sourceTokenPath)
+	if err := sourceTokenWatcher.Add(sourceTokenPath); err != nil {
 		return fmt.Errorf("could not watch token file %s: %w", sourceTokenPath, err)
 	}
 
-	// Copy token if initial access is possible
-	if _, err := os.Stat(sourceTokenPath); err == nil {
-		c.logger.Info("Initial token copy to host", "sourcePath", sourceTokenPath, "destinationPath", hostTokenPath)
-		if err := copyToken(sourceTokenPath, hostTokenPath); err != nil {
-			c.logger.Error("Failed initial token copy", "error", err)
-		}
+	if err := copyToken(sourceTokenPath, hostTokenPath); err != nil {
+		c.logger.Info("Failed to perform initial copy token", "error", err)
 	}
 
 	for {
 		select {
-		case event, ok := <-watcher.Events:
+		case event, ok := <-sourceTokenWatcher.Events:
 			if !ok {
-				c.logger.Error("Token watcher event is not ok", "event", event)
-				break
+				c.logger.Error("Token sourceTokenWatcher event is not ok", "event", event)
+				return fmt.Errorf("token sourceTokenWatcher event channel closed unexpectedly")
 			}
 
 			// Only handle events for the specific token file
@@ -387,51 +520,85 @@ func (c *Command) tokenFileWatcher(ctx context.Context, sourceTokenPath, hostTok
 				"event_type", event.Op.String(),
 				"file", event.Name)
 
-			if event.Name != sourceTokenPath {
-				c.logger.Info("Skipping event as it's not for the source token path", "event_path", event.Name, "source_token_path", sourceTokenPath)
-				break
-			}
 			// Handle Write event on symlink update to point to a new file
 			// but the symlink's creation timestamp changes on doing such update as well.
 
 			if event.Op&(fsnotify.Remove|fsnotify.Chmod) != 0 {
-				// Re-add watcher after remove/chmod
+				// Re-add sourceTokenWatcher after remove/chmod
 				backoff := time.Second
-				for i := 0; i < 5; i++ {
-					if err := watcher.Add(sourceTokenPath); err != nil {
-						c.logger.Error("Failed to re-add watcher after remove/chmod", "error", err, "attempt", i+1)
+				waitCount := 5
+				for i := 1; i <= waitCount; i++ {
+					if err := sourceTokenWatcher.Add(sourceTokenPath); err != nil {
+						c.logger.Error("Failed to re-add sourceTokenWatcher after remove/chmod", "error", err, "attempt", i+1)
 						time.Sleep(backoff)
 						backoff *= 2
-						continue
+						if waitCount == i {
+							return fmt.Errorf("failed to re-add sourceTokenWatcher after remove/chmod after %d attempts", waitCount)
+						}
 					}
-					break
 				}
-				if _, err := os.Stat(sourceTokenPath); err == nil {
-					if err := copyToken(sourceTokenPath, hostTokenPath); err != nil {
-						c.logger.Error("Failed to copy token after symlink update", "error", err)
-					} else {
-						c.logger.Info("Successfully copied new token after symlink update")
-					}
+
+				if err := copyToken(sourceTokenPath, hostTokenPath); err != nil {
+					c.logger.Error("Failed to copy token after symlink update", "error", err)
+				} else {
+					c.logger.Info("Successfully copied new token from source")
 				}
 			}
 
-		case err, ok := <-watcher.Errors:
+		case err, ok := <-sourceTokenWatcher.Errors:
 			if !ok {
-				c.logger.Error("Token watcher error channel closed")
-				continue
+				c.logger.Error("SourceTokenWatcher error channel closed")
+				return fmt.Errorf("SourceTokenWatcher error channel closed unexpectedly")
 			}
-			c.logger.Error("Token watcher error", "error", err)
+			c.logger.Error("SourceTokenWatcher error", "error", err)
 
 		case <-ctx.Done():
-			return nil
-		case <-c.sigCh:
 			return nil
 		}
 	}
 }
 
+func copyFileWithName(srcFile, destDir, destFileName string) error {
+	// if destFile is not passed we use the srcFile basepath
+	if _, err := os.Stat(srcFile); os.IsNotExist(err) {
+		return err
+	}
+	if destFileName == "" {
+		destFileName = filepath.Base(srcFile)
+	}
+	// If the destDir does not exist then the incorrect command line argument was used or
+	// the CNI settings for the kubelet are not correct.
+	info, err := os.Stat(destDir)
+	if os.IsNotExist(err) {
+		return err
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("destination directory %s is not a directory", destDir)
+	}
+
+	// Check if the user bit is enabled in folder permission.
+	if info.Mode().Perm()&(1<<(uint(7))) == 0 {
+		return fmt.Errorf("cannot write to destination directory %s", destDir)
+	}
+
+	srcBytes, err := os.ReadFile(srcFile)
+	if err != nil {
+		return fmt.Errorf("could not read %s file", srcFile)
+	}
+
+	err = os.WriteFile(filepath.Join(destDir, destFileName), srcBytes, info.Mode())
+	if err != nil {
+		return fmt.Errorf("error copying %s binary to %s", destFileName, destDir)
+	}
+	return nil
+}
+
 func copyToken(src, dst string) error {
 	// Read source token
+	if _, err := os.Stat(src); err != nil {
+		return err
+	}
 	content, err := os.ReadFile(src)
 	if err != nil {
 		return fmt.Errorf("failed to read source token: %w", err)

--- a/control-plane/subcommand/install-cni/command_test.go
+++ b/control-plane/subcommand/install-cni/command_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -103,6 +104,379 @@ func TestRun_DirectoryWatcher(t *testing.T) {
 	// If we exit the test too quickly it can cause a race condition where File event 3 is still running and we
 	// delete the config file while the test is doing a write.
 	time.Sleep(50 * time.Millisecond)
+}
+
+func TestRun_TokenFileWatcher(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		testFunc    func(t *testing.T, cmd *Command, sourceTokenPath, hostTokenPath string, ctx context.Context)
+	}{
+		{
+			name:        "source token file deletion and recreation",
+			description: "Test that when source token file is deleted and recreated with new content, host file reflects updated content",
+			testFunc: func(t *testing.T, cmd *Command, sourceTokenPath, hostTokenPath string, ctx context.Context) {
+				// Create initial source token file
+				initialContent := "initial-token-content-12345"
+				err := os.WriteFile(sourceTokenPath, []byte(initialContent), 0644)
+				require.NoError(t, err)
+
+				// Start token file watcher
+				go func() {
+					err := cmd.tokenFileWatcher(ctx, sourceTokenPath, hostTokenPath)
+					if err != nil && ctx.Err() == nil {
+						t.Errorf("tokenFileWatcher error: %v", err)
+					}
+				}()
+
+				// Wait for initial copy
+				time.Sleep(200 * time.Millisecond)
+
+				// Verify initial copy worked
+				retry.Run(t, func(r *retry.R) {
+					content, err := os.ReadFile(hostTokenPath)
+					require.NoError(r, err, "Host token file should exist")
+					require.Equal(r, initialContent, string(content), "Initial content should match")
+				})
+
+				t.Log("Step 1: Delete source token file")
+				err = os.Remove(sourceTokenPath)
+				require.NoError(t, err)
+
+				// Wait for file system event processing
+				time.Sleep(100 * time.Millisecond)
+
+				t.Log("Step 2: Recreate source token file with new content")
+				updatedContent := "updated-token-content-67890"
+				err = os.WriteFile(sourceTokenPath, []byte(updatedContent), 0644)
+				require.NoError(t, err)
+
+				// Wait for token watcher to detect and copy new content
+				time.Sleep(300 * time.Millisecond)
+
+				t.Log("Step 3: Verify host token file has updated content")
+				retry.Run(t, func(r *retry.R) {
+					content, err := os.ReadFile(hostTokenPath)
+					require.NoError(r, err, "Host token file should still exist")
+					require.Equal(r, updatedContent, string(content), "Host token should have updated content")
+				})
+			},
+		},
+		{
+			name:        "multiple source token updates",
+			description: "Test multiple consecutive updates to source token file are reflected in host file",
+			testFunc: func(t *testing.T, cmd *Command, sourceTokenPath, hostTokenPath string, ctx context.Context) {
+				// Create initial source token file
+				initialContent := "token-v1"
+				err := os.WriteFile(sourceTokenPath, []byte(initialContent), 0644)
+				require.NoError(t, err)
+
+				// Start token file watcher
+				go func() {
+					err := cmd.tokenFileWatcher(ctx, sourceTokenPath, hostTokenPath)
+					if err != nil && ctx.Err() == nil {
+						t.Errorf("tokenFileWatcher error: %v", err)
+					}
+				}()
+
+				// Wait for initial copy
+				time.Sleep(200 * time.Millisecond)
+
+				// Test multiple updates
+				updates := []string{"token-v2", "token-v3", "token-v4"}
+				for i, content := range updates {
+					t.Logf("Step %d: Update token to %s", i+1, content)
+
+					// Remove and recreate with new content
+					err = os.Remove(sourceTokenPath)
+					require.NoError(t, err)
+					time.Sleep(50 * time.Millisecond)
+
+					err = os.WriteFile(sourceTokenPath, []byte(content), 0644)
+					require.NoError(t, err)
+					time.Sleep(200 * time.Millisecond)
+
+					// Verify host file has the latest content
+					retry.Run(t, func(r *retry.R) {
+						hostContent, err := os.ReadFile(hostTokenPath)
+						require.NoError(r, err, "Host token file should exist")
+						require.Equal(r, content, string(hostContent), "Host token should have latest content")
+					})
+				}
+			},
+		},
+		{
+			name:        "source token chmod event handling",
+			description: "Test that chmod events on source token trigger re-copy to host",
+			testFunc: func(t *testing.T, cmd *Command, sourceTokenPath, hostTokenPath string, ctx context.Context) {
+				// Create initial source token file
+				initialContent := "chmod-test-token-abc123"
+				err := os.WriteFile(sourceTokenPath, []byte(initialContent), 0644)
+				require.NoError(t, err)
+
+				// Start token file watcher
+				go func() {
+					err := cmd.tokenFileWatcher(ctx, sourceTokenPath, hostTokenPath)
+					if err != nil && ctx.Err() == nil {
+						t.Errorf("tokenFileWatcher error: %v", err)
+					}
+				}()
+
+				// Wait for initial copy
+				time.Sleep(200 * time.Millisecond)
+
+				// Verify initial copy worked
+				retry.Run(t, func(r *retry.R) {
+					content, err := os.ReadFile(hostTokenPath)
+					require.NoError(r, err, "Host token file should exist")
+					require.Equal(r, initialContent, string(content), "Initial content should match")
+				})
+
+				t.Log("Step 1: Update source token content and trigger chmod")
+				updatedContent := "chmod-updated-token-xyz789"
+				err = os.WriteFile(sourceTokenPath, []byte(updatedContent), 0600)
+				require.NoError(t, err)
+
+				// Trigger chmod event which should cause re-copy
+				err = os.Chmod(sourceTokenPath, 0644)
+				require.NoError(t, err)
+
+				// Wait for token watcher to detect chmod and copy new content
+				time.Sleep(300 * time.Millisecond)
+
+				t.Log("Step 2: Verify host token file has updated content after chmod")
+				retry.Run(t, func(r *retry.R) {
+					content, err := os.ReadFile(hostTokenPath)
+					require.NoError(r, err, "Host token file should still exist")
+					require.Equal(r, updatedContent, string(content), "Host token should have updated content after chmod")
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp directories
+			tempDir := t.TempDir()
+
+			// Setup paths
+			sourceTokenPath := filepath.Join(tempDir, "source-token")
+			hostTokenPath := filepath.Join(tempDir, "host-token")
+
+			// Setup the Command
+			ui := cli.NewMockUi()
+			cmd := &Command{
+				UI: ui,
+			}
+			cmd.init()
+			var err error
+			cmd.logger, err = common.Logger("info", false)
+			require.NoError(t, err)
+
+			// Create context
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			// Run the specific test
+			tt.testFunc(t, cmd, sourceTokenPath, hostTokenPath, ctx)
+		})
+	}
+}
+
+func TestRun_SignalCleanup(t *testing.T) {
+	tests := []struct {
+		name            string
+		signal          os.Signal
+		autorotateToken bool
+		description     string
+	}{
+		{
+			name:            "SIGTERM cleanup with autorotate token",
+			signal:          syscall.SIGTERM,
+			autorotateToken: true,
+			description:     "Test that SIGTERM signal triggers cleanup of all files including host token",
+		},
+		{
+			name:            "SIGINT cleanup with autorotate token",
+			signal:          os.Interrupt,
+			autorotateToken: true,
+			description:     "Test that SIGINT signal triggers cleanup of all files including host token",
+		},
+		{
+			name:            "SIGTERM cleanup without autorotate token",
+			signal:          syscall.SIGTERM,
+			autorotateToken: false,
+			description:     "Test that SIGTERM signal triggers cleanup of CNI binary and kubeconfig (no host token)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp directories
+			tempDir := t.TempDir()
+			binDir := t.TempDir()
+			sourceDir := t.TempDir()
+
+			// Create configuration
+			uid := fmt.Sprintf("%d", time.Now().UnixNano())
+			cfg := &config.CNIConfig{
+				Name:         config.DefaultPluginName,
+				Type:         config.DefaultPluginType,
+				CNITokenPath: filepath.Join(sourceDir, "token"),
+				CNIHostTokenPath: func() string {
+					if tt.autorotateToken {
+						return filepath.Join(tempDir, config.DefaultCNIHostTokenFilename+"-"+uid)
+					}
+					return ""
+				}(),
+				AutorotateToken: tt.autorotateToken,
+				CNIBinDir:       binDir,
+				CNINetDir:       tempDir,
+				Kubeconfig:      "ZZZ-consul-cni-kubeconfig",
+				LogLevel:        "info",
+				Multus:          false,
+			}
+
+			// Setup the Command with custom signal channel
+			ui := cli.NewMockUi()
+			cmd := &Command{
+				UI:                  ui,
+				flagCNIBinSourceDir: sourceDir,
+				sigCh:               make(chan os.Signal, 1), // Custom signal channel for testing
+				flagInstallationID:  uid,
+			}
+
+			var err error
+			cmd.logger, err = common.Logger("info", false)
+			require.NoError(t, err)
+
+			// Create all the files and sourceFiles required for test
+			t.Log("Creating files for test setup...")
+
+			// Create source CNI binary for copying
+			err = os.WriteFile(filepath.Join(sourceDir, config.DefaultPluginType), []byte("test-binary-content"), 0755)
+			require.NoError(t, err)
+
+			// Create a CNI config file to test cleanup
+			configFile := filepath.Join(cfg.CNINetDir, "10-test.conflist")
+			configContent := `{
+				"cniVersion": "0.3.1",
+				"name": "test-network",
+				"plugins": [
+					{
+						"type": "bridge",
+						"bridge": "cni0"
+					}
+				]
+			}`
+			err = os.WriteFile(configFile, []byte(configContent), 0644)
+			require.NoError(t, err)
+
+			// 2. Kubeconfig file
+			kubeconfigPath := filepath.Join(cfg.CNINetDir, cfg.Kubeconfig+"-"+uid)
+			configContentByte, err := os.ReadFile("testdata/ZZZ-consul-cni-kubeconfig-tokenautorotate.golden")
+			require.NoError(t, err)
+			err = os.WriteFile(kubeconfigPath, configContentByte, 0644)
+			require.NoError(t, err)
+
+			// 3. Source token file (if autorotate is enabled)
+			if tt.autorotateToken {
+				// Also create source token
+				err = os.WriteFile(cfg.CNITokenPath, []byte("test-source-token"), 0644)
+				require.NoError(t, err)
+			}
+
+			// Start the command in a goroutine
+			var runResult int
+			var runErr error
+			done := make(chan struct{})
+
+			go func() {
+				defer close(done)
+				// Create args that would normally be passed to Run
+				args := []string{
+					"-cni-bin-dir", binDir,
+					"-cni-net-dir", tempDir,
+					"-bin-source-dir", sourceDir,
+					"-cni-token-path", sourceDir,
+					"-kubeconfig", cfg.Kubeconfig,
+					"-installation-id", uid,
+					"-log-level", "info",
+				}
+				if tt.autorotateToken {
+					args = append(args, "-autorotate-token")
+				}
+
+				runResult = cmd.Run(args)
+
+			}()
+
+			time.Sleep(2000 * time.Millisecond)
+
+			// Verify all files exist before cleanup
+			t.Log("Verifying files exist before signal...")
+			cniBinaryPath := filepath.Join(cfg.CNIBinDir, cfg.Type)
+			_, err = os.Stat(cniBinaryPath)
+			require.NoError(t, err, "CNI binary should exist before cleanup")
+
+			// Verify the content of the CNI binary file
+			content, err := os.ReadFile(cniBinaryPath)
+			require.NoError(t, err, "Should be able to read CNI binary file")
+			require.Equal(t, "test-binary-content", string(content), "CNI binary content should match")
+
+			_, err = os.Stat(kubeconfigPath)
+			require.NoError(t, err, "Kubeconfig should exist before cleanup")
+			if tt.autorotateToken {
+				hostTokenPath := filepath.Join(tempDir, config.DefaultCNIHostTokenFilename+"-"+uid)
+				_, err = os.Stat(hostTokenPath)
+				require.NoError(t, err, "Host token should exist before cleanup")
+
+				// Verify the content of the host token file
+				content, err = os.ReadFile(hostTokenPath)
+				require.NoError(t, err, "Should be able to read host token file")
+				require.Equal(t, "test-source-token", string(content), "Host token content should match")
+			}
+
+			t.Logf("Sending %v signal to trigger cleanup...", tt.signal)
+			// Send the signal to trigger cleanup
+			cmd.sigCh <- tt.signal
+
+			// Wait for the command to complete
+			select {
+			case <-done:
+				t.Log("Command completed successfully")
+			case <-time.After(10 * time.Second):
+				t.Fatal("Command did not complete within timeout")
+			}
+
+			// Verify the command returned successfully (0)
+			require.Equal(t, 0, runResult, "Command should return 0 on successful cleanup")
+			require.NoError(t, runErr, "Command should not return an error")
+
+			// Wait a bit for cleanup to complete
+			time.Sleep(200 * time.Millisecond)
+
+			// Verify all files have been cleaned up
+			t.Log("Verifying files are cleaned up after signal...")
+
+			// Check CNI binary is removed
+			_, err = os.Stat(cniBinaryPath)
+			require.True(t, os.IsNotExist(err), "CNI binary should be removed after cleanup")
+
+			// Check kubeconfig is removed
+			_, err = os.Stat(kubeconfigPath)
+			require.True(t, os.IsNotExist(err), "Kubeconfig should be removed after cleanup")
+
+			// Check host token is removed (if it was created)
+			if tt.autorotateToken {
+				hostTokenPath := filepath.Join(tempDir, config.DefaultCNIHostTokenFilename+"-"+uid)
+				_, err = os.Stat(hostTokenPath)
+				require.True(t, os.IsNotExist(err), "Host token should be removed after cleanup")
+			}
+
+			t.Log("All files successfully cleaned up after signal")
+		})
+	}
 }
 
 func replaceFile(srcFile, destFile string) error {

--- a/control-plane/subcommand/install-cni/kubeconfig.go
+++ b/control-plane/subcommand/install-cni/kubeconfig.go
@@ -29,7 +29,7 @@ const (
 
 // createKubeConfig creates the kubeconfig file that the consul-cni plugin will use to communicate with the
 // kubernetes API.
-func createKubeConfig(cfg *config.CNIConfig) error {
+func createKubeConfig(destDir string, cfg *config.CNIConfig) error {
 	var restCfg *rest.Config
 
 	// TODO: Move clientset out of this method and put it in 'Run'
@@ -70,7 +70,7 @@ func createKubeConfig(cfg *config.CNIConfig) error {
 	}
 
 	// Write the kubeconfig file to the host.
-	destFile := filepath.Join(cfg.CNINetDir, cfg.Kubeconfig)
+	destFile := filepath.Join(destDir, cfg.Kubeconfig)
 	err = os.WriteFile(destFile, data, os.FileMode(0o644))
 	if err != nil {
 		return fmt.Errorf("error writing kube config file %s: %w", destFile, err)


### PR DESCRIPTION
Backport of [#4757](https://github.com/hashicorp/consul-k8s/pull/4757)

### Changes proposed in this PR ###  
- Race conditions handled for  upgrade between new  version of CNI pods
- Race conditions handled for upgrade between old version of CNI pod and new version of CNI pod
- Doesn't support backward compatibility 
- binWatcher for binary race conditions
- Test cases for OS sigterms and other signals
- Made watchers async 
- add versioning and installaiton id for pod deployments in kubeconfig and cni-host-token between restarts.
- Add podUID for better tracking owner of artifacts. if not unix timestamp is applicable

### How I've tested this PR ###
- deployment upgrade from 1.7 to current
- deployment upgrade from current to current (via other changes) 
- with and without autorotateToken
- removes CNI token file on daemonset delete.

### How I expect reviewers to test this PR ###
**Old version to new version of consul-k8s control-plane update**
_Older versions dont remove the binary file so newer plane times out and proceeds._ 
```
2025-09-08T20:17:22.888Z [INFO]  Running CNI install with configuration: name=consul-cni type=consul-cni cni_bin_dir=/opt/cni/bin cni_net_dir=/etc/cni/net.d multus=false kubeconfig=ZZZ-consul-cni-kubeconfig-1757362642888465801 log_level=info cni_token_path:=/var/run/secrets/kubernetes.io/serviceaccount/token cni_host_token_path=/etc/cni/net.d/cni-host-token-1757362642888465801 autorotate_token:=true
2025-09-08T20:17:22.888Z [INFO]  Copying consul-cni binary: destination=/opt/cni/bin
2025-09-08T20:17:22.888Z [INFO]  Creating destBinWatcher for: file=/opt/cni/bin/consul-cni
**2025-09-08T20:19:02.888Z [INFO]  Grace period timeout reached, older pod may not have cleaned up binary, proceeding with copy**
2025-09-08T20:19:08.929Z [INFO]  Successfully copied binary after grace period timeout
2025-09-08T20:19:08.944Z [INFO]  Getting default config file from: destination=/etc/cni/net.d
2025-09-08T20:19:08.945Z [INFO]  Using config file: file=/etc/cni/net.d/15-azure.conflist
2025-09-08T20:19:08.945Z [INFO]  Installing plugin: reason="consul-cni config has changed"
2025-09-08T20:19:08.945Z [INFO]  Creating directory watcher for: directory=/etc/cni/net.d
2025-09-08T20:19:08.945Z [INFO]  Creating kubeconfig: file=ZZZ-consul-cni-kubeconfig-1757362642888465801
2025-09-08T20:19:08.945Z [INFO]  Creating sourceTokenWatcher for: file=/var/run/secrets/kubernetes.io/serviceaccount/token
2025-09-08T20:19:08.946Z [INFO]  Token file updated: file=/etc/cni/net.d/cni-host-token-1757362642888465801
2025-09-08T20:19:08.946Z [INFO]  Token file updated: file=/etc/cni/net.d/cni-host-token-1757362642888465801
```
**New to New version of consul-k8s-control-plane -**
_Newer version would delete as a race condition so that is handled between upgrades_
```
2025-09-08T20:27:32.185Z [INFO]  Running CNI install with configuration: name=consul-cni type=consul-cni cni_bin_dir=/opt/cni/bin cni_net_dir=/etc/cni/net.d multus=false kubeconfig=ZZZ-consul-cni-kubeconfig-1757363252185513038 log_level=info cni_token_path:=/var/run/secrets/kubernetes.io/serviceaccount/token cni_host_token_path=/etc/cni/net.d/cni-host-token-1757363252185513038 autorotate_token:=true
2025-09-08T20:27:32.185Z [INFO]  Copying consul-cni binary: destination=/opt/cni/bin
2025-09-08T20:27:32.185Z [INFO]  Creating destBinWatcher for: file=/opt/cni/bin/consul-cni
2025-09-08T20:27:32.611Z [INFO]  Received binary file event: event_type=CHMOD file=/opt/cni/bin/consul-cni
**2025-09-08T20:27:32.611Z [INFO]  Received binary file event: event_type=REMOVE file=/opt/cni/bin/consul-cni**
2025-09-08T20:27:33.297Z [INFO]  Successfully copied updated binary from source
2025-09-08T20:27:33.297Z [INFO]  Getting default config file from: destination=/etc/cni/net.d
2025-09-08T20:27:33.298Z [INFO]  Using config file: file=/etc/cni/net.d/15-azure.conflist
2025-09-08T20:27:33.298Z [INFO]  Installing plugin: reason="consul-cni config missing from config file"
2025-09-08T20:27:33.298Z [INFO]  Creating directory watcher for: directory=/etc/cni/net.d
2025-09-08T20:27:33.298Z [INFO]  Creating sourceTokenWatcher for: file=/var/run/secrets/kubernetes.io/serviceaccount/token
2025-09-08T20:27:33.298Z [INFO]  Creating kubeconfig: file=ZZZ-consul-cni-kubeconfig-1757363252185513038
2025-09-08T20:27:33.299Z [INFO]  Token file updated: file=/etc/cni/net.d/cni-host-token-1757363252185513038
2025-09-08T20:27:33.299Z [INFO]  Token file updated: file=/etc/cni/net.d/cni-host-token-1757363252185513038
```

Post disablling CNI -
_No cni binary, kubeconfig, plugin-config and host-token if applicable remains on node_
```
root@aks-nodepool1-14707519-vmss000003:/opt/cni/bin# ls
LICENSE    azure-vnet       azure-vnet-telemetry  bridge  dummy     host-device  ipvlan    macvlan  ptp  static  tuning  vrf
README.md  azure-vnet-ipam  bandwidth             dhcp    firewall  host-local   loopback  portmap  sbr  tap     vlan

root@aks-nodepool1-14707519-vmss000003:/etc/cni/net.d# cat 15-azure.conflist
{
  "cniVersion": "0.3.0",
  "name": "azure",
  "plugins": [
    {
      "ipam": {
        "type": "azure-vnet-ipam"
      },
      "ipsToRouteViaHost": [
        "169.254.20.10"
      ],
      "mode": "transparent",
      "type": "azure-vnet"
    },
    {
      "capabilities": {
        "portMappings": true
      },
      "snat": true,
      "type": "portmap"
    }
  ]
}

root@aks-nodepool1-14707519-vmss000003:/etc/cni/net.d# ls
15-azure.conflist

```


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
