### PR TITLE
ci(eks): install hc-security-base host package for HC-COMPUTE-010

### DIFF
--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -84,9 +84,10 @@ locals {
   }
 
   # User-data that installs hc-security-base from internal Artifactory at boot.
+  # Credentials are base64-encoded so they embed safely regardless of content.
   hc_security_base_pre_userdata = var.enable_security_baseline ? templatefile("${path.module}/templates/install-hc-security-base.sh.tpl", {
-    afy_user     = var.afy_user
-    afy_password = var.afy_password
+    afy_user_b64     = base64encode(var.afy_user)
+    afy_password_b64 = base64encode(var.afy_password)
   }) : ""
 
   # Hardened node group: Canonical Ubuntu EKS AMI + hc-security-base install.

--- a/charts/consul/test/terraform/eks/main.tf
+++ b/charts/consul/test/terraform/eks/main.tf
@@ -43,6 +43,63 @@ resource "random_string" "suffix" {
   special = false
 }
 
+# HC-COMPUTE-010 / SECVULN-44200: Canonical Ubuntu EKS-optimized AMI used when
+# enable_security_baseline is true so the worker nodes can carry hc-security-base.
+data "aws_ami" "ubuntu_eks" {
+  count       = var.enable_security_baseline ? 1 : 0
+  most_recent = true
+  owners      = [var.ubuntu_eks_ami_owner]
+
+  filter {
+    name   = "name"
+    values = [format(var.ubuntu_eks_ami_name_filter, var.kubernetes_version)]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+locals {
+  # Baseline node group: default EKS-optimized Amazon Linux AMI (current behavior).
+  # The launch-template keys are set to their module defaults so this object has
+  # the same shape as hardened_node_group (required for the conditional below).
+  default_node_group = {
+    desired_capacity = 3
+    max_capacity     = 3
+    min_capacity     = 3
+
+    instance_types = ["m5.xlarge"]
+
+    ami_id                     = null
+    create_launch_template     = false
+    enable_bootstrap_user_data = false
+    pre_userdata               = ""
+  }
+
+  # User-data that installs hc-security-base from internal Artifactory at boot.
+  hc_security_base_pre_userdata = var.enable_security_baseline ? templatefile("${path.module}/templates/install-hc-security-base.sh.tpl", {
+    afy_user     = var.afy_user
+    afy_password = var.afy_password
+  }) : ""
+
+  # Hardened node group: Canonical Ubuntu EKS AMI + hc-security-base install.
+  # A custom AMI requires the module to render bootstrap user-data (the launch
+  # template) so the nodes still join the cluster.
+  hardened_node_group = merge(local.default_node_group, {
+    ami_id                     = one(data.aws_ami.ubuntu_eks[*].id)
+    create_launch_template     = true
+    enable_bootstrap_user_data = true
+    pre_userdata               = local.hc_security_base_pre_userdata
+  })
+}
+
 module "vpc" {
   count   = var.cluster_count
   source  = "terraform-aws-modules/vpc/aws"
@@ -91,13 +148,7 @@ module "eks" {
   vpc_id = module.vpc[count.index].vpc_id
 
   node_groups = {
-    first = {
-      desired_capacity = 3
-      max_capacity     = 3
-      min_capacity     = 3
-
-      instance_types = ["m5.xlarge"]
-    }
+    first = var.enable_security_baseline ? local.hardened_node_group : local.default_node_group
   }
 
   manage_aws_auth        = false

--- a/charts/consul/test/terraform/eks/templates/install-hc-security-base.sh.tpl
+++ b/charts/consul/test/terraform/eks/templates/install-hc-security-base.sh.tpl
@@ -1,0 +1,51 @@
+# HC-COMPUTE-010 / SECVULN-44200 - install hc-security-base (IBM CISO baseline).
+#
+# This runs as node pre_userdata (before /etc/eks/bootstrap.sh) on a Canonical
+# Ubuntu EKS AMI. It replicates the runtime subset of
+# ami-builder/scripts/packer-install_meta_deb.sh (enable internal Artifactory apt
+# repo, then install the package) so the compliance scanner finds hc-security-base
+# in the node package database. It deliberately does NOT run the heavy base-image
+# pruning that the Packer build does, to avoid disrupting a live EKS worker node.
+#
+# Failures are non-fatal: the node still joins the cluster (so CI is not blocked)
+# but the failure is logged for investigation.
+install_hc_security_base() {
+  export DEBIAN_FRONTEND=noninteractive
+
+  local AFY_USER='${afy_user}'
+  local AFY_PASSWORD='${afy_password}'
+  local BASE_URL="https://artifactory.hashicorp.engineering/artifactory"
+  local AUTH_FILE="/etc/apt/auth.conf.d/hc_artifactory.conf"
+  local SRC_FILE="/etc/apt/sources.list.d/hc_artifactory.list"
+  local GPG_FILE="/etc/apt/trusted.gpg.d/hc_artifactory.asc"
+  local CODENAME
+  CODENAME="$(lsb_release -cs)"
+
+  if [ -z "$AFY_USER" ] || [ -z "$AFY_PASSWORD" ]; then
+    echo "hc-security-base: Artifactory credentials not provided; skipping install"
+    return 1
+  fi
+
+  # Internal Artifactory apt auth (mode 0600, root-owned - holds credentials).
+  install -m 0600 -o root -g root /dev/null "$AUTH_FILE"
+  echo "machine artifactory.hashicorp.engineering login $AFY_USER password $AFY_PASSWORD" > "$AUTH_FILE"
+
+  # Fetch the Artifactory signing key first so the repo can be verified against it
+  # (signed-by) instead of disabling signature checks (trusted=yes).
+  curl -fsSL -u "$AFY_USER:$AFY_PASSWORD" "$BASE_URL/api/gpg/key/public" -o "$GPG_FILE"
+  chmod 0644 "$GPG_FILE"
+
+  printf 'deb [signed-by=%s] %s/deb %s main\ndeb [signed-by=%s] %s/deb deb main\n' \
+    "$GPG_FILE" "$BASE_URL" "$CODENAME" "$GPG_FILE" "$BASE_URL" > "$SRC_FILE"
+  chmod 0644 "$SRC_FILE"
+
+  apt-get -qy update
+  apt-get -qy install --no-install-recommends hc-security-base
+
+  # Hygiene: remove the internal repo + credentials from the running node once
+  # the package is installed; the compliance check only needs the package present.
+  rm -f "$AUTH_FILE" "$SRC_FILE"
+  apt-get -qy update || true
+}
+
+install_hc_security_base || echo "WARNING: hc-security-base install failed; node will still join the cluster"

--- a/charts/consul/test/terraform/eks/templates/install-hc-security-base.sh.tpl
+++ b/charts/consul/test/terraform/eks/templates/install-hc-security-base.sh.tpl
@@ -12,8 +12,14 @@
 install_hc_security_base() {
   export DEBIAN_FRONTEND=noninteractive
 
-  local AFY_USER='${afy_user}'
-  local AFY_PASSWORD='${afy_password}'
+  # Secrets are injected base64-encoded and decoded here at runtime. base64 text
+  # is [A-Za-z0-9+/=] only, so the embedded value can never contain a shell
+  # metacharacter (quote, '$', backtick, newline); decoding restores the exact
+  # original bytes. This is robust to arbitrary characters in the credential,
+  # unlike a raw shell literal which breaks on a quote.
+  local AFY_USER AFY_PASSWORD
+  AFY_USER="$(printf '%s' '${afy_user_b64}' | base64 -d)"
+  AFY_PASSWORD="$(printf '%s' '${afy_password_b64}' | base64 -d)"
   local BASE_URL="https://artifactory.hashicorp.engineering/artifactory"
   local AUTH_FILE="/etc/apt/auth.conf.d/hc_artifactory.conf"
   local SRC_FILE="/etc/apt/sources.list.d/hc_artifactory.list"
@@ -31,8 +37,10 @@ install_hc_security_base() {
   echo "machine artifactory.hashicorp.engineering login $AFY_USER password $AFY_PASSWORD" > "$AUTH_FILE"
 
   # Fetch the Artifactory signing key first so the repo can be verified against it
-  # (signed-by) instead of disabling signature checks (trusted=yes).
-  curl -fsSL -u "$AFY_USER:$AFY_PASSWORD" "$BASE_URL/api/gpg/key/public" -o "$GPG_FILE"
+  # (signed-by) instead of disabling signature checks (trusted=yes). Use the
+  # netrc auth file written above instead of -u so credentials are not exposed on
+  # the process command line (visible via ps / cloud-init logs).
+  curl -fsSL --netrc-file "$AUTH_FILE" "$BASE_URL/api/gpg/key/public" -o "$GPG_FILE"
   chmod 0644 "$GPG_FILE"
 
   printf 'deb [signed-by=%s] %s/deb %s main\ndeb [signed-by=%s] %s/deb deb main\n' \
@@ -42,9 +50,11 @@ install_hc_security_base() {
   apt-get -qy update
   apt-get -qy install --no-install-recommends hc-security-base
 
-  # Hygiene: remove the internal repo + credentials from the running node once
-  # the package is installed; the compliance check only needs the package present.
-  rm -f "$AUTH_FILE" "$SRC_FILE"
+  # Hygiene: remove the internal repo, credentials and signing key from the
+  # running node once the package is installed; the compliance check only needs
+  # the package present. Removing the key avoids permanently expanding the node's
+  # apt trust store beyond this one-time install.
+  rm -f "$AUTH_FILE" "$SRC_FILE" "$GPG_FILE"
   apt-get -qy update || true
 }
 

--- a/charts/consul/test/terraform/eks/variables.tf
+++ b/charts/consul/test/terraform/eks/variables.tf
@@ -70,3 +70,46 @@ variable "uptycs_webhook_tls_key" {
   description = "Base64-encoded TLS private key for kubequery webhook server."
   sensitive   = true
 }
+
+# ----------------------------------------------------------------------------
+# HC-COMPUTE-010 / SECVULN-44200 host baseline package
+#
+# The Wiz/Uptycs compliance scanner checks the node's host package database
+# (`dpkg --list | grep hc-security-base`). The Uptycs EDR DaemonSet above
+# covers the Kubernetes posture control but does NOT register the hc-security-base
+# package in the host package DB. The default EKS-optimized node image is Amazon
+# Linux, which cannot carry that Debian package. When enable_security_baseline is
+# true the worker nodes are launched from a Canonical Ubuntu EKS-optimized AMI and
+# hc-security-base is installed at boot from HashiCorp internal Artifactory,
+# mirroring ami-builder/scripts/packer-install_meta_deb.sh.
+# ----------------------------------------------------------------------------
+
+variable "enable_security_baseline" {
+  type        = bool
+  default     = false
+  description = "When true, run worker nodes on a Canonical Ubuntu EKS AMI and install hc-security-base at boot to satisfy HC-COMPUTE-010. Requires afy_user/afy_password. Validate in a single cluster before enabling in shared CI."
+}
+
+variable "ubuntu_eks_ami_owner" {
+  default     = "099720109477"
+  description = "AWS account id that owns the Ubuntu EKS AMIs (Canonical)."
+}
+
+variable "ubuntu_eks_ami_name_filter" {
+  default     = "ubuntu-eks/k8s_%s/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
+  description = "Name filter for the Canonical Ubuntu EKS AMI. %s is replaced with kubernetes_version."
+}
+
+variable "afy_user" {
+  type        = string
+  default     = ""
+  sensitive   = true
+  description = "HashiCorp Artifactory username used to fetch hc-security-base. Provide via TF_VAR_afy_user from CI secrets; never commit."
+}
+
+variable "afy_password" {
+  type        = string
+  default     = ""
+  sensitive   = true
+  description = "HashiCorp Artifactory password/token used to fetch hc-security-base. Provide via TF_VAR_afy_password from CI secrets; never commit."
+}


### PR DESCRIPTION
## What
Adds an **additive, toggle-gated** path so EKS acceptance worker nodes carry the `hc-security-base` Debian package required by **HC-COMPUTE-010 / SECVULN-44200**.

When `enable_security_baseline=true` (default **false**):
- worker nodes launch from a Canonical **Ubuntu EKS-optimized AMI**, and
- `hc-security-base` is installed at boot from internal Artifactory (mirrors `ami-builder/scripts/packer-install_meta_deb.sh`).

## Why
The merged Uptycs EDR DaemonSet (PR #5398) satisfies the Kubernetes posture control (HC-COMPUTE-011-K8) but does **not** register a package in the host DB. The Wiz/Uptycs scanner for HC-COMPUTE-010 checks `dpkg -l | grep hc-security-(base|pre-uptycs|wasatch)`, so the VMs stayed flagged after merge. This adds the host package **on top of** the DaemonSet (both are kept).

## Safety
- Default **OFF** → zero change to current CI until enabled via the workflow toggle.
- Uptycs `helm_release` resources untouched.
- Verified: `terraform fmt`/`validate` clean, `bash -n` on template OK, console OFF-path = default Amazon Linux node group (no AMI lookup, no launch template).

Enabled by companion PR in consul-k8s-workflows.