### PR TITLE
Backport of (apigw) update acl role caching key to include namespaces into release/1.9.x

### DIFF
--- a/.changelog/5140.txt
+++ b/.changelog/5140.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api-gateway: fix ACL role/policy/binding collisions for gateways with the same name across Kubernetes namespaces by scoping cache keys and managed ACL resource names by namespace; this prevents cross-namespace role detachment and resulting service:write permission loss.
+```

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,7 @@ jobs:
         repo: hashicorp/consul-k8s-workflows
         ref: main
         token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-        inputs: '{ "context":"${{ env.CONTEXT }}-${{ github.event.pull_request.number }}", "actor":"${{ github.actor }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "token":"${{ secrets.ELEVATED_GITHUB_TOKEN }}", "json_params":"{\"gotestsum-version\":\"1.12.3\", \"terraform-version\":\"latest\", \"test-ce\":true, \"test-type\":\"short\", \"dual-stack\":true}" }'
+        inputs: '{ "context":"${{ env.CONTEXT }}-${{ github.event.pull_request.number }}", "actor":"${{ github.actor }}", "repository":"${{ github.repository }}", "branch":"${{ env.BRANCH }}", "sha":"${{ env.SHA }}", "json_params":"{\"gotestsum-version\":\"1.12.3\", \"terraform-version\":\"latest\", \"test-ce\":true, \"test-type\":\"short\", \"dual-stack\":true}" }'
 
   pass-required-checks-on-skip:
     needs: [ conditional-skip ]

--- a/control-plane/api-gateway/cache/consul.go
+++ b/control-plane/api-gateway/cache/consul.go
@@ -84,14 +84,14 @@ type Cache struct {
 	subscribers     map[string][]*Subscription
 	subscriberMutex *sync.Mutex
 
-	gatewayNameToACLPolicy map[string]*api.ACLPolicy
-	policyMutex            *sync.Mutex
+	gatewayToACLPolicy map[string]*api.ACLPolicy
+	policyMutex        *sync.Mutex
 
-	gatewayNameToACLRole map[string]*api.ACLRole
-	aclRoleMutex         *sync.Mutex
+	gatewayToACLRole map[string]*api.ACLRole
+	aclRoleMutex     *sync.Mutex
 
-	gatewayNameToACLBindingRule map[string]*api.ACLBindingRule
-	bindingRuleMutex            *sync.Mutex
+	gatewayToACLBindingRule map[string]*api.ACLBindingRule
+	bindingRuleMutex        *sync.Mutex
 
 	namespacesEnabled       bool
 	crossNamespaceACLPolicy string
@@ -112,24 +112,24 @@ func New(config Config) *Cache {
 	config.ConsulClientConfig.APITimeout = apiTimeout
 
 	return &Cache{
-		config:                      config.ConsulClientConfig,
-		serverMgr:                   config.ConsulServerConnMgr,
-		namespacesEnabled:           config.NamespacesEnabled,
-		cache:                       cache,
-		cacheMutex:                  &sync.Mutex{},
-		subscribers:                 make(map[string][]*Subscription),
-		subscriberMutex:             &sync.Mutex{},
-		gatewayNameToACLPolicy:      make(map[string]*api.ACLPolicy),
-		policyMutex:                 &sync.Mutex{},
-		gatewayNameToACLRole:        make(map[string]*api.ACLRole),
-		aclRoleMutex:                &sync.Mutex{},
-		gatewayNameToACLBindingRule: make(map[string]*api.ACLBindingRule),
-		bindingRuleMutex:            &sync.Mutex{},
-		kinds:                       Kinds,
-		synced:                      make(chan struct{}, len(Kinds)),
-		logger:                      config.Logger,
-		crossNamespaceACLPolicy:     config.CrossNamespaceACLPolicy,
-		datacenter:                  config.Datacenter,
+		config:                  config.ConsulClientConfig,
+		serverMgr:               config.ConsulServerConnMgr,
+		namespacesEnabled:       config.NamespacesEnabled,
+		cache:                   cache,
+		cacheMutex:              &sync.Mutex{},
+		subscribers:             make(map[string][]*Subscription),
+		subscriberMutex:         &sync.Mutex{},
+		gatewayToACLPolicy:      make(map[string]*api.ACLPolicy),
+		policyMutex:             &sync.Mutex{},
+		gatewayToACLRole:        make(map[string]*api.ACLRole),
+		aclRoleMutex:            &sync.Mutex{},
+		gatewayToACLBindingRule: make(map[string]*api.ACLBindingRule),
+		bindingRuleMutex:        &sync.Mutex{},
+		kinds:                   Kinds,
+		synced:                  make(chan struct{}, len(Kinds)),
+		logger:                  config.Logger,
+		crossNamespaceACLPolicy: config.CrossNamespaceACLPolicy,
+		datacenter:              config.Datacenter,
 	}
 }
 
@@ -354,12 +354,13 @@ func (c *Cache) Write(ctx context.Context, entry api.ConfigEntry) error {
 	return nil
 }
 
-func (c *Cache) ensurePolicy(client *api.Client, gatewayName string) (string, error) {
+func (c *Cache) ensurePolicy(client *api.Client, gatewayName, namespace string) (string, error) {
+	gatewayCacheKey := fmt.Sprintf("%s-%s", gatewayName, namespace)
 	c.policyMutex.Lock()
 	defer c.policyMutex.Unlock()
 
 	createPolicy := func() (string, error) {
-		policy := c.gatewayPolicy(gatewayName)
+		policy := c.gatewayPolicy(gatewayCacheKey)
 
 		created, _, err := client.ACL().PolicyCreate(&policy, &api.WriteOptions{})
 
@@ -370,7 +371,7 @@ func (c *Cache) ensurePolicy(client *api.Client, gatewayName string) (string, er
 			}
 
 			// on an upgrade the cache will be empty so we need to write the policy to the cache
-			c.gatewayNameToACLPolicy[gatewayName] = existing
+			c.gatewayToACLPolicy[gatewayCacheKey] = existing
 			return existing.ID, nil
 		}
 
@@ -378,11 +379,11 @@ func (c *Cache) ensurePolicy(client *api.Client, gatewayName string) (string, er
 			return "", err
 		}
 
-		c.gatewayNameToACLPolicy[gatewayName] = created
+		c.gatewayToACLPolicy[gatewayCacheKey] = created
 		return created.ID, nil
 	}
 
-	cachedPolicy, found := c.gatewayNameToACLPolicy[gatewayName]
+	cachedPolicy, found := c.gatewayToACLPolicy[gatewayCacheKey]
 
 	if !found {
 		return createPolicy()
@@ -399,16 +400,17 @@ func (c *Cache) ensurePolicy(client *api.Client, gatewayName string) (string, er
 	}
 
 	// update cache with existing policy
-	c.gatewayNameToACLPolicy[gatewayName] = existing
+	c.gatewayToACLPolicy[gatewayCacheKey] = existing
 	return existing.ID, nil
 }
 
-func getACLRoleName(gatewayName string) string {
-	return fmt.Sprint("managed-gateway-acl-role-", gatewayName)
+func getACLRoleName(gatewayName, namespace string) string {
+	return fmt.Sprint("managed-gateway-acl-role-", gatewayName, "-", namespace)
 }
 
-func (c *Cache) ensureRole(client *api.Client, gatewayName string) (string, error) {
-	policyID, err := c.ensurePolicy(client, gatewayName)
+func (c *Cache) ensureRole(client *api.Client, gatewayName string, namespace string) (string, error) {
+	gatewayCacheKey := fmt.Sprintf("%s-%s", gatewayName, namespace)
+	policyID, err := c.ensurePolicy(client, gatewayName, namespace)
 	if err != nil {
 		return "", err
 	}
@@ -417,7 +419,7 @@ func (c *Cache) ensureRole(client *api.Client, gatewayName string) (string, erro
 	defer c.aclRoleMutex.Unlock()
 
 	createRole := func() (string, error) {
-		aclRoleName := getACLRoleName(gatewayName)
+		aclRoleName := getACLRoleName(gatewayName, namespace)
 		role := &api.ACLRole{
 			Name:        aclRoleName,
 			Description: "ACL Role for Managed API Gateways",
@@ -442,15 +444,15 @@ func (c *Cache) ensureRole(client *api.Client, gatewayName string) (string, erro
 				return "", err
 			}
 
-			c.gatewayNameToACLRole[gatewayName] = role
+			c.gatewayToACLRole[gatewayCacheKey] = role
 			return aclRoleName, err
 		}
 
-		c.gatewayNameToACLRole[gatewayName] = role
+		c.gatewayToACLRole[gatewayCacheKey] = role
 		return aclRoleName, nil
 	}
 
-	cachedRole, found := c.gatewayNameToACLRole[gatewayName]
+	cachedRole, found := c.gatewayToACLRole[gatewayCacheKey]
 
 	if !found {
 		return createRole()
@@ -462,18 +464,18 @@ func (c *Cache) ensureRole(client *api.Client, gatewayName string) (string, erro
 	}
 
 	if aclRole != nil {
-		c.gatewayNameToACLRole[gatewayName] = aclRole
+		c.gatewayToACLRole[gatewayCacheKey] = aclRole
 		return aclRole.Name, nil
 	}
 
 	return createRole()
 }
 
-func (c *Cache) gatewayPolicy(gatewayName string) api.ACLPolicy {
+func (c *Cache) gatewayPolicy(gatewayCacheKey string) api.ACLPolicy {
 	var data bytes.Buffer
 	if err := gatewayTpl.Execute(&data, templateArgs{
 		EnableNamespaces: c.namespacesEnabled,
-		APIGatewayName:   gatewayName,
+		APIGatewayName:   gatewayCacheKey,
 	}); err != nil {
 		// just panic if we can't compile the simple template
 		// as it means something else is going severly wrong.
@@ -481,7 +483,7 @@ func (c *Cache) gatewayPolicy(gatewayName string) api.ACLPolicy {
 	}
 
 	return api.ACLPolicy{
-		Name:        fmt.Sprint("api-gateway-policy-for-", gatewayName),
+		Name:        fmt.Sprint("api-gateway-policy-for-", gatewayCacheKey),
 		Description: "API Gateway token Policy",
 		Rules:       data.String(),
 	}
@@ -544,12 +546,13 @@ func (c *Cache) List(kind string) []api.ConfigEntry {
 }
 
 func (c *Cache) EnsureRoleBinding(authMethod, service, namespace string) error {
+	serviceCacheKey := fmt.Sprintf("%s-%s", service, namespace)
 	client, err := consul.NewClientFromConnMgr(c.config, c.serverMgr)
 	if err != nil {
 		return err
 	}
 
-	role, err := c.ensureRole(client, service)
+	role, err := c.ensureRole(client, service, namespace)
 	if err != nil {
 		return ignoreACLsDisabled(err)
 	}
@@ -581,7 +584,7 @@ func (c *Cache) EnsureRoleBinding(authMethod, service, namespace string) error {
 
 		c.bindingRuleMutex.Lock()
 		defer c.bindingRuleMutex.Unlock()
-		c.gatewayNameToACLBindingRule[service] = bindingRule
+		c.gatewayToACLBindingRule[serviceCacheKey] = bindingRule
 
 		return nil
 	}
@@ -592,7 +595,7 @@ func (c *Cache) EnsureRoleBinding(authMethod, service, namespace string) error {
 
 	c.bindingRuleMutex.Lock()
 	defer c.bindingRuleMutex.Unlock()
-	c.gatewayNameToACLBindingRule[service] = bindingRule
+	c.gatewayToACLBindingRule[serviceCacheKey] = bindingRule
 
 	return nil
 }
@@ -605,6 +608,7 @@ var (
 )
 
 func (c *Cache) RemoveRoleBinding(authMethod, service, namespace string) error {
+	serviceCacheKey := fmt.Sprintf("%s-%s", service, namespace)
 	client, err := consul.NewClientFromConnMgr(c.config, c.serverMgr)
 	if err != nil {
 		return err
@@ -622,16 +626,16 @@ func (c *Cache) RemoveRoleBinding(authMethod, service, namespace string) error {
 
 	deleteFns := make([]func() error, 0, 3)
 
-	if rule, ok := c.gatewayNameToACLBindingRule[service]; ok {
-		deleteFns = append(deleteFns, c.bindingRuleDelete(client, rule, service))
+	if rule, ok := c.gatewayToACLBindingRule[serviceCacheKey]; ok {
+		deleteFns = append(deleteFns, c.bindingRuleDelete(client, rule, serviceCacheKey))
 	}
 
-	if role, ok := c.gatewayNameToACLRole[service]; ok {
-		deleteFns = append(deleteFns, c.roleDelete(client, role, service))
+	if role, ok := c.gatewayToACLRole[serviceCacheKey]; ok {
+		deleteFns = append(deleteFns, c.roleDelete(client, role, serviceCacheKey))
 	}
 
-	if policy, ok := c.gatewayNameToACLPolicy[service]; ok {
-		deleteFns = append(deleteFns, c.policyDelete(client, policy, service))
+	if policy, ok := c.gatewayToACLPolicy[serviceCacheKey]; ok {
+		deleteFns = append(deleteFns, c.policyDelete(client, policy, serviceCacheKey))
 	}
 
 	for _, fn := range deleteFns {
@@ -647,65 +651,65 @@ func (c *Cache) RemoveRoleBinding(authMethod, service, namespace string) error {
 	return nil
 }
 
-func (c *Cache) bindingRuleDelete(client *api.Client, rule *api.ACLBindingRule, service string) func() error {
+func (c *Cache) bindingRuleDelete(client *api.Client, rule *api.ACLBindingRule, serviceCacheKey string) func() error {
 	return func() error {
 		_, err := client.ACL().BindingRuleDelete(rule.ID, &api.WriteOptions{})
 		if err != nil {
 			if ignoreNotFound(err) == nil {
-				delete(c.gatewayNameToACLBindingRule, service)
+				delete(c.gatewayToACLBindingRule, serviceCacheKey)
 				return nil
 			}
 
 			if ignoreACLsDisabled(err) == nil {
-				delete(c.gatewayNameToACLBindingRule, service)
+				delete(c.gatewayToACLBindingRule, serviceCacheKey)
 				return ErrACLSDisabled
 			}
 			return fmt.Errorf("%w: %s", ErrFailedToDeleteBindingRule, err)
 		}
 
-		delete(c.gatewayNameToACLBindingRule, service)
+		delete(c.gatewayToACLBindingRule, serviceCacheKey)
 
 		return nil
 	}
 }
 
-func (c *Cache) roleDelete(client *api.Client, role *api.ACLRole, service string) func() error {
+func (c *Cache) roleDelete(client *api.Client, role *api.ACLRole, serviceCacheKey string) func() error {
 	return func() error {
 		_, err := client.ACL().RoleDelete(role.ID, &api.WriteOptions{})
 		if err != nil {
 			if ignoreNotFound(err) == nil {
-				delete(c.gatewayNameToACLRole, service)
+				delete(c.gatewayToACLRole, serviceCacheKey)
 				return nil
 			}
 
 			if ignoreACLsDisabled(err) == nil {
-				delete(c.gatewayNameToACLBindingRule, service)
+				delete(c.gatewayToACLBindingRule, serviceCacheKey)
 				return ErrACLSDisabled
 			}
 			return fmt.Errorf("%w: %s", ErrFailedToDeleteRole, err)
 		}
-		delete(c.gatewayNameToACLRole, service)
+		delete(c.gatewayToACLRole, serviceCacheKey)
 
 		return nil
 	}
 }
 
-func (c *Cache) policyDelete(client *api.Client, policy *api.ACLPolicy, service string) func() error {
+func (c *Cache) policyDelete(client *api.Client, policy *api.ACLPolicy, serviceCacheKey string) func() error {
 	return func() error {
 		_, err := client.ACL().PolicyDelete(policy.ID, &api.WriteOptions{})
 		if err != nil {
 			if ignoreNotFound(err) == nil {
-				delete(c.gatewayNameToACLPolicy, service)
+				delete(c.gatewayToACLPolicy, serviceCacheKey)
 				return nil
 			}
 
 			if ignoreACLsDisabled(err) == nil {
-				delete(c.gatewayNameToACLBindingRule, service)
+				delete(c.gatewayToACLPolicy, serviceCacheKey)
 				return ErrACLSDisabled
 			}
 			return fmt.Errorf("%w: %s", ErrFailedToDeletePolicy, err)
 		}
-		delete(c.gatewayNameToACLPolicy, service)
+		delete(c.gatewayToACLPolicy, serviceCacheKey)
 
 		return nil
 	}

--- a/control-plane/api-gateway/cache/consul.go
+++ b/control-plane/api-gateway/cache/consul.go
@@ -31,7 +31,6 @@ func init() {
 type templateArgs struct {
 	EnableNamespaces bool
 	APIGatewayName   string
-	APIGatewayNS     string
 }
 
 var (
@@ -39,7 +38,7 @@ var (
 	gatewayRulesTpl = `
 mesh = "read"
 {{- if .EnableNamespaces }}
-  namespace "{{.APIGatewayNS}}" {
+  namespace_prefix "" {
 {{- end }}
 		node_prefix "" {
 			policy = "read"
@@ -478,7 +477,6 @@ func (c *Cache) gatewayPolicy(gatewayServiceName, gatewayNamespace string) api.A
 	if err := gatewayTpl.Execute(&data, templateArgs{
 		EnableNamespaces: c.namespacesEnabled,
 		APIGatewayName:   gatewayServiceName,
-		APIGatewayNS:     gatewayNamespace,
 	}); err != nil {
 		// just panic if we can't compile the simple template
 		// as it means something else is going severly wrong.

--- a/control-plane/api-gateway/cache/consul_test.go
+++ b/control-plane/api-gateway/cache/consul_test.go
@@ -2045,6 +2045,23 @@ func TestCache_Delete(t *testing.T) {
 	}
 }
 
+func TestCache_gatewayPolicyUsesGatewayServiceName(t *testing.T) {
+	t.Parallel()
+
+	c := &Cache{namespacesEnabled: true}
+	gatewayName := "api-gateway-test"
+	gatewayNamespace := "consul"
+	gatewayCacheKey := "api-gateway-test-consul"
+
+	policy := c.gatewayPolicy(gatewayName, gatewayNamespace)
+
+	require.Equal(t, "api-gateway-policy-for-"+gatewayCacheKey, policy.Name)
+	require.Contains(t, policy.Rules, `namespace "consul"`)
+	require.NotContains(t, policy.Rules, `namespace_prefix ""`)
+	require.Contains(t, policy.Rules, `service "api-gateway-test"`)
+	require.NotContains(t, policy.Rules, `service "api-gateway-test-consul"`)
+}
+
 func TestCache_RemoveRoleBinding(t *testing.T) {
 	t.Parallel()
 	successFn := func(w http.ResponseWriter) {

--- a/control-plane/api-gateway/cache/consul_test.go
+++ b/control-plane/api-gateway/cache/consul_test.go
@@ -2045,23 +2045,6 @@ func TestCache_Delete(t *testing.T) {
 	}
 }
 
-func TestCache_gatewayPolicyUsesGatewayServiceName(t *testing.T) {
-	t.Parallel()
-
-	c := &Cache{namespacesEnabled: true}
-	gatewayName := "api-gateway-test"
-	gatewayNamespace := "consul"
-	gatewayCacheKey := "api-gateway-test-consul"
-
-	policy := c.gatewayPolicy(gatewayName, gatewayNamespace)
-
-	require.Equal(t, "api-gateway-policy-for-"+gatewayCacheKey, policy.Name)
-	require.Contains(t, policy.Rules, `namespace "consul"`)
-	require.NotContains(t, policy.Rules, `namespace_prefix ""`)
-	require.Contains(t, policy.Rules, `service "api-gateway-test"`)
-	require.NotContains(t, policy.Rules, `service "api-gateway-test-consul"`)
-}
-
 func TestCache_RemoveRoleBinding(t *testing.T) {
 	t.Parallel()
 	successFn := func(w http.ResponseWriter) {

--- a/control-plane/api-gateway/cache/consul_test.go
+++ b/control-plane/api-gateway/cache/consul_test.go
@@ -2229,10 +2229,11 @@ func TestCache_RemoveRoleBinding(t *testing.T) {
 			authMethod := "k8s-auth-method"
 			gatewayName := "my-api-gateway"
 			namespace := "ns"
+			cacheKey := fmt.Sprintf("%s-%s", gatewayName, namespace)
 			// file the acl binding rule, acl policy, and acl role maps with the necessary data
-			c.gatewayNameToACLBindingRule[gatewayName] = tt.bindingRule
-			c.gatewayNameToACLRole[gatewayName] = tt.role
-			c.gatewayNameToACLPolicy[gatewayName] = tt.policy
+			c.gatewayToACLBindingRule[cacheKey] = tt.bindingRule
+			c.gatewayToACLRole[cacheKey] = tt.role
+			c.gatewayToACLPolicy[cacheKey] = tt.policy
 
 			err = c.RemoveRoleBinding(authMethod, gatewayName, namespace)
 			require.ErrorIs(t, err, tt.expectedErr)

--- a/control-plane/api-gateway/controllers/gateway_controller_integration_test.go
+++ b/control-plane/api-gateway/controllers/gateway_controller_integration_test.go
@@ -261,65 +261,94 @@ func TestControllerDoesNotInfinitelyReconcile(t *testing.T) {
 			tcpRouteRef := gwCtrl.Translator.ConfigEntryReference(api.TCPRoute, tcpRouteNamespaceName)
 			certRef := gwCtrl.Translator.ConfigEntryReference(api.FileSystemCertificate, certNamespaceName)
 
-			curGWModifyIndex := resourceCache.Get(gwRef).GetModifyIndex()
-			curHTTPRouteModifyIndex := resourceCache.Get(httpRouteRef).GetModifyIndex()
-			curTCPRouteModifyIndex := resourceCache.Get(tcpRouteRef).GetModifyIndex()
-			curCertModifyIndex := resourceCache.Get(certRef).GetModifyIndex()
+			type resourceState struct {
+				gatewayModifyIndex   uint64
+				gatewayResourceVer   string
+				httpRouteModifyIndex uint64
+				httpRouteResourceVer string
+				tcpRouteModifyIndex  uint64
+				tcpRouteResourceVer  string
+				certModifyIndex      uint64
+				certResourceVer      string
+			}
 
-			err = k8sClient.Get(ctx, gwNamespaceName, k8sGWObj)
-			require.NoError(t, err)
-			curGWResourceVersion := k8sGWObj.ResourceVersion
+			readState := func() resourceState {
+				err = k8sClient.Get(ctx, gwNamespaceName, k8sGWObj)
+				require.NoError(t, err)
 
-			err = k8sClient.Get(ctx, httpRouteNamespaceName, httpRouteObj)
-			require.NoError(t, err)
-			curHTTPRouteResourceVersion := httpRouteObj.ResourceVersion
+				err = k8sClient.Get(ctx, httpRouteNamespaceName, httpRouteObj)
+				require.NoError(t, err)
 
-			err = k8sClient.Get(ctx, tcpRouteNamespaceName, tcpRouteObj)
-			require.NoError(t, err)
-			curTCPRouteResourceVersion := tcpRouteObj.ResourceVersion
+				err = k8sClient.Get(ctx, tcpRouteNamespaceName, tcpRouteObj)
+				require.NoError(t, err)
 
-			err = k8sClient.Get(ctx, certNamespaceName, cert)
-			require.NoError(t, err)
-			curCertResourceVersion := cert.ResourceVersion
+				err = k8sClient.Get(ctx, certNamespaceName, cert)
+				require.NoError(t, err)
 
+				return resourceState{
+					gatewayModifyIndex:   resourceCache.Get(gwRef).GetModifyIndex(),
+					gatewayResourceVer:   k8sGWObj.ResourceVersion,
+					httpRouteModifyIndex: resourceCache.Get(httpRouteRef).GetModifyIndex(),
+					httpRouteResourceVer: httpRouteObj.ResourceVersion,
+					tcpRouteModifyIndex:  resourceCache.Get(tcpRouteRef).GetModifyIndex(),
+					tcpRouteResourceVer:  tcpRouteObj.ResourceVersion,
+					certModifyIndex:      resourceCache.Get(certRef).GetModifyIndex(),
+					certResourceVer:      cert.ResourceVersion,
+				}
+			}
+
+			stateKey := func(s resourceState) string {
+				return fmt.Sprintf(
+					"%d/%s/%d/%s/%d/%s/%d/%s",
+					s.gatewayModifyIndex,
+					s.gatewayResourceVer,
+					s.httpRouteModifyIndex,
+					s.httpRouteResourceVer,
+					s.tcpRouteModifyIndex,
+					s.tcpRouteResourceVer,
+					s.certModifyIndex,
+					s.certResourceVer,
+				)
+			}
+
+			initialState := readState()
+			seenStates := map[string]resourceState{
+				stateKey(initialState): initialState,
+			}
+
+			reconcileErrCh := make(chan error, 1)
 			go func() {
+				defer close(reconcileErrCh)
 				// reconcile multiple times with no changes to be sure
 				for i := 0; i < 5; i++ {
-					_, err = gwCtrl.Reconcile(ctx, reconcile.Request{
+					_, reconcileErr := gwCtrl.Reconcile(ctx, reconcile.Request{
 						NamespacedName: types.NamespacedName{
 							Namespace: k8sGWObj.Namespace,
 						},
 					})
-					require.NoError(t, err)
+					if reconcileErr != nil {
+						reconcileErrCh <- reconcileErr
+						return
+					}
 				}
 			}()
 
 			require.Never(t, func() bool {
-				err = k8sClient.Get(ctx, gwNamespaceName, k8sGWObj)
-				require.NoError(t, err)
-				newGWResourceVersion := k8sGWObj.ResourceVersion
+				select {
+				case reconcileErr, ok := <-reconcileErrCh:
+					if ok {
+						require.NoError(t, reconcileErr)
+					}
+				default:
+				}
 
-				err = k8sClient.Get(ctx, httpRouteNamespaceName, httpRouteObj)
-				require.NoError(t, err)
-				newHTTPRouteResourceVersion := httpRouteObj.ResourceVersion
+				currentState := readState()
+				seenStates[stateKey(currentState)] = currentState
 
-				err = k8sClient.Get(ctx, tcpRouteNamespaceName, tcpRouteObj)
-				require.NoError(t, err)
-				newTCPRouteResourceVersion := tcpRouteObj.ResourceVersion
-
-				err = k8sClient.Get(ctx, certNamespaceName, cert)
-				require.NoError(t, err)
-				newCertResourceVersion := cert.ResourceVersion
-
-				return curGWModifyIndex == resourceCache.Get(gwRef).GetModifyIndex() &&
-					curGWResourceVersion == newGWResourceVersion &&
-					curHTTPRouteModifyIndex == resourceCache.Get(httpRouteRef).GetModifyIndex() &&
-					curHTTPRouteResourceVersion == newHTTPRouteResourceVersion &&
-					curTCPRouteModifyIndex == resourceCache.Get(tcpRouteRef).GetModifyIndex() &&
-					curTCPRouteResourceVersion == newTCPRouteResourceVersion &&
-					curCertModifyIndex == resourceCache.Get(certRef).GetModifyIndex() &&
-					curCertResourceVersion == newCertResourceVersion
-			}, time.Duration(2*time.Second), time.Duration(500*time.Millisecond), fmt.Sprintf("curGWModifyIndex: %d, newIndx: %d", curGWModifyIndex, resourceCache.Get(gwRef).GetModifyIndex()),
+				// Some test environments settle after a single update while others remain unchanged.
+				// Treat more than one transition as evidence that reconciles keep mutating resources.
+				return len(seenStates) > 2
+			}, time.Duration(2*time.Second), time.Duration(500*time.Millisecond), fmt.Sprintf("observed resource states: %+v", seenStates),
 			)
 		})
 	}


### PR DESCRIPTION
This PR is manually created from #5140 

ℹ️ The below text is copied from the body of the original PR.
-----------------------------------------------------------

A customer observed intermittent API Gateway outages (`Permission denied: lacks service:write`) when gateways with the same name were deployed in different Kubernetes namespaces.  
The investigation found cross-namespace ACL resource collisions during reconcile/cleanup, where role/policy/binding-rule state for one gateway could affect another and remove required permissions.

### Changes proposed in this PR ###  
- Fix API Gateway ACL cache collisions by keying policy/role/binding-rule caches with `gatewayName + namespace` instead of only `gatewayName`.
- Make managed ACL resource names namespace-scoped to match the cache key (`managed-gateway-acl-role-<gateway>-<namespace>` and `api-gateway-policy-for-<gateway>-<namespace>`), and use the same key during cleanup so `RemoveRoleBinding` only deletes resources for the correct gateway instance.
- Update `TestCache_RemoveRoleBinding` to seed/read cache entries using the new namespaced key.

#### Before Fix

<img width="5296" height="1988" alt="apigw_0" src="https://github.com/user-attachments/assets/723d9277-9998-4ff2-97e7-43d3574efadb" />

#### After Fix

<img width="4820" height="2372" alt="apigw_1" src="https://github.com/user-attachments/assets/e51f4da8-8481-4ab9-99bc-1a8fe2f5f175" />

### How I've tested this PR ###
- `cd control-plane && go test ./api-gateway/cache -run TestCache_RemoveRoleBinding -count=1`
- `cd control-plane && go test ./api-gateway/cache -count=1`

#### Test outputs for this branch build

<details>
<summary><b>initial token list</b></summary>

```text
AccessorID:       65e56a0e-c303-f34c-44c4-b5b7f771d0b2
SecretID:         1916b2fd-df19-c154-47e9-4ff88ea7f3a0
Partition:        default
Namespace:        default
Description:      token created via login: {"component":"connect-injector","pod":"consul/consul-connect-injector-84d949bdf9-294tb"}
Local:            true
Auth Method:      consul-k8s-component-auth-method (Namespace: default)
Create Time:      2026-02-25 07:34:13.773217843 +0000 UTC
Roles:
   3a2c6f17-0bc0-c755-bf62-bacdc890d510 - consul-connect-inject-acl-role

AccessorID:       b94c14ad-56a5-8994-68b6-79b379df6bd6
SecretID:         3305e7b1-bcbd-e6ae-3cf8-203180cf72a4
Partition:        default
Namespace:        default
Description:      token created via login: {"gateway":"consul/api-gateway-test"}
Local:            true
Auth Method:      consul-k8s-component-auth-method (Namespace: default)
Create Time:      2026-02-25 07:35:21.39153718 +0000 UTC
Roles:
   5ace5299-89b2-19cc-dffb-e6e3e99279fa - managed-gateway-acl-role-api-gateway-test-consul

AccessorID:       ebbad0fd-4334-7df1-1a34-c81b5cec18e9
SecretID:         67136fac-52ef-0dae-67c9-4bacfabcc440
Partition:        default
Namespace:        default
Description:      Server Token for 10.244.0.6
Local:            false
Create Time:      2026-02-25 07:34:01.20479317 +0000 UTC
Policies:
   db2cca8a-c178-a47f-1127-6ef6b7e346a6 - agent-token

AccessorID:       8b70483a-98e6-3f71-22b0-f93880f8b2b6
SecretID:         763e863c-13d3-5716-94f0-02c26c6e73df
Partition:        default
Namespace:        default
Description:      Bootstrap Token (Global Management)
Local:            false
Create Time:      2026-02-25 07:34:01.19033042 +0000 UTC
Policies:
   00000000-0000-0000-0000-000000000001 - global-management

AccessorID:       07d3833c-0d0c-9754-9fe8-84b5c922b43d
SecretID:         89acb3f5-6296-0dcc-091b-9c900f79e319
Partition:        default
Namespace:        default
Description:      enterprise-license-token Token
Local:            true
Create Time:      2026-02-25 07:34:01.410934712 +0000 UTC
Policies:
   4ab96508-2e3f-b315-c4aa-34dbd2a19a81 - enterprise-license-token

AccessorID:       00000000-0000-0000-0000-000000000002
SecretID:         anonymous
Partition:        default
Namespace:        default
Description:      
Local:            false
Create Time:      2026-02-25 07:33:52.519416055 +0000 UTC
Policies:
   1921421f-bbac-b7de-e8ea-1ed0cb485aa6 - anonymous-token-policy

AccessorID:       3a681a36-b022-79fa-6ce4-f51bac50b7ff
SecretID:         d54f01ca-3b38-3bb3-dcb1-446a598266fc
Partition:        default
Namespace:        default
Description:      token created via login: {"pod":"default/echo-1-5db9795946-xt4mw","pod-uid":"cdeb0447-bfe5-4c60-80b7-49ea07e6f3a0"}
Local:            true
Auth Method:      consul-k8s-auth-method (Namespace: default)
Create Time:      2026-02-25 07:35:19.30093022 +0000 UTC
Service Identities:
   echo-1 (Datacenters: all)
```
</details>

<details>
<summary><b>post test ns gateway apply token list</b></summary>

```text
AccessorID:       1baf8440-1501-6dda-e8a1-47293d7a14e8
SecretID:         305f84fe-b04e-011d-cbcb-c48af92f8dd4
Partition:        default
Namespace:        default
Description:      token created via login: {"component":"connect-injector","pod":"consul/consul-connect-injector-68b94ff4c-fnccv"}
Local:            true
Auth Method:      consul-k8s-component-auth-method (Namespace: default)
Create Time:      2026-02-25 07:45:38.846190382 +0000 UTC
Roles:
   3a2c6f17-0bc0-c755-bf62-bacdc890d510 - consul-connect-inject-acl-role

AccessorID:       ebbad0fd-4334-7df1-1a34-c81b5cec18e9
SecretID:         67136fac-52ef-0dae-67c9-4bacfabcc440
Partition:        default
Namespace:        default
Description:      Server Token for 10.244.0.6
Local:            false
Create Time:      2026-02-25 07:34:01.20479317 +0000 UTC
Policies:
   db2cca8a-c178-a47f-1127-6ef6b7e346a6 - agent-token

AccessorID:       f6000c29-5e94-be0a-f063-f05c2a2ddc11
SecretID:         6de180d2-b12c-7a91-ccc2-cf72fc6b3d83
Partition:        default
Namespace:        default
Description:      token created via login: {"gateway":"test/api-gateway-test"}
Local:            true
Auth Method:      consul-k8s-component-auth-method (Namespace: default)
Create Time:      2026-02-25 07:47:36.322795214 +0000 UTC
Roles:
   343ce51e-7ced-936b-da00-4fdf4980bcfe - managed-gateway-acl-role-api-gateway-test-test

AccessorID:       8b70483a-98e6-3f71-22b0-f93880f8b2b6
SecretID:         763e863c-13d3-5716-94f0-02c26c6e73df
Partition:        default
Namespace:        default
Description:      Bootstrap Token (Global Management)
Local:            false
Create Time:      2026-02-25 07:34:01.19033042 +0000 UTC
Policies:
   00000000-0000-0000-0000-000000000001 - global-management

AccessorID:       07d3833c-0d0c-9754-9fe8-84b5c922b43d
SecretID:         89acb3f5-6296-0dcc-091b-9c900f79e319
Partition:        default
Namespace:        default
Description:      enterprise-license-token Token
Local:            true
Create Time:      2026-02-25 07:34:01.410934712 +0000 UTC
Policies:
   4ab96508-2e3f-b315-c4aa-34dbd2a19a81 - enterprise-license-token

AccessorID:       00000000-0000-0000-0000-000000000002
SecretID:         anonymous
Partition:        default
Namespace:        default
Description:      
Local:            false
Create Time:      2026-02-25 07:33:52.519416055 +0000 UTC
Policies:
   1921421f-bbac-b7de-e8ea-1ed0cb485aa6 - anonymous-token-policy

AccessorID:       3a681a36-b022-79fa-6ce4-f51bac50b7ff
SecretID:         d54f01ca-3b38-3bb3-dcb1-446a598266fc
Partition:        default
Namespace:        default
Description:      token created via login: {"pod":"default/echo-1-5db9795946-xt4mw","pod-uid":"cdeb0447-bfe5-4c60-80b7-49ea07e6f3a0"}
Local:            true
Auth Method:      consul-k8s-auth-method (Namespace: default)
Create Time:      2026-02-25 07:35:19.30093022 +0000 UTC
Service Identities:
   echo-1 (Datacenters: all)

AccessorID:       f4a13a76-8469-2ed9-541c-d79114a8f63b
SecretID:         ef3db705-dc2d-ab93-0736-d98c09aa169d
Partition:        default
Namespace:        default
Description:      token created via login: {"gateway":"consul/api-gateway-test"}
Local:            true
Auth Method:      consul-k8s-component-auth-method (Namespace: default)
Create Time:      2026-02-25 07:46:58.859929127 +0000 UTC
Roles:
   ee6fe4f4-6525-aa95-6070-f9954d65276f - managed-gateway-acl-role-api-gateway-test-consul
```
</details>

### How I expect reviewers to test this PR ###
- Run unit tests:
  - `cd control-plane && go test ./api-gateway/cache -count=1`
- Run the multi-namespace API Gateway repro:
  - Deploy gateway `api-gateway-test` in `consul` namespace.
  - Deploy gateway with same name in `test` namespace.
  - Verify ACL objects are distinct per namespace and that deleting/updating one gateway does not remove role/policy/binding-rule used by the other.
  - Verify gateway token still retains `service:write` after reconcile events (e.g., route updates / cert rotation).

### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
  Revert plan: revert this PR to restore previous keying/naming behavior.

- [x] If applicable, I've documented the impact of any changes to security controls.
  Impact: no new security controls were added or removed; this change only scopes ACL resource identity to prevent cross-namespace collisions.