### PR TITLE
CSL-15012: add podSecurityContext for the generate manifests job

### DIFF
--- a/.changelog/5341.txt
+++ b/.changelog/5341.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+helm: add pod level securityContext to get write access to the PVC.
+```

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -39,6 +39,13 @@ and consul-k8s-control-plane images.
 {{- end -}}
 {{- end -}}
 
+{{- define "consul.podSecurityContext" -}}
+{{- if .Values.global.podSecurityContext.enabled -}}
+securityContext:
+  fsGroup: 100
+  fsGroupChangePolicy: OnRootMismatch
+{{- end -}}
+{{- end -}}
 
 {{- define "consul.restrictedSecurityContextWithNetBindService" -}}
 {{- if not .Values.global.enablePodSecurityPolicies -}}

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -40,7 +40,7 @@ and consul-k8s-control-plane images.
 {{- end -}}
 
 {{- define "consul.podSecurityContext" -}}
-{{- if .Values.global.podSecurityContext.enabled -}}
+{{- if and .Values.global.podSecurityContext.enabled (not .Values.global.openshift.enabled) -}}
 securityContext:
   fsGroup: 100
   fsGroupChangePolicy: OnRootMismatch

--- a/charts/consul/templates/generate-manifests-job.yaml
+++ b/charts/consul/templates/generate-manifests-job.yaml
@@ -35,6 +35,7 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "consul.fullname" . }}-generate-manifests
+      {{- include "consul.podSecurityContext" . | nindent 6 }}
       containers:
         - name: generate-manifests
           image: {{ .Values.global.imageK8S }}

--- a/charts/consul/test/unit/generate-manifests-job.bats
+++ b/charts/consul/test/unit/generate-manifests-job.bats
@@ -34,7 +34,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
       . | tee /dev/stderr |
-      yq '.kind' | tee /dev/stderr)
+      yq -r '.kind' | tee /dev/stderr)
 
   [ "${actual}" = "Job" ]
 }
@@ -47,7 +47,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
       . | tee /dev/stderr |
-      yq '.kind' | tee /dev/stderr)
+      yq -r '.kind' | tee /dev/stderr)
 
   [ "${actual}" = "Job" ]
 }
@@ -60,7 +60,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
       . | tee /dev/stderr |
-      yq '.metadata.annotations."helm.sh/hook"' | tee /dev/stderr)
+      yq -r '.metadata.annotations."helm.sh/hook"' | tee /dev/stderr)
 
   [ "${actual}" = "pre-upgrade" ]
 }
@@ -73,7 +73,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
       . | tee /dev/stderr |
-      yq '.metadata.annotations."helm.sh/hook-delete-policy"' | tee /dev/stderr)
+      yq -r '.metadata.annotations."helm.sh/hook-delete-policy"' | tee /dev/stderr)
 
   [ "${actual}" = "hook-succeeded,before-hook-creation" ]
 }
@@ -86,7 +86,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.restartPolicy' | tee /dev/stderr)
+      yq -r '.spec.template.spec.restartPolicy' | tee /dev/stderr)
 
   [ "${actual}" = "Never" ]
 }
@@ -99,7 +99,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.volumes[0].persistentVolumeClaim.claimName' | tee /dev/stderr)
+      yq -r '.spec.template.spec.volumes[0].persistentVolumeClaim.claimName' | tee /dev/stderr)
 
   [ "${actual}" = "release-name-consul-gatewayapi-pvc" ]
 }
@@ -112,7 +112,7 @@ load _helpers
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].volumeMounts[0].mountPath' | tee /dev/stderr)
+      yq -r '.spec.template.spec.containers[0].volumeMounts[0].mountPath' | tee /dev/stderr)
 
   [ "${actual}" = "/output/" ]
 }
@@ -120,34 +120,32 @@ load _helpers
 @test "generateManifests/Job: consulapi-enabled argument added when consulapi CRD enabled" {
   cd `chart_dir`
 
-  local spec=$(helm template \
+  run bash -c "
+    helm template \
       -s templates/generate-manifests-job.yaml \
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
       --set 'global.crds.consulapi.enabled=true' \
-      . | tee /dev/stderr |
-      yq -o=json '.spec.template.spec.containers[0].args' | tee /dev/stderr)
+      . | yq -r '.spec.template.spec.containers[0].args[]' | grep '^-consulapi-enabled=true$'
+  "
 
-  local actual=$(echo "$spec" | jq '.[4]')
-
-  [ "${actual}" = "\"-consulapi-enabled=true\"" ]
+  [ "$status" -eq 0 ]
 }
 
 @test "generateManifests/Job: openshift scc argument added when openshift enabled" {
   cd `chart_dir`
 
-  local spec=$(helm template \
+  run bash -c "
+    helm template \
       -s templates/generate-manifests-job.yaml \
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
       --set 'global.openshift.enabled=true' \
       --set 'connectInject.apiGateway.managedGatewayClass.openshiftSCCName=restricted-v2' \
-      . | tee /dev/stderr |
-      yq -o=json '.spec.template.spec.containers[0].args' | tee /dev/stderr)
+      . | yq -r '.spec.template.spec.containers[0].args[]' | grep '^-openshift-scc-name=restricted-v2$'
+  "
 
-  local actual=$(echo "$spec" | jq '.[4]')
-
-  [ "${actual}" = "\"-openshift-scc-name=restricted-v2\"" ]
+  [ "$status" -eq 0 ]
 }
 
 @test "generateManifests/Job: renders configured image" {
@@ -159,7 +157,7 @@ load _helpers
       --set 'global.generateManifests=true' \
       --set 'global.imageK8S=hashicorp/consul-k8s-control-plane:2.0.0' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
 
   [ "${actual}" = "hashicorp/consul-k8s-control-plane:2.0.0" ]
 }
@@ -174,7 +172,7 @@ load _helpers
       --set 'global.podSecurityContext.enabled=true' \
       --set 'global.openshift.enabled=false' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
+      yq -r '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
 
   [ "${actual}" = "100" ]
 }

--- a/charts/consul/test/unit/generate-manifests-job.bats
+++ b/charts/consul/test/unit/generate-manifests-job.bats
@@ -26,7 +26,6 @@ load _helpers
   [ "$status" -eq 0 ]
 }
 
-
 @test "generateManifests/Job: enabled when connectInject.enabled and global.generateManifests are true" {
   cd `chart_dir`
 
@@ -34,7 +33,8 @@ load _helpers
       -s templates/generate-manifests-job.yaml \
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
-      . | yq '.kind')
+      . | tee /dev/stderr |
+      yq '.kind' | tee /dev/stderr)
 
   [ "${actual}" = "Job" ]
 }
@@ -46,7 +46,8 @@ load _helpers
       -s templates/generate-manifests-job.yaml \
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
-      . | yq '.kind')
+      . | tee /dev/stderr |
+      yq '.kind' | tee /dev/stderr)
 
   [ "${actual}" = "Job" ]
 }
@@ -58,7 +59,8 @@ load _helpers
       -s templates/generate-manifests-job.yaml \
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
-      . | yq '.metadata.annotations."helm.sh/hook"')
+      . | tee /dev/stderr |
+      yq '.metadata.annotations."helm.sh/hook"' | tee /dev/stderr)
 
   [ "${actual}" = "pre-upgrade" ]
 }
@@ -70,7 +72,8 @@ load _helpers
       -s templates/generate-manifests-job.yaml \
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
-      . | yq '.metadata.annotations."helm.sh/hook-delete-policy"')
+      . | tee /dev/stderr |
+      yq '.metadata.annotations."helm.sh/hook-delete-policy"' | tee /dev/stderr)
 
   [ "${actual}" = "hook-succeeded,before-hook-creation" ]
 }
@@ -82,7 +85,8 @@ load _helpers
       -s templates/generate-manifests-job.yaml \
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
-      . | yq '.spec.template.spec.restartPolicy')
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.restartPolicy' | tee /dev/stderr)
 
   [ "${actual}" = "Never" ]
 }
@@ -94,7 +98,8 @@ load _helpers
       -s templates/generate-manifests-job.yaml \
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
-      . | yq '.spec.template.spec.volumes[0].persistentVolumeClaim.claimName')
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.volumes[0].persistentVolumeClaim.claimName' | tee /dev/stderr)
 
   [ "${actual}" = "release-name-consul-gatewayapi-pvc" ]
 }
@@ -106,7 +111,8 @@ load _helpers
       -s templates/generate-manifests-job.yaml \
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
-      . | yq '.spec.template.spec.containers[0].volumeMounts[0].mountPath')
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].volumeMounts[0].mountPath' | tee /dev/stderr)
 
   [ "${actual}" = "/output/" ]
 }
@@ -114,32 +120,34 @@ load _helpers
 @test "generateManifests/Job: consulapi-enabled argument added when consulapi CRD enabled" {
   cd `chart_dir`
 
-  run bash -c "
-    helm template \
+  local spec=$(helm template \
       -s templates/generate-manifests-job.yaml \
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
       --set 'global.crds.consulapi.enabled=true' \
-      . | yq '.spec.template.spec.containers[0].args[]' | grep -- '-consulapi-enabled=true'
-  "
+      . | tee /dev/stderr |
+      yq -o=json '.spec.template.spec.containers[0].args' | tee /dev/stderr)
 
-  [ "$status" -eq 0 ]
+  local actual=$(echo "$spec" | jq '.[4]')
+
+  [ "${actual}" = "\"-consulapi-enabled=true\"" ]
 }
 
 @test "generateManifests/Job: openshift scc argument added when openshift enabled" {
   cd `chart_dir`
 
-  run bash -c "
-    helm template \
+  local spec=$(helm template \
       -s templates/generate-manifests-job.yaml \
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
       --set 'global.openshift.enabled=true' \
       --set 'connectInject.apiGateway.managedGatewayClass.openshiftSCCName=restricted-v2' \
-      . | yq '.spec.template.spec.containers[0].args[]' | grep -- '-openshift-scc-name=restricted-v2'
-  "
+      . | tee /dev/stderr |
+      yq -o=json '.spec.template.spec.containers[0].args' | tee /dev/stderr)
 
-  [ "$status" -eq 0 ]
+  local actual=$(echo "$spec" | jq '.[4]')
+
+  [ "${actual}" = "\"-openshift-scc-name=restricted-v2\"" ]
 }
 
 @test "generateManifests/Job: renders configured image" {
@@ -150,7 +158,8 @@ load _helpers
       --set 'connectInject.enabled=true' \
       --set 'global.generateManifests=true' \
       --set 'global.imageK8S=hashicorp/consul-k8s-control-plane:2.0.0' \
-      . | yq '.spec.template.spec.containers[0].image')
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers[0].image' | tee /dev/stderr)
 
   [ "${actual}" = "hashicorp/consul-k8s-control-plane:2.0.0" ]
 }
@@ -164,7 +173,8 @@ load _helpers
       --set 'global.generateManifests=true' \
       --set 'global.podSecurityContext.enabled=true' \
       --set 'global.openshift.enabled=false' \
-      . | yq '.spec.template.spec.securityContext.fsGroup')
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
 
   [ "${actual}" = "100" ]
 }

--- a/charts/consul/test/unit/generate-manifests-job.bats
+++ b/charts/consul/test/unit/generate-manifests-job.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "generateManifests/Job: disabled when connectInject.enabled=false" {
+  cd `chart_dir`
+
+  run helm template \
+      --set 'connectInject.enabled=false' \
+      --set 'global.generateManifests=false' \
+      -s templates/generate-manifests-job.yaml \
+      .
+
+  [ "$status" -ne 0 ]
+}
+
+@test "generateManifests/Job: status 0 when enabled" {
+  cd `chart_dir`
+
+  run helm template \
+      --set 'connectInject.enabled=true' \
+      --set 'global.generateManifests=true' \
+      -s templates/generate-manifests-job.yaml \
+      .
+
+  [ "$status" -eq 0 ]
+}
+
+
+@test "generateManifests/Job: enabled when connectInject.enabled and global.generateManifests are true" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -s templates/generate-manifests-job.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.generateManifests=true' \
+      . | yq '.kind')
+
+  [ "${actual}" = "Job" ]
+}
+
+@test "generateManifests/Job: renders Job kind correctly" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -s templates/generate-manifests-job.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.generateManifests=true' \
+      . | yq '.kind')
+
+  [ "${actual}" = "Job" ]
+}
+
+@test "generateManifests/Job: contains pre-upgrade hook annotation" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -s templates/generate-manifests-job.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.generateManifests=true' \
+      . | yq '.metadata.annotations."helm.sh/hook"')
+
+  [ "${actual}" = "pre-upgrade" ]
+}
+
+@test "generateManifests/Job: contains hook delete policy" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -s templates/generate-manifests-job.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.generateManifests=true' \
+      . | yq '.metadata.annotations."helm.sh/hook-delete-policy"')
+
+  [ "${actual}" = "hook-succeeded,before-hook-creation" ]
+}
+
+@test "generateManifests/Job: restartPolicy is Never" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -s templates/generate-manifests-job.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.generateManifests=true' \
+      . | yq '.spec.template.spec.restartPolicy')
+
+  [ "${actual}" = "Never" ]
+}
+
+@test "generateManifests/Job: mounts gatewayapi pvc correctly" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -s templates/generate-manifests-job.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.generateManifests=true' \
+      . | yq '.spec.template.spec.volumes[0].persistentVolumeClaim.claimName')
+
+  [ "${actual}" = "release-name-consul-gatewayapi-pvc" ]
+}
+
+@test "generateManifests/Job: mounts output directory correctly" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -s templates/generate-manifests-job.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.generateManifests=true' \
+      . | yq '.spec.template.spec.containers[0].volumeMounts[0].mountPath')
+
+  [ "${actual}" = "/output/" ]
+}
+
+@test "generateManifests/Job: consulapi-enabled argument added when consulapi CRD enabled" {
+  cd `chart_dir`
+
+  run bash -c "
+    helm template \
+      -s templates/generate-manifests-job.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.generateManifests=true' \
+      --set 'global.crds.consulapi.enabled=true' \
+      . | yq '.spec.template.spec.containers[0].args[]' | grep -- '-consulapi-enabled=true'
+  "
+
+  [ "$status" -eq 0 ]
+}
+
+@test "generateManifests/Job: openshift scc argument added when openshift enabled" {
+  cd `chart_dir`
+
+  run bash -c "
+    helm template \
+      -s templates/generate-manifests-job.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.generateManifests=true' \
+      --set 'global.openshift.enabled=true' \
+      --set 'connectInject.apiGateway.managedGatewayClass.openshiftSCCName=restricted-v2' \
+      . | yq '.spec.template.spec.containers[0].args[]' | grep -- '-openshift-scc-name=restricted-v2'
+  "
+
+  [ "$status" -eq 0 ]
+}
+
+@test "generateManifests/Job: renders configured image" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -s templates/generate-manifests-job.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.generateManifests=true' \
+      --set 'global.imageK8S=hashicorp/consul-k8s-control-plane:2.0.0' \
+      . | yq '.spec.template.spec.containers[0].image')
+
+  [ "${actual}" = "hashicorp/consul-k8s-control-plane:2.0.0" ]
+}
+
+@test "generateManifests/Job: renders podSecurityContext when enabled" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -s templates/generate-manifests-job.yaml \
+      --set 'connectInject.enabled=true' \
+      --set 'global.generateManifests=true' \
+      --set 'global.podSecurityContext.enabled=true' \
+      --set 'global.openshift.enabled=false' \
+      . | yq '.spec.template.spec.securityContext.fsGroup')
+
+  [ "${actual}" = "100" ]
+}

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -812,6 +812,11 @@ global:
     enableTcpRoute: true
     consulapi:
       enabled: false
+
+  # Add additional securityContext at pod level for volume permissions.
+  podSecurityContext:
+    enabled: true
+
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.
   openshift:

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -816,7 +816,6 @@ global:
   # Add additional pod-level securityContext for the generate-manifests Job when volume permissions require it.
   podSecurityContext:
     enabled: false
-    fsGroup: 100
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -813,9 +813,10 @@ global:
     consulapi:
       enabled: false
 
-  # Add additional securityContext at pod level for volume permissions.
+  # Add additional pod-level securityContext for the generate-manifests Job when volume permissions require it.
   podSecurityContext:
-    enabled: true
+    enabled: false
+    fsGroup: 100
 
   # Configuration for running this Helm chart on the Red Hat OpenShift platform.
   # This Helm chart currently supports OpenShift v4.x+.


### PR DESCRIPTION
# Changes
add the pod level securityContext to get access to the PVC.

ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/