### PR TITLE
fix(ci): Stale branch cleanup

### DIFF
--- a/.github/workflows/delete-merged-pr-branches.yaml
+++ b/.github/workflows/delete-merged-pr-branches.yaml
@@ -1,0 +1,137 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+name: Delete Branches with Merged/Closed PRs
+on:
+  schedule:
+    - cron: "0 6 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run: log branches that would be deleted without actually deleting them"
+        type: boolean
+        default: true
+      min-days-since-merge:
+        description: "Only delete if PR was merged/closed at least this many days ago (default: 7)"
+        type: number
+        default: 7
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  delete-merged-pr-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete branches whose PRs are merged or closed
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            // inputs.dry-run is the string 'true'/'false' for workflow_dispatch (boolean inputs),
+            // or '' for schedule triggers. Compare as string to avoid type-coercion bugs.
+            const dryRun = '${{ inputs.dry-run }}' === 'true';
+            const minDaysSinceMerge = ${{ inputs.min-days-since-merge || 7 }};
+            const cutoffDate = new Date(Date.now() - minDaysSinceMerge * 24 * 60 * 60 * 1000);
+
+            // Branches that must never be deleted by this workflow
+            // These are protected from deletion by org rulesets but still adding an extra check here
+            const PROTECTED_PATTERNS = [
+              /^main$/,
+              /^master$/,
+              /^release\/.+/,
+              /^develop$/,
+            ];
+
+            const isProtected = (name) => PROTECTED_PATTERNS.some((p) => p.test(name));
+
+            console.log(`dry-run: ${dryRun}`);
+            console.log(`min-days-since-merge: ${minDaysSinceMerge}`);
+            console.log(`Cutoff date: ${cutoffDate.toISOString()}`);
+
+            // Paginate all non-protected branches
+            const allBranches = await github.paginate(github.rest.repos.listBranches, {
+              owner,
+              repo,
+              protected: false,
+              per_page: 100,
+            });
+
+            console.log(`\nTotal unprotected branches found: ${allBranches.length}`);
+
+            const toDelete = [];
+            const skipped = [];
+
+            for (const branch of allBranches) {
+              const name = branch.name;
+
+              if (isProtected(name)) {
+                skipped.push({ name, reason: "matches protected pattern" });
+                continue;
+              }
+
+              // Look for closed PRs (merged PRs have state=closed + merged_at set)
+              const { data: prs } = await github.rest.pulls.list({
+                owner,
+                repo,
+                head: `${owner}:${name}`,
+                state: "closed",
+                per_page: 1,
+                sort: "updated",
+                direction: "desc",
+              });
+
+              if (prs.length === 0) {
+                skipped.push({ name, reason: "no closed PR found" });
+                continue;
+              }
+
+              const pr = prs[0];
+              const closedAt = new Date(pr.closed_at);
+              const wasMerged = pr.merged_at !== null;
+
+              if (closedAt > cutoffDate) {
+                skipped.push({
+                  name,
+                  reason: `PR #${pr.number} closed too recently (${pr.closed_at})`,
+                });
+                continue;
+              }
+
+              toDelete.push({
+                name,
+                prNumber: pr.number,
+                prState: wasMerged ? "merged" : "closed (unmerged)",
+                closedAt: pr.closed_at,
+              });
+            }
+
+            console.log(`\n=== Branches to delete (${toDelete.length}) ===`);
+            for (const b of toDelete) {
+              console.log(`  ${b.name} — PR #${b.prNumber} ${b.prState} on ${b.closedAt}`);
+              if (!dryRun) {
+                try {
+                  await github.rest.git.deleteRef({
+                    owner,
+                    repo,
+                    ref: `heads/${b.name}`,
+                  });
+                  console.log(`  ✓ Deleted`);
+                } catch (err) {
+                  console.log(`  ✗ Failed to delete: ${err.message}`);
+                }
+              }
+            }
+
+            console.log(`\n=== Skipped branches (${skipped.length}) ===`);
+            for (const b of skipped) {
+              console.log(`  ${b.name} — ${b.reason}`);
+            }
+
+            console.log(`\n=== Summary ===`);
+            console.log(`  Deleted : ${dryRun ? 0 : toDelete.length} (dry-run: ${dryRun})`);
+            console.log(`  Would delete: ${toDelete.length}`);
+            console.log(`  Skipped : ${skipped.length}`);

--- a/.github/workflows/delete-merged-pr-branches.yaml
+++ b/.github/workflows/delete-merged-pr-branches.yaml
@@ -79,6 +79,7 @@ jobs:
                 continue;
               }
 
+              try {
               // Skip branches that currently have an open PR — they are actively in use
               const { data: openPrs } = await github.rest.pulls.list({
                 owner,
@@ -137,6 +138,13 @@ jobs:
                 prState: wasMerged ? "merged" : "closed (unmerged)",
                 closedAt: pr.closed_at,
               });
+              } catch (err) {
+                if (err.status === 403 || err.status === 429) {
+                  console.log(`  Rate limited on branch ${name}, stopping early.`);
+                  break;
+                }
+                console.log(`  Error processing ${name}: ${err.message}`);
+              }
             }
 
             console.log(`\n=== Branches to delete (${toDelete.length}) ===`);

--- a/.github/workflows/delete-merged-pr-branches.yaml
+++ b/.github/workflows/delete-merged-pr-branches.yaml
@@ -3,8 +3,6 @@
 
 name: Delete Branches with Merged/Closed PRs
 on:
-  schedule:
-    - cron: "0 6 * * 1-5"
   workflow_dispatch:
     inputs:
       dry-run:
@@ -31,10 +29,13 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            // inputs.dry-run is the string 'true'/'false' for workflow_dispatch (boolean inputs),
-            // or '' for schedule triggers. Compare as string to avoid type-coercion bugs.
+            // inputs.dry-run is the string 'true'/'false' for workflow_dispatch boolean inputs.
+            // Compare as string to avoid type-coercion bugs.
             const dryRun = '${{ inputs.dry-run }}' === 'true';
-            const minDaysSinceMerge = ${{ inputs.min-days-since-merge || 7 }};
+            const minDaysSinceMerge = Number(${{ inputs.min-days-since-merge || 7 }});
+            if (isNaN(minDaysSinceMerge) || minDaysSinceMerge < 0) {
+              throw new Error(`Invalid min-days-since-merge value: ${minDaysSinceMerge}`);
+            }
             const cutoffDate = new Date(Date.now() - minDaysSinceMerge * 24 * 60 * 60 * 1000);
 
             // Branches that must never be deleted by this workflow
@@ -70,6 +71,20 @@ jobs:
 
               if (isProtected(name)) {
                 skipped.push({ name, reason: "matches protected pattern" });
+                continue;
+              }
+
+              // Skip branches that currently have an open PR — they are actively in use
+              const { data: openPrs } = await github.rest.pulls.list({
+                owner,
+                repo,
+                head: `${owner}:${name}`,
+                state: "open",
+                per_page: 1,
+              });
+
+              if (openPrs.length > 0) {
+                skipped.push({ name, reason: `has open PR #${openPrs[0].number}` });
                 continue;
               }
 

--- a/.github/workflows/delete-merged-pr-branches.yaml
+++ b/.github/workflows/delete-merged-pr-branches.yaml
@@ -37,7 +37,7 @@ jobs:
             // inputs.dry-run is the string 'true'/'false' for workflow_dispatch boolean inputs.
             // Compare as string to avoid type-coercion bugs.
             const dryRun = '${{ inputs.dry-run }}' === 'true';
-            const minDaysSinceMerge = Number(${{ inputs.min-days-since-merge || 7 }});
+            const minDaysSinceMerge = Number('${{ inputs.min-days-since-merge }}');
             if (isNaN(minDaysSinceMerge) || minDaysSinceMerge < 0) {
               throw new Error(`Invalid min-days-since-merge value: ${minDaysSinceMerge}`);
             }
@@ -110,9 +110,19 @@ jobs:
               }
 
               const pr = prs[0];
+
+              const branchSha = branch.commit?.sha;
+              const prHeadSha = pr.head?.sha;
+              if (branchSha && prHeadSha && branchSha !== prHeadSha) {
+                skipped.push({
+                  name,
+                  reason: `latest closed PR #${pr.number} does not match current branch head (${prHeadSha} != ${branchSha})`,
+                });
+                continue;
+              }
+
               const closedAt = new Date(pr.closed_at);
               const wasMerged = pr.merged_at !== null;
-
               if (closedAt > cutoffDate) {
                 skipped.push({
                   name,

--- a/.github/workflows/delete-merged-pr-branches.yaml
+++ b/.github/workflows/delete-merged-pr-branches.yaml
@@ -14,6 +14,11 @@ on:
         type: number
         default: 7
 
+# cancel existing runs of the same workflow on the same ref
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: read

--- a/.github/workflows/stale-branches.yaml
+++ b/.github/workflows/stale-branches.yaml
@@ -2,6 +2,7 @@ name: Stale Branches
 on:
   schedule:
     - cron: "0 6 * * 1-5"
+  workflow_dispatch:
 
 permissions:
   issues: write
@@ -11,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Stale Branches
-        uses: crs-k/stale-branches@c6e09a3de1046d68b21eccdca23321d0ec277964 # v7.0.0
+        uses: crs-k/stale-branches@e876b957ab08f0bad43c8cc271a22cdd7604bd09 # v9.0.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           days-before-stale: 120
@@ -22,3 +23,4 @@ jobs:
           compare-branches: "info"
           ignore-issue-interaction: true
           pr-check: true
+          max-issues: 500


### PR DESCRIPTION

### Changes proposed in this PR ###  
- Increased max-issue input to stale-branch workflow from defalt 20 to allow processing of all the branches
- Upgraded crs-k/stale-branches version in stale-branch workflow to latest


- Added a workflow to clean up branches whose PRs have been merged or closed.

Since this repo doesn't have GitHub's "automatically delete head branches" setting enabled, there is a backlog of ~600 stale branches. The workflow addresses that by:

- Running on manual workflow_dispatch triggers
- Fetching all unprotected branches and checking each one for a closed PR
- Skipping protected branches (main, master, release/*, develop) and any branch with no closed PR associated
- Deleting branches whose PR was merged or closed more than 7 days ago (configurable via min-days-since-merge)
- Supporting a dry-run mode (default true for manual triggers) that logs what would be deleted without actually deleting anything

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
