### PR TITLE
validate service name length in annotation before assignment

### DIFF
--- a/.changelog/5097.txt
+++ b/.changelog/5097.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-Added input length validation on "consul.hashicorp.com/service-name" annotation to fix CVE SECVULN-36742
+Added input length validation on "consul.hashicorp.com/service-name" annotation
 ```

--- a/.changelog/5097.txt
+++ b/.changelog/5097.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Added input length validation on "consul.hashicorp.com/service-name" annotation to fix CVE SECVULN-36742
+```

--- a/control-plane/catalog/to-consul/resource.go
+++ b/control-plane/catalog/to-consul/resource.go
@@ -443,7 +443,15 @@ func (t *ServiceResource) generateRegistrations(key string) {
 
 	// If the name is explicitly annotated, adopt that name
 	if v, ok := svc.Annotations[annotationServiceName]; ok {
-		baseService.Service = strings.TrimSpace(v)
+		trimmedName := strings.TrimSpace(v)
+		if len(trimmedName) < 1 || len(trimmedName) > 64 {
+			t.Log.Warn("invalid service name length in annotation -- must be 1-64 characters",
+				"service", svc.Name,
+				"namespace", svc.Namespace,
+				"length", len(trimmedName))
+		} else {
+			baseService.Service = trimmedName
+		}
 	}
 
 	// Update the Consul namespace based on namespace settings


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Added input length validation on "consul.hashicorp.com/service-name" 

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
