### PR TITLE
acceptance tests for terminating gateway secret rotation (#5218)

### DIFF
--- a/acceptance/tests/fixtures/cases/terminating-gateway-secret-rotation/kustomization.yaml
+++ b/acceptance/tests/fixtures/cases/terminating-gateway-secret-rotation/kustomization.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../fixtures/bases/terminating-gateway
+patches:
+- path: terminating-gateway.yaml
+

--- a/acceptance/tests/fixtures/cases/terminating-gateway-secret-rotation/secret-initial.yaml
+++ b/acceptance/tests/fixtures/cases/terminating-gateway-secret-rotation/secret-initial.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tgw-rotation-secret
+data:
+  tls.crt: "aW5pdGlhbC1jZXJ0"
+  tls.key: "aW5pdGlhbC1rZXk="
+  ca.crt: "aW5pdGlhbC1jYQ=="
+

--- a/acceptance/tests/fixtures/cases/terminating-gateway-secret-rotation/secret-rotated-1.yaml
+++ b/acceptance/tests/fixtures/cases/terminating-gateway-secret-rotation/secret-rotated-1.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tgw-rotation-secret
+data:
+  tls.crt: "cm90YXRlZDEtY2VydA=="
+  tls.key: "cm90YXRlZDEta2V5"
+  ca.crt: "cm90YXRlZDEtY2E="

--- a/acceptance/tests/fixtures/cases/terminating-gateway-secret-rotation/secret-rotated.yaml
+++ b/acceptance/tests/fixtures/cases/terminating-gateway-secret-rotation/secret-rotated.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tgw-rotation-secret
+data:
+  tls.crt: "cm90YXRlZC1jZXJ0"
+  tls.key: "cm90YXRlZC1rZXk="
+  ca.crt: "cm90YXRlZC1jYQ=="
+

--- a/acceptance/tests/fixtures/cases/terminating-gateway-secret-rotation/terminating-gateway.yaml
+++ b/acceptance/tests/fixtures/cases/terminating-gateway-secret-rotation/terminating-gateway.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: TerminatingGateway
+metadata:
+  name: tg
+spec:
+  services:
+    - name: static-server
+      caFile: /consul/userconfig/tgw-rotation-secret/ca.crt
+      certFile: /consul/userconfig/tgw-rotation-secret/tls.crt
+      keyFile: /consul/userconfig/tgw-rotation-secret/tls.key
+      secretRef:
+        name: tgw-rotation-secret
+

--- a/acceptance/tests/terminating-gateway/terminating_gateway_secret_rotation_test.go
+++ b/acceptance/tests/terminating-gateway/terminating_gateway_secret_rotation_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package terminatinggateway
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/k8s"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerminatingGatewaySecretRotation(t *testing.T) {
+	cases := []struct {
+		secure bool
+	}{
+		{secure: false},
+		{secure: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("secure: %t", tc.secure), func(t *testing.T) {
+			ctx := suite.Environment().DefaultContext(t)
+			cfg := suite.Config()
+
+			logger.Log(t, "preinstalling initial secret for terminating gateway")
+			k8s.RunKubectl(t, ctx.KubectlOptions(t), "apply", "-f", "../fixtures/cases/terminating-gateway-secret-rotation/secret-initial.yaml")
+			helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
+				k8s.RunKubectl(t, ctx.KubectlOptions(t), "delete", "-f", "../fixtures/cases/terminating-gateway-secret-rotation/secret-initial.yaml")
+			})
+
+			helmValues := map[string]string{
+				"connectInject.enabled":                             "true",
+				"terminatingGateways.enabled":                       "true",
+				"terminatingGateways.gateways[0].name":              "tg",
+				"terminatingGateways.gateways[0].replicas":          "1",
+				"terminatingGateways.defaults.extraVolumes[0].type": "secret",
+				"terminatingGateways.defaults.extraVolumes[0].name": "tgw-rotation-secret",
+				"global.acls.manageSystemACLs":                      strconv.FormatBool(tc.secure),
+				"global.tls.enabled":                                strconv.FormatBool(tc.secure),
+			}
+
+			logger.Log(t, "creating consul cluster")
+			releaseName := helpers.RandomName()
+			consulCluster := consul.NewHelmCluster(t, helmValues, ctx, cfg, releaseName)
+			consulCluster.Create(t)
+			consulClient, _ := consulCluster.SetupConsulClient(t, tc.secure)
+
+			logger.Log(t, "deploying static server and external registration")
+			k8s.DeployKustomize(t, ctx.KubectlOptions(t), cfg.NoCleanupOnFailure, cfg.NoCleanup, cfg.DebugDirectory, "../fixtures/bases/static-server")
+			k8sOpts := helpers.K8sOptions{
+				Options:             ctx.KubectlOptions(t),
+				NoCleanupOnFailure:  cfg.NoCleanupOnFailure,
+				NoCleanup:           cfg.NoCleanup,
+				KustomizeConfigPath: "../fixtures/bases/external-service-registration",
+			}
+			consulOpts := helpers.ConsulOptions{
+				ConsulClient:                    consulClient,
+				ExternalServiceNameRegistration: "static-server-registration",
+			}
+			helpers.RegisterExternalServiceCRD(t, k8sOpts, consulOpts)
+
+			logger.Log(t, "creating terminating gateway with linked secretRef")
+			k8s.RunKubectl(t, ctx.KubectlOptions(t), "apply", "-f", "../fixtures/cases/terminating-gateway-secret-rotation/terminating-gateway.yaml")
+
+			retry.RunWith(&retry.Counter{Wait: 2 * time.Second, Count: 60}, t, func(r *retry.R) {
+				waitForTerminatingGatewayEntry(r, consulClient, "tg")
+			})
+
+			logger.Log(t, "rotating terminating gateway secret first")
+			k8s.RunKubectl(t, ctx.KubectlOptions(t), "apply", "-f", "../fixtures/cases/terminating-gateway-secret-rotation/secret-rotated.yaml")
+
+			time.Sleep(5 * time.Second)
+
+			metaKey := fmt.Sprintf("consul.hashicorp.com/secret/%s/last-rotation", "tgw-rotation-secret")
+			var firstRotation string
+			retry.RunWith(&retry.Counter{Wait: 2 * time.Second, Count: 60}, t, func(r *retry.R) {
+				firstRotation = readRotationTimestamp(r, consulClient, "tg", metaKey)
+			})
+
+			logger.Log(t, "rotating terminating gateway secret second time")
+			k8s.RunKubectl(t, ctx.KubectlOptions(t), "apply", "-f", "../fixtures/cases/terminating-gateway-secret-rotation/secret-rotated-1.yaml")
+
+			time.Sleep(5 * time.Second)
+
+			var secondRotation string
+			retry.RunWith(&retry.Counter{Wait: 2 * time.Second, Count: 60}, t, func(r *retry.R) {
+				secondRotation = readRotationTimestamp(r, consulClient, "tg", metaKey)
+				require.NotEqual(r, firstRotation, secondRotation)
+			})
+		})
+	}
+}
+
+func readRotationTimestamp(t require.TestingT, consulClient *api.Client, gatewayName, metaKey string) string {
+	entry, _, err := consulClient.ConfigEntries().Get(api.TerminatingGateway, gatewayName, nil)
+	require.NoError(t, err)
+
+	tgEntry, ok := entry.(*api.TerminatingGatewayConfigEntry)
+	require.True(t, ok, "could not cast to TerminatingGatewayConfigEntry")
+	require.NotNil(t, tgEntry.Meta)
+
+	rotation := tgEntry.Meta[metaKey]
+	require.NotEmpty(t, rotation)
+
+	_, parseErr := time.Parse(time.RFC3339Nano, rotation)
+	require.NoError(t, parseErr)
+
+	return rotation
+}
+
+func waitForTerminatingGatewayEntry(t require.TestingT, consulClient *api.Client, gatewayName string) {
+	entry, _, err := consulClient.ConfigEntries().Get(api.TerminatingGateway, gatewayName, nil)
+	require.NoError(t, err)
+
+	_, ok := entry.(*api.TerminatingGatewayConfigEntry)
+	require.True(t, ok, "could not cast to TerminatingGatewayConfigEntry")
+}

--- a/control-plane/api/v1alpha1/terminatinggateway_types.go
+++ b/control-plane/api/v1alpha1/terminatinggateway_types.go
@@ -5,6 +5,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"reflect"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -336,8 +337,44 @@ func (in *TerminatingGateway) MatchesConsul(candidate capi.ConfigEntry) bool {
 	if !ok {
 		return false
 	}
+	desired, ok := in.ToConsul("").(*capi.TerminatingGatewayConfigEntry)
+	if !ok {
+		return false
+	}
 	// No datacenter is passed to ToConsul as we ignore the Meta field when checking for equality.
-	return cmp.Equal(in.ToConsul(""), configEntry, cmpopts.IgnoreFields(capi.TerminatingGatewayConfigEntry{}, "Partition", "Namespace", "Meta", "ModifyIndex", "CreateIndex"), cmpopts.IgnoreUnexported(), cmpopts.EquateEmpty())
+	return cmp.Equal(
+		normalizeTerminatingGatewayForCompare(desired),
+		normalizeTerminatingGatewayForCompare(configEntry),
+		cmpopts.IgnoreFields(capi.TerminatingGatewayConfigEntry{}, "Partition", "Namespace", "Meta", "ModifyIndex", "CreateIndex"),
+		cmpopts.IgnoreUnexported(),
+		cmpopts.EquateEmpty(),
+	)
+}
+
+func normalizeTerminatingGatewayForCompare(in *capi.TerminatingGatewayConfigEntry) *capi.TerminatingGatewayConfigEntry {
+	if in == nil {
+		return nil
+	}
+
+	normalized := *in
+	normalized.Services = append([]capi.LinkedService(nil), in.Services...)
+	for i := range normalized.Services {
+		clearLinkedServiceStringField(&normalized.Services[i], "Namespace")
+		clearLinkedServiceStringField(&normalized.Services[i], "Partition")
+	}
+
+	return &normalized
+}
+
+func clearLinkedServiceStringField(in *capi.LinkedService, field string) {
+	v := reflect.ValueOf(in)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return
+	}
+	fieldValue := v.Elem().FieldByName(field)
+	if fieldValue.IsValid() && fieldValue.CanSet() && fieldValue.Kind() == reflect.String {
+		fieldValue.SetString("")
+	}
 }
 
 func (in *TerminatingGateway) Validate(consulMeta common.ConsulMeta) error {

--- a/control-plane/api/v1alpha1/terminatinggateway_types_test.go
+++ b/control-plane/api/v1alpha1/terminatinggateway_types_test.go
@@ -88,6 +88,27 @@ func TestTerminatingGateway_MatchesConsul(t *testing.T) {
 			},
 			Matches: true,
 		},
+		"linked service namespace defaulted by consul matches": {
+			Ours: TerminatingGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+				},
+				Spec: TerminatingGatewaySpec{
+					Services: []LinkedService{{
+						Name: "name",
+					}},
+				},
+			},
+			Theirs: &capi.TerminatingGatewayConfigEntry{
+				Kind: capi.TerminatingGateway,
+				Name: "name",
+				Services: []capi.LinkedService{{
+					Name:      "name",
+					Namespace: "default",
+				}},
+			},
+			Matches: true,
+		},
 		"different types does not match": {
 			Ours: TerminatingGateway{
 				ObjectMeta: metav1.ObjectMeta{

--- a/control-plane/controllers/configentries/configentry_controller.go
+++ b/control-plane/controllers/configentries/configentry_controller.go
@@ -176,7 +176,8 @@ func (r *ConfigEntryController) ReconcileEntry(ctx context.Context, crdCtrl Cont
 			if err != nil {
 				return r.syncUnknownWithError(ctx, logger, crdCtrl, configEntry, ConsulAgentError, err)
 			}
-			return r.syncSuccessful(ctx, crdCtrl, configEntry)
+			logger.Info("secret metadata sync completed")
+			return ctrl.Result{}, nil
 		}
 	}
 

--- a/control-plane/controllers/configentries/terminatinggateway_controller.go
+++ b/control-plane/controllers/configentries/terminatinggateway_controller.go
@@ -222,9 +222,12 @@ func (r *TerminatingGatewayController) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, deployErr
 	}
 
-	termGW.SetSyncedCondition(corev1.ConditionTrue, "DeploymentReady", "Deployment ready")
-	if err := r.UpdateStatus(ctx, termGW); err != nil {
-		return ctrl.Result{}, err
+	status, reason, message := termGW.SyncedCondition()
+	if status != corev1.ConditionTrue || reason != "DeploymentReady" || message != "Deployment ready" {
+		termGW.SetSyncedCondition(corev1.ConditionTrue, "DeploymentReady", "Deployment ready")
+		if err := r.UpdateStatus(ctx, termGW); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	return result, nil


### PR DESCRIPTION
* acceptance tests for terminating gateway secret rotation

* adding wait for resource retry

* fix: prevent TG reconcile loop on secret rotation (enterprise)

* removing local test images

### Changes proposed in this PR ###  
-
-

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
