### PR TITLE
test(api-gateway): secondary tests for CSL-12699 — API Gateway scaling beyond 8 replicas

### DIFF
--- a/acceptance/tests/api-gateway/api_gateway_scaling_test.go
+++ b/acceptance/tests/api-gateway/api_gateway_scaling_test.go
@@ -386,3 +386,404 @@ func restartAPIGatewayController(t *testing.T, ctx environment.TestContext) {
 		logger.Logf(t, "API Gateway controller restarted and ready")
 	})
 }
+
+// TestAPIGateway_Scaling_EnterpriseGateEnabledStaticReplicasBeyond8 verifies that
+// a gateway can be scaled beyond the previous hard limit of 8 replicas using
+// the consul.hashicorp.com/default-replicas annotation.
+// This is the primary regression test for CSL-12699.
+func TestAPIGateway_Scaling_EnterpriseGateEnabledStaticReplicasBeyond8(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfigured(t)
+
+	ctx := suite.Environment().DefaultContext(t)
+	consulCluster := installScalingCluster(t, true)
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValid(t, consulClient)
+
+	restartAPIGatewayController(t, ctx)
+
+	cfg := suite.Config()
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	gatewayClassName := createScalingGatewayClassResources(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{})
+
+	// Set default-replicas to 10 — beyond the old hard limit of 8.
+	gateway := createScalingGateway(t, k8sClient, ctx.KubectlOptions(t).Namespace, gatewayClassName, map[string]string{
+		annotationDefaultReplicas: "10",
+	}, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	waitForGatewayDeploymentReplicas(t, k8sClient, gateway.Name, gateway.Namespace, 10)
+
+	// No HPA should be created for a static-replica configuration.
+	waitForGatewayHPAAbsent(t, k8sClient, gateway.Name, gateway.Namespace)
+
+	logger.Logf(t, "confirmed gateway %s/%s scaled to 10 replicas (beyond previous hard limit of 8)", gateway.Namespace, gateway.Name)
+}
+
+// TestAPIGateway_Scaling_EnterpriseGateEnabledUserManagedHPA verifies that when a
+// user creates their own HPA targeting the gateway deployment, the controller
+// detects it, enters hpa-user mode, and does NOT create or overwrite the user HPA.
+func TestAPIGateway_Scaling_EnterpriseGateEnabledUserManagedHPA(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfigured(t)
+
+	ctx := suite.Environment().DefaultContext(t)
+	consulCluster := installScalingCluster(t, true)
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValid(t, consulClient)
+
+	restartAPIGatewayController(t, ctx)
+
+	cfg := suite.Config()
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	namespace := ctx.KubectlOptions(t).Namespace
+	gatewayClassName := createScalingGatewayClassResources(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{
+		DefaultInstances: ptr.To(int32(2)),
+		MinInstances:     ptr.To(int32(1)),
+		MaxInstances:     ptr.To(int32(4)),
+	})
+
+	// Create a gateway with no scaling annotations so that it starts up cleanly
+	// using the deprecated GCC deployment spec.
+	gateway := createScalingGateway(t, k8sClient, namespace, gatewayClassName, nil, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+	waitForGatewayDeploymentReplicas(t, k8sClient, gateway.Name, gateway.Namespace, 2)
+
+	// Now simulate the user creating their own HPA for the gateway deployment.
+	userHPAName := fmt.Sprintf("%s-user-hpa", gateway.Name)
+	userMinReplicas := int32(3)
+	userMaxReplicas := int32(15)
+	userHPA := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      userHPAName,
+			Namespace: namespace,
+			// No OwnerReferences — this is intentionally NOT controller-managed.
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       gateway.Name,
+			},
+			MinReplicas: &userMinReplicas,
+			MaxReplicas: userMaxReplicas,
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: ptr.To(int32(60)),
+						},
+					},
+				},
+			},
+		},
+	}
+	err := k8sClient.Create(context.Background(), userHPA)
+	require.NoError(t, err)
+	helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
+		require.NoError(t, client.IgnoreNotFound(k8sClient.Delete(context.Background(), userHPA)))
+	})
+
+	// Trigger a reconcile to make the controller detect the user HPA.
+	triggerGatewayReconcile(t, k8sClient, gateway.Name, gateway.Namespace)
+
+	// Verify the controller does NOT create its own HPA (name = <gateway>-hpa).
+	controllerHPAName := fmt.Sprintf("%s-hpa", gateway.Name)
+	retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 2 * time.Second}, t, func(r *retry.R) {
+		err := k8sClient.Get(context.Background(), types.NamespacedName{
+			Name:      controllerHPAName,
+			Namespace: namespace,
+		}, &autoscalingv2.HorizontalPodAutoscaler{})
+		require.True(r, apierrors.IsNotFound(err),
+			"controller must not create its own HPA when a user-managed HPA is detected; got: %v", err)
+	})
+
+	// Verify the user HPA was NOT deleted.
+	var fetchedUserHPA autoscalingv2.HorizontalPodAutoscaler
+	err = k8sClient.Get(context.Background(), types.NamespacedName{Name: userHPAName, Namespace: namespace}, &fetchedUserHPA)
+	require.NoError(t, err, "user-managed HPA must not be deleted by the controller")
+	require.Equal(t, userMaxReplicas, fetchedUserHPA.Spec.MaxReplicas)
+
+	logger.Logf(t, "confirmed controller correctly deferred to user-managed HPA for gateway %s/%s", namespace, gateway.Name)
+}
+
+// TestAPIGateway_Scaling_EnterpriseGateEnabledAnnotationTransitionStaticToHPA verifies
+// that updating a gateway's annotation from static replicas to HPA mode:
+//  1. Creates a controller-managed HPA
+//  2. The deployment replica count is governed by the HPA
+func TestAPIGateway_Scaling_EnterpriseGateEnabledAnnotationTransitionStaticToHPA(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfigured(t)
+
+	ctx := suite.Environment().DefaultContext(t)
+	consulCluster := installScalingCluster(t, true)
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValid(t, consulClient)
+
+	restartAPIGatewayController(t, ctx)
+
+	cfg := suite.Config()
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	namespace := ctx.KubectlOptions(t).Namespace
+	gatewayClassName := createScalingGatewayClassResources(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{})
+
+	// Phase 1: start with static replicas.
+	gateway := createScalingGateway(t, k8sClient, namespace, gatewayClassName, map[string]string{
+		annotationDefaultReplicas: "5",
+	}, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	waitForGatewayDeploymentReplicas(t, k8sClient, gateway.Name, gateway.Namespace, 5)
+	waitForGatewayHPAAbsent(t, k8sClient, gateway.Name, gateway.Namespace)
+
+	// Phase 2: switch to HPA mode by updating the annotations.
+	var liveGateway gwv1.Gateway
+	err := k8sClient.Get(context.Background(), types.NamespacedName{Name: gateway.Name, Namespace: namespace}, &liveGateway)
+	require.NoError(t, err)
+
+	liveGateway.Annotations = map[string]string{
+		annotationHPAEnabled:     "true",
+		annotationHPAMinReplicas: "2",
+		annotationHPAMaxReplicas: "20",
+		annotationHPACPUTarget:   "65",
+	}
+	err = k8sClient.Update(context.Background(), &liveGateway)
+	require.NoError(t, err)
+	logger.Logf(t, "updated gateway %s/%s annotations to enable HPA mode", namespace, gateway.Name)
+
+	// Verify controller-managed HPA is created with the specified configuration.
+	hpa := waitForGatewayHPA(t, k8sClient, gateway.Name, gateway.Namespace)
+	require.NotNil(t, hpa.Spec.MinReplicas)
+	require.Equal(t, int32(2), *hpa.Spec.MinReplicas)
+	require.Equal(t, int32(20), hpa.Spec.MaxReplicas)
+	require.Len(t, hpa.Spec.Metrics, 1)
+	require.NotNil(t, hpa.Spec.Metrics[0].Resource)
+	require.NotNil(t, hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+	require.Equal(t, int32(65), *hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+
+	logger.Logf(t, "confirmed transition from static to HPA mode for gateway %s/%s", namespace, gateway.Name)
+}
+
+// TestAPIGateway_Scaling_EnterpriseGateEnabledAnnotationTransitionHPAToStatic verifies
+// that removing the HPA annotations (switching back to static) from a gateway:
+//  1. Deletes the controller-managed HPA
+//  2. Sets the deployment to the specified static replica count
+func TestAPIGateway_Scaling_EnterpriseGateEnabledAnnotationTransitionHPAToStatic(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfigured(t)
+
+	ctx := suite.Environment().DefaultContext(t)
+	consulCluster := installScalingCluster(t, true)
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValid(t, consulClient)
+
+	restartAPIGatewayController(t, ctx)
+
+	cfg := suite.Config()
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	namespace := ctx.KubectlOptions(t).Namespace
+	gatewayClassName := createScalingGatewayClassResources(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{})
+
+	// Phase 1: start in HPA mode.
+	gateway := createScalingGateway(t, k8sClient, namespace, gatewayClassName, map[string]string{
+		annotationHPAEnabled:     "true",
+		annotationHPAMinReplicas: "3",
+		annotationHPAMaxReplicas: "15",
+		annotationHPACPUTarget:   "70",
+	}, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	hpa := waitForGatewayHPA(t, k8sClient, gateway.Name, gateway.Namespace)
+	require.Equal(t, int32(15), hpa.Spec.MaxReplicas)
+	waitForGatewayDeploymentReplicas(t, k8sClient, gateway.Name, gateway.Namespace, 3)
+
+	// Phase 2: switch to static mode by replacing all annotations with a static replica count.
+	var liveGateway gwv1.Gateway
+	err := k8sClient.Get(context.Background(), types.NamespacedName{Name: gateway.Name, Namespace: namespace}, &liveGateway)
+	require.NoError(t, err)
+
+	liveGateway.Annotations = map[string]string{
+		annotationDefaultReplicas: "7",
+	}
+	err = k8sClient.Update(context.Background(), &liveGateway)
+	require.NoError(t, err)
+	logger.Logf(t, "updated gateway %s/%s annotations to switch to static mode with 7 replicas", namespace, gateway.Name)
+
+	// Verify the controller-managed HPA is removed.
+	waitForGatewayHPAAbsent(t, k8sClient, gateway.Name, gateway.Namespace)
+
+	// Verify the deployment is set to the new static replica count.
+	waitForGatewayDeploymentReplicas(t, k8sClient, gateway.Name, gateway.Namespace, 7)
+
+	logger.Logf(t, "confirmed transition from HPA to static mode for gateway %s/%s", namespace, gateway.Name)
+}
+
+// TestAPIGateway_Scaling_EnterpriseGateEnabledDanglingUserHPA covers the "dangling HPA"
+// scenario from the PR: a user-managed HPA already exists targeting the gateway deployment
+// at the time the controller first reconciles the gateway. The controller must detect it
+// immediately on the first reconcile, enter hpa-user mode, and never overwrite or delete
+// the pre-existing HPA.
+func TestAPIGateway_Scaling_EnterpriseGateEnabledDanglingUserHPA(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfigured(t)
+
+	ctx := suite.Environment().DefaultContext(t)
+	consulCluster := installScalingCluster(t, true)
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValid(t, consulClient)
+
+	restartAPIGatewayController(t, ctx)
+
+	cfg := suite.Config()
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	namespace := ctx.KubectlOptions(t).Namespace
+	gatewayClassName := createScalingGatewayClassResources(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{
+		DefaultInstances: ptr.To(int32(2)),
+		MinInstances:     ptr.To(int32(1)),
+		MaxInstances:     ptr.To(int32(4)),
+	})
+
+	// Determine the gateway name ahead of time so the HPA can reference it
+	// before the gateway is created (simulating a "dangling" pre-existing HPA).
+	danglingGatewayName := helpers.RandomName()
+	danglingHPAName := fmt.Sprintf("%s-dangling-hpa", danglingGatewayName)
+	danglingMinReplicas := int32(5)
+	danglingMaxReplicas := int32(20)
+
+	// Step 1: create the user HPA BEFORE the gateway exists.
+	danglingHPA := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      danglingHPAName,
+			Namespace: namespace,
+			// No OwnerReferences — pure user-managed resource.
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       danglingGatewayName,
+			},
+			MinReplicas: &danglingMinReplicas,
+			MaxReplicas: danglingMaxReplicas,
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: ptr.To(int32(55)),
+						},
+					},
+				},
+			},
+		},
+	}
+	err := k8sClient.Create(context.Background(), danglingHPA)
+	require.NoError(t, err)
+	helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
+		require.NoError(t, client.IgnoreNotFound(k8sClient.Delete(context.Background(), danglingHPA)))
+	})
+	logger.Logf(t, "created dangling HPA %s/%s before gateway exists", namespace, danglingHPAName)
+
+	// Step 2: now create the gateway with the pre-determined name.
+	gateway := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      danglingGatewayName,
+			Namespace: namespace,
+		},
+		Spec: gwv1.GatewaySpec{
+			GatewayClassName: gwv1.ObjectName(gatewayClassName),
+			Listeners: []gwv1.Listener{
+				{
+					Name:     gwv1.SectionName("http"),
+					Port:     8080,
+					Protocol: gwv1.HTTPProtocolType,
+				},
+			},
+		},
+	}
+	err = k8sClient.Create(context.Background(), gateway)
+	require.NoError(t, err)
+	helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
+		require.NoError(t, client.IgnoreNotFound(k8sClient.Delete(context.Background(), gateway)))
+	})
+	logger.Logf(t, "created gateway %s/%s after dangling HPA already existed", namespace, danglingGatewayName)
+
+	// Step 3: the controller must detect the dangling HPA on first reconcile and NOT
+	// create its own controller-managed HPA (<gateway>-hpa).
+	controllerHPAName := fmt.Sprintf("%s-hpa", danglingGatewayName)
+	retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 2 * time.Second}, t, func(r *retry.R) {
+		err := k8sClient.Get(context.Background(), types.NamespacedName{
+			Name:      controllerHPAName,
+			Namespace: namespace,
+		}, &autoscalingv2.HorizontalPodAutoscaler{})
+		require.True(r, apierrors.IsNotFound(err),
+			"controller must not create its own HPA when a dangling user HPA already targets the deployment; got: %v", err)
+	})
+
+	// Step 4: verify the dangling HPA was NOT deleted or modified by the controller.
+	var fetchedHPA autoscalingv2.HorizontalPodAutoscaler
+	err = k8sClient.Get(context.Background(), types.NamespacedName{Name: danglingHPAName, Namespace: namespace}, &fetchedHPA)
+	require.NoError(t, err, "dangling user HPA must not be deleted by the controller")
+	require.Equal(t, danglingMaxReplicas, fetchedHPA.Spec.MaxReplicas,
+		"dangling user HPA spec must not be modified by the controller")
+
+	logger.Logf(t, "confirmed controller correctly deferred to dangling user HPA for gateway %s/%s", namespace, danglingGatewayName)
+}
+
+// TestAPIGateway_Scaling_EnterpriseGateEnabledFutureGatewayUpgrade covers the
+// "upgrade pre-existing gateway" scenario from the PR: a gateway already exists and
+// is running with the deprecated GatewayClassConfig-based replica bounds. After the
+// operator upgrades the Helm chart with scaling.enabled=true and adds HPA annotations
+// to the gateway, the controller must create the controller-managed HPA and respect
+// the new annotation-driven configuration going forward.
+func TestAPIGateway_Scaling_EnterpriseGateEnabledFutureGatewayUpgrade(t *testing.T) {
+	skipUnlessEnterpriseLicenseConfigured(t)
+
+	ctx := suite.Environment().DefaultContext(t)
+	consulCluster := installScalingCluster(t, true)
+	consulClient, _ := consulCluster.SetupConsulClient(t, false)
+	requireEnterpriseLicenseValid(t, consulClient)
+
+	restartAPIGatewayController(t, ctx)
+
+	cfg := suite.Config()
+	k8sClient := ctx.ControllerRuntimeClient(t)
+	namespace := ctx.KubectlOptions(t).Namespace
+
+	// Simulate a pre-existing gateway that was created with the deprecated GCC deployment
+	// spec (old behaviour before the scaling feature was available).
+	gatewayClassName := createScalingGatewayClassResources(t, k8sClient, cfg.NoCleanupOnFailure, cfg.NoCleanup, v1alpha1.DeploymentSpec{
+		DefaultInstances: ptr.To(int32(3)),
+		MinInstances:     ptr.To(int32(1)),
+		MaxInstances:     ptr.To(int32(8)), // old hard limit still set in GCC
+	})
+
+	gateway := createScalingGateway(t, k8sClient, namespace, gatewayClassName, nil, cfg.NoCleanupOnFailure, cfg.NoCleanup)
+
+	// Confirm it starts at 3 replicas as per GCC default.
+	waitForGatewayDeploymentReplicas(t, k8sClient, gateway.Name, gateway.Namespace, 3)
+	waitForGatewayHPAAbsent(t, k8sClient, gateway.Name, gateway.Namespace)
+
+	// Simulate the operator "upgrading" the gateway by adding HPA annotations
+	// (as they would after enabling the scaling feature and wanting auto-scaling).
+	var liveGateway gwv1.Gateway
+	err := k8sClient.Get(context.Background(), types.NamespacedName{Name: gateway.Name, Namespace: namespace}, &liveGateway)
+	require.NoError(t, err)
+
+	liveGateway.Annotations = map[string]string{
+		annotationHPAEnabled:     "true",
+		annotationHPAMinReplicas: "4",
+		annotationHPAMaxReplicas: "16", // beyond the old GCC hard limit of 8
+		annotationHPACPUTarget:   "70",
+	}
+	err = k8sClient.Update(context.Background(), &liveGateway)
+	require.NoError(t, err)
+	logger.Logf(t, "upgraded gateway %s/%s with HPA annotations (maxReplicas=16, beyond old GCC cap of 8)", namespace, gateway.Name)
+
+	// Verify the controller-managed HPA is created with the new values —
+	// specifically that maxReplicas=16 is honoured, not capped at the old GCC max of 8.
+	hpa := waitForGatewayHPA(t, k8sClient, gateway.Name, gateway.Namespace)
+	require.NotNil(t, hpa.Spec.MinReplicas)
+	require.Equal(t, int32(4), *hpa.Spec.MinReplicas)
+	require.Equal(t, int32(16), hpa.Spec.MaxReplicas,
+		"HPA maxReplicas must respect the annotation value, not the old GCC cap of 8")
+
+	logger.Logf(t, "confirmed post-upgrade HPA for gateway %s/%s has maxReplicas=16 (old cap was 8)", namespace, gateway.Name)
+}
+

--- a/control-plane/api-gateway/gatekeeper/scaling_mode_test.go
+++ b/control-plane/api-gateway/gatekeeper/scaling_mode_test.go
@@ -1,0 +1,402 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package gatekeeper
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	logrtest "github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+)
+
+// newScalingTestScheme returns a scheme with all types required for scaling tests.
+func newScalingTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, gwv1.Install(s))
+	require.NoError(t, v1alpha1.AddToScheme(s))
+	require.NoError(t, autoscalingv2.AddToScheme(s))
+	return s
+}
+
+// makeGateway builds a minimal Gateway with optional annotations for test use.
+func makeGateway(name, namespace string, annotations map[string]string) gwv1.Gateway {
+	return gwv1.Gateway{
+		TypeMeta: metav1.TypeMeta{APIVersion: "gateway.networking.k8s.io/v1", Kind: "Gateway"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: gwv1.GatewaySpec{
+			Listeners: []gwv1.Listener{
+				{Name: "http", Port: 8080, Protocol: gwv1.HTTPProtocolType},
+			},
+		},
+	}
+}
+
+// makeUserHPA builds an HPA that is NOT owned by a Gateway (simulates a user-managed HPA).
+func makeUserHPA(name, namespace, targetDeployment string) *autoscalingv2.HorizontalPodAutoscaler {
+	return &autoscalingv2.HorizontalPodAutoscaler{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "autoscaling/v2",
+			Kind:       "HorizontalPodAutoscaler",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			// No OwnerReferences → not controller-managed
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       targetDeployment,
+			},
+			MaxReplicas: 10,
+		},
+	}
+}
+
+// TestDetermineScalingMode validates the priority chain:
+//
+//	user-managed HPA  >  Gateway annotations  >  GCC deployment spec  >  none
+func TestDetermineScalingMode(t *testing.T) {
+	t.Parallel()
+
+	const (
+		gwName    = "my-gateway"
+		gwNS      = "default"
+		hpaName   = "user-hpa"
+		deployKey = gwName // gateway and its deployment share the same name
+	)
+
+	tests := []struct {
+		name          string
+		annotations   map[string]string
+		gccDeploySpec v1alpha1.DeploymentSpec
+		existingHPAs  []*autoscalingv2.HorizontalPodAutoscaler
+		// assertions
+		wantMode        string
+		wantStaticValue *int32 // non-nil when mode == "static"
+		wantHPAMin      *int32 // non-nil when mode == "hpa-controller"
+		wantHPAMax      *int32
+		wantError       bool
+	}{
+		{
+			name: "user-managed HPA has highest priority, overrides annotations",
+			annotations: map[string]string{
+				AnnotationDefaultReplicas: "5",
+			},
+			existingHPAs: []*autoscalingv2.HorizontalPodAutoscaler{
+				makeUserHPA(hpaName, gwNS, deployKey),
+			},
+			wantMode: "hpa-user",
+		},
+		{
+			name: "user-managed HPA has highest priority, overrides GCC",
+			gccDeploySpec: v1alpha1.DeploymentSpec{
+				DefaultInstances: int32Ptr(3),
+				MaxInstances:     int32Ptr(5),
+			},
+			existingHPAs: []*autoscalingv2.HorizontalPodAutoscaler{
+				makeUserHPA(hpaName, gwNS, deployKey),
+			},
+			wantMode: "hpa-user",
+		},
+		{
+			name: "static annotation takes priority over GCC deployment spec",
+			annotations: map[string]string{
+				AnnotationDefaultReplicas: "12",
+			},
+			gccDeploySpec: v1alpha1.DeploymentSpec{
+				DefaultInstances: int32Ptr(3),
+				MaxInstances:     int32Ptr(8),
+			},
+			wantMode:        "static",
+			wantStaticValue: int32Ptr(12),
+		},
+		{
+			name: "static annotation allows replicas beyond the old hard limit of 8",
+			annotations: map[string]string{
+				AnnotationDefaultReplicas: "20",
+			},
+			wantMode:        "static",
+			wantStaticValue: int32Ptr(20),
+		},
+		{
+			name: "HPA annotation takes priority over GCC deployment spec",
+			annotations: map[string]string{
+				AnnotationHPAEnabled:     "true",
+				AnnotationHPAMinReplicas: "4",
+				AnnotationHPAMaxReplicas: "30",
+				AnnotationHPACPUTarget:   "75",
+			},
+			gccDeploySpec: v1alpha1.DeploymentSpec{
+				DefaultInstances: int32Ptr(3),
+				MaxInstances:     int32Ptr(8),
+			},
+			wantMode:   "hpa-controller",
+			wantHPAMin: int32Ptr(4),
+			wantHPAMax: int32Ptr(30),
+		},
+		{
+			name: "GCC deployment spec is fallback when no annotations are present",
+			gccDeploySpec: v1alpha1.DeploymentSpec{
+				DefaultInstances: int32Ptr(3),
+				MaxInstances:     int32Ptr(5),
+			},
+			wantMode:        "static",
+			wantStaticValue: int32Ptr(3),
+		},
+		{
+			name:          "no annotations and no GCC spec returns none",
+			gccDeploySpec: v1alpha1.DeploymentSpec{},
+			wantMode:      "none",
+		},
+		{
+			name: "invalid static replicas annotation returns error",
+			annotations: map[string]string{
+				AnnotationDefaultReplicas: "not-a-number",
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid HPA annotations (min > max) returns error",
+			annotations: map[string]string{
+				AnnotationHPAEnabled:     "true",
+				AnnotationHPAMinReplicas: "15",
+				AnnotationHPAMaxReplicas: "5",
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := newScalingTestScheme(t)
+			gw := makeGateway(gwName, gwNS, tt.annotations)
+
+			objs := []client.Object{&gw}
+			for _, hpa := range tt.existingHPAs {
+				objs = append(objs, hpa)
+			}
+
+			fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+			log := logrtest.New(t)
+			g := New(log, fakeClient, nil, fakeClient)
+
+			gcc := v1alpha1.GatewayClassConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-gcc"},
+				Spec: v1alpha1.GatewayClassConfigSpec{
+					DeploymentSpec: tt.gccDeploySpec,
+				},
+			}
+
+			result, err := g.DetermineScalingMode(context.Background(), gw, gcc)
+
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, tt.wantMode, result.Mode)
+
+			if tt.wantStaticValue != nil {
+				require.NotNil(t, result.StaticReplicas)
+				require.Equal(t, *tt.wantStaticValue, *result.StaticReplicas)
+			}
+
+			if tt.wantHPAMin != nil {
+				require.NotNil(t, result.HPAConfig)
+				require.Equal(t, *tt.wantHPAMin, result.HPAConfig.MinReplicas)
+			}
+
+			if tt.wantHPAMax != nil {
+				require.NotNil(t, result.HPAConfig)
+				require.Equal(t, *tt.wantHPAMax, result.HPAConfig.MaxReplicas)
+			}
+		})
+	}
+}
+
+// TestReconcileScaling validates that ReconcileScaling applies the correct HPA side-effects:
+//   - hpa-controller mode creates/updates a controller-managed HPA
+//   - static mode deletes any controller-managed HPA
+//   - none mode deletes any controller-managed HPA
+//   - hpa-user mode leaves user HPA untouched and deletes controller HPA
+func TestReconcileScaling(t *testing.T) {
+	t.Parallel()
+
+	const (
+		gwName = "reconcile-gw"
+		gwNS   = "default"
+	)
+
+	hpaName := fmt.Sprintf("%s-hpa", gwName)
+
+	// controllerOwnedHPA simulates an HPA previously created by the controller.
+	controllerOwnedHPA := func(gw *gwv1.Gateway) *autoscalingv2.HorizontalPodAutoscaler {
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "autoscaling/v2",
+				Kind:       "HorizontalPodAutoscaler",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hpaName,
+				Namespace: gwNS,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "gateway.networking.k8s.io/v1",
+						Kind:       "Gateway",
+						Name:       gw.Name,
+						UID:        gw.UID,
+						Controller: func() *bool { b := true; return &b }(),
+					},
+				},
+			},
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       gwName,
+				},
+				MaxReplicas: 5,
+			},
+		}
+		return hpa
+	}
+
+	tests := []struct {
+		name           string
+		annotations    map[string]string
+		gccDeploySpec  v1alpha1.DeploymentSpec
+		existingHPAs   func(gw *gwv1.Gateway) []*autoscalingv2.HorizontalPodAutoscaler
+		wantMode       string
+		wantHPACreated bool // controller-managed HPA should exist after reconcile
+		wantHPAAbsent  bool // no controller-managed HPA should exist after reconcile
+	}{
+		{
+			name: "hpa-controller mode creates controller-managed HPA",
+			annotations: map[string]string{
+				AnnotationHPAEnabled:     "true",
+				AnnotationHPAMinReplicas: "3",
+				AnnotationHPAMaxReplicas: "25",
+				AnnotationHPACPUTarget:   "70",
+			},
+			existingHPAs:   nil,
+			wantMode:       "hpa-controller",
+			wantHPACreated: true,
+		},
+		{
+			name: "hpa-controller mode updates existing controller-managed HPA",
+			annotations: map[string]string{
+				AnnotationHPAEnabled:     "true",
+				AnnotationHPAMinReplicas: "5",
+				AnnotationHPAMaxReplicas: "50",
+				AnnotationHPACPUTarget:   "60",
+			},
+			existingHPAs: func(gw *gwv1.Gateway) []*autoscalingv2.HorizontalPodAutoscaler {
+				return []*autoscalingv2.HorizontalPodAutoscaler{controllerOwnedHPA(gw)}
+			},
+			wantMode:       "hpa-controller",
+			wantHPACreated: true,
+		},
+		{
+			name: "static mode deletes pre-existing controller-managed HPA",
+			annotations: map[string]string{
+				AnnotationDefaultReplicas: "10",
+			},
+			existingHPAs: func(gw *gwv1.Gateway) []*autoscalingv2.HorizontalPodAutoscaler {
+				return []*autoscalingv2.HorizontalPodAutoscaler{controllerOwnedHPA(gw)}
+			},
+			wantMode:      "static",
+			wantHPAAbsent: true,
+		},
+		{
+			name:          "none mode deletes pre-existing controller-managed HPA",
+			annotations:   nil,
+			gccDeploySpec: v1alpha1.DeploymentSpec{},
+			existingHPAs: func(gw *gwv1.Gateway) []*autoscalingv2.HorizontalPodAutoscaler {
+				return []*autoscalingv2.HorizontalPodAutoscaler{controllerOwnedHPA(gw)}
+			},
+			wantMode:      "none",
+			wantHPAAbsent: true,
+		},
+		{
+			name:        "hpa-user mode does not delete user-managed HPA",
+			annotations: nil,
+			existingHPAs: func(gw *gwv1.Gateway) []*autoscalingv2.HorizontalPodAutoscaler {
+				// A user-managed HPA targeting the same deployment (no owner reference)
+				return []*autoscalingv2.HorizontalPodAutoscaler{makeUserHPA("user-hpa", gwNS, gwName)}
+			},
+			wantMode: "hpa-user",
+			// The controller-managed HPA (<gwName>-hpa) should not exist; user's HPA is untouched.
+			wantHPAAbsent: true, // specifically the <gwName>-hpa; user's "user-hpa" remains
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := newScalingTestScheme(t)
+			gw := makeGateway(gwName, gwNS, tt.annotations)
+
+			objs := []client.Object{&gw}
+			if tt.existingHPAs != nil {
+				for _, hpa := range tt.existingHPAs(&gw) {
+					objs = append(objs, hpa)
+				}
+			}
+
+			fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+			log := logrtest.New(t)
+			g := New(log, fakeClient, nil, fakeClient)
+
+			gcc := v1alpha1.GatewayClassConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-gcc"},
+				Spec: v1alpha1.GatewayClassConfigSpec{
+					DeploymentSpec: tt.gccDeploySpec,
+				},
+			}
+
+			result, err := g.ReconcileScaling(context.Background(), gw, gcc)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, tt.wantMode, result.Mode)
+
+			// Verify controller-managed HPA state.
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+			getErr := fakeClient.Get(context.Background(), types.NamespacedName{Name: hpaName, Namespace: gwNS}, hpa)
+
+			if tt.wantHPACreated {
+				require.NoError(t, getErr, "expected controller-managed HPA %s/%s to exist", gwNS, hpaName)
+			}
+
+			if tt.wantHPAAbsent {
+				require.True(t, client.IgnoreNotFound(getErr) == nil && getErr != nil,
+					"expected controller-managed HPA %s/%s to be absent, but got: %v", gwNS, hpaName, getErr)
+			}
+		})
+	}
+}

--- a/control-plane/api-gateway/gatekeeper/scaling_test.go
+++ b/control-plane/api-gateway/gatekeeper/scaling_test.go
@@ -437,3 +437,167 @@ func TestResolvedDeploymentReplicas(t *testing.T) {
 func int32Ptr(i int32) *int32 {
 	return &i
 }
+
+func TestScalingAnnotationsConfigured(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "nil annotations returns false",
+			annotations: nil,
+			expected:    false,
+		},
+		{
+			name:        "empty annotations returns false",
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		{
+			name: "default-replicas annotation is recognized",
+			annotations: map[string]string{
+				AnnotationDefaultReplicas: "5",
+			},
+			expected: true,
+		},
+		{
+			name: "hpa-enabled annotation is recognized",
+			annotations: map[string]string{
+				AnnotationHPAEnabled: "true",
+			},
+			expected: true,
+		},
+		{
+			name: "hpa-minimum-replicas annotation is recognized",
+			annotations: map[string]string{
+				AnnotationHPAMinReplicas: "2",
+			},
+			expected: true,
+		},
+		{
+			name: "hpa-maximum-replicas annotation is recognized",
+			annotations: map[string]string{
+				AnnotationHPAMaxReplicas: "20",
+			},
+			expected: true,
+		},
+		{
+			name: "hpa-cpu-utilisation-target annotation is recognized",
+			annotations: map[string]string{
+				AnnotationHPACPUTarget: "80",
+			},
+			expected: true,
+		},
+		{
+			name: "legacy hyphenated hpa-cpu-utilization-target annotation is recognized",
+			annotations: map[string]string{
+				annotationHPACPUTargetUS: "70",
+			},
+			expected: true,
+		},
+		{
+			name: "unrelated annotation returns false",
+			annotations: map[string]string{
+				"some.other/annotation": "value",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gateway := gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-gateway",
+					Namespace:   "default",
+					Annotations: tt.annotations,
+				},
+			}
+			require.Equal(t, tt.expected, scalingAnnotationsConfigured(gateway))
+		})
+	}
+}
+
+func TestResolvedDeploymentReplicas_EdgeCases(t *testing.T) {
+	gcc := v1alpha1.GatewayClassConfig{
+		Spec: v1alpha1.GatewayClassConfigSpec{
+			DeploymentSpec: v1alpha1.DeploymentSpec{
+				DefaultInstances: int32Ptr(3),
+				MaxInstances:     int32Ptr(8),
+				MinInstances:     int32Ptr(1),
+			},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		scalingConfig   *ScalingConfig
+		currentReplicas *int32
+		expected        int32
+	}{
+		{
+			name:            "nil scalingConfig falls back to deploymentReplicas with gcc default",
+			scalingConfig:   nil,
+			currentReplicas: nil,
+			expected:        3,
+		},
+		{
+			name:          "nil scalingConfig with current replicas above gcc max clamps to max",
+			scalingConfig: nil,
+			// currentReplicas is above gcc.MaxInstances=8 so deploymentReplicas clamps to 8
+			currentReplicas: int32Ptr(15),
+			expected:        8,
+		},
+		{
+			name: "hpa-user mode with nil currentReplicas seeds at default 1",
+			scalingConfig: &ScalingConfig{
+				Mode: "hpa-user",
+			},
+			currentReplicas: nil,
+			expected:        1,
+		},
+		{
+			name: "hpa-user mode preserves current replicas regardless of gcc bounds",
+			scalingConfig: &ScalingConfig{
+				Mode: "hpa-user",
+			},
+			currentReplicas: int32Ptr(20),
+			expected:        20,
+		},
+		{
+			name: "static mode with nil StaticReplicas and no fallback seeds at default 1",
+			scalingConfig: &ScalingConfig{
+				Mode:           "static",
+				StaticReplicas: nil,
+			},
+			currentReplicas: nil,
+			expected:        1,
+		},
+		{
+			name: "static annotation allows replicas well beyond the previous hard limit of 8",
+			scalingConfig: &ScalingConfig{
+				Mode:           "static",
+				StaticReplicas: int32Ptr(16),
+			},
+			currentReplicas: nil,
+			expected:        16,
+		},
+		{
+			name: "unknown mode falls back to default 1",
+			scalingConfig: &ScalingConfig{
+				Mode: "unknown-mode",
+			},
+			currentReplicas: nil,
+			expected:        1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			replicas := resolvedDeploymentReplicas(tt.scalingConfig, gcc, tt.currentReplicas)
+			require.NotNil(t, replicas)
+			require.Equal(t, tt.expected, *replicas)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Secondary testing for CSL-12699 covering annotation-driven API Gateway scaling introduced in #5288.

Aligns with all scenarios described in the PR acceptance criteria:
- Controller-managed gateway with scaling annotations
- User-managed HPA with CPU utilization targets
- Dangling user HPA scenario (HPA created before gateway exists)
- Future gateway / upgrade pre-existing gateway scenario
- HPA annotation updates (static→HPA and HPA→static transitions)
- HPA precedence tests
- Replicas beyond the previous hard limit of 8

## Files Changed

### Unit Tests
| File | Tests Added |
|------|-------------|
| `control-plane/api-gateway/gatekeeper/scaling_test.go` | `TestScalingAnnotationsConfigured`, `TestResolvedDeploymentReplicas_EdgeCases` |
| `control-plane/api-gateway/gatekeeper/scaling_mode_test.go` (new) | `TestDetermineScalingMode`, `TestReconcileScaling` |

### Acceptance Tests
| Test | Scenario |
|------|----------|
| `TestAPIGateway_Scaling_EnterpriseGateEnabledStaticReplicasBeyond8` | Regression test — static replicas set to 10 (beyond old cap of 8) |
| `TestAPIGateway_Scaling_EnterpriseGateEnabledUserManagedHPA` | User creates HPA after gateway — controller defers |
| `TestAPIGateway_Scaling_EnterpriseGateEnabledDanglingUserHPA` | User HPA exists BEFORE gateway is created — controller detects on first reconcile |
| `TestAPIGateway_Scaling_EnterpriseGateEnabledFutureGatewayUpgrade` | Pre-existing gateway upgraded with HPA annotations — maxReplicas=16 honoured (old GCC cap was 8) |
| `TestAPIGateway_Scaling_EnterpriseGateEnabledAnnotationTransitionStaticToHPA` | Live annotation update: static → HPA |
| `TestAPIGateway_Scaling_EnterpriseGateEnabledAnnotationTransitionHPAToStatic` | Live annotation update: HPA → static, controller-managed HPA deleted |

## Related
- Original feature PR: #5288
- Backport to release/2.0.x: #5312
- Ticket: CSL-12699