### PR TITLE
fix(custom-gw): filename mismatch

### DIFF
--- a/.changelog/5334.txt
+++ b/.changelog/5334.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+custom-gateway: Fix filename mismatch in gateway-resources-configmap-custom that prevented CPU and memory resource limits from being applied to the custom GatewayClassConfig.
+```

--- a/control-plane/subcommand/gateway-resources-custom/command.go
+++ b/control-plane/subcommand/gateway-resources-custom/command.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	gatewayConfigFilename  = "/consul/config/config-ocp.yaml"
-	resourceConfigFilename = "/consul/config/resources-ocp.json"
+	resourceConfigFilename = "/consul/config/resources.json"
 	meshGatewayComponent   = "consul-mesh-gateway"
 )
 


### PR DESCRIPTION
### Changes proposed in this PR ###  
- when we set the min and max requests and limits of cpu and mem, new custom gatewayclassconfig of new custom gateway is not picking.
- This was  due to a file name mismatch because resources-ocp was not found.
- Fixed that mismatch with this PR

### How I've tested this PR ###

Deployed to a local kind cluster via helm install with custom CPU/memory resource values and maxInstances=3. Verified the consul-api-gateway-custom. GatewayClassConfig reflected all values correctly in .spec.deployment.resources and .spec.deployment.maxInstances(, confirming the fix.

<img width="1025" height="395" alt="Screenshot 2026-05-20 at 3 11 47 PM" src="https://github.com/user-attachments/assets/b82389fd-7327-49e1-8025-878b7b1af28d" />


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
