### PR TITLE
[release/2.0.x] security: upgrade pymdown-extensions 9.11 -> 10.0 to fix GHSA-jh85-wwv9-24hv

### DIFF
--- a/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
+++ b/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
@@ -16,7 +16,7 @@ mkdocs-redirects==1.2.0
 mkdocs-mermaid2-plugin==0.6.0
 pep562==1.1
 Pygments==2.15.1
-pymdown-extensions==9.11
+pymdown-extensions==10.0
 PyYAML==6.0
 six==1.16.0
 tornado==6.3.2


### PR DESCRIPTION
Backports #5291 to release/2.0.x.

Upgrades pymdown-extensions from 9.11 to 10.0 in control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt to address GHSA-jh85-wwv9-24hv / CVE-2023-32309.

## Why only 2.0.x

This change is applicable to release/2.0.x because that branch contains the affected gateway07 requirements file and still pins pymdown-extensions==9.11.

It is not applicable to release/1.8.x or release/1.9.x because those branches do not contain control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt and have no equivalent pymdown-extensions pin under control-plane to update.

## Testing

No code logic changes. This backport only updates the pinned Python dependency version in the gateway07 docs requirements file.