### PR TITLE
Manisha/backport 13047 1.7

### DIFF
--- a/.changelog/5062.txt
+++ b/.changelog/5062.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Updates code logic in CNI during application pod creation.
+```

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,8 +29,8 @@ jobs:
         workflow: test.yml
         repo: hashicorp/consul-k8s-workflows
         ref: main
-        token: ${{ secrets.TEST_13047 }}
-        inputs: '{ "context":"${{ env.CONTEXT }}-${{ github.event.pull_request.number }}", "actor":"${{ github.actor }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "token":"${{ secrets.TEST_13047 }}" }'
+        token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+        inputs: '{ "context":"${{ env.CONTEXT }}-${{ github.event.pull_request.number }}", "actor":"${{ github.actor }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'
 
   pass-required-checks-on-skip:
     needs: [ conditional-skip ]
@@ -53,7 +53,7 @@ jobs:
     - name: Update final status
       uses: docker://ghcr.io/curtbushko/commit-status-action:e1d661c757934ab35c74210b4b70c44099ec747a
       env:
-        INPUT_TOKEN: ${{ secrets.TEST_13047 }}
+        INPUT_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
         INPUT_REPOSITORY: ${{ github.repository }}
         INPUT_CONTEXT: ${{ matrix.check-name }}
         INPUT_STATE: success

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,8 +29,8 @@ jobs:
         workflow: test.yml
         repo: hashicorp/consul-k8s-workflows
         ref: main
-        token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-        inputs: '{ "context":"${{ env.CONTEXT }}-${{ github.event.pull_request.number }}", "actor":"${{ github.actor }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}" }'
+        token: ${{ secrets.TEST_13047 }}
+        inputs: '{ "context":"${{ env.CONTEXT }}-${{ github.event.pull_request.number }}", "actor":"${{ github.actor }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "token":"${{ secrets.TEST_13047 }}" }'
 
   pass-required-checks-on-skip:
     needs: [ conditional-skip ]
@@ -53,7 +53,7 @@ jobs:
     - name: Update final status
       uses: docker://ghcr.io/curtbushko/commit-status-action:e1d661c757934ab35c74210b4b70c44099ec747a
       env:
-        INPUT_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+        INPUT_TOKEN: ${{ secrets.TEST_13047 }}
         INPUT_REPOSITORY: ${{ github.repository }}
         INPUT_CONTEXT: ${{ matrix.check-name }}
         INPUT_STATE: success

--- a/acceptance/tests/consul-dns/consul_dns_partitions_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_partitions_test.go
@@ -125,7 +125,7 @@ func TestConsulDNSProxy_WithPartitionsAndCatalogSync(t *testing.T) {
 					if v.preProcessingFunc != nil {
 						v.preProcessingFunc(t)
 					}
-					verifyDNS(t, releaseName, staticServerNamespace, v.requestingCtx, v.svcContext,
+					verifyDNS(t, cfg, releaseName, staticServerNamespace, v.requestingCtx, v.svcContext,
 						podLabelSelector, v.svcName, v.shouldResolveDNS, dnsUtilsPodIndex)
 					dnsUtilsPodIndex++
 				})

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/hashicorp/consul-k8s/acceptance/framework/config"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
@@ -149,7 +151,7 @@ func TestConsulDNS(t *testing.T) {
 			if c.enableDNSProxy && c.port == privilegedPort {
 				validateDNSProxyPrivilegedPort(t, ctx, releaseName)
 			}
-			verifyDNS(t, releaseName, ctx.KubectlOptions(t).Namespace, ctx, ctx, "app=consul,component=server",
+			verifyDNS(t, cfg, releaseName, ctx.KubectlOptions(t).Namespace, ctx, ctx, "app=consul,component=server",
 				"consul.service.consul", true, 0)
 		})
 	}
@@ -227,12 +229,20 @@ func updateCoreDNS(t *testing.T, ctx environment.TestContext, coreDNSConfigFile 
 	_, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), restartCoreDNSCommand...)
 	require.NoError(t, err)
 	// Wait for restart to finish.
-	out, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "rollout", "status", "--timeout", "1m", "--watch", "deployment/coredns", "-n", "kube-system")
+	out, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t), "rollout", "status", "--timeout", "5m", "--watch", "deployment/coredns", "-n", "kube-system")
 	require.NoError(t, err, out, "rollout status command errored, this likely means the rollout didn't complete in time")
 }
 
-func verifyDNS(t *testing.T, releaseName string, svcNamespace string, requestingCtx, svcContext environment.TestContext,
-	podLabelSelector, svcName string, shouldResolveDNSRecord bool, dnsUtilsPodIndex int) {
+func verifyDNS(
+	t *testing.T,
+	cfg *config.TestConfig,
+	releaseName string,
+	svcNamespace string,
+	requestingCtx, svcContext environment.TestContext,
+	podLabelSelector, svcName string,
+	shouldResolveDNSRecord bool,
+	dnsUtilsPodIndex int,
+) {
 	podList, err := svcContext.KubernetesClient(t).CoreV1().Pods(svcNamespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: podLabelSelector,
 	})
@@ -246,53 +256,51 @@ func verifyDNS(t *testing.T, releaseName string, svcNamespace string, requesting
 	logger.Log(t, "launch a pod to test the dns resolution.")
 	dnsUtilsPod := fmt.Sprintf("%s-dns-utils-pod-%d", releaseName, dnsUtilsPodIndex)
 	dnsTestPodArgs := []string{
-		"run", "-it", dnsUtilsPod, "--restart", "Never", "--image", "anubhavmishra/tiny-tools", "--", "dig", svcName,
+		"run", "-i", dnsUtilsPod, "--rm",
+		"--restart", "Never",
+		"--image", "anubhavmishra/tiny-tools",
+		"--labels", "release=" + releaseName,
+		"--", "dig", svcName, "ANY",
 	}
 
-	helpers.Cleanup(t, suite.Config().NoCleanupOnFailure, suite.Config().NoCleanup, func() {
-		// Note: this delete command won't wait for pods to be fully terminated.
-		// This shouldn't cause any test pollution because the underlying
-		// objects are deployments, and so when other tests create these
-		// they should have different pod names.
-		k8s.RunKubectl(t, requestingCtx.KubectlOptions(t), "delete", "pod", dnsUtilsPod)
-	})
-
-	retry.Run(t, func(r *retry.R) {
-		logger.Log(t, "run the dns utilize pod and query DNS for the service.")
-		logs, err := k8s.RunKubectlAndGetOutputE(r, requestingCtx.KubectlOptions(r), dnsTestPodArgs...)
+	var logs string
+	retry.RunWith(&retry.Counter{Wait: 30 * time.Second, Count: 10}, t, func(r *retry.R) {
+		logs, err = k8s.RunKubectlAndGetOutputE(r, requestingCtx.KubectlOptions(r), dnsTestPodArgs...)
 		require.NoError(r, err)
+		logger.Logf(t, "verify the DNS results. with logs: \n%s", logs)
 
-		// When the `dig` request is successful, a section of it's response looks like the following:
-		//
-		// ;; ANSWER SECTION:
-		// consul.service.consul.	0	IN	A	<consul-server-pod-ip>
-		//
-		// ;; Query time: 2 msec
-		// ;; SERVER: <dns-ip>#<dns-port>(<dns-ip>)
-		// ;; WHEN: Mon Aug 10 15:02:40 UTC 2020
-		// ;; MSG SIZE  rcvd: 98
-		//
-		// We assert on the existence of the ANSWER SECTION, The consul-server IPs being present in the ANSWER SECTION and the the DNS IP mentioned in the SERVER: field
+		// Normalize whitespace for reliable matching
+		cleanLogs := strings.ReplaceAll(logs, "\t", " ")
+		cleanLogs = strings.Join(strings.Fields(cleanLogs), " ")
 
-		logger.Log(t, "verify the DNS results.")
-		// strip logs of tabs, newlines and spaces to make it easier to assert on the content when there is a DNS match
-		strippedLogs := strings.Replace(logs, "\t", "", -1)
-		strippedLogs = strings.Replace(strippedLogs, "\n", "", -1)
-		strippedLogs = strings.Replace(strippedLogs, " ", "", -1)
-		for _, ip := range servicePodIPs {
-			aRecordPattern := "%s.5INA%s"
-			aRecord := fmt.Sprintf(aRecordPattern, svcName, ip)
-			if shouldResolveDNSRecord {
-				require.Contains(r, logs, "ANSWER SECTION:")
-				require.Contains(r, strippedLogs, aRecord)
+		for _, ipStr := range servicePodIPs {
+			ip := net.ParseIP(ipStr)
+			require.NotNil(r, ip, "failed to parse IP: %s", ipStr)
+
+			// Build a regex that tolerates TTL and spacing variations
+			var recordPattern string
+			if ip.To4() != nil {
+				// IPv4 record (A)
+				recordPattern = fmt.Sprintf(`%s\.\s+\d+\s+IN\s+A\s+%s`, regexp.QuoteMeta(svcName), regexp.QuoteMeta(ipStr))
 			} else {
-				require.NotContains(r, logs, "ANSWER SECTION:")
-				require.NotContains(r, strippedLogs, aRecord)
-				require.Contains(r, logs, "status: NXDOMAIN")
-				require.Contains(r, logs, "AUTHORITY SECTION:\nconsul.\t\t\t5\tIN\tSOA\tns.consul. hostmaster.consul.")
+				// IPv6 record (AAAA)
+				recordPattern = fmt.Sprintf(`%s\.\s+\d+\s+IN\s+AAAA\s+%s`, regexp.QuoteMeta(svcName), regexp.QuoteMeta(ipStr))
+			}
+
+			matched, _ := regexp.MatchString(recordPattern, cleanLogs)
+
+			if shouldResolveDNSRecord {
+				require.Contains(r, logs, "ANSWER SECTION:", "expected ANSWER SECTION in dig output but none found.\nFull logs:\n%s", logs)
+				require.Truef(r, matched, "expected DNS record for %s with IP %s not found.\nPattern: %s\nLogs:\n%s", svcName, ipStr, recordPattern, logs)
+			} else {
+				require.NotContains(r, logs, "ANSWER SECTION:", "unexpected ANSWER SECTION in dig output.\nLogs:\n%s", logs)
+				require.Falsef(r, matched, "unexpected DNS record for %s found with IP %s.\nLogs:\n%s", svcName, ipStr, logs)
+				require.Contains(r, logs, "status: NXDOMAIN", "expected NXDOMAIN when record should not resolve.\nLogs:\n%s", logs)
+				require.Contains(r, logs, "AUTHORITY SECTION:", "expected AUTHORITY SECTION in NXDOMAIN response.\nLogs:\n%s", logs)
 			}
 		}
 	})
+
 }
 
 func getDNSServiceClusterIP(t *testing.T, requestingCtx environment.TestContext, releaseName string, enableDNSProxy bool) (string, error) {

--- a/control-plane/cni/main_test.go
+++ b/control-plane/cni/main_test.go
@@ -7,11 +7,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/hashicorp/consul/sdk/iptables"
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,6 +124,7 @@ func Test_cmdAdd(t *testing.T) {
 				iptablesConfigJson, err := json.Marshal(&cfg)
 				require.NoError(t, err)
 				pod.Annotations[annotationRedirectTraffic] = string(iptablesConfigJson)
+				pod.Annotations[annotationDualStack] = "consul.hashicorp.com/dual-stack"
 				_, err = cmd.client.CoreV1().Pods(defaultNamespace).Create(context.Background(), pod, metav1.CreateOptions{})
 				require.NoError(t, err)
 
@@ -146,6 +151,7 @@ func Test_cmdAdd(t *testing.T) {
 				iptablesConfigJson, err := json.Marshal(&cfg)
 				require.NoError(t, err)
 				pod.Annotations[annotationRedirectTraffic] = string(iptablesConfigJson)
+				pod.Annotations[annotationDualStack] = "consul.hashicorp.com/dual-stack"
 				_, err = cmd.client.CoreV1().Pods(defaultNamespace).Create(context.Background(), pod, metav1.CreateOptions{})
 				require.NoError(t, err)
 
@@ -190,6 +196,226 @@ func Test_cmdAdd(t *testing.T) {
 	}
 }
 
+func writeKubeconfig(t *testing.T, dir string, valid bool) string {
+	t.Helper()
+
+	var data string
+	if valid {
+		data = `
+apiVersion: v1
+kind: Config
+clusters:
+- name: test
+  cluster:
+    server: https://127.0.0.1:6443
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+current-context: test
+users:
+- name: test
+  user:
+    token: fake-token
+`
+	} else {
+		data = `
+apiVersion: v1
+kind: Config
+clusters:
+- name: test
+  cluster: {}
+`
+	}
+
+	path := filepath.Join(dir, "kubeconfig")
+
+	if err := os.WriteFile(path, []byte(data), 0600); err != nil {
+		t.Fatalf("failed to write kubeconfig: %v", err)
+	}
+
+	return path
+}
+
+// TestResolveKubeconfigPath tests the resolveKubeconfigPath function
+func TestResolveKubeconfigPath(t *testing.T) {
+	tests := []struct {
+		name                  string
+		setup                 func(t *testing.T, dir string)
+		wantSuffix            string
+		expectError           bool
+		expectedErrorContains error
+	}{
+		{
+			name: "stable kubeconfig exists",
+			setup: func(t *testing.T, dir string) {
+				path := filepath.Join(dir, "kubeconfig")
+				if err := os.WriteFile(path, []byte("stable"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantSuffix:  "kubeconfig",
+			expectError: false,
+		},
+		{
+			name: "stable path is directory, fallback to versioned",
+			setup: func(t *testing.T, dir string) {
+				if err := os.Mkdir(filepath.Join(dir, "kubeconfig"), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(
+					filepath.Join(dir, "kubeconfig-1"),
+					[]byte("v1"),
+					0644,
+				); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantSuffix:  "kubeconfig-1",
+			expectError: false,
+		},
+		{
+			name: "single versioned kubeconfig",
+			setup: func(t *testing.T, dir string) {
+				if err := os.WriteFile(
+					filepath.Join(dir, "kubeconfig-123"),
+					[]byte("v123"),
+					0644,
+				); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantSuffix:  "kubeconfig-123",
+			expectError: false,
+		},
+		{
+			name: "multiple versioned kubeconfigs, newest chosen",
+			setup: func(t *testing.T, dir string) {
+				old := filepath.Join(dir, "kubeconfig-old")
+				newer := filepath.Join(dir, "kubeconfig-new")
+
+				if err := os.WriteFile(old, []byte("old"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				time.Sleep(10 * time.Millisecond) // ensure mtime difference
+				if err := os.WriteFile(newer, []byte("new"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantSuffix:  "kubeconfig-new",
+			expectError: false,
+		},
+		{
+			name: "no kubeconfig files",
+			setup: func(t *testing.T, dir string) {
+				// nothing created
+			},
+			expectError:           true,
+			expectedErrorContains: fmt.Errorf("no kubeconfig found"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tc.setup(t, dir)
+
+			got, err := resolveKubeconfigPath(dir, "kubeconfig")
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got nil (path=%s)", got)
+					return
+				}
+				require.Contains(t, err.Error(), tc.expectedErrorContains.Error())
+				return
+
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !filepath.IsAbs(got) {
+				t.Fatalf("expected absolute path, got %s", got)
+			}
+
+			if !strings.HasSuffix(got, tc.wantSuffix) {
+				t.Fatalf("expected suffix %q, got %q", tc.wantSuffix, got)
+			}
+		})
+	}
+}
+
+func TestCreateK8sClient(t *testing.T) {
+	t.Parallel()
+	logger := hclog.NewNullLogger()
+
+	tests := []struct {
+		setup                 func(t *testing.T) *PluginConf
+		expectedErrorContains error
+		expectedError         bool
+		expectClient          bool
+		name                  string
+	}{
+		{
+			name: "Client success",
+			setup: func(t *testing.T) *PluginConf {
+				dir := t.TempDir()
+				writeKubeconfig(t, dir, true)
+				return &PluginConf{
+					CNINetDir:  dir,
+					Kubeconfig: "kubeconfig",
+				}
+			},
+			expectedError: false,
+			expectClient:  true,
+		},
+		{
+			name: "No Kubeconfig found",
+			setup: func(t *testing.T) *PluginConf {
+				dir := t.TempDir()
+				return &PluginConf{
+					CNINetDir:  dir,
+					Kubeconfig: "",
+				}
+			},
+			expectedErrorContains: fmt.Errorf("failed to load kubeconfig"),
+			expectedError:         true,
+			expectClient:          false,
+		},
+		{
+			name: "error from BuildConfigFromFlags",
+			setup: func(t *testing.T) *PluginConf {
+				dir := t.TempDir()
+				writeKubeconfig(t, dir, false) // invalid content
+				return &PluginConf{
+					CNINetDir:  dir,
+					Kubeconfig: "kubeconfig", // ALWAYS this
+				}
+			},
+			expectedErrorContains: fmt.Errorf("failed to load kubeconfig"),
+			expectedError:         true,
+			expectClient:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setup(t)
+			cmd := &Command{}
+			err := cmd.createK8sClient(cfg, logger)
+			if tt.expectedError {
+				require.Contains(t, err.Error(), tt.expectedErrorContains.Error())
+				t.Logf("✅ expected error occurred: %v", err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, cmd.client)
+				t.Log("✅ client created successfully")
+			}
+		})
+	}
+}
 func TestSkipTrafficRedirection(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/control-plane/subcommand/inject-connect/command.go
+++ b/control-plane/subcommand/inject-connect/command.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/mitchellh/cli"
@@ -26,6 +27,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -394,11 +396,20 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:           scheme,
-		LeaderElection:   true,
-		LeaderElectionID: "consul-controller-lock",
-		Logger:           zapLogger,
+	cfg := ctrl.GetConfigOrDie()
+	cfg.Timeout = 90 * time.Second
+	cfg.QPS = 50
+	cfg.Burst = 100
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                  scheme,
+		LeaderElection:          true,
+		LeaderElectionID:        "consul-controller-lock",
+		Logger:                  zapLogger,
+		LeaderElectionNamespace: c.flagReleaseNamespace,
+		LeaseDuration:           ptr.To(90 * time.Second),
+		RenewDeadline:           ptr.To(60 * time.Second),
+		RetryPeriod:             ptr.To(15 * time.Second),
 		Metrics: metricsserver.Options{
 			BindAddress: "0.0.0.0:9444",
 		},


### PR DESCRIPTION
This PR is copy auto-generated from https://github.com/hashicorp/consul-k8s/pull/5062 to be assessed for backporting due to the inclusion of the label backport/1.7.x.

🚨

Warning automatic cherry-pick of commits failed. If the first commit failed,
you will see a blank no-op commit below. If at least one commit succeeded, you
will see the cherry-picked commits up to, not including, the commit where
the merge conflict occurred.
The person who merged in the original PR is:
@vdinesh4738
This person should resolve the merge-conflict(s) by either:

Manually completing the cherry picks into this branch
Creating a new branch and manually cherry-picking all commits being backported
merge conflict error: POST https://api.github.com/repos/hashicorp/consul-k8s/merges: 409 Merge conflict []
The below text is copied from the body of the original PR.

Provided fix for the segmentation fault or SIGSEGV with consul-cni network plugin's code, which is common across the platform till date on Multus cni extension.

Background:
As per jira, when we enable cni and Multus, and then deploy the application with the api-resource 'network-attachment-definition' annotation like 'k8s.v1.cni.cncf.io/networks': '[{"namespace": "consul", "name":"consul-consul-cni"}]' is attached to the application pod, the application pod fails to come up at pod init with error in

Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox. (more detailed in the jira: https://hashicorp.atlassian.net/browse/CSL-13047

Root cause:
Creation of client with unavailable Kubeconfig or with the wrong Kubeconfig file name causing nil pointer dereference.

Fix:
Created the function to looks/fetch the latest Kubeconfig file and creates client.

Validation:
With the cni and Multus enabled: we update the iptables in the pod network ns.
With this fix : App is up and running and the iptables are updated in the pod network ns.