### PR TITLE
Assign name to CSI driver role, so that cleanup script be able to clean stale roles properly

### DIFF
--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -126,6 +126,7 @@ provider "kubernetes" {
 
 resource "aws_iam_role" "csi-driver-role" {
   count = var.cluster_count
+  name  = "consul-k8s-csi-role-${random_id.suffix[count.index].dec}"
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [


### PR DESCRIPTION
**Issue:**
Previously, when creating the AWS EBS CSI driver IAM role, we didn't specify a name for it. Because of this, Terraform autogenerated the role name, which starts with the default `terraform-` prefix.
Our [manual cleanup script](https://github.com/hashicorp/consul-k8s/blob/28d34a70883ec0a232b03d4df118fa34f7938a99/hack/aws-acceptance-test-cleanup/main.go#L769) filters out and deletes stale resources based on the `consul-k8s-` prefix. Since the CSI driver role was created without this prefix, it was not being filtered and remained orphaned if terraform destroy failed.

```
func cleanupIAMRoles(ctx context.Context, iamClient *iam.IAM) error {
	var rolesToDelete []*iam.Role
	rolesToDelete, err := filterIAMRolesWithPrefix(ctx, iamClient, "consul-k8s-")
```

<img width="2250" height="1071" alt="image" src="https://github.com/user-attachments/assets/834a70fa-70ed-410c-9afd-6426d7d76f00" />



#
**Fix:**
To ensure the [cleanup script](https://github.com/hashicorp/consul-k8s/blob/28d34a70883ec0a232b03d4df118fa34f7938a99/hack/aws-acceptance-test-cleanup/main.go#L769) detects this role if a test fails to tear down cleanly, I modified `main.tf` to explicitly set the role's name. It now uses the `consul-k8s-csi-role-` prefix appended with the random cluster suffix (matching our other resources).
Because it now has the `consul-k8s-` prefix, the existing `main.go` cleanup logic will automatically filter it and delete it.

**Test**
Tested it on my personal AWS sandbox account.
Results:
Existing role name:
<img width="1972" height="721" alt="image" src="https://github.com/user-attachments/assets/55e949ab-6f4c-4420-b8a1-7f81c91bf8a4" />
Post fix role name: 
<img width="2014" height="698" alt="image" src="https://github.com/user-attachments/assets/61d4c158-1659-4235-aba9-126fcf553c35" />
