### PR TITLE
Setup New long lived branch for 2.0

### DIFF
--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: consul
-version: 1.10.0-dev
-appVersion: 1.23-dev
+version: 2.0.0-dev
+appVersion: 2.0-dev
 kubeVersion: ">=1.22.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
@@ -16,11 +16,11 @@ annotations:
   artifacthub.io/prerelease: true
   artifacthub.io/images: |
     - name: consul
-      image: docker.mirror.hashicorp.services/hashicorppreview/consul:1.23-dev
+      image: docker.mirror.hashicorp.services/hashicorppreview/consul:2.0-dev
     - name: consul-k8s-control-plane
-      image: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.10-dev
+      image: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:2.0-dev
     - name: consul-dataplane
-      image: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.10-dev
+      image: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:2.0-dev
     - name: envoy
       image: envoyproxy/envoy:v1.25.11
   artifacthub.io/license: MPL-2.0

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -67,7 +67,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.10.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: docker.mirror.hashicorp.services/hashicorppreview/consul:1.23.0-dev
+  image: docker.mirror.hashicorp.services/hashicorppreview/consul:2.0-dev
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.
@@ -87,7 +87,7 @@ global:
   # image that is used for functionality such as catalog sync.
   # This can be overridden per component.
   # @default: hashicorp/consul-k8s-control-plane:<latest version>
-  imageK8S: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.10.0-dev
+  imageK8S: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:2.0-dev
 
   # The image pull policy used globally for images controlled by Consul (consul, consul-dataplane, consul-k8s, consul-telemetry-collector).
   # One of "IfNotPresent", "Always", "Never", and "". Refer to https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
@@ -794,7 +794,7 @@ global:
   # The name (and tag) of the consul-dataplane Docker image used for the
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
   # @default: hashicorp/consul-dataplane:<latest supported version>
-  imageConsulDataplane: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.10.0-dev
+  imageConsulDataplane: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:2.0-dev
 
   # Disable this once the manifests are generated and subsequent helm upgrades
   

--- a/version/version.go
+++ b/version/version.go
@@ -17,7 +17,7 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
-	Version = "1.10.0"
+	Version = "2.0.0"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
Setup New long lived branch for 2.0

Preparing the new long-lived branch [as per release docs](https://github.com/hashicorp/engineering-docs/blob/main/consul/consul-k8s/release-process.md#prepare-long-lived-release-branch-x-for-future-development)
```

make prepare-release-dev \
  CONSUL_K8S_RELEASE_VERSION=1.9.7 \
  CONSUL_K8S_RELEASE_DATE="April 30, 2026" \
  CONSUL_K8S_NEXT_RELEASE_VERSION=2.0.0 \
  CONSUL_K8S_CONSUL_VERSION=2.0.0 \
  CONSUL_K8S_CONSUL_DATAPLANE_VERSION=2.0.0
```