### PR TITLE
Post Fix: For code consistency with lower version

### DIFF
--- a/control-plane/api-gateway/gatekeeper/deployment_test.go
+++ b/control-plane/api-gateway/gatekeeper/deployment_test.go
@@ -408,9 +408,8 @@ func TestAdditionalAccessLogVolumeMount(t *testing.T) {
 			}
 
 			g := &Gatekeeper{
-				Log:          logr.Discard(),
-				Client:       fakeClient,
-				ConsulConfig: nil,
+				Log:    logr.Discard(),
+				Client: fakeClient,
 			}
 
 			initialvolume := []corev1.Volume{}


### PR DESCRIPTION
### Changes proposed in this PR ###  
As ConsulConfig member (datatype) is not present in the lower version (<1.9) of Gatekeeper struct, therefore removing it from the deployment test to have code consistency. 

Main: https://github.com/hashicorp/consul-k8s/pull/5026/changes#diff-b12bed6fcec6932ba9a1dd3cb403ad5db9b7d75dd6ac573c58a70ce0d922bdb0R413

Lower version 1.8.x: https://github.com/hashicorp/consul-k8s/pull/5043/changes#diff-b12bed6fcec6932ba9a1dd3cb403ad5db9b7d75dd6ac573c58a70ce0d922bdb0R412
