### PR TITLE
[release/2.0.x] security: upgrade Jinja2 3.1.2 -> 3.1.6 to fix GHSA-h5c8-rqwp-cp95

### DIFF
--- a/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
+++ b/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
@@ -1,6 +1,6 @@
 Click==8.1.3
 htmlmin==0.1.12
-Jinja2==3.1.2
+Jinja2==3.1.6
 jsmin==3.0.1
 livereload==2.6.3
 # mkdocs 2.4.1 requires Markdown < 3.4.0


### PR DESCRIPTION
## Summary

Backports #5285 to release/2.0.x.

This updates Jinja2 from 3.1.2 to 3.1.6 in control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt to address GHSA-h5c8-rqwp-cp95 / CVE-2024-22195.

## Why only 2.0.x

This change is applicable to release/2.0.x because that branch contains the affected gateway07 requirements file and still pins Jinja2==3.1.2.

It is not applicable to release/1.8.x or release/1.9.x because those branches do not contain control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt and do not have an equivalent Jinja2 pin under control-plane to update.

## Testing

No code logic changes. This backport only updates the pinned Python dependency version in the gateway07 docs requirements file.