### PR TITLE
Abhishek/cloud test fix

### DIFF
--- a/acceptance/framework/consul/helm_cluster.go
+++ b/acceptance/framework/consul/helm_cluster.go
@@ -101,7 +101,7 @@ func NewHelmCluster(
 	// like AKS where volumes take a long time to mount.
 	extraArgs := map[string][]string{
 		"install": {"--timeout", "15m", "--debug", "--skip-crds"},
-		"upgrade": {"--timeout", "15m", "--debug", "--skip-crds"},
+		"upgrade": {"--timeout", "15m", "--skip-crds"},
 		"delete":  {"--timeout", "15m", "--debug"},
 	}
 
@@ -158,7 +158,7 @@ func (h *HelmCluster) Create(t *testing.T) {
 	}
 
 	// Retry the install in case previous tests have not finished cleaning up.
-	retry.RunWith(&retry.Counter{Wait: 2 * time.Second, Count: 30}, t, func(r *retry.R) {
+	retry.RunWith(&retry.Counter{Wait: 2 * time.Second, Count: 3}, t, func(r *retry.R) {
 		err := helm.UpgradeE(r, h.helmOptions, chartName, h.releaseName)
 		require.NoError(r, err)
 	})

--- a/charts/consul/test/terraform/aks/main.tf
+++ b/charts/consul/test/terraform/aks/main.tf
@@ -76,10 +76,12 @@ resource "azurerm_kubernetes_cluster" "default" {
   // communication is tested, the connections goes through the appropriate gateway
   // rather than directly from pod to pod.
   network_profile {
-    network_plugin = "kubenet"
-    service_cidr   = "10.0.0.0/16"
-    dns_service_ip = "10.0.0.10"
-    pod_cidr       = "10.244.0.0/16"
+    network_plugin      = "azure"
+    network_plugin_mode = "overlay"
+    network_policy      = "calico"
+    service_cidr        = "10.0.0.0/16"
+    dns_service_ip      = "10.0.0.10"
+    pod_cidr            = "10.244.0.0/16"
   }
 
   default_node_pool {

--- a/charts/consul/test/terraform/aks/main.tf
+++ b/charts/consul/test/terraform/aks/main.tf
@@ -66,15 +66,42 @@ resource "azurerm_kubernetes_cluster" "default" {
   kubernetes_version                = var.kubernetes_version
   role_based_access_control_enabled = true
 
-  // We're setting the network plugin and other network properties explicitly
-  // here even though they are the same as defaults to ensure that none of these CIDRs
-  // overlap with our vnet and subnet. Please see
-  // https://docs.microsoft.com/en-us/azure/aks/configure-kubenet#create-an-aks-cluster-in-the-virtual-network.
-  // We want to use kubenet plugin rather than Azure CNI because pods
-  // using kubenet will not be routable when we peer VNets,
-  // and that gives us more confidence that in any tests where cross-cluster
-  // communication is tested, the connections goes through the appropriate gateway
-  // rather than directly from pod to pod.
+  // We set the network plugin and CIDRs explicitly (even where they match the
+  // defaults) to ensure none of the pod/service CIDRs overlap with the VNet
+  // and subnet defined above.
+  //
+  // We use Azure CNI in *overlay* mode (network_plugin = "azure" with
+  // network_plugin_mode = "overlay"). Previously this configuration used
+  // kubenet, but kubenet was replaced for the following reasons:
+  //
+  //   1. On AKS v1.35, several partition-related acceptance tests started
+  //      failing. The partition-init container calls the consul-server API,
+  //      and the consul-server pod in turn tries to reach itself over RPC on
+  //      port 8300; that pod-to-self connection was not reachable on 1.35
+  //      with kubenet. 
+  //      A similar symptom is reported in https://github.com/Azure/AKS/issues/5669. 
+  //      The root cause is not yet confirmed (it may or may not be kubenet itself); 
+  //      switching to Azure CNI overlay made all the failing partition tests pass.
+  //      TODO: track down the actual root cause on AKS 1.35 + kubenet.
+  //
+  //   2. Kubenet is deprecated in AKS and scheduled for retirement by 2028.
+  //      Even before then, Azure _may_restrict_ its use for newly created
+  //      clusters, so moving off it now is a good idea regardless.
+  //
+  // Why overlay specifically (and not standard Azure CNI): 
+  // the original reason for choosing kubenet was that kubenet pod IPs are not 
+  // routable across peered VNets, which forces cross-cluster test traffic to go
+  // through the mesh/mesh-gateway rather than pod-to-pod directly. 
+  // Azure CNI overlay *preserves* this property — pods get IPs from a private pod_cidr
+  // that is not advertised to the VNet, and egress to peered VNets is SNAT'd
+  // to the node IP. Standard (non-overlay) Azure CNI would assign pod IPs
+  // from the VNet subnet and make them routable across peering, which would
+  // invalidate those tests.
+  //
+  // Refs:
+  //   https://learn.microsoft.com/azure/aks/azure-cni-overlay
+  //   https://learn.microsoft.com/en-us/azure/aks/concepts-network-azure-cni-overlay
+
   network_profile {
     network_plugin      = "azure"
     network_plugin_mode = "overlay"


### PR DESCRIPTION
### Changes proposed in this PR ###  

1. Reduce `helmUpgrade` retry count from 30 to 3 and remove `debug` flag for `helmUpgrade` arguments.
    - Each `helmUpgrade` takes almost ~5-15 minutes to deploy consul. In case of failures, 30 retry will evenually take ~5h-7h which is of no use. As per logs, a successful test do not trigger `helmUpgrade` more than once. In order to find any specific issue with consul deployment using helm, 3 retry is sufficient. So, reducing the retry count to 3. Logs are attached in Jira.
    - Removing `debug` flag from `helmUpgrade` is required because, whenever consul deployment fails, it logs user config and final applied config together in the logs, which pushes the raw logs to be around 50k-80k lines, which is hard to navigate and read it. 
    User can read the general logs and then can re-run the pipeline in debug mode to get the helm debug details, if there is any issue with helm-deployment.
3. Change the AKS test cluster network plugin **from `kubenet` to `Azure CNI in overlay mode`** (network_plugin = "azure", network_plugin_mode = "overlay") in [main.tf](https://github.com/hashicorp/consul-k8s/blob/3434f0fecb6612e64abd28e7c52f8661eb917ead/charts/consul/test/terraform/aks/main.tf#L69).

     **Why ?** 
     - On AKS v1.35, several partition-related Consul acceptance tests started failing [ref](https://github.com/hashicorp/consul-k8s-workflows/actions/runs/26699081198). The failure path is:
            - The `partition-init` container calls the `consul-server` API to create a partition.
            - On receiving the request, the `consul-server` pod tries to reach itself over RPC on port 8300.
            - That pod-to-self connection is not reachable on AKS 1.35 with `kubenet`, so the request hangs / fails.
            - The same tests pass on AKS 1.33 with `kubenet`, and they pass on AKS 1.35 once the network plugin is switched to `Azure CNI overlay`.
            - Supporting logs attached below.
     - A similar symptom is reported upstream in https://github.com/Azure/AKS/issues/5669 around kubenet used with AKS 1.35.
     - **The root cause is not yet confirmed** — it may be a kubenet-specific regression in 1.35, or it may be something else that overlay happens to sidestep. 
     - **Tracking root cause is out of scope for this PR; this change unblocks the CI pipeline.**
     - Additional motivation for moving off kubenet regardless of the root cause:
         - Kubenet is deprecated in AKS and scheduled for retirement by 2028.
         - Azure may restrict kubenet for newly created clusters before the retirement date, so moving off it now is a good idea.

**Why overlay specifically (and not standard Azure CNI)**
The original reason this config used kubenet was that kubenet pod IPs are not routable across peered VNets, which forces cross-cluster test traffic (peering, WAN federation, partitions, sameness) to go through the mesh / mesh-gateway rather than pod-to-pod directly — that's the behavior under test.

Azure CNI overlay preserves this property: pods get IPs from a private pod_cidr that is not advertised to the VNet, and egress to peered VNets is SNAT'd to the node IP. Standard (non-overlay) Azure CNI would assign pod IPs from the VNet subnet and make them routable across peering, which would invalidate those tests.

### How I've tested this PR ###
Re-ran the previously failing partition related acceptance tests (dns, partition, vault) on AKS 1.35 → **all passed**.
Changes have been tested with below PR:
[Consul-k8s-workflow PR](https://github.com/hashicorp/consul-k8s-workflows/pull/116)
[Consul-k8s PR](https://github.com/hashicorp/consul-k8s/pull/5280)

**Supporting logs:**
Failing `partition-init` container logs (when used kubenet with AKS 1.35):
```
2026-05-05T09:02:57.817Z [INFO]  consul-server-connection-manager: trying to connect to a Consul server
2026-05-05T09:02:57.818Z [DEBUG] consul-server-connection-manager: Resolved DNS name: name=48.200.32.52 ip-addrs=["{48.200.32.52 }"]
2026-05-05T09:02:57.818Z [INFO]  consul-server-connection-manager: discovered Consul servers: addresses=[48.200.32.52:8502]
2026-05-05T09:02:57.818Z [INFO]  consul-server-connection-manager: current prioritized list of known Consul servers: addresses=[48.200.32.52:8502]
2026-05-05T09:02:57.818Z [DEBUG] consul-server-connection-manager: switching to Consul server: address=48.200.32.52:8502
2026-05-05T09:02:58.112Z [DEBUG] consul-server-connection-manager: feature: supported=true name=DATAPLANE_FEATURES_EDGE_CERTIFICATE_MANAGEMENT
2026-05-05T09:02:58.112Z [DEBUG] consul-server-connection-manager: feature: supported=true name=DATAPLANE_FEATURES_ENVOY_BOOTSTRAP_CONFIGURATION
2026-05-05T09:02:58.112Z [DEBUG] consul-server-connection-manager: feature: supported=false name=DATAPLANE_FEATURES_FIPS
2026-05-05T09:02:58.112Z [DEBUG] consul-server-connection-manager: feature: supported=true name=DATAPLANE_FEATURES_WATCH_SERVERS
2026-05-05T09:02:58.112Z [INFO]  consul-server-connection-manager: connected to Consul server: address=48.200.32.52:8502
2026-05-05T09:03:03.118Z [ERROR] Error reading Partition from Consul: name=secondary error="Get \"https://48.200.32.52:8501/v1/partition/secondary?dc=dc1&partition=secondary\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"
2026-05-05T09:03:03.118Z [INFO]  Retrying in 1s
2026-05-05T09:03:09.119Z [ERROR] Error reading Partition from Consul: name=secondary error="Get \"https://48.200.32.52:8501/v1/partition/secondary?dc=dc1&partition=secondary\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"
2026-05-05T09:03:09.119Z [INFO]  Retrying in 1s
2026-05-05T09:03:36.568Z [ERROR] Error reading Partition from Consul: name=secondary error="Unexpected response code: 503 (connection error: desc = \"transport: Error while dialing: dial tcp <nil>->192.168.1.5:8300: i/o timeout\")"
2026-05-05T09:03:36.568Z [INFO]  Retrying in 1s
2026-05-05T09:03:42.573Z [ERROR] Error reading Partition from Consul: name=secondary error="Get \"https://48.200.32.52:8501/v1/partition/secondary?dc=dc1&partition=secondary\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"
2026-05-05T09:03:42.573Z [INFO]  Retrying in 1s
2026-05-05T09:03:48.576Z [ERROR] Error reading Partition from Consul: name=secondary error="Get \"https://48.200.32.52:8501/v1/partition/secondary?dc=dc1&partition=secondary\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"
2026-05-05T09:03:48.576Z [INFO]  Retrying in 1s
2026-05-05T09:03:51.830Z [ERROR] Error reading Partition from Consul: name=secondary error="Unexpected response code: 503 (connection error: desc = \"transport: Error while dialing: dial tcp <nil>->192.168.1.5:8300: i/o timeout\")"
2026-05-05T09:03:51.830Z [INFO]  Retrying in 1s
```

Successful `partition-init` container log (when used Azure CNI overlay with AKS 1.35):
```
2026-05-08T07:29:48.231Z [INFO]  consul-server-connection-manager: trying to connect to a Consul server
2026-05-08T07:29:48.231Z [DEBUG] consul-server-connection-manager: Resolved DNS name: name=4.155.126.142 ip-addrs=["{4.155.126.142 }"]
2026-05-08T07:29:48.231Z [INFO]  consul-server-connection-manager: discovered Consul servers: addresses=[4.155.126.142:8502]
2026-05-08T07:29:48.231Z [INFO]  consul-server-connection-manager: current prioritized list of known Consul servers: addresses=[4.155.126.142:8502]
2026-05-08T07:29:48.231Z [DEBUG] consul-server-connection-manager: switching to Consul server: address=4.155.126.142:8502
2026-05-08T07:29:48.431Z [DEBUG] consul-server-connection-manager: feature: supported=false name=DATAPLANE_FEATURES_FIPS
2026-05-08T07:29:48.431Z [DEBUG] consul-server-connection-manager: feature: supported=true name=DATAPLANE_FEATURES_WATCH_SERVERS
2026-05-08T07:29:48.431Z [DEBUG] consul-server-connection-manager: feature: supported=true name=DATAPLANE_FEATURES_EDGE_CERTIFICATE_MANAGEMENT
2026-05-08T07:29:48.431Z [DEBUG] consul-server-connection-manager: feature: supported=true name=DATAPLANE_FEATURES_ENVOY_BOOTSTRAP_CONFIGURATION
2026-05-08T07:29:48.431Z [INFO]  consul-server-connection-manager: connected to Consul server: address=4.155.126.142:8502
2026-05-08T07:29:48.697Z [INFO]  Successfully created Admin Partition: name=secondary
2026-05-08T07:29:48.697Z [INFO]  consul-server-connection-manager: stopping
2026-05-08T07:29:48.697Z [DEBUG] consul-server-connection-manager: backoff: retry after=588.459313ms
2026-05-08T07:29:48.697Z [DEBUG] consul-server-connection-manager: aborting: error="context canceled"
```