### PR TITLE
Fix duplicate imagePullPolicy in Server StatefulSet

### DIFF
--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -355,7 +355,7 @@ spec:
       containers:
         - name: consul
           image: "{{ default .Values.global.image .Values.server.image | trimPrefix "\"" | trimSuffix "\"" }}"
-          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          {{ template "consul.imagePullPolicy" . }}
           env:
             - name: ADVERTISE_IP
               valueFrom:

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -355,7 +355,6 @@ spec:
       containers:
         - name: consul
           image: "{{ default .Values.global.image .Values.server.image | trimPrefix "\"" | trimSuffix "\"" }}"
-          {{ template "consul.imagePullPolicy" . }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
             - name: ADVERTISE_IP


### PR DESCRIPTION
### This PR is cloned from https://github.com/hashicorp/consul-k8s/pull/5300

### Changes proposed in this PR ###  
- Remove duplicate `imagePullPolicy` from StatefulSet that was introduced in https://github.com/hashicorp/consul-k8s/commit/28142553cb4b6e5e46c3db130a004d55ef09ee5d. This isn't necessarily a problem when only using Helm, but does become a problem when using a [Helm Post-Render like Kustomize](https://helm.sh/docs/topics/advanced/#post-rendering). Kustomize will error because there is a duplicate `imagePullPolicy` line when `server.enabled=true` and  `global.imagePullPolicy` are set.

I didn't create a changelog entry because this seems like a [typo/fix that doesn't require one](https://github.com/hashicorp/consul-k8s/blob/d3ee874e927b215f113ac34cc211fefa91166d77/CONTRIBUTING.md#adding-a-changelog-entry).

### How I've tested this PR ###

There isn't anything to test- this line should have been removed when [{{ template "consul.imagePullPolicy" . }}](https://github.com/chrstein0/consul-k8s/blob/d3ee874e927b215f113ac34cc211fefa91166d77/charts/consul/templates/_helpers.tpl#L610-L626) was added.

### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
