### PR TITLE
Fix permanent skip of pod registration when Endpoints lags behind Pod IP assignment

### DIFF
--- a/.changelog/5386.txt
+++ b/.changelog/5386.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+control-plane: fix a race during startup where pod registration could be permanently skipped when the Kubernetes Endpoints object lagged behind Pod IP assignment. The endpoints controller now requeues reconciliation until the Endpoints address is populated.
+```

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller.go
@@ -62,6 +62,11 @@ const (
 	// This address does not need to be routable as this node is ephemeral, and we're only providing it because
 	// Consul's API currently requires node address to be provided when registering a node.
 	consulNodeAddress = "127.0.0.1"
+
+	// endpointsLagRequeueInterval is how long to wait before retrying a reconcile when
+	// the Pod has a valid IP but the backing Endpoints object hasn't been populated yet.
+	// This handles the startup race where the Endpoints object lags behind Pod IP assignment.
+	endpointsLagRequeueInterval = 2 * time.Second
 )
 
 type Controller struct {
@@ -147,6 +152,11 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	var errs error
 	var serviceEndpoints corev1.Endpoints
 
+	// requeueForEndpointsLag is set to true when registration is skipped because the
+	// Endpoints object hasn't yet been populated with a Pod's IP, even though the Pod
+	// already has one. This is a transient startup condition, so we requeue to retry.
+	requeueForEndpointsLag := false
+
 	// Ignore the request if the namespace of the endpoint is not allowed.
 	if common.ShouldIgnore(req.Namespace, r.DenyK8sNamespacesSet, r.AllowK8sNamespacesSet) {
 		return ctrl.Result{}, nil
@@ -224,6 +234,18 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 				// Skip registration if node information is incomplete to prevent duplicate registrations.
 				if pod.Spec.NodeName == "" || address.IP == "" || pod.Status.HostIP == "" {
+					// If the Endpoints address IP is empty but the Pod already has a valid IP,
+					// this is a transient startup race where the Endpoints object is lagging
+					// behind Pod IP assignment. Requeue so we retry once Endpoints catches up,
+					// instead of treating this as a terminal skip.
+					if address.IP == "" && pod.Status.PodIP != "" {
+						requeueForEndpointsLag = true
+						r.Log.Info("Endpoints address not yet populated for pod with valid IP; will requeue",
+							"pod", pod.Name, "namespace", pod.Namespace,
+							"nodeName", pod.Spec.NodeName, "podIP", pod.Status.PodIP, "hostIP", pod.Status.HostIP)
+						continue
+					}
+
 					r.Log.Info("skipping pod registration due to incomplete node information",
 						"pod", pod.Name, "namespace", pod.Namespace,
 						"nodeName", pod.Spec.NodeName, "podIP", address.IP, "hostIP", pod.Status.HostIP)
@@ -286,6 +308,15 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err != nil {
 		r.Log.Error(err, "failed to deregister endpoints", "name", serviceEndpoints.Name, "ns", serviceEndpoints.Namespace)
 		errs = multierror.Append(errs, err)
+	}
+
+	// If we skipped registering a pod because its Endpoints address wasn't populated yet,
+	// requeue so we retry once the Endpoints object catches up. Use the shorter of the two
+	// intervals (the existing deregister requeue vs. our lag requeue) so neither is delayed.
+	if requeueForEndpointsLag {
+		if requeueAfter == 0 || endpointsLagRequeueInterval < requeueAfter {
+			requeueAfter = endpointsLagRequeueInterval
+		}
 	}
 
 	return ctrl.Result{RequeueAfter: requeueAfter}, errs

--- a/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
+++ b/control-plane/connect-inject/controllers/endpoints/endpoints_controller_test.go
@@ -3255,6 +3255,109 @@ func TestReconcile_PodErrorPreservesToken(t *testing.T) {
 
 }
 
+// TestReconcile_EndpointsLagBehindPodIP verifies the controller's handling of the
+// startup race where a Pod already has a valid Status.PodIP but the backing Endpoints
+// object hasn't yet been populated with that IP (address.IP == "").
+//
+// In this case the controller should NOT treat the skip as terminal: it should requeue
+// (RequeueAfter == endpointsLagRequeueInterval) so registration is retried once the
+// Endpoints object catches up, and it should not register the service prematurely.
+//
+// It also verifies the genuinely-incomplete case (Pod has no IP either), where the
+// controller should skip without requeueing for endpoints lag.
+func TestReconcile_EndpointsLagBehindPodIP(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		// podIP is the IP set on the Pod's Status.PodIP.
+		podIP string
+		// expectRequeue indicates whether we expect a requeue for the endpoints-lag condition.
+		expectRequeue bool
+	}{
+		{
+			name:          "pod has valid IP but endpoints address IP is empty - should requeue",
+			podIP:         "10.244.0.16",
+			expectRequeue: true,
+		},
+		{
+			name:          "pod also has no IP yet - genuinely incomplete, should not requeue",
+			podIP:         "",
+			expectRequeue: false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			svcName := "echo-3"
+
+			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+
+			// Pod is managed by this controller and injected, with a (possibly empty) PodIP.
+			pod1 := createServicePod("pod1", tt.podIP, true, true)
+
+			// The Endpoints object exists and references the pod, but its address IP is empty,
+			// simulating the window where Endpoints lags behind Pod IP assignment.
+			endpoint := &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      svcName,
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						NotReadyAddresses: []corev1.EndpointAddress{
+							{
+								IP: "",
+								TargetRef: &corev1.ObjectReference{
+									Kind:      "Pod",
+									Name:      "pod1",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			k8sObjects := []runtime.Object{pod1, endpoint, &ns, &node}
+			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(k8sObjects...).Build()
+
+			testClient := test.TestServerWithMockConnMgrWatcher(t, nil)
+			consulClient := testClient.APIClient
+
+			ep := &Controller{
+				Client:                fakeClient,
+				Log:                   logrtest.New(t),
+				ConsulClientConfig:    testClient.Cfg,
+				ConsulServerConnMgr:   testClient.Watcher,
+				AllowK8sNamespacesSet: mapset.NewSetWith("*"),
+				DenyK8sNamespacesSet:  mapset.NewSetWith(),
+				ReleaseName:           "consulServer",
+				ReleaseNamespace:      "default",
+			}
+
+			namespacedName := types.NamespacedName{Namespace: "default", Name: svcName}
+
+			resp, err := ep.Reconcile(context.Background(), ctrl.Request{NamespacedName: namespacedName})
+			require.NoError(t, err)
+
+			if tt.expectRequeue {
+				require.Equal(t, endpointsLagRequeueInterval, resp.RequeueAfter,
+					"expected reconcile to requeue while Endpoints catches up to Pod IP")
+			} else {
+				require.Zero(t, resp.RequeueAfter,
+					"expected no endpoints-lag requeue when the Pod itself has no IP yet")
+			}
+
+			// In either case, the service must not have been registered prematurely because
+			// the Endpoints address IP was empty.
+			serviceInstances, _, err := consulClient.Catalog().Service(svcName, "", nil)
+			require.NoError(t, err)
+			require.Empty(t, serviceInstances, "service should not be registered while address IP is empty")
+		})
+	}
+}
+
 type fakeClientWithPodCustomization struct {
 	client.WithWatch
 }


### PR DESCRIPTION

### Changes proposed in this PR ###
- Fixed a race condition in the endpoints controller (`control-plane/connect-inject/controllers/endpoints/endpoints_controller.go`) where pod registration could be **permanently skipped** during startup. When a Pod already had a valid `Status.PodIP` but the backing Kubernetes Endpoints object had not yet been populated (`address.IP == ""`), the controller treated this transient state as terminal: it `continue`d past the address and returned a success result with no requeue, so reconciliation was never retried unless an external event modified the Endpoints object.
- Added a targeted requeue mechanism: when registration is skipped specifically because `address.IP == ""` while `pod.Status.PodIP != ""`, the controller now sets a flag and returns `ctrl.Result{RequeueAfter: endpointsLagRequeueInterval}` (2s) so reconciliation retries once the Endpoints object catches up. Genuinely incomplete pods (no Pod IP yet) still skip without requeuing, avoiding a busy loop.
- Improved the skip log line to report the Pod's real IP (`pod.Status.PodIP`) instead of the empty Endpoints `address.IP`, which previously produced misleading `podIP: ""` entries.

### How I've tested this PR ###
- Added unit test `TestReconcile_EndpointsLagBehindPodIP` covering both cases:
  - Pod has a valid IP but the Endpoints address IP is empty → asserts `RequeueAfter == endpointsLagRequeueInterval` and that the service is **not** registered prematurely.
  - Pod also has no IP yet (genuinely incomplete) → asserts no endpoints-lag requeue and no registration.
- Ran the package build and the new test locally — both pass:
  ```
  --- PASS: TestReconcile_EndpointsLagBehindPodIP (4.20s)
      --- PASS: .../pod_has_valid_IP_but_endpoints_address_IP_is_empty_-_should_requeue
      --- PASS: .../pod_also_has_no_IP_yet_-_genuinely_incomplete,_should_not_requeue
  ```
- Reproduced the original failure using the multi-datacenter peered failover scenario, where an echo service (e.g. `echo-3`) intermittently remained stuck in `Init:0/1` with an unregistered service and an empty/lagging Endpoints object.

### How I expect reviewers to test this PR ###
- Run the new unit test:
  ```sh
  cd control-plane
  # This package starts a Consul Enterprise test agent and requires a license:
  export CONSUL_LICENSE_PATH=/path/to/consul.hclic   # or set CONSUL_LICENSE
  go test ./connect-inject/controllers/endpoints/ -run TestReconcile_EndpointsLagBehindPodIP -v
  ```
- Optionally reproduce end-to-end with the multi-DC failover scenario: spin up the three peered clusters, repeatedly recreate the environment, and confirm that services no longer remain permanently stuck in `Init:0/1` / unregistered when the Endpoints object briefly lags behind Pod IP assignment. Without the fix the issue is intermittent but reproducible across several environment resets; with the fix the controller self-heals via requeue.

### Checklist ###
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

  This change fixes a startup race where Consul service registration could be permanently skipped, leaving mesh services unregistered until the Endpoints object was manually modified or recreated. The fix requeues reconciliation so the controller retries once the Endpoints object catches up.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

  No special revert plan required — reverting the pull request fully restores the previous behavior. The change is isolated to the endpoints controller's reconcile flow and adds no persistent state or migrations.

- [x] If applicable, I've documented the impact of any changes to security controls.

  No impact to security controls. This change does not alter access control, authentication, authorization, ACL token handling, or logging pipelines; it only adjusts reconcile requeue behavior and a log message's field value.