### PR TITLE
security: upgrade tornado 6.3.2 -> 6.5.1 to fix GHSA-7cx3-6m66-7c5m (CVE-2025-47287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ SECURITY:
 
 * security: update go to 1.26 [[GH-5269](https://github.com/hashicorp/consul-k8s/issues/5269)]
 * security: update google.golang.org/grpc to fix CVE-2026-33186 [[GH-5183](https://github.com/hashicorp/consul-k8s/issues/5183)]
+* security: upgrade tornado 6.3.2 -> 6.5.1 to fix GHSA-7cx3-6m66-7c5m (CVE-2025-47287) [[GH-5299](https://github.com/hashicorp/consul-k8s/pull/5299)]
 
 FEATURES:
 

--- a/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
+++ b/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
@@ -19,4 +19,4 @@ Pygments==2.15.1
 pymdown-extensions==10.0
 PyYAML==6.0
 six==1.16.0
-tornado==6.3.2
+tornado==6.5.1


### PR DESCRIPTION
## Summary

Upgrades `tornado` from `6.3.2` to `6.5.1` in `control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt` to resolve a high-severity security vulnerability.

## Vulnerability Details

| Field | Detail |
|-------|--------|
| **Advisory** | [GHSA-7cx3-6m66-7c5m](https://github.com/advisories/GHSA-7cx3-6m66-7c5m) |
| **CVE** | CVE-2025-47287 |


**Description:** When Tornado's `multipart/form-data` parser encounters certain errors, it logs a warning but continues trying to parse the remainder of the data. This allows remote attackers to generate an extremely high volume of logs, constituting a DoS attack. The impact is compounded by the fact that the logging subsystem is synchronous.

## Fix

```diff
-tornado==6.3.2
+tornado==6.5.1
```

- Patched version: `6.5` (see [upstream fix](https://github.com/tornadoweb/tornado/commit/b39b892bf78fe8fea01dd45199aa88307e7162f3))
- Upgraded to `6.5.1` to include all patches introduced in the `6.5` line
- All other pinned dependencies in `requirements.txt` remain unchanged and are compatible

