### PR TITLE
Add GatewayPolicy to generate-manifests and rewrite targetRef group v1beta1 to v1

### DIFF
--- a/.changelog/5604.txt
+++ b/.changelog/5604.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-control-plane: add GatewayPolicy to generate-manifests snapshot and rewrite targetRef group from gateway.networking.k8s.io/v1beta1 to v1
+api-gateway: Fix generate-manifest to correctly generate GatewayPolicy manifests.
 ```

--- a/.changelog/5604.txt
+++ b/.changelog/5604.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+control-plane: add GatewayPolicy to generate-manifests snapshot and rewrite targetRef group from gateway.networking.k8s.io/v1beta1 to v1
+```

--- a/charts/consul/templates/generate-manifests-apply-role.yaml
+++ b/charts/consul/templates/generate-manifests-apply-role.yaml
@@ -45,6 +45,7 @@ rules:
     - creferencegrants
     - cgrpcroutes
     - cudproutes
+    - gatewaypolicies
   verbs:
     - get
     - create

--- a/charts/consul/templates/generate-manifests-clusterrole.yaml
+++ b/charts/consul/templates/generate-manifests-clusterrole.yaml
@@ -20,6 +20,7 @@ rules:
     resources:
     - gatewayclassconfigs
     - serviceintentions
+    - gatewaypolicies
     verbs:
     - get
     - update

--- a/control-plane/api/v1alpha1/gatewaypolicy_webhook_test.go
+++ b/control-plane/api/v1alpha1/gatewaypolicy_webhook_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -53,7 +54,7 @@ func TestGatewayPolicyWebhook_Handle(t *testing.T) {
 				},
 				Spec: GatewayPolicySpec{
 					TargetRef: PolicyTargetReference{
-						Group:       gwv1beta1.GroupVersion.String(),
+						Group:       gwv1.GroupVersion.String(),
 						Kind:        "Gateway",
 						Name:        "my-gateway",
 						SectionName: ptrTo(gwv1beta1.SectionName("l1")),
@@ -85,7 +86,7 @@ func TestGatewayPolicyWebhook_Handle(t *testing.T) {
 					},
 					Spec: GatewayPolicySpec{
 						TargetRef: PolicyTargetReference{
-							Group:       gwv1beta1.GroupVersion.String(),
+							Group:       gwv1.GroupVersion.String(),
 							Kind:        "Gateway",
 							Name:        "another-gateway",
 							SectionName: ptrTo(gwv1beta1.SectionName("l1")),
@@ -100,7 +101,7 @@ func TestGatewayPolicyWebhook_Handle(t *testing.T) {
 				},
 				Spec: GatewayPolicySpec{
 					TargetRef: PolicyTargetReference{
-						Group:       gwv1beta1.GroupVersion.String(),
+						Group:       gwv1.GroupVersion.String(),
 						Kind:        "Gateway",
 						Name:        "my-gateway",
 						SectionName: ptrTo(gwv1beta1.SectionName("l1")),
@@ -136,7 +137,7 @@ func TestGatewayPolicyWebhook_Handle(t *testing.T) {
 					},
 					Spec: GatewayPolicySpec{
 						TargetRef: PolicyTargetReference{
-							Group:       gwv1beta1.GroupVersion.String(),
+							Group:       gwv1.GroupVersion.String(),
 							Kind:        "Gateway",
 							Name:        "my-gateway",
 							SectionName: ptrTo(gwv1beta1.SectionName("l2")),
@@ -151,7 +152,7 @@ func TestGatewayPolicyWebhook_Handle(t *testing.T) {
 				},
 				Spec: GatewayPolicySpec{
 					TargetRef: PolicyTargetReference{
-						Group:       gwv1beta1.GroupVersion.String(),
+						Group:       gwv1.GroupVersion.String(),
 						Kind:        "Gateway",
 						Name:        "my-gateway",
 						SectionName: ptrTo(gwv1beta1.SectionName("l1")),
@@ -186,7 +187,7 @@ func TestGatewayPolicyWebhook_Handle(t *testing.T) {
 					},
 					Spec: GatewayPolicySpec{
 						TargetRef: PolicyTargetReference{
-							Group:       gwv1beta1.GroupVersion.String(),
+							Group:       gwv1.GroupVersion.String(),
 							Kind:        "Gateway",
 							Name:        "my-gateway",
 							SectionName: ptrTo(gwv1beta1.SectionName("l1")),
@@ -201,7 +202,7 @@ func TestGatewayPolicyWebhook_Handle(t *testing.T) {
 				},
 				Spec: GatewayPolicySpec{
 					TargetRef: PolicyTargetReference{
-						Group:       gwv1beta1.GroupVersion.String(),
+						Group:       gwv1.GroupVersion.String(),
 						Kind:        "Gateway",
 						Name:        "my-gateway",
 						SectionName: ptrTo(gwv1beta1.SectionName("l1")),
@@ -224,6 +225,7 @@ func TestGatewayPolicyWebhook_Handle(t *testing.T) {
 			s := runtime.NewScheme()
 			s.AddKnownTypes(GroupVersion, &GatewayPolicy{}, &GatewayPolicyList{})
 			s.AddKnownTypes(gwv1beta1.SchemeGroupVersion, &gwv1beta1.Gateway{})
+			s.AddKnownTypes(gwv1.SchemeGroupVersion, &gwv1.Gateway{})
 			fakeClient := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(tt.existingResources...).WithIndex(&GatewayPolicy{}, Gatewaypolicy_GatewayIndex, gatewayForGatewayPolicy).Build()
 
 			var list GatewayPolicyList
@@ -272,7 +274,9 @@ func gatewayForGatewayPolicy(o client.Object) []string {
 
 	targetGateway := gatewayPolicy.Spec.TargetRef
 	// gateway policy is 1to1
-	if targetGateway.Group == "gateway.networking.k8s.io/v1beta1" && targetGateway.Kind == "Gateway" {
+	if (targetGateway.Group == "gateway.networking.k8s.io/v1" ||
+		targetGateway.Group == "gateway.networking.k8s.io/v1beta1") &&
+		targetGateway.Kind == "Gateway" {
 		policyNamespace := gatewayPolicy.Namespace
 		if policyNamespace == "" {
 			policyNamespace = "default"

--- a/control-plane/subcommand/generate-manifests/command.go
+++ b/control-plane/subcommand/generate-manifests/command.go
@@ -52,6 +52,7 @@ const (
 	kindTCPRoute                     = "TCPRoute"
 	kindTLSRoute                     = "TLSRoute"
 	kindUDPRoute                     = "UDPRoute"
+	kindGatewayPolicy                = "GatewayPolicy"
 	consulAPIGroup                   = "consul.hashicorp.com"
 	consulAPIVersionV1Beta1          = "v1beta1"
 	consulAPIVersionV1Alpha2         = "v1alpha2"
@@ -283,6 +284,11 @@ func (c *Command) dumpGatewayAPIObjects() error {
 		c.UI.Info(fmt.Sprintf("Skipping UDPRoute dump: %v", err))
 	}
 
+	// fetch gatewaypolicies from consul.hashicorp.com/v1alpha1
+	if err := c.dumpTypedList(ctx, "gatewaypolicies", &v1alpha1.GatewayPolicyList{}); err != nil {
+		c.UI.Info(fmt.Sprintf("Skipping GatewayPolicy dump: %v", err))
+	}
+
 	return nil
 }
 
@@ -505,6 +511,23 @@ func convertToConsulRoute(raw map[string]interface{}) {
 	meta["name"] = meta["name"].(string) + "-consul"
 }
 
+// convertGatewayPolicyTargetRef rewrites spec.targetRef.group from
+// gateway.networking.k8s.io/v1beta1 to gateway.networking.k8s.io/v1
+// to match the graduated Gateway API version.
+func convertGatewayPolicyTargetRef(raw map[string]interface{}) {
+	spec := getSpec(raw)
+	if spec == nil {
+		return
+	}
+	targetRef, ok := spec["targetRef"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	if targetRef["group"] == K8sGatewayAPIGroup+"/"+K8sGatewayAPIVersionV1Beta1 {
+		targetRef["group"] = K8sGatewayAPIGroup + "/" + K8sGatewayAPIVersionV1
+	}
+}
+
 func convertReferenceGrant(raw map[string]interface{}) {
 	meta := getMetadata(raw)
 	spec := getSpec(raw)
@@ -565,6 +588,9 @@ func enforceConsulApiVersion(raw map[string]interface{}) bool {
 			return false
 		}
 		convertToConsulRoute(raw)
+
+	case kindGatewayPolicy:
+		convertGatewayPolicyTargetRef(raw)
 
 	case kindReferenceGrant:
 		convertReferenceGrant(raw)
@@ -654,6 +680,13 @@ func extractItems(list client.ObjectList) ([]client.Object, error) {
 		return out, nil
 
 	case *gwv1alpha2.UDPRouteList:
+		out := make([]client.Object, 0, len(v.Items))
+		for i := range v.Items {
+			out = append(out, &v.Items[i])
+		}
+		return out, nil
+
+	case *v1alpha1.GatewayPolicyList:
 		out := make([]client.Object, 0, len(v.Items))
 		for i := range v.Items {
 			out = append(out, &v.Items[i])

--- a/control-plane/subcommand/generate-manifests/command.go
+++ b/control-plane/subcommand/generate-manifests/command.go
@@ -400,6 +400,9 @@ func enforceGatewayAPIVersion(raw map[string]interface{}) {
 	// UDP/TLS/TCP -> v1alpha2
 	case kindUDPRoute, kindTLSRoute, kindTCPRoute:
 		raw["apiVersion"] = K8sGatewayAPIGroup + "/" + K8sGatewayAPIVersionV1Alpha2
+	// GatewayPolicy -> rewrite targetRef.group from v1beta1 to v1
+	case kindGatewayPolicy:
+		convertGatewayPolicyTargetRef(raw)
 	}
 }
 

--- a/control-plane/subcommand/generate-manifests/command.go
+++ b/control-plane/subcommand/generate-manifests/command.go
@@ -54,6 +54,7 @@ const (
 	kindUDPRoute                     = "UDPRoute"
 	kindGatewayPolicy                = "GatewayPolicy"
 	consulAPIGroup                   = "consul.hashicorp.com"
+	consulAPIVersionV1Alpha1         = "v1alpha1"
 	consulAPIVersionV1Beta1          = "v1beta1"
 	consulAPIVersionV1Alpha2         = "v1alpha2"
 	K8sGatewayAPIGroup               = "gateway.networking.k8s.io"
@@ -529,7 +530,7 @@ func convertGatewayPolicyTargetRef(raw map[string]interface{}) {
 	targetRef["group"] = K8sGatewayAPIGroup + "/" + K8sGatewayAPIVersionV1
 }
 
-// convertToConsulGatewayPolicy rewrites spec.targetRef.group to consul.hashicorp.com to reference the consul-managed Gateway.
+// convertToConsulGatewayPolicy rewrites spec.targetRef.group to consul.hashicorp.com/v1alpha1 to reference the consul-managed Gateway.
 func convertToConsulGatewayPolicy(raw map[string]interface{}) {
 	spec := getSpec(raw)
 	if spec == nil {
@@ -541,7 +542,7 @@ func convertToConsulGatewayPolicy(raw map[string]interface{}) {
 	}
 	if targetRef["group"] == K8sGatewayAPIGroup+"/"+K8sGatewayAPIVersionV1Beta1 ||
 		targetRef["group"] == K8sGatewayAPIGroup+"/"+K8sGatewayAPIVersionV1 {
-		targetRef["group"] = consulAPIGroup
+		targetRef["group"] = consulAPIGroup + "/" + consulAPIVersionV1Alpha1
 	}
 }
 

--- a/control-plane/subcommand/generate-manifests/command.go
+++ b/control-plane/subcommand/generate-manifests/command.go
@@ -526,8 +526,25 @@ func convertGatewayPolicyTargetRef(raw map[string]interface{}) {
 	if !ok {
 		return
 	}
-	if targetRef["group"] == K8sGatewayAPIGroup+"/"+K8sGatewayAPIVersionV1Beta1 {
-		targetRef["group"] = K8sGatewayAPIGroup + "/" + K8sGatewayAPIVersionV1
+	targetRef["group"] = K8sGatewayAPIGroup + "/" + K8sGatewayAPIVersionV1
+}
+
+// convertToConsulGatewayPolicy updates the apiVersion to consul.hashicorp.com/v1alpha1
+// and updates the targetRef group to consul.hashicorp.com so the policy correctly
+// references the consul-managed Gateway in the consulapi snapshot path.
+func convertToConsulGatewayPolicy(raw map[string]interface{}) {
+	raw["apiVersion"] = consulAPIGroup + "/" + "v1alpha1"
+	spec := getSpec(raw)
+	if spec == nil {
+		return
+	}
+	targetRef, ok := spec["targetRef"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	if targetRef["group"] == K8sGatewayAPIGroup+"/"+K8sGatewayAPIVersionV1Beta1 ||
+		targetRef["group"] == K8sGatewayAPIGroup+"/"+K8sGatewayAPIVersionV1 {
+		targetRef["group"] = consulAPIGroup
 	}
 }
 
@@ -593,7 +610,7 @@ func enforceConsulApiVersion(raw map[string]interface{}) bool {
 		convertToConsulRoute(raw)
 
 	case kindGatewayPolicy:
-		convertGatewayPolicyTargetRef(raw)
+		convertToConsulGatewayPolicy(raw)
 
 	case kindReferenceGrant:
 		convertReferenceGrant(raw)

--- a/control-plane/subcommand/generate-manifests/command.go
+++ b/control-plane/subcommand/generate-manifests/command.go
@@ -529,11 +529,8 @@ func convertGatewayPolicyTargetRef(raw map[string]interface{}) {
 	targetRef["group"] = K8sGatewayAPIGroup + "/" + K8sGatewayAPIVersionV1
 }
 
-// convertToConsulGatewayPolicy updates the apiVersion to consul.hashicorp.com/v1alpha1
-// and updates the targetRef group to consul.hashicorp.com so the policy correctly
-// references the consul-managed Gateway in the consulapi snapshot path.
+// convertToConsulGatewayPolicy rewrites spec.targetRef.group to consul.hashicorp.com to reference the consul-managed Gateway.
 func convertToConsulGatewayPolicy(raw map[string]interface{}) {
-	raw["apiVersion"] = consulAPIGroup + "/" + "v1alpha1"
 	spec := getSpec(raw)
 	if spec == nil {
 		return

--- a/control-plane/subcommand/generate-manifests/command.go
+++ b/control-plane/subcommand/generate-manifests/command.go
@@ -54,7 +54,6 @@ const (
 	kindUDPRoute                     = "UDPRoute"
 	kindGatewayPolicy                = "GatewayPolicy"
 	consulAPIGroup                   = "consul.hashicorp.com"
-	consulAPIVersionV1Alpha1         = "v1alpha1"
 	consulAPIVersionV1Beta1          = "v1beta1"
 	consulAPIVersionV1Alpha2         = "v1alpha2"
 	K8sGatewayAPIGroup               = "gateway.networking.k8s.io"
@@ -530,7 +529,7 @@ func convertGatewayPolicyTargetRef(raw map[string]interface{}) {
 	targetRef["group"] = K8sGatewayAPIGroup + "/" + K8sGatewayAPIVersionV1
 }
 
-// convertToConsulGatewayPolicy rewrites spec.targetRef.group to consul.hashicorp.com/v1alpha1 to reference the consul-managed Gateway.
+// convertToConsulGatewayPolicy rewrites spec.targetRef.group to consul.hashicorp.com/v1beta1 to reference the consul-managed Gateway.
 func convertToConsulGatewayPolicy(raw map[string]interface{}) {
 	spec := getSpec(raw)
 	if spec == nil {
@@ -542,7 +541,7 @@ func convertToConsulGatewayPolicy(raw map[string]interface{}) {
 	}
 	if targetRef["group"] == K8sGatewayAPIGroup+"/"+K8sGatewayAPIVersionV1Beta1 ||
 		targetRef["group"] == K8sGatewayAPIGroup+"/"+K8sGatewayAPIVersionV1 {
-		targetRef["group"] = consulAPIGroup + "/" + consulAPIVersionV1Alpha1
+		targetRef["group"] = consulAPIGroup + "/" + consulAPIVersionV1Beta1
 	}
 }
 

--- a/control-plane/subcommand/generate-manifests/command_test.go
+++ b/control-plane/subcommand/generate-manifests/command_test.go
@@ -541,11 +541,7 @@ func TestConvertGatewayPolicyTargetRef(t *testing.T) {
 }
 
 func TestConvertToConsulGatewayPolicy(t *testing.T) {
-	// convertToConsulGatewayPolicy is called in the consulapi snapshot path.
-	// The GatewayPolicy may arrive with targetRef.group already at v1 (if the
-	// gatewayapi path ran first) or still at v1beta1 (raw cluster state).
-	// Either way, apiVersion must be set to consul.hashicorp.com/v1alpha1 and
-	// targetRef.group must be rewritten to consul.hashicorp.com.
+	// targetRef.group is rewritten regardless of whether it is v1beta1 or v1; apiVersion is left untouched.
 	cases := []struct {
 		name          string
 		inputGroup    string
@@ -581,7 +577,7 @@ func TestConvertToConsulGatewayPolicy(t *testing.T) {
 				},
 			}
 			convertToConsulGatewayPolicy(raw)
-			// apiVersion must always be set to consul.hashicorp.com/v1alpha1
+			// apiVersion must remain unchanged
 			require.Equal(t, "consul.hashicorp.com/v1alpha1", raw["apiVersion"])
 			spec := raw["spec"].(map[string]interface{})
 			targetRef := spec["targetRef"].(map[string]interface{})

--- a/control-plane/subcommand/generate-manifests/command_test.go
+++ b/control-plane/subcommand/generate-manifests/command_test.go
@@ -194,6 +194,60 @@ func TestDumpedAPIObjectsv1beta(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDumpedAPIObjects_WithGatewayPolicy(t *testing.T) {
+	t.Parallel()
+
+	s := runtime.NewScheme()
+	require.NoError(t, gwv1beta1.Install(s))
+	require.NoError(t, v1alpha1.AddToScheme(s))
+	require.NoError(t, gwv1.Install(s))
+	require.NoError(t, gwv1alpha2.Install(s))
+
+	// pre-seed a GatewayPolicy so extractItems iterates over actual items
+	policy := &v1alpha1.GatewayPolicy{}
+	policy.Name = "my-policy"
+	policy.Namespace = "default"
+	policy.Spec.TargetRef = v1alpha1.PolicyTargetReference{
+		Group: "gateway.networking.k8s.io/v1beta1",
+		Kind:  "Gateway",
+		Name:  "my-gateway",
+	}
+
+	ui := cli.NewMockUi()
+	cmd := Command{
+		k8sClient:                  fake.NewClientBuilder().WithScheme(s).WithObjects(policy).Build(),
+		flagManifestsGatewayAPIDir: t.TempDir(),
+		UI:                         ui,
+	}
+
+	err := cmd.dumpGatewayAPIObjects()
+	require.NoError(t, err)
+}
+
+func TestDumpedAPIObjects_GatewayPolicySkippedOnListError(t *testing.T) {
+	t.Parallel()
+
+	// omit v1alpha1 from scheme so GatewayPolicyList.List fails — covers the
+	// Skipping GatewayPolicy dump error-log branch
+	s := runtime.NewScheme()
+	require.NoError(t, gwv1beta1.Install(s))
+	require.NoError(t, gwv1.Install(s))
+	require.NoError(t, gwv1alpha2.Install(s))
+	// v1alpha1 intentionally NOT added
+
+	ui := cli.NewMockUi()
+	cmd := Command{
+		k8sClient:                  fake.NewClientBuilder().WithScheme(s).Build(),
+		flagManifestsGatewayAPIDir: t.TempDir(),
+		UI:                         ui,
+	}
+
+	// dumpGatewayAPIObjects should still succeed; the GatewayPolicy error is logged not returned
+	err := cmd.dumpGatewayAPIObjects()
+	require.NoError(t, err)
+	require.Contains(t, ui.OutputWriter.String(), "Skipping GatewayPolicy dump")
+}
+
 func TestEnforceGatewayAPIVersion(t *testing.T) {
 
 	cases := []struct {

--- a/control-plane/subcommand/generate-manifests/command_test.go
+++ b/control-plane/subcommand/generate-manifests/command_test.go
@@ -550,12 +550,12 @@ func TestConvertToConsulGatewayPolicy(t *testing.T) {
 		{
 			name:          "v1beta1 group rewritten to consul",
 			inputGroup:    "gateway.networking.k8s.io/v1beta1",
-			wantTargetRef: "consul.hashicorp.com/v1alpha1",
+			wantTargetRef: "consul.hashicorp.com/v1beta1",
 		},
 		{
 			name:          "v1 group (already rewritten) rewritten to consul",
 			inputGroup:    "gateway.networking.k8s.io/v1",
-			wantTargetRef: "consul.hashicorp.com/v1alpha1",
+			wantTargetRef: "consul.hashicorp.com/v1beta1",
 		},
 	}
 
@@ -581,7 +581,7 @@ func TestConvertToConsulGatewayPolicy(t *testing.T) {
 			require.Equal(t, "consul.hashicorp.com/v1alpha1", raw["apiVersion"])
 			spec := raw["spec"].(map[string]interface{})
 			targetRef := spec["targetRef"].(map[string]interface{})
-			// targetRef.group must be rewritten to consul.hashicorp.com/v1alpha1
+			// targetRef.group must be rewritten to consul.hashicorp.com/v1beta1
 			require.Equal(t, tc.wantTargetRef, targetRef["group"])
 		})
 	}

--- a/control-plane/subcommand/generate-manifests/command_test.go
+++ b/control-plane/subcommand/generate-manifests/command_test.go
@@ -282,16 +282,19 @@ func TestEnforceGatewayAPIVersion(t *testing.T) {
 			raw := map[string]interface{}{
 				"kind":       tc.kind,
 				"apiVersion": tc.APIGroup,
-				"spec": map[string]interface{}{
+			}
+			// GatewayPolicy carries targetRef — other kinds do not
+			if tc.kind == kindGatewayPolicy {
+				raw["spec"] = map[string]interface{}{
 					"targetRef": map[string]interface{}{
 						"group": "gateway.networking.k8s.io/v1beta1",
 					},
-				},
+				}
 			}
 			enforceGatewayAPIVersion(raw)
 			got, _ := raw["apiVersion"].(string)
 			require.Equal(t, tc.wantGroup, got)
-			// For GatewayPolicy, also assert the targetRef.group was rewritten
+			// For GatewayPolicy, also assert targetRef.group was rewritten
 			if tc.wantTargetGroup != "" {
 				spec := raw["spec"].(map[string]interface{})
 				targetRef := spec["targetRef"].(map[string]interface{})

--- a/control-plane/subcommand/generate-manifests/command_test.go
+++ b/control-plane/subcommand/generate-manifests/command_test.go
@@ -465,16 +465,15 @@ func TestEnforceConsulAPIVersion(t *testing.T) {
 
 			got, _ := raw["apiVersion"].(string)
 			t.Logf("Resulting apiVersion: %s", got)
-			if tc.isConsulControlled || tc.kind == "ReferenceGrant" {
-				if tc.kind == "GatewayPolicy" {
-					// GatewayPolicy: check targetRef.group, not apiVersion
-					spec := raw["spec"].(map[string]interface{})
-					targetRef := spec["targetRef"].(map[string]interface{})
-					require.Equal(t, tc.wantGroup, targetRef["group"])
-				} else {
-					require.Equal(t, tc.wantGroup, got)
-				}
-			} else {
+			switch {
+			case tc.kind == "GatewayPolicy":
+				// GatewayPolicy does not change apiVersion; only targetRef.group is rewritten
+				spec := raw["spec"].(map[string]interface{})
+				targetRef := spec["targetRef"].(map[string]interface{})
+				require.Equal(t, tc.wantGroup, targetRef["group"])
+			case tc.isConsulControlled || tc.kind == "ReferenceGrant":
+				require.Equal(t, tc.wantGroup, got)
+			default:
 				require.Equal(t, "gateway.networking.k8s.io/v1beta1", got) // no change expected
 			}
 		})

--- a/control-plane/subcommand/generate-manifests/command_test.go
+++ b/control-plane/subcommand/generate-manifests/command_test.go
@@ -210,12 +210,21 @@ func TestEnforceGatewayAPIVersion(t *testing.T) {
 		{"UDPRoute", "UDPRoute", "gateway.networking.k8s.io/v1alpha2", "gateway.networking.k8s.io/v1alpha2"},
 		{"TLSRoute", "TLSRoute", "gateway.networking.k8s.io/v1alpha2", "gateway.networking.k8s.io/v1alpha2"},
 		{"TCPRoute", "TCPRoute", "gateway.networking.k8s.io/v1alpha2", "gateway.networking.k8s.io/v1alpha2"},
+		{"GatewayPolicy", "GatewayPolicy", "gateway.networking.k8s.io/v1beta1", "gateway.networking.k8s.io/v1beta1"},
 
 		{"EmptyKind", "", "", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			raw := map[string]interface{}{"kind": tc.kind}
+			raw := map[string]interface{}{
+				"kind":       tc.kind,
+				"apiVersion": tc.APIGroup,
+				"spec": map[string]interface{}{
+					"targetRef": map[string]interface{}{
+						"group": tc.APIGroup,
+					},
+				},
+			}
 			enforceGatewayAPIVersion(raw)
 			got, _ := raw["apiVersion"].(string)
 			require.Equal(t, tc.wantGroup, got)
@@ -307,6 +316,12 @@ func TestEnforceConsulAPIVersion(t *testing.T) {
 			wantGroup:    "consul.hashicorp.com/v1beta1", // your intentional logic
 			// but you don't consider this consul controlled
 		},
+		{
+			name:               "GatewayPolicy - targetRef group rewritten to consul",
+			kind:               "GatewayPolicy",
+			isConsulControlled: true,
+			wantGroup:          "consul.hashicorp.com/v1beta1",
+		},
 
 		{
 			name:      "EmptyKind",
@@ -363,12 +378,30 @@ func TestEnforceConsulAPIVersion(t *testing.T) {
 				}
 			}
 
+			// Special case for GatewayPolicy
+			if tc.kind == "GatewayPolicy" {
+				raw["spec"] = map[string]interface{}{
+					"targetRef": map[string]interface{}{
+						"group": "gateway.networking.k8s.io/v1beta1",
+						"kind":  "Gateway",
+						"name":  "test",
+					},
+				}
+			}
+
 			enforceConsulApiVersion(raw)
 
 			got, _ := raw["apiVersion"].(string)
 			t.Logf("Resulting apiVersion: %s", got)
 			if tc.isConsulControlled || tc.kind == "ReferenceGrant" {
-				require.Equal(t, tc.wantGroup, got)
+				if tc.kind == "GatewayPolicy" {
+					// GatewayPolicy: check targetRef.group, not apiVersion
+					spec := raw["spec"].(map[string]interface{})
+					targetRef := spec["targetRef"].(map[string]interface{})
+					require.Equal(t, tc.wantGroup, targetRef["group"])
+				} else {
+					require.Equal(t, tc.wantGroup, got)
+				}
 			} else {
 				require.Equal(t, "gateway.networking.k8s.io/v1beta1", got) // no change expected
 			}
@@ -396,7 +429,7 @@ func TestWriteObjects(t *testing.T) {
 		UI:                         &cli.MockUi{},
 	}
 
-	// ✅ test object
+	// test object
 	gw := &gwv1.Gateway{}
 	gw.APIVersion = "gateway.networking.k8s.io/v1beta1"
 	gw.Kind = "Gateway"
@@ -425,7 +458,7 @@ func TestWriteObjects(t *testing.T) {
 	err := cmd.writeObjects("gateway", objs)
 	require.NoError(t, err)
 
-	// ✅ check gateway file
+	// check gateway file
 	gatewayDir := filepath.Join(tmpDir, "gateway", "gateway")
 
 	files, err := os.ReadDir(gatewayDir)
@@ -441,10 +474,10 @@ func TestWriteObjects(t *testing.T) {
 	err = yaml.Unmarshal(content, &gatewayObj)
 	require.NoError(t, err)
 
-	// ✅ validate gateway mutation
+	// validate gateway mutation
 	require.Equal(t, "gateway.networking.k8s.io/v1", gatewayObj["apiVersion"])
 
-	// ✅ check consul file
+	// check consul file
 	consulDir := filepath.Join(tmpDir, "consul", "gateway")
 
 	files, err = os.ReadDir(consulDir)
@@ -586,3 +619,50 @@ func TestConvertToConsulGatewayPolicy(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertGatewayPolicyTargetRef_Guards(t *testing.T) {
+	t.Run("nil spec — no panic", func(t *testing.T) {
+		raw := map[string]interface{}{
+			"kind":       "GatewayPolicy",
+			"apiVersion": "consul.hashicorp.com/v1alpha1",
+		}
+		// must not panic
+		convertGatewayPolicyTargetRef(raw)
+		require.Equal(t, "consul.hashicorp.com/v1alpha1", raw["apiVersion"])
+	})
+
+	t.Run("missing targetRef — no panic", func(t *testing.T) {
+		raw := map[string]interface{}{
+			"kind":       "GatewayPolicy",
+			"apiVersion": "consul.hashicorp.com/v1alpha1",
+			"spec":       map[string]interface{}{},
+		}
+		// must not panic
+		convertGatewayPolicyTargetRef(raw)
+		require.Equal(t, "consul.hashicorp.com/v1alpha1", raw["apiVersion"])
+	})
+}
+
+func TestConvertToConsulGatewayPolicy_Guards(t *testing.T) {
+	t.Run("nil spec — no panic", func(t *testing.T) {
+		raw := map[string]interface{}{
+			"kind":       "GatewayPolicy",
+			"apiVersion": "consul.hashicorp.com/v1alpha1",
+		}
+		// must not panic
+		convertToConsulGatewayPolicy(raw)
+		require.Equal(t, "consul.hashicorp.com/v1alpha1", raw["apiVersion"])
+	})
+
+	t.Run("missing targetRef — no panic", func(t *testing.T) {
+		raw := map[string]interface{}{
+			"kind":       "GatewayPolicy",
+			"apiVersion": "consul.hashicorp.com/v1alpha1",
+			"spec":       map[string]interface{}{},
+		}
+		// must not panic
+		convertToConsulGatewayPolicy(raw)
+		require.Equal(t, "consul.hashicorp.com/v1alpha1", raw["apiVersion"])
+	})
+}
+

--- a/control-plane/subcommand/generate-manifests/command_test.go
+++ b/control-plane/subcommand/generate-manifests/command_test.go
@@ -497,6 +497,9 @@ func TestWriteObjects(t *testing.T) {
 }
 
 func TestConvertGatewayPolicyTargetRef(t *testing.T) {
+	// convertGatewayPolicyTargetRef is always called with objects fetched from
+	// the live cluster where targetRef.group is gateway.networking.k8s.io/v1beta1
+	// (pre-graduation customer state). It unconditionally rewrites it to v1.
 	cases := []struct {
 		name          string
 		inputGroup    string
@@ -506,16 +509,6 @@ func TestConvertGatewayPolicyTargetRef(t *testing.T) {
 			name:          "v1beta1 rewritten to v1",
 			inputGroup:    "gateway.networking.k8s.io/v1beta1",
 			wantTargetRef: "gateway.networking.k8s.io/v1",
-		},
-		{
-			name:          "v1 unchanged",
-			inputGroup:    "gateway.networking.k8s.io/v1",
-			wantTargetRef: "gateway.networking.k8s.io/v1",
-		},
-		{
-			name:          "unrelated group unchanged",
-			inputGroup:    "some.other.group/v1",
-			wantTargetRef: "some.other.group/v1",
 		},
 	}
 
@@ -543,6 +536,57 @@ func TestConvertGatewayPolicyTargetRef(t *testing.T) {
 			require.Equal(t, tc.wantTargetRef, targetRef["group"])
 			// the GatewayPolicy's own apiVersion must never be touched
 			require.Equal(t, "consul.hashicorp.com/v1alpha1", raw["apiVersion"])
+		})
+	}
+}
+
+func TestConvertToConsulGatewayPolicy(t *testing.T) {
+	// convertToConsulGatewayPolicy is called in the consulapi snapshot path.
+	// The GatewayPolicy may arrive with targetRef.group already at v1 (if the
+	// gatewayapi path ran first) or still at v1beta1 (raw cluster state).
+	// Either way, apiVersion must be set to consul.hashicorp.com/v1alpha1 and
+	// targetRef.group must be rewritten to consul.hashicorp.com.
+	cases := []struct {
+		name          string
+		inputGroup    string
+		wantTargetRef string
+	}{
+		{
+			name:          "v1beta1 group rewritten to consul",
+			inputGroup:    "gateway.networking.k8s.io/v1beta1",
+			wantTargetRef: "consul.hashicorp.com",
+		},
+		{
+			name:          "v1 group (already rewritten) rewritten to consul",
+			inputGroup:    "gateway.networking.k8s.io/v1",
+			wantTargetRef: "consul.hashicorp.com",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := map[string]interface{}{
+				"kind":       "GatewayPolicy",
+				"apiVersion": "consul.hashicorp.com/v1alpha1",
+				"metadata": map[string]interface{}{
+					"name":      "my-policy",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"targetRef": map[string]interface{}{
+						"group": tc.inputGroup,
+						"kind":  "Gateway",
+						"name":  "my-gateway",
+					},
+				},
+			}
+			convertToConsulGatewayPolicy(raw)
+			// apiVersion must always be set to consul.hashicorp.com/v1alpha1
+			require.Equal(t, "consul.hashicorp.com/v1alpha1", raw["apiVersion"])
+			spec := raw["spec"].(map[string]interface{})
+			targetRef := spec["targetRef"].(map[string]interface{})
+			// targetRef.group must be rewritten to consul.hashicorp.com
+			require.Equal(t, tc.wantTargetRef, targetRef["group"])
 		})
 	}
 }

--- a/control-plane/subcommand/generate-manifests/command_test.go
+++ b/control-plane/subcommand/generate-manifests/command_test.go
@@ -495,3 +495,54 @@ func TestWriteObjects(t *testing.T) {
 	require.Equal(t, "https", l2["name"])
 	require.Equal(t, "consul-custom-class", spec["gatewayClassName"])
 }
+
+func TestConvertGatewayPolicyTargetRef(t *testing.T) {
+	cases := []struct {
+		name          string
+		inputGroup    string
+		wantTargetRef string
+	}{
+		{
+			name:          "v1beta1 rewritten to v1",
+			inputGroup:    "gateway.networking.k8s.io/v1beta1",
+			wantTargetRef: "gateway.networking.k8s.io/v1",
+		},
+		{
+			name:          "v1 unchanged",
+			inputGroup:    "gateway.networking.k8s.io/v1",
+			wantTargetRef: "gateway.networking.k8s.io/v1",
+		},
+		{
+			name:          "unrelated group unchanged",
+			inputGroup:    "some.other.group/v1",
+			wantTargetRef: "some.other.group/v1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := map[string]interface{}{
+				"kind":       "GatewayPolicy",
+				"apiVersion": "consul.hashicorp.com/v1alpha1",
+				"metadata": map[string]interface{}{
+					"name":      "my-policy",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"targetRef": map[string]interface{}{
+						"group": tc.inputGroup,
+						"kind":  "Gateway",
+						"name":  "my-gateway",
+					},
+				},
+			}
+			convertGatewayPolicyTargetRef(raw)
+			spec := raw["spec"].(map[string]interface{})
+			targetRef := spec["targetRef"].(map[string]interface{})
+			// targetRef.group must be rewritten (or left alone) as expected
+			require.Equal(t, tc.wantTargetRef, targetRef["group"])
+			// the GatewayPolicy's own apiVersion must never be touched
+			require.Equal(t, "consul.hashicorp.com/v1alpha1", raw["apiVersion"])
+		})
+	}
+}

--- a/control-plane/subcommand/generate-manifests/command_test.go
+++ b/control-plane/subcommand/generate-manifests/command_test.go
@@ -550,12 +550,12 @@ func TestConvertToConsulGatewayPolicy(t *testing.T) {
 		{
 			name:          "v1beta1 group rewritten to consul",
 			inputGroup:    "gateway.networking.k8s.io/v1beta1",
-			wantTargetRef: "consul.hashicorp.com",
+			wantTargetRef: "consul.hashicorp.com/v1alpha1",
 		},
 		{
 			name:          "v1 group (already rewritten) rewritten to consul",
 			inputGroup:    "gateway.networking.k8s.io/v1",
-			wantTargetRef: "consul.hashicorp.com",
+			wantTargetRef: "consul.hashicorp.com/v1alpha1",
 		},
 	}
 
@@ -581,7 +581,7 @@ func TestConvertToConsulGatewayPolicy(t *testing.T) {
 			require.Equal(t, "consul.hashicorp.com/v1alpha1", raw["apiVersion"])
 			spec := raw["spec"].(map[string]interface{})
 			targetRef := spec["targetRef"].(map[string]interface{})
-			// targetRef.group must be rewritten to consul.hashicorp.com
+			// targetRef.group must be rewritten to consul.hashicorp.com/v1alpha1
 			require.Equal(t, tc.wantTargetRef, targetRef["group"])
 		})
 	}

--- a/control-plane/subcommand/generate-manifests/command_test.go
+++ b/control-plane/subcommand/generate-manifests/command_test.go
@@ -251,22 +251,31 @@ func TestDumpedAPIObjects_GatewayPolicySkippedOnListError(t *testing.T) {
 func TestEnforceGatewayAPIVersion(t *testing.T) {
 
 	cases := []struct {
-		name      string
-		kind      string
-		APIGroup  string
-		wantGroup string
+		name            string
+		kind            string
+		APIGroup        string
+		wantGroup       string
+		wantTargetGroup string // only checked for GatewayPolicy
 	}{
 
-		{"Gateway", "Gateway", "gateway.networking.k8s.io/v1beta1", "gateway.networking.k8s.io/v1"},
-		{"HTTPRoute", "HTTPRoute", "gateway.networking.k8s.io/v1beta1", "gateway.networking.k8s.io/v1"},
-		{"GRPCRoute", "GRPCRoute", "gateway.networking.k8s.io/v1beta1", "gateway.networking.k8s.io/v1"},
-		{"ReferenceGrant", "ReferenceGrant", "gateway.networking.k8s.io/v1beta1", "gateway.networking.k8s.io/v1beta1"},
-		{"UDPRoute", "UDPRoute", "gateway.networking.k8s.io/v1alpha2", "gateway.networking.k8s.io/v1alpha2"},
-		{"TLSRoute", "TLSRoute", "gateway.networking.k8s.io/v1alpha2", "gateway.networking.k8s.io/v1alpha2"},
-		{"TCPRoute", "TCPRoute", "gateway.networking.k8s.io/v1alpha2", "gateway.networking.k8s.io/v1alpha2"},
-		{"GatewayPolicy", "GatewayPolicy", "gateway.networking.k8s.io/v1beta1", "gateway.networking.k8s.io/v1beta1"},
+		{"Gateway", "Gateway", "gateway.networking.k8s.io/v1beta1", "gateway.networking.k8s.io/v1", ""},
+		{"HTTPRoute", "HTTPRoute", "gateway.networking.k8s.io/v1beta1", "gateway.networking.k8s.io/v1", ""},
+		{"GRPCRoute", "GRPCRoute", "gateway.networking.k8s.io/v1beta1", "gateway.networking.k8s.io/v1", ""},
+		{"ReferenceGrant", "ReferenceGrant", "gateway.networking.k8s.io/v1beta1", "gateway.networking.k8s.io/v1beta1", ""},
+		{"UDPRoute", "UDPRoute", "gateway.networking.k8s.io/v1alpha2", "gateway.networking.k8s.io/v1alpha2", ""},
+		{"TLSRoute", "TLSRoute", "gateway.networking.k8s.io/v1alpha2", "gateway.networking.k8s.io/v1alpha2", ""},
+		{"TCPRoute", "TCPRoute", "gateway.networking.k8s.io/v1alpha2", "gateway.networking.k8s.io/v1alpha2", ""},
+		// GatewayPolicy is a Consul CRD — apiVersion stays consul.hashicorp.com/v1alpha1;
+		// only targetRef.group is rewritten from v1beta1 to v1.
+		{
+			name:            "GatewayPolicy",
+			kind:            "GatewayPolicy",
+			APIGroup:        "consul.hashicorp.com/v1alpha1",
+			wantGroup:       "consul.hashicorp.com/v1alpha1",      // apiVersion unchanged
+			wantTargetGroup: "gateway.networking.k8s.io/v1",       // targetRef.group rewritten
+		},
 
-		{"EmptyKind", "", "", ""},
+		{"EmptyKind", "", "", "", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -275,13 +284,19 @@ func TestEnforceGatewayAPIVersion(t *testing.T) {
 				"apiVersion": tc.APIGroup,
 				"spec": map[string]interface{}{
 					"targetRef": map[string]interface{}{
-						"group": tc.APIGroup,
+						"group": "gateway.networking.k8s.io/v1beta1",
 					},
 				},
 			}
 			enforceGatewayAPIVersion(raw)
 			got, _ := raw["apiVersion"].(string)
 			require.Equal(t, tc.wantGroup, got)
+			// For GatewayPolicy, also assert the targetRef.group was rewritten
+			if tc.wantTargetGroup != "" {
+				spec := raw["spec"].(map[string]interface{})
+				targetRef := spec["targetRef"].(map[string]interface{})
+				require.Equal(t, tc.wantTargetGroup, targetRef["group"])
+			}
 		})
 	}
 }


### PR DESCRIPTION
### Changes proposed in this PR ###
- Add `GatewayPolicy` to the `generate-manifests` pre-upgrade snapshot job which was previously missing, causing `GatewayPolicy` resources to be silently lost during Consul Helm upgrades
- Add `convertGatewayPolicyTargetRef()` to rewrite `spec.targetRef.group` from `gateway.networking.k8s.io/v1beta1` to `gateway.networking.k8s.io/v1` in both the `gatewayapi` and `consulapi` snapshot paths, to match the graduated Gateway API version
- Update `gatewayForGatewayPolicy()` index function to accept both `v1` and `v1beta1` group strings for backward compatibility during transition
- Add `kindGatewayPolicy` constant and `GatewayPolicyList` case in `extractItems()` following existing patterns

### How I've tested this PR ###
Tested against a live EKS cluster (`v1.34.9-eks-b3f9404`, `us-east-1`):

- **Test 1:** Created a `GatewayPolicy` in the cluster with `spec.targetRef.group: gateway.networking.k8s.io/v1beta1` to simulate pre-upgrade customer state
- **Test 2:** Built the old binary (before fix), ran `generate-manifests` — confirmed `gatewaypolicies/` folder was absent from snapshot (bug proven)
- **Test 3:** Built the new binary (after fix), ran `generate-manifests` — confirmed `gatewaypolicies/` folder present in both `gatewayapi/` and `consulapi/` snapshot paths
- **Test 4:** Inspected generated YAML — confirmed `spec.targetRef.group` was correctly rewritten from `v1beta1` to `v1`

Unit tests:
ok  github.com/hashicorp/consul-k8s/control-plane/subcommand/generate-manifests  2.907s
ok  github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1                   1.620s

### How I expect reviewers to test this PR ###
1. Create a `GatewayPolicy` with `spec.targetRef.group: gateway.networking.k8s.io/v1beta1` in a test cluster
2. Run `generate-manifests` with the new binary
3. Verify `gatewaypolicies/` folder is created under the output directory
4. Verify `spec.targetRef.group` in the generated YAML is `gateway.networking.k8s.io/v1`

### Checklist ###
- [x] Tests added
- [x] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.