### PR TITLE
Support file-based envoy access logs via proxy-defaults for sidecar proxies and API gateway

### DIFF
--- a/.changelog/5008.txt
+++ b/.changelog/5008.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+api-gateway: Add support for file-based Envoy access log sinks via proxy-defaults. Previously, only stdout logging was supported.
+connect-inject: When proxy-defaults enables file-based access logs, automatically inject an emptyDir volume and volumeMount into the consul-dataplane container.
+```

--- a/control-plane/api-gateway/gatekeeper/deployment.go
+++ b/control-plane/api-gateway/gatekeeper/deployment.go
@@ -338,6 +338,10 @@ func deploymentReplicas(gcc v1alpha1.GatewayClassConfig, currentReplicas *int32)
 // fetches the global proxy-defaults config from consul and checks if access logs are enabled.
 // If enabled and of type file, it returns the access log path to be used for creating volume mount.
 func (g *Gatekeeper) getAccessLogPathFromProxyDefaults() (string, error) {
+	// If no ConsulConfig is provided, skip fetching proxy-defaults.
+	if g.ConsulConfig == nil {
+		return "", nil
+	}
 
 	consulClient, err := consul.NewClient(g.ConsulConfig.APIClientConfig, g.ConsulConfig.APITimeout)
 	if err != nil {

--- a/control-plane/api-gateway/gatekeeper/deployment.go
+++ b/control-plane/api-gateway/gatekeeper/deployment.go
@@ -5,7 +5,9 @@ package gatekeeper
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
@@ -22,6 +24,8 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
+	"github.com/hashicorp/consul-k8s/control-plane/consul"
+	capi "github.com/hashicorp/consul/api"
 )
 
 const (
@@ -109,6 +113,18 @@ func (g *Gatekeeper) deployment(gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayC
 	}
 
 	volumes, mounts := volumesAndMounts(gateway)
+
+	//Checking whether an additional volume is required for access logs defined in the proxy-defaults.
+	accessLogPath, err := g.getAccessLogPathFromProxyDefaults()
+	if err != nil {
+		g.Log.Error(err, "error fetching proxy defaults for access logs")
+		return nil, err
+	}
+
+	if accessLogPath != "" {
+		volumes = append(volumes, accessLogVolume())
+		mounts = append(mounts, accessLogVolumeMount(accessLogPath))
+	}
 
 	container, err := consulDataplaneContainer(metrics, config, gcc, gateway, mounts)
 	if err != nil {
@@ -317,4 +333,35 @@ func deploymentReplicas(gcc v1alpha1.GatewayClassConfig, currentReplicas *int32)
 
 	}
 	return &instanceValue
+}
+
+// fetches the global proxy-defaults config from consul and checks if access logs are enabled.
+// If enabled and of type file, it returns the access log path to be used for creating volume mount.
+func (g *Gatekeeper) getAccessLogPathFromProxyDefaults() (string, error) {
+
+	consulClient, err := consul.NewClient(g.ConsulConfig.APIClientConfig, g.ConsulConfig.APITimeout)
+	if err != nil {
+		return "", fmt.Errorf("unable to connect with consul client %s", err)
+	}
+
+	cfgEntry, _, err := consulClient.ConfigEntries().Get(capi.ProxyDefaults, capi.ProxyConfigGlobal, nil)
+	if err != nil && !strings.Contains(err.Error(), "404") {
+		return "", fmt.Errorf("error checking global proxy-defaults: %s", err)
+	}
+
+	if err != nil && strings.Contains(err.Error(), "404") {
+		return "", nil
+	}
+
+	proxyDefaults, ok := cfgEntry.(*capi.ProxyConfigEntry)
+	if !ok {
+		return "", fmt.Errorf("unexpected type for proxy-defaults: %T", cfgEntry)
+	}
+
+	if proxyDefaults.AccessLogs.Enabled {
+		if proxyDefaults.AccessLogs.Type == capi.FileLogSinkType {
+			return proxyDefaults.AccessLogs.Path, nil
+		}
+	}
+	return "", nil
 }

--- a/control-plane/api-gateway/gatekeeper/volumes.go
+++ b/control-plane/api-gateway/gatekeeper/volumes.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 )
 
+const accessLogVolumeName = "envoy-access-logs"
+
 // volumesAndMounts generates the list of volumes for the Deployment and the list of volume
 // mounts for the primary container in the Deployment. There are two volumes that are created:
 // - one empty volume for holding connect-inject data
@@ -49,8 +51,6 @@ func volumesAndMounts(gateway v1beta1.Gateway) ([]corev1.Volume, []corev1.Volume
 
 	return volumes, mounts
 }
-
-const accessLogVolumeName = "envoy-access-logs"
 
 func accessLogVolume() corev1.Volume {
 	return corev1.Volume{

--- a/control-plane/api-gateway/gatekeeper/volumes.go
+++ b/control-plane/api-gateway/gatekeeper/volumes.go
@@ -4,6 +4,8 @@
 package gatekeeper
 
 import (
+	"path/filepath"
+
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -46,4 +48,22 @@ func volumesAndMounts(gateway v1beta1.Gateway) ([]corev1.Volume, []corev1.Volume
 	}
 
 	return volumes, mounts
+}
+
+const accessLogVolumeName = "envoy-access-logs"
+
+func accessLogVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: accessLogVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumDefault},
+		},
+	}
+}
+
+func accessLogVolumeMount(path string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      accessLogVolumeName,
+		MountPath: filepath.Dir(path),
+	}
 }

--- a/control-plane/connect-inject/constants/annotations_and_labels.go
+++ b/control-plane/connect-inject/constants/annotations_and_labels.go
@@ -235,6 +235,10 @@ const (
 	AnnotationSidecarProbePeriodSeconds            = "consul.hashicorp.com/sidecar-probe-period-seconds"
 	AnnotationSidecarProbeFailureThreshold         = "consul.hashicorp.com/sidecar-probe-failure-threshold"
 	AnnotationSidecarProbeCheckTimeoutSeconds      = "consul.hashicorp.com/sidecar-probe-check-timeout-seconds"
+
+	// annotations for sidecar access volumes.
+	AnnotationConsulSidecarAccessLogEnabled = "consul.hashicorp.com/consul-sidecar-access-log-enabled"
+	AnnotationConsulSidecarAccessLogPath    = "consul.hashicorp.com/consul-sidecar-access-log-path"
 )
 
 // Annotations used by Prometheus.

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
@@ -194,6 +194,11 @@ func (w *MeshWebhook) consulDataplaneSidecar(namespace corev1.Namespace, pod cor
 		})
 	}
 
+	// Add the access log volume mount if it exists in the pod.
+	if accessLogVolMount, ok := findAccessLogVolumeMount(pod); ok {
+		container.VolumeMounts = append(container.VolumeMounts, accessLogVolMount)
+	}
+
 	// Add any extra VolumeMounts.
 	if userVolMount, ok := pod.Annotations[constants.AnnotationConsulSidecarUserVolumeMount]; ok {
 		var volumeMounts []corev1.VolumeMount

--- a/control-plane/connect-inject/webhook/container_volume.go
+++ b/control-plane/connect-inject/webhook/container_volume.go
@@ -4,12 +4,15 @@
 package webhook
 
 import (
+	"path/filepath"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
 // volumeName is the name of the volume that is created to store the
 // Consul Connect injection data.
 const volumeName = "consul-connect-inject-data"
+const accessLogVolumeName = "envoy-access-logs"
 
 // containerVolume returns the volume data to add to the pod. This volume
 // is used for shared data between containers.
@@ -19,5 +22,21 @@ func (w *MeshWebhook) containerVolume() corev1.Volume {
 		VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory},
 		},
+	}
+}
+
+func accessLogVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: accessLogVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumDefault},
+		},
+	}
+}
+
+func accessLogVolumeMount(path string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      accessLogVolumeName,
+		MountPath: filepath.Dir(path),
 	}
 }

--- a/control-plane/connect-inject/webhook/mesh_webhook.go
+++ b/control-plane/connect-inject/webhook/mesh_webhook.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/consul"
 	"github.com/hashicorp/consul-k8s/control-plane/namespaces"
 	"github.com/hashicorp/consul-k8s/version"
+	capi "github.com/hashicorp/consul/api"
 )
 
 const (
@@ -274,6 +275,17 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 	// Optionally mount data volume to other containers
 	w.injectVolumeMount(pod)
 
+	// Optionally mount data volume to envoy sidecar if file based access logs are enabled
+	accessLogPath, err := w.getAccessLogPathFromProxyDefaults()
+	if err != nil {
+		w.Log.Error(err, "unable to get access log path from proxy defaults", "request name", req.Name)
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("unable to get access log path from proxy defaults: %s", err))
+	}
+
+	if accessLogPath != "" {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, accessLogVolume())
+	}
+
 	// Optionally add any volumes that are to be used by the envoy sidecar.
 	if _, ok := pod.Annotations[constants.AnnotationConsulSidecarUserVolume]; ok {
 		var userVolumes []corev1.Volume
@@ -332,6 +344,11 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 			w.Log.Error(err, "error configuring injection sidecar container", "request name", req.Name)
 			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error configuring injection sidecar container: %s", err))
 		}
+
+		if accessLogPath != "" {
+			envoySidecar.VolumeMounts = append(envoySidecar.VolumeMounts, accessLogVolumeMount(accessLogPath))
+		}
+
 		//Append the Envoy sidecar before the application container only if lifecycle enabled.
 		if lifecycleEnabled && !consulDataplaneSidecarEnabled && ok == nil {
 			pod.Spec.Containers = append([]corev1.Container{envoySidecar}, pod.Spec.Containers...)
@@ -414,6 +431,9 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 			if err != nil {
 				w.Log.Error(err, "error configuring injection sidecar container", "request name", req.Name)
 				return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error configuring injection sidecar container: %s", err))
+			}
+			if accessLogPath != "" {
+				envoySidecar.VolumeMounts = append(envoySidecar.VolumeMounts, accessLogVolumeMount(accessLogPath))
 			}
 			// If Lifecycle is enabled, add to the list of sidecar containers to be added
 			// to pod containers at the end in order to preserve relative ordering.
@@ -769,4 +789,46 @@ func sliceContains(slice []string, entry string) bool {
 		}
 	}
 	return false
+}
+
+// fetches the global proxy-defaults config from consul and checks if access logs are enabled.
+// If enabled and of file type, it returns the access log path to be used for creating volume mount.
+func (w *MeshWebhook) getAccessLogPathFromProxyDefaults() (string, error) {
+	// If no ConsulConfig is provided, skip fetching proxy-defaults.
+	if w.ConsulConfig == nil || w.ConsulServerConnMgr == nil {
+		w.Log.Info("no ConsulConfig or ConsulServerConnMgr provided, skipping fetching proxy-defaults")
+		return "", nil
+	}
+
+	serverState, err := w.ConsulServerConnMgr.State()
+	if err != nil {
+		return "", fmt.Errorf("unable to get consul server connection state: %s", err)
+	}
+
+	consulClient, err := consul.NewClientFromConnMgrState(w.ConsulConfig, serverState)
+	if err != nil {
+		return "", fmt.Errorf("unable to connect with consul client %s", err)
+	}
+
+	cfgEntry, _, err := consulClient.ConfigEntries().Get(capi.ProxyDefaults, capi.ProxyConfigGlobal, nil)
+	if err != nil && !strings.Contains(err.Error(), "404") {
+		return "", fmt.Errorf("error fetching global proxy-defaults: %s", err)
+	}
+
+	// If proxy-defaults not found, return empty string.
+	if err != nil && strings.Contains(err.Error(), "404") {
+		return "", nil
+	}
+
+	proxyDefaults, ok := cfgEntry.(*capi.ProxyConfigEntry)
+	if !ok {
+		return "", fmt.Errorf("unexpected type for proxy-defaults: %T", cfgEntry)
+	}
+
+	if proxyDefaults.AccessLogs.Enabled {
+		if proxyDefaults.AccessLogs.Type == capi.FileLogSinkType {
+			return proxyDefaults.AccessLogs.Path, nil
+		}
+	}
+	return "", nil
 }

--- a/control-plane/connect-inject/webhook/mesh_webhook.go
+++ b/control-plane/connect-inject/webhook/mesh_webhook.go
@@ -276,7 +276,7 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 	w.injectVolumeMount(pod)
 
 	// Optionally mount data volume to envoy sidecar if file based access logs are enabled
-	err = w.additionalAccessLogVolumeMount(&pod)
+	err = w.mountAdditionalAccessLogVolume(&pod)
 	if err != nil {
 		w.Log.Error(err, "unable to mount additional access log volume", "request name", req.Name)
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("unable to mount additional access log volume: %s", err))
@@ -780,8 +780,8 @@ func sliceContains(slice []string, entry string) bool {
 }
 
 // Fetches the global proxy-defaults config from Consul and checks if access logs are enabled.
-// If enabled and of file type, it returns the access log path to be used for creating a volume mount.
-func (w *MeshWebhook) additionalAccessLogVolumeMount(pod *corev1.Pod) error {
+// If enabled and of file type, it adds the access log volume to the pod.
+func (w *MeshWebhook) mountAdditionalAccessLogVolume(pod *corev1.Pod) error {
 	// If no ConsulConfig is provided, skip fetching proxy-defaults.
 	if w.ConsulConfig == nil || w.ConsulServerConnMgr == nil {
 		w.Log.Info("no ConsulConfig or ConsulServerConnMgr provided, skipping fetching proxy-defaults")

--- a/control-plane/connect-inject/webhook/mesh_webhook_test.go
+++ b/control-plane/connect-inject/webhook/mesh_webhook_test.go
@@ -2435,7 +2435,7 @@ func TestHandler_checkUnsupportedMultiPortCases(t *testing.T) {
 	}
 }
 
-func TestHandler_additionalAccessLogVolumeMount(t *testing.T) {
+func TestHandler_mountAdditionalAccessLogVolumeMount(t *testing.T) {
 	cases := []struct {
 		Name              string
 		Webhook           MeshWebhook
@@ -2491,7 +2491,7 @@ func TestHandler_additionalAccessLogVolumeMount(t *testing.T) {
 				},
 			}
 
-			err := tt.Webhook.additionalAccessLogVolumeMount(pod)
+			err := tt.Webhook.mountAdditionalAccessLogVolume(pod)
 			if tt.WantErr {
 				require.Error(t, err)
 				require.Equal(t, 0, len(pod.Spec.Volumes))

--- a/control-plane/consul/proxydefaults.go
+++ b/control-plane/consul/proxydefaults.go
@@ -1,0 +1,48 @@
+package consul
+
+import (
+	"fmt"
+	"strings"
+
+	capi "github.com/hashicorp/consul/api"
+)
+
+// fetches the global proxy-defaults config from consul and checks if access logs are enabled.
+// If enabled and of file type, it returns the access log path to be used for creating volume mount.
+// Returns nil if proxy-defaults not found.
+func FetchProxyDefaultsFromConsul(config *Config, serverConnMgr ServerConnectionManager) (*capi.ProxyConfigEntry, error) {
+	if config == nil {
+		return nil, fmt.Errorf("consul config is not defined")
+	}
+
+	var consulClient *capi.Client
+	var err error
+	if serverConnMgr != nil {
+		consulClient, err = NewClientFromConnMgr(config, serverConnMgr)
+		if err != nil {
+			return nil, fmt.Errorf("unable to connect with consul client %s", err)
+		}
+	} else {
+		consulClient, err = NewClient(config.APIClientConfig, config.APITimeout)
+		if err != nil {
+			return nil, fmt.Errorf("unable to connect with consul client %s", err)
+		}
+	}
+
+	cfgEntry, _, err := consulClient.ConfigEntries().Get(capi.ProxyDefaults, capi.ProxyConfigGlobal, nil)
+	if err != nil && !strings.Contains(err.Error(), "404") {
+		return nil, fmt.Errorf("error fetching global proxy-defaults: %s", err)
+	}
+
+	// If proxy-defaults not found, return empty string.
+	if err != nil && strings.Contains(err.Error(), "404") {
+		return nil, nil
+	}
+
+	proxyDefaults, ok := cfgEntry.(*capi.ProxyConfigEntry)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type for proxy-defaults: %T", cfgEntry)
+	}
+
+	return proxyDefaults, nil
+}

--- a/control-plane/consul/proxydefaults_test.go
+++ b/control-plane/consul/proxydefaults_test.go
@@ -1,0 +1,253 @@
+package consul
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul-server-connection-manager/discovery"
+	capi "github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestFetchProxyDefaultsFromConsul(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		config           *Config
+		serverConnMgr    ServerConnectionManager
+		setupMockServer  func() *httptest.Server
+		expectedEntry    *capi.ProxyConfigEntry
+		expectError      bool
+		expectedErrorMsg string
+	}{
+		"successfully fetches proxy-defaults with access logs": {
+			setupMockServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/v1/config/proxy-defaults/global" {
+						response := map[string]interface{}{
+							"Kind":      "proxy-defaults",
+							"Name":      "global",
+							"Namespace": "default",
+							"Config": map[string]interface{}{
+								"envoy_dogstatsd_url":   "udp://127.0.0.1:9125",
+								"envoy_access_log_path": "/var/log/consul/access.log",
+							},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+			},
+			expectedEntry: &capi.ProxyConfigEntry{
+				Kind: capi.ProxyDefaults,
+				Name: capi.ProxyConfigGlobal,
+				Config: map[string]interface{}{
+					"envoy_dogstatsd_url":   "udp://127.0.0.1:9125",
+					"envoy_access_log_path": "/var/log/consul/access.log",
+				},
+			},
+			expectError: false,
+		},
+		"successfully fetches proxy-defaults without access logs": {
+			setupMockServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/v1/config/proxy-defaults/global" {
+						response := map[string]interface{}{
+							"Kind":      "proxy-defaults",
+							"Name":      "global",
+							"Namespace": "default",
+							"Config": map[string]interface{}{
+								"envoy_dogstatsd_url": "udp://127.0.0.1:9125",
+							},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+			},
+			expectedEntry: &capi.ProxyConfigEntry{
+				Kind: capi.ProxyDefaults,
+				Name: capi.ProxyConfigGlobal,
+				Config: map[string]interface{}{
+					"envoy_dogstatsd_url": "udp://127.0.0.1:9125",
+				},
+			},
+			expectError: false,
+		},
+		"returns nil when proxy-defaults not found (404)": {
+			setupMockServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/v1/config/proxy-defaults/global" {
+						w.WriteHeader(http.StatusNotFound)
+						json.NewEncoder(w).Encode(map[string]string{
+							"error": "Config entry not found",
+						})
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+			},
+			expectedEntry: nil,
+			expectError:   false,
+		},
+		"returns error when config is nil": {
+			config:           nil,
+			expectedEntry:    nil,
+			expectError:      true,
+			expectedErrorMsg: "consul config is not defined",
+		},
+		"returns error when consul server returns 500": {
+			setupMockServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/v1/config/proxy-defaults/global" {
+						w.WriteHeader(http.StatusInternalServerError)
+						json.NewEncoder(w).Encode(map[string]string{
+							"error": "Internal server error",
+						})
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+			},
+			expectedEntry:    nil,
+			expectError:      true,
+			expectedErrorMsg: "error fetching global proxy-defaults",
+		},
+		"successfully fetches with ServerConnectionManager": {
+			setupMockServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/v1/config/proxy-defaults/global" {
+						response := map[string]interface{}{
+							"Kind":      "proxy-defaults",
+							"Name":      "global",
+							"Namespace": "default",
+							"Config": map[string]interface{}{
+								"protocol": "http",
+							},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+			},
+			expectedEntry: &capi.ProxyConfigEntry{
+				Kind: capi.ProxyDefaults,
+				Name: capi.ProxyConfigGlobal,
+				Config: map[string]interface{}{
+					"protocol": "http",
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var config *Config
+			var serverConnMgr ServerConnectionManager
+
+			// Setup mock server if provided
+			var mockServer *httptest.Server
+			if tc.setupMockServer != nil {
+				mockServer = tc.setupMockServer()
+				defer mockServer.Close()
+
+				// Parse server URL
+				parsedURL, err := url.Parse(mockServer.URL)
+				require.NoError(t, err)
+
+				host := strings.Split(parsedURL.Host, ":")[0]
+				port, err := strconv.Atoi(parsedURL.Port())
+				require.NoError(t, err)
+
+				// Create config
+				config = &Config{
+					APIClientConfig: &capi.Config{
+						Address: mockServer.URL,
+						Scheme:  "http",
+					},
+					HTTPPort: port,
+				}
+
+				// Setup ServerConnectionManager if needed
+				if strings.Contains(name, "ServerConnectionManager") {
+					serverConnMgr = MockConnMgrForIPAndPort(t, host, port, false)
+				}
+			}
+
+			// Override config if test case provides it
+			if tc.config != nil {
+				config = tc.config
+			}
+			if tc.serverConnMgr != nil {
+				serverConnMgr = tc.serverConnMgr
+			}
+
+			// Call the function
+			result, err := FetchProxyDefaultsFromConsul(config, serverConnMgr)
+
+			// Assert results
+			if tc.expectError {
+				require.Error(t, err)
+				if tc.expectedErrorMsg != "" {
+					require.Contains(t, err.Error(), tc.expectedErrorMsg)
+				}
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				if tc.expectedEntry == nil {
+					require.Nil(t, result)
+				} else {
+					require.NotNil(t, result)
+					require.Equal(t, tc.expectedEntry.Kind, result.Kind)
+					require.Equal(t, tc.expectedEntry.Name, result.Name)
+					require.Equal(t, tc.expectedEntry.Config, result.Config)
+				}
+			}
+		})
+	}
+}
+
+func MockConnMgrForIPAndPort(t *testing.T, ip string, port int, enableGRPCConn bool) *MockServerConnectionManager {
+	parsedIP := net.ParseIP(ip)
+	connMgr := &MockServerConnectionManager{}
+
+	mockState := discovery.State{
+		Address: discovery.Addr{
+			TCPAddr: net.TCPAddr{
+				IP:   parsedIP,
+				Port: port,
+			},
+		},
+	}
+
+	// If the connection is enabled, some tests will receive extra HTTP API calls where
+	// the server is being dialed.
+	if enableGRPCConn {
+		conn, err := grpc.DialContext(
+			context.Background(),
+			net.JoinHostPort(parsedIP.String(), strconv.Itoa(port)),
+			grpc.WithTransportCredentials(insecure.NewCredentials()))
+		require.NoError(t, err)
+		mockState.GRPCConn = conn
+	}
+	connMgr.On("State").Return(mockState, nil)
+	connMgr.On("Run").Return(nil)
+	connMgr.On("Stop").Return(nil)
+	return connMgr
+}


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Fetch the global proxy-defaults configuration from the Consul server.

- When proxy-defaults has access logs enabled with a file-based sink, automatically inject a new emptyDir volume and corresponding volume mount into the consul-dataplane container.

- This ensures both API Gateway and sidecar proxies receive the required volume when file-based Envoy access logs are configured.

### How I've tested this PR ###

- Set up a local kind Kubernetes cluster.
- Built the local control-plane image:
````GOOS=linux make dev-docker````
- Loaded the built image into the kind cluster:
````kind load docker-image consul-k8s-control-plane:local````
- Applied the following Helm values while following the tutorial:
https://developer.hashicorp.com/consul/tutorials/get-started-kubernetes/kubernetes-gs-ingress
````
  image: hashicorp/consul:1.22.0
  imageK8S: consul-k8s-control-plane:local
  imageConsulDataplane: hashicorp/consul-dataplane:1.9
````
- Verified that the consul-dataplane pods for both sidecars and API Gateway received the expected volume and mount when file-based access logs were enabled.

### How I expect reviewers to test this PR ###
- Build the control-plane image locally using make dev-docker.
- Load it into a test Kubernetes cluster (kind or equivalent).
- Enable file-based access logging in proxy-defaults.
- Confirm that a new volume and volumeMount are added to:
  - API Gateway dataplane pods
  - Sidecar proxy dataplane pods
### Checklist ###
- [x ] Tests added
- [ x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

