### PR TITLE
CSL-13505: GatewayClassConfig is not picked on re-configuring from the terminal in kubernetes

### DIFF
--- a/control-plane/api-gateway-ocp/binding/binder.go
+++ b/control-plane/api-gateway-ocp/binding/binder.go
@@ -130,21 +130,21 @@ func (b *Binder) Snapshot() *Snapshot {
 
 	authFilters := b.config.Resources.GetExternalAuthFilters()
 	if !isGatewayDeleted {
-		var updated bool
+		var updatedGcc bool
 
-		gatewayClassConfig, updated = serializeGatewayClassConfig(&b.config.Gateway, gatewayClassConfig)
+		gatewayClassConfig, updatedGcc = serializeGatewayClassConfig(&b.config.Gateway, gatewayClassConfig)
 
 		// we don't have a deletion but if we add a finalizer for the gateway, then just add it and return
 		// otherwise try and resolve as much as possible
-		if common.EnsureFinalizer(&b.config.Gateway) || updated {
+		if common.EnsureFinalizer(&b.config.Gateway) || updatedGcc {
 			// if we've added the finalizer or serialized the class config, then update
 			snapshot.Kubernetes.Updates.Add(&b.config.Gateway)
-			return snapshot
+			// return snapshot
 		}
 
 		// calculate the status for the gateway
 		gatewayValidation = validateGateway(b.config.Gateway, registrationPods, b.config.ConsulGateway)
-		listenerValidation = validateListeners(b.config.Gateway, b.config.Gateway.Spec.Listeners, b.config.Resources, b.config.GatewayClassConfig)
+		listenerValidation = validateListeners(b.config.Gateway, b.config.Gateway.Spec.Listeners, b.config.Resources, gatewayClassConfig)
 		policyValidation = validateGatewayPolicies(b.config.Gateway, b.config.Policies, b.config.Resources)
 		authFilterValidation = validateAuthFilters(authFilters, b.config.Resources)
 	}

--- a/control-plane/api-gateway-ocp/controllers/gateway_controller.go
+++ b/control-plane/api-gateway-ocp/controllers/gateway_controller.go
@@ -89,6 +89,7 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 
 	}
+	log.Info("Gateway found: " + fmt.Sprintf("%+v", gateway))
 
 	// get the gateway class
 	gatewayClass, err := r.getGatewayClassForGateway(ctx, gateway)

--- a/control-plane/api-gateway-ocp/controllers/gateway_controller.go
+++ b/control-plane/api-gateway-ocp/controllers/gateway_controller.go
@@ -67,6 +67,7 @@ type GatewayController struct {
 	denyK8sNamespacesSet  mapset.Set
 	client.Client
 	ConsulConfig *consul.Config
+	ApiReader    client.Reader
 }
 
 // Reconcile handles the reconciliation loop for Gateway objects.
@@ -76,7 +77,7 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	var gateway gwv1beta1.Gateway
 
-	log := r.Log.WithValues("gateway-custom", req.NamespacedName)
+	log := r.Log.V(1).WithValues("gateway-custom", req.NamespacedName)
 	log.Info("Reconciling Gateway -  starting for custom consul networking API version")
 
 	// get the gateway
@@ -211,7 +212,7 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	})
 
 	updates := binder.Snapshot()
-
+	r.Log.V(1).Info("updates binder: " + fmt.Sprintf("%+v", updates))
 	if updates.UpsertGatewayDeployment {
 		if err := r.cache.EnsureRoleBinding(r.HelmConfig.AuthMethod, gateway.Name, gateway.Namespace); err != nil {
 			log.Error(err, "error creating role binding")
@@ -229,7 +230,8 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, err
 		}
 		r.gatewayCache.EnsureSubscribed(nonNormalizedConsulKey, req.NamespacedName)
-	} else {
+	} else if gateway.DeletionTimestamp != nil && !gateway.GetDeletionTimestamp().IsZero() {
+		r.Log.Info("gateway delete detected, deleting gateway resources")
 		err := r.deleteGatekeeperResources(ctx, log, &gateway)
 		if err != nil {
 			if k8serrors.IsConflict(err) {
@@ -367,7 +369,7 @@ func configEntriesTo[T api.ConfigEntry](entries []api.ConfigEntry) []T {
 }
 
 func (r *GatewayController) deleteGatekeeperResources(ctx context.Context, log logr.Logger, gw *gwv1beta1.Gateway) error {
-	gk := gatekeeper.New(log, r.Client, r.ConsulConfig)
+	gk := gatekeeper.New(log, r.Client, r.ConsulConfig, r.ApiReader)
 	err := gk.Delete(ctx, *gw)
 	if err != nil {
 		return err
@@ -377,7 +379,7 @@ func (r *GatewayController) deleteGatekeeperResources(ctx context.Context, log l
 }
 
 func (r *GatewayController) updateGatekeeperResources(ctx context.Context, log logr.Logger, gw *gwv1beta1.Gateway, gwcc *v1alpha1.GatewayClassConfig) error {
-	gk := gatekeeper.New(log, r.Client, r.ConsulConfig)
+	gk := gatekeeper.New(log, r.Client, r.ConsulConfig, r.ApiReader)
 	err := gk.Upsert(ctx, *gw, *gwcc, r.HelmConfig)
 	if err != nil {
 		return err
@@ -426,6 +428,7 @@ func SetupGatewayControllerWithManager(ctx context.Context, mgr ctrl.Manager, co
 	r := &GatewayController{
 		Client:     mgr.GetClient(),
 		Log:        mgr.GetLogger(),
+		ApiReader:  mgr.GetAPIReader(),
 		HelmConfig: config.HelmConfig.Normalize(),
 		Translator: common.ResourceTranslator{
 			EnableConsulNamespaces: config.HelmConfig.EnableNamespaces,
@@ -471,11 +474,6 @@ func SetupGatewayControllerWithManager(ctx context.Context, mgr ctrl.Manager, co
 		// 		return mapToCustomGateway(obj)
 		// 	}), builder.WithPredicates(predicate),
 		// ).
-		Watches(
-			&corev1.Pod{},
-			handler.EnqueueRequestsFromMapFunc(r.transformPods),
-			builder.WithPredicates(predicate),
-		).
 		// Watches(
 		// 	&corev1.Service{},
 		// 	handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -510,11 +508,11 @@ func SetupGatewayControllerWithManager(ctx context.Context, mgr ctrl.Manager, co
 			&corev1.Endpoints{},
 			handler.EnqueueRequestsFromMapFunc(r.transformEndpoints),
 		).
-		// Watches(
-		// 	&corev1.Pod{},
-		// 	handler.EnqueueRequestsFromMapFunc(r.transformPods),
-		// 	builder.WithPredicates(predicate),
-		// ).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.transformPods),
+			builder.WithPredicates(predicate),
+		).
 		WatchesRawSource(
 			source.Channel(
 				c.Subscribe(ctx, api.APIGateway, r.transformConsulGateway).Events(),

--- a/control-plane/api-gateway-ocp/controllers/gateway_controller.go
+++ b/control-plane/api-gateway-ocp/controllers/gateway_controller.go
@@ -451,35 +451,13 @@ func SetupGatewayControllerWithManager(ctx context.Context, mgr ctrl.Manager, co
 		ServerMgr:    config.ConsulServerConnMgr,
 		AuthMethod:   config.HelmConfig.AuthMethod,
 	}
-	/*
-	   ctrl.NewControllerManagedBy(mgr).
-	   	Named("gateway-custom").
-	   	For(
-	   		&gwv1beta1.Gateway{},
-	   		builder.WithPredicates(predicate.GenerationChangedPredicate{}),
-	   	).
-	   	Watches(...).
-	   	Complete(r)
 
-	*/
 	return c, cleaner, ctrl.NewControllerManagedBy(mgr).
 		Named("gateway-custom").
 		For(&gwv1beta1.Gateway{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.Pod{}).
-		// Watches(
-		// 	&appsv1.Deployment{},
-		// 	handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
-		// 		return mapToCustomGateway(obj)
-		// 	}), builder.WithPredicates(predicate),
-		// ).
-		// Watches(
-		// 	&corev1.Service{},
-		// 	handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
-		// 		return mapToCustomGateway(obj)
-		// 	}),
-		// ).
 		Watches(
 			&gwv1beta1.ReferenceGrant{},
 			handler.EnqueueRequestsFromMapFunc(r.transformReferenceGrant),

--- a/control-plane/api-gateway-ocp/gatekeeper/deployment.go
+++ b/control-plane/api-gateway-ocp/gatekeeper/deployment.go
@@ -6,6 +6,7 @@ package gatekeeper
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
@@ -36,7 +37,14 @@ func (g *Gatekeeper) upsertDeployment(ctx context.Context, gateway gwv1beta1.Gat
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return err
 	} else if k8serrors.IsNotFound(err) {
-		exists = false
+		time.Sleep(5 * time.Second)
+		err = g.ApiReader.Get(ctx, g.namespacedName(gateway), existingDeployment)
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return err
+		} else if k8serrors.IsNotFound(err) {
+			g.Log.Info("No existing deployment found.")
+			exists = false
+		}
 	} else {
 		exists = true
 	}

--- a/control-plane/api-gateway-ocp/gatekeeper/gatekeeper.go
+++ b/control-plane/api-gateway-ocp/gatekeeper/gatekeeper.go
@@ -22,14 +22,16 @@ type Gatekeeper struct {
 	Log          logr.Logger
 	Client       client.Client
 	ConsulConfig *consul.Config
+	ApiReader    client.Reader
 }
 
 // New creates a new Gatekeeper from the Config.
-func New(log logr.Logger, client client.Client, consulConfig *consul.Config) *Gatekeeper {
+func New(log logr.Logger, client client.Client, consulConfig *consul.Config, apiReader client.Reader) *Gatekeeper {
 	return &Gatekeeper{
 		Log:          log,
 		Client:       client,
 		ConsulConfig: consulConfig,
+		ApiReader:    apiReader,
 	}
 }
 

--- a/control-plane/api-gateway/binding/annotations.go
+++ b/control-plane/api-gateway/binding/annotations.go
@@ -5,7 +5,7 @@ package binding
 
 import (
 	"encoding/json"
-	"fmt"
+	"reflect"
 
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -19,10 +19,9 @@ type gatewayClassConfigSnapshot struct {
 	Generation int64                       `json:"generation"`
 }
 
-var log = ctrl.Log.WithName("serialize-gatewayclassconfig")
+var log = ctrl.Log.WithName("serialize-gatewayclassconfig-standard")
 
 func serializeGatewayClassConfig(gw *gwv1beta1.Gateway, gwcc *v1alpha1.GatewayClassConfig) (*v1alpha1.GatewayClassConfig, bool) {
-	// If the gateway class config is nil, we can't serialize it, so return early.
 	if gwcc == nil {
 		return nil, false
 	}
@@ -30,45 +29,72 @@ func serializeGatewayClassConfig(gw *gwv1beta1.Gateway, gwcc *v1alpha1.GatewayCl
 	if gw.Annotations == nil {
 		gw.Annotations = make(map[string]string)
 	}
-	log = log.WithValues("gatewayClassConfigSerialize", gwcc.Name)
-
-	if annotatedConfig, ok := gw.Annotations[common.AnnotationGatewayClassConfig]; ok {
-
-		var gwccs gatewayClassConfigSnapshot
-		if err := json.Unmarshal([]byte(annotatedConfig), &gwccs); err == nil {
-			log.Info("gatewayClassSnapshot: " + fmt.Sprintf("%+v", gwccs))
-			// if we can unmarshal the gateway, check if the generation matches
-			if gwccs.Generation == gwcc.Generation {
-				// if the generation matches, return the annotated config
-				return &gwccs.Config, false
+	key := common.AnnotationGatewayClassConfig
+	if annotatedConfig, ok := gw.Annotations[key]; ok {
+		var config v1alpha1.GatewayClassConfigSpec
+		if err := json.Unmarshal([]byte(annotatedConfig), &config); err == nil {
+			if reflect.DeepEqual(config, gwcc.Spec) {
+				return gwcc, false
 			}
+
 		}
-
-		// var config v1alpha1.GatewayClassConfig
-		// if err := json.Unmarshal([]byte(annotatedConfig), &config.Spec); err == nil {
-		// 	// if we can unmarshal the gateway, return it
-		// 	return &config, false
-		// }
 	}
 
-	// update the snapshot annotation with the new config and generation.
-	// If we failed to unmarshal or there was no annotation, this will overwrite the annotation with the new config and generation.
-	// If we successfully unmarshaled but the generation was different, this will update the annotation with the new config and generation.
-
-	snapshot := gatewayClassConfigSnapshot{
-		Config:     *gwcc,
-		Generation: gwcc.Generation,
-	}
-	marshaledSnapshot, err := json.Marshal(snapshot)
-	if err != nil {
-		// if we failed to marshal the snapshot, fallback to marshaling the config without the generation
-		marshaled, _ := json.Marshal(gwcc.Spec)
-		gw.Annotations[common.AnnotationGatewayClassConfig] = string(marshaled)
-		log.Info("fallback marshal: " + fmt.Sprintf("%+v", marshaled))
-		return gwcc, false
-	}
-	log.Info("marshaledSnapshot: " + string(marshaledSnapshot))
-	gw.Annotations[common.AnnotationGatewayClassConfig] = string(marshaledSnapshot)
-
+	// otherwise if we failed to unmarshal or there was no annotation, marshal it onto
+	// the gateway
+	marshaled, _ := json.Marshal(gwcc.Spec)
+	gw.Annotations[key] = string(marshaled)
+	log.Info("gwcc to be used for stable: " + string(marshaled) + "and generation: " + string(gwcc.Generation))
 	return gwcc, true
 }
+
+// func serializeGatewayClassConfig(gw *gwv1beta1.Gateway, gwcc *v1alpha1.GatewayClassConfig) (*v1alpha1.GatewayClassConfig, bool) {
+// 	// If the gateway class config is nil, we can't serialize it, so return early.
+// 	if gwcc == nil {
+// 		return nil, false
+// 	}
+
+// 	if gw.Annotations == nil {
+// 		gw.Annotations = make(map[string]string)
+// 	}
+
+// 	if annotatedConfig, ok := gw.Annotations[common.AnnotationGatewayClassConfig]; ok {
+
+// 		var gwccs gatewayClassConfigSnapshot
+// 		if err := json.Unmarshal([]byte(annotatedConfig), &gwccs); err == nil {
+// 			log.Info("gatewayClassSnapshot: " + fmt.Sprintf("%+v", gwccs))
+// 			// if we can unmarshal the gateway, check if the generation matches
+// 			if gwccs.Generation == gwcc.Generation {
+// 				// if the generation matches, return the annotated config
+// 				return &gwccs.Config, false
+// 			}
+// 		}
+
+// 		// var config v1alpha1.GatewayClassConfig
+// 		// if err := json.Unmarshal([]byte(annotatedConfig), &config.Spec); err == nil {
+// 		// 	// if we can unmarshal the gateway, return it
+// 		// 	return &config, false
+// 		// }
+// 	}
+
+// 	// update the snapshot annotation with the new config and generation.
+// 	// If we failed to unmarshal or there was no annotation, this will overwrite the annotation with the new config and generation.
+// 	// If we successfully unmarshaled but the generation was different, this will update the annotation with the new config and generation.
+
+// 	snapshot := gatewayClassConfigSnapshot{
+// 		Config:     *gwcc,
+// 		Generation: gwcc.Generation,
+// 	}
+// 	marshaledSnapshot, err := json.Marshal(snapshot)
+// 	if err != nil {
+// 		// if we failed to marshal the snapshot, fallback to marshaling the config without the generation
+// 		marshaled, _ := json.Marshal(gwcc.Spec)
+// 		gw.Annotations[common.AnnotationGatewayClassConfig] = string(marshaled)
+// 		log.Info("fallback marshal: " + fmt.Sprintf("%+v", marshaled))
+// 		return gwcc, false
+// 	}
+// 	log.Info("marshaledSnapshot: " + string(marshaledSnapshot))
+// 	gw.Annotations[common.AnnotationGatewayClassConfig] = string(marshaledSnapshot)
+
+// 	return gwcc, true
+// }

--- a/control-plane/api-gateway/gatekeeper/gatekeeper.go
+++ b/control-plane/api-gateway/gatekeeper/gatekeeper.go
@@ -22,14 +22,16 @@ type Gatekeeper struct {
 	Log          logr.Logger
 	Client       client.Client
 	ConsulConfig *consul.Config
+	ApiReader    client.Reader
 }
 
 // New creates a new Gatekeeper from the Config.
-func New(log logr.Logger, client client.Client, consulConfig *consul.Config) *Gatekeeper {
+func New(log logr.Logger, client client.Client, consulConfig *consul.Config, apiReader client.Reader) *Gatekeeper {
 	return &Gatekeeper{
 		Log:          log,
 		Client:       client,
 		ConsulConfig: consulConfig,
+		ApiReader:    apiReader,
 	}
 }
 


### PR DESCRIPTION


`in the code: 

1. I have removed the early return on serialise gwcc to continue the reconcile.
Added the new condition for deletion of the gateway to delete the resources.

Working as expected:
Initial State:
min: 1; max: 5; and default instances to 1.
Perform scale out to 5. → it works.
Perform scale out to 8 → it rollbacks to 5 replicas.
Configured State:
min:1, default-2 and max instances to 8.
Now perform scale out or rollout restart:
Step 1:
perform scale out to 8 ---> replicas will be set to 8. (expected)
perform rollout ---> it holds to replicas = 5 (expected)
All instructions will work as expected.`