### PR TITLE
fix(api-gateway): prevent gateway controller from processing non-consul gateways

### DIFF
--- a/.changelog/4952.txt
+++ b/.changelog/4952.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api-gateway: Fixed isuue when gateway controller processes non-consul gateways & deletes resources without provenance validation
+```

--- a/control-plane/api-gateway/controllers/gateway_controller.go
+++ b/control-plane/api-gateway/controllers/gateway_controller.go
@@ -94,6 +94,19 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
+	// Early return if this gateway doesn't belong to the consul controller
+	if gatewayClass == nil || string(gatewayClass.Spec.ControllerName) != common.GatewayClassControllerName {
+		log.Info("Skipping gateway reconciliation - not controlled by consul",
+			"gatewayClassName", gateway.Spec.GatewayClassName,
+			"controllerName", func() string {
+				if gatewayClass != nil {
+					return string(gatewayClass.Spec.ControllerName)
+				}
+				return "unknown"
+			}())
+		return ctrl.Result{}, nil
+	}
+
 	// get the gateway class config
 	gatewayClassConfig, err := r.getConfigForGatewayClass(ctx, gatewayClass)
 	if err != nil {


### PR DESCRIPTION
### Changes proposed in this PR ###  

Add early return check in gateway controller Reconcile method to skip
gateways that don't belong to the consul controller. This prevents the
controller from processing and potentially deleting resources for
gateways managed by other gateway controllers in multi-controller
environments.

The fix checks the GatewayClass.Spec.ControllerName against the consul
controller name (consul.hashicorp.com/gateway-controller) and returns
early if there's no match or if the GatewayClass is missing.

This follows the same pattern already used in the GatewayClass controller
and prevents unauthorized resource deletion that could occur when multiple
gateway controllers are deployed in the same cluster.

Fixes: Gateway controller reconciliation of non-consul gateways

Addresses Issue #4894

### How I've tested this PR ###

Added comprehensive unit tests (TestGatewayControllerReconcile) to validate:

- Gateways with non-consul GatewayClasses return early without processing
- Gateways with missing GatewayClasses return early without processing
- Gateways with consul GatewayClasses continue past the early return check

Locally built a docker image, deployed consul to k8s cluster via Helm chart to validate functionality

### How I expect reviewers to test this PR ###

Run unit tests, build image locally, deploy to k8s with helm chart.

### Checklist ###
- [X] Tests added
- [X] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
