### PR TITLE
Shashank/update consul dns tests for ocp

### DIFF
--- a/acceptance/tests/consul-dns/consul_dns_partitions_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_partitions_test.go
@@ -4,7 +4,10 @@
 package consuldns
 
 import (
+	"crypto/tls"
+	"encoding/pem"
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -54,6 +57,7 @@ const nonPrivilegedPort = "8053"
 // - properly not resolving DNS for unexported services when ACLs are enabled.
 // - properly resolving DNS for exported services when ACLs are enabled.
 func TestConsulDNSProxy_WithPartitionsAndCatalogSync(t *testing.T) {
+	t.Skip("skipping test temporarily")
 	env := suite.Environment()
 	cfg := suite.Config()
 
@@ -73,16 +77,16 @@ func TestConsulDNSProxy_WithPartitionsAndCatalogSync(t *testing.T) {
 		// 	secure: false,
 		// 	port:   privilegedPort,
 		// },
-		// {
-		// 	name:   "not secure - ACLs and auto-encrypt not enabled",
-		// 	secure: false,
-		// 	port:   nonPrivilegedPort,
-		// },
 		{
 			name:   "secure - ACLs and auto-encrypt enabled",
 			secure: true,
 			port:   privilegedPort,
 		},
+		// {
+		// 	name:   "not secure - ACLs and auto-encrypt not enabled",
+		// 	secure: false,
+		// 	port:   nonPrivilegedPort,
+		// },
 		{
 			name:   "secure - ACLs and auto-encrypt enabled",
 			secure: true,
@@ -276,28 +280,25 @@ func getVerifications(defaultClusterContext environment.TestContext, secondaryCl
 	return verifications
 }
 
-// clearAuthMethodCACertOnce waits until the named Consul k8s auth methods exist in the given
-// partition, clears their CACert field, and returns.  It must be called as a goroutine started
-// BEFORE secondaryConsulCluster.Create(t) so the pods can recover from CrashLoopBackOff.
+// fixAuthMethodCACertOnce waits until the named Consul k8s auth methods exist in the given
+// partition, then replaces their CACert with the public CA chain fetched from the actual
+// API server endpoint.  It must be called as a goroutine started BEFORE
+// secondaryConsulCluster.Create(t) so the pods can recover from CrashLoopBackOff.
 //
 // Why this is needed: server-acl-init reads the service account secret's ca.crt (the cluster-
 // internal CA) and stores it in the auth method's CACert field.  On OpenShift ROSA, the
-// external API server endpoint (api.*.openshiftapps.com) uses a Let's Encrypt certificate,
-// which the internal CA does NOT sign.  Every time a component pod calls ACL Login, the
-// Consul server calls /apis/authentication.k8s.io/v1/tokenreviews on the external endpoint,
-// fails to verify the LE cert against the internal CA, and returns "x509: certificate signed
-// by unknown authority".  Clearing CACert to "" makes Consul fall back to its container's
-// system trust bundle, which already includes the ISRG Root X1 (Let's Encrypt) CA.
+// external API server endpoint (api.*.openshiftapps.com) uses a publicly-trusted certificate
+// (e.g. Let's Encrypt), which the internal CA does NOT sign.  Every time a component pod
+// calls ACL Login, the Consul server calls /apis/authentication.k8s.io/v1/tokenreviews on
+// the external endpoint, fails to verify the cert against the internal CA, and returns
+// "x509: certificate signed by unknown authority".
+//
+// The fix replaces CACert with the intermediate + root CA certificates from the API server's
+// TLS chain, allowing the Consul server to validate the endpoint's certificate.
 //
 // server-acl-init creates the auth method once and exits; it does not re-set CACert on retry.
-// Therefore a single clear is sufficient.
-//
-// The function reuses the existing consulClient (port-forwarded to the primary cluster's Consul
-// server) rather than opening a direct connection to the expose-servers LoadBalancer.  Direct
-// LB access can be blocked by ELB security groups that restrict inbound traffic to the
-// secondary cluster's CIDR; the port-forward routes through the k8s API server and is always
-// reachable from the test runner.
-func clearAuthMethodCACertOnce(consulClient *api.Client, releaseName, partition string) {
+// Therefore a single fix is sufficient.
+func fixAuthMethodCACertOnce(consulClient *api.Client, releaseName, partition string) {
 	names := []string{
 		fmt.Sprintf("%s-consul-k8s-component-auth-method", releaseName),
 		fmt.Sprintf("%s-consul-k8s-auth-method", releaseName),
@@ -313,7 +314,22 @@ func clearAuthMethodCACertOnce(consulClient *api.Client, releaseName, partition 
 				time.Sleep(5 * time.Second)
 				continue
 			}
-			method.Config["CACert"] = ""
+
+			// Get the API server host from the auth method config.
+			host, _ := method.Config["Host"].(string)
+			if host == "" {
+				time.Sleep(5 * time.Second)
+				continue
+			}
+
+			// Fetch the public CA chain from the API server's TLS endpoint.
+			caCert := fetchTLSCACertFromHost(host)
+			if caCert == "" {
+				time.Sleep(5 * time.Second)
+				continue
+			}
+
+			method.Config["CACert"] = caCert
 			if _, _, err = consulClient.ACL().AuthMethodUpdate(method, writeOpts); err != nil {
 				time.Sleep(5 * time.Second)
 				continue
@@ -321,6 +337,45 @@ func clearAuthMethodCACertOnce(consulClient *api.Client, releaseName, partition 
 			break
 		}
 	}
+}
+
+// fetchTLSCACertFromHost connects to the given HTTPS host, retrieves the TLS
+// certificate chain, and returns PEM-encoded CA certificates (intermediate + root)
+// that can validate the server's leaf certificate.
+func fetchTLSCACertFromHost(host string) string {
+	u, err := url.Parse(host)
+	if err != nil {
+		return ""
+	}
+	addr := u.Host
+	if !strings.Contains(addr, ":") {
+		addr = addr + ":443"
+	}
+
+	conn, err := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true})
+	if err != nil {
+		return ""
+	}
+	defer conn.Close()
+
+	certs := conn.ConnectionState().PeerCertificates
+	if len(certs) < 2 {
+		return ""
+	}
+
+	// Collect all non-leaf certificates (intermediates + root) as PEM.
+	var pemCerts []byte
+	for _, cert := range certs[1:] {
+		if cert.IsCA || cert.BasicConstraintsValid {
+			block := &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}
+			pemCerts = append(pemCerts, pem.EncodeToMemory(block)...)
+		}
+	}
+
+	if len(pemCerts) == 0 {
+		return ""
+	}
+	return string(pemCerts)
 }
 
 func restartDNSProxy(t *testing.T, releaseName string, ctx environment.TestContext) {
@@ -454,18 +509,14 @@ func setupClustersAndStaticService(t *testing.T, cfg *config.TestConfig, default
 	// the background goroutine that clears the CACert concurrently with secondary-cluster Create.
 	consulClient, _ := defaultConsulCluster.SetupConsulClient(t, c.secure)
 
-	// On OpenShift with ACLs enabled, server-acl-init creates auth methods in the secondary
-	// partition with CACert set to the cluster-internal CA. The external API server uses a
-	// publicly-trusted cert (e.g. Let's Encrypt), so token review calls fail with
-	// "x509: certificate signed by unknown authority" and every component pod enters
-	// CrashLoopBackOff before we can call clearAuthMethodCACert sequentially.
-	//
-	// Fix: start a goroutine that polls via the existing consulClient (port-forwarded to the
-	// primary Consul server) until the auth methods appear, then clears their CACert.  Using
-	// the port-forward avoids ELB security-group restrictions that would block a direct
-	// connection from the test-runner machine to the expose-servers LoadBalancer.
-	if c.secure && cfg.EnableOpenshift {
-		go clearAuthMethodCACertOnce(consulClient, releaseName, secondaryPartition)
+	// On OpenShift ROSA, server-acl-init stores the cluster-internal CA in the auth
+	// method's CACert field, but the external API server endpoint uses a publicly-
+	// trusted certificate.  This goroutine polls until auth methods appear, then
+	// replaces CACert with the correct public CA chain fetched from the API server's
+	// TLS handshake, allowing pods to recover from CrashLoopBackOff before the
+	// readiness timeout expires.
+	if c.secure && isOpenShift(t, secondaryClusterContext) {
+		go fixAuthMethodCACertOnce(consulClient, releaseName, secondaryPartition)
 	}
 
 	// Install the consul cluster without servers in the client cluster kubernetes context.

--- a/acceptance/tests/consul-dns/consul_dns_partitions_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_partitions_test.go
@@ -57,7 +57,6 @@ const nonPrivilegedPort = "8053"
 // - properly not resolving DNS for unexported services when ACLs are enabled.
 // - properly resolving DNS for exported services when ACLs are enabled.
 func TestConsulDNSProxy_WithPartitionsAndCatalogSync(t *testing.T) {
-	t.Skip("skipping test temporarily")
 	env := suite.Environment()
 	cfg := suite.Config()
 
@@ -72,21 +71,21 @@ func TestConsulDNSProxy_WithPartitionsAndCatalogSync(t *testing.T) {
 	}
 
 	cases := []dnsWithPartitionsTestCase{
-		// {
-		// 	name:   "not secure - ACLs and auto-encrypt not enabled",
-		// 	secure: false,
-		// 	port:   privilegedPort,
-		// },
+		{
+			name:   "not secure - ACLs and auto-encrypt not enabled",
+			secure: false,
+			port:   privilegedPort,
+		},
 		{
 			name:   "secure - ACLs and auto-encrypt enabled",
 			secure: true,
 			port:   privilegedPort,
 		},
-		// {
-		// 	name:   "not secure - ACLs and auto-encrypt not enabled",
-		// 	secure: false,
-		// 	port:   nonPrivilegedPort,
-		// },
+		{
+			name:   "not secure - ACLs and auto-encrypt not enabled",
+			secure: false,
+			port:   nonPrivilegedPort,
+		},
 		{
 			name:   "secure - ACLs and auto-encrypt enabled",
 			secure: true,

--- a/acceptance/tests/consul-dns/consul_dns_partitions_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_partitions_test.go
@@ -305,8 +305,8 @@ func fixAuthMethodCACertOnce(consulClient *api.Client, releaseName, partition st
 	queryOpts := &api.QueryOptions{Partition: partition}
 	writeOpts := &api.WriteOptions{Partition: partition}
 
-	deadline := time.Now().Add(10 * time.Minute)
 	for _, amName := range names {
+		deadline := time.Now().Add(10 * time.Minute)
 		for time.Now().Before(deadline) {
 			method, _, err := consulClient.ACL().AuthMethodRead(amName, queryOpts)
 			if err != nil || method == nil {
@@ -550,8 +550,6 @@ func setupClustersAndStaticService(t *testing.T, cfg *config.TestConfig, default
 	helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
 		k8s.RunKubectl(t, secondaryClusterContext.KubectlOptions(t), "delete", "ns", staticServerNamespace)
 	})
-
-	consulClient, _ := defaultConsulCluster.SetupConsulClient(t, c.secure)
 
 	defaultPartitionQueryOpts := &api.QueryOptions{Namespace: defaultNamespace, Partition: defaultPartition}
 	secondaryPartitionQueryOpts := &api.QueryOptions{Namespace: defaultNamespace, Partition: secondaryPartition}

--- a/acceptance/tests/consul-dns/consul_dns_partitions_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_partitions_test.go
@@ -4,11 +4,7 @@
 package consuldns
 
 import (
-	"crypto/tls"
-	"encoding/pem"
 	"fmt"
-	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -279,104 +275,6 @@ func getVerifications(defaultClusterContext environment.TestContext, secondaryCl
 	return verifications
 }
 
-// fixAuthMethodCACertOnce waits until the named Consul k8s auth methods exist in the given
-// partition, then replaces their CACert with the public CA chain fetched from the actual
-// API server endpoint.  It must be called as a goroutine started BEFORE
-// secondaryConsulCluster.Create(t) so the pods can recover from CrashLoopBackOff.
-//
-// Why this is needed: server-acl-init reads the service account secret's ca.crt (the cluster-
-// internal CA) and stores it in the auth method's CACert field.  On OpenShift ROSA, the
-// external API server endpoint (api.*.openshiftapps.com) uses a publicly-trusted certificate
-// (e.g. Let's Encrypt), which the internal CA does NOT sign.  Every time a component pod
-// calls ACL Login, the Consul server calls /apis/authentication.k8s.io/v1/tokenreviews on
-// the external endpoint, fails to verify the cert against the internal CA, and returns
-// "x509: certificate signed by unknown authority".
-//
-// The fix replaces CACert with the intermediate + root CA certificates from the API server's
-// TLS chain, allowing the Consul server to validate the endpoint's certificate.
-//
-// server-acl-init creates the auth method once and exits; it does not re-set CACert on retry.
-// Therefore a single fix is sufficient.
-func fixAuthMethodCACertOnce(consulClient *api.Client, releaseName, partition string) {
-	names := []string{
-		fmt.Sprintf("%s-consul-k8s-component-auth-method", releaseName),
-		fmt.Sprintf("%s-consul-k8s-auth-method", releaseName),
-	}
-	queryOpts := &api.QueryOptions{Partition: partition}
-	writeOpts := &api.WriteOptions{Partition: partition}
-
-	for _, amName := range names {
-		deadline := time.Now().Add(10 * time.Minute)
-		for time.Now().Before(deadline) {
-			method, _, err := consulClient.ACL().AuthMethodRead(amName, queryOpts)
-			if err != nil || method == nil {
-				time.Sleep(5 * time.Second)
-				continue
-			}
-
-			// Get the API server host from the auth method config.
-			host, _ := method.Config["Host"].(string)
-			if host == "" {
-				time.Sleep(5 * time.Second)
-				continue
-			}
-
-			// Fetch the public CA chain from the API server's TLS endpoint.
-			caCert := fetchTLSCACertFromHost(host)
-			if caCert == "" {
-				time.Sleep(5 * time.Second)
-				continue
-			}
-
-			method.Config["CACert"] = caCert
-			if _, _, err = consulClient.ACL().AuthMethodUpdate(method, writeOpts); err != nil {
-				time.Sleep(5 * time.Second)
-				continue
-			}
-			break
-		}
-	}
-}
-
-// fetchTLSCACertFromHost connects to the given HTTPS host, retrieves the TLS
-// certificate chain, and returns PEM-encoded CA certificates (intermediate + root)
-// that can validate the server's leaf certificate.
-func fetchTLSCACertFromHost(host string) string {
-	u, err := url.Parse(host)
-	if err != nil {
-		return ""
-	}
-	addr := u.Host
-	if !strings.Contains(addr, ":") {
-		addr = addr + ":443"
-	}
-
-	conn, err := tls.Dial("tcp", addr, &tls.Config{})
-	if err != nil {
-		return ""
-	}
-	defer conn.Close()
-
-	certs := conn.ConnectionState().PeerCertificates
-	if len(certs) < 2 {
-		return ""
-	}
-
-	// Collect all non-leaf certificates (intermediates + root) as PEM.
-	var pemCerts []byte
-	for _, cert := range certs[1:] {
-		if cert.IsCA || cert.BasicConstraintsValid {
-			block := &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}
-			pemCerts = append(pemCerts, pem.EncodeToMemory(block)...)
-		}
-	}
-
-	if len(pemCerts) == 0 {
-		return ""
-	}
-	return string(pemCerts)
-}
-
 func restartDNSProxy(t *testing.T, releaseName string, ctx environment.TestContext) {
 	dnsDeploymentName := fmt.Sprintf("deployment/%s-consul-dns-proxy", releaseName)
 	restartDNSProxyCommand := []string{"rollout", "restart", dnsDeploymentName}
@@ -504,19 +402,7 @@ func setupClustersAndStaticService(t *testing.T, cfg *config.TestConfig, default
 
 	helpers.MergeMaps(clientHelmValues, commonHelmValues)
 
-	// Initialize consulClient now (primary cluster is already ready) so we can pass it to
-	// the background goroutine that clears the CACert concurrently with secondary-cluster Create.
 	consulClient, _ := defaultConsulCluster.SetupConsulClient(t, c.secure)
-
-	// On OpenShift ROSA, server-acl-init stores the cluster-internal CA in the auth
-	// method's CACert field, but the external API server endpoint uses a publicly-
-	// trusted certificate.  This goroutine polls until auth methods appear, then
-	// replaces CACert with the correct public CA chain fetched from the API server's
-	// TLS handshake, allowing pods to recover from CrashLoopBackOff before the
-	// readiness timeout expires.
-	if c.secure && isOpenShift(t, secondaryClusterContext) {
-		go fixAuthMethodCACertOnce(consulClient, releaseName, secondaryPartition)
-	}
 
 	// Install the consul cluster without servers in the client cluster kubernetes context.
 	secondaryConsulCluster := consul.NewHelmCluster(t, clientHelmValues, secondaryClusterContext, cfg, releaseName)
@@ -612,52 +498,4 @@ func setupClustersAndStaticService(t *testing.T, cfg *config.TestConfig, default
 	require.Equal(t, []string{"k8s"}, service[0].ServiceTags)
 
 	return releaseName, consulClient, defaultPartitionQueryOpts, secondaryPartitionQueryOpts, defaultConsulCluster
-}
-
-func reconcileComponentAuthMethodForOpenShift(t *testing.T, consulClient *api.Client, releaseName, secondaryPartition string, secondaryCtx environment.TestContext) {
-	t.Helper()
-
-	options := secondaryCtx.KubectlOptions(t)
-	configPath, err := options.GetConfigPath(t)
-	require.NoError(t, err)
-
-	apiConfig, err := terratestk8s.LoadApiClientConfigE(configPath, options.ContextName)
-	require.NoError(t, err)
-
-	require.NotEmpty(t, apiConfig.Host)
-
-	caBundle := apiConfig.CAData
-	if len(caBundle) == 0 && apiConfig.CAFile != "" {
-		caBundle, err = os.ReadFile(apiConfig.CAFile)
-		require.NoError(t, err)
-	}
-	require.NotEmpty(t, caBundle, "kubeconfig CA bundle must be present for OpenShift auth-method override")
-
-	authMethodName := fmt.Sprintf("%s-consul-k8s-component-auth-method", releaseName)
-	partitions := []string{defaultPartition, secondaryPartition}
-
-	counter := &retry.Counter{Count: 30, Wait: 10 * time.Second}
-	retry.RunWith(counter, t, func(r *retry.R) {
-		updatedAny := false
-		for _, partition := range partitions {
-			readOpts := &api.QueryOptions{Partition: partition}
-			authMethod, _, readErr := consulClient.ACL().AuthMethodRead(authMethodName, readOpts)
-			require.NoError(r, readErr)
-			if authMethod == nil {
-				continue
-			}
-
-			authMethod.Config["Host"] = apiConfig.Host
-			authMethod.Config["CACert"] = string(caBundle)
-
-			writeOpts := &api.WriteOptions{Partition: partition}
-			_, _, updateErr := consulClient.ACL().AuthMethodUpdate(authMethod, writeOpts)
-			require.NoError(r, updateErr)
-			updatedAny = true
-		}
-
-		if !updatedAny {
-			r.Errorf("waiting for auth method %q to exist before updating OpenShift Host/CACert", authMethodName)
-		}
-	})
 }

--- a/acceptance/tests/consul-dns/consul_dns_partitions_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_partitions_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -67,20 +68,20 @@ func TestConsulDNSProxy_WithPartitionsAndCatalogSync(t *testing.T) {
 	}
 
 	cases := []dnsWithPartitionsTestCase{
-		{
-			name:   "not secure - ACLs and auto-encrypt not enabled",
-			secure: false,
-			port:   privilegedPort,
-		},
+		// {
+		// 	name:   "not secure - ACLs and auto-encrypt not enabled",
+		// 	secure: false,
+		// 	port:   privilegedPort,
+		// },
+		// {
+		// 	name:   "not secure - ACLs and auto-encrypt not enabled",
+		// 	secure: false,
+		// 	port:   nonPrivilegedPort,
+		// },
 		{
 			name:   "secure - ACLs and auto-encrypt enabled",
 			secure: true,
 			port:   privilegedPort,
-		},
-		{
-			name:   "not secure - ACLs and auto-encrypt not enabled",
-			secure: false,
-			port:   nonPrivilegedPort,
 		},
 		{
 			name:   "secure - ACLs and auto-encrypt enabled",
@@ -275,6 +276,53 @@ func getVerifications(defaultClusterContext environment.TestContext, secondaryCl
 	return verifications
 }
 
+// clearAuthMethodCACertOnce waits until the named Consul k8s auth methods exist in the given
+// partition, clears their CACert field, and returns.  It must be called as a goroutine started
+// BEFORE secondaryConsulCluster.Create(t) so the pods can recover from CrashLoopBackOff.
+//
+// Why this is needed: server-acl-init reads the service account secret's ca.crt (the cluster-
+// internal CA) and stores it in the auth method's CACert field.  On OpenShift ROSA, the
+// external API server endpoint (api.*.openshiftapps.com) uses a Let's Encrypt certificate,
+// which the internal CA does NOT sign.  Every time a component pod calls ACL Login, the
+// Consul server calls /apis/authentication.k8s.io/v1/tokenreviews on the external endpoint,
+// fails to verify the LE cert against the internal CA, and returns "x509: certificate signed
+// by unknown authority".  Clearing CACert to "" makes Consul fall back to its container's
+// system trust bundle, which already includes the ISRG Root X1 (Let's Encrypt) CA.
+//
+// server-acl-init creates the auth method once and exits; it does not re-set CACert on retry.
+// Therefore a single clear is sufficient.
+//
+// The function reuses the existing consulClient (port-forwarded to the primary cluster's Consul
+// server) rather than opening a direct connection to the expose-servers LoadBalancer.  Direct
+// LB access can be blocked by ELB security groups that restrict inbound traffic to the
+// secondary cluster's CIDR; the port-forward routes through the k8s API server and is always
+// reachable from the test runner.
+func clearAuthMethodCACertOnce(consulClient *api.Client, releaseName, partition string) {
+	names := []string{
+		fmt.Sprintf("%s-consul-k8s-component-auth-method", releaseName),
+		fmt.Sprintf("%s-consul-k8s-auth-method", releaseName),
+	}
+	queryOpts := &api.QueryOptions{Partition: partition}
+	writeOpts := &api.WriteOptions{Partition: partition}
+
+	deadline := time.Now().Add(10 * time.Minute)
+	for _, amName := range names {
+		for time.Now().Before(deadline) {
+			method, _, err := consulClient.ACL().AuthMethodRead(amName, queryOpts)
+			if err != nil || method == nil {
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			method.Config["CACert"] = ""
+			if _, _, err = consulClient.ACL().AuthMethodUpdate(method, writeOpts); err != nil {
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			break
+		}
+	}
+}
+
 func restartDNSProxy(t *testing.T, releaseName string, ctx environment.TestContext) {
 	dnsDeploymentName := fmt.Sprintf("deployment/%s-consul-dns-proxy", releaseName)
 	restartDNSProxyCommand := []string{"rollout", "restart", dnsDeploymentName}
@@ -402,6 +450,24 @@ func setupClustersAndStaticService(t *testing.T, cfg *config.TestConfig, default
 
 	helpers.MergeMaps(clientHelmValues, commonHelmValues)
 
+	// Initialize consulClient now (primary cluster is already ready) so we can pass it to
+	// the background goroutine that clears the CACert concurrently with secondary-cluster Create.
+	consulClient, _ := defaultConsulCluster.SetupConsulClient(t, c.secure)
+
+	// On OpenShift with ACLs enabled, server-acl-init creates auth methods in the secondary
+	// partition with CACert set to the cluster-internal CA. The external API server uses a
+	// publicly-trusted cert (e.g. Let's Encrypt), so token review calls fail with
+	// "x509: certificate signed by unknown authority" and every component pod enters
+	// CrashLoopBackOff before we can call clearAuthMethodCACert sequentially.
+	//
+	// Fix: start a goroutine that polls via the existing consulClient (port-forwarded to the
+	// primary Consul server) until the auth methods appear, then clears their CACert.  Using
+	// the port-forward avoids ELB security-group restrictions that would block a direct
+	// connection from the test-runner machine to the expose-servers LoadBalancer.
+	if c.secure && cfg.EnableOpenshift {
+		go clearAuthMethodCACertOnce(consulClient, releaseName, secondaryPartition)
+	}
+
 	// Install the consul cluster without servers in the client cluster kubernetes context.
 	secondaryConsulCluster := consul.NewHelmCluster(t, clientHelmValues, secondaryClusterContext, cfg, releaseName)
 	secondaryConsulCluster.Create(t)
@@ -418,25 +484,24 @@ func setupClustersAndStaticService(t *testing.T, cfg *config.TestConfig, default
 	}
 
 	logger.Logf(t, "creating namespaces %s in servers cluster", staticServerNamespace)
-	k8s.RunKubectl(t, defaultClusterContext.KubectlOptions(t), "create", "ns", staticServerNamespace)
+	_, err := k8s.RunKubectlAndGetOutputE(t, defaultClusterContext.KubectlOptions(t), "create", "ns", staticServerNamespace)
+	if err != nil && !strings.Contains(err.Error(), "AlreadyExists") {
+		require.NoError(t, err)
+	}
 	helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
 		k8s.RunKubectl(t, defaultClusterContext.KubectlOptions(t), "delete", "ns", staticServerNamespace)
 	})
 
 	logger.Logf(t, "creating namespaces %s in clients cluster", staticServerNamespace)
-	k8s.RunKubectl(t, secondaryClusterContext.KubectlOptions(t), "create", "ns", staticServerNamespace)
+	_, err = k8s.RunKubectlAndGetOutputE(t, secondaryClusterContext.KubectlOptions(t), "create", "ns", staticServerNamespace)
+	if err != nil && !strings.Contains(err.Error(), "AlreadyExists") {
+		require.NoError(t, err)
+	}
 	helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
 		k8s.RunKubectl(t, secondaryClusterContext.KubectlOptions(t), "delete", "ns", staticServerNamespace)
 	})
 
 	consulClient, _ := defaultConsulCluster.SetupConsulClient(t, c.secure)
-
-	if c.secure && (cfg.UseOpenshift || cfg.EnableOpenshift) {
-		// On OpenShift, external API host certificates may not be signed by the same CA
-		// that is present in the auth-method service-account secret. Ensure the Consul
-		// component auth method uses the kubeconfig endpoint and CA bundle for tokenreviews.
-		reconcileComponentAuthMethodForOpenShift(t, consulClient, releaseName, secondaryPartition, secondaryClusterContext)
-	}
 
 	defaultPartitionQueryOpts := &api.QueryOptions{Namespace: defaultNamespace, Partition: defaultPartition}
 	secondaryPartitionQueryOpts := &api.QueryOptions{Namespace: defaultNamespace, Partition: secondaryPartition}

--- a/acceptance/tests/consul-dns/consul_dns_partitions_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_partitions_test.go
@@ -351,7 +351,7 @@ func fetchTLSCACertFromHost(host string) string {
 		addr = addr + ":443"
 	}
 
-	conn, err := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true})
+	conn, err := tls.Dial("tcp", addr, &tls.Config{})
 	if err != nil {
 		return ""
 	}
@@ -534,18 +534,18 @@ func setupClustersAndStaticService(t *testing.T, cfg *config.TestConfig, default
 	}
 
 	logger.Logf(t, "creating namespaces %s in servers cluster", staticServerNamespace)
-	_, err := k8s.RunKubectlAndGetOutputE(t, defaultClusterContext.KubectlOptions(t), "create", "ns", staticServerNamespace)
+	out, err := k8s.RunKubectlAndGetOutputE(t, defaultClusterContext.KubectlOptions(t), "create", "ns", staticServerNamespace)
 	if err != nil && !strings.Contains(err.Error(), "AlreadyExists") {
-		require.NoError(t, err)
+		require.NoError(t, err, "failed to create namespace %s in servers cluster: %s", staticServerNamespace, out)
 	}
 	helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
 		k8s.RunKubectl(t, defaultClusterContext.KubectlOptions(t), "delete", "ns", staticServerNamespace)
 	})
 
 	logger.Logf(t, "creating namespaces %s in clients cluster", staticServerNamespace)
-	_, err = k8s.RunKubectlAndGetOutputE(t, secondaryClusterContext.KubectlOptions(t), "create", "ns", staticServerNamespace)
+	out, err = k8s.RunKubectlAndGetOutputE(t, secondaryClusterContext.KubectlOptions(t), "create", "ns", staticServerNamespace)
 	if err != nil && !strings.Contains(err.Error(), "AlreadyExists") {
-		require.NoError(t, err)
+		require.NoError(t, err, "failed to create namespace %s in clients cluster: %s", staticServerNamespace, out)
 	}
 	helpers.Cleanup(t, cfg.NoCleanupOnFailure, cfg.NoCleanup, func() {
 		k8s.RunKubectl(t, secondaryClusterContext.KubectlOptions(t), "delete", "ns", staticServerNamespace)

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -184,7 +184,74 @@ func createACLTokenWithGivenPolicy(t *testing.T, consulClient *api.Client, polic
 	return err, dnsProxyToken
 }
 
+// isOpenShift returns true if the cluster is an OpenShift cluster, detected by
+// the presence of the openshift-dns namespace.
+func isOpenShift(t *testing.T, ctx environment.TestContext) bool {
+	_, err := ctx.KubernetesClient(t).CoreV1().Namespaces().Get(
+		context.Background(), "openshift-dns", metav1.GetOptions{})
+	return err == nil
+}
+
+// configureOpenShiftDNSForConsul patches the OpenShift DNS Operator CR to forward
+// consul domain queries to the Consul DNS service or proxy. This is the correct
+// approach for OpenShift clusters where DNS is managed by the DNS Operator in the
+// openshift-dns namespace rather than CoreDNS in kube-system.
+func configureOpenShiftDNSForConsul(t *testing.T, ctx environment.TestContext, releaseName string, enableDNSProxy bool, port string) {
+	dnsIP, err := getDNSServiceClusterIP(t, ctx, releaseName, enableDNSProxy)
+	require.NoError(t, err)
+
+	upstream := dnsIP
+	if enableDNSProxy {
+		upstream = fmt.Sprintf("%s:%s", dnsIP, port)
+	}
+
+	logger.Logf(t, "Configuring OpenShift DNS Operator to forward consul domain to %s", upstream)
+	patchJSON := fmt.Sprintf(
+		`{"spec":{"servers":[{"name":"consul-dns","zones":["consul"],"forwardPlugin":{"policy":"Sequential","upstreams":["%s"]}}]}}`,
+		upstream)
+
+	_, err = k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t),
+		"patch", "dns.operator.openshift.io", "default",
+		"--type=merge", "--patch", patchJSON)
+	require.NoError(t, err)
+
+	// Wait for the DNS Operator to update the dns-default ConfigMap with the consul forwarding rule.
+	logger.Log(t, "Waiting for OpenShift DNS ConfigMap to reflect consul forwarding rule...")
+	timer := &retry.Timer{Timeout: 5 * time.Minute, Wait: 10 * time.Second}
+	retry.RunWith(timer, t, func(r *retry.R) {
+		cm, err := ctx.KubernetesClient(t).CoreV1().ConfigMaps("openshift-dns").Get(
+			context.Background(), "dns-default", metav1.GetOptions{})
+		require.NoError(r, err)
+		corefile, ok := cm.Data["Corefile"]
+		require.True(r, ok, "dns-default ConfigMap missing Corefile key")
+		require.Contains(r, corefile, upstream,
+			"dns-default Corefile does not yet contain consul forwarding rule for %s", upstream)
+	})
+
+	// Give CoreDNS time to reload the new configuration via the reload plugin.
+	time.Sleep(15 * time.Second)
+
+	// Cleanup: remove the consul server entry from the DNS Operator CR.
+	t.Cleanup(func() {
+		logger.Log(t, "Restoring OpenShift DNS Operator configuration (removing consul servers entry)...")
+		_, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t),
+			"patch", "dns.operator.openshift.io", "default",
+			"--type=merge", "--patch", `{"spec":{"servers":[]}}`)
+		if err != nil {
+			logger.Log(t, "Warning: failed to restore OpenShift DNS Operator config:", err)
+		}
+		time.Sleep(5 * time.Second)
+	})
+}
+
 func updateCoreDNSWithConsulDomain(t *testing.T, ctx environment.TestContext, releaseName string, enableDNSProxy bool, port string) {
+	// On OpenShift, DNS is managed by the DNS Operator in openshift-dns, not CoreDNS
+	// in kube-system. Use the DNS Operator CR to configure consul domain forwarding.
+	if isOpenShift(t, ctx) {
+		configureOpenShiftDNSForConsul(t, ctx, releaseName, enableDNSProxy, port)
+		return
+	}
+
 	actualName := getCoreDNSConfigMapName(t, ctx)
 
 	// 1. BACKUP: Capture the current state

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -51,10 +51,10 @@ func TestConsulDNS(t *testing.T) {
 		manageSystemACLs     bool
 		port                 string
 	}{
-		// {tlsEnabled: false, connectInjectEnabled: true, aclsEnabled: false, manageSystemACLs: false, enableDNSProxy: false, port: privilegedPort},
-		// {tlsEnabled: false, connectInjectEnabled: true, aclsEnabled: false, manageSystemACLs: false, enableDNSProxy: true, port: privilegedPort},
-		// {tlsEnabled: true, connectInjectEnabled: true, aclsEnabled: true, manageSystemACLs: true, enableDNSProxy: false, port: privilegedPort},
-		// {tlsEnabled: true, connectInjectEnabled: true, aclsEnabled: true, manageSystemACLs: true, enableDNSProxy: true, port: privilegedPort},
+		{tlsEnabled: false, connectInjectEnabled: true, aclsEnabled: false, manageSystemACLs: false, enableDNSProxy: false, port: privilegedPort},
+		{tlsEnabled: false, connectInjectEnabled: true, aclsEnabled: false, manageSystemACLs: false, enableDNSProxy: true, port: privilegedPort},
+		{tlsEnabled: true, connectInjectEnabled: true, aclsEnabled: true, manageSystemACLs: true, enableDNSProxy: false, port: privilegedPort},
+		{tlsEnabled: true, connectInjectEnabled: true, aclsEnabled: true, manageSystemACLs: true, enableDNSProxy: true, port: privilegedPort},
 		{tlsEnabled: true, connectInjectEnabled: false, aclsEnabled: true, manageSystemACLs: false, enableDNSProxy: true, port: privilegedPort},
 		{tlsEnabled: false, connectInjectEnabled: true, aclsEnabled: false, manageSystemACLs: false, enableDNSProxy: false, port: nonPrivilegedPort},
 		{tlsEnabled: false, connectInjectEnabled: true, aclsEnabled: false, manageSystemACLs: false, enableDNSProxy: true, port: nonPrivilegedPort},

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -205,6 +205,13 @@ func configureOpenShiftDNSForConsul(t *testing.T, ctx environment.TestContext, r
 		upstream = fmt.Sprintf("%s:%s", dnsIP, port)
 	}
 
+	// Snapshot the existing spec.servers before patching so we can restore it in cleanup.
+	existingServers, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t),
+		"get", "dns.operator.openshift.io", "default",
+		"-o", "jsonpath={.spec.servers}")
+	require.NoError(t, err)
+	logger.Logf(t, "Captured existing OpenShift DNS Operator spec.servers: %s", existingServers)
+
 	logger.Logf(t, "Configuring OpenShift DNS Operator to forward consul domain to %s", upstream)
 	patchJSON := fmt.Sprintf(
 		`{"spec":{"servers":[{"name":"consul-dns","zones":["consul"],"forwardPlugin":{"policy":"Sequential","upstreams":["%s"]}}]}}`,
@@ -231,12 +238,18 @@ func configureOpenShiftDNSForConsul(t *testing.T, ctx environment.TestContext, r
 	// Give CoreDNS time to reload the new configuration via the reload plugin.
 	time.Sleep(15 * time.Second)
 
-	// Cleanup: remove the consul server entry from the DNS Operator CR.
+	// Cleanup: restore the original spec.servers snapshot.
 	t.Cleanup(func() {
-		logger.Log(t, "Restoring OpenShift DNS Operator configuration (removing consul servers entry)...")
+		logger.Log(t, "Restoring OpenShift DNS Operator configuration to original spec.servers...")
+		var restorePatch string
+		if existingServers == "" || existingServers == "null" {
+			restorePatch = `{"spec":{"servers":null}}`
+		} else {
+			restorePatch = fmt.Sprintf(`{"spec":{"servers":%s}}`, existingServers)
+		}
 		_, err := k8s.RunKubectlAndGetOutputE(t, ctx.KubectlOptions(t),
 			"patch", "dns.operator.openshift.io", "default",
-			"--type=merge", "--patch", `{"spec":{"servers":[]}}`)
+			"--type=merge", "--patch", restorePatch)
 		if err != nil {
 			logger.Log(t, "Warning: failed to restore OpenShift DNS Operator config:", err)
 		}

--- a/acceptance/tests/consul-dns/consul_dns_test.go
+++ b/acceptance/tests/consul-dns/consul_dns_test.go
@@ -51,10 +51,10 @@ func TestConsulDNS(t *testing.T) {
 		manageSystemACLs     bool
 		port                 string
 	}{
-		{tlsEnabled: false, connectInjectEnabled: true, aclsEnabled: false, manageSystemACLs: false, enableDNSProxy: false, port: privilegedPort},
-		{tlsEnabled: false, connectInjectEnabled: true, aclsEnabled: false, manageSystemACLs: false, enableDNSProxy: true, port: privilegedPort},
-		{tlsEnabled: true, connectInjectEnabled: true, aclsEnabled: true, manageSystemACLs: true, enableDNSProxy: false, port: privilegedPort},
-		{tlsEnabled: true, connectInjectEnabled: true, aclsEnabled: true, manageSystemACLs: true, enableDNSProxy: true, port: privilegedPort},
+		// {tlsEnabled: false, connectInjectEnabled: true, aclsEnabled: false, manageSystemACLs: false, enableDNSProxy: false, port: privilegedPort},
+		// {tlsEnabled: false, connectInjectEnabled: true, aclsEnabled: false, manageSystemACLs: false, enableDNSProxy: true, port: privilegedPort},
+		// {tlsEnabled: true, connectInjectEnabled: true, aclsEnabled: true, manageSystemACLs: true, enableDNSProxy: false, port: privilegedPort},
+		// {tlsEnabled: true, connectInjectEnabled: true, aclsEnabled: true, manageSystemACLs: true, enableDNSProxy: true, port: privilegedPort},
 		{tlsEnabled: true, connectInjectEnabled: false, aclsEnabled: true, manageSystemACLs: false, enableDNSProxy: true, port: privilegedPort},
 		{tlsEnabled: false, connectInjectEnabled: true, aclsEnabled: false, manageSystemACLs: false, enableDNSProxy: false, port: nonPrivilegedPort},
 		{tlsEnabled: false, connectInjectEnabled: true, aclsEnabled: false, manageSystemACLs: false, enableDNSProxy: true, port: nonPrivilegedPort},

--- a/control-plane/api/v1alpha1/gatewaypolicy_webhook.go
+++ b/control-plane/api/v1alpha1/gatewaypolicy_webhook.go
@@ -65,7 +65,7 @@ func (v *GatewayPolicyWebhook) Handle(ctx context.Context, req admission.Request
 	return admission.Allowed("gateway policy is valid")
 }
 
-// func to check the resource targetref.kind is Gateway
+// isTargetRefKindGateway checks if the resource targetref.kind is Gateway.
 func (v *GatewayPolicyWebhook) isTargetRefKindGateway(resource GatewayPolicy) bool {
 	return resource.Spec.TargetRef.Kind == "Gateway"
 }

--- a/control-plane/api/v1alpha1/gatewaypolicy_webhook_custom.go
+++ b/control-plane/api/v1alpha1/gatewaypolicy_webhook_custom.go
@@ -66,7 +66,7 @@ func (v *CustomGatewayPolicyWebhook) Handle(ctx context.Context, req admission.R
 	return admission.Allowed("gateway policy is valid")
 }
 
-// func to check the resource targetref.kind is Gateway
+// isTargetRefKindGateway checks if the resource targetref.kind is Gateway.
 func (v *CustomGatewayPolicyWebhook) isTargetRefKindGateway(resource CustomGatewayPolicy) bool {
 	return resource.Spec.TargetRef.Kind == "Gateway"
 }

--- a/control-plane/subcommand/generate-manifests/command_test.go
+++ b/control-plane/subcommand/generate-manifests/command_test.go
@@ -383,7 +383,7 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
-// test function for writeObjects to validate the output manifests are in the expected format and have the expected mutations
+// TestWriteObjects validates the output manifests are in the expected format and have the expected mutations.
 func TestWriteObjects(t *testing.T) {
 	tmpDir := t.TempDir()
 	gatewayMap = map[string]bool{}


### PR DESCRIPTION
### Changes proposed in this PR ###  
Updated consul-dns acceptance test to be compatible for Openshift clusters.
-

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
