### PR TITLE
[release/1.9.x] build: bump go-discover commit in control-plane Dockerfile

### DIFF
--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -18,7 +18,7 @@
 # either).
 ARG GOLANG_VERSION
 FROM golang:${GOLANG_VERSION}-alpine3.23 AS go-discover
-RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@c9daf450621856f81604e3495af612b95db907d5
+RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@fe618ff0bb1c6adbcdff76bdfd9e850ee0193c47
 
 # dev copies the binary from a local build
 # -----------------------------------


### PR DESCRIPTION
## Summary
- backport #5215 to release/1.9.x
- bump go-discover in control-plane Dockerfile from c9daf450621856f81604e3495af612b95db907d5 to fe618ff0bb1c6adbcdff76bdfd9e850ee0193c47

## Testing
- not run; Dockerfile dependency pin update only
