### PR TITLE
fix(helm): only create server cluster scope RBAC when necessary

### DIFF
--- a/.changelog/5582.txt
+++ b/.changelog/5582.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+helm: Only create server clusterrole/binding when server or global is enabled.
+```

--- a/charts/consul/templates/server-clusterrole.yaml
+++ b/charts/consul/templates/server-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -14,3 +15,4 @@ rules:
   resources: ["nodes"]
   verbs:
   - get
+{{- end }}

--- a/charts/consul/templates/server-clusterrolebinding.yaml
+++ b/charts/consul/templates/server-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if (or (and (ne (.Values.server.enabled | toString) "-") .Values.server.enabled) (and (eq (.Values.server.enabled | toString) "-") .Values.global.enabled)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -16,3 +17,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "consul.fullname" . }}-server
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/consul/test/unit/server-clusterrole.bats
+++ b/charts/consul/test/unit/server-clusterrole.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "server/ClusterRole: enabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-clusterrole.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/ClusterRole: disabled with global.enabled=false" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/server-clusterrole.yaml  \
+      --set 'global.enabled=false' \
+      .
+}
+
+@test "server/ClusterRole: disabled with server disabled" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/server-clusterrole.yaml  \
+      --set 'server.enabled=false' \
+      .
+}
+
+@test "server/ClusterRole: enabled with server enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-clusterrole.yaml  \
+      --set 'server.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/ClusterRole: enabled with server enabled and global.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-clusterrole.yaml  \
+      --set 'global.enabled=false' \
+      --set 'server.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/charts/consul/test/unit/server-clusterrolebinding.bats
+++ b/charts/consul/test/unit/server-clusterrolebinding.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "server/ClusterRoleBinding: enabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-clusterrolebinding.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/ClusterRoleBinding: disabled with global.enabled=false" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/server-clusterrolebinding.yaml  \
+      --set 'global.enabled=false' \
+      .
+}
+
+@test "server/ClusterRoleBinding: disabled with server disabled" {
+  cd `chart_dir`
+  assert_empty helm template \
+      -s templates/server-clusterrolebinding.yaml  \
+      --set 'server.enabled=false' \
+      .
+}
+
+@test "server/ClusterRoleBinding: enabled with server enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-clusterrolebinding.yaml  \
+      --set 'server.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/ClusterRoleBinding: enabled with server enabled and global.enabled=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-clusterrolebinding.yaml  \
+      --set 'global.enabled=false' \
+      --set 'server.enabled=true' \
+      . | tee /dev/stderr |
+      yq -s 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}


### PR DESCRIPTION
### Changes proposed in this PR ###  

Currently cluster scope RBAC is created even when matching service account is not.
Apply same condition to server clusterrole/binding than role/binding.

### How I've tested this PR ###

bats unit tests and chart deployment

### How I expect reviewers to test this PR ###

using bats and helm install

### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
