### PR TITLE
[release/2.0.x] security: upgrade tornado 6.3.2 -> 6.5.1 to fix GHSA-7cx3-6m66-7c5m (CVE-2025-47287)

### DIFF
--- a/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
+++ b/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
@@ -19,4 +19,4 @@ Pygments==2.15.1
 pymdown-extensions==10.0
 PyYAML==6.0
 six==1.16.0
-tornado==6.3.2
+tornado==6.5.1


### PR DESCRIPTION
## Summary

Backport of #5299 to `release/2.0.x`.

Cherry-picked commit `106d042bb` from PR #5299.

Upgrades `tornado` from `6.3.2` to `6.5.1` in `control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt` to resolve a high-severity DoS vulnerability.

## Vulnerability Details

| Field | Detail |
|-------|--------|
| **Advisory** | [GHSA-7cx3-6m66-7c5m](https://github.com/advisories/GHSA-7cx3-6m66-7c5m) |
| **CVE** | CVE-2025-47287 |

## Affected Branches

| Branch | Affected | Notes |
|--------|----------|-------|
| `main` | Yes | Fixed in #5299 |
| `release/2.0.x` | Yes | This PR |
| `release/1.9.x` | No | `gateway07/` directory does not exist |
| `release/1.8.x` | No | `gateway07/` directory does not exist |

## Fix

```diff
-tornado==6.3.2
+tornado==6.5.1
```

