### PR TITLE
Fix EKS acceptance test Terraform version compatibility

### DIFF
--- a/.changelog/4898.txt
+++ b/.changelog/4898.txt
@@ -1,0 +1,4 @@
+```release-note:improvements
+Updated terraform provider version for eks acceptance test.
+
+```

--- a/.github/workflows/pr-cloud-acceptance.yml
+++ b/.github/workflows/pr-cloud-acceptance.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           workflow: cloud.yml
           repo: hashicorp/consul-k8s-workflows
-          ref: fix-consul-k8s
+          ref: main
           token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
           inputs: '{ "context":"${{ env.CONTEXT }}-${{ github.event.pull_request.number }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ github.sha }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'

--- a/.github/workflows/pr-cloud-acceptance.yml
+++ b/.github/workflows/pr-cloud-acceptance.yml
@@ -5,8 +5,8 @@ on:
     types: [opened, synchronize]
     # Runs on PRs to main and all release branches
     branches:
-      - main
-      - "release/**"
+      
+      - fix-eks-acceptance-consul-k8s
 # these should be the only settings that you will ever need to change
 env:
   BRANCH: ${{ github.event.pull_request.head.ref }}
@@ -22,6 +22,6 @@ jobs:
         with:
           workflow: cloud.yml
           repo: hashicorp/consul-k8s-workflows
-          ref: main
+          ref: fix-consul-k8s
           token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
           inputs: '{ "context":"${{ env.CONTEXT }}-${{ github.event.pull_request.number }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ github.sha }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'

--- a/.github/workflows/pr-cloud-acceptance.yml
+++ b/.github/workflows/pr-cloud-acceptance.yml
@@ -5,8 +5,8 @@ on:
     types: [opened, synchronize]
     # Runs on PRs to main and all release branches
     branches:
-      
-      - fix-eks-acceptance-consul-k8s
+      - main
+      - "release/**"
 # these should be the only settings that you will ever need to change
 env:
   BRANCH: ${{ github.event.pull_request.head.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ cni: cleanup of cni binary on previous pod deletion to improve security posture 
 BUG FIXES:
 
 * api-gateway: Fixed an issue where the gateway controller failed to detect annotation changes in deployments triggered by rollout restarts, preventing restarts from completing successfully. [[GH-4767](https://github.com/hashicorp/consul-k8s/issues/4767)]
+* acceptance-tests: Fixed EKS acceptance test Terraform configuration by updating AWS provider version from invalid "~>= 6.4.1" to "~> 5.0" and VPC module version from "4.0.0" to "5.0.0" to resolve compatibility issues. [[GH-4898](https://github.com/hashicorp/consul-k8s/issues/4898)]
 
 ## 1.8.1 (August 20, 2025)
 

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -11,9 +11,13 @@ terraform {
 
 provider "aws" {
   region = var.region
-  assume_role {
-    role_arn = var.role_arn
-    duration = "2700s"
+  
+  dynamic "assume_role" {
+    for_each = var.role_arn != "" ? [1] : []
+    content {
+      role_arn = var.role_arn
+      duration = "2700s"
+    }
   }
 }
 

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -42,13 +42,18 @@ module "vpc" {
 
   name = "consul-k8s-${random_id.suffix[count.index].dec}"
   # The cidr range needs to be unique in each VPC to allow setting up a peering connection.
-  cidr                 = format("10.%s.0.0/16", count.index)
-  azs                  = data.aws_availability_zones.available.names
-  private_subnets      = [format("10.%s.1.0/24", count.index), format("10.%s.2.0/24", count.index), format("10.%s.3.0/24", count.index)]
-  public_subnets       = [format("10.%s.4.0/24", count.index), format("10.%s.5.0/24", count.index), format("10.%s.6.0/24", count.index)]
-  enable_nat_gateway   = true
-  single_nat_gateway   = true
-  enable_dns_hostnames = true
+  cidr               = format("10.%s.0.0/16", count.index)
+  azs                = data.aws_availability_zones.available.names
+  private_subnets    = [format("10.%s.1.0/24", count.index), format("10.%s.2.0/24", count.index), format("10.%s.3.0/24", count.index)]
+  public_subnets     = [format("10.%s.4.0/24", count.index), format("10.%s.5.0/24", count.index), format("10.%s.6.0/24", count.index)]
+  enable_nat_gateway = true
+  single_nat_gateway = true
+
+  # Enable dual-stack (IPv4 + IPv6) support for acceptance tests
+  enable_ipv6                  = true
+  public_subnet_ipv6_prefixes  = [0, 1, 2]
+  private_subnet_ipv6_prefixes = [3, 4, 5]
+  enable_dns_hostnames         = true
 
   public_subnet_tags = {
     "kubernetes.io/cluster/consul-k8s-${random_id.suffix[count.index].dec}" = "shared"

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -11,7 +11,7 @@ terraform {
 
 provider "aws" {
   region = var.region
-  
+
   dynamic "assume_role" {
     for_each = var.role_arn != "" ? [1] : []
     content {

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -11,6 +11,10 @@ terraform {
 
 provider "aws" {
   region = var.region
+  assume_role {
+    role_arn = var.role_arn
+    duration = "2700s"
+  }
 }
 
 resource "random_id" "suffix" {

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -4,18 +4,13 @@
 terraform {
   required_providers {
     aws = {
-      version = "~>= 6.4.1"
+      version = "~> 5.0"
     }
   }
 }
 
 provider "aws" {
   region = var.region
-
-  assume_role {
-    role_arn = var.role_arn
-    duration = "2700s"
-  }
 }
 
 resource "random_id" "suffix" {
@@ -35,7 +30,7 @@ resource "random_string" "suffix" {
 module "vpc" {
   count   = var.cluster_count
   source  = "terraform-aws-modules/vpc/aws"
-  version = "4.0.0"
+  version = "5.0.0"
 
   name = "consul-k8s-${random_id.suffix[count.index].dec}"
   # The cidr range needs to be unique in each VPC to allow setting up a peering connection.

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0"
+      version = "~>= 6.4.1"
     }
   }
 }


### PR DESCRIPTION
Fixes Terraform version compatibility issues in EKS acceptance tests:

- Updated AWS provider from >= 4.0.0to ~> 5.0
- Updated VPC module from 4.0.0 to 5.0.0  
- Removed assume_role block to eliminate warnings
- Resolves vpc = true EIP compatibility error

Fixes: EKS acceptance test failures due to Terraform version incompatibility