### PR TITLE
flaky tests fixes in peering, api-gateway, wan-federation, sameness packages

### DIFF
--- a/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
+++ b/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
@@ -2,24 +2,20 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # Cloud package is not included in test suite as it is triggered from a non consul-k8s repo and requires HCP credentials
-- {runner: 0, test-packages: "api-gateway"}
+- {runner: 0, test-packages: "partitions"}
 - {runner: 1, test-packages: "peering"}
 - {runner: 2, test-packages: "sameness"}
-- {runner: 3, test-packages: "wan-federation"}
-# - {runner: 0, test-packages: "partitions"}
-# - {runner: 1, test-packages: "peering"}
-# - {runner: 2, test-packages: "sameness"}
-# - {runner: 3, test-packages: "connect"}
-# - {runner: 4, test-packages: "snapshot-agent"}
-# - {runner: 5, test-packages: "wan-federation"}
-# - {runner: 6, test-packages: "cli"}
-# - {runner: 7, test-packages: "vault"}
-# - {runner: 8, test-packages: "metrics"}
-# - {runner: 9, test-packages: "server"}
-# - {runner: 10, test-packages: "api-gateway"}
-# - {runner: 12, test-packages: "sync"}
-# - {runner: 13, test-packages: "example"}
-# - {runner: 14, test-packages: "consul-dns"}
-# - {runner: 15, test-packages: "config-entries"}
-# - {runner: 16, test-packages: "terminating-gateway"}
-# - {runner: 17, test-packages: "basic"}
+- {runner: 3, test-packages: "connect"}
+- {runner: 4, test-packages: "snapshot-agent"}
+- {runner: 5, test-packages: "wan-federation"}
+- {runner: 6, test-packages: "cli"}
+- {runner: 7, test-packages: "vault"}
+- {runner: 8, test-packages: "metrics"}
+- {runner: 9, test-packages: "server"}
+- {runner: 10, test-packages: "api-gateway"}
+- {runner: 12, test-packages: "sync"}
+- {runner: 13, test-packages: "example"}
+- {runner: 14, test-packages: "consul-dns"}
+- {runner: 15, test-packages: "config-entries"}
+- {runner: 16, test-packages: "terminating-gateway"}
+- {runner: 17, test-packages: "basic"}

--- a/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
+++ b/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
@@ -2,20 +2,21 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # Cloud package is not included in test suite as it is triggered from a non consul-k8s repo and requires HCP credentials
-- {runner: 0, test-packages: "partitions"}
-- {runner: 1, test-packages: "peering"}
-- {runner: 2, test-packages: "sameness"}
-- {runner: 3, test-packages: "connect"}
-- {runner: 4, test-packages: "snapshot-agent"}
-- {runner: 5, test-packages: "wan-federation"}
-- {runner: 6, test-packages: "cli"}
-- {runner: 7, test-packages: "vault"}
-- {runner: 8, test-packages: "metrics"}
-- {runner: 9, test-packages: "server"}
-- {runner: 10, test-packages: "api-gateway"}
-- {runner: 12, test-packages: "sync"}
-- {runner: 13, test-packages: "example"}
-- {runner: 14, test-packages: "consul-dns"}
-- {runner: 15, test-packages: "config-entries"}
-- {runner: 16, test-packages: "terminating-gateway"}
-- {runner: 17, test-packages: "basic"}
+- {runner: 0, test-packages: "api-gateway"}
+# - {runner: 0, test-packages: "partitions"}
+# - {runner: 1, test-packages: "peering"}
+# - {runner: 2, test-packages: "sameness"}
+# - {runner: 3, test-packages: "connect"}
+# - {runner: 4, test-packages: "snapshot-agent"}
+# - {runner: 5, test-packages: "wan-federation"}
+# - {runner: 6, test-packages: "cli"}
+# - {runner: 7, test-packages: "vault"}
+# - {runner: 8, test-packages: "metrics"}
+# - {runner: 9, test-packages: "server"}
+# - {runner: 10, test-packages: "api-gateway"}
+# - {runner: 12, test-packages: "sync"}
+# - {runner: 13, test-packages: "example"}
+# - {runner: 14, test-packages: "consul-dns"}
+# - {runner: 15, test-packages: "config-entries"}
+# - {runner: 16, test-packages: "terminating-gateway"}
+# - {runner: 17, test-packages: "basic"}

--- a/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
+++ b/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
@@ -5,6 +5,7 @@
 - {runner: 0, test-packages: "api-gateway"}
 - {runner: 1, test-packages: "peering"}
 - {runner: 2, test-packages: "sameness"}
+- {runner: 3, test-packages: "wan-federation"}
 # - {runner: 0, test-packages: "partitions"}
 # - {runner: 1, test-packages: "peering"}
 # - {runner: 2, test-packages: "sameness"}

--- a/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
+++ b/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
@@ -4,6 +4,7 @@
 # Cloud package is not included in test suite as it is triggered from a non consul-k8s repo and requires HCP credentials
 - {runner: 0, test-packages: "api-gateway"}
 - {runner: 1, test-packages: "peering"}
+- {runner: 2, test-packages: "sameness"}
 # - {runner: 0, test-packages: "partitions"}
 # - {runner: 1, test-packages: "peering"}
 # - {runner: 2, test-packages: "sameness"}

--- a/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
+++ b/acceptance/ci-inputs/kind_acceptance_test_packages.yaml
@@ -3,6 +3,7 @@
 
 # Cloud package is not included in test suite as it is triggered from a non consul-k8s repo and requires HCP credentials
 - {runner: 0, test-packages: "api-gateway"}
+- {runner: 1, test-packages: "peering"}
 # - {runner: 0, test-packages: "partitions"}
 # - {runner: 1, test-packages: "peering"}
 # - {runner: 2, test-packages: "sameness"}

--- a/acceptance/framework/helpers/helpers.go
+++ b/acceptance/framework/helpers/helpers.go
@@ -432,7 +432,10 @@ func WaitForHTTPRouteWithRetry(t *testing.T, kubectlOptions *k8s.KubectlOptions,
 		if attempt < maxAttempts {
 			logger.Logf(t, "httproute not found after %d seconds, attempting delete/recreate (attempt %d/%d)", checksPerAttempt*2, attempt, maxAttempts)
 			// Delete the httproute if it exists in a bad state
-			k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "delete", "httproute", routeName, "--ignore-not-found=true")
+			_, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "delete", "httproute", routeName, "--ignore-not-found=true")
+			if err != nil {
+				logger.Logf(t, "warning: failed to delete httproute %s: %v", routeName, err)
+			}
 			// Recreate by reapplying the base resources
 			out, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "apply", "-k", kustomizeDir)
 			require.NoError(t, err, out)

--- a/acceptance/framework/helpers/helpers.go
+++ b/acceptance/framework/helpers/helpers.go
@@ -488,3 +488,13 @@ func EnsurePeeringAcceptorSecret(t *testing.T, r *retry.R, kubectlOptions *k8s.K
 	require.NotEmpty(r, acceptorSecretName)
 	return acceptorSecretName
 }
+
+// HasStatusCondition checks if a condition exists with the expected status and reason.
+func HasStatusCondition(conditions []metav1.Condition, toCheck metav1.Condition) bool {
+	for _, c := range conditions {
+		if c.Type == toCheck.Type {
+			return c.Reason == toCheck.Reason && c.Status == toCheck.Status
+		}
+	}
+	return false
+}

--- a/acceptance/tests/api-gateway/api_gateway_external_servers_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_external_servers_test.go
@@ -90,8 +90,11 @@ func TestAPIGateway_ExternalServers(t *testing.T) {
 	})
 
 	logger.Log(t, "creating api-gateway resources")
-	out, err = k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "apply", "-k", "../fixtures/bases/api-gateway")
-	require.NoError(t, err, out)
+	// Apply api-gateway resources with retry logic to handle intermittent failures
+	retry.Run(t, func(r *retry.R) {
+		out, err := k8s.RunKubectlAndGetOutputE(r, ctx.KubectlOptions(r), "apply", "-k", "../fixtures/bases/api-gateway")
+		require.NoError(r, err, out)
+	})
 	helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
 		// Ignore errors here because if the test ran as expected
 		// the custom resources will have been deleted.

--- a/acceptance/tests/api-gateway/api_gateway_external_servers_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_external_servers_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -100,45 +99,7 @@ func TestAPIGateway_ExternalServers(t *testing.T) {
 	})
 
 	// Wait for the httproute to exist before patching, with delete/recreate fallback
-	logger.Log(t, "waiting for httproute to be created")
-	found := false
-	maxAttempts := 3
-	checksPerAttempt := 5
-
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		logger.Log(t, "httproute existence check attempt %d/%d", attempt, maxAttempts)
-
-		// Check for httproute existence using simple loop (like kitchen sink test)
-		for i := range checksPerAttempt {
-			_, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "get", "httproute", "http-route")
-			if err == nil {
-				found = true
-				logger.Log(t, "httproute http-route found successfully")
-				break
-			}
-			logger.Logf(t, "httproute check %d/%d: %v", i+1, checksPerAttempt, err)
-			time.Sleep(2 * time.Second)
-		}
-
-		if found {
-			break
-		}
-
-		if attempt < maxAttempts {
-			logger.Log(t, "httproute not found after %d seconds, attempting delete/recreate (attempt %d/%d)", checksPerAttempt*2, attempt, maxAttempts)
-			// Delete the httproute if it exists in a bad state
-			k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "delete", "httproute", "http-route", "--ignore-not-found=true")
-			// Recreate by reapplying the base resources
-			out, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "apply", "-k", "../fixtures/bases/api-gateway")
-			require.NoError(t, err, out)
-			// Brief pause to let the recreation start
-			time.Sleep(2 * time.Second)
-		}
-	}
-
-	if !found {
-		require.Fail(t, "httproute http-route was not found after 3 attempts with delete/recreate")
-	}
+	helpers.WaitForHTTPRouteWithRetry(t, ctx.KubectlOptions(t), "http-route", "../fixtures/bases/api-gateway")
 
 	logger.Log(t, "patching route to target server")
 	k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "httproute", "http-route", "-p", `{"spec":{"rules":[{"backendRefs":[{"name":"static-server","port":80}]}]}}`, "--type=merge")

--- a/acceptance/tests/api-gateway/api_gateway_external_servers_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_external_servers_test.go
@@ -99,13 +99,34 @@ func TestAPIGateway_ExternalServers(t *testing.T) {
 		k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "delete", "-k", "../fixtures/bases/api-gateway")
 	})
 
-	// Wait for the httproute to exist before patching
+	// Wait for the httproute to exist before patching, with delete/recreate fallback
 	logger.Log(t, "waiting for httproute to be created")
-	routeCounter := &retry.Counter{Count: 30, Wait: 2 * time.Second}
-	retry.RunWith(routeCounter, t, func(r *retry.R) {
-		_, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "get", "httproute", "http-route")
-		require.NoError(r, err, "httproute http-route does not exist yet")
-	})
+	for attempt := 1; attempt <= 3; attempt++ {
+		logger.Log(t, "httproute existence check attempt %d/3", attempt)
+		found := false
+		shortCounter := &retry.Counter{Count: 5, Wait: 2 * time.Second} // 10 seconds total
+		retry.RunWith(shortCounter, t, func(r *retry.R) {
+			_, err := k8s.RunKubectlAndGetOutputE(r, ctx.KubectlOptions(r), "get", "httproute", "http-route")
+			if err == nil {
+				found = true
+			}
+			require.NoError(r, err, "httproute http-route does not exist yet")
+		})
+		
+		if found {
+			logger.Log(t, "httproute http-route found successfully")
+			break
+		}
+		
+		if attempt < 3 {
+			logger.Log(t, "httproute not found after 10s, attempting delete/recreate (attempt %d/3)", attempt)
+			// Delete the httproute if it exists in a bad state
+			k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "delete", "httproute", "http-route", "--ignore-not-found=true")
+			// Recreate by reapplying the base resources
+			out, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "apply", "-k", "../fixtures/bases/api-gateway")
+			require.NoError(t, err, out)
+		}
+	}
 
 	logger.Log(t, "patching route to target server")
 	k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "httproute", "http-route", "-p", `{"spec":{"rules":[{"backendRefs":[{"name":"static-server","port":80}]}]}}`, "--type=merge")

--- a/acceptance/tests/api-gateway/api_gateway_external_servers_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_external_servers_test.go
@@ -98,6 +98,10 @@ func TestAPIGateway_ExternalServers(t *testing.T) {
 		k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "delete", "-k", "../fixtures/bases/api-gateway")
 	})
 
+	// Wait for the httproute to be created before patching
+	logger.Log(t, "waiting for httproute to be created")
+	k8s.RunKubectl(t, ctx.KubectlOptions(t), "wait", "--for=jsonpath='{.metadata.name}'=http-route", "httproute", "http-route", "--timeout=60s")
+
 	logger.Log(t, "patching route to target server")
 	k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "httproute", "http-route", "-p", `{"spec":{"rules":[{"backendRefs":[{"name":"static-server","port":80}]}]}}`, "--type=merge")
 

--- a/acceptance/tests/api-gateway/api_gateway_external_servers_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_external_servers_test.go
@@ -101,31 +101,43 @@ func TestAPIGateway_ExternalServers(t *testing.T) {
 
 	// Wait for the httproute to exist before patching, with delete/recreate fallback
 	logger.Log(t, "waiting for httproute to be created")
-	for attempt := 1; attempt <= 3; attempt++ {
-		logger.Log(t, "httproute existence check attempt %d/3", attempt)
-		found := false
-		shortCounter := &retry.Counter{Count: 5, Wait: 2 * time.Second} // 10 seconds total
-		retry.RunWith(shortCounter, t, func(r *retry.R) {
-			_, err := k8s.RunKubectlAndGetOutputE(r, ctx.KubectlOptions(r), "get", "httproute", "http-route")
+	found := false
+	maxAttempts := 3
+	checksPerAttempt := 5
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		logger.Log(t, "httproute existence check attempt %d/%d", attempt, maxAttempts)
+
+		// Check for httproute existence using simple loop (like kitchen sink test)
+		for i := range checksPerAttempt {
+			_, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "get", "httproute", "http-route")
 			if err == nil {
 				found = true
+				logger.Log(t, "httproute http-route found successfully")
+				break
 			}
-			require.NoError(r, err, "httproute http-route does not exist yet")
-		})
-		
+			logger.Logf(t, "httproute check %d/%d: %v", i+1, checksPerAttempt, err)
+			time.Sleep(2 * time.Second)
+		}
+
 		if found {
-			logger.Log(t, "httproute http-route found successfully")
 			break
 		}
-		
-		if attempt < 3 {
-			logger.Log(t, "httproute not found after 10s, attempting delete/recreate (attempt %d/3)", attempt)
+
+		if attempt < maxAttempts {
+			logger.Log(t, "httproute not found after %d seconds, attempting delete/recreate (attempt %d/%d)", checksPerAttempt*2, attempt, maxAttempts)
 			// Delete the httproute if it exists in a bad state
 			k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "delete", "httproute", "http-route", "--ignore-not-found=true")
 			// Recreate by reapplying the base resources
 			out, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "apply", "-k", "../fixtures/bases/api-gateway")
 			require.NoError(t, err, out)
+			// Brief pause to let the recreation start
+			time.Sleep(2 * time.Second)
 		}
+	}
+
+	if !found {
+		require.Fail(t, "httproute http-route was not found after 3 attempts with delete/recreate")
 	}
 
 	logger.Log(t, "patching route to target server")

--- a/acceptance/tests/api-gateway/api_gateway_external_servers_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_external_servers_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -98,9 +99,13 @@ func TestAPIGateway_ExternalServers(t *testing.T) {
 		k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "delete", "-k", "../fixtures/bases/api-gateway")
 	})
 
-	// Wait for the httproute to be created before patching
+	// Wait for the httproute to exist before patching
 	logger.Log(t, "waiting for httproute to be created")
-	k8s.RunKubectl(t, ctx.KubectlOptions(t), "wait", "--for=jsonpath='{.metadata.name}'=http-route", "httproute", "http-route", "--timeout=60s")
+	routeCounter := &retry.Counter{Count: 30, Wait: 2 * time.Second}
+	retry.RunWith(routeCounter, t, func(r *retry.R) {
+		_, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "get", "httproute", "http-route")
+		require.NoError(r, err, "httproute http-route does not exist yet")
+	})
 
 	logger.Log(t, "patching route to target server")
 	k8s.RunKubectl(t, ctx.KubectlOptions(t), "patch", "httproute", "http-route", "-p", `{"spec":{"rules":[{"backendRefs":[{"name":"static-server","port":80}]}]}}`, "--type=merge")

--- a/acceptance/tests/api-gateway/api_gateway_kitchen_sink_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_kitchen_sink_test.go
@@ -400,7 +400,7 @@ func checkHTTPRouteReady(t *testing.T, k8sClient client.Client, routeName, names
 	return success
 }
 
-// waitForHTTPRouteReady waits for HTTPRoute to be ready with recreation attempts
+// waitForHTTPRouteReady waits for HTTPRoute to be ready with recreation attempts.
 func waitForHTTPRouteReady(t *testing.T, ctx environment.TestContext, k8sClient client.Client, routeName, namespace, fixturePath string, applyCounter *retry.Counter) {
 	maxRetries := 5
 

--- a/acceptance/tests/api-gateway/api_gateway_kitchen_sink_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_kitchen_sink_test.go
@@ -211,13 +211,13 @@ func TestAPIGateway_KitchenSink(t *testing.T) {
 	}
 }
 
-// checkGatewayReady checks if the Gateway resource is ready using existing retry logic
+// checkGatewayReady checks if the Gateway resource is ready using existing retry logic.
 func checkGatewayReady(t *testing.T, k8sClient client.Client, gatewayName, namespace string) (bool, string) {
 	var success bool
 	var gatewayAddress string
 	gatewayCounter := &retry.Counter{Count: 10, Wait: 6 * time.Second}
 
-	// Use a loop instead of retry.RunWith to avoid runtime.Goexit() issues when require fails
+	// Use a loop instead of retry.RunWith to avoid runtime.Goexit() issues when require fails.
 	for i := 0; i < gatewayCounter.Count; i++ {
 		var gateway gwv1beta1.Gateway
 		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: gatewayName, Namespace: namespace}, &gateway)
@@ -227,7 +227,7 @@ func checkGatewayReady(t *testing.T, k8sClient client.Client, gatewayName, names
 			continue
 		}
 
-		// Check all conditions, if any fail we'll continue to next attempt
+		// Check all conditions, if any fail we'll continue to next attempt.
 		if len(gateway.Finalizers) != 1 {
 			logger.Log(t, fmt.Sprintf("Gateway check attempt %d: wrong number of finalizers", i+1))
 			time.Sleep(gatewayCounter.Wait)
@@ -240,7 +240,7 @@ func checkGatewayReady(t *testing.T, k8sClient client.Client, gatewayName, names
 			continue
 		}
 
-		// Check status conditions
+		// Check status conditions.
 		if !helpers.HasStatusCondition(gateway.Status.Conditions, trueCondition("Accepted", "Accepted")) ||
 			!helpers.HasStatusCondition(gateway.Status.Conditions, trueCondition("ConsulAccepted", "Accepted")) {
 			logger.Log(t, fmt.Sprintf("Gateway check attempt %d: missing required status conditions", i+1))
@@ -260,7 +260,7 @@ func checkGatewayReady(t *testing.T, k8sClient client.Client, gatewayName, names
 			continue
 		}
 
-		// Check listener conditions
+		// Check listener conditions.
 		if !helpers.HasStatusCondition(gateway.Status.Listeners[0].Conditions, trueCondition("Accepted", "Accepted")) ||
 			!helpers.HasStatusCondition(gateway.Status.Listeners[0].Conditions, falseCondition("Conflicted", "NoConflicts")) ||
 			!helpers.HasStatusCondition(gateway.Status.Listeners[0].Conditions, trueCondition("ResolvedRefs", "ResolvedRefs")) {
@@ -269,14 +269,14 @@ func checkGatewayReady(t *testing.T, k8sClient client.Client, gatewayName, names
 			continue
 		}
 
-		// Check that we have an address to use
+		// Check that we have an address to use.
 		if len(gateway.Status.Addresses) < 2 {
 			logger.Log(t, fmt.Sprintf("Gateway check attempt %d: not enough addresses", i+1))
 			time.Sleep(gatewayCounter.Wait)
 			continue
 		}
 
-		// All checks passed
+		// All checks passed.
 		gatewayAddress = gateway.Status.Addresses[0].Value
 		success = true
 		break
@@ -291,7 +291,7 @@ func checkGatewayReady(t *testing.T, k8sClient client.Client, gatewayName, names
 	return success, gatewayAddress
 }
 
-// waitForGatewayReady waits for Gateway to be ready with recreation attempts
+// waitForGatewayReady waits for Gateway to be ready with recreation attempts.
 func waitForGatewayReady(t *testing.T, ctx environment.TestContext, k8sClient client.Client, gatewayName, namespace, fixturePath string, applyCounter *retry.Counter) string {
 	maxRetries := 5
 
@@ -330,13 +330,13 @@ func waitForGatewayReady(t *testing.T, ctx environment.TestContext, k8sClient cl
 	return ""
 }
 
-// checkHTTPRouteReady checks if the HTTPRoute resource is ready using existing retry logic
+// checkHTTPRouteReady checks if the HTTPRoute resource is ready using existing retry logic.
 func checkHTTPRouteReady(t *testing.T, k8sClient client.Client, routeName, namespace string) bool {
 	var success bool
 	var httpRoute gwv1beta1.HTTPRoute
 	httpRouteCounter := &retry.Counter{Count: 10, Wait: 6 * time.Second}
 
-	// Use a loop instead of retry.RunWith to avoid runtime.Goexit() issues when require fails
+	// Use a loop instead of retry.RunWith to avoid runtime.Goexit() issues when require fails.
 	for i := 0; i < httpRouteCounter.Count; i++ {
 		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: routeName, Namespace: namespace}, &httpRoute)
 		if err != nil {

--- a/acceptance/tests/api-gateway/api_gateway_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_test.go
@@ -155,9 +155,13 @@ func TestAPIGateway_Basic(t *testing.T) {
 			logger.Log(t, "creating static-client pod")
 			k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/bases/static-client")
 
-			// Wait for the httproute to be created before patching
+			// Wait for the httproute to exist before patching
 			logger.Log(t, "waiting for httproute to be created")
-			k8s.RunKubectl(t, ctx.KubectlOptions(t), "wait", "--for=jsonpath='{.metadata.name}'=http-route", "httproute", "http-route", "--timeout=60s")
+			routeCounter := &retry.Counter{Count: 30, Wait: 2 * time.Second}
+			retry.RunWith(routeCounter, t, func(r *retry.R) {
+				_, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "get", "httproute", "http-route")
+				require.NoError(r, err, "httproute http-route does not exist yet")
+			})
 
 			logger.Log(t, "patching route to target http server")
 			// Use retries to handle intermittent failures when patching the httproute
@@ -411,11 +415,14 @@ func TestAPIGateway_JWTAuth_Basic(t *testing.T) {
 
 	// Wait for all the httproutes to be created immediately after applying the main resources
 	logger.Log(t, "waiting for httproutes to be created")
-	k8s.RunKubectl(t, ctx.KubectlOptions(t), "wait", "--for=jsonpath='{.metadata.name}'=http-route", "httproute", "http-route", "--timeout=60s")
-	k8s.RunKubectl(t, ctx.KubectlOptions(t), "wait", "--for=jsonpath='{.metadata.name}'=http-route-auth", "httproute", "http-route-auth", "--timeout=60s")
-	k8s.RunKubectl(t, ctx.KubectlOptions(t), "wait", "--for=jsonpath='{.metadata.name}'=http-route-no-auth-on-auth-listener", "httproute", "http-route-no-auth-on-auth-listener", "--timeout=60s")
-	k8s.RunKubectl(t, ctx.KubectlOptions(t), "wait", "--for=jsonpath='{.metadata.name}'=http-route2-auth", "httproute", "http-route2-auth", "--timeout=60s")
-	k8s.RunKubectl(t, ctx.KubectlOptions(t), "wait", "--for=jsonpath='{.metadata.name}'=http-route-auth-invalid", "httproute", "http-route-auth-invalid", "--timeout=60s")
+	routeNames := []string{"http-route", "http-route-auth", "http-route-no-auth-on-auth-listener", "http-route2-auth", "http-route-auth-invalid"}
+	routeCounter := &retry.Counter{Count: 30, Wait: 2 * time.Second}
+	for _, routeName := range routeNames {
+		retry.RunWith(routeCounter, t, func(r *retry.R) {
+			_, err := k8s.RunKubectlAndGetOutputE(r, ctx.KubectlOptions(r), "get", "httproute", routeName)
+			require.NoError(r, err, "httproute %s should exist", routeName)
+		})
+	}
 
 	out, err = k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "apply", "-n", "other", "-f", "../fixtures/cases/api-gateways/jwt-auth/external-ref-other-ns.yaml")
 	require.NoError(t, err, out)
@@ -456,7 +463,7 @@ func TestAPIGateway_JWTAuth_Basic(t *testing.T) {
 	k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/bases/static-client")
 
 	k8s.RunKubectl(t, ctx.KubectlOptions(t), "wait", "--for=condition=available", "--timeout=5m", fmt.Sprintf("deploy/%s", "static-server"))
-	
+
 	// Grab a kubernetes client so that we can verify binding
 	// behavior prior to issuing requests through the gateway.
 	k8sClient := ctx.ControllerRuntimeClient(t)

--- a/acceptance/tests/api-gateway/api_gateway_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_test.go
@@ -156,45 +156,7 @@ func TestAPIGateway_Basic(t *testing.T) {
 			k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/bases/static-client")
 
 			// Wait for the httproute to exist before patching, with delete/recreate fallback
-			logger.Log(t, "waiting for httproute to be created")
-			found := false
-			maxAttempts := 3
-			checksPerAttempt := 5
-
-			for attempt := 1; attempt <= maxAttempts; attempt++ {
-				logger.Log(t, "httproute existence check attempt %d/%d", attempt, maxAttempts)
-
-				// Check for httproute existence using simple loop (like kitchen sink test)
-				for i := range checksPerAttempt {
-					_, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "get", "httproute", "http-route")
-					if err == nil {
-						found = true
-						logger.Log(t, "httproute http-route found successfully")
-						break
-					}
-					logger.Logf(t, "httproute check %d/%d: %v", i+1, checksPerAttempt, err)
-					time.Sleep(2 * time.Second)
-				}
-
-				if found {
-					break
-				}
-
-				if attempt < maxAttempts {
-					logger.Log(t, "httproute not found after %d seconds, attempting delete/recreate (attempt %d/%d)", checksPerAttempt*2, attempt, maxAttempts)
-					// Delete the httproute if it exists in a bad state
-					k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "delete", "httproute", "http-route", "--ignore-not-found=true")
-					// Recreate by reapplying the base resources
-					out, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "apply", "-k", "../fixtures/bases/api-gateway")
-					require.NoError(t, err, out)
-					// Brief pause to let the recreation start
-					time.Sleep(2 * time.Second)
-				}
-			}
-
-			if !found {
-				require.Fail(t, "httproute http-route was not found after 3 attempts with delete/recreate")
-			}
+			helpers.WaitForHTTPRouteWithRetry(t, ctx.KubectlOptions(t), "http-route", "../fixtures/bases/api-gateway")
 
 			logger.Log(t, "patching route to target http server")
 			// Use retries to handle intermittent failures when patching the httproute
@@ -449,42 +411,8 @@ func TestAPIGateway_JWTAuth_Basic(t *testing.T) {
 	// Wait for all the httproutes to be created immediately after applying the main resources
 	logger.Log(t, "waiting for httproutes to be created")
 	routeNames := []string{"http-route", "http-route-auth", "http-route-no-auth-on-auth-listener", "http-route2-auth", "http-route-auth-invalid"}
-	maxAttempts, checksPerAttempt := 3, 5
 	for _, routeName := range routeNames {
-		found := false
-		for attempt := 1; attempt <= maxAttempts; attempt++ {
-			logger.Logf(t, "checking for httproute %s existence check attempt %d/%d", routeName, attempt, maxAttempts)
-
-			for i := range checksPerAttempt {
-				_, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "get", "httproute", routeName)
-				if err == nil {
-					found = true
-					logger.Logf(t, "httproute %s found successfully", routeName)
-					break
-				}
-				logger.Logf(t, "httproute %s check %d/%d: %v", routeName, i+1, checksPerAttempt, err)
-				time.Sleep(2 * time.Second)
-			}
-
-			if found {
-				break
-			}
-
-			if attempt < maxAttempts {
-				logger.Logf(t, "httproute %s not found after %d seconds, attempting delete/recreate (attempt %d/%d)", routeName, checksPerAttempt*2, attempt, maxAttempts)
-				// Delete the httproute if it exists in a bad state
-				k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "delete", "httproute", routeName, "--ignore-not-found=true")
-				// Recreate by reapplying the base resources
-				out, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "apply", "-k", "../fixtures/cases/api-gateways/jwt-auth")
-				require.NoError(t, err, out)
-				// Brief pause to let the recreation start
-				time.Sleep(2 * time.Second)
-			}
-		}
-
-		if !found {
-			require.Failf(t, "httproute %s was not found after %d attempts with delete/recreate", routeName, maxAttempts)
-		}
+		helpers.WaitForHTTPRouteWithRetry(t, ctx.KubectlOptions(t), routeName, "../fixtures/cases/api-gateways/jwt-auth")
 	}
 
 	out, err = k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "apply", "-n", "other", "-f", "../fixtures/cases/api-gateways/jwt-auth/external-ref-other-ns.yaml")

--- a/acceptance/tests/api-gateway/api_gateway_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_test.go
@@ -157,31 +157,43 @@ func TestAPIGateway_Basic(t *testing.T) {
 
 			// Wait for the httproute to exist before patching, with delete/recreate fallback
 			logger.Log(t, "waiting for httproute to be created")
-			for attempt := 1; attempt <= 3; attempt++ {
-				logger.Log(t, "httproute existence check attempt %d/3", attempt)
-				found := false
-				shortCounter := &retry.Counter{Count: 5, Wait: 2 * time.Second} // 10 seconds total
-				retry.RunWith(shortCounter, t, func(r *retry.R) {
-					_, err := k8s.RunKubectlAndGetOutputE(r, ctx.KubectlOptions(r), "get", "httproute", "http-route")
+			found := false
+			maxAttempts := 3
+			checksPerAttempt := 5
+
+			for attempt := 1; attempt <= maxAttempts; attempt++ {
+				logger.Log(t, "httproute existence check attempt %d/%d", attempt, maxAttempts)
+
+				// Check for httproute existence using simple loop (like kitchen sink test)
+				for i := range checksPerAttempt {
+					_, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "get", "httproute", "http-route")
 					if err == nil {
 						found = true
+						logger.Log(t, "httproute http-route found successfully")
+						break
 					}
-					require.NoError(r, err, "httproute http-route does not exist yet")
-				})
-				
+					logger.Logf(t, "httproute check %d/%d: %v", i+1, checksPerAttempt, err)
+					time.Sleep(2 * time.Second)
+				}
+
 				if found {
-					logger.Log(t, "httproute http-route found successfully")
 					break
 				}
-				
-				if attempt < 3 {
-					logger.Log(t, "httproute not found after 10s, attempting delete/recreate (attempt %d/3)", attempt)
+
+				if attempt < maxAttempts {
+					logger.Log(t, "httproute not found after %d seconds, attempting delete/recreate (attempt %d/%d)", checksPerAttempt*2, attempt, maxAttempts)
 					// Delete the httproute if it exists in a bad state
 					k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "delete", "httproute", "http-route", "--ignore-not-found=true")
 					// Recreate by reapplying the base resources
 					out, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "apply", "-k", "../fixtures/bases/api-gateway")
 					require.NoError(t, err, out)
+					// Brief pause to let the recreation start
+					time.Sleep(2 * time.Second)
 				}
+			}
+
+			if !found {
+				require.Fail(t, "httproute http-route was not found after 3 attempts with delete/recreate")
 			}
 
 			logger.Log(t, "patching route to target http server")

--- a/acceptance/tests/api-gateway/api_gateway_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_test.go
@@ -155,13 +155,34 @@ func TestAPIGateway_Basic(t *testing.T) {
 			logger.Log(t, "creating static-client pod")
 			k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/bases/static-client")
 
-			// Wait for the httproute to exist before patching
+			// Wait for the httproute to exist before patching, with delete/recreate fallback
 			logger.Log(t, "waiting for httproute to be created")
-			routeCounter := &retry.Counter{Count: 30, Wait: 2 * time.Second}
-			retry.RunWith(routeCounter, t, func(r *retry.R) {
-				_, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "get", "httproute", "http-route")
-				require.NoError(r, err, "httproute http-route does not exist yet")
-			})
+			for attempt := 1; attempt <= 3; attempt++ {
+				logger.Log(t, "httproute existence check attempt %d/3", attempt)
+				found := false
+				shortCounter := &retry.Counter{Count: 5, Wait: 2 * time.Second} // 10 seconds total
+				retry.RunWith(shortCounter, t, func(r *retry.R) {
+					_, err := k8s.RunKubectlAndGetOutputE(r, ctx.KubectlOptions(r), "get", "httproute", "http-route")
+					if err == nil {
+						found = true
+					}
+					require.NoError(r, err, "httproute http-route does not exist yet")
+				})
+				
+				if found {
+					logger.Log(t, "httproute http-route found successfully")
+					break
+				}
+				
+				if attempt < 3 {
+					logger.Log(t, "httproute not found after 10s, attempting delete/recreate (attempt %d/3)", attempt)
+					// Delete the httproute if it exists in a bad state
+					k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "delete", "httproute", "http-route", "--ignore-not-found=true")
+					// Recreate by reapplying the base resources
+					out, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "apply", "-k", "../fixtures/bases/api-gateway")
+					require.NoError(t, err, out)
+				}
+			}
 
 			logger.Log(t, "patching route to target http server")
 			// Use retries to handle intermittent failures when patching the httproute

--- a/acceptance/tests/partitions/partitions_gateway_test.go
+++ b/acceptance/tests/partitions/partitions_gateway_test.go
@@ -232,8 +232,11 @@ func TestPartitions_Gateway(t *testing.T) {
 	})
 
 	logger.Log(t, "creating api-gateway resources")
-	out, err = k8s.RunKubectlAndGetOutputE(t, secondaryPartitionClusterStaticServerOpts, "apply", "-k", "../fixtures/bases/api-gateway")
-	require.NoError(t, err, out)
+	// Apply api-gateway resources with retry logic to handle intermittent failures
+	retry.Run(t, func(r *retry.R) {
+		out, err := k8s.RunKubectlAndGetOutputE(t, secondaryPartitionClusterStaticServerOpts, "apply", "-k", "../fixtures/bases/api-gateway")
+		require.NoError(r, err, out)
+	})
 	helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
 		// Ignore errors here because if the test ran as expected
 		// the custom resources will have been deleted.

--- a/acceptance/tests/peering/peering_connect_namespaces_test.go
+++ b/acceptance/tests/peering/peering_connect_namespaces_test.go
@@ -220,37 +220,7 @@ func TestPeering_ConnectNamespaces(t *testing.T) {
 
 			// Ensure the secret is created with retry logic for recreating the peering acceptor if needed.
 			retry.RunWith(timer, t, func(r *retry.R) {
-				acceptorSecretName, err := k8s.RunKubectlAndGetOutputE(r, staticClientPeerClusterContext.KubectlOptions(r), "get", "peeringacceptor", "server", "-o", "jsonpath={.status.secret.name}")
-				require.NoError(r, err)
-
-				// If the secret name is empty, retry recreating the peering acceptor up to 5 times
-				if acceptorSecretName == "" {
-					const maxRetries = 5
-					for attempt := 1; attempt <= maxRetries; attempt++ {
-						logger.Log(t, fmt.Sprintf("peering acceptor secret name is empty, recreating peering acceptor (attempt %d/%d)", attempt, maxRetries))
-						k8s.KubectlDelete(t, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
-
-						time.Sleep(5 * time.Second)
-
-						k8s.KubectlApply(t, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
-
-						time.Sleep(10 * time.Second)
-
-						acceptorSecretName, err = k8s.RunKubectlAndGetOutputE(r, staticClientPeerClusterContext.KubectlOptions(r), "get", "peeringacceptor", "server", "-o", "jsonpath={.status.secret.name}")
-						require.NoError(r, err)
-
-						if acceptorSecretName != "" {
-							logger.Log(t, fmt.Sprintf("peering acceptor secret name successfully created after %d attempts", attempt))
-							break
-						}
-
-						if attempt == maxRetries {
-							logger.Log(t, fmt.Sprintf("peering acceptor secret name still empty after %d attempts", maxRetries))
-						}
-					}
-				}
-
-				require.NotEmpty(r, acceptorSecretName)
+				helpers.EnsurePeeringAcceptorSecret(t, r, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
 			})
 
 			// Copy secret from client peer to server peer.

--- a/acceptance/tests/peering/peering_connect_test.go
+++ b/acceptance/tests/peering/peering_connect_test.go
@@ -189,6 +189,34 @@ func TestPeering_Connect(t *testing.T) {
 			retry.RunWith(timer, t, func(r *retry.R) {
 				acceptorSecretName, err := k8s.RunKubectlAndGetOutputE(r, staticClientPeerClusterContext.KubectlOptions(r), "get", "peeringacceptor", "server", "-o", "jsonpath={.status.secret.name}")
 				require.NoError(r, err)
+
+				// If the secret name is empty, retry recreating the peering acceptor up to 5 times
+				if acceptorSecretName == "" {
+					const maxRetries = 5
+					for attempt := 1; attempt <= maxRetries; attempt++ {
+						logger.Log(t, fmt.Sprintf("peering acceptor secret name is empty, recreating peering acceptor (attempt %d/%d)", attempt, maxRetries))
+						k8s.KubectlDelete(t, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
+
+						time.Sleep(5 * time.Second)
+
+						k8s.KubectlApply(t, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
+
+						time.Sleep(10 * time.Second)
+
+						acceptorSecretName, err = k8s.RunKubectlAndGetOutputE(r, staticClientPeerClusterContext.KubectlOptions(r), "get", "peeringacceptor", "server", "-o", "jsonpath={.status.secret.name}")
+						require.NoError(r, err)
+
+						if acceptorSecretName != "" {
+							logger.Log(t, fmt.Sprintf("peering acceptor secret name successfully created after %d attempts", attempt))
+							break
+						}
+
+						if attempt == maxRetries {
+							logger.Log(t, fmt.Sprintf("peering acceptor secret name still empty after %d attempts", maxRetries))
+						}
+					}
+				}
+
 				require.NotEmpty(r, acceptorSecretName)
 			})
 

--- a/acceptance/tests/peering/peering_connect_test.go
+++ b/acceptance/tests/peering/peering_connect_test.go
@@ -187,37 +187,7 @@ func TestPeering_Connect(t *testing.T) {
 			// Ensure the secret is created.
 			timer = &retry.Timer{Timeout: 30 * time.Minute, Wait: 60 * time.Second}
 			retry.RunWith(timer, t, func(r *retry.R) {
-				acceptorSecretName, err := k8s.RunKubectlAndGetOutputE(r, staticClientPeerClusterContext.KubectlOptions(r), "get", "peeringacceptor", "server", "-o", "jsonpath={.status.secret.name}")
-				require.NoError(r, err)
-
-				// If the secret name is empty, retry recreating the peering acceptor up to 5 times
-				if acceptorSecretName == "" {
-					const maxRetries = 5
-					for attempt := 1; attempt <= maxRetries; attempt++ {
-						logger.Log(t, fmt.Sprintf("peering acceptor secret name is empty, recreating peering acceptor (attempt %d/%d)", attempt, maxRetries))
-						k8s.KubectlDelete(t, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
-
-						time.Sleep(5 * time.Second)
-
-						k8s.KubectlApply(t, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
-
-						time.Sleep(10 * time.Second)
-
-						acceptorSecretName, err = k8s.RunKubectlAndGetOutputE(r, staticClientPeerClusterContext.KubectlOptions(r), "get", "peeringacceptor", "server", "-o", "jsonpath={.status.secret.name}")
-						require.NoError(r, err)
-
-						if acceptorSecretName != "" {
-							logger.Log(t, fmt.Sprintf("peering acceptor secret name successfully created after %d attempts", attempt))
-							break
-						}
-
-						if attempt == maxRetries {
-							logger.Log(t, fmt.Sprintf("peering acceptor secret name still empty after %d attempts", maxRetries))
-						}
-					}
-				}
-
-				require.NotEmpty(r, acceptorSecretName)
+				helpers.EnsurePeeringAcceptorSecret(t, r, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
 			})
 
 			// Copy secret from client peer to server peer.

--- a/acceptance/tests/peering/peering_gateway_test.go
+++ b/acceptance/tests/peering/peering_gateway_test.go
@@ -314,45 +314,7 @@ func TestPeering_Gateway(t *testing.T) {
 	})
 
 	// Wait for the httproute to exist before patching, with delete/recreate fallback
-	logger.Log(t, "waiting for httproute to be created")
-	found := false
-	maxAttempts := 3
-	checksPerAttempt := 5
-
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		logger.Log(t, "httproute existence check attempt %d/%d", attempt, maxAttempts)
-
-		// Check for httproute existence using simple loop (like kitchen sink test)
-		for i := range checksPerAttempt {
-			_, err := k8s.RunKubectlAndGetOutputE(t, staticClientOpts, "get", "httproute", "http-route")
-			if err == nil {
-				found = true
-				logger.Log(t, "httproute http-route found successfully")
-				break
-			}
-			logger.Logf(t, "httproute check %d/%d: %v", i+1, checksPerAttempt, err)
-			time.Sleep(2 * time.Second)
-		}
-
-		if found {
-			break
-		}
-
-		if attempt < maxAttempts {
-			logger.Log(t, "httproute not found after %d seconds, attempting delete/recreate (attempt %d/%d)", checksPerAttempt*2, attempt, maxAttempts)
-			// Delete the httproute if it exists in a bad state
-			k8s.RunKubectlAndGetOutputE(t, staticClientOpts, "delete", "httproute", "http-route", "--ignore-not-found=true")
-			// Recreate by reapplying the base resources
-			out, err := k8s.RunKubectlAndGetOutputE(t, staticClientOpts, "apply", "-k", "../fixtures/bases/api-gateway")
-			require.NoError(t, err, out)
-			// Brief pause to let the recreation start
-			time.Sleep(2 * time.Second)
-		}
-	}
-
-	if !found {
-		require.Fail(t, "httproute http-route was not found after 3 attempts with delete/recreate")
-	}
+	helpers.WaitForHTTPRouteWithRetry(t, staticClientOpts, "http-route", "../fixtures/bases/api-gateway")
 
 	logger.Log(t, "patching route to target server")
 	k8s.RunKubectl(t, staticClientOpts, "patch", "httproute", "http-route", "-p", `{"spec":{"rules":[{"backendRefs":[{"group":"consul.hashicorp.com","kind":"MeshService","name":"mesh-service","port":80}]}]}}`, "--type=merge")

--- a/acceptance/tests/peering/peering_gateway_test.go
+++ b/acceptance/tests/peering/peering_gateway_test.go
@@ -247,8 +247,11 @@ func TestPeering_Gateway(t *testing.T) {
 	})
 
 	logger.Log(t, "creating api-gateway resources in client peer")
-	out, err = k8s.RunKubectlAndGetOutputE(t, staticClientOpts, "apply", "-k", "../fixtures/bases/api-gateway")
-	require.NoError(t, err, out)
+	// Apply api-gateway resources with retry logic to handle intermittent failures
+	retry.Run(t, func(r *retry.R) {
+		out, err := k8s.RunKubectlAndGetOutputE(r, staticClientOpts, "apply", "-k", "../fixtures/bases/api-gateway")
+		require.NoError(r, err, out)
+	})
 	helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
 		// Ignore errors here because if the test ran as expected
 		// the custom resources will have been deleted.

--- a/acceptance/tests/peering/peering_gateway_test.go
+++ b/acceptance/tests/peering/peering_gateway_test.go
@@ -313,6 +313,10 @@ func TestPeering_Gateway(t *testing.T) {
 		k8s.KubectlDeleteK(t, staticClientOpts, "../fixtures/cases/api-gateways/peer-resolver")
 	})
 
+	// Wait for the httproute to be created before patching
+	logger.Log(t, "waiting for httproute to be created")
+	k8s.RunKubectl(t, staticClientOpts, "wait", "--for=jsonpath='{.metadata.name}'=http-route", "httproute", "http-route", "--timeout=60s")
+
 	logger.Log(t, "patching route to target server")
 	k8s.RunKubectl(t, staticClientOpts, "patch", "httproute", "http-route", "-p", `{"spec":{"rules":[{"backendRefs":[{"group":"consul.hashicorp.com","kind":"MeshService","name":"mesh-service","port":80}]}]}}`, "--type=merge")
 

--- a/acceptance/tests/peering/peering_gateway_test.go
+++ b/acceptance/tests/peering/peering_gateway_test.go
@@ -168,37 +168,7 @@ func TestPeering_Gateway(t *testing.T) {
 
 	// Ensure the secret is created.
 	retry.RunWith(timer, t, func(r *retry.R) {
-		acceptorSecretName, err := k8s.RunKubectlAndGetOutputE(r, staticClientPeerClusterContext.KubectlOptions(r), "get", "peeringacceptor", "server", "-o", "jsonpath={.status.secret.name}")
-		require.NoError(r, err)
-
-		// If the secret name is empty, retry recreating the peering acceptor up to 5 times
-		if acceptorSecretName == "" {
-			const maxRetries = 5
-			for attempt := 1; attempt <= maxRetries; attempt++ {
-				logger.Log(t, fmt.Sprintf("peering acceptor secret name is empty, recreating peering acceptor (attempt %d/%d)", attempt, maxRetries))
-				k8s.KubectlDelete(t, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
-
-				time.Sleep(5 * time.Second)
-
-				k8s.KubectlApply(t, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
-
-				time.Sleep(10 * time.Second)
-
-				acceptorSecretName, err = k8s.RunKubectlAndGetOutputE(r, staticClientPeerClusterContext.KubectlOptions(r), "get", "peeringacceptor", "server", "-o", "jsonpath={.status.secret.name}")
-				require.NoError(r, err)
-
-				if acceptorSecretName != "" {
-					logger.Log(t, fmt.Sprintf("peering acceptor secret name successfully created after %d attempts", attempt))
-					break
-				}
-
-				if attempt == maxRetries {
-					logger.Log(t, fmt.Sprintf("peering acceptor secret name still empty after %d attempts", maxRetries))
-				}
-			}
-		}
-
-		require.NotEmpty(r, acceptorSecretName)
+		helpers.EnsurePeeringAcceptorSecret(t, r, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
 	})
 
 	// Copy secret from client peer to server peer.

--- a/acceptance/tests/peering/peering_gateway_test.go
+++ b/acceptance/tests/peering/peering_gateway_test.go
@@ -170,6 +170,34 @@ func TestPeering_Gateway(t *testing.T) {
 	retry.RunWith(timer, t, func(r *retry.R) {
 		acceptorSecretName, err := k8s.RunKubectlAndGetOutputE(r, staticClientPeerClusterContext.KubectlOptions(r), "get", "peeringacceptor", "server", "-o", "jsonpath={.status.secret.name}")
 		require.NoError(r, err)
+
+		// If the secret name is empty, retry recreating the peering acceptor up to 5 times
+		if acceptorSecretName == "" {
+			const maxRetries = 5
+			for attempt := 1; attempt <= maxRetries; attempt++ {
+				logger.Log(t, fmt.Sprintf("peering acceptor secret name is empty, recreating peering acceptor (attempt %d/%d)", attempt, maxRetries))
+				k8s.KubectlDelete(t, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
+
+				time.Sleep(5 * time.Second)
+
+				k8s.KubectlApply(t, staticClientPeerClusterContext.KubectlOptions(t), "../fixtures/bases/peering/peering-acceptor.yaml")
+
+				time.Sleep(10 * time.Second)
+
+				acceptorSecretName, err = k8s.RunKubectlAndGetOutputE(r, staticClientPeerClusterContext.KubectlOptions(r), "get", "peeringacceptor", "server", "-o", "jsonpath={.status.secret.name}")
+				require.NoError(r, err)
+
+				if acceptorSecretName != "" {
+					logger.Log(t, fmt.Sprintf("peering acceptor secret name successfully created after %d attempts", attempt))
+					break
+				}
+
+				if attempt == maxRetries {
+					logger.Log(t, fmt.Sprintf("peering acceptor secret name still empty after %d attempts", maxRetries))
+				}
+			}
+		}
+
 		require.NotEmpty(r, acceptorSecretName)
 	})
 

--- a/acceptance/tests/peering/peering_gateway_test.go
+++ b/acceptance/tests/peering/peering_gateway_test.go
@@ -313,13 +313,34 @@ func TestPeering_Gateway(t *testing.T) {
 		k8s.KubectlDeleteK(t, staticClientOpts, "../fixtures/cases/api-gateways/peer-resolver")
 	})
 
-	// Wait for the httproute to exist before patching
+	// Wait for the httproute to exist before patching, with delete/recreate fallback
 	logger.Log(t, "waiting for httproute to be created")
-	routeCounter := &retry.Counter{Count: 30, Wait: 2 * time.Second}
-	retry.RunWith(routeCounter, t, func(r *retry.R) {
-		_, err := k8s.RunKubectlAndGetOutputE(t, staticClientOpts, "get", "httproute", "http-route")
-		require.NoError(r, err, "httproute http-route does not exist yet")
-	})
+	for attempt := 1; attempt <= 3; attempt++ {
+		logger.Log(t, "httproute existence check attempt %d/3", attempt)
+		found := false
+		shortCounter := &retry.Counter{Count: 5, Wait: 2 * time.Second} // 10 seconds total
+		retry.RunWith(shortCounter, t, func(r *retry.R) {
+			_, err := k8s.RunKubectlAndGetOutputE(r, staticClientOpts, "get", "httproute", "http-route")
+			if err == nil {
+				found = true
+			}
+			require.NoError(r, err, "httproute http-route does not exist yet")
+		})
+		
+		if found {
+			logger.Log(t, "httproute http-route found successfully")
+			break
+		}
+		
+		if attempt < 3 {
+			logger.Log(t, "httproute not found after 10s, attempting delete/recreate (attempt %d/3)", attempt)
+			// Delete the httproute if it exists in a bad state
+			k8s.RunKubectlAndGetOutputE(t, staticClientOpts, "delete", "httproute", "http-route", "--ignore-not-found=true")
+			// Recreate by reapplying the base resources
+			out, err := k8s.RunKubectlAndGetOutputE(t, staticClientOpts, "apply", "-k", "../fixtures/bases/api-gateway")
+			require.NoError(t, err, out)
+		}
+	}
 
 	logger.Log(t, "patching route to target server")
 	k8s.RunKubectl(t, staticClientOpts, "patch", "httproute", "http-route", "-p", `{"spec":{"rules":[{"backendRefs":[{"group":"consul.hashicorp.com","kind":"MeshService","name":"mesh-service","port":80}]}]}}`, "--type=merge")

--- a/acceptance/tests/sameness/sameness_test.go
+++ b/acceptance/tests/sameness/sameness_test.go
@@ -509,6 +509,11 @@ func TestFailover_Connect(t *testing.T) {
 				v.checkLocalities(t)
 			}
 
+			// Allow extra time for the mesh to stabilize after any PeeringAcceptor retries
+			// This ensures sameness groups and service discovery are fully synchronized
+			logger.Log(t, "allowing mesh to stabilize before failover validation")
+			time.Sleep(30 * time.Second)
+
 			// Verify all the failover Scenarios
 			logger.Log(t, "verifying failover scenarios")
 
@@ -580,6 +585,11 @@ func TestFailover_Connect(t *testing.T) {
 					testClusters.verifyServerUpState(t, cfg.EnableTransparentProxy)
 					// We're resetting the scale, so make sure we have all the new IP addresses saved
 					testClusters.setServerIP(t)
+
+					// Allow time for services to be fully registered and propagated across the mesh
+					// after scaling operations, especially important after PeeringAcceptor recreations
+					logger.Logf(t, "allowing services to stabilize for %s perspective", sc.name)
+					time.Sleep(15 * time.Second)
 
 					for i, v := range sc.failovers {
 						// Verify Failover (If this is the first check, then just verifying we're starting with the right server)
@@ -655,25 +665,40 @@ func (c *cluster) serviceTargetCheck(t *testing.T, expectedName string, curlAddr
 		// This silences extra output like the request progress bar, but preserves errors.
 		resp, err = k8s.RunKubectlAndGetOutputE(r, c.clientOpts, "exec", "-i",
 			staticClientDeployment, "-c", staticClientName, "--", "curl", "-sS", curlAddress)
+		if err != nil {
+			logger.Logf(r, "serviceTargetCheck curl failed from cluster %s to %s: %v", c.name, curlAddress, err)
+		} else {
+			logger.Logf(r, "serviceTargetCheck response from cluster %s: %s", c.name, resp)
+		}
 		require.NoError(r, err)
 		assert.Contains(r, resp, expectedName)
 	})
-	logger.Log(t, resp)
+	logger.Logf(t, "serviceTargetCheck final response for cluster %s: %s", c.name, resp)
 }
 
 // preparedQueryFailoverCheck verifies that failover occurs when executing the prepared query. It also assures that
 // executing the prepared query via DNS also provides expected results.
 func (c *cluster) preparedQueryFailoverCheck(t *testing.T, cfg *config.TestConfig, releaseName string, epq expectedPQ, failover *cluster) {
 	timer := &retry.Timer{Timeout: retryTimeout, Wait: 5 * time.Second}
-	resp, _, err := c.client.PreparedQuery().Execute(*c.pqID, &api.QueryOptions{Namespace: staticServerNamespace, Partition: c.partition})
-	require.NoError(t, err)
-	require.Len(t, resp.Nodes, 1)
 
-	assert.Equal(t, epq.partition, resp.Nodes[0].Service.Partition)
-	assert.Equal(t, epq.peerName, resp.Nodes[0].Service.PeerName)
-	assert.Equal(t, epq.namespace, resp.Nodes[0].Service.Namespace)
-	addr := strings.ReplaceAll(resp.Nodes[0].Service.Address, ":0:", "::")
-	assert.Equal(t, *failover.staticServerIP, addr)
+	// Use retry for prepared query execution to handle timing issues
+	var resp *api.PreparedQueryExecuteResponse
+	retry.RunWith(timer, t, func(r *retry.R) {
+		var err error
+		resp, _, err = c.client.PreparedQuery().Execute(*c.pqID, &api.QueryOptions{Namespace: staticServerNamespace, Partition: c.partition})
+		require.NoError(r, err)
+		require.Len(r, resp.Nodes, 1, "Expected exactly 1 node in prepared query response")
+
+		// Validate the response matches expected failover target
+		assert.Equal(r, epq.partition, resp.Nodes[0].Service.Partition)
+		assert.Equal(r, epq.peerName, resp.Nodes[0].Service.PeerName)
+		assert.Equal(r, epq.namespace, resp.Nodes[0].Service.Namespace)
+		addr := strings.ReplaceAll(resp.Nodes[0].Service.Address, ":0:", "::")
+		assert.Equal(r, *failover.staticServerIP, addr)
+
+		logger.Logf(r, "Prepared query validation succeeded for cluster %s: partition=%s, peer=%s, addr=%s",
+			c.name, resp.Nodes[0].Service.Partition, resp.Nodes[0].Service.PeerName, addr)
+	})
 
 	// Verify that dns lookup is successful, there is no guarantee that the ip address is unique, so for PQ this is
 	// just verifying that we can query using DNS and that the ip address is correct. It does not however prove
@@ -696,6 +721,8 @@ func (c *cluster) dnsFailoverCheck(t *testing.T, cfg *config.TestConfig, release
 		// where we are verifying DNS for a partition
 		logs := dnsQuery(r, cfg, releaseName, dnsLookup, c.primaryCluster, failover)
 
+		logger.Logf(r, "DNS query from cluster %s for failover target %s: %s", c.name, failover.name, logs)
+
 		assert.Contains(r, logs, fmt.Sprintf("SERVER: %s", *c.primaryCluster.dnsIP))
 		assert.Contains(r, logs, "ANSWER SECTION:")
 		assert.Contains(r, logs, *failover.staticServerIP)
@@ -710,14 +737,16 @@ func (c *cluster) dnsFailoverCheck(t *testing.T, cfg *config.TestConfig, release
 			expectedName = strings.Replace(expectedName, "kind-", "", -1)
 		}
 		assert.Contains(r, logs, expectedName)
+
+		logger.Logf(r, "DNS failover check successful for cluster %s -> %s", c.name, failover.name)
 	})
 }
 
 // waitForPeeringAcceptorReady waits for a PeeringAcceptor to be fully processed and ready
-// If it doesn't become ready in ~15 minutes, it will delete and recreate the resource.
+// If it doesn't become ready in ~24 minutes, it will delete and recreate the resource.
 func (c *cluster) waitForPeeringAcceptorReady(t *testing.T, cfg *config.TestConfig, acceptorName string) {
 	maxRetries := 3
-	shortTimeout := 5 * time.Minute // Try for 5 minutes before recreating
+	shortTimeout := 8 * time.Minute // Try for 8 minutes before recreating
 
 	for attempt := range maxRetries {
 		if attempt > 0 {
@@ -734,8 +763,8 @@ func (c *cluster) waitForPeeringAcceptorReady(t *testing.T, cfg *config.TestConf
 			acceptorDir := fmt.Sprintf("../fixtures/bases/sameness/peering/%s-acceptor", c.name)
 			applyResources(t, cfg, acceptorDir, c.context.KubectlOptions(t))
 
-			// Wait a moment for the resource to be created
-			time.Sleep(5 * time.Second)
+			// Wait for the resource to be fully created and processed
+			time.Sleep(10 * time.Second)
 		}
 
 		ready := c.checkPeeringAcceptorReady(t, acceptorName, shortTimeout)
@@ -758,48 +787,78 @@ func (c *cluster) waitForPeeringAcceptorReady(t *testing.T, cfg *config.TestConf
 func (c *cluster) checkPeeringAcceptorReady(t *testing.T, acceptorName string, timeout time.Duration) bool {
 	// Keep checking until timeout for peeringAcceptor to be ready
 	endTime := time.Now().Add(timeout)
+	sleepInterval := 5 * time.Second
+	maxSleepInterval := 30 * time.Second
+	logInterval := 30 * time.Second
+	lastLogTime := time.Now().Add(-logInterval) // Force initial log
+
 	for time.Now().Before(endTime) {
 		// Verify the peeringacceptor resource exists
 		_, err := k8s.RunKubectlAndGetOutputE(t, c.context.KubectlOptions(t), "get", "peeringacceptor", acceptorName)
 		if err != nil {
-			logger.Logf(t, "PeeringAcceptor %s does not exist yet on cluster %s: %v", acceptorName, c.name, err)
-			time.Sleep(2 * time.Second)
+			if time.Since(lastLogTime) >= logInterval {
+				logger.Logf(t, "PeeringAcceptor %s does not exist yet on cluster %s: %v", acceptorName, c.name, err)
+				lastLogTime = time.Now()
+			}
+			time.Sleep(sleepInterval)
+			// Exponential backoff up to maxSleepInterval
+			if sleepInterval < maxSleepInterval {
+				sleepInterval = sleepInterval * 3 / 2
+				if sleepInterval > maxSleepInterval {
+					sleepInterval = maxSleepInterval
+				}
+			}
 			continue
 		}
 
 		// Check if the peeringacceptor has a status with conditions
 		statusOutput, err := k8s.RunKubectlAndGetOutputE(t, c.context.KubectlOptions(t), "get", "peeringacceptor", acceptorName, "-o", "jsonpath={.status}")
 		if err != nil {
-			logger.Logf(t, "Failed to get PeeringAcceptor %s status on cluster %s: %v", acceptorName, c.name, err)
-			time.Sleep(2 * time.Second)
+			if time.Since(lastLogTime) >= logInterval {
+				logger.Logf(t, "Failed to get PeeringAcceptor %s status on cluster %s: %v", acceptorName, c.name, err)
+				lastLogTime = time.Now()
+			}
+			time.Sleep(sleepInterval)
 			continue
 		}
 		if strings.TrimSpace(statusOutput) == "" || strings.TrimSpace(statusOutput) == "{}" {
-			logger.Logf(t, "PeeringAcceptor %s does not have status populated yet on cluster %s", acceptorName, c.name)
-			time.Sleep(2 * time.Second)
+			if time.Since(lastLogTime) >= logInterval {
+				logger.Logf(t, "PeeringAcceptor %s does not have status populated yet on cluster %s", acceptorName, c.name)
+				lastLogTime = time.Now()
+			}
+			time.Sleep(sleepInterval)
 			continue
 		}
 
 		// Check if the secret name is populated
 		secretName, err := k8s.RunKubectlAndGetOutputE(t, c.context.KubectlOptions(t), "get", "peeringacceptor", acceptorName, "-o", "jsonpath={.status.secret.name}")
 		if err != nil {
-			logger.Logf(t, "Failed to get secret name from PeeringAcceptor %s on cluster %s: %v", acceptorName, c.name, err)
-			time.Sleep(2 * time.Second)
+			if time.Since(lastLogTime) >= logInterval {
+				logger.Logf(t, "Failed to get secret name from PeeringAcceptor %s on cluster %s: %v", acceptorName, c.name, err)
+				lastLogTime = time.Now()
+			}
+			time.Sleep(sleepInterval)
 			continue
 		}
 
 		secretName = strings.TrimSpace(secretName)
 		if secretName == "" {
-			logger.Logf(t, "PeeringAcceptor %s secret name is not populated yet on cluster %s", acceptorName, c.name)
-			time.Sleep(2 * time.Second)
+			if time.Since(lastLogTime) >= logInterval {
+				logger.Logf(t, "PeeringAcceptor %s secret name is not populated yet on cluster %s", acceptorName, c.name)
+				lastLogTime = time.Now()
+			}
+			time.Sleep(sleepInterval)
 			continue
 		}
 
 		// Verify the secret actually exists
 		_, err = k8s.RunKubectlAndGetOutputE(t, c.context.KubectlOptions(t), "get", "secret", secretName)
 		if err != nil {
-			logger.Logf(t, "Secret %s referenced by PeeringAcceptor %s does not exist yet on cluster %s: %v", secretName, acceptorName, c.name, err)
-			time.Sleep(2 * time.Second)
+			if time.Since(lastLogTime) >= logInterval {
+				logger.Logf(t, "Secret %s referenced by PeeringAcceptor %s does not exist yet on cluster %s: %v", secretName, acceptorName, c.name, err)
+				lastLogTime = time.Now()
+			}
+			time.Sleep(sleepInterval)
 			continue
 		}
 
@@ -807,7 +866,14 @@ func (c *cluster) checkPeeringAcceptorReady(t *testing.T, acceptorName string, t
 		return true
 	}
 
+	// Add diagnostic information when failing
 	logger.Logf(t, "PeeringAcceptor %s failed to become ready within %v on cluster %s", acceptorName, timeout, c.name)
+
+	// Get detailed status for debugging
+	if statusOutput, err := k8s.RunKubectlAndGetOutputE(t, c.context.KubectlOptions(t), "describe", "peeringacceptor", acceptorName); err == nil {
+		logger.Logf(t, "PeeringAcceptor %s description on cluster %s:\n%s", acceptorName, c.name, statusOutput)
+	}
+
 	return false
 }
 

--- a/acceptance/tests/wan-federation/wan_federation_gateway_test.go
+++ b/acceptance/tests/wan-federation/wan_federation_gateway_test.go
@@ -142,8 +142,11 @@ func TestWANFederation_Gateway(t *testing.T) {
 		k8s.DeployKustomize(t, secondaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
 
 		logger.Log(t, "creating api-gateway resources in dc1")
-		out, err := k8s.RunKubectlAndGetOutputE(t, primaryContext.KubectlOptions(t), "apply", "-k", "../fixtures/bases/api-gateway")
-		require.NoError(t, err, out)
+		// Apply api-gateway resources with retry logic to handle intermittent failures
+		retry.Run(t, func(r *retry.R) {
+			out, err := k8s.RunKubectlAndGetOutputE(t, primaryContext.KubectlOptions(t), "apply", "-k", "../fixtures/bases/api-gateway")
+			require.NoError(r, err, out)
+		})
 		helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
 			// Ignore errors here because if the test ran as expected
 			// the custom resources will have been deleted.
@@ -172,8 +175,11 @@ func TestWANFederation_Gateway(t *testing.T) {
 		k8s.DeployKustomize(t, primaryContext.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/cases/static-server-inject")
 
 		logger.Log(t, "creating api-gateway resources in dc2")
-		out, err := k8s.RunKubectlAndGetOutputE(t, secondaryContext.KubectlOptions(t), "apply", "-k", "../fixtures/bases/api-gateway")
-		require.NoError(t, err, out)
+		// Apply api-gateway resources with retry logic to handle intermittent failures
+		retry.Run(t, func(r *retry.R) {
+			out, err := k8s.RunKubectlAndGetOutputE(t, secondaryContext.KubectlOptions(t), "apply", "-k", "../fixtures/bases/api-gateway")
+			require.NoError(r, err, out)
+		})
 		helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
 			// Ignore errors here because if the test ran as expected
 			// the custom resources will have been deleted.

--- a/acceptance/tests/wan-federation/wan_federation_gateway_test.go
+++ b/acceptance/tests/wan-federation/wan_federation_gateway_test.go
@@ -156,6 +156,10 @@ func TestWANFederation_Gateway(t *testing.T) {
 			k8s.KubectlDeleteK(t, secondaryContext.KubectlOptions(t), "../fixtures/cases/api-gateways/dc1-to-dc2-resolver")
 		})
 
+		// Wait for the httproute to be created before patching
+		logger.Log(t, "waiting for httproute to be created")
+		k8s.RunKubectl(t, primaryContext.KubectlOptions(t), "wait", "--for=jsonpath='{.metadata.name}'=http-route", "httproute", "http-route", "--timeout=60s")
+
 		// patching the route to target a MeshService since we don't have the corresponding Kubernetes service in this
 		// cluster.
 		k8s.RunKubectl(t, primaryContext.KubectlOptions(t), "patch", "httproute", "http-route", "-p", `{"spec":{"rules":[{"backendRefs":[{"group":"consul.hashicorp.com","kind":"MeshService","name":"mesh-service","port":80}]}]}}`, "--type=merge")
@@ -182,6 +186,10 @@ func TestWANFederation_Gateway(t *testing.T) {
 		helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
 			k8s.KubectlDeleteK(t, secondaryContext.KubectlOptions(t), "../fixtures/cases/api-gateways/dc2-to-dc1-resolver")
 		})
+
+		// Wait for the httproute to be created before patching
+		logger.Log(t, "waiting for httproute to be created")
+		k8s.RunKubectl(t, secondaryContext.KubectlOptions(t), "wait", "--for=jsonpath='{.metadata.name}'=http-route", "httproute", "http-route", "--timeout=60s")
 
 		// patching the route to target a MeshService since we don't have the corresponding Kubernetes service in this
 		// cluster.

--- a/acceptance/tests/wan-federation/wan_federation_gateway_test.go
+++ b/acceptance/tests/wan-federation/wan_federation_gateway_test.go
@@ -158,31 +158,43 @@ func TestWANFederation_Gateway(t *testing.T) {
 
 		// Wait for the httproute to exist before patching, with delete/recreate fallback
 		logger.Log(t, "waiting for httproute to be created")
-		for attempt := 1; attempt <= 3; attempt++ {
-			logger.Log(t, "httproute existence check attempt %d/3", attempt)
-			found := false
-			shortCounter := &retry.Counter{Count: 5, Wait: 2 * time.Second} // 10 seconds total
-			retry.RunWith(shortCounter, t, func(r *retry.R) {
+		found := false
+		maxAttempts := 3
+		checksPerAttempt := 5
+
+		for attempt := 1; attempt <= maxAttempts; attempt++ {
+			logger.Log(t, "httproute existence check attempt %d/%d", attempt, maxAttempts)
+
+			// Check for httproute existence using simple loop (like kitchen sink test)
+			for i := 0; i < checksPerAttempt; i++ {
 				_, err := k8s.RunKubectlAndGetOutputE(t, primaryContext.KubectlOptions(t), "get", "httproute", "http-route")
 				if err == nil {
 					found = true
+					logger.Log(t, "httproute http-route found successfully")
+					break
 				}
-				require.NoError(r, err, "httproute http-route does not exist yet")
-			})
-			
+				logger.Log(t, "httproute check %d/%d: %v", i+1, checksPerAttempt, err)
+				time.Sleep(2 * time.Second)
+			}
+
 			if found {
-				logger.Log(t, "httproute http-route found successfully")
 				break
 			}
-			
-			if attempt < 3 {
-				logger.Log(t, "httproute not found after 10s, attempting delete/recreate (attempt %d/3)", attempt)
+
+			if attempt < maxAttempts {
+				logger.Log(t, "httproute not found after %d seconds, attempting delete/recreate (attempt %d/%d)", checksPerAttempt*2, attempt, maxAttempts)
 				// Delete the httproute if it exists in a bad state
 				k8s.RunKubectlAndGetOutputE(t, primaryContext.KubectlOptions(t), "delete", "httproute", "http-route", "--ignore-not-found=true")
 				// Recreate by reapplying the base resources
 				out, err := k8s.RunKubectlAndGetOutputE(t, primaryContext.KubectlOptions(t), "apply", "-k", "../fixtures/bases/api-gateway")
 				require.NoError(t, err, out)
+				// Brief pause to let the recreation start
+				time.Sleep(2 * time.Second)
 			}
+		}
+
+		if !found {
+			require.Fail(t, "httproute http-route was not found after 3 attempts with delete/recreate")
 		}
 
 		// patching the route to target a MeshService since we don't have the corresponding Kubernetes service in this
@@ -214,31 +226,43 @@ func TestWANFederation_Gateway(t *testing.T) {
 
 		// Wait for the httproute to exist before patching, with delete/recreate fallback
 		logger.Log(t, "waiting for httproute to be created")
-		for attempt := 1; attempt <= 3; attempt++ {
-			logger.Log(t, "httproute existence check attempt %d/3", attempt)
-			found := false
-			shortCounter := &retry.Counter{Count: 5, Wait: 2 * time.Second} // 10 seconds total
-			retry.RunWith(shortCounter, t, func(r *retry.R) {
+		found := false
+		maxAttempts := 3
+		checksPerAttempt := 5
+
+		for attempt := 1; attempt <= maxAttempts; attempt++ {
+			logger.Log(t, "httproute existence check attempt %d/%d", attempt, maxAttempts)
+
+			// Check for httproute existence using simple loop (like kitchen sink test)
+			for i := range checksPerAttempt {
 				_, err := k8s.RunKubectlAndGetOutputE(t, secondaryContext.KubectlOptions(t), "get", "httproute", "http-route")
 				if err == nil {
 					found = true
+					logger.Log(t, "httproute http-route found successfully")
+					break
 				}
-				require.NoError(r, err, "httproute http-route does not exist yet")
-			})
-			
+				logger.Logf(t, "httproute check %d/%d: %v", i+1, checksPerAttempt, err)
+				time.Sleep(2 * time.Second)
+			}
+
 			if found {
-				logger.Log(t, "httproute http-route found successfully")
 				break
 			}
-			
-			if attempt < 3 {
-				logger.Log(t, "httproute not found after 10s, attempting delete/recreate (attempt %d/3)", attempt)
+
+			if attempt < maxAttempts {
+				logger.Log(t, "httproute not found after %d seconds, attempting delete/recreate (attempt %d/%d)", checksPerAttempt*2, attempt, maxAttempts)
 				// Delete the httproute if it exists in a bad state
 				k8s.RunKubectlAndGetOutputE(t, secondaryContext.KubectlOptions(t), "delete", "httproute", "http-route", "--ignore-not-found=true")
 				// Recreate by reapplying the base resources
 				out, err := k8s.RunKubectlAndGetOutputE(t, secondaryContext.KubectlOptions(t), "apply", "-k", "../fixtures/bases/api-gateway")
 				require.NoError(t, err, out)
+				// Brief pause to let the recreation start
+				time.Sleep(2 * time.Second)
 			}
+		}
+
+		if !found {
+			require.Fail(t, "httproute http-route was not found after 3 attempts with delete/recreate")
 		}
 
 		// patching the route to target a MeshService since we don't have the corresponding Kubernetes service in this


### PR DESCRIPTION
### Changes proposed in this PR ###  
-
Because of some intermittent infra issues the gateway and httproute objects are not going to Ready state in the expected time. Even though we already have retry blocks with reasonable timeouts, these objects are just stuck in Not Ready state causing the tests to fail intermittently. Updated the retry blocks to have shorter timeout for checking state of these resources and deleting/recreating them if these don't become ready in expected time. This issue is observed in tests in api-gateway, wan-federation packages.

Similar issue was observed with peeringAcceptors not getting ready in expected time, followed same pattern of having reduced timeout for checking resource readiness then recreating it. This issue was observed in peering package tests.

A minor change in sameness package test to remove redundant secret cleanup function. Deleting peeringAcceptor should cleanup the corresponding secret as well.

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
