### PR TITLE
api-gateway-custom: add scaling support and openshift coverage (#5288)

### DIFF
--- a/acceptance/framework/helpers/helpers.go
+++ b/acceptance/framework/helpers/helpers.go
@@ -166,6 +166,55 @@ type K8sOptions struct {
 	KustomizeConfigPath string
 }
 
+// ResourceToCleanup describes a Kubernetes resource that may need forced finalizer cleanup.
+type ResourceToCleanup struct {
+	// Type is the kubectl resource type, for example "crd", "namespace", "pod".
+	Type string
+	// Name is the resource name.
+	Name string
+	// Namespace is optional; leave empty for cluster-scoped resources.
+	Namespace string
+}
+
+// ForceCleanupTerminatingResources force-removes finalizers from resources that may be
+// stuck in Terminating from prior test runs, then waits for deletion.
+func ForceCleanupTerminatingResources(t *testing.T, resources []ResourceToCleanup, timeout time.Duration) {
+	t.Helper()
+
+	for _, resource := range resources {
+		if resource.Type == "" || resource.Name == "" {
+			t.Fatalf("resource type and name are required, got type=%q name=%q", resource.Type, resource.Name)
+		}
+
+		resourceRef := fmt.Sprintf("%s/%s", resource.Type, resource.Name)
+		timeoutArg := fmt.Sprintf("--timeout=%s", timeout)
+
+		// Attempt deletion first without waiting so we can patch finalizers if needed.
+		deleteArgs := []string{"delete", resource.Type, resource.Name, "--ignore-not-found=true", "--wait=false"}
+		if resource.Namespace != "" {
+			deleteArgs = append(deleteArgs, "-n", resource.Namespace)
+		}
+		_, _ = exec.Command("kubectl", deleteArgs...).CombinedOutput()
+
+		// Best-effort patch to strip finalizers; this is safe if the resource no longer exists.
+		patchArgs := []string{"patch", resource.Type, resource.Name, "--type=merge", "-p", `{"metadata":{"finalizers":[]}}`}
+		if resource.Namespace != "" {
+			patchArgs = append(patchArgs, "-n", resource.Namespace)
+		}
+		_, _ = exec.Command("kubectl", patchArgs...).CombinedOutput()
+
+		waitArgs := []string{"wait", "--for=delete", timeoutArg, resourceRef}
+		if resource.Namespace != "" {
+			waitArgs = append(waitArgs, "-n", resource.Namespace)
+		}
+
+		output, err := exec.Command("kubectl", waitArgs...).CombinedOutput()
+		if err != nil && !strings.Contains(string(output), "not found") {
+			require.NoErrorf(t, err, "failed waiting for %s deletion: %s", resourceRef, string(output))
+		}
+	}
+}
+
 type ConsulOptions struct {
 	ConsulClient                    *api.Client
 	Namespace                       string

--- a/acceptance/tests/api-gateway/api_gateway_scaling_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_scaling_test.go
@@ -34,8 +34,6 @@ const (
 	annotationHPAMinReplicas  = "consul.hashicorp.com/hpa-minimum-replicas"
 	annotationHPAMaxReplicas  = "consul.hashicorp.com/hpa-maximum-replicas"
 	annotationHPACPUTarget    = "consul.hashicorp.com/hpa-cpu-utilisation-target"
-
-	testReconcileAnnotation = "test.hashicorp.com/reconcile-nonce"
 )
 
 func TestAPIGateway_Scaling_EnterpriseGateDisabledIgnoresGatewayAnnotations(t *testing.T) {
@@ -125,6 +123,47 @@ func TestAPIGateway_Scaling_EnterpriseGateEnabledControllerManagedHPA(t *testing
 	waitForGatewayDeploymentReplicas(t, k8sClient, gateway.Name, gateway.Namespace, 3)
 }
 
+func TestAPIGateway_Scaling_AnnotatedGatewayBeforeUpgradeReconcilesAfterUpgrade(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfigured(t)
+
+	ctx := suite.Environment().DefaultContext(t)
+	consulCluster := installScalingCluster(t, false)
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValid(t, consulClient)
+
+	cfg := suite.Config()
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	gatewayClassName := createScalingGatewayClassResources(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{})
+
+	gateway := createScalingGateway(t, k8sClient, ctx.KubectlOptions(t).Namespace, gatewayClassName, map[string]string{
+		annotationHPAEnabled:     "true",
+		annotationHPAMinReplicas: "2",
+		annotationHPAMaxReplicas: "8",
+		annotationHPACPUTarget:   "70",
+	}, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	waitForGatewayDeploymentReplicas(t, k8sClient, gateway.Name, gateway.Namespace, 1)
+	waitForGatewayHPAAbsent(t, k8sClient, gateway.Name, gateway.Namespace)
+
+	logger.Logf(t, "TEST ACTION: upgrading control plane with pre-existing annotated Gateway %s/%s", gateway.Namespace, gateway.Name)
+	consulCluster.Upgrade(t, map[string]string{
+		"connectInject.apiGateway.managedGatewayClass.scaling.enabled": "true",
+	})
+
+	// Restart the API Gateway controller to ensure it detects the enterprise license
+	// after the upgrade enables scaling.
+	restartAPIGatewayController(t, ctx)
+
+	hpa := waitForGatewayHPA(t, k8sClient, gateway.Name, gateway.Namespace)
+	require.NotNil(t, hpa.Spec.MinReplicas)
+	require.Equal(t, int32(2), *hpa.Spec.MinReplicas)
+	require.Equal(t, int32(8), hpa.Spec.MaxReplicas)
+	require.Len(t, hpa.Spec.Metrics, 1)
+	require.NotNil(t, hpa.Spec.Metrics[0].Resource)
+	require.NotNil(t, hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+	require.Equal(t, int32(70), *hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+}
+
 func TestAPIGateway_Scaling_EnterpriseGateEnabledPreservesManualScale(t *testing.T) {
 	skipUnlessEnterpriseLicenseConfigured(t)
 
@@ -150,8 +189,181 @@ func TestAPIGateway_Scaling_EnterpriseGateEnabledPreservesManualScale(t *testing
 
 	waitForGatewayDeploymentReplicas(t, k8sClient, gateway.Name, gateway.Namespace, 2)
 	scaleGatewayDeployment(t, k8sClient, gateway.Name, gateway.Namespace, 5)
-	triggerGatewayReconcile(t, k8sClient, gateway.Name, gateway.Namespace)
 	waitForGatewayDeploymentReplicas(t, k8sClient, gateway.Name, gateway.Namespace, 5)
+}
+
+func TestAPIGateway_Scaling_UserManagedHPATakesPrecedenceOverAnnotations(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfigured(t)
+
+	ctx := suite.Environment().DefaultContext(t)
+	consulCluster := installScalingCluster(t, true)
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValid(t, consulClient)
+
+	restartAPIGatewayController(t, ctx)
+
+	cfg := suite.Config()
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	namespace := ctx.KubectlOptions(t).Namespace
+	gatewayClassName := createScalingGatewayClassResources(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{})
+
+	// Start with controller-managed HPA via annotations.
+	gateway := createScalingGateway(t, k8sClient, namespace, gatewayClassName, map[string]string{
+		annotationHPAEnabled:     "true",
+		annotationHPAMinReplicas: "2",
+		annotationHPAMaxReplicas: "8",
+		annotationHPACPUTarget:   "70",
+	}, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	waitForGatewayHPA(t, k8sClient, gateway.Name, gateway.Namespace)
+
+	// User now creates their own HPA targeting the gateway deployment.
+	createUserManagedHPA(t, k8sClient, gateway.Name, gateway.Namespace, 4, 12, 60, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	// Controller-managed HPA must be removed; user HPA must remain untouched.
+	waitForGatewayHPAAbsent(t, k8sClient, gateway.Name, gateway.Namespace)
+	requireUserHPAUnchanged(t, k8sClient, gateway.Name, gateway.Namespace, 4, 12, 60)
+}
+
+func TestAPIGateway_Scaling_UserManagedHPAPreservesManualScale(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfigured(t)
+
+	ctx := suite.Environment().DefaultContext(t)
+	consulCluster := installScalingCluster(t, true)
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValid(t, consulClient)
+
+	restartAPIGatewayController(t, ctx)
+
+	cfg := suite.Config()
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	namespace := ctx.KubectlOptions(t).Namespace
+
+	// GatewayClassConfig still sets deprecated default replicas to confirm the
+	// user HPA wins over the deprecated source as well.
+	gatewayClassName := createScalingGatewayClassResources(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{
+		DefaultInstances: ptr.To(int32(2)),
+		MinInstances:     ptr.To(int32(1)),
+		MaxInstances:     ptr.To(int32(5)),
+	})
+
+	gateway := createScalingGateway(t, k8sClient, namespace, gatewayClassName, nil, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+	waitForGatewayDeploymentReplicas(t, k8sClient, gateway.Name, gateway.Namespace, 2)
+
+	// Add a user-managed HPA, then manually scale the deployment.
+	createUserManagedHPA(t, k8sClient, gateway.Name, gateway.Namespace, 1, 10, 80, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+	scaleGatewayDeployment(t, k8sClient, gateway.Name, gateway.Namespace, 6)
+
+	// Controller must not overwrite replicas while a user-managed HPA exists.
+	waitForGatewayDeploymentReplicas(t, k8sClient, gateway.Name, gateway.Namespace, 6)
+	waitForGatewayHPAAbsent(t, k8sClient, gateway.Name, gateway.Namespace)
+	requireUserHPAUnchanged(t, k8sClient, gateway.Name, gateway.Namespace, 1, 10, 80)
+}
+
+func TestAPIGateway_Scaling_UserManagedHPARemovedRestoresControllerHPA(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfigured(t)
+
+	ctx := suite.Environment().DefaultContext(t)
+	consulCluster := installScalingCluster(t, true)
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValid(t, consulClient)
+
+	restartAPIGatewayController(t, ctx)
+
+	cfg := suite.Config()
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	namespace := ctx.KubectlOptions(t).Namespace
+	gatewayClassName := createScalingGatewayClassResources(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{})
+
+	gateway := createScalingGateway(t, k8sClient, namespace, gatewayClassName, map[string]string{
+		annotationHPAEnabled:     "true",
+		annotationHPAMinReplicas: "2",
+		annotationHPAMaxReplicas: "6",
+		annotationHPACPUTarget:   "75",
+	}, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	// Controller-managed HPA exists initially.
+	waitForGatewayHPA(t, k8sClient, gateway.Name, gateway.Namespace)
+
+	// User adds their own HPA; controller HPA must disappear.
+	userHPAName := createUserManagedHPA(t, k8sClient, gateway.Name, gateway.Namespace, 3, 9, 65, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+	waitForGatewayHPAAbsent(t, k8sClient, gateway.Name, gateway.Namespace)
+
+	// User deletes their HPA; controller-managed HPA must come back from annotations.
+	deleteUserManagedHPA(t, k8sClient, userHPAName, gateway.Namespace)
+
+	hpa := waitForGatewayHPA(t, k8sClient, gateway.Name, gateway.Namespace)
+	require.NotNil(t, hpa.Spec.MinReplicas)
+	require.Equal(t, int32(2), *hpa.Spec.MinReplicas)
+	require.Equal(t, int32(6), hpa.Spec.MaxReplicas)
+	require.Len(t, hpa.Spec.Metrics, 1)
+	require.NotNil(t, hpa.Spec.Metrics[0].Resource)
+	require.NotNil(t, hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+	require.Equal(t, int32(75), *hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+}
+
+func TestAPIGateway_Scaling_UserManagedHPAUpdatesDriveReplicaChanges(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfigured(t)
+
+	ctx := suite.Environment().DefaultContext(t)
+	consulCluster := installScalingCluster(t, true)
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValid(t, consulClient)
+
+	restartAPIGatewayController(t, ctx)
+
+	cfg := suite.Config()
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	namespace := ctx.KubectlOptions(t).Namespace
+	gatewayClassName := createScalingGatewayClassResources(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{})
+
+	gateway := createScalingGateway(t, k8sClient, namespace, gatewayClassName, nil, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	// Create the user-managed HPA with a low minReplicas so the deployment
+	// initially settles at that floor.
+	hpaName := createUserManagedHPA(t, k8sClient, gateway.Name, gateway.Namespace, 1, 10, 80, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	// Controller must yield the deployment to the user HPA.
+	waitForGatewayHPAAbsent(t, k8sClient, gateway.Name, gateway.Namespace)
+	waitForGatewayDeploymentReplicas(t, k8sClient, gateway.Name, gateway.Namespace, 1)
+
+	// User raises minReplicas. The Kubernetes HPA controller must scale the
+	// deployment up to the new floor, and the consul controller must not
+	// interfere.
+	updateUserManagedHPAReplicaBounds(t, k8sClient, hpaName, gateway.Namespace, 4, 10)
+	waitForGatewayDeploymentReplicas(t, k8sClient, gateway.Name, gateway.Namespace, 4)
+
+	// User raises minReplicas further; deployment must follow.
+	updateUserManagedHPAReplicaBounds(t, k8sClient, hpaName, gateway.Namespace, 6, 10)
+	waitForGatewayDeploymentReplicas(t, k8sClient, gateway.Name, gateway.Namespace, 6)
+
+	// Controller-managed HPA must remain absent throughout.
+	waitForGatewayHPAAbsent(t, k8sClient, gateway.Name, gateway.Namespace)
+}
+
+func TestAPIGateway_Scaling_DanglingUserHPABeforeGatewayTakesPrecedence(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfigured(t)
+
+	ctx := suite.Environment().DefaultContext(t)
+	consulCluster := installScalingCluster(t, true)
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValid(t, consulClient)
+
+	restartAPIGatewayController(t, ctx)
+
+	cfg := suite.Config()
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	namespace := ctx.KubectlOptions(t).Namespace
+	gatewayClassName := createScalingGatewayClassResources(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{})
+	gatewayName := helpers.RandomName()
+
+	hpaName := createUserManagedHPAForTarget(t, k8sClient, "dangling-user-hpa", namespace, gatewayName, 3, 9, 65, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	gateway := createScalingGatewayWithName(t, k8sClient, gatewayName, namespace, gatewayClassName, nil, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	waitForGatewayPodsReady(t, k8sClient, gateway.Name, gateway.Namespace, 1)
+	waitForGatewayHPAAbsent(t, k8sClient, gateway.Name, gateway.Namespace)
+	requireUserHPAForTargetUnchanged(t, k8sClient, hpaName, gateway.Namespace, gateway.Name, 3, 9, 65)
 }
 
 func installScalingCluster(t *testing.T, scalingEnabled bool) *consul.HelmCluster {
@@ -248,11 +460,29 @@ func createScalingGateway(
 ) *gwv1.Gateway {
 	t.Helper()
 
+	return createScalingGatewayWithName(t, k8sClient, helpers.RandomName(), namespace, gatewayClassName, annotations, noCleanupOnFailure, noCleanup)
+}
+
+func createScalingGatewayWithName(
+	t *testing.T,
+	k8sClient client.Client,
+	gatewayName string,
+	namespace string,
+	gatewayClassName string,
+	annotations map[string]string,
+	noCleanupOnFailure bool,
+	noCleanup bool,
+) *gwv1.Gateway {
+	t.Helper()
+
 	gateway := &gwv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        helpers.RandomName(),
+			Name:        gatewayName,
 			Namespace:   namespace,
 			Annotations: annotations,
+			Labels: map[string]string{
+				"component": "api-gateway",
+			},
 		},
 		Spec: gwv1.GatewaySpec{
 			GatewayClassName: gwv1.ObjectName(gatewayClassName),
@@ -273,6 +503,7 @@ func createScalingGateway(
 	})
 
 	logger.Logf(t, "created gateway %s/%s", gateway.Namespace, gateway.Name)
+	logger.Logf(t, "TEST INPUT: Gateway %s/%s spec gatewayClass=%s listeners=%s annotations=%s", gateway.Namespace, gateway.Name, gateway.Spec.GatewayClassName, gatewayListeners(gateway.Spec.Listeners), gatewayAnnotations(gateway.Annotations))
 	return gateway
 }
 
@@ -288,32 +519,72 @@ func waitForGatewayDeploymentReplicas(t *testing.T, k8sClient client.Client, gat
 	})
 }
 
+func waitForGatewayPodsReady(t *testing.T, k8sClient client.Client, gatewayName, namespace string, minReady int32) {
+	t.Helper()
+
+	retry.RunWith(&retry.Timer{Timeout: 5 * time.Minute, Wait: 5 * time.Second}, t, func(r *retry.R) {
+		var deployment appsv1.Deployment
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: gatewayName, Namespace: namespace}, &deployment)
+		require.NoError(r, err)
+		require.NotNil(r, deployment.Spec.Selector)
+		require.NotEmpty(r, deployment.Spec.Selector.MatchLabels)
+
+		var pods corev1.PodList
+		err = k8sClient.List(context.Background(), &pods, client.InNamespace(namespace), client.MatchingLabels(deployment.Spec.Selector.MatchLabels))
+		require.NoError(r, err)
+		require.NotEmpty(r, pods.Items)
+
+		var readyPods int32
+		for _, pod := range pods.Items {
+			if pod.Status.Phase != corev1.PodRunning {
+				continue
+			}
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+					readyPods++
+					break
+				}
+			}
+		}
+
+		require.GreaterOrEqual(r, readyPods, minReady)
+	})
+
+	logger.Logf(t, "BEHAVIOR RESULT: gateway deployment %s/%s has at least %d ready pod(s)", namespace, gatewayName, minReady)
+}
+
 func waitForGatewayHPA(t *testing.T, k8sClient client.Client, gatewayName, namespace string) *autoscalingv2.HorizontalPodAutoscaler {
 	t.Helper()
 
+	controllerHPAName := fmt.Sprintf("%s-hpa", gatewayName)
 	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 2 * time.Second}, t, func(r *retry.R) {
 		err := k8sClient.Get(context.Background(), types.NamespacedName{
-			Name:      fmt.Sprintf("%s-hpa", gatewayName),
+			Name:      controllerHPAName,
 			Namespace: namespace,
 		}, hpa)
 		require.NoError(r, err)
 	})
 
+	logger.Logf(t, "BEHAVIOR RESULT: controller-managed HPA %s/%s exists spec=%s owners=%s", namespace, controllerHPAName, hpaSpec(hpa), hpaOwnerReferences(hpa.OwnerReferences))
 	return hpa
 }
 
 func waitForGatewayHPAAbsent(t *testing.T, k8sClient client.Client, gatewayName, namespace string) {
 	t.Helper()
 
+	controllerHPAName := fmt.Sprintf("%s-hpa", gatewayName)
+
 	retry.RunWith(&retry.Timer{Timeout: 1 * time.Minute, Wait: 2 * time.Second}, t, func(r *retry.R) {
 		err := k8sClient.Get(context.Background(), types.NamespacedName{
-			Name:      fmt.Sprintf("%s-hpa", gatewayName),
+			Name:      controllerHPAName,
 			Namespace: namespace,
 		}, &autoscalingv2.HorizontalPodAutoscaler{})
 		require.Error(r, err)
 		require.True(r, apierrors.IsNotFound(err), "expected HPA to be absent, got %v", err)
 	})
+
+	logger.Logf(t, "BEHAVIOR RESULT: controller-managed HPA %s/%s is absent", namespace, controllerHPAName)
 }
 
 func scaleGatewayDeployment(t *testing.T, k8sClient client.Client, gatewayName, namespace string, replicas int32) {
@@ -328,24 +599,6 @@ func scaleGatewayDeployment(t *testing.T, k8sClient client.Client, gatewayName, 
 	require.NoError(t, err)
 
 	logger.Logf(t, "manually scaled deployment %s/%s to %d replicas", namespace, gatewayName, replicas)
-}
-
-func triggerGatewayReconcile(t *testing.T, k8sClient client.Client, gatewayName, namespace string) {
-	t.Helper()
-
-	var gateway gwv1.Gateway
-	err := k8sClient.Get(context.Background(), types.NamespacedName{Name: gatewayName, Namespace: namespace}, &gateway)
-	require.NoError(t, err)
-
-	if gateway.Annotations == nil {
-		gateway.Annotations = map[string]string{}
-	}
-	gateway.Annotations[testReconcileAnnotation] = fmt.Sprintf("%d", time.Now().UnixNano())
-
-	err = k8sClient.Update(context.Background(), &gateway)
-	require.NoError(t, err)
-
-	logger.Logf(t, "triggered reconcile for gateway %s/%s", namespace, gatewayName)
 }
 
 func restartAPIGatewayController(t *testing.T, ctx environment.TestContext) {
@@ -385,4 +638,228 @@ func restartAPIGatewayController(t *testing.T, ctx environment.TestContext) {
 		}
 		logger.Logf(t, "API Gateway controller restarted and ready")
 	})
+}
+
+// createUserManagedHPA creates an HPA owned by the user (no Gateway owner reference)
+// targeting the gateway's Deployment. Returns the HPA name.
+func createUserManagedHPA(
+	t *testing.T,
+	k8sClient client.Client,
+	gatewayName, namespace string,
+	minReplicas, maxReplicas, cpuTarget int32,
+	noCleanupOnFailure bool,
+	noCleanup bool,
+) string {
+	t.Helper()
+
+	// Use a name distinct from the controller-managed "<gateway>-hpa" so the
+	// two can coexist if the controller has not yet reconciled.
+	hpaName := fmt.Sprintf("%s-user-hpa", gatewayName)
+	return createUserManagedHPAForTarget(t, k8sClient, hpaName, namespace, gatewayName, minReplicas, maxReplicas, cpuTarget, noCleanupOnFailure, noCleanup)
+}
+
+func createUserManagedHPAForTarget(
+	t *testing.T,
+	k8sClient client.Client,
+	hpaName, namespace, targetName string,
+	minReplicas, maxReplicas, cpuTarget int32,
+	noCleanupOnFailure bool,
+	noCleanup bool,
+) string {
+	t.Helper()
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hpaName,
+			Namespace: namespace,
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       targetName,
+			},
+			MinReplicas: ptr.To(minReplicas),
+			MaxReplicas: maxReplicas,
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: ptr.To(cpuTarget),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := k8sClient.Create(context.Background(), hpa)
+	require.NoError(t, err)
+	helpers.Cleanup(t, noCleanupOnFailure, noCleanup, func() {
+		logger.Logf(t, "TEST CLEANUP: deleting user-managed HPA %s/%s", namespace, hpaName)
+		require.NoError(t, client.IgnoreNotFound(k8sClient.Delete(context.Background(), hpa)))
+	})
+
+	logger.Logf(t, "TEST INPUT: user-managed HPA %s/%s spec=%s owners=%s", namespace, hpaName, hpaSpec(hpa), hpaOwnerReferences(hpa.OwnerReferences))
+	return hpaName
+}
+
+// updateUserManagedHPAReplicaBounds updates the min/max replicas on an existing
+// user-managed HPA. Retries on conflict to tolerate concurrent updates by the
+// kubernetes HPA controller writing status.
+func updateUserManagedHPAReplicaBounds(t *testing.T, k8sClient client.Client, hpaName, namespace string, minReplicas, maxReplicas int32) {
+	t.Helper()
+
+	retry.RunWith(&retry.Timer{Timeout: 30 * time.Second, Wait: 1 * time.Second}, t, func(r *retry.R) {
+		var hpa autoscalingv2.HorizontalPodAutoscaler
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: hpaName, Namespace: namespace}, &hpa)
+		require.NoError(r, err)
+
+		hpa.Spec.MinReplicas = ptr.To(minReplicas)
+		hpa.Spec.MaxReplicas = maxReplicas
+
+		err = k8sClient.Update(context.Background(), &hpa)
+		require.NoError(r, err)
+	})
+
+	logger.Logf(t, "TEST ACTION: updated user-managed HPA %s/%s to min=%d max=%d", namespace, hpaName, minReplicas, maxReplicas)
+}
+
+// deleteUserManagedHPA deletes a user-managed HPA by name.
+func deleteUserManagedHPA(t *testing.T, k8sClient client.Client, hpaName, namespace string) {
+	t.Helper()
+
+	logger.Logf(t, "TEST ACTION: deleting user-managed HPA %s/%s so controller-managed HPA can be restored", namespace, hpaName)
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Name: hpaName, Namespace: namespace},
+	}
+	err := k8sClient.Delete(context.Background(), hpa)
+	require.NoError(t, client.IgnoreNotFound(err))
+
+	// Confirm it's actually gone before returning.
+	retry.RunWith(&retry.Timer{Timeout: 1 * time.Minute, Wait: 2 * time.Second}, t, func(r *retry.R) {
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: hpaName, Namespace: namespace}, &autoscalingv2.HorizontalPodAutoscaler{})
+		require.True(r, apierrors.IsNotFound(err), "expected user HPA to be deleted, got %v", err)
+	})
+
+	logger.Logf(t, "BEHAVIOR RESULT: user-managed HPA %s/%s was deleted by the test action", namespace, hpaName)
+}
+
+// requireUserHPAUnchanged asserts the user-managed HPA still exists with its
+// original spec and has not acquired a Gateway owner reference.
+func requireUserHPAUnchanged(t *testing.T, k8sClient client.Client, gatewayName, namespace string, minReplicas, maxReplicas, cpuTarget int32) {
+	t.Helper()
+
+	hpaName := fmt.Sprintf("%s-user-hpa", gatewayName)
+	requireUserHPAForTargetUnchanged(t, k8sClient, hpaName, namespace, gatewayName, minReplicas, maxReplicas, cpuTarget)
+}
+
+func requireUserHPAForTargetUnchanged(t *testing.T, k8sClient client.Client, hpaName, namespace, targetName string, minReplicas, maxReplicas, cpuTarget int32) {
+	t.Helper()
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+
+	retry.RunWith(&retry.Timer{Timeout: 1 * time.Minute, Wait: 2 * time.Second}, t, func(r *retry.R) {
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: hpaName, Namespace: namespace}, hpa)
+		require.NoError(r, err)
+		require.Equal(r, "Deployment", hpa.Spec.ScaleTargetRef.Kind)
+		require.Equal(r, targetName, hpa.Spec.ScaleTargetRef.Name)
+		require.NotNil(r, hpa.Spec.MinReplicas)
+		require.Equal(r, minReplicas, *hpa.Spec.MinReplicas)
+		require.Equal(r, maxReplicas, hpa.Spec.MaxReplicas)
+		require.Len(r, hpa.Spec.Metrics, 1)
+		require.NotNil(r, hpa.Spec.Metrics[0].Resource)
+		require.NotNil(r, hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+		require.Equal(r, cpuTarget, *hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+
+		for _, owner := range hpa.OwnerReferences {
+			require.NotEqualf(r, "Gateway", owner.Kind, "user HPA unexpectedly owned by Gateway %s", owner.Name)
+		}
+	})
+
+	logger.Logf(t, "BEHAVIOR RESULT: user-managed HPA %s/%s still exists unchanged spec=%s owners=%s", namespace, hpaName, hpaSpec(hpa), hpaOwnerReferences(hpa.OwnerReferences))
+}
+
+func gatewayListeners(listeners []gwv1.Listener) string {
+	if len(listeners) == 0 {
+		return "none"
+	}
+
+	result := ""
+	for i, listener := range listeners {
+		if i > 0 {
+			result += ", "
+		}
+		result += fmt.Sprintf("%s:%d/%s", listener.Name, listener.Port, listener.Protocol)
+	}
+	return result
+}
+
+func gatewayAnnotations(annotations map[string]string) string {
+	if len(annotations) == 0 {
+		return "none"
+	}
+
+	keys := []string{
+		annotationDefaultReplicas,
+		annotationHPAEnabled,
+		annotationHPAMinReplicas,
+		annotationHPAMaxReplicas,
+		annotationHPACPUTarget,
+	}
+
+	result := ""
+	for _, key := range keys {
+		value, ok := annotations[key]
+		if !ok {
+			continue
+		}
+		if result != "" {
+			result += ", "
+		}
+		result += fmt.Sprintf("%s=%s", key, value)
+	}
+	if result == "" {
+		return "custom annotations present"
+	}
+	return result
+}
+
+func hpaSpec(hpa *autoscalingv2.HorizontalPodAutoscaler) string {
+	minReplicas := "nil"
+	if hpa.Spec.MinReplicas != nil {
+		minReplicas = fmt.Sprintf("%d", *hpa.Spec.MinReplicas)
+	}
+
+	cpuTarget := "nil"
+	if len(hpa.Spec.Metrics) > 0 && hpa.Spec.Metrics[0].Resource != nil && hpa.Spec.Metrics[0].Resource.Target.AverageUtilization != nil {
+		cpuTarget = fmt.Sprintf("%d", *hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+	}
+
+	return fmt.Sprintf("target=%s/%s min=%s max=%d cpuAverageUtilization=%s", hpa.Spec.ScaleTargetRef.Kind, hpa.Spec.ScaleTargetRef.Name, minReplicas, hpa.Spec.MaxReplicas, cpuTarget)
+}
+
+func hpaOwnerReferences(ownerReferences []metav1.OwnerReference) string {
+	if len(ownerReferences) == 0 {
+		return "none"
+	}
+
+	owners := ""
+	for i, owner := range ownerReferences {
+		if i > 0 {
+			owners += ", "
+		}
+
+		controller := "false"
+		if owner.Controller != nil && *owner.Controller {
+			controller = "true"
+		}
+		owners += fmt.Sprintf("%s/%s(controller=%s)", owner.Kind, owner.Name, controller)
+	}
+
+	return owners
 }

--- a/acceptance/tests/openshift/api_gateway_scaling_openshift_test.go
+++ b/acceptance/tests/openshift/api_gateway_scaling_openshift_test.go
@@ -1,0 +1,863 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package openshift
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul-k8s/acceptance/framework/consul"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/environment"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
+	"github.com/hashicorp/consul-k8s/acceptance/framework/logger"
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	scalingAnnotationDefaultReplicas = "consul.hashicorp.com/default-replicas"
+	scalingAnnotationHPAEnabled      = "consul.hashicorp.com/hpa-enabled"
+	scalingAnnotationHPAMinReplicas  = "consul.hashicorp.com/hpa-minimum-replicas"
+	scalingAnnotationHPAMaxReplicas  = "consul.hashicorp.com/hpa-maximum-replicas"
+	scalingAnnotationHPACPUTarget    = "consul.hashicorp.com/hpa-cpu-utilisation-target"
+)
+
+func TestOpenshift_APIGateway_Scaling_EnterpriseGateEnabledControllerManagedHPA(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfiguredOCP(t)
+
+	cfg := suite.Config()
+	ctx := suite.Environment().DefaultContext(t)
+
+	newOpenshiftClusterWithHelmValues(t, cfg, false, false, map[string]string{
+		"connectInject.apiGateway.enabled":                             "true",
+		"connectInject.apiGateway.managedGatewayClass.scaling.enabled": "true",
+		"global.logLevel": "debug",
+	})
+
+	consulCluster := consul.NewHelmCluster(t, map[string]string{}, ctx, cfg, "")
+	consulCluster.SetNamespace("consul")
+
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValidOCP(t, consulClient)
+	restartAPIGatewayControllerOCP(t, ctx)
+
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	gatewayNamespace, _ := createNamespace(t, ctx, cfg)
+	gatewayClassName := createScalingGatewayClassResourcesOCP(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{})
+
+	gateway := createScalingGatewayOCP(t, k8sClient, gatewayNamespace, gatewayClassName, map[string]string{
+		scalingAnnotationHPAEnabled:     "true",
+		scalingAnnotationHPAMinReplicas: "3",
+		scalingAnnotationHPAMaxReplicas: "25",
+		scalingAnnotationHPACPUTarget:   "70",
+	}, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	hpa := waitForGatewayHPAOCP(t, k8sClient, gateway.Name, gateway.Namespace)
+	require.NotNil(t, hpa.Spec.MinReplicas)
+	require.Equal(t, int32(3), *hpa.Spec.MinReplicas)
+	require.Equal(t, int32(25), hpa.Spec.MaxReplicas)
+	require.Len(t, hpa.Spec.Metrics, 1)
+	require.NotNil(t, hpa.Spec.Metrics[0].Resource)
+	require.NotNil(t, hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+	require.Equal(t, int32(70), *hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+
+	waitForGatewayDeploymentReplicasOCP(t, k8sClient, gateway.Name, gateway.Namespace, 3)
+}
+
+func TestOpenshift_APIGateway_Scaling_EnterpriseGateDisabledIgnoresGatewayAnnotations(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfiguredOCP(t)
+
+	cfg := suite.Config()
+	ctx := suite.Environment().DefaultContext(t)
+
+	newOpenshiftClusterWithHelmValues(t, cfg, false, false, map[string]string{
+		"connectInject.apiGateway.enabled":                             "true",
+		"connectInject.apiGateway.managedGatewayClass.scaling.enabled": "false",
+		"global.logLevel": "debug",
+	})
+
+	consulCluster := consul.NewHelmCluster(t, map[string]string{}, ctx, cfg, "")
+	consulCluster.SetNamespace("consul")
+
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValidOCP(t, consulClient)
+
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	gatewayNamespace, _ := createNamespace(t, ctx, cfg)
+	gatewayClassName := createScalingGatewayClassResourcesOCP(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{
+		DefaultInstances: ptr.To(int32(3)),
+		MinInstances:     ptr.To(int32(1)),
+		MaxInstances:     ptr.To(int32(5)),
+	})
+
+	gateway := createScalingGatewayOCP(t, k8sClient, gatewayNamespace, gatewayClassName, map[string]string{
+		scalingAnnotationHPAEnabled:     "true",
+		scalingAnnotationHPAMinReplicas: "2",
+		scalingAnnotationHPAMaxReplicas: "10",
+		scalingAnnotationHPACPUTarget:   "70",
+	}, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	waitForGatewayDeploymentReplicasOCP(t, k8sClient, gateway.Name, gateway.Namespace, 3)
+	waitForGatewayHPAAbsentOCP(t, k8sClient, gateway.Name, gateway.Namespace)
+}
+
+func TestOpenshift_APIGateway_Scaling_EnterpriseGateEnabledStaticReplicas(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfiguredOCP(t)
+
+	cfg := suite.Config()
+	ctx := suite.Environment().DefaultContext(t)
+
+	newOpenshiftClusterWithHelmValues(t, cfg, false, false, map[string]string{
+		"connectInject.apiGateway.enabled":                             "true",
+		"connectInject.apiGateway.managedGatewayClass.scaling.enabled": "true",
+		"global.logLevel": "debug",
+	})
+
+	consulCluster := consul.NewHelmCluster(t, map[string]string{}, ctx, cfg, "")
+	consulCluster.SetNamespace("consul")
+
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValidOCP(t, consulClient)
+	restartAPIGatewayControllerOCP(t, ctx)
+
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	gatewayNamespace, _ := createNamespace(t, ctx, cfg)
+	gatewayClassName := createScalingGatewayClassResourcesOCP(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{})
+
+	gateway := createScalingGatewayOCP(t, k8sClient, gatewayNamespace, gatewayClassName, map[string]string{
+		scalingAnnotationDefaultReplicas: "4",
+	}, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	waitForGatewayDeploymentReplicasOCP(t, k8sClient, gateway.Name, gateway.Namespace, 4)
+}
+
+func TestOpenshift_APIGateway_Scaling_EnterpriseGateEnabledPreservesManualScale(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfiguredOCP(t)
+
+	cfg := suite.Config()
+	ctx := suite.Environment().DefaultContext(t)
+
+	newOpenshiftClusterWithHelmValues(t, cfg, false, false, map[string]string{
+		"connectInject.apiGateway.enabled":                             "true",
+		"connectInject.apiGateway.managedGatewayClass.scaling.enabled": "true",
+		"global.logLevel": "debug",
+	})
+
+	consulCluster := consul.NewHelmCluster(t, map[string]string{}, ctx, cfg, "")
+	consulCluster.SetNamespace("consul")
+
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValidOCP(t, consulClient)
+	restartAPIGatewayControllerOCP(t, ctx)
+
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	gatewayNamespace, _ := createNamespace(t, ctx, cfg)
+	gatewayClassName := createScalingGatewayClassResourcesOCP(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{
+		DefaultInstances: ptr.To(int32(2)),
+		MinInstances:     ptr.To(int32(1)),
+		MaxInstances:     ptr.To(int32(3)),
+	})
+
+	gateway := createScalingGatewayOCP(t, k8sClient, gatewayNamespace, gatewayClassName, nil, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	waitForGatewayDeploymentReplicasOCP(t, k8sClient, gateway.Name, gateway.Namespace, 2)
+	scaleGatewayDeploymentOCP(t, k8sClient, gateway.Name, gateway.Namespace, 5)
+	waitForGatewayDeploymentReplicasOCP(t, k8sClient, gateway.Name, gateway.Namespace, 5)
+	waitForGatewayDeploymentReplicasOCP(t, k8sClient, gateway.Name, gateway.Namespace, 5)
+}
+
+func TestOpenshift_APIGateway_Scaling_UserManagedHPATakesPrecedenceOverAnnotations(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfiguredOCP(t)
+
+	cfg := suite.Config()
+	ctx := suite.Environment().DefaultContext(t)
+
+	newOpenshiftClusterWithHelmValues(t, cfg, false, false, map[string]string{
+		"connectInject.apiGateway.enabled":                             "true",
+		"connectInject.apiGateway.managedGatewayClass.scaling.enabled": "true",
+		"global.logLevel": "debug",
+	})
+
+	consulCluster := consul.NewHelmCluster(t, map[string]string{}, ctx, cfg, "")
+	consulCluster.SetNamespace("consul")
+
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValidOCP(t, consulClient)
+	restartAPIGatewayControllerOCP(t, ctx)
+
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	gatewayNamespace, _ := createNamespace(t, ctx, cfg)
+	gatewayClassName := createScalingGatewayClassResourcesOCP(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{})
+
+	gateway := createScalingGatewayOCP(t, k8sClient, gatewayNamespace, gatewayClassName, map[string]string{
+		scalingAnnotationHPAEnabled:     "true",
+		scalingAnnotationHPAMinReplicas: "2",
+		scalingAnnotationHPAMaxReplicas: "8",
+		scalingAnnotationHPACPUTarget:   "70",
+	}, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	waitForGatewayHPAOCP(t, k8sClient, gateway.Name, gateway.Namespace)
+
+	createUserManagedHPAOCP(t, k8sClient, gateway.Name, gateway.Namespace, 4, 12, 60, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	waitForGatewayHPAAbsentOCP(t, k8sClient, gateway.Name, gateway.Namespace)
+	requireUserHPAUnchangedOCP(t, k8sClient, gateway.Name, gateway.Namespace, 4, 12, 60)
+}
+
+func TestOpenshift_APIGateway_Scaling_UserManagedHPAPreservesManualScale(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfiguredOCP(t)
+
+	cfg := suite.Config()
+	ctx := suite.Environment().DefaultContext(t)
+
+	newOpenshiftClusterWithHelmValues(t, cfg, false, false, map[string]string{
+		"connectInject.apiGateway.enabled":                             "true",
+		"connectInject.apiGateway.managedGatewayClass.scaling.enabled": "true",
+		"global.logLevel": "debug",
+	})
+
+	consulCluster := consul.NewHelmCluster(t, map[string]string{}, ctx, cfg, "")
+	consulCluster.SetNamespace("consul")
+
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValidOCP(t, consulClient)
+	restartAPIGatewayControllerOCP(t, ctx)
+
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	gatewayNamespace, _ := createNamespace(t, ctx, cfg)
+	gatewayClassName := createScalingGatewayClassResourcesOCP(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{
+		DefaultInstances: ptr.To(int32(2)),
+		MinInstances:     ptr.To(int32(1)),
+		MaxInstances:     ptr.To(int32(5)),
+	})
+
+	gateway := createScalingGatewayOCP(t, k8sClient, gatewayNamespace, gatewayClassName, nil, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+	waitForGatewayDeploymentReplicasOCP(t, k8sClient, gateway.Name, gateway.Namespace, 2)
+
+	createUserManagedHPAOCP(t, k8sClient, gateway.Name, gateway.Namespace, 1, 10, 80, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+	scaleGatewayDeploymentOCP(t, k8sClient, gateway.Name, gateway.Namespace, 6)
+
+	waitForGatewayDeploymentReplicasOCP(t, k8sClient, gateway.Name, gateway.Namespace, 6)
+	waitForGatewayHPAAbsentOCP(t, k8sClient, gateway.Name, gateway.Namespace)
+	requireUserHPAUnchangedOCP(t, k8sClient, gateway.Name, gateway.Namespace, 1, 10, 80)
+}
+
+func TestOpenshift_APIGateway_Scaling_UserManagedHPARemovedRestoresControllerHPA(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfiguredOCP(t)
+
+	cfg := suite.Config()
+	ctx := suite.Environment().DefaultContext(t)
+
+	newOpenshiftClusterWithHelmValues(t, cfg, false, false, map[string]string{
+		"connectInject.apiGateway.enabled":                             "true",
+		"connectInject.apiGateway.managedGatewayClass.scaling.enabled": "true",
+		"global.logLevel": "debug",
+	})
+
+	consulCluster := consul.NewHelmCluster(t, map[string]string{}, ctx, cfg, "")
+	consulCluster.SetNamespace("consul")
+
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValidOCP(t, consulClient)
+	restartAPIGatewayControllerOCP(t, ctx)
+
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	gatewayNamespace, _ := createNamespace(t, ctx, cfg)
+	gatewayClassName := createScalingGatewayClassResourcesOCP(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{})
+
+	gateway := createScalingGatewayOCP(t, k8sClient, gatewayNamespace, gatewayClassName, map[string]string{
+		scalingAnnotationHPAEnabled:     "true",
+		scalingAnnotationHPAMinReplicas: "2",
+		scalingAnnotationHPAMaxReplicas: "6",
+		scalingAnnotationHPACPUTarget:   "75",
+	}, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	waitForGatewayHPAOCP(t, k8sClient, gateway.Name, gateway.Namespace)
+
+	userHPAName := createUserManagedHPAOCP(t, k8sClient, gateway.Name, gateway.Namespace, 3, 9, 65, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+	waitForGatewayHPAAbsentOCP(t, k8sClient, gateway.Name, gateway.Namespace)
+
+	deleteUserManagedHPAOCP(t, k8sClient, userHPAName, gateway.Namespace)
+
+	hpa := waitForGatewayHPAOCP(t, k8sClient, gateway.Name, gateway.Namespace)
+	require.NotNil(t, hpa.Spec.MinReplicas)
+	require.Equal(t, int32(2), *hpa.Spec.MinReplicas)
+	require.Equal(t, int32(6), hpa.Spec.MaxReplicas)
+	require.Len(t, hpa.Spec.Metrics, 1)
+	require.NotNil(t, hpa.Spec.Metrics[0].Resource)
+	require.NotNil(t, hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+	require.Equal(t, int32(75), *hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+}
+
+func TestOpenshift_APIGateway_Scaling_UserManagedHPAUpdatesDriveReplicaChanges(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfiguredOCP(t)
+
+	cfg := suite.Config()
+	ctx := suite.Environment().DefaultContext(t)
+
+	newOpenshiftClusterWithHelmValues(t, cfg, false, false, map[string]string{
+		"connectInject.apiGateway.enabled":                             "true",
+		"connectInject.apiGateway.managedGatewayClass.scaling.enabled": "true",
+		"global.logLevel": "debug",
+	})
+
+	consulCluster := consul.NewHelmCluster(t, map[string]string{}, ctx, cfg, "")
+	consulCluster.SetNamespace("consul")
+
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValidOCP(t, consulClient)
+	restartAPIGatewayControllerOCP(t, ctx)
+
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	gatewayNamespace, _ := createNamespace(t, ctx, cfg)
+	gatewayClassName := createScalingGatewayClassResourcesOCP(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{})
+
+	gateway := createScalingGatewayOCP(t, k8sClient, gatewayNamespace, gatewayClassName, nil, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	hpaName := createUserManagedHPAOCP(t, k8sClient, gateway.Name, gateway.Namespace, 1, 10, 80, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	waitForGatewayHPAAbsentOCP(t, k8sClient, gateway.Name, gateway.Namespace)
+	waitForGatewayDeploymentReplicasOCP(t, k8sClient, gateway.Name, gateway.Namespace, 1)
+
+	updateUserManagedHPAReplicaBoundsOCP(t, k8sClient, hpaName, gateway.Namespace, 4, 10)
+	waitForGatewayDeploymentReplicasOCP(t, k8sClient, gateway.Name, gateway.Namespace, 4)
+
+	updateUserManagedHPAReplicaBoundsOCP(t, k8sClient, hpaName, gateway.Namespace, 6, 10)
+	waitForGatewayDeploymentReplicasOCP(t, k8sClient, gateway.Name, gateway.Namespace, 6)
+
+	waitForGatewayHPAAbsentOCP(t, k8sClient, gateway.Name, gateway.Namespace)
+}
+
+func TestOpenshift_APIGateway_Scaling_DanglingUserHPABeforeGatewayTakesPrecedence(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfiguredOCP(t)
+
+	cfg := suite.Config()
+	ctx := suite.Environment().DefaultContext(t)
+
+	newOpenshiftClusterWithHelmValues(t, cfg, false, false, map[string]string{
+		"connectInject.apiGateway.enabled":                             "true",
+		"connectInject.apiGateway.managedGatewayClass.scaling.enabled": "true",
+		"global.logLevel": "debug",
+	})
+
+	consulCluster := consul.NewHelmCluster(t, map[string]string{}, ctx, cfg, "")
+	consulCluster.SetNamespace("consul")
+
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValidOCP(t, consulClient)
+	restartAPIGatewayControllerOCP(t, ctx)
+
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	gatewayNamespace, _ := createNamespace(t, ctx, cfg)
+	gatewayClassName := createScalingGatewayClassResourcesOCP(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{})
+	gatewayName := helpers.RandomName()
+
+	hpaName := createUserManagedHPAForTargetOCP(t, k8sClient, "dangling-user-hpa", gatewayNamespace, gatewayName, 3, 9, 65, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	gateway := createScalingGatewayWithNameOCP(t, k8sClient, gatewayName, gatewayNamespace, gatewayClassName, nil, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	waitForGatewayPodsReadyOCP(t, k8sClient, gateway.Name, gateway.Namespace, 1)
+	waitForGatewayHPAAbsentOCP(t, k8sClient, gateway.Name, gateway.Namespace)
+	requireUserHPAForTargetUnchangedOCP(t, k8sClient, hpaName, gateway.Namespace, gateway.Name, 3, 9, 65)
+}
+
+func skipUnlessEnterpriseLicenseConfiguredOCP(t *testing.T) {
+	t.Helper()
+
+	cfg := suite.Config()
+	if !cfg.EnableEnterprise {
+		t.Skipf("skipping this test because -enable-enterprise is not set")
+	}
+	if cfg.EnterpriseLicense == "" {
+		t.Skipf("skipping this test because no enterprise license is configured")
+	}
+}
+
+func requireEnterpriseLicenseValidOCP(t *testing.T, consulClient *api.Client) {
+	t.Helper()
+
+	retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 2 * time.Second}, t, func(r *retry.R) {
+		license, err := consulClient.Operator().LicenseGet(nil)
+		require.NoError(r, err)
+		require.NotNil(r, license)
+		require.True(r, license.Valid)
+	})
+}
+
+func createScalingGatewayClassResourcesOCP(
+	t *testing.T,
+	k8sClient client.Client,
+	noCleanupOnFailure bool,
+	noCleanup bool,
+	deploymentSpec v1alpha1.DeploymentSpec,
+) string {
+	t.Helper()
+
+	gatewayClassConfigName := helpers.RandomName()
+	gatewayClassName := helpers.RandomName()
+
+	gatewayClassConfig := &v1alpha1.GatewayClassConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: gatewayClassConfigName,
+		},
+		Spec: v1alpha1.GatewayClassConfigSpec{
+			DeploymentSpec: deploymentSpec,
+		},
+	}
+
+	err := k8sClient.Create(context.Background(), gatewayClassConfig)
+	require.NoError(t, err)
+	helpers.Cleanup(t, noCleanupOnFailure, noCleanup, func() {
+		require.NoError(t, client.IgnoreNotFound(k8sClient.Delete(context.Background(), gatewayClassConfig)))
+	})
+
+	gatewayClass := &gwv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: gatewayClassName,
+		},
+		Spec: gwv1.GatewayClassSpec{
+			ControllerName: gwv1.GatewayController(gatewayClassControllerName),
+			ParametersRef: &gwv1.ParametersReference{
+				Group: gwv1.Group(v1alpha1.ConsulHashicorpGroup),
+				Kind:  gwv1.Kind(v1alpha1.GatewayClassConfigKind),
+				Name:  gatewayClassConfigName,
+			},
+		},
+	}
+
+	err = k8sClient.Create(context.Background(), gatewayClass)
+	require.NoError(t, err)
+	helpers.Cleanup(t, noCleanupOnFailure, noCleanup, func() {
+		require.NoError(t, client.IgnoreNotFound(k8sClient.Delete(context.Background(), gatewayClass)))
+	})
+
+	return gatewayClassName
+}
+
+func createScalingGatewayOCP(
+	t *testing.T,
+	k8sClient client.Client,
+	namespace string,
+	gatewayClassName string,
+	annotations map[string]string,
+	noCleanupOnFailure bool,
+	noCleanup bool,
+) *gwv1.Gateway {
+	t.Helper()
+
+	return createScalingGatewayWithNameOCP(t, k8sClient, helpers.RandomName(), namespace, gatewayClassName, annotations, noCleanupOnFailure, noCleanup)
+}
+
+func createScalingGatewayWithNameOCP(
+	t *testing.T,
+	k8sClient client.Client,
+	gatewayName string,
+	namespace string,
+	gatewayClassName string,
+	annotations map[string]string,
+	noCleanupOnFailure bool,
+	noCleanup bool,
+) *gwv1.Gateway {
+	t.Helper()
+
+	gateway := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        gatewayName,
+			Namespace:   namespace,
+			Annotations: annotations,
+			Labels: map[string]string{
+				"component": "api-gateway",
+			},
+		},
+		Spec: gwv1.GatewaySpec{
+			GatewayClassName: gwv1.ObjectName(gatewayClassName),
+			Listeners: []gwv1.Listener{
+				{
+					Name:     gwv1.SectionName("http"),
+					Port:     8080,
+					Protocol: gwv1.HTTPProtocolType,
+				},
+			},
+		},
+	}
+
+	err := k8sClient.Create(context.Background(), gateway)
+	require.NoError(t, err)
+	helpers.Cleanup(t, noCleanupOnFailure, noCleanup, func() {
+		require.NoError(t, client.IgnoreNotFound(k8sClient.Delete(context.Background(), gateway)))
+	})
+
+	logger.Logf(t, "created gateway %s/%s", gateway.Namespace, gateway.Name)
+	logger.Logf(t, "TEST INPUT: Gateway %s/%s spec gatewayClass=%s listeners=%s annotations=%s", gateway.Namespace, gateway.Name, gateway.Spec.GatewayClassName, gatewayListenersOCP(gateway.Spec.Listeners), gatewayAnnotationsOCP(gateway.Annotations))
+	return gateway
+}
+
+func waitForGatewayDeploymentReplicasOCP(t *testing.T, k8sClient client.Client, gatewayName, namespace string, want int32) {
+	t.Helper()
+
+	retry.RunWith(&retry.Timer{Timeout: 5 * time.Minute, Wait: 5 * time.Second}, t, func(r *retry.R) {
+		var deployment appsv1.Deployment
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: gatewayName, Namespace: namespace}, &deployment)
+		require.NoError(r, err)
+		require.NotNil(r, deployment.Spec.Replicas)
+		require.Equal(r, want, *deployment.Spec.Replicas)
+	})
+}
+
+func waitForGatewayPodsReadyOCP(t *testing.T, k8sClient client.Client, gatewayName, namespace string, minReady int32) {
+	t.Helper()
+
+	retry.RunWith(&retry.Timer{Timeout: 5 * time.Minute, Wait: 5 * time.Second}, t, func(r *retry.R) {
+		var deployment appsv1.Deployment
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: gatewayName, Namespace: namespace}, &deployment)
+		require.NoError(r, err)
+		require.NotNil(r, deployment.Spec.Selector)
+		require.NotEmpty(r, deployment.Spec.Selector.MatchLabels)
+
+		var pods corev1.PodList
+		err = k8sClient.List(context.Background(), &pods, client.InNamespace(namespace), client.MatchingLabels(deployment.Spec.Selector.MatchLabels))
+		require.NoError(r, err)
+		require.NotEmpty(r, pods.Items)
+
+		var readyPods int32
+		for _, pod := range pods.Items {
+			if pod.Status.Phase != corev1.PodRunning {
+				continue
+			}
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+					readyPods++
+					break
+				}
+			}
+		}
+
+		require.GreaterOrEqual(r, readyPods, minReady)
+	})
+
+	logger.Logf(t, "BEHAVIOR RESULT: gateway deployment %s/%s has at least %d ready pod(s)", namespace, gatewayName, minReady)
+}
+
+func waitForGatewayHPAOCP(t *testing.T, k8sClient client.Client, gatewayName, namespace string) *autoscalingv2.HorizontalPodAutoscaler {
+	t.Helper()
+
+	controllerHPAName := fmt.Sprintf("%s-hpa", gatewayName)
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 2 * time.Second}, t, func(r *retry.R) {
+		err := k8sClient.Get(context.Background(), types.NamespacedName{
+			Name:      controllerHPAName,
+			Namespace: namespace,
+		}, hpa)
+		require.NoError(r, err)
+	})
+
+	logger.Logf(t, "BEHAVIOR RESULT: controller-managed HPA %s/%s exists spec=%s owners=%s", namespace, controllerHPAName, hpaSpecOCP(hpa), hpaOwnerReferencesOCP(hpa.OwnerReferences))
+	return hpa
+}
+
+func waitForGatewayHPAAbsentOCP(t *testing.T, k8sClient client.Client, gatewayName, namespace string) {
+	t.Helper()
+
+	controllerHPAName := fmt.Sprintf("%s-hpa", gatewayName)
+
+	retry.RunWith(&retry.Timer{Timeout: 1 * time.Minute, Wait: 2 * time.Second}, t, func(r *retry.R) {
+		err := k8sClient.Get(context.Background(), types.NamespacedName{
+			Name:      controllerHPAName,
+			Namespace: namespace,
+		}, &autoscalingv2.HorizontalPodAutoscaler{})
+		require.Error(r, err)
+		require.True(r, apierrors.IsNotFound(err), "expected HPA to be absent, got %v", err)
+	})
+
+	logger.Logf(t, "BEHAVIOR RESULT: controller-managed HPA %s/%s is absent", namespace, controllerHPAName)
+}
+
+func scaleGatewayDeploymentOCP(t *testing.T, k8sClient client.Client, gatewayName, namespace string, replicas int32) {
+	t.Helper()
+
+	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 2 * time.Second}, t, func(r *retry.R) {
+		var deployment appsv1.Deployment
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: gatewayName, Namespace: namespace}, &deployment)
+		require.NoError(r, err)
+
+		deployment.Spec.Replicas = ptr.To(replicas)
+		err = k8sClient.Update(context.Background(), &deployment)
+		require.NoError(r, err)
+	})
+
+	logger.Logf(t, "manually scaled deployment %s/%s to %d replicas", namespace, gatewayName, replicas)
+}
+
+func restartAPIGatewayControllerOCP(t *testing.T, ctx environment.TestContext) {
+	t.Helper()
+
+	k8sClient := ctx.KubernetesClient(t)
+
+	pods, err := k8sClient.CoreV1().Pods("consul").List(context.Background(), metav1.ListOptions{
+		LabelSelector: "app=consul,component=connect-injector",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, pods.Items, "no connect-injector pods found")
+
+	for _, pod := range pods.Items {
+		err = k8sClient.CoreV1().Pods("consul").Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+		require.NoError(t, err)
+		logger.Logf(t, "deleted pod consul/%s to restart API Gateway controller", pod.Name)
+	}
+
+	retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 2 * time.Second}, t, func(r *retry.R) {
+		pods, err := k8sClient.CoreV1().Pods("consul").List(context.Background(), metav1.ListOptions{
+			LabelSelector: "app=consul,component=connect-injector",
+		})
+		require.NoError(r, err)
+		require.NotEmpty(r, pods.Items, "no connect-injector pods found after restart")
+
+		for _, pod := range pods.Items {
+			require.Equal(r, corev1.PodRunning, pod.Status.Phase, "pod %s not running", pod.Name)
+			ready := false
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == corev1.PodReady {
+					require.Equal(r, corev1.ConditionTrue, condition.Status, "pod %s not ready", pod.Name)
+					ready = true
+				}
+			}
+			require.True(r, ready, "pod %s missing ready condition", pod.Name)
+		}
+	})
+
+	logger.Logf(t, "API Gateway controller restarted and ready")
+}
+
+// createUserManagedHPAOCP creates an HPA owned by the user (no Gateway owner
+// reference) targeting the gateway's Deployment. Returns the HPA name.
+func createUserManagedHPAOCP(
+	t *testing.T,
+	k8sClient client.Client,
+	gatewayName, namespace string,
+	minReplicas, maxReplicas, cpuTarget int32,
+	noCleanupOnFailure bool,
+	noCleanup bool,
+) string {
+	t.Helper()
+
+	hpaName := fmt.Sprintf("%s-user-hpa", gatewayName)
+	return createUserManagedHPAForTargetOCP(t, k8sClient, hpaName, namespace, gatewayName, minReplicas, maxReplicas, cpuTarget, noCleanupOnFailure, noCleanup)
+}
+
+func createUserManagedHPAForTargetOCP(
+	t *testing.T,
+	k8sClient client.Client,
+	hpaName, namespace, targetName string,
+	minReplicas, maxReplicas, cpuTarget int32,
+	noCleanupOnFailure bool,
+	noCleanup bool,
+) string {
+	t.Helper()
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hpaName,
+			Namespace: namespace,
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       targetName,
+			},
+			MinReplicas: ptr.To(minReplicas),
+			MaxReplicas: maxReplicas,
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: ptr.To(cpuTarget),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := k8sClient.Create(context.Background(), hpa)
+	require.NoError(t, err)
+	helpers.Cleanup(t, noCleanupOnFailure, noCleanup, func() {
+		logger.Logf(t, "TEST CLEANUP: deleting user-managed HPA %s/%s", namespace, hpaName)
+		require.NoError(t, client.IgnoreNotFound(k8sClient.Delete(context.Background(), hpa)))
+	})
+
+	logger.Logf(t, "TEST INPUT: user-managed HPA %s/%s spec=%s owners=%s", namespace, hpaName, hpaSpecOCP(hpa), hpaOwnerReferencesOCP(hpa.OwnerReferences))
+	return hpaName
+}
+
+// updateUserManagedHPAReplicaBoundsOCP updates the min/max replicas on an
+// existing user-managed HPA, retrying on conflict.
+func updateUserManagedHPAReplicaBoundsOCP(t *testing.T, k8sClient client.Client, hpaName, namespace string, minReplicas, maxReplicas int32) {
+	t.Helper()
+
+	retry.RunWith(&retry.Timer{Timeout: 30 * time.Second, Wait: 1 * time.Second}, t, func(r *retry.R) {
+		var hpa autoscalingv2.HorizontalPodAutoscaler
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: hpaName, Namespace: namespace}, &hpa)
+		require.NoError(r, err)
+
+		hpa.Spec.MinReplicas = ptr.To(minReplicas)
+		hpa.Spec.MaxReplicas = maxReplicas
+
+		err = k8sClient.Update(context.Background(), &hpa)
+		require.NoError(r, err)
+	})
+
+	logger.Logf(t, "TEST ACTION: updated user-managed HPA %s/%s to min=%d max=%d", namespace, hpaName, minReplicas, maxReplicas)
+}
+
+// deleteUserManagedHPAOCP deletes a user-managed HPA by name.
+func deleteUserManagedHPAOCP(t *testing.T, k8sClient client.Client, hpaName, namespace string) {
+	t.Helper()
+
+	logger.Logf(t, "TEST ACTION: deleting user-managed HPA %s/%s so controller-managed HPA can be restored", namespace, hpaName)
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Name: hpaName, Namespace: namespace},
+	}
+	err := k8sClient.Delete(context.Background(), hpa)
+	require.NoError(t, client.IgnoreNotFound(err))
+
+	retry.RunWith(&retry.Timer{Timeout: 1 * time.Minute, Wait: 2 * time.Second}, t, func(r *retry.R) {
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: hpaName, Namespace: namespace}, &autoscalingv2.HorizontalPodAutoscaler{})
+		require.True(r, apierrors.IsNotFound(err), "expected user HPA to be deleted, got %v", err)
+	})
+
+	logger.Logf(t, "BEHAVIOR RESULT: user-managed HPA %s/%s was deleted by the test action", namespace, hpaName)
+}
+
+// requireUserHPAUnchangedOCP asserts the user-managed HPA still exists with its
+// original spec and has not acquired a Gateway owner reference.
+func requireUserHPAUnchangedOCP(t *testing.T, k8sClient client.Client, gatewayName, namespace string, minReplicas, maxReplicas, cpuTarget int32) {
+	t.Helper()
+
+	hpaName := fmt.Sprintf("%s-user-hpa", gatewayName)
+	requireUserHPAForTargetUnchangedOCP(t, k8sClient, hpaName, namespace, gatewayName, minReplicas, maxReplicas, cpuTarget)
+}
+
+func requireUserHPAForTargetUnchangedOCP(t *testing.T, k8sClient client.Client, hpaName, namespace, targetName string, minReplicas, maxReplicas, cpuTarget int32) {
+	t.Helper()
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+
+	retry.RunWith(&retry.Timer{Timeout: 1 * time.Minute, Wait: 2 * time.Second}, t, func(r *retry.R) {
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: hpaName, Namespace: namespace}, hpa)
+		require.NoError(r, err)
+		require.Equal(r, "Deployment", hpa.Spec.ScaleTargetRef.Kind)
+		require.Equal(r, targetName, hpa.Spec.ScaleTargetRef.Name)
+		require.NotNil(r, hpa.Spec.MinReplicas)
+		require.Equal(r, minReplicas, *hpa.Spec.MinReplicas)
+		require.Equal(r, maxReplicas, hpa.Spec.MaxReplicas)
+		require.Len(r, hpa.Spec.Metrics, 1)
+		require.NotNil(r, hpa.Spec.Metrics[0].Resource)
+		require.NotNil(r, hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+		require.Equal(r, cpuTarget, *hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+
+		for _, owner := range hpa.OwnerReferences {
+			require.NotEqualf(r, "Gateway", owner.Kind, "user HPA unexpectedly owned by Gateway %s", owner.Name)
+		}
+	})
+
+	logger.Logf(t, "BEHAVIOR RESULT: user-managed HPA %s/%s still exists unchanged spec=%s owners=%s", namespace, hpaName, hpaSpecOCP(hpa), hpaOwnerReferencesOCP(hpa.OwnerReferences))
+}
+
+func gatewayListenersOCP(listeners []gwv1.Listener) string {
+	if len(listeners) == 0 {
+		return "none"
+	}
+
+	result := ""
+	for i, listener := range listeners {
+		if i > 0 {
+			result += ", "
+		}
+		result += fmt.Sprintf("%s:%d/%s", listener.Name, listener.Port, listener.Protocol)
+	}
+	return result
+}
+
+func gatewayAnnotationsOCP(annotations map[string]string) string {
+	if len(annotations) == 0 {
+		return "none"
+	}
+
+	keys := []string{
+		scalingAnnotationDefaultReplicas,
+		scalingAnnotationHPAEnabled,
+		scalingAnnotationHPAMinReplicas,
+		scalingAnnotationHPAMaxReplicas,
+		scalingAnnotationHPACPUTarget,
+	}
+
+	result := ""
+	for _, key := range keys {
+		value, ok := annotations[key]
+		if !ok {
+			continue
+		}
+		if result != "" {
+			result += ", "
+		}
+		result += fmt.Sprintf("%s=%s", key, value)
+	}
+	if result == "" {
+		return "custom annotations present"
+	}
+	return result
+}
+
+func hpaSpecOCP(hpa *autoscalingv2.HorizontalPodAutoscaler) string {
+	minReplicas := "nil"
+	if hpa.Spec.MinReplicas != nil {
+		minReplicas = fmt.Sprintf("%d", *hpa.Spec.MinReplicas)
+	}
+
+	cpuTarget := "nil"
+	if len(hpa.Spec.Metrics) > 0 && hpa.Spec.Metrics[0].Resource != nil && hpa.Spec.Metrics[0].Resource.Target.AverageUtilization != nil {
+		cpuTarget = fmt.Sprintf("%d", *hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+	}
+
+	return fmt.Sprintf("target=%s/%s min=%s max=%d cpuAverageUtilization=%s", hpa.Spec.ScaleTargetRef.Kind, hpa.Spec.ScaleTargetRef.Name, minReplicas, hpa.Spec.MaxReplicas, cpuTarget)
+}
+
+func hpaOwnerReferencesOCP(ownerReferences []metav1.OwnerReference) string {
+	if len(ownerReferences) == 0 {
+		return "none"
+	}
+
+	owners := ""
+	for i, owner := range ownerReferences {
+		if i > 0 {
+			owners += ", "
+		}
+
+		controller := "false"
+		if owner.Controller != nil && *owner.Controller {
+			controller = "true"
+		}
+		owners += fmt.Sprintf("%s/%s(controller=%s)", owner.Kind, owner.Name, controller)
+	}
+
+	return owners
+}

--- a/acceptance/tests/openshift/openshift_test_runner.go
+++ b/acceptance/tests/openshift/openshift_test_runner.go
@@ -2,8 +2,11 @@ package openshift
 
 import (
 	"os/exec"
+	"sort"
 	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/consul-k8s/acceptance/framework/config"
 	"github.com/hashicorp/consul-k8s/acceptance/framework/helpers"
@@ -12,12 +15,16 @@ import (
 )
 
 func newOpenshiftCluster(t *testing.T, cfg *config.TestConfig, secure, namespaceMirroring bool) {
+	newOpenshiftClusterWithHelmValues(t, cfg, secure, namespaceMirroring, nil)
+}
+
+func newOpenshiftClusterWithHelmValues(t *testing.T, cfg *config.TestConfig, secure, namespaceMirroring bool, extraHelmValues map[string]string) {
 	// Cleanup of old consul secret
 	cmd := exec.Command("kubectl", "delete", "secret", "-n", "consul", "consul-ent-license")
 	_, _ = cmd.CombinedOutput()
 
 	// Cleanup of old consul helm installtion and namespace
-	cmd = exec.Command("helm", "uninstall", "consul", "--namespace", "consul")
+	cmd = exec.Command("helm", "uninstall", "consul", "--namespace", "consul", "--no-hooks")
 	_, _ = cmd.CombinedOutput()
 
 	// Bypass finalizers for the consul namespace deletion.
@@ -29,9 +36,17 @@ func newOpenshiftCluster(t *testing.T, cfg *config.TestConfig, secure, namespace
 	cmd = exec.Command("kubectl", "delete", "namespace", "consul")
 	_, _ = cmd.CombinedOutput()
 
+	// Ensure resources from prior runs are not stuck in Terminating.
+	helpers.ForceCleanupTerminatingResources(t, []helpers.ResourceToCleanup{
+		{Type: "crd", Name: "gatewayclassconfigs.consul.hashicorp.com"},
+	}, 180*time.Second)
+
+	var output []byte
+	var err error
+
 	// Add the hashicorp helm repo
 	cmd = exec.Command("helm", "repo", "add", "hashicorp", "https://helm.releases.hashicorp.com")
-	output, err := cmd.CombinedOutput()
+	output, err = cmd.CombinedOutput()
 	require.NoErrorf(t, err, "failed to add hashicorp helm repo: %s", string(output))
 
 	// FUTURE for some reason NewHelmCluster creates a consul server pod that runs as root which
@@ -60,32 +75,68 @@ func newOpenshiftCluster(t *testing.T, cfg *config.TestConfig, secure, namespace
 		assert.NoErrorf(t, err, "failed to delete secret: %s", string(output))
 	})
 
+	// Create CRD explicitly and let Helm treat it as externally managed to avoid
+	// CRD delete/recreate races across tests.
+	cmd = exec.Command("kubectl", "apply", "-f", "../../../control-plane/config/crd/bases/consul.hashicorp.com_gatewayclassconfigs.yaml")
+	output, err = cmd.CombinedOutput()
+	require.NoErrorf(t, err, "failed to apply GatewayClassConfig CRD: %s", string(output))
+	cmd = exec.Command("kubectl", "wait", "--for=condition=Established", "--timeout=120s", "crd/gatewayclassconfigs.consul.hashicorp.com")
+	output, err = cmd.CombinedOutput()
+	require.NoErrorf(t, err, "failed waiting for GatewayClassConfig CRD to be established: %s", string(output))
+	cmd = exec.Command("kubectl", "label", "crd", "gatewayclassconfigs.consul.hashicorp.com", "app.kubernetes.io/managed-by=Helm", "--overwrite")
+	output, err = cmd.CombinedOutput()
+	require.NoErrorf(t, err, "failed to label GatewayClassConfig CRD for Helm ownership: %s", string(output))
+	cmd = exec.Command("kubectl", "annotate", "crd", "gatewayclassconfigs.consul.hashicorp.com", "meta.helm.sh/release-name=consul", "meta.helm.sh/release-namespace=consul", "--overwrite")
+	output, err = cmd.CombinedOutput()
+	require.NoErrorf(t, err, "failed to annotate GatewayClassConfig CRD for Helm ownership: %s", string(output))
+	// Normalize ownership metadata on existing Consul CRDs. Prior local runs may
+	// leave these tied to a different Helm release/namespace and block install.
+	cmd = exec.Command("bash", "-c", `for crd in $(kubectl get crd -o name | grep '\.consul\.hashicorp\.com$'); do kubectl label "$crd" app.kubernetes.io/managed-by=Helm --overwrite >/dev/null 2>&1 || true; kubectl annotate "$crd" meta.helm.sh/release-name=consul meta.helm.sh/release-namespace=consul --overwrite >/dev/null 2>&1 || true; done`)
+	output, err = cmd.CombinedOutput()
+	require.NoErrorf(t, err, "failed to normalize Consul CRD ownership metadata: %s", string(output))
+
 	chartPath := "../../../charts/consul"
-	cmd = exec.Command("helm", "upgrade", "--install", "consul", chartPath,
+	helmArgs := []string{"upgrade", "--install", "consul", chartPath,
 		"--namespace", "consul",
 		"--set", "global.name=consul",
 		"--set", "connectInject.enabled=true",
 		"--set", "connectInject.transparentProxy.defaultEnabled=false",
 		"--set", "connectInject.apiGateway.managedGatewayClass.mapPrivilegedContainerPorts=8000",
-		"--set", "global.acls.manageSystemACLs="+strconv.FormatBool(secure),
-		"--set", "global.tls.enabled="+strconv.FormatBool(secure),
-		"--set", "global.tls.enableAutoEncrypt="+strconv.FormatBool(secure),
-		"--set", "global.enableConsulNamespaces="+strconv.FormatBool(namespaceMirroring),
-		"--set", "global.consulNamespaces.mirroringK8S="+strconv.FormatBool(namespaceMirroring),
+		"--set", "global.acls.manageSystemACLs=" + strconv.FormatBool(secure),
+		"--set", "global.tls.enabled=" + strconv.FormatBool(secure),
+		"--set", "global.tls.enableAutoEncrypt=" + strconv.FormatBool(secure),
+		"--set", "global.enableConsulNamespaces=" + strconv.FormatBool(namespaceMirroring),
+		"--set", "global.consulNamespaces.mirroringK8S=" + strconv.FormatBool(namespaceMirroring),
 		"--set", "global.openshift.enabled=true",
-		"--set", "global.image="+cfg.ConsulImage,
-		"--set", "global.imageK8S="+cfg.ConsulK8SImage,
-		"--set", "global.imageConsulDataplane="+cfg.ConsulDataplaneImage,
+		"--set", "global.image=" + cfg.ConsulImage,
+		"--set", "global.imageK8S=" + cfg.ConsulK8SImage,
+		"--set", "global.imageConsulDataplane=" + cfg.ConsulDataplaneImage,
 		"--set", "global.enterpriseLicense.secretName=consul-ent-license",
 		"--set", "global.enterpriseLicense.secretKey=key",
-		"--set", "connectInject.apiGateway.manageExternalCRDs=true",
-	)
+		"--set", "connectInject.apiGateway.manageExternalCRDs=false",
+	}
+
+	if len(extraHelmValues) > 0 {
+		keys := make([]string, 0, len(extraHelmValues))
+		for key := range extraHelmValues {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		for _, key := range keys {
+			helmArgs = append(helmArgs, "--set", key+"="+extraHelmValues[key])
+		}
+	}
+
+	cmd = exec.Command("helm", helmArgs...)
 
 	output, err = cmd.CombinedOutput()
 	helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
-		cmd := exec.Command("helm", "uninstall", "consul", "--namespace", "consul")
+		cmd := exec.Command("helm", "uninstall", "consul", "--namespace", "consul", "--no-hooks")
 		output, err := cmd.CombinedOutput()
-		require.NoErrorf(t, err, "failed to uninstall consul: %s", string(output))
+		if err != nil && !strings.Contains(string(output), "release: not found") {
+			require.NoErrorf(t, err, "failed to uninstall consul: %s", string(output))
+		}
 	})
 
 	require.NoErrorf(t, err, "failed to install consul: %s", string(output))

--- a/control-plane/api-gateway-custom/common/helm_config.go
+++ b/control-plane/api-gateway-custom/common/helm_config.go
@@ -51,6 +51,10 @@ type HelmConfig struct {
 	// by default on a deployed gateway, passed from the helm chart via command-line flags to our controller.
 	EnableGatewayMetrics bool
 
+	// EnableGatewayScaling indicates whether Enterprise API Gateway scaling features
+	// such as Gateway scaling annotations and controller-managed HPAs are enabled.
+	EnableGatewayScaling bool
+
 	// The default path to use for scraping prometheus metrics, passed from the helm chart via command-line flags to our controller.
 	DefaultPrometheusScrapePath string
 

--- a/control-plane/api-gateway-custom/controllers/gateway_controller.go
+++ b/control-plane/api-gateway-custom/controllers/gateway_controller.go
@@ -19,6 +19,7 @@ import (
 	gwv1alpha2 "github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom/apis/v1alpha2"
 	gwv1beta1 "github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom/apis/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,6 +39,7 @@ import (
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway-custom/cache"
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway-custom/common"
 	"github.com/hashicorp/consul-k8s/control-plane/api-gateway-custom/gatekeeper"
+	apicommon "github.com/hashicorp/consul-k8s/control-plane/api/common"
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	"github.com/hashicorp/consul-k8s/control-plane/consul"
 )
@@ -47,6 +49,7 @@ type CustomGatewayControllerConfig struct {
 	HelmConfig              common.HelmConfig
 	ConsulClientConfig      *consul.Config
 	ConsulServerConnMgr     consul.ServerConnectionManager
+	ConsulMeta              apicommon.ConsulMeta
 	NamespacesEnabled       bool
 	CrossNamespaceACLPolicy string
 	Partition               string
@@ -69,6 +72,7 @@ type GatewayController struct {
 	client.Client
 	ConsulConfig *consul.Config
 	ApiReader    client.Reader
+	ConsulMeta   apicommon.ConsulMeta
 }
 
 // Reconcile handles the reconciliation loop for Gateway objects.
@@ -160,6 +164,7 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// add our current gateway even if it's not controlled by us so we
 	// can garbage collect any resources for it.
 	resources.ReferenceCountGateway(gateway)
+	effectiveHelmConfig := r.effectiveHelmConfig(log)
 
 	if err := r.fetchControlledGateways(ctx, resources); err != nil {
 		log.Error(err, "unable to fetch controlled gateways")
@@ -221,7 +226,7 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		ConsulGateway:         consulGateway,
 		ConsulGatewayServices: consulServices,
 		Policies:              policies,
-		HelmConfig:            r.HelmConfig,
+		HelmConfig:            effectiveHelmConfig,
 	})
 
 	updates := binder.Snapshot()
@@ -232,7 +237,7 @@ func (r *GatewayController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, err
 		}
 
-		err := r.updateGatekeeperResources(ctx, log, &gateway, updates.GatewayClassConfig)
+		err := r.updateGatekeeperResources(ctx, log, &gateway, updates.GatewayClassConfig, effectiveHelmConfig)
 		if err != nil {
 			if k8serrors.IsConflict(err) {
 				log.Info("error updating object when updating gateway resources, will try to re-reconcile")
@@ -391,9 +396,9 @@ func (r *GatewayController) deleteGatekeeperResources(ctx context.Context, log l
 	return nil
 }
 
-func (r *GatewayController) updateGatekeeperResources(ctx context.Context, log logr.Logger, gw *gwv1beta1.Gateway, gwcc *v1alpha1.GatewayClassConfig) error {
+func (r *GatewayController) updateGatekeeperResources(ctx context.Context, log logr.Logger, gw *gwv1beta1.Gateway, gwcc *v1alpha1.GatewayClassConfig, config common.HelmConfig) error {
 	gk := gatekeeper.New(log, r.Client, r.ConsulConfig, r.ApiReader)
-	err := gk.Upsert(ctx, *gw, *gwcc, r.HelmConfig)
+	err := gk.Upsert(ctx, *gw, *gwcc, config)
 	if err != nil {
 		return err
 	}
@@ -444,6 +449,7 @@ func SetupGatewayControllerWithManager(ctx context.Context, mgr ctrl.Manager, co
 		cache:                 c,
 		gatewayCache:          gwc,
 		ConsulConfig:          config.ConsulClientConfig,
+		ConsulMeta:            config.ConsulMeta,
 	}
 
 	cleaner := binding.Cleaner{
@@ -453,7 +459,7 @@ func SetupGatewayControllerWithManager(ctx context.Context, mgr ctrl.Manager, co
 		AuthMethod:   config.HelmConfig.AuthMethod,
 	}
 
-	return c, cleaner, ctrl.NewControllerManagedBy(mgr).
+	builder := ctrl.NewControllerManagedBy(mgr).
 		Named("gateway-consul").
 		For(&gwv1beta1.Gateway{}, builder.WithPredicates(gwPredicate)).
 		Owns(&appsv1.Deployment{}).
@@ -491,7 +497,16 @@ func SetupGatewayControllerWithManager(ctx context.Context, mgr ctrl.Manager, co
 			&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.transformPods),
 			builder.WithPredicates(podPredicate),
-		).
+		)
+
+	if config.HelmConfig.EnableGatewayScaling && config.ConsulMeta.IsEnterpriseDistribution {
+		builder = builder.Watches(
+			&autoscalingv2.HorizontalPodAutoscaler{},
+			handler.EnqueueRequestsFromMapFunc(r.transformHPA),
+		)
+	}
+
+	return c, cleaner, builder.
 		WatchesRawSource(
 			source.Channel(
 				c.Subscribe(ctx, api.APIGateway, r.transformConsulGateway).Events(),
@@ -540,6 +555,21 @@ func SetupGatewayControllerWithManager(ctx context.Context, mgr ctrl.Manager, co
 			handler.EnqueueRequestsFromMapFunc(r.transformRouteAuthFilter),
 		).
 		Complete(r)
+}
+
+func (r *GatewayController) effectiveHelmConfig(log logr.Logger) common.HelmConfig {
+	config := r.HelmConfig
+	if !config.EnableGatewayScaling {
+		return config
+	}
+
+	if r.ConsulMeta.IsEnterpriseDistribution {
+		return config
+	}
+
+	log.Info("Ignoring Gateway scaling annotations because the connected Consul cluster does not report a valid enterprise license. Enable a valid Consul Enterprise license to allow annotation-driven scaling and HPA reconciliation.")
+	config.EnableGatewayScaling = false
+	return config
 }
 
 // transformGatewayClass will check the list of GatewayClass objects for a matching
@@ -774,6 +804,22 @@ func (r *GatewayController) transformPods(ctx context.Context, o client.Object) 
 	}
 
 	return nil
+}
+
+func (r *GatewayController) transformHPA(_ context.Context, o client.Object) []reconcile.Request {
+	hpa := o.(*autoscalingv2.HorizontalPodAutoscaler)
+	if hpa.Spec.ScaleTargetRef.Kind != "Deployment" || hpa.Spec.ScaleTargetRef.Name == "" {
+		return nil
+	}
+
+	return []reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Namespace: hpa.Namespace,
+				Name:      hpa.Spec.ScaleTargetRef.Name,
+			},
+		},
+	}
 }
 
 // transformEndpoints will return a list of gateways that are referenced

--- a/control-plane/api-gateway-custom/controllers/gateway_controller_enterprise_scaling_test.go
+++ b/control-plane/api-gateway-custom/controllers/gateway_controller_enterprise_scaling_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/hashicorp/consul-k8s/control-plane/api-gateway-custom/common"
+	apicommon "github.com/hashicorp/consul-k8s/control-plane/api/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomGatewayControllerEffectiveHelmConfig(t *testing.T) {
+	t.Parallel()
+
+	controller := GatewayController{
+		HelmConfig: common.HelmConfig{
+			EnableGatewayScaling: true,
+		},
+		ConsulMeta: apicommon.ConsulMeta{},
+	}
+
+	require.False(t, controller.effectiveHelmConfig(testr.New(t)).EnableGatewayScaling)
+
+	controller.ConsulMeta.IsEnterpriseDistribution = true
+	require.True(t, controller.effectiveHelmConfig(testr.New(t)).EnableGatewayScaling)
+}

--- a/control-plane/api-gateway-custom/gatekeeper/deployment.go
+++ b/control-plane/api-gateway-custom/gatekeeper/deployment.go
@@ -54,20 +54,30 @@ func (g *Gatekeeper) upsertDeployment(ctx context.Context, gateway gwv1beta1.Gat
 		currentReplicas = existingDeployment.Spec.Replicas
 	}
 
-	deployment, err := g.deployment(gateway, gcc, config, currentReplicas)
+	var replicas *int32
+	if config.EnableGatewayScaling {
+		scalingConfig, err := g.ReconcileScaling(ctx, gateway, gcc)
+		if err != nil {
+			g.Log.Error(err, "failed to reconcile scaling configuration")
+			return err
+		}
+		replicas = resolvedDeploymentReplicas(scalingConfig, gcc, currentReplicas)
+	} else {
+		logScalingFeatureDisabled(g.Log, gateway)
+		if err := g.DeleteHPA(ctx, gateway); err != nil {
+			g.Log.Error(err, "failed to delete controller-managed HPA while scaling is disabled")
+			return err
+		}
+		replicas = deploymentReplicas(gcc, currentReplicas)
+	}
+
+	deployment, err := g.deployment(gateway, gcc, config, replicas)
 	if err != nil {
 		return err
 	}
 
-	if exists {
-		g.Log.V(1).Info("Existing Gateway Deployment found.")
-
-		// If the user has set the number of replicas, let's respect that.
-		deployment.Spec.Replicas = existingDeployment.Spec.Replicas
-	}
-
 	mutated := deployment.DeepCopy()
-	mutator := newDeploymentMutator(deployment, mutated, existingDeployment, exists, gcc, gateway, g.Client.Scheme())
+	mutator := newDeploymentMutator(deployment, mutated, existingDeployment, exists, gateway, g.Client.Scheme())
 
 	result, err := controllerutil.CreateOrUpdate(ctx, g.Client, mutated, mutator)
 	if err != nil {
@@ -95,7 +105,7 @@ func (g *Gatekeeper) deleteDeployment(ctx context.Context, gwName types.Namespac
 	return err
 }
 
-func (g *Gatekeeper) deployment(gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config common.HelmConfig, currentReplicas *int32) (*appsv1.Deployment, error) {
+func (g *Gatekeeper) deployment(gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig, config common.HelmConfig, replicas *int32) (*appsv1.Deployment, error) {
 	initContainer, err := g.initContainer(config, gateway.Name, gateway.Namespace)
 	if err != nil {
 		return nil, err
@@ -129,7 +139,7 @@ func (g *Gatekeeper) deployment(gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayC
 			Labels:    common.LabelsForGateway(&gateway),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: deploymentReplicas(gcc, currentReplicas),
+			Replicas: replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: common.LabelsForGateway(&gateway),
 			},
@@ -170,10 +180,10 @@ func (g *Gatekeeper) deployment(gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayC
 	}, nil
 }
 
-func mergeDeployments(gcc v1alpha1.GatewayClassConfig, a, b *appsv1.Deployment) *appsv1.Deployment {
+func mergeDeployments(a, b *appsv1.Deployment) *appsv1.Deployment {
 	if !compareDeployments(a, b) {
 		b.Spec.Template = a.Spec.Template
-		b.Spec.Replicas = deploymentReplicas(gcc, a.Spec.Replicas)
+		b.Spec.Replicas = a.Spec.Replicas
 	}
 
 	return b
@@ -242,9 +252,9 @@ func mergeAnnotation(b *appsv1.Deployment, annotations map[string]string) {
 
 }
 
-func newDeploymentMutator(deployment, mutated, existingDeployment *appsv1.Deployment, deploymentExists bool, gcc v1alpha1.GatewayClassConfig, gateway gwv1beta1.Gateway, scheme *runtime.Scheme) resourceMutator {
+func newDeploymentMutator(deployment, mutated, existingDeployment *appsv1.Deployment, deploymentExists bool, gateway gwv1beta1.Gateway, scheme *runtime.Scheme) resourceMutator {
 	return func() error {
-		mutated = mergeDeployments(gcc, deployment, mutated)
+		mutated = mergeDeployments(deployment, mutated)
 		if deploymentExists {
 			mergeAnnotation(mutated, existingDeployment.Spec.Template.Annotations)
 		}

--- a/control-plane/api-gateway-custom/gatekeeper/gatekeeper_test.go
+++ b/control-plane/api-gateway-custom/gatekeeper/gatekeeper_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1149,6 +1150,7 @@ func TestUpsert(t *testing.T) {
 			require.NoError(t, rbac.AddToScheme(s))
 			require.NoError(t, corev1.AddToScheme(s))
 			require.NoError(t, appsv1.AddToScheme(s))
+			require.NoError(t, autoscalingv2.AddToScheme(s))
 
 			log := logrtest.New(t)
 
@@ -1402,6 +1404,7 @@ func TestDelete(t *testing.T) {
 			require.NoError(t, rbac.AddToScheme(s))
 			require.NoError(t, corev1.AddToScheme(s))
 			require.NoError(t, appsv1.AddToScheme(s))
+			require.NoError(t, autoscalingv2.AddToScheme(s))
 
 			log := logrtest.New(t)
 

--- a/control-plane/api-gateway-custom/gatekeeper/scaling.go
+++ b/control-plane/api-gateway-custom/gatekeeper/scaling.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
+	gwv1beta1 "github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom/apis/v1beta1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -16,59 +17,46 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 )
 
 const (
-	// Annotation keys for scaling configuration.
 	AnnotationDefaultReplicas = "consul.hashicorp.com/default-replicas"
 	AnnotationHPAEnabled      = "consul.hashicorp.com/hpa-enabled"
 	AnnotationHPAMinReplicas  = "consul.hashicorp.com/hpa-minimum-replicas"
 	AnnotationHPAMaxReplicas  = "consul.hashicorp.com/hpa-maximum-replicas"
 	AnnotationHPACPUTarget    = "consul.hashicorp.com/hpa-cpu-utilisation-target"
 
-	// Backward-compatible alias for the earlier hyphenated US spelling.
 	annotationHPACPUTargetUS = "consul.hashicorp.com/hpa-cpu-utilization-target"
 
-	// Default values.
 	defaultHPAMinReplicas = 1
 	defaultHPAMaxReplicas = 10
 	defaultCPUTarget      = 80
 )
 
-// ScalingConfig holds the parsed scaling configuration from Gateway annotations.
 type ScalingConfig struct {
-	// Mode indicates the scaling mode: "static", "hpa-controller", "hpa-user", or "none"
 	Mode string
 
-	// StaticReplicas is the fixed number of replicas (for static mode)
 	StaticReplicas *int32
 
-	// HPAConfig holds HPA configuration (for hpa-controller mode)
 	HPAConfig *HPAConfig
 
-	// UseGatewayClassFallback indicates the deprecated GatewayClassConfig
-	// deployment fields are still the source of truth for replicas.
 	UseGatewayClassFallback bool
 }
 
-// HPAConfig holds HPA-specific configuration.
 type HPAConfig struct {
 	MinReplicas    int32
 	MaxReplicas    int32
 	CPUTargetValue int32
 }
 
-// ParseScalingAnnotations extracts and validates scaling configuration from Gateway annotations.
-func ParseScalingAnnotations(gateway gwv1.Gateway, log logr.Logger) (*ScalingConfig, error) {
+func ParseScalingAnnotations(gateway gwv1beta1.Gateway, log logr.Logger) (*ScalingConfig, error) {
 	annotations := gateway.Annotations
 	if annotations == nil {
 		return &ScalingConfig{Mode: "none"}, nil
 	}
 
-	// Check for HPA enabled annotation
 	if hpaEnabled, ok := annotationValue(annotations, AnnotationHPAEnabled); ok && hpaEnabled == "true" {
 		hpaConfig, err := parseHPAAnnotations(annotations, log)
 		if err != nil {
@@ -81,7 +69,6 @@ func ParseScalingAnnotations(gateway gwv1.Gateway, log logr.Logger) (*ScalingCon
 		}, nil
 	}
 
-	// Check for static replica annotation
 	if replicasStr, ok := annotations[AnnotationDefaultReplicas]; ok {
 		replicas, err := strconv.ParseInt(replicasStr, 10, 32)
 		if err != nil {
@@ -104,15 +91,13 @@ func ParseScalingAnnotations(gateway gwv1.Gateway, log logr.Logger) (*ScalingCon
 	return &ScalingConfig{Mode: "none"}, nil
 }
 
-// parseHPAAnnotations extracts HPA configuration from annotations.
-func parseHPAAnnotations(annotations map[string]string, log logr.Logger) (*HPAConfig, error) {
+func parseHPAAnnotations(annotations map[string]string, _ logr.Logger) (*HPAConfig, error) {
 	config := &HPAConfig{
 		MinReplicas:    defaultHPAMinReplicas,
 		MaxReplicas:    defaultHPAMaxReplicas,
 		CPUTargetValue: defaultCPUTarget,
 	}
 
-	// Parse min replicas
 	if minStr, ok := annotationValue(annotations, AnnotationHPAMinReplicas); ok {
 		min, err := strconv.ParseInt(minStr, 10, 32)
 		if err == nil && min >= 1 {
@@ -122,7 +107,6 @@ func parseHPAAnnotations(annotations map[string]string, log logr.Logger) (*HPACo
 		}
 	}
 
-	// Parse max replicas
 	if maxStr, ok := annotationValue(annotations, AnnotationHPAMaxReplicas); ok {
 		max, err := strconv.ParseInt(maxStr, 10, 32)
 		if err == nil && max >= 1 {
@@ -132,9 +116,7 @@ func parseHPAAnnotations(annotations map[string]string, log logr.Logger) (*HPACo
 		}
 	}
 
-	// Validate min/max relationship
 	if config.MinReplicas <= config.MaxReplicas {
-		// Parse CPU target
 		if cpuStr, ok := annotationValue(annotations, AnnotationHPACPUTarget, annotationHPACPUTargetUS); ok {
 			cpu, err := strconv.ParseInt(cpuStr, 10, 32)
 			if err == nil && cpu >= 1 && cpu <= 100 {
@@ -159,7 +141,7 @@ func annotationValue(annotations map[string]string, keys ...string) (string, boo
 	return "", false
 }
 
-func scalingAnnotationsConfigured(gateway gwv1.Gateway) bool {
+func scalingAnnotationsConfigured(gateway gwv1beta1.Gateway) bool {
 	annotations := gateway.Annotations
 	if annotations == nil {
 		return false
@@ -175,7 +157,7 @@ func scalingAnnotationsConfigured(gateway gwv1.Gateway) bool {
 	return false
 }
 
-func logScalingFeatureDisabled(log logr.Logger, gateway gwv1.Gateway) {
+func logScalingFeatureDisabled(log logr.Logger, gateway gwv1beta1.Gateway) {
 	if !scalingAnnotationsConfigured(gateway) {
 		return
 	}
@@ -185,20 +167,15 @@ func logScalingFeatureDisabled(log logr.Logger, gateway gwv1.Gateway) {
 		"gateway", client.ObjectKeyFromObject(&gateway))
 }
 
-// DetectUserManagedHPA checks if a user has created their own HPA for the gateway.
-func (g *Gatekeeper) DetectUserManagedHPA(ctx context.Context, gateway gwv1.Gateway) (bool, error) {
+func (g *Gatekeeper) DetectUserManagedHPA(ctx context.Context, gateway gwv1beta1.Gateway) (bool, error) {
 	hpaList := &autoscalingv2.HorizontalPodAutoscalerList{}
 	err := g.Client.List(ctx, hpaList, client.InNamespace(gateway.Namespace))
 	if err != nil {
 		return false, err
 	}
 
-	deploymentName := gateway.Name
 	for _, hpa := range hpaList.Items {
-		// Check if this HPA targets our deployment
-		if hpa.Spec.ScaleTargetRef.Kind == "Deployment" &&
-			hpa.Spec.ScaleTargetRef.Name == deploymentName {
-			// Check if it's NOT controller-managed (no owner reference to gateway)
+		if hpa.Spec.ScaleTargetRef.Kind == "Deployment" && hpa.Spec.ScaleTargetRef.Name == gateway.Name {
 			isControllerManaged := false
 			for _, owner := range hpa.OwnerReferences {
 				if owner.Kind == "Gateway" && owner.Name == gateway.Name {
@@ -216,8 +193,7 @@ func (g *Gatekeeper) DetectUserManagedHPA(ctx context.Context, gateway gwv1.Gate
 	return false, nil
 }
 
-// UpsertHPA creates or updates an HPA resource for the gateway.
-func (g *Gatekeeper) UpsertHPA(ctx context.Context, gateway gwv1.Gateway, config *HPAConfig) error {
+func (g *Gatekeeper) UpsertHPA(ctx context.Context, gateway gwv1beta1.Gateway, config *HPAConfig) error {
 	hpa := &autoscalingv2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-hpa", gateway.Name),
@@ -226,12 +202,10 @@ func (g *Gatekeeper) UpsertHPA(ctx context.Context, gateway gwv1.Gateway, config
 	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, g.Client, hpa, func() error {
-		// Set owner reference
 		if err := ctrl.SetControllerReference(&gateway, hpa, g.Client.Scheme()); err != nil {
 			return err
 		}
 
-		// Configure HPA spec
 		hpa.Spec = autoscalingv2.HorizontalPodAutoscalerSpec{
 			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 				APIVersion: "apps/v1",
@@ -256,7 +230,6 @@ func (g *Gatekeeper) UpsertHPA(ctx context.Context, gateway gwv1.Gateway, config
 
 		return nil
 	})
-
 	if err != nil {
 		return fmt.Errorf("failed to create/update HPA: %w", err)
 	}
@@ -265,38 +238,31 @@ func (g *Gatekeeper) UpsertHPA(ctx context.Context, gateway gwv1.Gateway, config
 	return nil
 }
 
-// DeleteHPA removes the controller-managed HPA for a gateway.
-func (g *Gatekeeper) DeleteHPA(ctx context.Context, gateway gwv1.Gateway) error {
+func (g *Gatekeeper) DeleteHPA(ctx context.Context, gateway gwv1beta1.Gateway) error {
 	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 	hpaName := fmt.Sprintf("%s-hpa", gateway.Name)
 
-	// First, fetch the HPA to check if it exists and if we own it
 	err := g.Client.Get(ctx, client.ObjectKey{
 		Name:      hpaName,
 		Namespace: gateway.Namespace,
 	}, hpa)
-
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}
-
 	if err != nil {
 		return fmt.Errorf("failed to get HPA: %w", err)
 	}
 
-	// Verify that this controller owns the HPA before deleting
 	if !metav1.IsControlledBy(hpa, &gateway) {
 		g.Log.V(1).Info("HPA exists but is not controller-managed, skipping deletion",
 			"gateway", gateway.Name, "hpa", hpaName)
 		return nil
 	}
 
-	// Delete the controller-managed HPA
 	err = g.Client.Delete(ctx, hpa)
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}
-
 	if err != nil {
 		return fmt.Errorf("failed to delete HPA: %w", err)
 	}
@@ -305,7 +271,6 @@ func (g *Gatekeeper) DeleteHPA(ctx context.Context, gateway gwv1.Gateway) error 
 	return nil
 }
 
-// LogDeprecationWarnings logs warnings for deprecated GatewayClassConfig fields.
 func LogDeprecationWarnings(gcc v1alpha1.GatewayClassConfig, log logr.Logger) {
 	if gcc.Spec.DeploymentSpec.DefaultInstances != nil ||
 		gcc.Spec.DeploymentSpec.MaxInstances != nil ||
@@ -319,12 +284,9 @@ func LogDeprecationWarnings(gcc v1alpha1.GatewayClassConfig, log logr.Logger) {
 	}
 }
 
-// DetermineScalingMode determines the final scaling mode considering all sources.
-func (g *Gatekeeper) DetermineScalingMode(ctx context.Context, gateway gwv1.Gateway, gcc v1alpha1.GatewayClassConfig) (*ScalingConfig, error) {
-	// Log deprecation warnings for GCC fields
+func (g *Gatekeeper) DetermineScalingMode(ctx context.Context, gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig) (*ScalingConfig, error) {
 	LogDeprecationWarnings(gcc, g.Log)
 
-	// Priority 1: Check for user-managed HPA
 	hasUserHPA, err := g.DetectUserManagedHPA(ctx, gateway)
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect user-managed HPA: %w", err)
@@ -335,7 +297,6 @@ func (g *Gatekeeper) DetermineScalingMode(ctx context.Context, gateway gwv1.Gate
 		return &ScalingConfig{Mode: "hpa-user"}, nil
 	}
 
-	// Priority 2: Check Gateway annotations
 	config, err := ParseScalingAnnotations(gateway, g.Log)
 	if err != nil {
 		return nil, err
@@ -345,7 +306,6 @@ func (g *Gatekeeper) DetermineScalingMode(ctx context.Context, gateway gwv1.Gate
 		return config, nil
 	}
 
-	// Priority 3: Fall back to GCC (deprecated)
 	if gcc.Spec.DeploymentSpec.DefaultInstances != nil ||
 		gcc.Spec.DeploymentSpec.MaxInstances != nil ||
 		gcc.Spec.DeploymentSpec.MinInstances != nil {
@@ -356,14 +316,10 @@ func (g *Gatekeeper) DetermineScalingMode(ctx context.Context, gateway gwv1.Gate
 		}, nil
 	}
 
-	// Default: no controller-owned scaling. New deployments seed at 1 replica,
-	// and existing deployments keep their current scale to allow manual scaling.
 	return &ScalingConfig{Mode: "none"}, nil
 }
 
-// ReconcileScaling handles the complete scaling reconciliation for a gateway
-// and returns the resolved scaling mode after HPA side effects are applied.
-func (g *Gatekeeper) ReconcileScaling(ctx context.Context, gateway gwv1.Gateway, gcc v1alpha1.GatewayClassConfig) (*ScalingConfig, error) {
+func (g *Gatekeeper) ReconcileScaling(ctx context.Context, gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClassConfig) (*ScalingConfig, error) {
 	scalingConfig, err := g.DetermineScalingMode(ctx, gateway, gcc)
 	if err != nil {
 		return nil, err
@@ -371,37 +327,20 @@ func (g *Gatekeeper) ReconcileScaling(ctx context.Context, gateway gwv1.Gateway,
 
 	switch scalingConfig.Mode {
 	case "hpa-user":
-		// User manages HPA, ensure we don't have a controller-managed HPA
 		if err := g.DeleteHPA(ctx, gateway); err != nil {
 			g.Log.Error(err, "failed to delete controller-managed HPA")
 		}
-		return scalingConfig, nil
-
 	case "hpa-controller":
-		// Create/update controller-managed HPA
 		if err := g.UpsertHPA(ctx, gateway, scalingConfig.HPAConfig); err != nil {
 			return nil, err
 		}
-		return scalingConfig, nil
-
-	case "static":
-		// Ensure no controller-managed HPA exists
+	case "static", "none":
 		if err := g.DeleteHPA(ctx, gateway); err != nil {
 			g.Log.Error(err, "failed to delete controller-managed HPA")
 		}
-		return scalingConfig, nil
-
-	case "none":
-		// Scaling is unmanaged by the controller. Ensure any controller-managed
-		// HPA is removed and preserve the current Deployment scale.
-		if err := g.DeleteHPA(ctx, gateway); err != nil {
-			g.Log.Error(err, "failed to delete controller-managed HPA")
-		}
-		return scalingConfig, nil
-
-	default:
-		return scalingConfig, nil
 	}
+
+	return scalingConfig, nil
 }
 
 func resolvedDeploymentReplicas(scalingConfig *ScalingConfig, gcc v1alpha1.GatewayClassConfig, currentReplicas *int32) *int32 {

--- a/control-plane/api-gateway-custom/gatekeeper/scaling_test.go
+++ b/control-plane/api-gateway-custom/gatekeeper/scaling_test.go
@@ -1,0 +1,208 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package gatekeeper
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	gwv1beta1 "github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom/apis/v1beta1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+)
+
+func TestParseScalingAnnotations(t *testing.T) {
+	log := logr.Discard()
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    *ScalingConfig
+		expectError bool
+	}{
+		{name: "no annotations", annotations: nil, expected: &ScalingConfig{Mode: "none"}},
+		{
+			name: "static replicas valid",
+			annotations: map[string]string{
+				AnnotationDefaultReplicas: "15",
+			},
+			expected: &ScalingConfig{Mode: "static", StaticReplicas: int32Ptr(15)},
+		},
+		{name: "static replicas invalid - not a number", annotations: map[string]string{AnnotationDefaultReplicas: "invalid"}, expectError: true},
+		{name: "static replicas invalid - zero", annotations: map[string]string{AnnotationDefaultReplicas: "0"}, expectError: true},
+		{name: "static replicas invalid - negative", annotations: map[string]string{AnnotationDefaultReplicas: "-5"}, expectError: true},
+		{
+			name: "HPA enabled with defaults",
+			annotations: map[string]string{
+				AnnotationHPAEnabled: "true",
+			},
+			expected: &ScalingConfig{
+				Mode: "hpa-controller",
+				HPAConfig: &HPAConfig{
+					MinReplicas:    defaultHPAMinReplicas,
+					MaxReplicas:    defaultHPAMaxReplicas,
+					CPUTargetValue: defaultCPUTarget,
+				},
+			},
+		},
+		{
+			name: "HPA enabled with custom values",
+			annotations: map[string]string{
+				AnnotationHPAEnabled:     "true",
+				AnnotationHPAMinReplicas: "2",
+				AnnotationHPAMaxReplicas: "50",
+				AnnotationHPACPUTarget:   "70",
+			},
+			expected: &ScalingConfig{
+				Mode:      "hpa-controller",
+				HPAConfig: &HPAConfig{MinReplicas: 2, MaxReplicas: 50, CPUTargetValue: 70},
+			},
+		},
+		{
+			name: "legacy hyphenated CPU target spelling remains supported",
+			annotations: map[string]string{
+				AnnotationHPAEnabled:     "true",
+				AnnotationHPAMinReplicas: "3",
+				AnnotationHPAMaxReplicas: "25",
+				annotationHPACPUTargetUS: "65",
+			},
+			expected: &ScalingConfig{
+				Mode:      "hpa-controller",
+				HPAConfig: &HPAConfig{MinReplicas: 3, MaxReplicas: 25, CPUTargetValue: 65},
+			},
+		},
+		{name: "HPA with min > max", annotations: map[string]string{AnnotationHPAEnabled: "true", AnnotationHPAMinReplicas: "10", AnnotationHPAMaxReplicas: "5"}, expectError: true},
+		{name: "HPA with invalid CPU target", annotations: map[string]string{AnnotationHPAEnabled: "true", AnnotationHPACPUTarget: "150"}, expectError: true},
+		{name: "HPA with CPU target zero", annotations: map[string]string{AnnotationHPAEnabled: "true", AnnotationHPACPUTarget: "0"}, expectError: true},
+		{
+			name: "HPA takes precedence over static",
+			annotations: map[string]string{
+				AnnotationHPAEnabled:      "true",
+				AnnotationDefaultReplicas: "10",
+			},
+			expected: &ScalingConfig{
+				Mode: "hpa-controller",
+				HPAConfig: &HPAConfig{
+					MinReplicas:    defaultHPAMinReplicas,
+					MaxReplicas:    defaultHPAMaxReplicas,
+					CPUTargetValue: defaultCPUTarget,
+				},
+			},
+		},
+		{name: "HPA disabled explicitly", annotations: map[string]string{AnnotationHPAEnabled: "false"}, expected: &ScalingConfig{Mode: "none"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gateway := gwv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-gateway",
+					Namespace:   "default",
+					Annotations: tt.annotations,
+				},
+			}
+
+			result, err := ParseScalingAnnotations(gateway, log)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected.Mode, result.Mode)
+			if tt.expected.StaticReplicas != nil {
+				require.NotNil(t, result.StaticReplicas)
+				require.Equal(t, *tt.expected.StaticReplicas, *result.StaticReplicas)
+			}
+			if tt.expected.HPAConfig != nil {
+				require.NotNil(t, result.HPAConfig)
+				require.Equal(t, tt.expected.HPAConfig.MinReplicas, result.HPAConfig.MinReplicas)
+				require.Equal(t, tt.expected.HPAConfig.MaxReplicas, result.HPAConfig.MaxReplicas)
+				require.Equal(t, tt.expected.HPAConfig.CPUTargetValue, result.HPAConfig.CPUTargetValue)
+			}
+		})
+	}
+}
+
+func TestParseHPAAnnotations(t *testing.T) {
+	log := logr.Discard()
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    *HPAConfig
+		expectError bool
+	}{
+		{name: "defaults when no annotations", annotations: map[string]string{}, expected: &HPAConfig{MinReplicas: defaultHPAMinReplicas, MaxReplicas: defaultHPAMaxReplicas, CPUTargetValue: defaultCPUTarget}},
+		{name: "custom min replicas", annotations: map[string]string{AnnotationHPAMinReplicas: "5"}, expected: &HPAConfig{MinReplicas: 5, MaxReplicas: defaultHPAMaxReplicas, CPUTargetValue: defaultCPUTarget}},
+		{name: "custom max replicas", annotations: map[string]string{AnnotationHPAMaxReplicas: "100"}, expected: &HPAConfig{MinReplicas: defaultHPAMinReplicas, MaxReplicas: 100, CPUTargetValue: defaultCPUTarget}},
+		{name: "all custom values", annotations: map[string]string{AnnotationHPAMinReplicas: "3", AnnotationHPAMaxReplicas: "30", AnnotationHPACPUTarget: "60"}, expected: &HPAConfig{MinReplicas: 3, MaxReplicas: 30, CPUTargetValue: 60}},
+		{name: "legacy hyphenated CPU target spelling", annotations: map[string]string{annotationHPACPUTargetUS: "55"}, expected: &HPAConfig{MinReplicas: defaultHPAMinReplicas, MaxReplicas: defaultHPAMaxReplicas, CPUTargetValue: 55}},
+		{name: "invalid min replicas - not a number", annotations: map[string]string{AnnotationHPAMinReplicas: "abc"}, expectError: true},
+		{name: "invalid min replicas - zero", annotations: map[string]string{AnnotationHPAMinReplicas: "0"}, expectError: true},
+		{name: "invalid max replicas - not a number", annotations: map[string]string{AnnotationHPAMaxReplicas: "xyz"}, expectError: true},
+		{name: "min greater than max", annotations: map[string]string{AnnotationHPAMinReplicas: "20", AnnotationHPAMaxReplicas: "10"}, expectError: true},
+		{name: "CPU target out of range - too high", annotations: map[string]string{AnnotationHPACPUTarget: "101"}, expectError: true},
+		{name: "CPU target out of range - too low", annotations: map[string]string{AnnotationHPACPUTarget: "0"}, expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseHPAAnnotations(tt.annotations, log)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected.MinReplicas, result.MinReplicas)
+			require.Equal(t, tt.expected.MaxReplicas, result.MaxReplicas)
+			require.Equal(t, tt.expected.CPUTargetValue, result.CPUTargetValue)
+		})
+	}
+}
+
+func TestResolvedDeploymentReplicas(t *testing.T) {
+	max := int32(8)
+	min := int32(1)
+	defaultInstances := int32(15)
+	gcc := v1alpha1.GatewayClassConfig{
+		Spec: v1alpha1.GatewayClassConfigSpec{
+			DeploymentSpec: v1alpha1.DeploymentSpec{
+				DefaultInstances: &defaultInstances,
+				MaxInstances:     &max,
+				MinInstances:     &min,
+			},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		scalingConfig   *ScalingConfig
+		currentReplicas *int32
+		expected        int32
+	}{
+		{name: "unmanaged scaling preserves current replicas", scalingConfig: &ScalingConfig{Mode: "none"}, currentReplicas: int32Ptr(12), expected: 12},
+		{name: "unmanaged scaling seeds new deployment at default replica count", scalingConfig: &ScalingConfig{Mode: "none"}, expected: 1},
+		{name: "gateway class fallback seeds new deployment using deprecated bounds", scalingConfig: &ScalingConfig{Mode: "static", UseGatewayClassFallback: true}, expected: 8},
+		{name: "gateway class fallback preserves current replicas above deprecated max", scalingConfig: &ScalingConfig{Mode: "static", UseGatewayClassFallback: true}, currentReplicas: int32Ptr(15), expected: 15},
+		{name: "controller HPA preserves current replicas above deprecated max", scalingConfig: &ScalingConfig{Mode: "hpa-controller", HPAConfig: &HPAConfig{MinReplicas: 2}}, currentReplicas: int32Ptr(15), expected: 15},
+		{name: "controller HPA seeds new deployment from min replicas", scalingConfig: &ScalingConfig{Mode: "hpa-controller", HPAConfig: &HPAConfig{MinReplicas: 2}}, expected: 2},
+		{name: "gateway static annotation ignores deprecated max", scalingConfig: &ScalingConfig{Mode: "static", StaticReplicas: int32Ptr(20)}, expected: 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			replicas := resolvedDeploymentReplicas(tt.scalingConfig, gcc, tt.currentReplicas)
+			require.NotNil(t, replicas)
+			require.Equal(t, tt.expected, *replicas)
+		})
+	}
+}
+
+func int32Ptr(i int32) *int32 {
+	return &i
+}

--- a/control-plane/subcommand/inject-connect/v1controllers.go
+++ b/control-plane/subcommand/inject-connect/v1controllers.go
@@ -110,6 +110,12 @@ func (c *Command) configureControllers(ctx context.Context, mgr manager.Manager,
 		return err
 	}
 
+	isEnterpriseDistribution, err := consul.IsEnterpriseDistribution(consulConfig, watcher)
+	if err != nil {
+		setupLog.Info("Unable to validate Consul enterprise license for enterprise feature gating; enterprise-only gateway scaling will remain disabled until a valid license is detected", "error", err)
+		isEnterpriseDistribution = false
+	}
+
 	if c.flagEnableCustomGatewayCRDController {
 		// register field indexes for consul.hashicorp.com API controllers for custom
 		if err := gatewaycontrollerscustom.RegisterFieldIndexes(ctx, mgr); err != nil {
@@ -162,14 +168,18 @@ func (c *Command) configureControllers(ctx context.Context, mgr manager.Manager,
 				ConsulPartition:             c.consul.Partition,
 				ConsulCACert:                string(c.caCertPem),
 				EnableGatewayMetrics:        c.flagEnableGatewayMetrics,
+				EnableGatewayScaling:        c.flagEnableGatewayScaling,
 				DefaultPrometheusScrapePath: c.flagDefaultPrometheusScrapePath,
 				DefaultPrometheusScrapePort: c.flagDefaultPrometheusScrapePort,
 				InitContainerResources:      &c.initContainerResources,
 			},
-			AllowK8sNamespacesSet:   allowK8sNamespaces,
-			DenyK8sNamespacesSet:    denyK8sNamespaces,
-			ConsulClientConfig:      consulConfig,
-			ConsulServerConnMgr:     watcher,
+			AllowK8sNamespacesSet: allowK8sNamespaces,
+			DenyK8sNamespacesSet:  denyK8sNamespaces,
+			ConsulClientConfig:    consulConfig,
+			ConsulServerConnMgr:   watcher,
+			ConsulMeta: apicommon.ConsulMeta{
+				IsEnterpriseDistribution: isEnterpriseDistribution,
+			},
 			NamespacesEnabled:       c.flagEnableNamespaces,
 			CrossNamespaceACLPolicy: c.flagCrossNamespaceACLPolicy,
 			Partition:               c.consul.Partition,
@@ -205,12 +215,6 @@ func (c *Command) configureControllers(ctx context.Context, mgr manager.Manager,
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GatewayClass")
 		return err
-	}
-
-	isEnterpriseDistribution, err := consul.IsEnterpriseDistribution(consulConfig, watcher)
-	if err != nil {
-		setupLog.Info("Unable to validate Consul enterprise license for enterprise feature gating; enterprise-only gateway scaling will remain disabled until a valid license is detected", "error", err)
-		isEnterpriseDistribution = false
 	}
 
 	cache, cleaner, err := gatewaycontrollers.SetupGatewayControllerWithManager(ctx, mgr, gatewaycontrollers.GatewayControllerConfig{


### PR DESCRIPTION
* api-gateway-custom: add scaling support and openshift coverage

* test(api-gateway): add scaling tests for OpenShift with custom annotations

* refactor(api-gateway): simplify HPA annotation parsing and validation logic

* test(api-gateway): add user-managed HPA tests to validate scaling behavior

* refactor(api-gateway): remove unused reconcile trigger functions and annotations from scaling tests

* refactor(api-gateway): remove retargetUserManagedHPA and retargetUserManagedHPAOCP functions to streamline scaling tests

### Changes proposed in this PR ###  
-
-

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
