### PR TITLE
security: upgrade Jinja2 3.1.2 -> 3.1.6 to fix GHSA-h5c8-rqwp-cp95 (CVE-2024-22195)

### DIFF
--- a/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
+++ b/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
@@ -1,6 +1,6 @@
 Click==8.1.3
 htmlmin==0.1.12
-Jinja2==3.1.2
+Jinja2==3.1.6
 jsmin==3.0.1
 livereload==2.6.3
 # mkdocs 2.4.1 requires Markdown < 3.4.0


### PR DESCRIPTION
## Summary

Upgrades `Jinja2` from `3.1.2` to `3.1.6` in `control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt` to resolve a known security vulnerability.


## Fix

```diff
-Jinja2==3.1.2
+Jinja2==3.1.6
```

- Patched version: `3.1.3` (see [upstream fix](https://github.com/pallets/jinja/commit/716795349a41d4983a9a4771f7d883c96ea17be7))
- Upgraded to `3.1.6` (latest stable) to include all subsequent patches
- `MarkupSafe==2.1.2` is compatible and unaffected

