### PR TITLE
fix(helm): do not expose client GRPC port when disabled

### DIFF
--- a/charts/consul/templates/client-daemonset.yaml
+++ b/charts/consul/templates/client-daemonset.yaml
@@ -451,9 +451,11 @@ spec:
               hostPort: 8501
               name: https
             {{- end }}
+            {{- if .Values.client.grpc }}
             - containerPort: 8502
               hostPort: 8502
               name: grpc
+            {{- end }}
             - containerPort: 8301
               {{- if .Values.client.exposeGossipPorts }}
               hostPort: 8301

--- a/charts/consul/test/unit/client-daemonset.bats
+++ b/charts/consul/test/unit/client-daemonset.bats
@@ -164,6 +164,27 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "client/DaemonSet: grpc port 8502 is exposed by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'client.enabled=true' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[] | select(.name=="consul") | .ports[] | select(.name=="grpc")] | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "client/DaemonSet: grpc port 8502 is not exposed when client.grpc=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/client-daemonset.yaml  \
+      --set 'client.enabled=true' \
+      --set 'client.grpc=false' \
+      . | tee /dev/stderr |
+      yq '[.spec.template.spec.containers[] | select(.name=="consul") | .ports[] | select(.containerPort==8502)] | length' | tee /dev/stderr)
+  [ "${actual}" = "0" ]
+}
+
 #--------------------------------------------------------------------
 # nodeMeta
 


### PR DESCRIPTION
### Changes proposed in this PR ###  

Consistency fix, and also work around conflict when server and client are running on same node with server.exposeGossipAndRPCPorts

### How I've tested this PR ###

bats unit tests and chart deployment

### How I expect reviewers to test this PR ###

using bats and helm install

### Checklist ###
- [x] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
