### PR TITLE
Backport of Support file-based envoy access logs via proxy-defaults for sidecar proxies and API gateway into release/1.9.x

### DIFF
--- a/.changelog/5008.txt
+++ b/.changelog/5008.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+api-gateway: Add support for file-based Envoy access log sinks via proxy-defaults. Previously, only stdout logging was supported.
+connect-inject: When proxy-defaults enables file-based access logs, automatically inject an emptyDir volume and volumeMount into the consul-dataplane container.
+```

--- a/.changelog/5026.txt
+++ b/.changelog/5026.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api-gateway: Added backward compatibility support for file-based Envoy access log sinks via proxy-defaults.
+```

--- a/control-plane/api-gateway/gatekeeper/deployment.go
+++ b/control-plane/api-gateway/gatekeeper/deployment.go
@@ -23,8 +23,6 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
-	"github.com/hashicorp/consul-k8s/control-plane/consul"
-	capi "github.com/hashicorp/consul/api"
 )
 
 const (
@@ -50,7 +48,7 @@ func (g *Gatekeeper) upsertDeployment(ctx context.Context, gateway gwv1beta1.Gat
 		currentReplicas = existingDeployment.Spec.Replicas
 	}
 
-	deployment, err := g.deployment(gateway, gcc, config, currentReplicas)
+	deployment, err := g.deployment(ctx, gateway, gcc, config, currentReplicas)
 	if err != nil {
 		return err
 	}
@@ -91,7 +89,7 @@ func (g *Gatekeeper) deleteDeployment(ctx context.Context, gwName types.Namespac
 	return err
 }
 
-func (g *Gatekeeper) deployment(gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config common.HelmConfig, currentReplicas *int32) (*appsv1.Deployment, error) {
+func (g *Gatekeeper) deployment(ctx context.Context, gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config common.HelmConfig, currentReplicas *int32) (*appsv1.Deployment, error) {
 	initContainer, err := g.initContainer(config, gateway.Name, gateway.Namespace)
 	if err != nil {
 		return nil, err
@@ -113,7 +111,7 @@ func (g *Gatekeeper) deployment(gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayC
 
 	volumes, mounts := volumesAndMounts(gateway)
 
-	volumes, mounts, err = g.additionalAccessLogVolumeMount(volumes, mounts)
+	volumes, mounts, err = g.additionalAccessLogVolumeMount(ctx, volumes, mounts)
 	if err != nil {
 		g.Log.Error(err, "error fetching proxy defaults for access logs")
 		return nil, err
@@ -329,21 +327,28 @@ func deploymentReplicas(gcc v1alpha1.GatewayClassConfig, currentReplicas *int32)
 }
 
 // Checking whether an additional volume is required for access logs defined in the proxy-defaults.
-func (g *Gatekeeper) additionalAccessLogVolumeMount(volumes []corev1.Volume, mounts []corev1.VolumeMount) ([]corev1.Volume, []corev1.VolumeMount, error) {
-	// If no ConsulConfig is provided, skip fetching proxy-defaults.
-	if g.ConsulConfig == nil {
+// fetch the proxy-defaults resource and check if access logs are enabled and of type file.
+func (g *Gatekeeper) additionalAccessLogVolumeMount(ctx context.Context, volumes []corev1.Volume, mounts []corev1.VolumeMount) ([]corev1.Volume, []corev1.VolumeMount, error) {
+
+	var proxyDefaultsList v1alpha1.ProxyDefaultsList
+	err := g.Client.List(ctx, &proxyDefaultsList)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return volumes, mounts, fmt.Errorf("error fetching proxy-defaults: %s", err.Error())
+	} else if k8serrors.IsNotFound(err) {
 		return volumes, mounts, nil
 	}
 
-	proxyDefaults, err := consul.FetchProxyDefaultsFromConsul(g.ConsulConfig, nil)
-	if err != nil {
-		return volumes, mounts, fmt.Errorf("error fetching proxy-defaults from consul: %s", err.Error())
+	// If there are no proxy-defaults, return.
+	if len(proxyDefaultsList.Items) == 0 {
+		return volumes, mounts, nil
 	}
 
-	if proxyDefaults != nil {
-		if proxyDefaults.AccessLogs.Enabled {
-			if proxyDefaults.AccessLogs.Type == capi.FileLogSinkType {
-				accessPath := proxyDefaults.AccessLogs.Path
+	// Will always have only one proxy-defaults resource.
+	proxyDefaults := &proxyDefaultsList.Items[0]
+	if proxyDefaults.Spec.AccessLogs != nil {
+		if proxyDefaults.Spec.AccessLogs.Enabled {
+			if proxyDefaults.Spec.AccessLogs.Type == v1alpha1.FileLogSinkType {
+				accessPath := proxyDefaults.Spec.AccessLogs.Path
 				volumes = append(volumes, accessLogVolume())
 				mounts = append(mounts, accessLogVolumeMount(accessPath))
 				return volumes, mounts, nil

--- a/control-plane/api-gateway/gatekeeper/deployment_test.go
+++ b/control-plane/api-gateway/gatekeeper/deployment_test.go
@@ -4,18 +4,38 @@
 package gatekeeper
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"github.com/hashicorp/consul-k8s/control-plane/consul"
+	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
+	capi "github.com/hashicorp/consul/api"
 )
+
+type consulServerRespCfg struct {
+	hasProxyDefaults   bool
+	errOnProxyDefaults bool
+	accessLogEnabled   bool
+	fileLogSinkType    bool
+	fileLogPath        string
+}
 
 func Test_compareDeployments(t *testing.T) {
 	testCases := []struct {
@@ -291,4 +311,141 @@ func TestMergeDeployments_ProbePropagation(t *testing.T) {
 	assert.NotNil(t, containerUpdated.LivenessProbe.TCPSocket)
 	assert.Nil(t, containerUpdated.LivenessProbe.HTTPGet)
 	assert.Equal(t, int32(9090), containerUpdated.LivenessProbe.TCPSocket.Port.IntVal)
+}
+
+func TestAdditionalAccessLogVolumeMount(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		srvResponseConfig consulServerRespCfg
+	}
+
+	cases := map[string]testCase{
+		"no proxy-defaults configured": {
+			srvResponseConfig: consulServerRespCfg{
+				hasProxyDefaults: false,
+			},
+		},
+		"error fetching proxy-defaults": {
+			srvResponseConfig: consulServerRespCfg{
+				errOnProxyDefaults: true,
+			},
+		},
+		"access-logs disabled in proxy-defaults": {
+			srvResponseConfig: consulServerRespCfg{
+				hasProxyDefaults: true,
+				accessLogEnabled: false,
+			},
+		},
+		"access-logs enabled but sink is not file type": {
+			srvResponseConfig: consulServerRespCfg{
+				hasProxyDefaults: true,
+				accessLogEnabled: true,
+				fileLogSinkType:  false,
+			},
+		},
+		"file-type access-log enabled with path": {
+			srvResponseConfig: consulServerRespCfg{
+				hasProxyDefaults: true,
+				accessLogEnabled: true,
+				fileLogSinkType:  true,
+				fileLogPath:      "/var/log/envoy/access.log",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := fake.NewClientBuilder().Build()
+			server, testClient := fakeConsulServer(t, tc.srvResponseConfig)
+			defer server.Close()
+
+			g := &Gatekeeper{
+				Log:          logr.Discard(),
+				Client:       client,
+				ConsulConfig: testClient.Cfg,
+			}
+
+			initialvolume := []corev1.Volume{}
+			initialmount := []corev1.VolumeMount{}
+
+			updatedVolumes, updatedMounts, err := g.additionalAccessLogVolumeMount(initialvolume, initialmount)
+			if tc.srvResponseConfig.errOnProxyDefaults {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "error fetching global proxy-defaults")
+				return
+			}
+			require.NoError(t, err)
+			if tc.srvResponseConfig.hasProxyDefaults && tc.srvResponseConfig.accessLogEnabled && tc.srvResponseConfig.fileLogSinkType {
+				// Expect volume and mount to be added
+				require.Len(t, updatedVolumes, 1)
+				require.Len(t, updatedMounts, 1)
+				require.Equal(t, accessLogVolumeName, updatedVolumes[0].Name)
+				require.Equal(t, accessLogVolumeName, updatedMounts[0].Name)
+				require.Equal(t, filepath.Dir(tc.srvResponseConfig.fileLogPath), updatedMounts[0].MountPath)
+			} else {
+				// Expect no additional volume or mount to be added
+				require.Len(t, updatedVolumes, 0)
+				require.Len(t, updatedMounts, 0)
+			}
+		})
+	}
+}
+
+func fakeConsulServer(t *testing.T, serverResponseConfig consulServerRespCfg) (*httptest.Server, *test.TestServerClient) {
+	t.Helper()
+	mux := buildMux(t, serverResponseConfig)
+	consulServer := httptest.NewServer(mux)
+
+	parsedURL, err := url.Parse(consulServer.URL)
+	require.NoError(t, err)
+	host := strings.Split(parsedURL.Host, ":")[0]
+
+	port, err := strconv.Atoi(parsedURL.Port())
+	require.NoError(t, err)
+
+	cfg := &consul.Config{APIClientConfig: &capi.Config{Address: host}, HTTPPort: port}
+	cfg.APIClientConfig.Address = consulServer.URL
+
+	testClient := &test.TestServerClient{
+		Cfg:     cfg,
+		Watcher: test.MockConnMgrForIPAndPort(t, host, port, false),
+	}
+
+	return consulServer, testClient
+}
+
+func buildMux(t *testing.T, cfg consulServerRespCfg) http.Handler {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/config/proxy-defaults/"+capi.ProxyConfigGlobal, func(w http.ResponseWriter, r *http.Request) {
+		if cfg.errOnProxyDefaults {
+			w.WriteHeader(500)
+			return
+		}
+		if !cfg.hasProxyDefaults {
+			w.WriteHeader(404)
+			return
+		}
+		w.WriteHeader(200)
+		accessLogType := capi.DefaultLogSinkType
+		if cfg.fileLogSinkType {
+			accessLogType = capi.FileLogSinkType
+		}
+		proxyDefaults := capi.ProxyConfigEntry{
+			AccessLogs: &capi.AccessLogsConfig{
+				Enabled: cfg.accessLogEnabled,
+				Type:    accessLogType,
+				Path:    cfg.fileLogPath,
+			},
+		}
+		val, err := json.Marshal(proxyDefaults)
+		if err != nil {
+			w.WriteHeader(500)
+			return
+		}
+		w.Write(val)
+	})
+
+	return mux
 }

--- a/control-plane/api-gateway/gatekeeper/deployment_test.go
+++ b/control-plane/api-gateway/gatekeeper/deployment_test.go
@@ -4,13 +4,8 @@
 package gatekeeper
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
+	"context"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -19,23 +14,14 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
-	"github.com/hashicorp/consul-k8s/control-plane/consul"
-	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
-	capi "github.com/hashicorp/consul/api"
 )
-
-type consulServerRespCfg struct {
-	hasProxyDefaults   bool
-	errOnProxyDefaults bool
-	accessLogEnabled   bool
-	fileLogSinkType    bool
-	fileLogPath        string
-}
 
 func Test_compareDeployments(t *testing.T) {
 	testCases := []struct {
@@ -316,36 +302,89 @@ func TestMergeDeployments_ProbePropagation(t *testing.T) {
 func TestAdditionalAccessLogVolumeMount(t *testing.T) {
 	t.Parallel()
 
+	type expectedResponse struct {
+		hasProxyDefaults   bool
+		errOnProxyDefaults bool
+		accessLogEnabled   bool
+		fileLogSinkType    bool
+		fileLogPath        string
+	}
+
 	type testCase struct {
-		srvResponseConfig consulServerRespCfg
+		expectedResponse     expectedResponse
+		proxyDefaultResource *v1alpha1.ProxyDefaults
 	}
 
 	cases := map[string]testCase{
 		"no proxy-defaults configured": {
-			srvResponseConfig: consulServerRespCfg{
+			proxyDefaultResource: nil,
+			expectedResponse: expectedResponse{
 				hasProxyDefaults: false,
 			},
 		},
 		"error fetching proxy-defaults": {
-			srvResponseConfig: consulServerRespCfg{
+			proxyDefaultResource: nil,
+			expectedResponse: expectedResponse{
 				errOnProxyDefaults: true,
 			},
 		},
 		"access-logs disabled in proxy-defaults": {
-			srvResponseConfig: consulServerRespCfg{
+			proxyDefaultResource: &v1alpha1.ProxyDefaults{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "global",
+				},
+				Spec: v1alpha1.ProxyDefaultsSpec{
+					MeshGateway: v1alpha1.MeshGateway{
+						Mode: "remote",
+					},
+					AccessLogs: &v1alpha1.AccessLogs{
+						Enabled: false,
+					},
+				},
+			},
+			expectedResponse: expectedResponse{
 				hasProxyDefaults: true,
 				accessLogEnabled: false,
 			},
 		},
 		"access-logs enabled but sink is not file type": {
-			srvResponseConfig: consulServerRespCfg{
+			proxyDefaultResource: &v1alpha1.ProxyDefaults{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "global",
+				},
+				Spec: v1alpha1.ProxyDefaultsSpec{
+					MeshGateway: v1alpha1.MeshGateway{
+						Mode: "remote",
+					},
+					AccessLogs: &v1alpha1.AccessLogs{
+						Enabled: true,
+						Type:    v1alpha1.DefaultLogSinkType,
+					},
+				},
+			},
+			expectedResponse: expectedResponse{
 				hasProxyDefaults: true,
 				accessLogEnabled: true,
 				fileLogSinkType:  false,
 			},
 		},
 		"file-type access-log enabled with path": {
-			srvResponseConfig: consulServerRespCfg{
+			proxyDefaultResource: &v1alpha1.ProxyDefaults{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "global",
+				},
+				Spec: v1alpha1.ProxyDefaultsSpec{
+					MeshGateway: v1alpha1.MeshGateway{
+						Mode: "remote",
+					},
+					AccessLogs: &v1alpha1.AccessLogs{
+						Enabled: true,
+						Type:    v1alpha1.FileLogSinkType,
+						Path:    "/var/log/envoy/access.log",
+					},
+				},
+			},
+			expectedResponse: expectedResponse{
 				hasProxyDefaults: true,
 				accessLogEnabled: true,
 				fileLogSinkType:  true,
@@ -356,33 +395,41 @@ func TestAdditionalAccessLogVolumeMount(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			client := fake.NewClientBuilder().Build()
-			server, testClient := fakeConsulServer(t, tc.srvResponseConfig)
-			defer server.Close()
+			ctx := context.Background()
+			var fakeClient client.WithWatch
+			s := runtime.NewScheme()
+			require.NoError(t, v1alpha1.AddToScheme(s))
+			if tc.proxyDefaultResource != nil {
+				fakeClient = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(tc.proxyDefaultResource).Build()
+			} else if tc.expectedResponse.errOnProxyDefaults {
+				fakeClient = fake.NewClientBuilder().Build()
+			} else {
+				fakeClient = fake.NewClientBuilder().WithScheme(s).Build()
+			}
 
 			g := &Gatekeeper{
 				Log:          logr.Discard(),
-				Client:       client,
-				ConsulConfig: testClient.Cfg,
+				Client:       fakeClient,
+				ConsulConfig: nil,
 			}
 
 			initialvolume := []corev1.Volume{}
 			initialmount := []corev1.VolumeMount{}
 
-			updatedVolumes, updatedMounts, err := g.additionalAccessLogVolumeMount(initialvolume, initialmount)
-			if tc.srvResponseConfig.errOnProxyDefaults {
+			updatedVolumes, updatedMounts, err := g.additionalAccessLogVolumeMount(ctx, initialvolume, initialmount)
+			if tc.expectedResponse.errOnProxyDefaults {
 				require.Error(t, err)
-				require.ErrorContains(t, err, "error fetching global proxy-defaults")
+				require.ErrorContains(t, err, "error fetching proxy-defaults")
 				return
 			}
 			require.NoError(t, err)
-			if tc.srvResponseConfig.hasProxyDefaults && tc.srvResponseConfig.accessLogEnabled && tc.srvResponseConfig.fileLogSinkType {
+			if tc.expectedResponse.hasProxyDefaults && tc.expectedResponse.accessLogEnabled && tc.expectedResponse.fileLogSinkType {
 				// Expect volume and mount to be added
 				require.Len(t, updatedVolumes, 1)
 				require.Len(t, updatedMounts, 1)
 				require.Equal(t, accessLogVolumeName, updatedVolumes[0].Name)
 				require.Equal(t, accessLogVolumeName, updatedMounts[0].Name)
-				require.Equal(t, filepath.Dir(tc.srvResponseConfig.fileLogPath), updatedMounts[0].MountPath)
+				require.Equal(t, filepath.Dir(tc.expectedResponse.fileLogPath), updatedMounts[0].MountPath)
 			} else {
 				// Expect no additional volume or mount to be added
 				require.Len(t, updatedVolumes, 0)
@@ -390,62 +437,4 @@ func TestAdditionalAccessLogVolumeMount(t *testing.T) {
 			}
 		})
 	}
-}
-
-func fakeConsulServer(t *testing.T, serverResponseConfig consulServerRespCfg) (*httptest.Server, *test.TestServerClient) {
-	t.Helper()
-	mux := buildMux(t, serverResponseConfig)
-	consulServer := httptest.NewServer(mux)
-
-	parsedURL, err := url.Parse(consulServer.URL)
-	require.NoError(t, err)
-	host := strings.Split(parsedURL.Host, ":")[0]
-
-	port, err := strconv.Atoi(parsedURL.Port())
-	require.NoError(t, err)
-
-	cfg := &consul.Config{APIClientConfig: &capi.Config{Address: host}, HTTPPort: port}
-	cfg.APIClientConfig.Address = consulServer.URL
-
-	testClient := &test.TestServerClient{
-		Cfg:     cfg,
-		Watcher: test.MockConnMgrForIPAndPort(t, host, port, false),
-	}
-
-	return consulServer, testClient
-}
-
-func buildMux(t *testing.T, cfg consulServerRespCfg) http.Handler {
-	t.Helper()
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/config/proxy-defaults/"+capi.ProxyConfigGlobal, func(w http.ResponseWriter, r *http.Request) {
-		if cfg.errOnProxyDefaults {
-			w.WriteHeader(500)
-			return
-		}
-		if !cfg.hasProxyDefaults {
-			w.WriteHeader(404)
-			return
-		}
-		w.WriteHeader(200)
-		accessLogType := capi.DefaultLogSinkType
-		if cfg.fileLogSinkType {
-			accessLogType = capi.FileLogSinkType
-		}
-		proxyDefaults := capi.ProxyConfigEntry{
-			AccessLogs: &capi.AccessLogsConfig{
-				Enabled: cfg.accessLogEnabled,
-				Type:    accessLogType,
-				Path:    cfg.fileLogPath,
-			},
-		}
-		val, err := json.Marshal(proxyDefaults)
-		if err != nil {
-			w.WriteHeader(500)
-			return
-		}
-		w.Write(val)
-	})
-
-	return mux
 }

--- a/control-plane/api-gateway/gatekeeper/volumes.go
+++ b/control-plane/api-gateway/gatekeeper/volumes.go
@@ -4,11 +4,15 @@
 package gatekeeper
 
 import (
+	"path/filepath"
+
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 )
+
+const accessLogVolumeName = "envoy-access-logs"
 
 // volumesAndMounts generates the list of volumes for the Deployment and the list of volume
 // mounts for the primary container in the Deployment. There are two volumes that are created:
@@ -46,4 +50,20 @@ func volumesAndMounts(gateway v1beta1.Gateway) ([]corev1.Volume, []corev1.Volume
 	}
 
 	return volumes, mounts
+}
+
+func accessLogVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: accessLogVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumDefault},
+		},
+	}
+}
+
+func accessLogVolumeMount(path string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      accessLogVolumeName,
+		MountPath: filepath.Dir(path),
+	}
 }

--- a/control-plane/connect-inject/constants/annotations_and_labels.go
+++ b/control-plane/connect-inject/constants/annotations_and_labels.go
@@ -235,6 +235,10 @@ const (
 	AnnotationSidecarProbePeriodSeconds            = "consul.hashicorp.com/sidecar-probe-period-seconds"
 	AnnotationSidecarProbeFailureThreshold         = "consul.hashicorp.com/sidecar-probe-failure-threshold"
 	AnnotationSidecarProbeCheckTimeoutSeconds      = "consul.hashicorp.com/sidecar-probe-check-timeout-seconds"
+
+	// annotations for sidecar access volumes.
+	AnnotationConsulSidecarAccessLogEnabled = "consul.hashicorp.com/consul-sidecar-access-log-enabled"
+	AnnotationConsulSidecarAccessLogPath    = "consul.hashicorp.com/consul-sidecar-access-log-path"
 )
 
 // Annotations used by Prometheus.

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
@@ -194,6 +194,11 @@ func (w *MeshWebhook) consulDataplaneSidecar(namespace corev1.Namespace, pod cor
 		})
 	}
 
+	// Add the access log volume mount if it exists in the pod.
+	if accessLogVolMount, ok := findAccessLogVolumeMount(pod); ok {
+		container.VolumeMounts = append(container.VolumeMounts, accessLogVolMount)
+	}
+
 	// Add any extra VolumeMounts.
 	if userVolMount, ok := pod.Annotations[constants.AnnotationConsulSidecarUserVolumeMount]; ok {
 		var volumeMounts []corev1.VolumeMount

--- a/control-plane/connect-inject/webhook/container_volume.go
+++ b/control-plane/connect-inject/webhook/container_volume.go
@@ -4,12 +4,15 @@
 package webhook
 
 import (
+	"path/filepath"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
 // volumeName is the name of the volume that is created to store the
 // Consul Connect injection data.
 const volumeName = "consul-connect-inject-data"
+const accessLogVolumeName = "envoy-access-logs"
 
 // containerVolume returns the volume data to add to the pod. This volume
 // is used for shared data between containers.
@@ -19,5 +22,21 @@ func (w *MeshWebhook) containerVolume() corev1.Volume {
 		VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory},
 		},
+	}
+}
+
+func accessLogVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: accessLogVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumDefault},
+		},
+	}
+}
+
+func accessLogVolumeMount(path string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      accessLogVolumeName,
+		MountPath: filepath.Dir(path),
 	}
 }

--- a/control-plane/connect-inject/webhook/mesh_webhook.go
+++ b/control-plane/connect-inject/webhook/mesh_webhook.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/consul"
 	"github.com/hashicorp/consul-k8s/control-plane/namespaces"
 	"github.com/hashicorp/consul-k8s/version"
+	capi "github.com/hashicorp/consul/api"
 )
 
 const (
@@ -273,6 +274,13 @@ func (w *MeshWebhook) Handle(ctx context.Context, req admission.Request) admissi
 
 	// Optionally mount data volume to other containers
 	w.injectVolumeMount(pod)
+
+	// Optionally mount data volume to envoy sidecar if file based access logs are enabled
+	err = w.mountAdditionalAccessLogVolume(&pod)
+	if err != nil {
+		w.Log.Error(err, "unable to mount additional access log volume", "request name", req.Name)
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("unable to mount additional access log volume: %s", err))
+	}
 
 	// Optionally add any volumes that are to be used by the envoy sidecar.
 	if _, ok := pod.Annotations[constants.AnnotationConsulSidecarUserVolume]; ok {
@@ -769,4 +777,45 @@ func sliceContains(slice []string, entry string) bool {
 		}
 	}
 	return false
+}
+
+// Fetches the global proxy-defaults config from Consul and checks if access logs are enabled.
+// If enabled and of file type, it adds the access log volume to the pod.
+func (w *MeshWebhook) mountAdditionalAccessLogVolume(pod *corev1.Pod) error {
+	// If no ConsulConfig is provided, skip fetching proxy-defaults.
+	if w.ConsulConfig == nil || w.ConsulServerConnMgr == nil {
+		w.Log.Info("no ConsulConfig or ConsulServerConnMgr provided, skipping fetching proxy-defaults")
+		return nil
+	}
+
+	proxyDefaults, err := consul.FetchProxyDefaultsFromConsul(w.ConsulConfig, w.ConsulServerConnMgr)
+	if err != nil {
+		return fmt.Errorf("error fetch proxy-defaults from consul: %s", err.Error())
+	}
+
+	if proxyDefaults != nil {
+		if proxyDefaults.AccessLogs.Enabled {
+			pod.Annotations[constants.AnnotationConsulSidecarAccessLogEnabled] = "true"
+			if proxyDefaults.AccessLogs.Type == capi.FileLogSinkType {
+				pod.Annotations[constants.AnnotationConsulSidecarAccessLogPath] = proxyDefaults.AccessLogs.Path
+				pod.Spec.Volumes = append(pod.Spec.Volumes, accessLogVolume())
+			}
+		}
+	}
+
+	return nil
+}
+
+func findAccessLogVolumeMount(pod corev1.Pod) (corev1.VolumeMount, bool) {
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == accessLogVolumeName {
+			if pod.Annotations[constants.AnnotationConsulSidecarAccessLogEnabled] == "true" {
+				if path, ok := pod.Annotations[constants.AnnotationConsulSidecarAccessLogPath]; ok {
+					return accessLogVolumeMount(path), true
+				}
+			}
+		}
+	}
+
+	return corev1.VolumeMount{}, false
 }

--- a/control-plane/connect-inject/webhook/mesh_webhook_test.go
+++ b/control-plane/connect-inject/webhook/mesh_webhook_test.go
@@ -6,6 +6,9 @@ package webhook
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -29,9 +32,19 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/lifecycle"
 	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/metrics"
 	"github.com/hashicorp/consul-k8s/control-plane/consul"
+	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 	"github.com/hashicorp/consul-k8s/control-plane/namespaces"
 	"github.com/hashicorp/consul-k8s/version"
+	capi "github.com/hashicorp/consul/api"
 )
+
+type consulServerRespCfg struct {
+	hasProxyDefaults   bool
+	errOnProxyDefaults bool
+	accessLogEnabled   bool
+	fileLogSinkType    bool
+	fileLogPath        string
+}
 
 func TestHandlerHandle(t *testing.T) {
 	t.Parallel()
@@ -2422,6 +2435,89 @@ func TestHandler_checkUnsupportedMultiPortCases(t *testing.T) {
 	}
 }
 
+func TestHandler_mountAdditionalAccessLogVolumeMount(t *testing.T) {
+	cases := []struct {
+		Name              string
+		Webhook           MeshWebhook
+		srvResponseConfig consulServerRespCfg
+		WantErr           bool
+	}{
+		{
+			Name: "no proxy-defaults configured",
+			srvResponseConfig: consulServerRespCfg{
+				hasProxyDefaults: false,
+			},
+		},
+		{
+			Name: "error fetching proxy-defaults",
+			srvResponseConfig: consulServerRespCfg{
+				hasProxyDefaults:   true,
+				errOnProxyDefaults: true,
+			},
+			WantErr: true,
+		},
+		{
+			Name: "access-logs enabled but sink is not file type",
+			srvResponseConfig: consulServerRespCfg{
+				hasProxyDefaults: true,
+				accessLogEnabled: true,
+				fileLogSinkType:  false,
+				fileLogPath:      "/var/log/access-log.txt",
+			},
+		},
+		{
+			Name: "file-type access-log enabled with path",
+			srvResponseConfig: consulServerRespCfg{
+				hasProxyDefaults: true,
+				accessLogEnabled: true,
+				fileLogSinkType:  true,
+				fileLogPath:      "/var/log/access-log.txt",
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			server, testClient := fakeConsulServer(t, tt.srvResponseConfig)
+			defer server.Close()
+
+			tt.Webhook.ConsulConfig = testClient.Cfg
+			tt.Webhook.ConsulServerConnMgr = testClient.Watcher
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pod",
+					Annotations: map[string]string{},
+				},
+			}
+
+			err := tt.Webhook.mountAdditionalAccessLogVolume(pod)
+			if tt.WantErr {
+				require.Error(t, err)
+				require.Equal(t, 0, len(pod.Spec.Volumes))
+				require.Equal(t, 0, len(pod.Annotations))
+				return
+			}
+			require.NoError(t, err)
+			if tt.srvResponseConfig.fileLogSinkType {
+				require.Equal(t, 1, len(pod.Spec.Volumes))
+				require.Equal(t, accessLogVolumeName, pod.Spec.Volumes[0].Name)
+				require.Equal(t, 2, len(pod.Annotations))
+				require.Equal(t, "true", pod.Annotations[constants.AnnotationConsulSidecarAccessLogEnabled])
+				require.Equal(t, tt.srvResponseConfig.fileLogPath, pod.Annotations[constants.AnnotationConsulSidecarAccessLogPath])
+
+			} else if tt.srvResponseConfig.accessLogEnabled {
+				require.Equal(t, 0, len(pod.Spec.Volumes))
+				require.Equal(t, 1, len(pod.Annotations))
+				require.Equal(t, "true", pod.Annotations[constants.AnnotationConsulSidecarAccessLogEnabled])
+			} else {
+				require.Equal(t, 0, len(pod.Spec.Volumes))
+				require.Equal(t, 0, len(pod.Annotations))
+			}
+		})
+	}
+}
+
 // encodeRaw is a helper to encode some data into a RawExtension.
 func encodeRaw(t *testing.T, input interface{}) runtime.RawExtension {
 	data, err := json.Marshal(input)
@@ -2515,4 +2611,62 @@ func clientWithNamespace(name string) kubernetes.Interface {
 		},
 	}
 	return fake.NewSimpleClientset(&ns)
+}
+
+func fakeConsulServer(t *testing.T, srvResponseConfig consulServerRespCfg) (*httptest.Server, *test.TestServerClient) {
+	t.Helper()
+	mux := buildMux(t, srvResponseConfig)
+	consulServer := httptest.NewServer(mux)
+
+	parsedURL, err := url.Parse(consulServer.URL)
+	require.NoError(t, err)
+	host := strings.Split(parsedURL.Host, ":")[0]
+
+	port, err := strconv.Atoi(parsedURL.Port())
+	require.NoError(t, err)
+
+	cfg := &consul.Config{APIClientConfig: &capi.Config{Address: host}, HTTPPort: port}
+	cfg.APIClientConfig.Address = consulServer.URL
+
+	testClient := &test.TestServerClient{
+		Cfg:     cfg,
+		Watcher: test.MockConnMgrForIPAndPort(t, host, port, false),
+	}
+
+	return consulServer, testClient
+}
+
+func buildMux(t *testing.T, cfg consulServerRespCfg) http.Handler {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/config/proxy-defaults/"+capi.ProxyConfigGlobal, func(w http.ResponseWriter, r *http.Request) {
+		if cfg.errOnProxyDefaults {
+			w.WriteHeader(500)
+			return
+		}
+		if !cfg.hasProxyDefaults {
+			w.WriteHeader(404)
+			return
+		}
+		w.WriteHeader(200)
+		accessLogType := capi.DefaultLogSinkType
+		if cfg.fileLogSinkType {
+			accessLogType = capi.FileLogSinkType
+		}
+		proxyDefaults := capi.ProxyConfigEntry{
+			AccessLogs: &capi.AccessLogsConfig{
+				Enabled: cfg.accessLogEnabled,
+				Type:    accessLogType,
+				Path:    cfg.fileLogPath,
+			},
+		}
+		val, err := json.Marshal(proxyDefaults)
+		if err != nil {
+			w.WriteHeader(500)
+			return
+		}
+		w.Write(val)
+	})
+
+	return mux
 }

--- a/control-plane/consul/proxydefaults.go
+++ b/control-plane/consul/proxydefaults.go
@@ -1,0 +1,48 @@
+package consul
+
+import (
+	"fmt"
+	"strings"
+
+	capi "github.com/hashicorp/consul/api"
+)
+
+// fetches the global proxy-defaults config from consul and checks if access logs are enabled.
+// If enabled and of file type, it returns the access log path to be used for creating volume mount.
+// Returns nil if proxy-defaults not found.
+func FetchProxyDefaultsFromConsul(config *Config, serverConnMgr ServerConnectionManager) (*capi.ProxyConfigEntry, error) {
+	if config == nil {
+		return nil, fmt.Errorf("consul config is not defined")
+	}
+
+	var consulClient *capi.Client
+	var err error
+	if serverConnMgr != nil {
+		consulClient, err = NewClientFromConnMgr(config, serverConnMgr)
+		if err != nil {
+			return nil, fmt.Errorf("unable to connect with consul client %s", err)
+		}
+	} else {
+		consulClient, err = NewClient(config.APIClientConfig, config.APITimeout)
+		if err != nil {
+			return nil, fmt.Errorf("unable to connect with consul client %s", err)
+		}
+	}
+
+	cfgEntry, _, err := consulClient.ConfigEntries().Get(capi.ProxyDefaults, capi.ProxyConfigGlobal, nil)
+	if err != nil && !strings.Contains(err.Error(), "404") {
+		return nil, fmt.Errorf("error fetching global proxy-defaults: %s", err)
+	}
+
+	// If proxy-defaults not found, return empty string.
+	if err != nil && strings.Contains(err.Error(), "404") {
+		return nil, nil
+	}
+
+	proxyDefaults, ok := cfgEntry.(*capi.ProxyConfigEntry)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type for proxy-defaults: %T", cfgEntry)
+	}
+
+	return proxyDefaults, nil
+}

--- a/control-plane/consul/proxydefaults_test.go
+++ b/control-plane/consul/proxydefaults_test.go
@@ -1,0 +1,253 @@
+package consul
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul-server-connection-manager/discovery"
+	capi "github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestFetchProxyDefaultsFromConsul(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		config           *Config
+		serverConnMgr    ServerConnectionManager
+		setupMockServer  func() *httptest.Server
+		expectedEntry    *capi.ProxyConfigEntry
+		expectError      bool
+		expectedErrorMsg string
+	}{
+		"successfully fetches proxy-defaults with access logs": {
+			setupMockServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/v1/config/proxy-defaults/global" {
+						response := map[string]interface{}{
+							"Kind":      "proxy-defaults",
+							"Name":      "global",
+							"Namespace": "default",
+							"Config": map[string]interface{}{
+								"envoy_dogstatsd_url":   "udp://127.0.0.1:9125",
+								"envoy_access_log_path": "/var/log/consul/access.log",
+							},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+			},
+			expectedEntry: &capi.ProxyConfigEntry{
+				Kind: capi.ProxyDefaults,
+				Name: capi.ProxyConfigGlobal,
+				Config: map[string]interface{}{
+					"envoy_dogstatsd_url":   "udp://127.0.0.1:9125",
+					"envoy_access_log_path": "/var/log/consul/access.log",
+				},
+			},
+			expectError: false,
+		},
+		"successfully fetches proxy-defaults without access logs": {
+			setupMockServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/v1/config/proxy-defaults/global" {
+						response := map[string]interface{}{
+							"Kind":      "proxy-defaults",
+							"Name":      "global",
+							"Namespace": "default",
+							"Config": map[string]interface{}{
+								"envoy_dogstatsd_url": "udp://127.0.0.1:9125",
+							},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+			},
+			expectedEntry: &capi.ProxyConfigEntry{
+				Kind: capi.ProxyDefaults,
+				Name: capi.ProxyConfigGlobal,
+				Config: map[string]interface{}{
+					"envoy_dogstatsd_url": "udp://127.0.0.1:9125",
+				},
+			},
+			expectError: false,
+		},
+		"returns nil when proxy-defaults not found (404)": {
+			setupMockServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/v1/config/proxy-defaults/global" {
+						w.WriteHeader(http.StatusNotFound)
+						json.NewEncoder(w).Encode(map[string]string{
+							"error": "Config entry not found",
+						})
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+			},
+			expectedEntry: nil,
+			expectError:   false,
+		},
+		"returns error when config is nil": {
+			config:           nil,
+			expectedEntry:    nil,
+			expectError:      true,
+			expectedErrorMsg: "consul config is not defined",
+		},
+		"returns error when consul server returns 500": {
+			setupMockServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/v1/config/proxy-defaults/global" {
+						w.WriteHeader(http.StatusInternalServerError)
+						json.NewEncoder(w).Encode(map[string]string{
+							"error": "Internal server error",
+						})
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+			},
+			expectedEntry:    nil,
+			expectError:      true,
+			expectedErrorMsg: "error fetching global proxy-defaults",
+		},
+		"successfully fetches with ServerConnectionManager": {
+			setupMockServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/v1/config/proxy-defaults/global" {
+						response := map[string]interface{}{
+							"Kind":      "proxy-defaults",
+							"Name":      "global",
+							"Namespace": "default",
+							"Config": map[string]interface{}{
+								"protocol": "http",
+							},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+			},
+			expectedEntry: &capi.ProxyConfigEntry{
+				Kind: capi.ProxyDefaults,
+				Name: capi.ProxyConfigGlobal,
+				Config: map[string]interface{}{
+					"protocol": "http",
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var config *Config
+			var serverConnMgr ServerConnectionManager
+
+			// Setup mock server if provided
+			var mockServer *httptest.Server
+			if tc.setupMockServer != nil {
+				mockServer = tc.setupMockServer()
+				defer mockServer.Close()
+
+				// Parse server URL
+				parsedURL, err := url.Parse(mockServer.URL)
+				require.NoError(t, err)
+
+				host := strings.Split(parsedURL.Host, ":")[0]
+				port, err := strconv.Atoi(parsedURL.Port())
+				require.NoError(t, err)
+
+				// Create config
+				config = &Config{
+					APIClientConfig: &capi.Config{
+						Address: mockServer.URL,
+						Scheme:  "http",
+					},
+					HTTPPort: port,
+				}
+
+				// Setup ServerConnectionManager if needed
+				if strings.Contains(name, "ServerConnectionManager") {
+					serverConnMgr = MockConnMgrForIPAndPort(t, host, port, false)
+				}
+			}
+
+			// Override config if test case provides it
+			if tc.config != nil {
+				config = tc.config
+			}
+			if tc.serverConnMgr != nil {
+				serverConnMgr = tc.serverConnMgr
+			}
+
+			// Call the function
+			result, err := FetchProxyDefaultsFromConsul(config, serverConnMgr)
+
+			// Assert results
+			if tc.expectError {
+				require.Error(t, err)
+				if tc.expectedErrorMsg != "" {
+					require.Contains(t, err.Error(), tc.expectedErrorMsg)
+				}
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				if tc.expectedEntry == nil {
+					require.Nil(t, result)
+				} else {
+					require.NotNil(t, result)
+					require.Equal(t, tc.expectedEntry.Kind, result.Kind)
+					require.Equal(t, tc.expectedEntry.Name, result.Name)
+					require.Equal(t, tc.expectedEntry.Config, result.Config)
+				}
+			}
+		})
+	}
+}
+
+func MockConnMgrForIPAndPort(t *testing.T, ip string, port int, enableGRPCConn bool) *MockServerConnectionManager {
+	parsedIP := net.ParseIP(ip)
+	connMgr := &MockServerConnectionManager{}
+
+	mockState := discovery.State{
+		Address: discovery.Addr{
+			TCPAddr: net.TCPAddr{
+				IP:   parsedIP,
+				Port: port,
+			},
+		},
+	}
+
+	// If the connection is enabled, some tests will receive extra HTTP API calls where
+	// the server is being dialed.
+	if enableGRPCConn {
+		conn, err := grpc.DialContext(
+			context.Background(),
+			net.JoinHostPort(parsedIP.String(), strconv.Itoa(port)),
+			grpc.WithTransportCredentials(insecure.NewCredentials()))
+		require.NoError(t, err)
+		mockState.GRPCConn = conn
+	}
+	connMgr.On("State").Return(mockState, nil)
+	connMgr.On("Run").Return(nil)
+	connMgr.On("Stop").Return(nil)
+	return connMgr
+}


### PR DESCRIPTION
## Backport

This PR manually cherry-picks the changes from #5008 and #5026 so they can be included in the backport/1.9.x.

The below text is copied from the body of the original PR.

---

### Changes proposed in this PR ###  
- Fetch the global proxy-defaults configuration from the Consul server.

- When proxy-defaults has access logs enabled with a file-based sink, automatically inject a new emptyDir volume and corresponding volume mount into the consul-dataplane container.

- This ensures both API Gateway and sidecar proxies receive the required volume when file-based Envoy access logs are configured.

### How I've tested this PR ###

- Set up a local kind Kubernetes cluster.
- Built the local control-plane image:
````GOOS=linux make dev-docker````
- Loaded the built image into the kind cluster:
````kind load docker-image consul-k8s-control-plane:local````
- Applied the following Helm values while following the tutorial:
https://developer.hashicorp.com/consul/tutorials/get-started-kubernetes/kubernetes-gs-ingress
````
  image: hashicorp/consul:1.22.0
  imageK8S: consul-k8s-control-plane:local
  imageConsulDataplane: hashicorp/consul-dataplane:1.9
````
- Verified that the consul-dataplane pods for both sidecars and API Gateway received the expected volume and mount when file-based access logs were enabled.

### How I expect reviewers to test this PR ###
- Build the control-plane image locally using make dev-docker.
- Load it into a test Kubernetes cluster (kind or equivalent).
- Enable file-based access logging in proxy-defaults.
- Confirm that a new volume and volumeMount are added to:
  - API Gateway dataplane pods
  - Sidecar proxy dataplane pods
### Checklist ###
- [x ] Tests added
- [ x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 



---

<details>
<summary> Overview of commits </summary>

 
  - 51d6113ec13f8bd231123e47ef9ba32268a9d6ae
  - 9ae5cf6b011030607ac1731782f8c4c3eb693369

</details>


