### PR TITLE
Feature/proxy log capture

### DIFF
--- a/cli/cmd/proxy/loglevel/command.go
+++ b/cli/cmd/proxy/loglevel/command.go
@@ -4,6 +4,7 @@
 package loglevel
 
 import (
+	"archive/zip"
 	"context"
 	"errors"
 	"fmt"
@@ -22,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/strings/slices"
 
 	"github.com/hashicorp/consul-k8s/cli/common"
 	"github.com/hashicorp/consul-k8s/cli/common/envoy"
@@ -38,6 +40,15 @@ const (
 	flagNameKubeConfig  = "kubeconfig"
 	flagNameKubeContext = "context"
 	flagNameCapture     = "capture"
+	flagNameOutput      = "output"
+
+	// outputFile writes the captured log to a plain .log file (default, preserves existing behavior).
+	outputFile = "file"
+	// outputArchive wraps the captured log in a .zip file.
+	outputArchive = "archive"
+
+	// sidecarContainerName is the name of the Consul-managed proxy container that emits Envoy logs.
+	sidecarContainerName = "consul-dataplane"
 
 	// minimum duration for log capture should be atleast 10seconds
 	minimumCaptureDuration = 10 * time.Second
@@ -73,6 +84,7 @@ type LogLevelCommand struct {
 	level       string
 	reset       bool
 	capture     time.Duration
+	output      string
 	kubeConfig  string
 	kubeContext string
 
@@ -105,6 +117,12 @@ func (l *LogLevelCommand) init() {
 		Target:  &l.capture,
 		Default: 0,
 		Usage:   "Captures pod log for the given duration according to existing/new update-level. It can be used with -update-level <any> flag to capture logs at that level or with -reset flag to capture logs at default info level",
+	})
+	f.StringVar(&flag.StringVar{
+		Name:    flagNameOutput,
+		Target:  &l.output,
+		Default: outputFile,
+		Usage:   "Output format for the captured log when used with -capture: 'file' (default, writes a plain .log file) or 'archive' (writes a .zip file).",
 	})
 
 	f.BoolVar(&flag.BoolVar{
@@ -222,6 +240,9 @@ func (l *LogLevelCommand) validateFlags() error {
 	}
 	if l.capture != 0 && l.capture < minimumCaptureDuration {
 		return fmt.Errorf("capture duration must be at least %s", minimumCaptureDuration)
+	}
+	if outputs := []string{outputFile, outputArchive}; !slices.Contains(outputs, l.output) {
+		return fmt.Errorf("-output must be one of %s", strings.Join(outputs, ", "))
 	}
 
 	return nil
@@ -426,22 +447,33 @@ func (l *LogLevelCommand) fetchPodLogs() error {
 
 	var podLogOptions *corev1.PodLogOptions
 	for _, container := range pod.Spec.Containers {
-		if container.Name == "consul-dataplane" {
+		if container.Name == sidecarContainerName {
 			podLogOptions = &corev1.PodLogOptions{
 				Container:    container.Name,
 				SinceSeconds: &sinceSeconds,
 				Timestamps:   true,
 			}
+			break
 		}
 	}
-	proxyLogFilePath := filepath.Join("proxy", fmt.Sprintf("proxy-log-%s.log", l.podName))
+	if podLogOptions == nil {
+		return fmt.Errorf("pod %q in namespace %q does not have a %q container; log capture is only supported for Consul-managed proxy sidecars", l.podName, l.namespace, sidecarContainerName)
+	}
+
+	// NOTE: output paths are relative to cwd /proxy only. Contents will be overwritten if
+	// the command is run multiple times for the same pod name or if the file already exists.
+	logFileName := fmt.Sprintf("proxy-log-%s.log", l.podName)
+	outputPath := filepath.Join("proxy", logFileName)
+	if l.output == outputArchive {
+		outputPath = filepath.Join("proxy", fmt.Sprintf("proxy-log-%s.zip", l.podName))
+	}
 
 	// metadata of log capture
 	l.UI.Output("Pod Name:             %s", pod.Name)
 	l.UI.Output("Container Name:       %s", podLogOptions.Container)
 	l.UI.Output("Namespace:            %s", pod.Namespace)
 	l.UI.Output("Log Capture Duration: %s", l.capture)
-	l.UI.Output("Log File Path:        %s", proxyLogFilePath)
+	l.UI.Output("Log File Path:        %s", outputPath)
 
 	durationChn := time.After(l.capture)
 	select {
@@ -450,20 +482,43 @@ func (l *LogLevelCommand) fetchPodLogs() error {
 		if err != nil {
 			return err
 		}
-		// Create file path and directory for storing logs
-		// NOTE: currently it is writing log file in cwd /proxy only. Also, log file contents will be overwritten if
-		// the command is run multiple times for the same pod name or if file already exists.
-		if err := os.MkdirAll(filepath.Dir(proxyLogFilePath), dirPermission); err != nil {
+
+		if err := os.MkdirAll(filepath.Dir(outputPath), dirPermission); err != nil {
 			return fmt.Errorf("error creating directory for log file: %w", err)
 		}
-		if err := os.WriteFile(proxyLogFilePath, logs, filePermission); err != nil {
+
+		if l.output == outputArchive {
+			if err := writeLogArchive(outputPath, logFileName, logs); err != nil {
+				return err
+			}
+		} else if err := os.WriteFile(outputPath, logs, filePermission); err != nil {
 			return fmt.Errorf("error writing log to file: %v", err)
 		}
-		l.UI.Output("Logs saved to '%s'", proxyLogFilePath, terminal.WithSuccessStyle())
+
+		l.UI.Output("Logs saved to '%s'", outputPath, terminal.WithSuccessStyle())
 		return nil
 	case <-l.Ctx.Done():
 		return fmt.Errorf("stopping collection due to shutdown signal received")
 	}
+}
+
+// writeLogArchive writes logs as a single entry named entryName into a new zip file at archivePath.
+func writeLogArchive(archivePath, entryName string, logs []byte) error {
+	f, err := os.Create(archivePath)
+	if err != nil {
+		return fmt.Errorf("error creating archive file: %w", err)
+	}
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+	entry, err := zw.Create(entryName)
+	if err != nil {
+		return fmt.Errorf("error creating archive entry: %w", err)
+	}
+	if _, err := entry.Write(logs); err != nil {
+		return fmt.Errorf("error writing archive entry: %w", err)
+	}
+	return zw.Close()
 }
 func (l *LogLevelCommand) getLogs(ctx context.Context, pod *corev1.Pod, podLogOptions *corev1.PodLogOptions) ([]byte, error) {
 	podLogRequest := l.kubernetes.CoreV1().Pods(l.namespace).GetLogs(pod.Name, podLogOptions)
@@ -539,6 +594,7 @@ func (l *LogLevelCommand) AutocompleteFlags() complete.Flags {
 		fmt.Sprintf("-%s", flagNameCapture):     complete.PredictAnything,
 		fmt.Sprintf("-%s", flagNameUpdateLevel): complete.PredictAnything,
 		fmt.Sprintf("-%s", flagNameReset):       complete.PredictNothing,
+		fmt.Sprintf("-%s", flagNameOutput):      complete.PredictNothing,
 		fmt.Sprintf("-%s", flagNameKubeConfig):  complete.PredictFiles("*"),
 		fmt.Sprintf("-%s", flagNameKubeContext): complete.PredictNothing,
 	}

--- a/cli/cmd/proxy/loglevel/command_test.go
+++ b/cli/cmd/proxy/loglevel/command_test.go
@@ -4,6 +4,7 @@
 package loglevel
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
 	"flag"
@@ -66,6 +67,10 @@ func TestFlagParsingFails(t *testing.T) {
 		},
 		"Invalid logger passed, -u newlogger": {
 			args: []string{podName, "-u", "newlogger:info"},
+			out:  1,
+		},
+		"Invalid output arg passed, -output foo": {
+			args: []string{podName, "-output", "foo"},
 			out:  1,
 		},
 	}
@@ -341,6 +346,97 @@ func TestLogCaptureWithNewLogLevels(t *testing.T) {
 	require.NoError(t, err, "expected to read the output file, but got an error")
 	require.Equal(t, expectedFileContent, string(actualFileContent), "log file content did not match expected content")
 }
+func TestLogCaptureWithArchiveOutput(t *testing.T) {
+	tempDir := t.TempDir()
+	originalWD, err := os.Getwd()
+	require.NoError(t, err)
+	err = os.Chdir(tempDir)
+	require.NoError(t, err)
+	defer os.Chdir(originalWD)
+
+	podName := "now-this-is-pod-racing"
+	fakePod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: "default",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "consul-dataplane",
+				},
+			},
+		},
+	}
+	buf := bytes.NewBuffer([]byte{})
+	c := setupCommand(buf)
+	c.Ctx = context.Background()
+	c.kubernetes = fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{fakePod}})
+	expectedLogContent := "2023-09-19T10:15:30Z INFO Sample log entry\n2023-09-19T10:15:31Z DEBUG Another log entry"
+	c.getLogFunc = func(ctx context.Context, pod *corev1.Pod, podLogOptions *corev1.PodLogOptions) ([]byte, error) {
+		return []byte(expectedLogContent), nil
+	}
+	duration := "30s"
+	args := []string{podName, "-capture", duration, "-output", "archive"}
+	out := c.Run(args)
+	require.Equal(t, 0, out)
+
+	expectedArchivePath := filepath.Join(tempDir, "proxy", "proxy-log-"+podName+".zip")
+	_, err = os.Stat(expectedArchivePath)
+	require.NoError(t, err, "expected archive to be created, but it was not")
+
+	zr, err := zip.OpenReader(expectedArchivePath)
+	require.NoError(t, err)
+	defer zr.Close()
+
+	require.Len(t, zr.File, 1)
+	require.Equal(t, "proxy-log-"+podName+".log", zr.File[0].Name)
+
+	rc, err := zr.File[0].Open()
+	require.NoError(t, err)
+	defer rc.Close()
+
+	content, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, expectedLogContent, string(content))
+}
+
+func TestLogCaptureFailsWithoutDataplaneContainer(t *testing.T) {
+	tempDir := t.TempDir()
+	originalWD, err := os.Getwd()
+	require.NoError(t, err)
+	err = os.Chdir(tempDir)
+	require.NoError(t, err)
+	defer os.Chdir(originalWD)
+
+	podName := "now-this-is-pod-racing"
+	fakePod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: "default",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "some-app-container",
+				},
+			},
+		},
+	}
+	buf := bytes.NewBuffer([]byte{})
+	c := setupCommand(buf)
+	c.Ctx = context.Background()
+	c.kubernetes = fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{fakePod}})
+
+	duration := "30s"
+	args := []string{podName, "-capture", duration}
+	out := c.Run(args)
+	require.Equal(t, 1, out)
+
+	_, err = os.Stat(filepath.Join(tempDir, "proxy", "proxy-log-"+podName+".log"))
+	require.True(t, os.IsNotExist(err), "expected no log file to be created")
+}
+
 func TestHelp(t *testing.T) {
 	t.Parallel()
 	buf := bytes.NewBuffer([]byte{})


### PR DESCRIPTION
Adds a -output flag (file/archive) to `consul-k8s proxy log` so captured logs can be bundled into a zip, and fixes a nil-pointer panic when a pod has no consul-dataplane container by returning a clear error instead.

### Changes proposed in this PR ###  
-
-

### How I've tested this PR ###


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
