### PR TITLE
adding target Consul version to hack/helm-reference-gen

### DIFF
--- a/hack/helm-reference-gen/main.go
+++ b/hack/helm-reference-gen/main.go
@@ -166,7 +166,29 @@ func main() {
 		fmt.Printf("no Consul version marked isLatest=true in %s; cannot continue: \n", versionMetadataPath)
 		os.Exit(1)
 	}
-	helmReferenceFile := filepath.Join(docsRepoPath, "content/consul", latestVersion, "content/docs/reference/k8s/helm.mdx")
+
+	// Be able to select the specific version for which we want to generate the Helm reference docs.
+	// If the CONSUL_VERSION env var is not set, default to JSON file latest version.
+	var selectedVersion string
+	envVarVersion, envVarPresent := os.LookupEnv("CONSUL_VERSION")
+	if !envVarPresent {
+		selectedVersion = latestVersion
+	} else {
+		// Verify that the selected version is present in the versionMetadata.json file.
+		for _, pv := range consulList {
+			if pv.Version == envVarVersion {
+				selectedVersion = envVarVersion
+				break
+			}
+		}
+		// If the selected version is not found in the json file, exit with an error.
+		if selectedVersion == "" {
+			fmt.Printf("CONSUL_VERSION %q not found in %s\n", envVarVersion, versionMetadataPath)
+			os.Exit(1)
+		}
+	}
+
+	helmReferenceFile := filepath.Join(docsRepoPath, "content/consul", selectedVersion, "content/docs/reference/k8s/helm.mdx")
 	helmReferenceBytes, err := os.ReadFile(helmReferenceFile)
 	if err != nil {
 		fmt.Println(err.Error())


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Added the `CONSUL_VERSION` parameter to _hack/helm-reference-gen_ that lets you target which Consul version are you generating a Helm Chart Values reference for.

### How I've tested this PR ###
I ran `make gen-helm-docs docsRepo=[...]`


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
