### PR TITLE
add configurable client ACL init startup staggering to smooth login storm

### DIFF
--- a/.changelog/5021.txt
+++ b/.changelog/5021.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client: Add optional startup staggering for client ACL init to spread /v1/acl/login calls and reduce login storms on large clusters. Controlled via client.aclInit.startupStagger.* values (disabled by default).
+```

--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -518,6 +518,8 @@ spec:
       {{- if (or .Values.global.acls.manageSystemACLs (and .Values.global.tls.enabled (not .Values.global.tls.enableAutoEncrypt))) }}
       initContainers:
       {{- if .Values.global.acls.manageSystemACLs }}
+      {{- $startupStagger := default (dict "enabled" false "minSeconds" 0 "maxSeconds" 0) .Values.client.aclInit.startupStagger }}
+      {{- $staggerEnabled := and $startupStagger.enabled (gt (int $startupStagger.maxSeconds) 0) }}
       - name: client-acl-init
         image: {{ .Values.global.imageK8S }}
         {{ template "consul.imagePullPolicy" . }}
@@ -543,6 +545,23 @@ spec:
           - "/bin/sh"
           - "-ec"
           - |
+            {{- if $staggerEnabled }}
+            min_delay={{ int $startupStagger.minSeconds }}
+            max_delay={{ int $startupStagger.maxSeconds }}
+            if [ $max_delay -lt $min_delay ]; then
+              echo "client-acl-init: startupStagger.maxSeconds (${max_delay}) must be >= startupStagger.minSeconds (${min_delay})" >&2
+              exit 1
+            fi
+            range=$((max_delay - min_delay))
+            if [ $range -gt 0 ]; then
+              jitter=$((RANDOM % (range + 1)))
+            else
+              jitter=0
+            fi
+            sleep_time=$((min_delay + jitter))
+            echo "client-acl-init: staggering for ${sleep_time}s before ACL login"
+            sleep ${sleep_time}
+            {{- end }}
             exec consul-k8s-control-plane acl-init \
               -log-level={{ default .Values.global.logLevel .Values.client.logLevel }} \
               -log-json={{ .Values.global.logJSON }} \

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1737,6 +1737,16 @@ client:
     # @recurse: false
     tlsInit: null
 
+  aclInit:
+    startupStagger:
+      # When true, adds a randomized sleep before running acl-init to avoid login storms
+      # against the Consul servers in large clusters. Defaults set to 0 for no sleep.
+      enabled: false
+      # Minimum seconds to sleep before attempting the ACL login.
+      minSeconds: 0
+      # Maximum seconds to sleep before attempting the ACL login.
+      maxSeconds: 0
+
   # A raw string of extra [JSON configuration](https://developer.hashicorp.com/consul/docs/agent/config/config-files) for Consul
   # clients. This will be saved as-is into a ConfigMap that is read by the Consul
   # client agents. This can be used to add additional configuration that
@@ -3787,4 +3797,3 @@ telemetryCollector:
   # it could be used to configure custom consul parameters.
   # @type: map
   extraEnvironmentVars: {}
-


### PR DESCRIPTION
### Changes proposed in this PR ###  
- This is to introduce configurable random delay ranges in client daemonsets during ACL login to ease the load when there are large number of nodes.
- This prevents login storm failures

### How I've tested this PR ###

- Install the chart with configured min and max delay ranges and init containers sleeps for random time before ACL login
is initiated.

### How I expect reviewers to test this PR ###


### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
