### PR TITLE
security: upgrade tornado 6.3.2 -> 6.5.1 to fix GHSA-8w49-h785-mj3c (CVE-2024-52804)

### DIFF
--- a/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
+++ b/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
@@ -19,4 +19,4 @@ Pygments==2.15.1
 pymdown-extensions==10.0
 PyYAML==6.0
 six==1.16.0
-tornado==6.3.2
+tornado==6.5.1


### PR DESCRIPTION
## Summary

Upgrades `tornado` from `6.3.2` to `6.5.1` in `control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt` to resolve a high-severity DoS vulnerability.

## Vulnerability Details

| Field | Detail |
|-------|--------|
| **Advisory** | [GHSA-8w49-h785-mj3c](https://github.com/advisories/GHSA-8w49-h785-mj3c) |
| **CVE** | CVE-2024-52804 |


**Description:** The HTTP cookie parsing algorithm in Tornado < 6.4.2 sometimes has quadratic complexity, leading to excessive CPU consumption when parsing maliciously-crafted cookie headers. This parsing occurs in the event loop thread and may block processing of other requests, causing a denial of service.

See also CVE-2024-7592 for a similar vulnerability in cpython.

## Fix

```diff
-tornado==6.3.2
+tornado==6.5.1
```

- Patched version: `6.4.2` (see [upstream fix](https://github.com/tornadoweb/tornado/commit/d5ba4a1695fbf7c6a3e54313262639b198291533))
- Upgraded to `6.5.1` (latest stable) to include all subsequent patches
- This upgrade also resolves [GHSA-7cx3-6m66-7c5m](https://github.com/advisories/GHSA-7cx3-6m66-7c5m) (CVE-2025-47287, covered in #5299)

## Affected Branches

| Branch | Affected | Notes |
|--------|----------|-------|
| `main` | Yes | Fixed by this PR |
| `release/2.0.x` | Yes | Backport needed (see #5300 for GHSA-7cx3-6m66-7c5m backport) |
| `release/1.9.x` | No | `gateway07/` directory does not exist |
| `release/1.8.x` | No | `gateway07/` directory does not exist |

