### PR TITLE
security: [backport release/2.0.x] upgrade tornado 6.3.2 -> 6.5.5 to fix GHSA-fqwm-6jpj-5wxc (CVE-2026-35536)

### DIFF
--- a/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
+++ b/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
@@ -19,4 +19,4 @@ Pygments==2.15.1
 pymdown-extensions==10.0
 PyYAML==6.0
 six==1.16.0
-tornado==6.3.2
+tornado==6.5.5


### PR DESCRIPTION
## Backport of #5297 to `release/2.0.x`

Cherry-pick of commit `2a62bdcd03618cc24452ddced61d2025814f7275` from PR #5297.

---

## Summary

Upgrades `tornado` from `6.3.2` to `6.5.5` in `control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt` to resolve a known security vulnerability.

## Vulnerability Details

| Field | Detail |
|-------|--------|
| **Advisory** | [GHSA-fqwm-6jpj-5wxc](https://github.com/advisories/GHSA-fqwm-6jpj-5wxc) |
| **CVE** | CVE-2026-35536 |
| **CWE** | CWE-159 (Improper Handling of Inputs) |

**Description:** In Tornado before 6.5.5, cookie attribute injection could occur because the `domain`, `path`, and `samesite` arguments to `.RequestHandler.set_cookie` were not checked for crafted characters.

## Fix

```diff
-tornado==6.3.2
+tornado==6.5.5
```

## Branches

| Branch | Status |
|--------|--------|
| `main` | Fixed via #5297 |
| `release/2.0.x` | This PR |
| `release/1.9.x` | Not affected — `requirements.txt` does not exist in this branch |
| `release/1.8.x` | Not affected — `requirements.txt` does not exist in this branch |