### PR TITLE
Publish documentation to UDR instead of the Consul repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1184,10 +1184,22 @@ generated from our `values.yaml` file.
 
 To generate the docs and update the `helm.mdx` file:
 
-1. Fork `hashicorp/consul` (https://github.com/hashicorp/consul) on GitHub.
+1. Fork `hashicorp/web-unified-docs` (https://github.com/hashicorp/web-unified-docs) on GitHub.
 1. Clone your fork:
    ```shell-session
-   git clone https://github.com/<your-username>/consul.git
+   git clone https://github.com/<your-username>/web-unified-docs.git
+   ```
+1. Change directory to `web-unified-docs`:
+   ```shell-session
+   cd /path/to/web-unified-docs
+   ```
+1. Install NPM dependencies
+   ```shell-session
+   npm i
+   ```
+1. Compile version metadata file
+   ```shell-session
+   npm run prebuild -- --onlyVersionMetadata
    ```
 1. Change directory into your `consul-k8s` repo:
    ```shell-session
@@ -1195,12 +1207,12 @@ To generate the docs and update the `helm.mdx` file:
    ```
 1. Run `make gen-helm-docs` using the path to your consul (not consul-k8s) repo:
    ```shell-session
-   make gen-helm-docs consul=<path-to-consul-repo>
+   make gen-helm-docs docsRepo=<path-to-docs-repo>
    # Examples:
-   # make gen-helm-docs consul=/Users/my-name/code/hashicorp/consul
-   # make gen-helm-docs consul=../consul
+   # make gen-helm-docs docsRepo=/Users/my-name/code/web-unified-docs
+   # make gen-helm-docs docsRepo=../web-unified-docs
    ```
-1. Open up a pull request to `hashicorp/consul` (in addition to your `hashicorp/consul-k8s` pull request)
+1. Open up a pull request to `hashicorp/web-unified-docs` (in addition to your `hashicorp/consul-k8s` pull request)
 
 ### values.yaml Annotations
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GOTESTSUM_PATH?=$(shell command -v gotestsum)
 
 .PHONY: gen-helm-docs
 gen-helm-docs: ## Generate Helm reference docs from values.yaml and update Consul website. Usage: make gen-helm-docs consul=<path-to-consul-repo>.
-	@cd hack/helm-reference-gen; go run ./... $(consul)
+	@cd hack/helm-reference-gen; go run ./... $(docsRepo)
 
 .PHONY: copy-crds-to-chart
 copy-crds-to-chart: ## Copy generated CRD YAML into charts/consul. Usage: make copy-crds-to-chart
@@ -315,7 +315,7 @@ ifeq (, $(shell which copywrite))
 	@echo "Installing copywrite"
 	@go install github.com/hashicorp/copywrite@latest
 endif
-	@copywrite headers --spdx "MPL-2.0" 
+	@copywrite headers --spdx "MPL-2.0"
 
 ##@ CI Targets
 

--- a/hack/helm-reference-gen/main.go
+++ b/hack/helm-reference-gen/main.go
@@ -125,7 +125,8 @@ func main() {
 	versionMetadataPath := filepath.Join(docsRepoPath, "app/api/versionMetadata.json")
 	versionMetadataBytes, err := os.ReadFile(versionMetadataPath)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Println(err.Error())
+		os.Exit(1)
 	}
 
 	// Parse versionMetadata.json so we can choose a Consul docs version if desired

--- a/hack/helm-reference-gen/main.go
+++ b/hack/helm-reference-gen/main.go
@@ -75,7 +75,7 @@ var (
 
 func main() {
 	validateFlag := flag.Bool("validate", false, "only validate that the markdown can be generated, don't actually generate anything")
-	consulRepoPath := "../../../consul"
+	docsRepoPath := "../../../web-unified-docs"
 	flag.Parse()
 
 	if len(os.Args) > 3 {
@@ -86,17 +86,17 @@ func main() {
 	if !*validateFlag {
 		// Only argument is path to Consul repo. If not set then we default.
 		if len(os.Args) < 2 {
-			abs, _ := filepath.Abs(consulRepoPath)
+			abs, _ := filepath.Abs(docsRepoPath)
 			fmt.Printf("Defaulting to Consul repo path: %s\n", abs)
 		} else {
 			// Support absolute and relative paths to the Consul repo.
 			if filepath.IsAbs(os.Args[1]) {
-				consulRepoPath = os.Args[1]
+				docsRepoPath = os.Args[1]
 			} else {
-				consulRepoPath = filepath.Join("../..", os.Args[1])
+				docsRepoPath = filepath.Join("../..", os.Args[1])
 			}
-			abs, _ := filepath.Abs(consulRepoPath)
-			fmt.Printf("Using Consul repo path: %s\n", abs)
+			abs, _ := filepath.Abs(docsRepoPath)
+			fmt.Printf("Using docs repo path: %s\n", abs)
 		}
 	}
 
@@ -119,7 +119,7 @@ func main() {
 	}
 
 	// Otherwise we'll go on to write the changes to the helm docs.
-	helmReferenceFile := filepath.Join(consulRepoPath, "website/content/docs/reference/k8s/helm.mdx")
+	helmReferenceFile := filepath.Join(docsRepoPath, "website/content/docs/reference/k8s/helm.mdx")
 	helmReferenceBytes, err := os.ReadFile(helmReferenceFile)
 	if err != nil {
 		fmt.Println(err.Error())


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Update `consul-k8s` to publish documentation to UDR instead of the Consul repo, following [the Consul migration to UDR](https://github.com/hashicorp/web-unified-docs/pull/1228)

### How I've tested this PR ###
I've run `go test` in the `hack/helm-reference` directory to ensure that the tests still pass

### How I expect reviewers to test this PR ###
run `make gen-helm-docs` and follow the [instructions in the README](https://github.com/hashicorp/consul-k8s/commit/d4cdae6772add714097fe32ed266ebdc98335f18) to build helm docs.

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211305784283870