### PR TITLE
cli/debug: fix 'seperate' typo in debugPodLogs comment

### DIFF
--- a/cli/cmd/debug/debugPodLogs.go
+++ b/cli/cmd/debug/debugPodLogs.go
@@ -288,7 +288,7 @@ func (l *LogCapture) getWorkloadLogs() error {
 	l.pushWorkloadContainers()
 	close(l.containersChan)
 
-	// seperate goroutine to close resultsChan
+	// separate goroutine to close resultsChan
 	// as soon as all logCollector workers are done.
 	go func() {
 		wg.Wait()


### PR DESCRIPTION
Fix a typo in the inline comment in `debugPodLogs.go`: `seperate` -> `separate`.