### PR TITLE
ci: add Go test coverage reporting

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,9 @@ jobs:
       - name: Run unit tests with coverage
         # -p 1 disables parallelism to avoid port conflicts from shared
         # default metrics / lifecycle server configuration.
-        run: cd control-plane && go test ./... -p 1 -coverprofile=coverage.txt -covermode=set
+        # -short skips integration tests that require the consul binary on PATH
+        # (consistent with the -short flag used by the main test workflow).
+        run: cd control-plane && go test ./... -short -p 1 -coverprofile=coverage.txt -covermode=set
 
       - name: Upload coverage profile
         if: always()

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           CONSUL_VERSION="2.0.0"
           curl -sSLO "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip"
-          unzip "consul_${CONSUL_VERSION}_linux_amd64.zip" -d /usr/local/bin
+          unzip -o "consul_${CONSUL_VERSION}_linux_amd64.zip" consul -d /usr/local/bin
           rm "consul_${CONSUL_VERSION}_linux_amd64.zip"
           consul version
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,86 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# Runs unit tests with coverage for the critical Go modules (control-plane, cli),
+# merges the profiles, and publishes the results via reusable-coverage-report.yml.
+# Triggers on PRs (posts a comment) and on pushes to main/release branches (updates badge).
+
+name: coverage
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release/**"
+  push:
+    branches:
+      - main
+      - "release/**"
+
+jobs:
+  conditional-skip:
+    uses: ./.github/workflows/reusable-conditional-skip.yml
+
+  get-go-version:
+    needs: [conditional-skip]
+    if: needs.conditional-skip.outputs.skip-ci != 'true'
+    uses: ./.github/workflows/reusable-get-go-version.yml
+
+  unit-tests-control-plane:
+    name: unit-tests (control-plane)
+    needs: [get-go-version]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: ${{ needs.get-go-version.outputs.go-version }}
+
+      - name: Run unit tests with coverage
+        # -p 1 disables parallelism to avoid port conflicts from shared
+        # default metrics / lifecycle server configuration.
+        run: cd control-plane && go test ./... -p 1 -coverprofile=coverage.txt -covermode=set
+
+      - name: Upload coverage profile
+        if: always()
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: control-plane-coverage
+          path: control-plane/coverage.txt
+          if-no-files-found: ignore
+
+  unit-tests-cli:
+    name: unit-tests (cli)
+    needs: [get-go-version]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: ${{ needs.get-go-version.outputs.go-version }}
+
+      - name: Run unit tests with coverage
+        run: cd cli && go test ./... -p 1 -coverprofile=coverage.txt -covermode=set
+
+      - name: Upload coverage profile
+        if: always()
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: cli-coverage
+          path: cli/coverage.txt
+          if-no-files-found: ignore
+
+  coverage-report:
+    needs:
+      - get-go-version
+      - unit-tests-control-plane
+      - unit-tests-cli
+    uses: ./.github/workflows/reusable-coverage-report.yml
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    with:
+      go-version: ${{ needs.get-go-version.outputs.go-version }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,21 +1,21 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-# Runs unit tests with coverage for the critical Go modules (control-plane, cli),
-# merges the profiles, and publishes the results via reusable-coverage-report.yml.
-# Triggers on PRs (posts a comment) and on pushes to main/release branches (updates badge).
+# Reusable workflow that runs unit tests with coverage for the critical Go
+# modules (control-plane, cli), merges the profiles, and publishes the results
+# via reusable-coverage-report.yml.
 
 name: coverage
 
 on:
-  pull_request:
-    branches:
-      - main
-      - "release/**"
-  push:
-    branches:
-      - main
-      - "release/**"
+  workflow_call:
+    inputs:
+      go-version:
+        required: true
+        type: string
+      pr-number:
+        required: false
+        type: string
 
 jobs:
   conditional-skip:
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: ${{ needs.get-go-version.outputs.go-version }}
+          go-version: ${{ inputs.go-version }}
 
       - name: Run unit tests with coverage
         # -p 1 disables parallelism to avoid port conflicts from shared
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: ${{ needs.get-go-version.outputs.go-version }}
+          go-version: ${{ inputs.go-version }}
 
       - name: Run unit tests with coverage
         run: cd cli && go test ./... -p 1 -coverprofile=coverage.txt -covermode=set
@@ -83,4 +83,5 @@ jobs:
       pull-requests: write
       id-token: write
     with:
-      go-version: ${{ needs.get-go-version.outputs.go-version }}
+      go-version: ${{ inputs.go-version }}
+      pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,12 +37,20 @@ jobs:
         with:
           go-version: ${{ inputs.go-version }}
 
+      - name: Install consul binary
+        # Several control-plane packages use testutil.NewTestServerConfigT which
+        # requires the consul binary on PATH to start a real test server.
+        run: |
+          CONSUL_VERSION="2.0.0"
+          curl -sSLO "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip"
+          unzip "consul_${CONSUL_VERSION}_linux_amd64.zip" -d /usr/local/bin
+          rm "consul_${CONSUL_VERSION}_linux_amd64.zip"
+          consul version
+
       - name: Run unit tests with coverage
         # -p 1 disables parallelism to avoid port conflicts from shared
         # default metrics / lifecycle server configuration.
-        # -short skips integration tests that require the consul binary on PATH
-        # (consistent with the -short flag used by the main test workflow).
-        run: cd control-plane && go test ./... -short -p 1 -coverprofile=coverage.txt -covermode=set
+        run: cd control-plane && go test ./... -p 1 -coverprofile=coverage.txt -covermode=set
 
       - name: Upload coverage profile
         if: always()

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -13,9 +13,19 @@ on:
 env:
   BRANCH: ${{ github.head_ref || github.ref_name }}
   CONTEXT: "merge"
-  SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  SHA: ${{ github.sha }}
 
 jobs:
+  get-go-version:
+    uses: ./.github/workflows/reusable-get-go-version.yml
+
+  coverage:
+    needs:
+      - get-go-version
+    uses: ./.github/workflows/coverage.yml
+    with:
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+
   test:
     name: test
     runs-on: ubuntu-latest

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -13,7 +13,7 @@ on:
 env:
   BRANCH: ${{ github.head_ref || github.ref_name }}
   CONTEXT: "merge"
-  SHA: ${{ github.sha }}
+  SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
   get-go-version:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,21 @@ jobs:
   conditional-skip:
     uses: ./.github/workflows/reusable-conditional-skip.yml
 
+  get-go-version:
+    needs: [conditional-skip]
+    if: needs.conditional-skip.outputs.skip-ci != 'true'
+    uses: ./.github/workflows/reusable-get-go-version.yml
+
+  coverage:
+    needs:
+      - conditional-skip
+      - get-go-version
+    if: needs.conditional-skip.outputs.skip-ci != 'true'
+    uses: ./.github/workflows/coverage.yml
+    with:
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+      pr-number: ${{ github.event.pull_request.number }}
+
   test:
     name: test
     needs: [ conditional-skip ]

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -1,0 +1,203 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# Reusable workflow: merges per-module coverage profiles, computes the total,
+# posts/edits a PR comment, uploads an HTML artifact, uploads to Codecov, and
+# (on main) pushes a coverage badge SVG to the `badges` branch for the README.
+
+name: reusable-coverage-report
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        required: true
+        type: string
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write  # required for OIDC tokenless Codecov upload
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Download coverage profiles
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          pattern: '*-coverage'
+          path: coverage-artifacts
+
+      - name: Compute coverage
+        id: coverage
+        run: |
+          PROFILES=$(find coverage-artifacts -name 'coverage.txt' 2>/dev/null | sort)
+          COUNT=$(echo "$PROFILES" | grep -c . || true)
+          echo "Found $COUNT coverage profile(s)"
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No coverage profiles found"
+            echo "total=N/A" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$COUNT" -eq 1 ]; then
+            cp "$(echo "$PROFILES")" merged-coverage.out
+          else
+            go install github.com/wadey/gocovmerge@latest
+            echo "$PROFILES" | xargs gocovmerge > merged-coverage.out
+          fi
+
+          # Exclude generated mock files and acceptance test paths.
+          # Go 1.20+ includes all compiled packages in the profile (even those
+          # without test files), which inflates the denominator.
+          TOTAL=$(awk '
+            /^mode:/ { next }
+            /\/mocks\/|\/mock_|\/acceptance\// { next }
+            { stmts += $2; if ($3 > 0) covered += $2 }
+            END { if (stmts > 0) printf "%.1f%%", covered/stmts*100; else print "0.0%" }
+          ' merged-coverage.out)
+          echo "Total coverage: $TOTAL"
+          echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
+
+          # Strip excluded lines from profile before generating HTML and per-package summary.
+          grep -v -e '/mocks/' -e '/mock_' -e '/acceptance/' merged-coverage.out > filtered-coverage.out || true
+          mv filtered-coverage.out merged-coverage.out
+
+          # Package-level summary grouped by top-level directory.
+          # go tool cover -func separates fields with variable numbers of tabs,
+          # so use $NF for the percentage and $1 for the path.
+          go tool cover -func merged-coverage.out | grep -v '^total:' | \
+            awk '{
+              sub(/^github\.com\/hashicorp\/consul-k8s\//, "", $1)
+              split($1, parts, "/")
+              pkg = parts[1]
+              gsub(/:.*/, "", pkg)
+              pct = $NF; gsub(/%/, "", pct)
+              sum[pkg] += pct; n[pkg]++
+            }
+            END {
+              for (pkg in sum) printf "%-40s %.1f%%\n", pkg, sum[pkg]/n[pkg]
+            }' | sort > pkg-summary.txt
+
+          {
+            echo "## Go Test Coverage"
+            echo ""
+            echo "**Total coverage: $TOTAL**"
+            echo ""
+            echo "| Package | Avg Coverage |"
+            echo "|---------|-------------|"
+            while IFS= read -r line; do
+              pkg=$(echo "$line" | awk '{print $1}')
+              pct=$(echo "$line" | awk '{print $2}')
+              echo "| \`$pkg\` | $pct |"
+            done < pkg-summary.txt
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          go tool cover -html=merged-coverage.out -o coverage.html
+
+      - name: Post PR comment
+        if: github.event_name == 'pull_request' && steps.coverage.outputs.total != 'N/A'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TOTAL: ${{ steps.coverage.outputs.total }}
+        run: |
+          BODY="### Go Test Coverage: **${TOTAL}**
+
+See the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the full per-package breakdown and downloadable HTML report."
+
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo "${{ github.repository }}" \
+            --body "$BODY" \
+            --edit-last 2>/dev/null || \
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo "${{ github.repository }}" \
+            --body "$BODY"
+
+      - name: Upload HTML coverage report
+        if: steps.coverage.outputs.total != 'N/A'
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: coverage-report-html
+          path: |
+            merged-coverage.out
+            coverage.html
+
+      - name: Upload to Codecov
+        if: steps.coverage.outputs.total != 'N/A'
+        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
+        with:
+          files: merged-coverage.out
+          use_oidc: true
+          fail_ci_if_error: false
+          verbose: false
+
+      - name: Update coverage badge
+        if: github.ref == 'refs/heads/main' && steps.coverage.outputs.total != 'N/A'
+        env:
+          TOTAL: ${{ steps.coverage.outputs.total }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PCT=$(echo "$TOTAL" | tr -d '%')
+          if awk "BEGIN {exit !($PCT >= 75)}"; then COLOR="#4c1"
+          elif awk "BEGIN {exit !($PCT >= 60)}"; then COLOR="#97CA00"
+          elif awk "BEGIN {exit !($PCT >= 40)}"; then COLOR="#dfb317"
+          else COLOR="#e05d44"
+          fi
+
+          # Compute dynamic text widths: label "coverage" = 62px, value width ~7px/char
+          LABEL="coverage"
+          LABEL_W=62
+          VAL_LEN=${#TOTAL}
+          VAL_W=$(( VAL_LEN * 7 + 10 ))
+          TOTAL_W=$(( LABEL_W + VAL_W ))
+          LABEL_MID=$(( LABEL_W / 2 + 1 ))
+          VAL_MID=$(( LABEL_W + VAL_W / 2 ))
+
+          cat > /tmp/coverage.svg <<SVGEOF
+          <svg xmlns="http://www.w3.org/2000/svg" width="${TOTAL_W}" height="20">
+            <linearGradient id="s" x2="0" y2="100%">
+              <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+              <stop offset="1" stop-opacity=".1"/>
+            </linearGradient>
+            <rect rx="3" width="${TOTAL_W}" height="20" fill="#555"/>
+            <rect rx="3" x="${LABEL_W}" width="${VAL_W}" height="20" fill="${COLOR}"/>
+            <rect x="${LABEL_W}" width="4" height="20" fill="${COLOR}"/>
+            <rect rx="3" width="${TOTAL_W}" height="20" fill="url(#s)"/>
+            <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+              <text x="${LABEL_MID}" y="15" fill="#010101" fill-opacity=".3">${LABEL}</text>
+              <text x="${LABEL_MID}" y="14">${LABEL}</text>
+              <text x="${VAL_MID}" y="15" fill="#010101" fill-opacity=".3">${TOTAL}</text>
+              <text x="${VAL_MID}" y="14">${TOTAL}</text>
+            </g>
+          </svg>
+          SVGEOF
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+
+          if git ls-remote --exit-code origin badges >/dev/null 2>&1; then
+            git fetch origin badges:badges --depth=1
+            git worktree add /tmp/badges-wt badges
+          else
+            git worktree add --detach /tmp/badges-wt HEAD
+            git -C /tmp/badges-wt checkout --orphan badges
+            git -C /tmp/badges-wt rm -rf . --quiet 2>/dev/null || true
+          fi
+
+          cp /tmp/coverage.svg /tmp/badges-wt/coverage.svg
+          git -C /tmp/badges-wt add coverage.svg
+          if git -C /tmp/badges-wt diff --staged --quiet; then
+            echo "Badge unchanged, skipping commit"
+          else
+            git -C /tmp/badges-wt commit -m "chore: update coverage badge [skip ci]"
+            git -C /tmp/badges-wt push origin HEAD:badges
+          fi

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -53,7 +53,7 @@ jobs:
           if [ "$COUNT" -eq 1 ]; then
             cp "$(echo "$PROFILES")" merged-coverage.out
           else
-            go install github.com/wadey/gocovmerge@latest
+            go install github.com/wadey/gocovmerge@b5bfa59ec0ad
             echo "$PROFILES" | xargs gocovmerge > merged-coverage.out
           fi
 
@@ -62,7 +62,7 @@ jobs:
           # without test files), which inflates the denominator.
           TOTAL=$(awk '
             /^mode:/ { next }
-            /\/mocks\/|\/mock_|\/acceptance\// { next }
+            /\/mocks\/|\/mock_|\/acceptance\/|\/cli\/helm\/mock\.go/ { next }
             { stmts += $2; if ($3 > 0) covered += $2 }
             END { if (stmts > 0) printf "%.1f%%", covered/stmts*100; else print "0.0%" }
           ' merged-coverage.out)
@@ -70,7 +70,7 @@ jobs:
           echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
 
           # Strip excluded lines from profile before generating HTML and per-package summary.
-          grep -v -e '/mocks/' -e '/mock_' -e '/acceptance/' merged-coverage.out > filtered-coverage.out || true
+          grep -v -e '/mocks/' -e '/mock_' -e '/acceptance/' -e '/cli/helm/mock.go' merged-coverage.out > filtered-coverage.out || true
           mv filtered-coverage.out merged-coverage.out
 
           # Package-level summary grouped by top-level directory.
@@ -107,24 +107,36 @@ jobs:
 
       - name: Post PR comment
         if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           TOTAL: ${{ steps.coverage.outputs.total }}
         run: |
+          MARKER="<!-- coverage-report-comment -->"
           BODY=$(cat <<EOF
+          ${MARKER}
+
           ### Go Test Coverage: **${TOTAL}**
 
           See the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the full per-package breakdown and downloadable HTML report.
           EOF
           )
 
-          gh pr comment ${{ inputs.pr-number }} \
-            --repo "${{ github.repository }}" \
-            --body "$BODY" \
-            --edit-last 2>/dev/null || \
-          gh pr comment ${{ inputs.pr-number }} \
-            --repo "${{ github.repository }}" \
-            --body "$BODY"
+          COMMENT_ID=$(gh api --paginate \
+            "repos/${{ github.repository }}/issues/${{ inputs.pr-number }}/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body // "" | contains("<!-- coverage-report-comment -->"))) | .id' \
+            | tail -n1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -f body="$BODY"
+          else
+            gh pr comment ${{ inputs.pr-number }} \
+              --repo "${{ github.repository }}" \
+              --body "$BODY"
+          fi
 
       - name: Upload HTML coverage report
         if: steps.coverage.outputs.total != 'N/A'

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -106,7 +106,7 @@ jobs:
           go tool cover -html=merged-coverage.out -o coverage.html
 
       - name: Post PR comment
-        if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'
+        if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -13,6 +13,9 @@ on:
       go-version:
         required: true
         type: string
+      pr-number:
+        required: false
+        type: string
 
 jobs:
   report:
@@ -103,20 +106,23 @@ jobs:
           go tool cover -html=merged-coverage.out -o coverage.html
 
       - name: Post PR comment
-        if: github.event_name == 'pull_request' && steps.coverage.outputs.total != 'N/A'
+        if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'
         env:
           GH_TOKEN: ${{ github.token }}
           TOTAL: ${{ steps.coverage.outputs.total }}
         run: |
-          BODY="### Go Test Coverage: **${TOTAL}**
+          BODY=$(cat <<EOF
+          ### Go Test Coverage: **${TOTAL}**
 
-See the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the full per-package breakdown and downloadable HTML report."
+          See the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the full per-package breakdown and downloadable HTML report.
+          EOF
+          )
 
-          gh pr comment ${{ github.event.pull_request.number }} \
+          gh pr comment ${{ inputs.pr-number }} \
             --repo "${{ github.repository }}" \
             --body "$BODY" \
             --edit-last 2>/dev/null || \
-          gh pr comment ${{ github.event.pull_request.number }} \
+          gh pr comment ${{ inputs.pr-number }} \
             --repo "${{ github.repository }}" \
             --body "$BODY"
 

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -37,6 +37,13 @@ jobs:
           pattern: '*-coverage'
           path: coverage-artifacts
 
+      - name: Create Go workspace for multi-module coverage analysis
+        # consul-k8s is a multi-module repo (control-plane/ and cli/ each have
+        # their own go.mod). go tool cover -func/-html needs to resolve package
+        # source paths across both modules. A go.work file at the root makes
+        # both modules visible without requiring a root-level go.mod.
+        run: go work init ./control-plane ./cli
+
       - name: Compute coverage
         id: coverage
         run: |

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
   <span>Consul on Kubernetes</span>
 </h1>
 
+[![Coverage](https://raw.githubusercontent.com/hashicorp/consul-k8s/badges/coverage.svg)](https://github.com/hashicorp/consul-k8s/actions/workflows/coverage.yml)
+
  **We're looking for feedback on how folks are using Consul on Kubernetes. Please fill out our brief [survey](https://hashicorp.sjc1.qualtrics.com/jfe/form/SV_4MANbw1BUku7YhL)!** 
 
 ## Overview

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+# Codecov configuration for consul-k8s.
+# Status checks are informational only — they will not block PRs.
+# https://docs.codecov.com/docs/codecovyml-reference
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+ignore:
+  # Generated mock files
+  - "control-plane/**/mock_*.go"
+  - "control-plane/**/mocks/**"
+  - "cli/helm/mock.go"
+  # Acceptance / integration tests (not unit-tested in this workflow)
+  - "acceptance/**"
+  # Helm chart templates and generated assets
+  - "charts/**"
+  # Version-only package with no logic to test
+  - "version/**"


### PR DESCRIPTION
## Summary

Instruments the `control-plane` and `cli` Go modules with coverage profiling and adds a reusable reporting workflow, matching what was done for `consul-dataplane` in #1083.

## Changes

- `.github/workflows/coverage.yml` — orchestrator: runs `go test -coverprofile` on `control-plane/` and `cli/` in parallel, uploads per-module artifacts, then calls the report workflow
- `.github/workflows/reusable-coverage-report.yml` — merges profiles with `gocovmerge`, computes total %, posts a PR comment (edit-last), uploads `coverage.html` + `merged-coverage.out` as artifact, and commits a dynamic SVG badge to the `badges` branch on pushes to `main`
- `codecov.yml` — informational-only Codecov config (non-blocking), excludes mocks, acceptance tests, charts
- `README.md` — adds coverage badge sourced from the `badges` branch

## What happens on each PR

1. `control-plane` and `cli` unit tests run with `-coverprofile=coverage.txt -covermode=set`
2. Profiles are uploaded as artifacts and merged into `merged-coverage.out`
3. Mock files (`/mocks/`, `/mock_`, `/acceptance/`) are excluded from the total
4. A comment is posted (or edited) on the PR: **"Go Test Coverage: XX.X%"**
5. An HTML report is uploaded as the `coverage-report-html` artifact



## Reference

Mirrors the approach from consul-dataplane: hashicorp/consul-dataplane#1083