### PR TITLE
fix(crd): add helm.sh/resource-policy:keep tombstone for Gateway API CRDs on OCP upgrade path from <2.0.0

### DIFF
--- a/charts/consul/templates/crd-gatewayclasses-external.yaml
+++ b/charts/consul/templates/crd-gatewayclasses-external.yaml
@@ -341,3 +341,40 @@ status:
   conditions: []
   storedVersions: []
 {{- end }}
+
+{{/*
+Tombstone: renders with helm.sh/resource-policy: keep when the primary CRD block
+is suppressed on OpenShift (isOcpGreaterthan4_18: true or installK8sNetworkingCRDs: false).
+This prevents Helm from issuing a DELETE for CRDs it previously owned (consul-k8s <2.0.0)
+that are now managed by the OpenShift Ingress Operator, which blocks deletions via
+ValidatingAdmissionPolicy 'openshift-ingress-operator-gatewayapi-crd-admission'.
+This tombstone is a no-op on fresh installs where the CRD was never Helm-managed.
+*/}}
+{{- if and
+    .Values.connectInject.enabled
+    (or
+        .Values.connectInject.apiGateway.manageExternalCRDs
+        .Values.connectInject.apiGateway.manageNonStandardCRDs
+    )
+    (default false .Values.global.openshift.enabled)
+    (or
+        (default false .Values.global.openshift.isOcpGreaterthan4_18)
+        (not (default true .Values.global.installK8sNetworkingCRDs))
+    )
+}}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  name: gatewayclasses.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    kind: GatewayClass
+    listKind: GatewayClassList
+    plural: gatewayclasses
+    singular: gatewayclass
+  scope: Cluster
+  versions: []
+{{- end }}

--- a/charts/consul/templates/crd-gateways-external.yaml
+++ b/charts/consul/templates/crd-gateways-external.yaml
@@ -895,3 +895,39 @@ status:
   conditions: []
   storedVersions: []
 {{- end }}
+{{/*
+Tombstone: renders with helm.sh/resource-policy: keep when the primary CRD block
+is suppressed on OpenShift (isOcpGreaterthan4_18: true or installK8sNetworkingCRDs: false).
+This prevents Helm from issuing a DELETE for CRDs it previously owned (consul-k8s <2.0.0)
+that are now managed by the OpenShift Ingress Operator, which blocks deletions via
+ValidatingAdmissionPolicy 'openshift-ingress-operator-gatewayapi-crd-admission'.
+This tombstone is a no-op on fresh installs where the CRD was never Helm-managed.
+*/}}
+{{- if and
+    .Values.connectInject.enabled
+    (or
+        .Values.connectInject.apiGateway.manageExternalCRDs
+        .Values.connectInject.apiGateway.manageNonStandardCRDs
+    )
+    (default false .Values.global.openshift.enabled)
+    (or
+        (default false .Values.global.openshift.isOcpGreaterthan4_18)
+        (not (default true .Values.global.installK8sNetworkingCRDs))
+    )
+}}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  name: gateways.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    kind: Gateway
+    listKind: GatewayList
+    plural: gateways
+    singular: gateway
+  scope: Namespaced
+  versions: []
+{{- end }}

--- a/charts/consul/templates/crd-httproutes-external.yaml
+++ b/charts/consul/templates/crd-httproutes-external.yaml
@@ -1923,3 +1923,39 @@ status:
   conditions: []
   storedVersions: []
 {{- end }}
+{{/*
+Tombstone: renders with helm.sh/resource-policy: keep when the primary CRD block
+is suppressed on OpenShift (isOcpGreaterthan4_18: true or installK8sNetworkingCRDs: false).
+This prevents Helm from issuing a DELETE for CRDs it previously owned (consul-k8s <2.0.0)
+that are now managed by the OpenShift Ingress Operator, which blocks deletions via
+ValidatingAdmissionPolicy 'openshift-ingress-operator-gatewayapi-crd-admission'.
+This tombstone is a no-op on fresh installs where the CRD was never Helm-managed.
+*/}}
+{{- if and
+    .Values.connectInject.enabled
+    (or
+        .Values.connectInject.apiGateway.manageExternalCRDs
+        .Values.connectInject.apiGateway.manageNonStandardCRDs
+    )
+    (default false .Values.global.openshift.enabled)
+    (or
+        (default false .Values.global.openshift.isOcpGreaterthan4_18)
+        (not (default true .Values.global.installK8sNetworkingCRDs))
+    )
+}}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  name: httproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    kind: HTTPRoute
+    listKind: HTTPRouteList
+    plural: httproutes
+    singular: httproute
+  scope: Namespaced
+  versions: []
+{{- end }}

--- a/charts/consul/templates/crd-referencegrants-external.yaml
+++ b/charts/consul/templates/crd-referencegrants-external.yaml
@@ -225,3 +225,40 @@ status:
   conditions: []
   storedVersions: []
 {{- end }}
+
+{{/*
+Tombstone: renders with helm.sh/resource-policy: keep when the primary CRD block
+is suppressed on OpenShift (isOcpGreaterthan4_18: true or installK8sNetworkingCRDs: false).
+This prevents Helm from issuing a DELETE for CRDs it previously owned (consul-k8s <2.0.0)
+that are now managed by the OpenShift Ingress Operator, which blocks deletions via
+ValidatingAdmissionPolicy 'openshift-ingress-operator-gatewayapi-crd-admission'.
+This tombstone is a no-op on fresh installs where the CRD was never Helm-managed.
+*/}}
+{{- if and
+    .Values.connectInject.enabled
+    (or
+        .Values.connectInject.apiGateway.manageExternalCRDs
+        .Values.connectInject.apiGateway.manageNonStandardCRDs
+    )
+    (default false .Values.global.openshift.enabled)
+    (or
+        (default false .Values.global.openshift.isOcpGreaterthan4_18)
+        (not (default true .Values.global.installK8sNetworkingCRDs))
+    )
+}}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  name: referencegrants.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    kind: ReferenceGrant
+    listKind: ReferenceGrantList
+    plural: referencegrants
+    singular: referencegrant
+  scope: Namespaced
+  versions: []
+{{- end }}

--- a/charts/consul/test/unit/crd-gatewayclasses-external.bats
+++ b/charts/consul/test/unit/crd-gatewayclasses-external.bats
@@ -26,3 +26,54 @@ load _helpers
         --set 'connectInject.apiGateway.manageExternalCRDs=false' \
         . 
 }
+
+@test "gatewayclasses/CRD tombstone: renders with resource-policy:keep on OCP when isOcpGreaterthan4_18=true and installK8sNetworkingCRDs=false" {
+    cd `chart_dir`
+    local actual=$(helm template \
+        -s templates/crd-gatewayclasses-external.yaml \
+        --set "global.openshift.enabled=true" \
+        --set "global.openshift.isOcpGreaterthan4_18=true" \
+        --set "global.installK8sNetworkingCRDs=false" \
+        . | tee /dev/stderr |
+        yq "select(.metadata.name == \"gatewayclasses.gateway.networking.k8s.io\")
+            | .metadata.annotations[\"helm.sh/resource-policy\"]")
+    [ "$actual" = "keep" ]
+}
+
+@test "gatewayclasses/CRD tombstone: renders with resource-policy:keep on OCP when installK8sNetworkingCRDs=false and isOcpGreaterthan4_18=false" {
+    cd `chart_dir`
+    local actual=$(helm template \
+        -s templates/crd-gatewayclasses-external.yaml \
+        --set "global.openshift.enabled=true" \
+        --set "global.openshift.isOcpGreaterthan4_18=false" \
+        --set "global.installK8sNetworkingCRDs=false" \
+        . | tee /dev/stderr |
+        yq "select(.metadata.annotations[\"helm.sh/resource-policy\"] == \"keep\")
+            | .metadata.name")
+    [ "$actual" = "gatewayclasses.gateway.networking.k8s.io" ]
+}
+
+@test "gatewayclasses/CRD tombstone: does NOT render when openshift.enabled=false" {
+    cd `chart_dir`
+    local actual=$(helm template \
+        -s templates/crd-gatewayclasses-external.yaml \
+        --set "global.openshift.enabled=false" \
+        --set "global.installK8sNetworkingCRDs=false" \
+        . | tee /dev/stderr |
+        yq "select(.metadata.annotations[\"helm.sh/resource-policy\"] == \"keep\") | .metadata.name")
+    [ -z "$actual" ]
+}
+
+@test "gatewayclasses/CRD tombstone: does NOT render when primary block is active (no duplicate)" {
+    cd `chart_dir`
+    # When primary block renders, tombstone must be suppressed — only one copy of the CRD
+    local count=$(helm template \
+        -s templates/crd-gatewayclasses-external.yaml \
+        --set "global.openshift.enabled=true" \
+        --set "global.openshift.isOcpGreaterthan4_18=false" \
+        --set "global.installK8sNetworkingCRDs=true" \
+        . | tee /dev/stderr |
+        yq "select(.metadata.name == \"gatewayclasses.gateway.networking.k8s.io\")" | grep -c "^---")
+    [ "$count" -eq 1 ]
+}
+

--- a/charts/consul/test/unit/crd-httproutes-external.bats
+++ b/charts/consul/test/unit/crd-httproutes-external.bats
@@ -26,3 +26,28 @@ load _helpers
         --set 'connectInject.apiGateway.manageExternalCRDs=false' \
         . 
 }
+
+@test "httproutes/CRD tombstone: renders with resource-policy:keep on OCP when isOcpGreaterthan4_18=true and installK8sNetworkingCRDs=false" {
+    cd `chart_dir`
+    local actual=$(helm template \
+        -s templates/crd-httproutes-external.yaml \
+        --set "global.openshift.enabled=true" \
+        --set "global.openshift.isOcpGreaterthan4_18=true" \
+        --set "global.installK8sNetworkingCRDs=false" \
+        . | tee /dev/stderr |
+        yq "select(.metadata.name == \"httproutes.gateway.networking.k8s.io\")
+            | .metadata.annotations[\"helm.sh/resource-policy\"]")
+    [ "$actual" = "keep" ]
+}
+
+@test "httproutes/CRD tombstone: does NOT render when openshift.enabled=false" {
+    cd `chart_dir`
+    local actual=$(helm template \
+        -s templates/crd-httproutes-external.yaml \
+        --set "global.openshift.enabled=false" \
+        --set "global.installK8sNetworkingCRDs=false" \
+        . | tee /dev/stderr |
+        yq "select(.metadata.annotations[\"helm.sh/resource-policy\"] == \"keep\") | .metadata.name")
+    [ -z "$actual" ]
+}
+

--- a/charts/consul/test/unit/crd-referencegrants-external.bats
+++ b/charts/consul/test/unit/crd-referencegrants-external.bats
@@ -2,48 +2,48 @@
 
 load _helpers
 
-@test "gateways/CustomResourceDefinition: enabled by default" {
+@test "referencegrants/CustomResourceDefinition: enabled by default" {
     cd `chart_dir`
     local actual=$(helm template \
-        -s templates/crd-gateways-external.yaml \
+        -s templates/crd-referencegrants-external.yaml \
         . | tee /dev/stderr |
         yq 'length > 0' | tee /dev/stderr)
     [ "$actual" = "true" ]
 }
 
-@test "gateways/CustomResourceDefinition: disabled with connectInject.enabled=false" {
+@test "referencegrants/CustomResourceDefinition: disabled with connectInject.enabled=false" {
     cd `chart_dir`
     assert_empty helm template \
-        -s templates/crd-gateways-external.yaml \
+        -s templates/crd-referencegrants-external.yaml \
         --set 'connectInject.enabled=false' \
-        . 
+        .
 }
 
-@test "gateways/CustomResourceDefinition: disabled with connectInject.apiGateway.manageExternalCRDs=false" {
+@test "referencegrants/CustomResourceDefinition: disabled with connectInject.apiGateway.manageExternalCRDs=false" {
     cd `chart_dir`
     assert_empty helm template \
-        -s templates/crd-gateways-external.yaml \
+        -s templates/crd-referencegrants-external.yaml \
         --set 'connectInject.apiGateway.manageExternalCRDs=false' \
-        . 
+        .
 }
 
-@test "gateways/CRD tombstone: renders with resource-policy:keep on OCP when isOcpGreaterthan4_18=true and installK8sNetworkingCRDs=false" {
+@test "referencegrants/CRD tombstone: renders with resource-policy:keep on OCP when isOcpGreaterthan4_18=true and installK8sNetworkingCRDs=false" {
     cd `chart_dir`
     local actual=$(helm template \
-        -s templates/crd-gateways-external.yaml \
+        -s templates/crd-referencegrants-external.yaml \
         --set "global.openshift.enabled=true" \
         --set "global.openshift.isOcpGreaterthan4_18=true" \
         --set "global.installK8sNetworkingCRDs=false" \
         . | tee /dev/stderr |
-        yq "select(.metadata.name == \"gateways.gateway.networking.k8s.io\")
+        yq "select(.metadata.name == \"referencegrants.gateway.networking.k8s.io\")
             | .metadata.annotations[\"helm.sh/resource-policy\"]")
     [ "$actual" = "keep" ]
 }
 
-@test "gateways/CRD tombstone: does NOT render when openshift.enabled=false" {
+@test "referencegrants/CRD tombstone: does NOT render when openshift.enabled=false" {
     cd `chart_dir`
     local actual=$(helm template \
-        -s templates/crd-gateways-external.yaml \
+        -s templates/crd-referencegrants-external.yaml \
         --set "global.openshift.enabled=false" \
         --set "global.installK8sNetworkingCRDs=false" \
         . | tee /dev/stderr |
@@ -51,15 +51,14 @@ load _helpers
     [ -z "$actual" ]
 }
 
-@test "gateways/CRD tombstone: does NOT render when primary block is active (no duplicate)" {
+@test "referencegrants/CRD tombstone: does NOT render when primary block is active (no duplicate)" {
     cd `chart_dir`
     local count=$(helm template \
-        -s templates/crd-gateways-external.yaml \
+        -s templates/crd-referencegrants-external.yaml \
         --set "global.openshift.enabled=true" \
         --set "global.openshift.isOcpGreaterthan4_18=false" \
         --set "global.installK8sNetworkingCRDs=true" \
         . | tee /dev/stderr |
-        yq "select(.metadata.name == \"gateways.gateway.networking.k8s.io\")" | grep -c "^---")
+        yq "select(.metadata.name == \"referencegrants.gateway.networking.k8s.io\")" | grep -c "^---")
     [ "$count" -eq 1 ]
 }
-

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -5,6 +5,11 @@
 
 # Holds values that affect multiple components of the chart.
 global:
+  # Installs the Gateway API CRDs (gatewayclasses, gateways, httproutes, referencegrants)
+  # when Consul on Kubernetes is installed. Set to false on OpenShift clusters where these
+  # CRDs are pre-installed and managed by the Ingress Operator — setting this to true on
+  # OpenShift will cause the install/upgrade to fail with a ValidatingAdmissionPolicy error.
+  # On non-OpenShift clusters this should remain true (default) so Consul installs the CRDs.
   installK8sNetworkingCRDs: true
   # The main enabled/disabled setting. If true, servers,
   # clients, Consul DNS and the Consul UI will be enabled. Each component can override


### PR DESCRIPTION
## Summary

When upgrading from **consul-k8s <2.0.0 to >=2.0.0** on **OpenShift >=4.16**, `helm upgrade` fails with:

```
Failed to delete customresourcedefinitions/gatewayclasses.gateway.networking.k8s.io:
forbidden: ValidatingAdmissionPolicy
'openshift-ingress-operator-gatewayapi-crd-admission' denied request:
Gateway API Custom Resource Definitions are managed by the Ingress Operator
and may not be modified
```

This affects all four CRDs: `gatewayclasses`, `gateways`, `httproutes`, `referencegrants` in `gateway.networking.k8s.io`.

## Root Cause

In consul-k8s <2.0.0, the CRD templates had a simple two-condition gate:

```yaml
{{- if and .Values.connectInject.enabled .Values.connectInject.apiGateway.manageExternalCRDs }}
```

Since `manageExternalCRDs` defaults to `true`, the four Gateway API CRDs were rendered and **stored in Helm's release manifest Secret** on every pre-2.0.0 install.

In consul-k8s 2.0.0+, additional gate conditions (`isOcpGreaterthan4_18`, `installK8sNetworkingCRDs`) were added to prevent Consul from conflicting with the OpenShift Ingress Operator. With the correct OCP values (`isOcpGreaterthan4_18: true`, `installK8sNetworkingCRDs: false`), these gates evaluate to `false` — the CRDs are absent from the new rendered manifest.

Helm's upgrade diff finds the four CRDs in the **old stored manifest** but not in the **new rendered manifest**, and issues a `DELETE` for each. OpenShift's `ValidatingAdmissionPolicy` named `openshift-ingress-operator-gatewayapi-crd-admission` blocks every `DELETE`, causing the upgrade to fail.

This affects **any customer upgrading from pre-2.0.0 consul-k8s on OpenShift >=4.16**, regardless of which values they set — because the old manifest state is the trigger, not the new values.

## Fix

Add a **companion tombstone block** to each of the four affected CRD template files. The tombstone renders the CRD metadata with `helm.sh/resource-policy: keep` when:

- `global.openshift.enabled: true` AND
- (`global.openshift.isOcpGreaterthan4_18: true` OR `global.installK8sNetworkingCRDs: false`)

This instructs Helm to **drop the CRD from its tracking manifest without issuing a DELETE** — the [correct Helm-native mechanism](https://helm.sh/docs/howto/charts_tips_and_tricks/#tell-helm-not-to-uninstall-a-resource) for transferring resource ownership away from a release.

The tombstone is a **no-op** on fresh 2.0.0+ installs where the CRD was never Helm-managed, and does not render on non-OCP clusters.

## Files Changed

| File | Change |
|------|--------|
| `charts/consul/templates/crd-gatewayclasses-external.yaml` | Add tombstone block |
| `charts/consul/templates/crd-gateways-external.yaml` | Add tombstone block |
| `charts/consul/templates/crd-httproutes-external.yaml` | Add tombstone block |
| `charts/consul/templates/crd-referencegrants-external.yaml` | Add tombstone block |
| `charts/consul/test/unit/crd-gatewayclasses-external.bats` | Add tombstone unit tests |
| `charts/consul/test/unit/crd-gateways-external.bats` | Add tombstone unit tests |
| `charts/consul/test/unit/crd-httproutes-external.bats` | Add tombstone unit tests |
| `charts/consul/test/unit/crd-referencegrants-external.bats` | New file with full test coverage |
| `charts/consul/values.yaml` | Improve `installK8sNetworkingCRDs` comment |

## Behaviour After This Fix

| Scenario | Primary block | Tombstone | Helm action |
|----------|--------------|-----------|-------------|
| Fresh install, non-OCP | ✅ renders | ❌ suppressed | CREATE CRDs — unchanged |
| OCP, `isOcpGreaterthan4_18: false`, `installK8sNetworkingCRDs: false` | ❌ suppressed | ✅ renders (keep) | DROP from manifest, no DELETE ✅ |
| OCP, `isOcpGreaterthan4_18: true`, `installK8sNetworkingCRDs: false` | ❌ suppressed | ✅ renders (keep) | DROP from manifest, no DELETE ✅ |
| Fresh install OCP >=4.19, no prior release | ❌ suppressed | ✅ renders (keep) | No-op (CRD not in cluster) |
| OCP, primary block active (`installK8sNetworkingCRDs: true`) | ✅ renders | ❌ suppressed | PATCH CRDs — unchanged |

## Testing

- New bats unit tests verify the tombstone renders with `resource-policy: keep` for OCP upgrade values
- Tests verify tombstone is suppressed when the primary block is active (no duplicate CRD objects)
- Tests verify tombstone does not render on non-OCP clusters
- Existing tests are unchanged
