### PR TITLE
sync-catalog: add missing health checks to NodePort service registrations

### DIFF
--- a/.changelog/5217.txt
+++ b/.changelog/5217.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sync-catalog: Add missing health checks to NodePort service registrations to match ClusterIP behavior from #3874
+```

--- a/control-plane/catalog/to-consul/resource.go
+++ b/control-plane/catalog/to-consul/resource.go
@@ -683,6 +683,20 @@ func (t *ServiceResource) generateRegistrations(key string) {
 							r.Service.ID = serviceID(r.Service.Service, endpointAddr)
 							r.Service.Address = address.Address
 							r.Service.Meta = updateServiceMeta(baseService.Meta, endpoint)
+							r.Check = &consulapi.AgentCheck{
+								CheckID:   consulHealthCheckID(endpointSlice.Namespace, serviceID(r.Service.Service, endpointAddr)),
+								Name:      consulKubernetesCheckName,
+								Namespace: baseService.Namespace,
+								Type:      consulKubernetesCheckType,
+								ServiceID: serviceID(r.Service.Service, endpointAddr),
+							}
+							if endpoint.Conditions.Ready != nil && *endpoint.Conditions.Ready {
+								r.Check.Status = consulapi.HealthPassing
+								r.Check.Output = kubernetesSuccessReasonMsg
+							} else {
+								r.Check.Status = consulapi.HealthCritical
+								r.Check.Output = kubernetesFailureReasonMsg
+							}
 							t.consulMap[key] = append(t.consulMap[key], &r)
 							// Only consider the first address that matches. In some cases
 							// there will be multiple addresses like when using AWS CNI.
@@ -704,6 +718,20 @@ func (t *ServiceResource) generateRegistrations(key string) {
 								r.Service.ID = serviceID(r.Service.Service, endpointAddr)
 								r.Service.Address = address.Address
 								r.Service.Meta = updateServiceMeta(baseService.Meta, endpoint)
+								r.Check = &consulapi.AgentCheck{
+									CheckID:   consulHealthCheckID(endpointSlice.Namespace, serviceID(r.Service.Service, endpointAddr)),
+									Name:      consulKubernetesCheckName,
+									Namespace: baseService.Namespace,
+									Type:      consulKubernetesCheckType,
+									ServiceID: serviceID(r.Service.Service, endpointAddr),
+								}
+								if endpoint.Conditions.Ready != nil && *endpoint.Conditions.Ready {
+									r.Check.Status = consulapi.HealthPassing
+									r.Check.Output = kubernetesSuccessReasonMsg
+								} else {
+									r.Check.Status = consulapi.HealthCritical
+									r.Check.Output = kubernetesFailureReasonMsg
+								}
 								t.consulMap[key] = append(t.consulMap[key], &r)
 								// Only consider the first address that matches. In some cases
 								// there will be multiple addresses like when using AWS CNI.

--- a/control-plane/catalog/to-consul/resource_test.go
+++ b/control-plane/catalog/to-consul/resource_test.go
@@ -1340,6 +1340,52 @@ func TestServiceResource_nodePort_externalFirstSync(t *testing.T) {
 	})
 }
 
+// Test that the proper registrations with health checks are generated for a NodePort type.
+func TestServiceResource_nodePort_healthCheck(t *testing.T) {
+	t.Parallel()
+	client := fake.NewSimpleClientset()
+	syncer := newTestSyncer()
+	serviceResource := defaultServiceResource(client, syncer)
+	serviceResource.NodePortSync = ExternalOnly
+
+	// Start the controller
+	closer := controller.TestControllerRun(&serviceResource)
+	defer closer()
+
+	createNodes(t, client)
+
+	// Insert the endpoint slice
+	createEndpointSlice(t, client, "foo", metav1.NamespaceDefault)
+
+	// Insert the service
+	svc := nodePortService("foo", metav1.NamespaceDefault)
+	_, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(context.Background(), svc, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Verify what we got
+	retry.Run(t, func(r *retry.R) {
+		syncer.Lock()
+		defer syncer.Unlock()
+		actual := syncer.Registrations
+		require.Len(r, actual, 3)
+		// Ready=true
+		require.Equal(r, consulKubernetesCheckName, actual[0].Check.Name)
+		require.Equal(r, consulapi.HealthPassing, actual[0].Check.Status)
+		require.Equal(r, kubernetesSuccessReasonMsg, actual[0].Check.Output)
+		require.Equal(r, consulKubernetesCheckType, actual[0].Check.Type)
+		// Ready=nil (unknown, treated as not ready)
+		require.Equal(r, consulKubernetesCheckName, actual[1].Check.Name)
+		require.Equal(r, consulapi.HealthCritical, actual[1].Check.Status)
+		require.Equal(r, kubernetesFailureReasonMsg, actual[1].Check.Output)
+		require.Equal(r, consulKubernetesCheckType, actual[1].Check.Type)
+		// Ready=false
+		require.Equal(r, consulKubernetesCheckName, actual[2].Check.Name)
+		require.Equal(r, consulapi.HealthCritical, actual[2].Check.Status)
+		require.Equal(r, kubernetesFailureReasonMsg, actual[2].Check.Output)
+		require.Equal(r, consulKubernetesCheckType, actual[2].Check.Type)
+	})
+}
+
 // Test that the proper registrations are generated for a ClusterIP type.
 func TestServiceResource_clusterIP(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Add Consul health checks to NodePort service registrations in `generateRegistrations()`
- Add `TestServiceResource_nodePort_healthCheck`

PR #3874 added endpoint health state to Consul health checks for services
synced via `registerServiceInstance()` (ClusterIP). The NodePort code path
in `generateRegistrations()` was not updated — NodePort services get
registered without any health check while ClusterIP services correctly
reflect endpoint readiness.

This was noted during the #3874 review:
> "For NodePort services which doesn't use registerServiceInstance, I'm
> thinking we'd have to manually add a check here and line 679."
> — @ndhanushkodi https://github.com/hashicorp/consul-k8s/pull/3874#issuecomment-1591831942

The fix adds the same `AgentCheck` with `endpoint.Conditions.Ready` logic
to both NodePort registration paths (ExternalIP and InternalIP fallback).

### How I've tested this PR ###
- Added `TestServiceResource_nodePort_healthCheck` covering Ready=true,
  Ready=nil, and Ready=false
- All existing tests pass without modification

### How I expect reviewers to test this PR ###
1. Deploy a NodePort service with `consul.hashicorp.com/service-sync: "true"` 
   and a readinessProbe
2. Check the Consul UI — a "Kubernetes Readiness Check" should appear
3. Scale down or delete a pod and confirm the check goes critical
4. Compare with a ClusterIP service — behavior should be identical

### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.
