### PR TITLE
Fix for the consul-injector-webhook issue during the OCP upgrade causing upgrade halt or cluster inaccessible

### DIFF
--- a/.changelog/5402.txt
+++ b/.changelog/5402.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+helm: Update the namespace selector of consul-connect-inject webhook to be ignored incase of openshift 
+```

--- a/.changelog/5402.txt
+++ b/.changelog/5402.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-helm: Update the namespace selector of consul-connect-inject webhook to be ignored incase of openshift 
+helm: Exclude OpenShift namespaces from the consul-connect-inject webhook injection by default
 ```

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2838,6 +2838,7 @@ connectInject:
   # want those pods injected and local-path-storage and openebs so that
   # Kind (Kubernetes In Docker) and [OpenEBS](https://openebs.io/) respectively can provision Pods used to create PVCs.
   # We also exclude gmp-system and gke-managed-cim namespaces that are used by GKE for managing the cluster.
+  # We also exclude any namespaces with the label `openshift.io/cluster-monitoring` since those are used by OpenShift for cluster monitoring and typically should not be injected.
   # Note that this exclusion is only supported in Kubernetes v1.21.1+.
   #
   # Example:

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -2853,6 +2853,8 @@ connectInject:
       - key: "kubernetes.io/metadata.name"
         operator: "NotIn"
         values: ["kube-system","local-path-storage","openebs","gmp-system","gke-managed-cim"]
+      - key: "openshift.io/cluster-monitoring"
+        operator: "DoesNotExist"
 
   # List of k8s namespaces to allow Connect sidecar
   # injection in. If a k8s namespace is not included or is listed in `k8sDenyNamespaces`,


### PR DESCRIPTION
Issue:
On upgrading the ocp to 4.18 to 4.19 and 4.19+, we encounter the consul-connect-injector web hook failing causing the ocp upgrade halt or making the cluster inaccessible, mainly when the schedule of the upgrade is delayed by some time.

Fix: To exclude the OpenShift namespace