### PR TITLE
security: upgrade tornado 6.3.2 -> 6.5.5 to fix GHSA-fqwm-6jpj-5wxc (CVE-2026-35536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ SECURITY:
 
 * security: update go to 1.26 [[GH-5269](https://github.com/hashicorp/consul-k8s/issues/5269)]
 * security: update google.golang.org/grpc to fix CVE-2026-33186 [[GH-5183](https://github.com/hashicorp/consul-k8s/issues/5183)]
+* security: upgrade tornado 6.3.2 -> 6.5.5 to fix GHSA-fqwm-6jpj-5wxc (CVE-2026-35536): cookie attribute injection via `.RequestHandler.set_cookie` [[GH-5297](https://github.com/hashicorp/consul-k8s/pull/5297)]
 
 FEATURES:
 

--- a/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
+++ b/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
@@ -19,4 +19,4 @@ Pygments==2.15.1
 pymdown-extensions==10.0
 PyYAML==6.0
 six==1.16.0
-tornado==6.3.2
+tornado==6.5.5


### PR DESCRIPTION
## Summary

Upgrades `tornado` from `6.3.2` to `6.5.5` in `control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt` to resolve a known security vulnerability.

## Vulnerability Details

| Field | Detail |
|-------|--------|
| **Advisory** | [GHSA-fqwm-6jpj-5wxc](https://github.com/advisories/GHSA-fqwm-6jpj-5wxc) |
| **CVE** | CVE-2026-35536 |
| **CWE** | CWE-159 (Improper Handling of Inputs) |

**Description:** In Tornado before 6.5.5, cookie attribute injection could occur because the `domain`, `path`, and `samesite` arguments to `.RequestHandler.set_cookie` were not checked for crafted characters. An attacker could potentially inject arbitrary cookie attributes via these unsanitized inputs.

## Fix

```diff
-tornado==6.3.2
+tornado==6.5.5
```

- Patched version: `6.5.5` (see [upstream release](https://github.com/tornadoweb/tornado/releases/tag/v6.5.5))
- Upgraded to `6.5.5` (minimum patched version) to resolve the vulnerability

## Testing

No code logic changes — this is a dependency version bump only. The `requirements.txt` is used for the MkDocs documentation build in `gateway-api-0.7.1-custom`.