### PR TITLE
Fix flaky test in sameness package

### DIFF
--- a/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
+++ b/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
@@ -2,21 +2,20 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # Cloud package is not included in test suite as it is triggered from a non consul-k8s repo and requires HCP credentials
-- {runner: 0, test-packages: "sameness"}
-# - {runner: 0, test-packages: "partitions"}
-# - {runner: 1, test-packages: "peering"}
-# - {runner: 2, test-packages: "sameness"}
-# - {runner: 3, test-packages: "connect"}
-# - {runner: 4, test-packages: "snapshot-agent"}
-# - {runner: 5, test-packages: "wan-federation"}
-# - {runner: 6, test-packages: "cli"}
-# - {runner: 7, test-packages: "vault"}
-# - {runner: 8, test-packages: "metrics"}
-# - {runner: 9, test-packages: "server"}
-# - {runner: 10, test-packages: "api-gateway"}
-# - {runner: 12, test-packages: "sync"}
-# - {runner: 13, test-packages: "example"}
-# - {runner: 14, test-packages: "consul-dns"}
-# - {runner: 15, test-packages: "config-entries"}
-# - {runner: 16, test-packages: "terminating-gateway"}
-# - {runner: 17, test-packages: "basic"}
+- {runner: 0, test-packages: "partitions"}
+- {runner: 1, test-packages: "peering"}
+- {runner: 2, test-packages: "sameness"}
+- {runner: 3, test-packages: "connect"}
+- {runner: 4, test-packages: "snapshot-agent"}
+- {runner: 5, test-packages: "wan-federation"}
+- {runner: 6, test-packages: "cli"}
+- {runner: 7, test-packages: "vault"}
+- {runner: 8, test-packages: "metrics"}
+- {runner: 9, test-packages: "server"}
+- {runner: 10, test-packages: "api-gateway"}
+- {runner: 12, test-packages: "sync"}
+- {runner: 13, test-packages: "example"}
+- {runner: 14, test-packages: "consul-dns"}
+- {runner: 15, test-packages: "config-entries"}
+- {runner: 16, test-packages: "terminating-gateway"}
+- {runner: 17, test-packages: "basic"}

--- a/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
+++ b/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
@@ -2,20 +2,21 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # Cloud package is not included in test suite as it is triggered from a non consul-k8s repo and requires HCP credentials
-- {runner: 0, test-packages: "partitions"}
-- {runner: 1, test-packages: "peering"}
-- {runner: 2, test-packages: "sameness"}
-- {runner: 3, test-packages: "connect"}
-- {runner: 4, test-packages: "snapshot-agent"}
-- {runner: 5, test-packages: "wan-federation"}
-- {runner: 6, test-packages: "cli"}
-- {runner: 7, test-packages: "vault"}
-- {runner: 8, test-packages: "metrics"}
-- {runner: 9, test-packages: "server"}
-- {runner: 10, test-packages: "api-gateway"}
-- {runner: 12, test-packages: "sync"}
-- {runner: 13, test-packages: "example"}
-- {runner: 14, test-packages: "consul-dns"}
-- {runner: 15, test-packages: "config-entries"}
-- {runner: 16, test-packages: "terminating-gateway"}
-- {runner: 17, test-packages: "basic"}
+- {runner: 0, test-packages: "sameness"}
+# - {runner: 0, test-packages: "partitions"}
+# - {runner: 1, test-packages: "peering"}
+# - {runner: 2, test-packages: "sameness"}
+# - {runner: 3, test-packages: "connect"}
+# - {runner: 4, test-packages: "snapshot-agent"}
+# - {runner: 5, test-packages: "wan-federation"}
+# - {runner: 6, test-packages: "cli"}
+# - {runner: 7, test-packages: "vault"}
+# - {runner: 8, test-packages: "metrics"}
+# - {runner: 9, test-packages: "server"}
+# - {runner: 10, test-packages: "api-gateway"}
+# - {runner: 12, test-packages: "sync"}
+# - {runner: 13, test-packages: "example"}
+# - {runner: 14, test-packages: "consul-dns"}
+# - {runner: 15, test-packages: "config-entries"}
+# - {runner: 16, test-packages: "terminating-gateway"}
+# - {runner: 17, test-packages: "basic"}


### PR DESCRIPTION
### Changes proposed in this PR ###  

In acceptance tests of sameness package 4 consul clusters are created and cluster peering is established among them. There is an intermittent issue where the peering acceptor object is not getting ready before the peering acceptor token is copied from one cluster to another which is causing the test to fail. Updated test to check for peering acceptor readiness and the secret to be present before we attempt to copy the token. It also recreates the peering acceptor if it is stuck without getting ready.

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
