### PR TITLE
security: upgrade pymdown-extensions 9.11 -> 10.0 to fix GHSA-jh85-wwv9-24hv (CVE-2023-32309)

### DIFF
--- a/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
+++ b/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
@@ -16,7 +16,7 @@ mkdocs-redirects==1.2.0
 mkdocs-mermaid2-plugin==0.6.0
 pep562==1.1
 Pygments==2.15.1
-pymdown-extensions==9.11
+pymdown-extensions==10.0
 PyYAML==6.0
 six==1.16.0
 tornado==6.3.2


### PR DESCRIPTION
## Summary

Upgrades `pymdown-extensions` from `9.11` to `10.0` in `control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt` to resolve a known high-severity security vulnerability.


## Fix


-pymdown-extensions==9.11
+pymdown-extensions==10.0


- Patched version: `10.0` (see [upstream fix](https://github.com/facelessuser/pymdown-extensions/commit/b7bb4878d6017c03c8dc97c42d8d3bb6ee81db9d))
- `mkdocs-material==9.1.12` declares `pymdown-extensions>=9.9.1` with no upper bound — fully compatible with `10.0`

