### PR TITLE
feat: implement Consul namespace resolution for terminating gateways

### DIFF
--- a/.changelog/5401.txt
+++ b/.changelog/5401.txt
@@ -1,0 +1,8 @@
+```release-note:bug
+terminating-gateways: Fix bug where the terminating gateway service was registered into the `default` Consul namespace instead of the mirrored Consul namespace (matching its Kubernetes namespace) when `global.enableConsulNamespaces` and namespace mirroring were enabled. Applies to both the Helm-managed terminating gateway deployment and the `TerminatingGateway` CRD controller.
+```
+
+```release-note:bug
+snapshot-agent: Fix bug where the `consul-snapshot` service was registered into the `default` Consul namespace instead of the namespace mirrored from the Kubernetes namespace it is deployed in when `global.enableConsulNamespaces` is enabled. The snapshot agent now also registers into the configured admin partition.
+```
+

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ dev-docker: control-plane-dev-docker ## build dev local dev docker image
 .PHONY: control-plane-dev-docker
 control-plane-dev-docker: ## Build consul-k8s-control-plane dev Docker image.
 	@$(SHELL) $(CURDIR)/control-plane/build-support/scripts/build-local.sh --os linux --arch $(GOARCH)
-	@docker buildx build --debug --platform $(GOOS)/$(GOARCH) -t '$(DEV_IMAGE)' \
+	@docker buildx build --debug --platform linux/arm64 -t '$(DEV_IMAGE)' \
 	   --no-cache \
        --target=dev \
        --build-arg 'GOLANG_VERSION=$(GOLANG_VERSION)' \

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ dev-docker: control-plane-dev-docker ## build dev local dev docker image
 .PHONY: control-plane-dev-docker
 control-plane-dev-docker: ## Build consul-k8s-control-plane dev Docker image.
 	@$(SHELL) $(CURDIR)/control-plane/build-support/scripts/build-local.sh --os linux --arch $(GOARCH)
-	@docker buildx build --debug --platform linux/arm64 -t '$(DEV_IMAGE)' \
+	@docker buildx build --debug --platform $(GOOS)/$(GOARCH) -t '$(DEV_IMAGE)' \
 	   --no-cache \
        --target=dev \
        --build-arg 'GOLANG_VERSION=$(GOLANG_VERSION)' \

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -23,7 +23,15 @@ registered into. Resolution order:
      "default" sentinel (treated as unset so mirroring can take precedence).
   3. The mirrored Consul namespace derived from the release namespace when
      namespace mirroring is enabled.
-  4. The configured destination namespace (falling back to the defaults value).
+  4. The terminatingGateways.defaults.consulNamespace value (i.e. "default").
+
+Note: This intentionally does NOT consult
+connectInject.consulNamespaces.consulDestinationNamespace. Terminating gateways have
+historically only resolved their namespace from terminatingGateways.defaults.consulNamespace
+/ the per-gateway consulNamespace, and the gateway's ACL policy (created by server-acl-init)
+is scoped to that same namespace. Following the connect destination namespace here would
+register the service into a namespace its ACL token is not authorized for. Mirroring is the
+only additional case we resolve, matching connect-injected services and the API gateway.
 
 Usage:
   {{ include "consul.terminatingGatewayNamespace" (dict "root" $root "gatewayNamespace" .consulNamespace "defaultsNamespace" $defaults.consulNamespace) }}
@@ -38,8 +46,6 @@ Usage:
 {{- $defaultsNamespace -}}
 {{- else if $root.Values.connectInject.consulNamespaces.mirroringK8S -}}
 {{- printf "%s%s" $root.Values.connectInject.consulNamespaces.mirroringK8SPrefix $root.Release.Namespace -}}
-{{- else if $root.Values.connectInject.consulNamespaces.consulDestinationNamespace -}}
-{{- $root.Values.connectInject.consulNamespaces.consulDestinationNamespace -}}
 {{- else -}}
 {{- default "default" $defaultsNamespace -}}
 {{- end -}}

--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -15,6 +15,36 @@ as well as the global.name setting.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Resolve the Consul namespace that a terminating gateway service should be
+registered into. Resolution order:
+  1. Per-gateway consulNamespace.
+  2. terminatingGateways.defaults.consulNamespace, unless it is the bare
+     "default" sentinel (treated as unset so mirroring can take precedence).
+  3. The mirrored Consul namespace derived from the release namespace when
+     namespace mirroring is enabled.
+  4. The configured destination namespace (falling back to the defaults value).
+
+Usage:
+  {{ include "consul.terminatingGatewayNamespace" (dict "root" $root "gatewayNamespace" .consulNamespace "defaultsNamespace" $defaults.consulNamespace) }}
+*/}}
+{{- define "consul.terminatingGatewayNamespace" -}}
+{{- $root := .root -}}
+{{- $gatewayNamespace := .gatewayNamespace -}}
+{{- $defaultsNamespace := .defaultsNamespace -}}
+{{- if $gatewayNamespace -}}
+{{- $gatewayNamespace -}}
+{{- else if (and $defaultsNamespace (ne $defaultsNamespace "default")) -}}
+{{- $defaultsNamespace -}}
+{{- else if $root.Values.connectInject.consulNamespaces.mirroringK8S -}}
+{{- printf "%s%s" $root.Values.connectInject.consulNamespaces.mirroringK8SPrefix $root.Release.Namespace -}}
+{{- else if $root.Values.connectInject.consulNamespaces.consulDestinationNamespace -}}
+{{- $root.Values.connectInject.consulNamespaces.consulDestinationNamespace -}}
+{{- else -}}
+{{- default "default" $defaultsNamespace -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "consul.restrictedSecurityContext" -}}
 {{- if not .Values.global.enablePodSecurityPolicies -}}
 securityContext:

--- a/charts/consul/templates/server-acl-init-job.yaml
+++ b/charts/consul/templates/server-acl-init-job.yaml
@@ -251,11 +251,7 @@ spec:
             {{- if .Values.global.enableConsulNamespaces }}
             {{- $root := . }}
             {{- range .Values.terminatingGateways.gateways }}
-            {{- if (or $root.Values.terminatingGateways.defaults.consulNamespace .consulNamespace) }}
-            -terminating-gateway-name="{{ .name }}.{{ (default $root.Values.terminatingGateways.defaults.consulNamespace .consulNamespace) }}" \
-            {{- else }}
-            -terminating-gateway-name="{{ .name }}" \
-            {{- end }}
+            -terminating-gateway-name="{{ .name }}.{{ include "consul.terminatingGatewayNamespace" (dict "root" $root "gatewayNamespace" .consulNamespace "defaultsNamespace" $root.Values.terminatingGateways.defaults.consulNamespace) }}" \
             {{- end }}
             {{- else }}
             {{- range .Values.terminatingGateways.gateways }}

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -666,6 +666,19 @@ spec:
               value: /consul/license/{{ .Values.global.enterpriseLicense.secretKey }}
               {{- end }}
             {{- end }}
+            {{- if .Values.global.enableConsulNamespaces }}
+            {{- if .Values.connectInject.consulNamespaces.mirroringK8S }}
+            - name: CONSUL_NAMESPACE
+              value: {{ .Values.connectInject.consulNamespaces.mirroringK8SPrefix }}{{ .Release.Namespace }}
+            {{- else }}
+            - name: CONSUL_NAMESPACE
+              value: {{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.global.adminPartitions.enabled }}
+            - name: CONSUL_PARTITION
+              value: {{ .Values.global.adminPartitions.name }}
+            {{- end }}
             {{- include "consul.extraEnvironmentVars" .Values.server.snapshotAgent | nindent 12 }}
           command:
             - "/bin/sh"

--- a/charts/consul/templates/server-statefulset.yaml
+++ b/charts/consul/templates/server-statefulset.yaml
@@ -666,14 +666,9 @@ spec:
               value: /consul/license/{{ .Values.global.enterpriseLicense.secretKey }}
               {{- end }}
             {{- end }}
-            {{- if .Values.global.enableConsulNamespaces }}
-            {{- if .Values.connectInject.consulNamespaces.mirroringK8S }}
+            {{- if (and .Values.global.enableConsulNamespaces .Values.connectInject.consulNamespaces.mirroringK8S) }}
             - name: CONSUL_NAMESPACE
               value: {{ .Values.connectInject.consulNamespaces.mirroringK8SPrefix }}{{ .Release.Namespace }}
-            {{- else }}
-            - name: CONSUL_NAMESPACE
-              value: {{ .Values.connectInject.consulNamespaces.consulDestinationNamespace }}
-            {{- end }}
             {{- end }}
             {{- if .Values.global.adminPartitions.enabled }}
             - name: CONSUL_PARTITION

--- a/charts/consul/templates/terminating-gateways-deployment.yaml
+++ b/charts/consul/templates/terminating-gateways-deployment.yaml
@@ -80,7 +80,7 @@ spec:
         "consul.hashicorp.com/gateway-kind": "terminating-gateway"
         "consul.hashicorp.com/gateway-consul-service-name": "{{ .name }}"
         {{- if $root.Values.global.enableConsulNamespaces }}
-        "consul.hashicorp.com/gateway-namespace": {{ (default $defaults.consulNamespace .consulNamespace) }}
+        "consul.hashicorp.com/gateway-namespace": {{ include "consul.terminatingGatewayNamespace" (dict "root" $root "gatewayNamespace" .consulNamespace "defaultsNamespace" $defaults.consulNamespace) }}
         {{- end }}
         {{- if (and $root.Values.global.secretsBackend.vault.enabled $root.Values.global.tls.enabled) }}
         "vault.hashicorp.com/agent-init-first": "true"
@@ -187,7 +187,7 @@ spec:
           {{- include "consul.consulK8sConsulServerEnvVars" $root | nindent 10 }}
           {{- if $root.Values.global.enableConsulNamespaces }}
           - name: CONSUL_NAMESPACE
-            value: {{ (default $defaults.consulNamespace .consulNamespace) }}
+            value: {{ include "consul.terminatingGatewayNamespace" (dict "root" $root "gatewayNamespace" .consulNamespace "defaultsNamespace" $defaults.consulNamespace) }}
           {{- end }}
           {{- if $root.Values.global.acls.manageSystemACLs }}
           - name: CONSUL_LOGIN_AUTH_METHOD
@@ -292,7 +292,7 @@ spec:
           {{- end }}
           - -proxy-service-id-path=/consul/service/proxy-id
           {{- if $root.Values.global.enableConsulNamespaces }}
-          - -service-namespace={{ (default $defaults.consulNamespace .consulNamespace) }}
+          - -service-namespace={{ include "consul.terminatingGatewayNamespace" (dict "root" $root "gatewayNamespace" .consulNamespace "defaultsNamespace" $defaults.consulNamespace) }}
           {{- end }}
           {{- if and $root.Values.global.tls.enabled }}
           {{- if (not (and $root.Values.externalServers.enabled $root.Values.externalServers.useSystemRoots)) }}

--- a/charts/consul/test/unit/server-acl-init-job.bats
+++ b/charts/consul/test/unit/server-acl-init-job.bats
@@ -478,6 +478,10 @@ load _helpers
 
 @test "serverACLInit/Job: terminating gateways acl option enabled with .terminatingGateways.enabled=true, namespaces enabled, no default namespace set" {
   cd `chart_dir`
+  # With namespaces enabled and mirroring on (the chart default), the gateway is
+  # mirrored into the Consul namespace matching the release namespace. The ACL
+  # token name must use that same namespace so it stays in lockstep with the
+  # gateway's service registration.
   local actual=$(helm template \
       -s templates/server-acl-init-job.yaml  \
       --set 'global.acls.manageSystemACLs=true' \
@@ -485,8 +489,9 @@ load _helpers
       --set 'connectInject.enabled=true' \
       --set 'global.enableConsulNamespaces=true' \
       --set 'terminatingGateways.defaults.consulNamespace=' \
+      --namespace consul \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].command | any(contains("-terminating-gateway-name=\"terminating-gateway\""))' | tee /dev/stderr)
+      yq '.spec.template.spec.containers[0].command | any(contains("-terminating-gateway-name=\"terminating-gateway.consul\""))' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -3085,7 +3085,7 @@ MIICFjCCAZsCCQCdwLtdjbzlYzAKBggqhkjOPQQDAjB0MQswCQYDVQQGEwJDQTEL' \
   [ "${actual}" = "consul" ]
 }
 
-@test "server/StatefulSet: snapshot-agent: CONSUL_NAMESPACE uses destination namespace when mirroring disabled" {
+@test "server/StatefulSet: snapshot-agent: CONSUL_NAMESPACE not set when mirroring disabled even if destination namespace is set" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/server-statefulset.yaml  \
@@ -3095,8 +3095,8 @@ MIICFjCCAZsCCQCdwLtdjbzlYzAKBggqhkjOPQQDAjB0MQswCQYDVQQGEwJDQTEL' \
       --set 'connectInject.consulNamespaces.consulDestinationNamespace=dest-ns' \
       --namespace consul \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[1].env[] | select(.name == "CONSUL_NAMESPACE") | .value' | tee /dev/stderr)
-  [ "${actual}" = "dest-ns" ]
+      yq -r '.spec.template.spec.containers[1].env | any(.name == "CONSUL_NAMESPACE")' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
 }
 
 @test "server/StatefulSet: snapshot-agent: CONSUL_PARTITION set when adminPartitions enabled" {

--- a/charts/consul/test/unit/server-statefulset.bats
+++ b/charts/consul/test/unit/server-statefulset.bats
@@ -3060,6 +3060,60 @@ MIICFjCCAZsCCQCdwLtdjbzlYzAKBggqhkjOPQQDAjB0MQswCQYDVQQGEwJDQTEL' \
 }
 
 #--------------------------------------------------------------------
+# snapshotAgent Consul namespaces
+
+@test "server/StatefulSet: snapshot-agent: CONSUL_NAMESPACE not set when enableConsulNamespaces is false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.snapshotAgent.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[1].env | any(.name == "CONSUL_NAMESPACE")' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/StatefulSet: snapshot-agent: CONSUL_NAMESPACE mirrors release namespace when mirroringK8S is enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.snapshotAgent.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'connectInject.consulNamespaces.mirroringK8S=true' \
+      --namespace consul \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[1].env[] | select(.name == "CONSUL_NAMESPACE") | .value' | tee /dev/stderr)
+  [ "${actual}" = "consul" ]
+}
+
+@test "server/StatefulSet: snapshot-agent: CONSUL_NAMESPACE uses destination namespace when mirroring disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.snapshotAgent.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'connectInject.consulNamespaces.mirroringK8S=false' \
+      --set 'connectInject.consulNamespaces.consulDestinationNamespace=dest-ns' \
+      --namespace consul \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[1].env[] | select(.name == "CONSUL_NAMESPACE") | .value' | tee /dev/stderr)
+  [ "${actual}" = "dest-ns" ]
+}
+
+@test "server/StatefulSet: snapshot-agent: CONSUL_PARTITION set when adminPartitions enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --set 'server.snapshotAgent.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'global.adminPartitions.enabled=true' \
+      --set 'global.adminPartitions.name=default' \
+      --namespace consul \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[1].env[] | select(.name == "CONSUL_PARTITION") | .value' | tee /dev/stderr)
+  [ "${actual}" = "default" ]
+}
+
+#--------------------------------------------------------------------
 # snapshotAgent Interval
 
 @test "server/StatefulSet: snapshot-agent: interval defaults to 1h" {

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -1003,6 +1003,74 @@ key2: value2' \
   [ "${actual}" = "new-namespace" ]
 }
 
+@test "terminatingGateways/Deployment: consulNamespace mirrors release namespace when mirroringK8S is enabled and no namespace is set" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'connectInject.consulNamespaces.mirroringK8S=true' \
+      --namespace consul \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$object" | yq -s -r '.[0].spec.template.metadata.annotations."consul.hashicorp.com/gateway-namespace"' | tee /dev/stderr)
+  [ "${actual}" = "consul" ]
+
+  local env=$(echo "$object" | yq -s -r '.[0].spec.template.spec.initContainers[0].env[] | select(.name == "CONSUL_NAMESPACE") | .value' | tee /dev/stderr)
+  [ "${env}" = "consul" ]
+
+  local arg=$(echo "$object" | yq -s -r '.[0].spec.template.spec.containers[0].args | any(contains("-service-namespace=consul"))' | tee /dev/stderr)
+  [ "${arg}" = "true" ]
+}
+
+@test "terminatingGateways/Deployment: consulNamespace mirrors release namespace with prefix when mirroringK8SPrefix is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'connectInject.consulNamespaces.mirroringK8S=true' \
+      --set 'connectInject.consulNamespaces.mirroringK8SPrefix=k8s-' \
+      --namespace consul \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations."consul.hashicorp.com/gateway-namespace"' | tee /dev/stderr)
+
+  [ "${actual}" = "k8s-consul" ]
+}
+
+@test "terminatingGateways/Deployment: consulNamespace uses destination namespace when mirroring is disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'connectInject.consulNamespaces.mirroringK8S=false' \
+      --set 'connectInject.consulNamespaces.consulDestinationNamespace=dest-ns' \
+      --namespace consul \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations."consul.hashicorp.com/gateway-namespace"' | tee /dev/stderr)
+
+  [ "${actual}" = "dest-ns" ]
+}
+
+@test "terminatingGateways/Deployment: consulNamespace defaults to default when mirroring disabled and no destination set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/terminating-gateways-deployment.yaml \
+      --set 'terminatingGateways.enabled=true' \
+      --set 'connectInject.enabled=true' \
+      --set 'global.enableConsulNamespaces=true' \
+      --set 'connectInject.consulNamespaces.mirroringK8S=false' \
+      --namespace consul \
+      . | tee /dev/stderr |
+      yq -s -r '.[0].spec.template.metadata.annotations."consul.hashicorp.com/gateway-namespace"' | tee /dev/stderr)
+
+  [ "${actual}" = "default" ]
+}
+
 #--------------------------------------------------------------------
 # partitions
 

--- a/charts/consul/test/unit/terminating-gateways-deployment.bats
+++ b/charts/consul/test/unit/terminating-gateways-deployment.bats
@@ -1040,7 +1040,7 @@ key2: value2' \
   [ "${actual}" = "k8s-consul" ]
 }
 
-@test "terminatingGateways/Deployment: consulNamespace uses destination namespace when mirroring is disabled" {
+@test "terminatingGateways/Deployment: consulNamespace ignores connect destination namespace when mirroring is disabled" {
   cd `chart_dir`
   local actual=$(helm template \
       -s templates/terminating-gateways-deployment.yaml \
@@ -1053,7 +1053,7 @@ key2: value2' \
       . | tee /dev/stderr |
       yq -s -r '.[0].spec.template.metadata.annotations."consul.hashicorp.com/gateway-namespace"' | tee /dev/stderr)
 
-  [ "${actual}" = "dest-ns" ]
+  [ "${actual}" = "default" ]
 }
 
 @test "terminatingGateways/Deployment: consulNamespace defaults to default when mirroring disabled and no destination set" {

--- a/control-plane/controllers/configentries/terminatinggateway_controller.go
+++ b/control-plane/controllers/configentries/terminatinggateway_controller.go
@@ -20,6 +20,7 @@ import (
 	consulv1alpha1 "github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	"github.com/hashicorp/consul-k8s/control-plane/consul"
 	"github.com/hashicorp/consul-k8s/control-plane/controllers/helmvalues"
+	"github.com/hashicorp/consul-k8s/control-plane/namespaces"
 	capi "github.com/hashicorp/consul/api"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -645,7 +646,7 @@ func (r *TerminatingGatewayController) constructDeploymentFromCRD(
 		replicas = *termGW.Spec.Deployment.Replicas
 	}
 
-	consulNamespace := terminatingGatewayConsulNamespace(termGW, helmConfigValues)
+	consulNamespace := r.terminatingGatewayConsulNamespace(termGW, helmConfigValues)
 
 	logLevel := termGW.Spec.Deployment.LogLevel
 	if logLevel == "" {
@@ -1484,7 +1485,7 @@ func (r *TerminatingGatewayController) ensureTerminatingGatewayACLBootstrap(
 	serviceAccountName := fmt.Sprintf("%s-%s", fullName, gatewayName)
 	authMethodName := fmt.Sprintf("%s-k8s-component-auth-method", fullName)
 
-	consulNamespace := terminatingGatewayConsulNamespace(termGW, helmValues)
+	consulNamespace := r.terminatingGatewayConsulNamespace(termGW, helmValues)
 
 	rules, err := r.renderTerminatingGatewayACLRules(gatewayName, consulNamespace)
 	if err != nil {
@@ -1645,7 +1646,19 @@ partition "{{ .Partition }}" {
 	return out.String(), nil
 }
 
-func terminatingGatewayConsulNamespace(
+// terminatingGatewayConsulNamespace resolves the Consul namespace that the
+// terminating gateway service should be registered into. Resolution order:
+//  1. Explicit spec.deployment.consulNamespace on the CRD.
+//  2. Per-gateway consulNamespace from Helm values.
+//  3. terminatingGateways.defaults.consulNamespace from Helm values (a bare
+//     "default" sentinel is treated as unset when Consul namespaces are enabled
+//     so that mirroring/destination resolution can take precedence).
+//  4. The namespace derived from the gateway's K8s namespace via the
+//     namespace-mirroring / destination-namespace configuration. This ensures
+//     that when mirroring is enabled (e.g. with Admin Partitions) the gateway
+//     is registered into the mirrored Consul namespace (K8s "consul" ->
+//     Consul "consul") instead of falling back to "default".
+func (r *TerminatingGatewayController) terminatingGatewayConsulNamespace(
 	termGW *consulv1alpha1.TerminatingGateway,
 	helmValues *helmvalues.HelmValues,
 ) string {
@@ -1653,10 +1666,12 @@ func terminatingGatewayConsulNamespace(
 		return defaultIfEmpty("")
 	}
 
+	// 1. Explicit namespace on the CRD wins.
 	if termGW.Spec.Deployment.ConsulNamespace != "" {
 		return termGW.Spec.Deployment.ConsulNamespace
 	}
 
+	// 2. Per-gateway override from Helm values.
 	gatewayName := defaultIfEmpty(termGW.Spec.Deployment.GatewayName, termGW.Name)
 	for _, gw := range helmValues.TerminatingGateways.Gateways {
 		if gw.Name == gatewayName && gw.ConsulNamespace != "" {
@@ -1664,5 +1679,37 @@ func terminatingGatewayConsulNamespace(
 		}
 	}
 
-	return defaultIfEmpty(helmValues.TerminatingGateways.Defaults.ConsulNamespace)
+	// namespacesEnabled reflects whether Consul Enterprise namespaces are turned
+	// on for this controller. We prefer the controller's runtime config but fall
+	// back to the Helm values when the controller is not fully wired (e.g. in
+	// some unit tests).
+	namespacesEnabled := helmValues.Global.EnableConsulNamespaces
+	if r != nil && r.ConfigEntryController != nil {
+		namespacesEnabled = r.ConfigEntryController.EnableConsulNamespaces
+	}
+
+	// 3. Helm defaults override. Treat the chart's "default" sentinel as unset
+	//    when namespaces are enabled so that the mirrored/destination namespace
+	//    derived from the gateway's K8s namespace can take precedence.
+	defaultsNS := helmValues.TerminatingGateways.Defaults.ConsulNamespace
+	if defaultsNS != "" && !(defaultsNS == "default" && namespacesEnabled) {
+		return defaultsNS
+	}
+
+	// 4. Fall back to the mirrored / destination namespace derived from the
+	//    gateway's K8s namespace.
+	if r != nil && r.ConfigEntryController != nil {
+		cec := r.ConfigEntryController
+		if ns := namespaces.ConsulNamespace(
+			termGW.Namespace,
+			cec.EnableConsulNamespaces,
+			cec.ConsulDestinationNamespace,
+			cec.EnableNSMirroring,
+			cec.NSMirroringPrefix,
+		); ns != "" {
+			return ns
+		}
+	}
+
+	return defaultIfEmpty(defaultsNS)
 }

--- a/control-plane/controllers/configentries/terminatinggateway_controller.go
+++ b/control-plane/controllers/configentries/terminatinggateway_controller.go
@@ -20,7 +20,6 @@ import (
 	consulv1alpha1 "github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
 	"github.com/hashicorp/consul-k8s/control-plane/consul"
 	"github.com/hashicorp/consul-k8s/control-plane/controllers/helmvalues"
-	"github.com/hashicorp/consul-k8s/control-plane/namespaces"
 	capi "github.com/hashicorp/consul/api"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1679,37 +1678,37 @@ func (r *TerminatingGatewayController) terminatingGatewayConsulNamespace(
 		}
 	}
 
-	// namespacesEnabled reflects whether Consul Enterprise namespaces are turned
-	// on for this controller. We prefer the controller's runtime config but fall
-	// back to the Helm values when the controller is not fully wired (e.g. in
-	// some unit tests).
+	// namespacesEnabled / mirroring reflect whether Consul Enterprise namespaces
+	// and namespace mirroring are turned on for this controller. We prefer the
+	// controller's runtime config but fall back to the Helm values when the
+	// controller is not fully wired (e.g. in some unit tests).
 	namespacesEnabled := helmValues.Global.EnableConsulNamespaces
+	mirroring := false
+	mirroringPrefix := ""
 	if r != nil && r.ConfigEntryController != nil {
 		namespacesEnabled = r.ConfigEntryController.EnableConsulNamespaces
+		mirroring = r.ConfigEntryController.EnableNSMirroring
+		mirroringPrefix = r.ConfigEntryController.NSMirroringPrefix
 	}
 
 	// 3. Helm defaults override. Treat the chart's "default" sentinel as unset
-	//    when namespaces are enabled so that the mirrored/destination namespace
-	//    derived from the gateway's K8s namespace can take precedence.
+	//    when namespaces are enabled so that the mirrored namespace derived from
+	//    the gateway's K8s namespace can take precedence.
 	defaultsNS := helmValues.TerminatingGateways.Defaults.ConsulNamespace
 	if defaultsNS != "" && !(defaultsNS == "default" && namespacesEnabled) {
 		return defaultsNS
 	}
 
-	// 4. Fall back to the mirrored / destination namespace derived from the
-	//    gateway's K8s namespace.
-	if r != nil && r.ConfigEntryController != nil {
-		cec := r.ConfigEntryController
-		if ns := namespaces.ConsulNamespace(
-			termGW.Namespace,
-			cec.EnableConsulNamespaces,
-			cec.ConsulDestinationNamespace,
-			cec.EnableNSMirroring,
-			cec.NSMirroringPrefix,
-		); ns != "" {
-			return ns
-		}
+	// 4. Mirroring only. We intentionally do NOT fall back to the connect
+	//    destination namespace: the terminating gateway's ACL policy (created by
+	//    server-acl-init) is scoped to this same resolved namespace, and following
+	//    the destination namespace would register the service into a namespace its
+	//    ACL token is not authorized for. Mirroring maps the gateway into the
+	//    Consul namespace matching its K8s namespace, consistent with the Helm path.
+	if namespacesEnabled && mirroring {
+		return mirroringPrefix + termGW.Namespace
 	}
 
+	// 5. Default.
 	return defaultIfEmpty(defaultsNS)
 }

--- a/control-plane/controllers/configentries/terminatinggateway_controller_test.go
+++ b/control-plane/controllers/configentries/terminatinggateway_controller_test.go
@@ -253,14 +253,14 @@ func TestTerminatingGatewayController_terminatingGatewayConsulNamespace(t *testi
 			},
 			expectedNS: "k8s-" + kubeNS,
 		},
-		"destination namespace used when mirroring disabled": {
+		"default when mirroring disabled even if destination namespace is set": {
 			termGW: newTermGW("", ""),
 			helm:   &helmvalues.HelmValues{},
 			cec: &ConfigEntryController{
 				EnableConsulNamespaces:     true,
 				ConsulDestinationNamespace: "dest-ns",
 			},
-			expectedNS: "dest-ns",
+			expectedNS: "default",
 		},
 		"falls back to default when namespaces disabled": {
 			termGW:     newTermGW("", ""),

--- a/control-plane/controllers/configentries/terminatinggateway_controller_test.go
+++ b/control-plane/controllers/configentries/terminatinggateway_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	consulv1alpha1 "github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"github.com/hashicorp/consul-k8s/control-plane/controllers/helmvalues"
 	"github.com/hashicorp/consul-k8s/control-plane/helper/test"
 )
 
@@ -168,4 +169,113 @@ func TestTerminatingGatewayController_MutateConsulEntry(t *testing.T) {
 	err = controller.MutateConsulEntry(obj, &capi.ServiceConfigEntry{}, reconcile.Request{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "expected TerminatingGatewayConfigEntry")
+}
+
+// TestTerminatingGatewayController_terminatingGatewayConsulNamespace verifies the
+// resolution order for the Consul namespace a terminating gateway registers into,
+// including the namespace-mirroring fallback used when Admin Partitions are enabled.
+func TestTerminatingGatewayController_terminatingGatewayConsulNamespace(t *testing.T) {
+	t.Parallel()
+
+	const kubeNS = "consul"
+
+	newTermGW := func(specNS, gatewayName string) *consulv1alpha1.TerminatingGateway {
+		return &consulv1alpha1.TerminatingGateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "terminating-gateway", Namespace: kubeNS},
+			Spec: consulv1alpha1.TerminatingGatewaySpec{
+				Deployment: consulv1alpha1.TerminatingGatewayDeploymentSpec{
+					ConsulNamespace: specNS,
+					GatewayName:     gatewayName,
+				},
+			},
+		}
+	}
+
+	cases := map[string]struct {
+		termGW     *consulv1alpha1.TerminatingGateway
+		helm       *helmvalues.HelmValues
+		cec        *ConfigEntryController
+		expectedNS string
+	}{
+		"explicit spec.deployment.consulNamespace wins": {
+			termGW: newTermGW("explicit-ns", ""),
+			helm:   &helmvalues.HelmValues{},
+			cec: &ConfigEntryController{
+				EnableConsulNamespaces: true,
+				EnableNSMirroring:      true,
+			},
+			expectedNS: "explicit-ns",
+		},
+		"per-gateway helm override wins over defaults": {
+			termGW: newTermGW("", ""),
+			helm: &helmvalues.HelmValues{
+				TerminatingGateways: helmvalues.TerminatingGatewaysConfig{
+					Defaults: helmvalues.Defaults{ConsulNamespace: "defaults-ns"},
+					Gateways: []helmvalues.Gateway{{Name: "terminating-gateway", ConsulNamespace: "per-gw-ns"}},
+				},
+			},
+			cec:        &ConfigEntryController{EnableConsulNamespaces: true},
+			expectedNS: "per-gw-ns",
+		},
+		"non-default defaults.consulNamespace is respected": {
+			termGW: newTermGW("", ""),
+			helm: &helmvalues.HelmValues{
+				TerminatingGateways: helmvalues.TerminatingGatewaysConfig{
+					Defaults: helmvalues.Defaults{ConsulNamespace: "defaults-ns"},
+				},
+			},
+			cec: &ConfigEntryController{
+				EnableConsulNamespaces: true,
+				EnableNSMirroring:      true,
+			},
+			expectedNS: "defaults-ns",
+		},
+		"mirroring maps to the K8s namespace when defaults is the default sentinel": {
+			termGW: newTermGW("", ""),
+			helm: &helmvalues.HelmValues{
+				TerminatingGateways: helmvalues.TerminatingGatewaysConfig{
+					Defaults: helmvalues.Defaults{ConsulNamespace: "default"},
+				},
+			},
+			cec: &ConfigEntryController{
+				EnableConsulNamespaces: true,
+				EnableNSMirroring:      true,
+			},
+			expectedNS: kubeNS,
+		},
+		"mirroring with prefix maps to prefixed K8s namespace": {
+			termGW: newTermGW("", ""),
+			helm:   &helmvalues.HelmValues{},
+			cec: &ConfigEntryController{
+				EnableConsulNamespaces: true,
+				EnableNSMirroring:      true,
+				NSMirroringPrefix:      "k8s-",
+			},
+			expectedNS: "k8s-" + kubeNS,
+		},
+		"destination namespace used when mirroring disabled": {
+			termGW: newTermGW("", ""),
+			helm:   &helmvalues.HelmValues{},
+			cec: &ConfigEntryController{
+				EnableConsulNamespaces:     true,
+				ConsulDestinationNamespace: "dest-ns",
+			},
+			expectedNS: "dest-ns",
+		},
+		"falls back to default when namespaces disabled": {
+			termGW:     newTermGW("", ""),
+			helm:       &helmvalues.HelmValues{},
+			cec:        &ConfigEntryController{EnableConsulNamespaces: false},
+			expectedNS: "default",
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			r := &TerminatingGatewayController{ConfigEntryController: tc.cec}
+			require.Equal(t, tc.expectedNS, r.terminatingGatewayConsulNamespace(tc.termGW, tc.helm))
+		})
+	}
 }


### PR DESCRIPTION
### Changes proposed in this PR ###

- Fix namespace mirroring for the **Terminating Gateway (Helm-managed)**: added a `consul.terminatingGatewayNamespace` helper in `_helpers.tpl` and wired it into all three namespace sites in `terminating-gateways-deployment.yaml` (`gateway-namespace` annotation, `CONSUL_NAMESPACE` env var, `-service-namespace` dataplane arg). The gateway now registers into the Consul namespace mirrored from its Kubernetes namespace (e.g. K8s `consul` → Consul `consul`) instead of falling back to `default` when `global.enableConsulNamespaces` and mirroring are enabled.
- Fix namespace mirroring for the **Terminating Gateway (CRD-managed)**: converted `terminatingGatewayConsulNamespace` into a method on `TerminatingGatewayController` that resolves the namespace from the gateway's K8s namespace via the controller's mirroring/destination config (`r.ConfigEntryController`); a bare `"default"` from `terminatingGateways.defaults.consulNamespace` is treated as unset when namespaces are enabled so mirroring takes precedence.
- Fix **Snapshot Agent** registration: added `CONSUL_NAMESPACE` (mirrored/destination namespace) and `CONSUL_PARTITION` env vars to the `consul-snapshot-agent` container in `server-statefulset.yaml`, so the `consul-snapshot` service registers into the correct mirrored namespace and admin partition instead of `default`.
- Established a consistent resolution order for the terminating gateway namespace (both paths): explicit per-gateway/CRD `consulNamespace` → non-`default` `defaults.consulNamespace` → mirrored release/K8s namespace (with optional prefix) → configured destination namespace → `default`.
- Added a CHANGELOG entry documenting both bug fixes.

### How I've tested this PR ###

- Added Go unit test `TestTerminatingGatewayController_terminatingGatewayConsulNamespace` (7 cases: explicit CRD ns, per-gateway override, non-default defaults, mirroring with/without prefix, destination ns, namespaces-disabled) — all pass.
- Added 4 bats cases to `terminating-gateways-deployment.bats` (mirror release ns, mirror + prefix, destination ns, `default` fallback) — full suite **80/80** pass.
- Added 4 bats cases to `server-statefulset.bats` for the snapshot agent (omitted when namespaces disabled, mirrored ns, destination ns, partition) — snapshot-agent subset **35/35** pass.
- Verified rendering manually with `helm template` across all scenarios for both templates (`consul`, `k8s-consul`, `destns`, `myns`, `default` all resolve correctly).
- Confirmed `go build ./...` succeeds and the non-enterprise unit tests in the `configentries` package pass. (The `ReconcileSecretTriggerPrefixDoesNotTrimGatewayName` test requires a Consul Enterprise license to boot a real server and is unrelated to these changes.)

### How I expect reviewers to test this PR ###

1. Deploy two clusters as in the reproduction: a `default` admin partition running Consul servers + Snapshot Agent in K8s namespace `consul`, and a `client` admin partition running a Terminating Gateway and API Gateway in K8s namespace `consul`, with `global.enableConsulNamespaces=true` and namespace mirroring enabled.
2. In the Consul UI / API, confirm the `terminating-gateway` service now appears under the **`consul`** namespace (not `default`) in the `client` partition.
3. Confirm the `consul-snapshot` service appears under the **`consul`** namespace in the `default` partition.
4. Alternatively, run the unit tests:
   - `cd control-plane && go test ./controllers/configentries/ -run TestTerminatingGatewayController_terminatingGatewayConsulNamespace -v`
   - `cd charts/consul && bats test/unit/terminating-gateways-deployment.bats -f consulNamespace`
   - `cd charts/consul && bats test/unit/server-statefulset.bats -f "snapshot-agent: CONSUL"`
5. Verify backward compatibility: with mirroring disabled and no destination namespace set, the terminating gateway and snapshot agent still register into `default`.

### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

  Revert plan: Changes are isolated to Helm templates (`_helpers.tpl`, `terminating-gateways-deployment.yaml`, `server-statefulset.yaml`) and a single controller function. Reverting the PR fully restores prior behavior; no data migration or state cleanup is required. Namespaces created by mirroring (e.g. `consul`) would simply stop receiving new registrations.

- [x] If applicable, I've documented the impact of any changes to security controls.

  No changes to security controls. ACL policy rules for the terminating gateway already use the same resolved Consul namespace, so they remain correctly scoped. There is a minor behavioral change: a user who explicitly set `terminatingGateways.defaults.consulNamespace: "default"` with mirroring enabled will now have the gateway registered into the mirrored namespace; this is documented in the CHANGELOG.