### PR TITLE
Fix path based cve suppression

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -29,6 +29,8 @@ container {
         "ALPINE-CVE-2026-22184",
         "CVE-2026-27171",
         "GHSA-p77j-4mvh-x3m3", // vulnerability in go-discover
+        ]  
+      paths = [ 
         // The OSV scanner will trip on several packages that are included in the
         // the UBI images. This is due to RHEL using the same base version in the
         // package name for the life of the distro regardless of whether or not

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -27,6 +27,8 @@ container {
       vulnerabilites = [
         "ALPINE-CVE-2026-27171",
         "ALPINE-CVE-2026-22184",
+        "CVE-2026-27171",
+        "GHSA-p77j-4mvh-x3m3", // vulnerability in go-discover
         // The OSV scanner will trip on several packages that are included in the
         // the UBI images. This is due to RHEL using the same base version in the
         // package name for the life of the distro regardless of whether or not

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -28,7 +28,9 @@ container {
         "ALPINE-CVE-2026-27171",
         "ALPINE-CVE-2026-22184",
         "CVE-2026-27171",
-        "GHSA-p77j-4mvh-x3m3", // vulnerability in go-discover
+        // vulnerability in go-discover
+        "GHSA-p77j-4mvh-x3m3",
+        "GO-2026-4762",
       ]  
       paths = [ 
         // The OSV scanner will trip on several packages that are included in the


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Suppressing go-discover CVE which will be fixed once grpc version is updated to latest in go-discover.