### PR TITLE
add enterprise gating while registering services with multiple ports

### DIFF
--- a/.changelog/5335.txt
+++ b/.changelog/5335.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+endpoints-controller: add enterprise gating while registering services with multiple ports. In consul CE cluster, register single port catalog service for pods with multiple container ports.
+```

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
@@ -125,6 +125,11 @@ type Controller struct {
 	// with config to enable telemetry forwarding.
 	EnableTelemetryCollector bool
 
+	// IsEnterpriseDistribution indicates whether the connected Consul cluster
+	// reports a valid enterprise license. Multi-port service registrations are
+	// only supported on Consul Enterprise.
+	IsEnterpriseDistribution bool
+
 	MetricsConfig metrics.Config
 	Log           logr.Logger
 
@@ -444,6 +449,12 @@ func (r *Controller) createServiceRegistrations(pod corev1.Pod, podIP string, se
 	consulServicePort, consulServicePorts, err := r.servicePortsForRegistration(pod, serviceEndpoints)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// Multi-port registrations are only supported on Consul Enterprise.
+	// On CE, fall back to single port registration using the default port.
+	if !r.IsEnterpriseDistribution && len(consulServicePorts) > 0 {
+		consulServicePorts = nil
 	}
 
 	var node corev1.Node

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
@@ -1117,8 +1117,9 @@ func TestCreateServiceRegistrations_SingleServiceMultiPort(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(pod, endpoints, namespace).Build()
 
 	epCtrl := Controller{
-		Client: fakeClient,
-		Log:    logrtest.New(t),
+		Client:                   fakeClient,
+		Log:                      logrtest.New(t),
+		IsEnterpriseDistribution: true,
 	}
 
 	serviceRegistration, proxyServiceRegistration, err := epCtrl.createServiceRegistrations(*pod, pod.Status.PodIP, *endpoints, api.HealthPassing)
@@ -1136,6 +1137,139 @@ func TestCreateServiceRegistrations_SingleServiceMultiPort(t *testing.T) {
 	require.Empty(t, proxyServiceRegistration.Service.Proxy.LocalServiceAddress)
 	require.Zero(t, proxyServiceRegistration.Service.Proxy.LocalServicePort)
 	require.Nil(t, proxyServiceRegistration.Service.Proxy.Expose.Paths)
+}
+
+// TestCreateServiceRegistrations_SingleServiceMultiPort_CEFallback verifies that when
+// IsEnterpriseDistribution is false (Consul CE), multi-port service registrations fall back
+// to single-port registration using the default port.
+func TestCreateServiceRegistrations_SingleServiceMultiPort_CEFallback(t *testing.T) {
+	t.Parallel()
+
+	pod := createServicePod("pod1", "1.2.3.4", true, true)
+	pod.Spec.Containers = []corev1.Container{
+		{
+			Name: "app",
+			Ports: []corev1.ContainerPort{
+				{
+					Name:          "http",
+					ContainerPort: 5050,
+				},
+				{
+					Name:          "metrics",
+					ContainerPort: 5051,
+				},
+			},
+		},
+	}
+	pod.Annotations[constants.AnnotationPort] = "http,metrics"
+	pod.Annotations[constants.AnnotationService] = "service-response"
+
+	endpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service-response",
+			Namespace: "default",
+		},
+		Subsets: []corev1.EndpointSubset{
+			{
+				Ports: []corev1.EndpointPort{
+					{Name: "http", Port: 5050},
+					{Name: "metrics", Port: 5051},
+				},
+			},
+		},
+	}
+
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(pod, endpoints, namespace).Build()
+
+	epCtrl := Controller{
+		Client:                   fakeClient,
+		Log:                      logrtest.New(t),
+		IsEnterpriseDistribution: false, // Consul CE
+	}
+
+	serviceRegistration, proxyServiceRegistration, err := epCtrl.createServiceRegistrations(*pod, pod.Status.PodIP, *endpoints, api.HealthPassing)
+	require.NoError(t, err)
+
+	// On CE, Ports should be nil and Port should be the default port value.
+	require.Nil(t, serviceRegistration.Service.Ports)
+	require.Equal(t, 5050, serviceRegistration.Service.Port)
+
+	// Proxy service should also have nil Ports on CE.
+	require.Nil(t, proxyServiceRegistration.Service.Ports)
+
+	// LocalServiceAddress and LocalServicePort should be set for single-port mode.
+	require.Equal(t, "127.0.0.1", proxyServiceRegistration.Service.Proxy.LocalServiceAddress)
+	require.Equal(t, 5050, proxyServiceRegistration.Service.Proxy.LocalServicePort)
+}
+
+// TestCreateServiceRegistrations_SingleServiceMultiPort_EnterpriseSetsMultiplePorts verifies that when
+// IsEnterpriseDistribution is true (Consul Enterprise), multi-port service registrations are preserved.
+func TestCreateServiceRegistrations_SingleServiceMultiPort_EnterpriseSetsMultiplePorts(t *testing.T) {
+	t.Parallel()
+
+	pod := createServicePod("pod1", "1.2.3.4", true, true)
+	pod.Spec.Containers = []corev1.Container{
+		{
+			Name: "app",
+			Ports: []corev1.ContainerPort{
+				{
+					Name:          "http",
+					ContainerPort: 5050,
+				},
+				{
+					Name:          "metrics",
+					ContainerPort: 5051,
+				},
+			},
+		},
+	}
+	pod.Annotations[constants.AnnotationPort] = "http,metrics"
+	pod.Annotations[constants.AnnotationService] = "service-response"
+
+	endpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service-response",
+			Namespace: "default",
+		},
+		Subsets: []corev1.EndpointSubset{
+			{
+				Ports: []corev1.EndpointPort{
+					{Name: "http", Port: 5050},
+					{Name: "metrics", Port: 5051},
+				},
+			},
+		},
+	}
+
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(pod, endpoints, namespace).Build()
+
+	epCtrl := Controller{
+		Client:                   fakeClient,
+		Log:                      logrtest.New(t),
+		IsEnterpriseDistribution: true, // Consul Enterprise
+	}
+
+	serviceRegistration, proxyServiceRegistration, err := epCtrl.createServiceRegistrations(*pod, pod.Status.PodIP, *endpoints, api.HealthPassing)
+	require.NoError(t, err)
+
+	// On Enterprise, Ports should be set and Port should be 0 (multi-port mode).
+	require.Equal(t, 0, serviceRegistration.Service.Port)
+	require.Equal(t, api.ServicePorts{
+		{Name: "http", Port: 5050, Default: true},
+		{Name: "metrics", Port: 5051, Default: false},
+	}, serviceRegistration.Service.Ports)
+
+	// Proxy service should also have Ports set on Enterprise.
+	require.Equal(t, api.ServicePorts{
+		{Name: "http", Port: 5050, Default: true},
+		{Name: "metrics", Port: 5051, Default: false},
+	}, proxyServiceRegistration.Service.Ports)
+
+	// LocalServiceAddress and LocalServicePort should NOT be set in multi-port mode.
+	require.Empty(t, proxyServiceRegistration.Service.Proxy.LocalServiceAddress)
+	require.Zero(t, proxyServiceRegistration.Service.Proxy.LocalServicePort)
 }
 
 func TestCreateServiceRegistrations_SingleServiceMultiPort_FromEndpointsFallback(t *testing.T) {
@@ -1179,8 +1313,9 @@ func TestCreateServiceRegistrations_SingleServiceMultiPort_FromEndpointsFallback
 	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(pod, endpoints, namespace).Build()
 
 	epCtrl := Controller{
-		Client: fakeClient,
-		Log:    logrtest.New(t),
+		Client:                   fakeClient,
+		Log:                      logrtest.New(t),
+		IsEnterpriseDistribution: true,
 	}
 
 	serviceRegistration, proxyServiceRegistration, err := epCtrl.createServiceRegistrations(*pod, pod.Status.PodIP, *endpoints, api.HealthPassing)
@@ -1242,8 +1377,9 @@ func TestCreateServiceRegistrations_SingleServiceMultiPort_DefaultPortAnnotation
 	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(pod, endpoints, namespace).Build()
 
 	epCtrl := Controller{
-		Client: fakeClient,
-		Log:    logrtest.New(t),
+		Client:                   fakeClient,
+		Log:                      logrtest.New(t),
+		IsEnterpriseDistribution: true,
 	}
 
 	serviceRegistration, _, err := epCtrl.createServiceRegistrations(*pod, pod.Status.PodIP, *endpoints, api.HealthPassing)
@@ -1297,8 +1433,9 @@ func TestCreateServiceRegistrations_SingleServiceMultiPort_DefaultPortAnnotation
 	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(pod, endpoints, namespace).Build()
 
 	epCtrl := Controller{
-		Client: fakeClient,
-		Log:    logrtest.New(t),
+		Client:                   fakeClient,
+		Log:                      logrtest.New(t),
+		IsEnterpriseDistribution: true,
 	}
 
 	serviceRegistration, _, err := epCtrl.createServiceRegistrations(*pod, pod.Status.PodIP, *endpoints, api.HealthPassing)
@@ -1352,8 +1489,9 @@ func TestCreateServiceRegistrations_SingleServiceMultiPort_DefaultPortAnnotation
 	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(pod, endpoints, namespace).Build()
 
 	epCtrl := Controller{
-		Client: fakeClient,
-		Log:    logrtest.New(t),
+		Client:                   fakeClient,
+		Log:                      logrtest.New(t),
+		IsEnterpriseDistribution: true,
 	}
 
 	serviceRegistration, _, err := epCtrl.createServiceRegistrations(*pod, pod.Status.PodIP, *endpoints, api.HealthPassing)
@@ -1406,8 +1544,9 @@ func TestCreateServiceRegistrations_SingleServiceMultiPort_MixedProtocolsFromAnn
 	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(pod, endpoints, namespace).Build()
 
 	epCtrl := Controller{
-		Client: fakeClient,
-		Log:    logrtest.New(t),
+		Client:                   fakeClient,
+		Log:                      logrtest.New(t),
+		IsEnterpriseDistribution: true,
 	}
 
 	_, _, err := epCtrl.createServiceRegistrations(*pod, pod.Status.PodIP, *endpoints, api.HealthPassing)
@@ -1455,8 +1594,9 @@ func TestCreateServiceRegistrations_SingleServiceMultiPort_MixedProtocolsFromEnd
 	fakeClient := fake.NewClientBuilder().WithRuntimeObjects(pod, endpoints, namespace).Build()
 
 	epCtrl := Controller{
-		Client: fakeClient,
-		Log:    logrtest.New(t),
+		Client:                   fakeClient,
+		Log:                      logrtest.New(t),
+		IsEnterpriseDistribution: true,
 	}
 
 	_, _, err := epCtrl.createServiceRegistrations(*pod, pod.Status.PodIP, *endpoints, api.HealthPassing)

--- a/control-plane/subcommand/inject-connect/v1controllers.go
+++ b/control-plane/subcommand/inject-connect/v1controllers.go
@@ -74,10 +74,19 @@ func (c *Command) configureControllers(ctx context.Context, mgr manager.Manager,
 		DefaultPrometheusScrapePath: c.flagDefaultPrometheusScrapePath,
 	}
 
-	isEnterpriseDistribution, err := consul.IsEnterpriseDistribution(consulConfig, watcher)
-	if err != nil {
-		setupLog.Info("Unable to validate Consul enterprise license for enterprise feature gating; multi-port service registrations will remain disabled until a valid license is detected", "error", err)
-		isEnterpriseDistribution = false
+	// If partitions are enabled, we know this is Consul Enterprise,
+	// so skip the license check. The license endpoint requires operator:read
+	// which is not allowed in partition-scoped ACL policies.
+	var isEnterpriseDistribution bool
+	if c.flagEnablePartitions {
+		isEnterpriseDistribution = true
+	} else {
+		var err error
+		isEnterpriseDistribution, err = consul.IsEnterpriseDistribution(consulConfig, watcher)
+		if err != nil {
+			setupLog.Info("Unable to validate Consul enterprise license for enterprise feature gating; multi-port service registrations will remain disabled until a valid license is detected", "error", err)
+			isEnterpriseDistribution = false
+		}
 	}
 
 	if err := (&endpoints.Controller{

--- a/control-plane/subcommand/inject-connect/v1controllers.go
+++ b/control-plane/subcommand/inject-connect/v1controllers.go
@@ -73,6 +73,13 @@ func (c *Command) configureControllers(ctx context.Context, mgr manager.Manager,
 		DefaultPrometheusScrapePort: c.flagDefaultPrometheusScrapePort,
 		DefaultPrometheusScrapePath: c.flagDefaultPrometheusScrapePath,
 	}
+
+	isEnterpriseDistribution, err := consul.IsEnterpriseDistribution(consulConfig, watcher)
+	if err != nil {
+		setupLog.Info("Unable to validate Consul enterprise license for enterprise feature gating; multi-port service registrations will remain disabled until a valid license is detected", "error", err)
+		isEnterpriseDistribution = false
+	}
+
 	if err := (&endpoints.Controller{
 		Client:                     mgr.GetClient(),
 		ConsulClientConfig:         consulConfig,
@@ -98,6 +105,7 @@ func (c *Command) configureControllers(ctx context.Context, mgr manager.Manager,
 		ReleaseNamespace:           c.flagReleaseNamespace,
 		EnableAutoEncrypt:          c.flagEnableAutoEncrypt,
 		EnableTelemetryCollector:   c.flagEnableTelemetryCollector,
+		IsEnterpriseDistribution:   isEnterpriseDistribution,
 		Context:                    ctx,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", endpoints.Controller{})
@@ -108,12 +116,6 @@ func (c *Command) configureControllers(ctx context.Context, mgr manager.Manager,
 	if err := gatewaycontrollers.RegisterFieldIndexes(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to register field indexes for gateway.networking.k8s.io API")
 		return err
-	}
-
-	isEnterpriseDistribution, err := consul.IsEnterpriseDistribution(consulConfig, watcher)
-	if err != nil {
-		setupLog.Info("Unable to validate Consul enterprise license for enterprise feature gating; enterprise-only gateway scaling will remain disabled until a valid license is detected", "error", err)
-		isEnterpriseDistribution = false
 	}
 
 	if c.flagEnableCustomGatewayCRDController {

--- a/control-plane/subcommand/server-acl-init/command.go
+++ b/control-plane/subcommand/server-acl-init/command.go
@@ -564,6 +564,20 @@ func (c *Command) Run(args []string) int {
 			c.log.Error(err.Error())
 			return 1
 		}
+
+		// Create a separate global ACL token that grants only operator:read so the
+		// connect-inject controller can call /v1/operator/license to detect whether
+		// Consul is enterprise. `operator` is a global-scope resource and cannot
+		// be granted to a partition-scoped token, so this token must be issued in
+		// the default partition. Only the primary DC's default-partition
+		// server-acl-init run creates it; all other partitions will mount the
+		// secret created here.
+		if primary && (c.consulFlags.Partition == "" || c.consulFlags.Partition == consulDefaultPartition) {
+			if err := c.createGlobalACL("connect-inject-operator-read", connectInjectOperatorReadRules, consulDC, primary, dynamicClient); err != nil {
+				c.log.Error(err.Error())
+				return 1
+			}
+		}
 	}
 
 	if c.flagCreateEntLicenseToken {

--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -45,6 +45,15 @@ service "consul-snapshot" {
 const entLicenseRules = `operator = "write"`
 const entPartitionLicenseRules = `acl = "write"`
 
+// connectInjectOperatorReadRules grants global operator:read so the connect-inject
+// controller can call /v1/operator/license to detect whether Consul is enterprise.
+// `operator` is a global-scope resource and cannot be granted to a partition-scoped
+// token, so this is created as a separate global policy attached to a token issued
+// in the default partition. The connect-inject controller uses this token only for
+// the IsEnterpriseDistribution check; all other Consul API calls continue to use
+// the partition-scoped connect-inject token.
+const connectInjectOperatorReadRules = `operator = "read"`
+
 // The partition token is utilized by the partition-init job and server-acl-init in
 // non-default partitions. This token requires permissions to create partitions, read the
 // agent endpoint during startup and have the ability to create an auth-method within a namespace
@@ -297,7 +306,6 @@ func (c *Command) injectRules() (string, error) {
 partition "{{ .PartitionName }}" {
   mesh = "write"
   acl = "write"
-  operator = "read"
 {{- else }}
   mesh = "write"
   operator = "write"

--- a/control-plane/subcommand/server-acl-init/rules.go
+++ b/control-plane/subcommand/server-acl-init/rules.go
@@ -297,6 +297,7 @@ func (c *Command) injectRules() (string, error) {
 partition "{{ .PartitionName }}" {
   mesh = "write"
   acl = "write"
+  operator = "read"
 {{- else }}
   mesh = "write"
   operator = "write"

--- a/control-plane/subcommand/server-acl-init/rules_test.go
+++ b/control-plane/subcommand/server-acl-init/rules_test.go
@@ -1080,6 +1080,14 @@ partition "part-1" {
 	}
 }
 
+// TestConnectInjectOperatorReadRules verifies the global operator:read policy
+// text used by the separate connect-inject operator-read token. This token is
+// required because Consul's operator resource is global-scope and cannot be
+// granted to a partition-scoped token.
+func TestConnectInjectOperatorReadRules(t *testing.T) {
+	require.Equal(t, `operator = "read"`, connectInjectOperatorReadRules)
+}
+
 // Test the dns-proxy rules with namespaces enabled or disabled.
 func TestDnsProxyRules(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
On clusters with consul CE while registering services with multiple container ports, send only the default port for service registration as multi-port services is an consul enterprise-only feature. Sending list of ports in consul catalog register api results in failure of connect-proxy service registration which can happen when a pod has more than 1 container port in the cluster using consul CE server.

### Changes proposed in this PR ###  
-
-

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
