### PR TITLE
fix: correct FIPS Consul version check in connect-init (CSL-13179) [backport 1.7.x]

### DIFF
--- a/.changelog/_5252.txt
+++ b/.changelog/_5252.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect-init: fix incorrect FIPS Consul version check that caused misleading WARN messages in the `consul-connect-inject-init` init container logs even when a fully FIPS-compliant setup was used.
+```

--- a/control-plane/subcommand/connect-init/command.go
+++ b/control-plane/subcommand/connect-init/command.go
@@ -164,13 +164,13 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 	if version.IsFIPS() {
-		// make sure we are also using FIPS Consul
-		var versionInfo map[string]interface{}
-		_, err := consulClient.Raw().Query("/v1/agent/version", versionInfo, nil)
-		if err != nil {
+		// Verify the Consul server is also a FIPS build. The consul-server-connection-manager
+		// already fetches supported dataplane features during initialization and stores them
+		// in state.DataplaneFeatures, so we read from there directly instead of making an
+		// additional gRPC call.
+		if state.DataplaneFeatures == nil {
 			c.logger.Warn("This is a FIPS build of consul-k8s, which should be used with FIPS Consul. Unable to verify FIPS Consul while setting up Consul API client.")
-		}
-		if val, ok := versionInfo["FIPS"]; !ok || val == "" {
+		} else if !state.DataplaneFeatures["DATAPLANE_FEATURES_FIPS"] {
 			c.logger.Warn("This is a FIPS build of consul-k8s, which should be used with FIPS Consul. A non-FIPS version of Consul was detected.")
 		}
 	}


### PR DESCRIPTION
## Summary

Backport of #5252 → `release/1.7.x` (consul-k8s 1.7.x, includes 1.7.6-fips1402 — original reporter's version).

**Jira:** CSL-13179

## What was broken

The FIPS check in `connect-init/command.go` had three bugs causing both WARN messages to fire unconditionally on every pod startup:
1. Called `/v1/agent/version` — endpoint does not exist in Consul (404)
2. `var versionInfo map[string]interface{}` is nil/passed by value — response never populated
3. No `else` guard — 'non-FIPS detected' warning fired even when the API call failed

## Fix

Read `state.DataplaneFeatures["DATAPLANE_FEATURES_FIPS"]` — already populated by `consul-server-connection-manager v0.1.12` (used on this branch) during watcher initialization with ACL token auto-injected via the watcher's gRPC unary interceptor. Zero extra network calls.

## Files Changed
- `control-plane/subcommand/connect-init/command.go`
- `.changelog/_5252.txt`