### PR TITLE
Add support for file-based Envoy access logging through proxy-defaults in API Gateway

### DIFF
--- a/.changelog/5026.txt
+++ b/.changelog/5026.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api-gateway: Added backward compatibility support for file-based Envoy access log sinks via proxy-defaults.
+```

--- a/control-plane/api-gateway/gatekeeper/deployment.go
+++ b/control-plane/api-gateway/gatekeeper/deployment.go
@@ -327,6 +327,7 @@ func deploymentReplicas(gcc v1alpha1.GatewayClassConfig, currentReplicas *int32)
 }
 
 // Checking whether an additional volume is required for access logs defined in the proxy-defaults.
+// fetch the proxy-defaults resource and check if access logs are enabled and of type file.
 func (g *Gatekeeper) additionalAccessLogVolumeMount(ctx context.Context, volumes []corev1.Volume, mounts []corev1.VolumeMount) ([]corev1.Volume, []corev1.VolumeMount, error) {
 
 	var proxyDefaultsList v1alpha1.ProxyDefaultsList

--- a/control-plane/api-gateway/gatekeeper/deployment.go
+++ b/control-plane/api-gateway/gatekeeper/deployment.go
@@ -23,8 +23,6 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	"github.com/hashicorp/consul-k8s/control-plane/connect-inject/constants"
-	"github.com/hashicorp/consul-k8s/control-plane/consul"
-	capi "github.com/hashicorp/consul/api"
 )
 
 const (
@@ -50,7 +48,7 @@ func (g *Gatekeeper) upsertDeployment(ctx context.Context, gateway gwv1beta1.Gat
 		currentReplicas = existingDeployment.Spec.Replicas
 	}
 
-	deployment, err := g.deployment(gateway, gcc, config, currentReplicas)
+	deployment, err := g.deployment(ctx, gateway, gcc, config, currentReplicas)
 	if err != nil {
 		return err
 	}
@@ -91,7 +89,7 @@ func (g *Gatekeeper) deleteDeployment(ctx context.Context, gwName types.Namespac
 	return err
 }
 
-func (g *Gatekeeper) deployment(gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config common.HelmConfig, currentReplicas *int32) (*appsv1.Deployment, error) {
+func (g *Gatekeeper) deployment(ctx context.Context, gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config common.HelmConfig, currentReplicas *int32) (*appsv1.Deployment, error) {
 	initContainer, err := g.initContainer(config, gateway.Name, gateway.Namespace)
 	if err != nil {
 		return nil, err
@@ -113,7 +111,7 @@ func (g *Gatekeeper) deployment(gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayC
 
 	volumes, mounts := volumesAndMounts(gateway)
 
-	volumes, mounts, err = g.additionalAccessLogVolumeMount(volumes, mounts)
+	volumes, mounts, err = g.additionalAccessLogVolumeMount(ctx, volumes, mounts)
 	if err != nil {
 		g.Log.Error(err, "error fetching proxy defaults for access logs")
 		return nil, err
@@ -329,21 +327,27 @@ func deploymentReplicas(gcc v1alpha1.GatewayClassConfig, currentReplicas *int32)
 }
 
 // Checking whether an additional volume is required for access logs defined in the proxy-defaults.
-func (g *Gatekeeper) additionalAccessLogVolumeMount(volumes []corev1.Volume, mounts []corev1.VolumeMount) ([]corev1.Volume, []corev1.VolumeMount, error) {
-	// If no ConsulConfig is provided, skip fetching proxy-defaults.
-	if g.ConsulConfig == nil {
+func (g *Gatekeeper) additionalAccessLogVolumeMount(ctx context.Context, volumes []corev1.Volume, mounts []corev1.VolumeMount) ([]corev1.Volume, []corev1.VolumeMount, error) {
+
+	var proxyDefaultsList v1alpha1.ProxyDefaultsList
+	err := g.Client.List(ctx, &proxyDefaultsList)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return volumes, mounts, fmt.Errorf("error fetching proxy-defaults: %s", err.Error())
+	} else if k8serrors.IsNotFound(err) {
 		return volumes, mounts, nil
 	}
 
-	proxyDefaults, err := consul.FetchProxyDefaultsFromConsul(g.ConsulConfig, nil)
-	if err != nil {
-		return volumes, mounts, fmt.Errorf("error fetching proxy-defaults from consul: %s", err.Error())
+	// If there are no proxy-defaults, return.
+	if len(proxyDefaultsList.Items) == 0 {
+		return volumes, mounts, nil
 	}
 
-	if proxyDefaults != nil {
-		if proxyDefaults.AccessLogs.Enabled {
-			if proxyDefaults.AccessLogs.Type == capi.FileLogSinkType {
-				accessPath := proxyDefaults.AccessLogs.Path
+	// Will always have only one proxy-defaults resource.
+	proxyDefaults := &proxyDefaultsList.Items[0]
+	if proxyDefaults.Spec.AccessLogs != nil {
+		if proxyDefaults.Spec.AccessLogs.Enabled {
+			if proxyDefaults.Spec.AccessLogs.Type == v1alpha1.FileLogSinkType {
+				accessPath := proxyDefaults.Spec.AccessLogs.Path
 				volumes = append(volumes, accessLogVolume())
 				mounts = append(mounts, accessLogVolumeMount(accessPath))
 				return volumes, mounts, nil

--- a/control-plane/api-gateway/gatekeeper/deployment_test.go
+++ b/control-plane/api-gateway/gatekeeper/deployment_test.go
@@ -4,13 +4,8 @@
 package gatekeeper
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
+	"context"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -19,23 +14,14 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway/common"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
-	"github.com/hashicorp/consul-k8s/control-plane/consul"
-	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
-	capi "github.com/hashicorp/consul/api"
 )
-
-type consulServerRespCfg struct {
-	hasProxyDefaults   bool
-	errOnProxyDefaults bool
-	accessLogEnabled   bool
-	fileLogSinkType    bool
-	fileLogPath        string
-}
 
 func Test_compareDeployments(t *testing.T) {
 	testCases := []struct {
@@ -316,36 +302,89 @@ func TestMergeDeployments_ProbePropagation(t *testing.T) {
 func TestAdditionalAccessLogVolumeMount(t *testing.T) {
 	t.Parallel()
 
+	type expectedResponse struct {
+		hasProxyDefaults   bool
+		errOnProxyDefaults bool
+		accessLogEnabled   bool
+		fileLogSinkType    bool
+		fileLogPath        string
+	}
+
 	type testCase struct {
-		srvResponseConfig consulServerRespCfg
+		expectedResponse     expectedResponse
+		proxyDefaultResource *v1alpha1.ProxyDefaults
 	}
 
 	cases := map[string]testCase{
 		"no proxy-defaults configured": {
-			srvResponseConfig: consulServerRespCfg{
+			proxyDefaultResource: nil,
+			expectedResponse: expectedResponse{
 				hasProxyDefaults: false,
 			},
 		},
 		"error fetching proxy-defaults": {
-			srvResponseConfig: consulServerRespCfg{
+			proxyDefaultResource: nil,
+			expectedResponse: expectedResponse{
 				errOnProxyDefaults: true,
 			},
 		},
 		"access-logs disabled in proxy-defaults": {
-			srvResponseConfig: consulServerRespCfg{
+			proxyDefaultResource: &v1alpha1.ProxyDefaults{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "global",
+				},
+				Spec: v1alpha1.ProxyDefaultsSpec{
+					MeshGateway: v1alpha1.MeshGateway{
+						Mode: "remote",
+					},
+					AccessLogs: &v1alpha1.AccessLogs{
+						Enabled: false,
+					},
+				},
+			},
+			expectedResponse: expectedResponse{
 				hasProxyDefaults: true,
 				accessLogEnabled: false,
 			},
 		},
 		"access-logs enabled but sink is not file type": {
-			srvResponseConfig: consulServerRespCfg{
+			proxyDefaultResource: &v1alpha1.ProxyDefaults{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "global",
+				},
+				Spec: v1alpha1.ProxyDefaultsSpec{
+					MeshGateway: v1alpha1.MeshGateway{
+						Mode: "remote",
+					},
+					AccessLogs: &v1alpha1.AccessLogs{
+						Enabled: true,
+						Type:    v1alpha1.DefaultLogSinkType,
+					},
+				},
+			},
+			expectedResponse: expectedResponse{
 				hasProxyDefaults: true,
 				accessLogEnabled: true,
 				fileLogSinkType:  false,
 			},
 		},
 		"file-type access-log enabled with path": {
-			srvResponseConfig: consulServerRespCfg{
+			proxyDefaultResource: &v1alpha1.ProxyDefaults{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "global",
+				},
+				Spec: v1alpha1.ProxyDefaultsSpec{
+					MeshGateway: v1alpha1.MeshGateway{
+						Mode: "remote",
+					},
+					AccessLogs: &v1alpha1.AccessLogs{
+						Enabled: true,
+						Type:    v1alpha1.FileLogSinkType,
+						Path:    "/var/log/envoy/access.log",
+					},
+				},
+			},
+			expectedResponse: expectedResponse{
 				hasProxyDefaults: true,
 				accessLogEnabled: true,
 				fileLogSinkType:  true,
@@ -356,33 +395,41 @@ func TestAdditionalAccessLogVolumeMount(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			client := fake.NewClientBuilder().Build()
-			server, testClient := fakeConsulServer(t, tc.srvResponseConfig)
-			defer server.Close()
+			ctx := context.Background()
+			var fakeClient client.WithWatch
+			s := runtime.NewScheme()
+			require.NoError(t, v1alpha1.AddToScheme(s))
+			if tc.proxyDefaultResource != nil {
+				fakeClient = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(tc.proxyDefaultResource).Build()
+			} else if tc.expectedResponse.errOnProxyDefaults {
+				fakeClient = fake.NewClientBuilder().Build()
+			} else {
+				fakeClient = fake.NewClientBuilder().WithScheme(s).Build()
+			}
 
 			g := &Gatekeeper{
 				Log:          logr.Discard(),
-				Client:       client,
-				ConsulConfig: testClient.Cfg,
+				Client:       fakeClient,
+				ConsulConfig: nil,
 			}
 
 			initialvolume := []corev1.Volume{}
 			initialmount := []corev1.VolumeMount{}
 
-			updatedVolumes, updatedMounts, err := g.additionalAccessLogVolumeMount(initialvolume, initialmount)
-			if tc.srvResponseConfig.errOnProxyDefaults {
+			updatedVolumes, updatedMounts, err := g.additionalAccessLogVolumeMount(ctx, initialvolume, initialmount)
+			if tc.expectedResponse.errOnProxyDefaults {
 				require.Error(t, err)
-				require.ErrorContains(t, err, "error fetching global proxy-defaults")
+				require.ErrorContains(t, err, "error fetching proxy-defaults")
 				return
 			}
 			require.NoError(t, err)
-			if tc.srvResponseConfig.hasProxyDefaults && tc.srvResponseConfig.accessLogEnabled && tc.srvResponseConfig.fileLogSinkType {
+			if tc.expectedResponse.hasProxyDefaults && tc.expectedResponse.accessLogEnabled && tc.expectedResponse.fileLogSinkType {
 				// Expect volume and mount to be added
 				require.Len(t, updatedVolumes, 1)
 				require.Len(t, updatedMounts, 1)
 				require.Equal(t, accessLogVolumeName, updatedVolumes[0].Name)
 				require.Equal(t, accessLogVolumeName, updatedMounts[0].Name)
-				require.Equal(t, filepath.Dir(tc.srvResponseConfig.fileLogPath), updatedMounts[0].MountPath)
+				require.Equal(t, filepath.Dir(tc.expectedResponse.fileLogPath), updatedMounts[0].MountPath)
 			} else {
 				// Expect no additional volume or mount to be added
 				require.Len(t, updatedVolumes, 0)
@@ -390,62 +437,4 @@ func TestAdditionalAccessLogVolumeMount(t *testing.T) {
 			}
 		})
 	}
-}
-
-func fakeConsulServer(t *testing.T, serverResponseConfig consulServerRespCfg) (*httptest.Server, *test.TestServerClient) {
-	t.Helper()
-	mux := buildMux(t, serverResponseConfig)
-	consulServer := httptest.NewServer(mux)
-
-	parsedURL, err := url.Parse(consulServer.URL)
-	require.NoError(t, err)
-	host := strings.Split(parsedURL.Host, ":")[0]
-
-	port, err := strconv.Atoi(parsedURL.Port())
-	require.NoError(t, err)
-
-	cfg := &consul.Config{APIClientConfig: &capi.Config{Address: host}, HTTPPort: port}
-	cfg.APIClientConfig.Address = consulServer.URL
-
-	testClient := &test.TestServerClient{
-		Cfg:     cfg,
-		Watcher: test.MockConnMgrForIPAndPort(t, host, port, false),
-	}
-
-	return consulServer, testClient
-}
-
-func buildMux(t *testing.T, cfg consulServerRespCfg) http.Handler {
-	t.Helper()
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/config/proxy-defaults/"+capi.ProxyConfigGlobal, func(w http.ResponseWriter, r *http.Request) {
-		if cfg.errOnProxyDefaults {
-			w.WriteHeader(500)
-			return
-		}
-		if !cfg.hasProxyDefaults {
-			w.WriteHeader(404)
-			return
-		}
-		w.WriteHeader(200)
-		accessLogType := capi.DefaultLogSinkType
-		if cfg.fileLogSinkType {
-			accessLogType = capi.FileLogSinkType
-		}
-		proxyDefaults := capi.ProxyConfigEntry{
-			AccessLogs: &capi.AccessLogsConfig{
-				Enabled: cfg.accessLogEnabled,
-				Type:    accessLogType,
-				Path:    cfg.fileLogPath,
-			},
-		}
-		val, err := json.Marshal(proxyDefaults)
-		if err != nil {
-			w.WriteHeader(500)
-			return
-		}
-		w.Write(val)
-	})
-
-	return mux
 }


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Instead of fetching proxy-defaults from the consul server, fetching it from the k8 resource object. 
- For the backward compatibility instead of relying on the consul config we fetch it from the k8 resource object. 

### How I've tested this PR ###
- Set up a local kind Kubernetes cluster.
- Built the local control-plane image:
````GOOS=linux make dev-docker````
- Loaded the built image into the kind cluster:
````kind load docker-image consul-k8s-control-plane:local````
- Applied the following Helm values while following the tutorial:
https://developer.hashicorp.com/consul/tutorials/get-started-kubernetes/kubernetes-gs-ingress
````
  image: hashicorp/consul:1.22.0
  imageK8S: consul-k8s-control-plane:local
  imageConsulDataplane: hashicorp/consul-dataplane:1.9
````
- Verified that the consul-dataplane pods for both sidecars and API Gateway received the expected volume and mount when file-based access logs were enabled.

### How I expect reviewers to test this PR ###
- Build the control-plane image locally using make dev-docker.
- Load it into a test Kubernetes cluster (kind or equivalent).
- Create a file proxy/proxy-defaults and enable file-based access logging in proxy-defaults.
````
apiVersion: consul.hashicorp.com/v1alpha1
kind: ProxyDefaults
metadata:
  name: global
spec:
  accessLogs:
    enabled: true
    type: file
    path: "/var/log/envoy/access-logs.txt"
  config:
    protocol: "http"

````
`kubectl apply -f proxy/proxy-defaults`
- Apply the api-gw
````
kubectl apply --filename api-gw/consul-api-gateway.yaml --namespace consul && \
kubectl wait --for=condition=accepted gateway/api-gateway --namespace consul --timeout=90s && \
kubectl apply --filename api-gw/routes.yaml --namespace consul && \
kubectl apply --filename api-gw/intentions.yaml --namespace consul`
````
- Confirm that a new volume and volumeMount are added to api-gateway
`kubectl describe po <api-gateway-pod> -n consul`
 
### Checklist ###
- [ x] Tests added
- [ x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 


