### PR TITLE
Changing the cleanupInlineCerts successful check from certSet to certsToDelete count

### DIFF
--- a/control-plane/api-gateway/binding/cleanup.go
+++ b/control-plane/api-gateway/binding/cleanup.go
@@ -192,7 +192,15 @@ func (c Cleaner) cleanupInlineCerts(client *api.Client) (bool, error) {
 		deletedCerts++
 	}
 
-	return certSet.Cardinality() == deletedCerts, mErr
+	c.Logger.Info(
+		"Inline-certificate cleanup complete",
+		"total-certs", certSet.Cardinality(),
+		"certs-to-keep", certsToKeep.Cardinality(),
+		"certs-to-delete", certsToDelete.Cardinality(),
+		"deleted", deletedCerts,
+	)
+
+	return certsToDelete.Cardinality() == deletedCerts, mErr
 }
 
 func ignoreNotFoundError(err error) error {


### PR DESCRIPTION
The cleanupInlineCerts function due to successful condition check based on certSet.Cardinality() == deletedCerts fails as even if there is one bound certSet, then its not deleted.

This causes its parent function func (c Cleaner) Run(ctx context.Context)  in infinite loop retrying deletion of cleanupACLRoleAndPolicy and cleanupInlineCerts


### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
