### PR TITLE
security: upgrade Python deps pymdown-extensions 10.0 → 11.0.1

### DIFF
--- a/.changelog/5609.txt
+++ b/.changelog/5609.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-Upgrade `pymdown-extensions` from `10.0` to `11.0.1` in `control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt` to resolve [GHSA-gm37-52c6-37mw](https://github.com/advisories/GHSA-gm37-52c6-37mw): exponential backtracking ReDoS in the `caret`, `tilde`, `betterem`, and `magiclink` inline processors, where a crafted Markdown input under 50 bytes can pin the rendering thread at 100% CPU indefinitely (CWE-1333, CVSS 7.5 High).
+Upgrade `pymdown-extensions` from `10.0` to `11.0.1` to resolve [GHSA-gm37-52c6-37mw](https://github.com/advisories/GHSA-gm37-52c6-37mw): exponential backtracking ReDoS in the `caret`, `tilde`, `betterem`, and `magiclink` inline processors, where a crafted Markdown input under 50 bytes can pin the rendering thread at 100% CPU indefinitely (CWE-1333, CVSS 7.5 High).
 ```

--- a/.changelog/5609.txt
+++ b/.changelog/5609.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Upgrade `pymdown-extensions` from `10.0` to `11.0.1` in `control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt` to resolve [GHSA-gm37-52c6-37mw](https://github.com/advisories/GHSA-gm37-52c6-37mw): exponential backtracking ReDoS in the `caret`, `tilde`, `betterem`, and `magiclink` inline processors, where a crafted Markdown input under 50 bytes can pin the rendering thread at 100% CPU indefinitely (CWE-1333, CVSS 7.5 High).
+```

--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/gruntwork-io/go-commons v0.8.0 // indirect
-	github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom v0.1.7 // indirect
+	github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom v0.1.8 // indirect
 	github.com/hashicorp/consul-k8s/version v0.0.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.16 // indirect

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -133,8 +133,8 @@ github.com/gruntwork-io/go-commons v0.8.0 h1:k/yypwrPqSeYHevLlEDmvmgQzcyTwrlZGRa
 github.com/gruntwork-io/go-commons v0.8.0/go.mod h1:gtp0yTtIBExIZp7vyIV9I0XQkVwiQZze678hvDXof78=
 github.com/gruntwork-io/terratest v0.46.7 h1:oqGPBBO87SEsvBYaA0R5xOq+Lm2Xc5dmFVfxEolfZeU=
 github.com/gruntwork-io/terratest v0.46.7/go.mod h1:6gI5MlLeyF+SLwqocA5GBzcTix+XiuxCy1BPwKuT+WM=
-github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom v0.1.7 h1:ANM2xKPVpOkszd+q/D3PGsp2vxRgMFIneFYX4tYcZ6A=
-github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom v0.1.7/go.mod h1:S7iNhVxysYBV07/4ltuVxOSHwgjLtCX5/3p5kHXpDQM=
+github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom v0.1.8 h1:X7zURhUqQ6MwBWMo9RVqeGqSOKRVASvQhyGRWUSE2Cw=
+github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom v0.1.8/go.mod h1:Wv+CIh2tteyGPdGErXtYyhGccaKOgMgTR1VztIGH13k=
 github.com/hashicorp/consul/api v1.34.4 h1:0U4YZ1Yp7K9WK9ex0gTJraFim26l02wCvsmf2ukalVE=
 github.com/hashicorp/consul/api v1.34.4/go.mod h1:vz5gBNeycefpAAVNVbLBFObUu3isju6EK8UVZjXSTWc=
 github.com/hashicorp/consul/sdk v0.18.1 h1:RDTeBvAeOveI2xI86sV+8WkaN7OkP4zz+cG3fOobDCM=

--- a/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
+++ b/control-plane/gateway07/gateway-api-0.7.1-custom/requirements.txt
@@ -17,7 +17,10 @@ mkdocs-redirects==1.2.0
 mkdocs-mermaid2-plugin==0.6.0
 pep562==1.1
 Pygments==2.15.1
-pymdown-extensions==10.0
+
+# pymdown-extensions 11.0.1 fixes GHSA-gm37-52c6-37mw: exponential ReDoS
+# in caret, tilde, betterem, and magiclink inline processors.
+pymdown-extensions==11.0.1
 PyYAML==6.0
 six==1.16.0
 # tornado 6.5.7 fixes GHSA-mgf9-4vpg-hj56 (CVE-2026-49855) gzip-bomb,

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/consul v0.4.1-0.20250919124332-fe5b36f5014c
 	github.com/hashicorp/consul-k8s/control-plane/cni v0.0.0-20260523165653-3434f0fecb66
-	github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom v0.1.7
+	github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom v0.1.8
 	github.com/hashicorp/consul-k8s/version v0.0.0
 	github.com/hashicorp/consul-server-connection-manager v0.1.12
 	github.com/hashicorp/consul/api v1.34.4

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -272,8 +272,8 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/consul v1.11.0-alpha.0.20260112121053-7ee7c79b61f0 h1:a14sOv/zObfDR4lSQebD9o9/6+Qy6yS56RpTQq+3P2A=
 github.com/hashicorp/consul v1.11.0-alpha.0.20260112121053-7ee7c79b61f0/go.mod h1:Q+SsUkHg8Gu+xuMku4nq+VHFYIT581yf8jOBBAW4bvc=
-github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom v0.1.7 h1:ANM2xKPVpOkszd+q/D3PGsp2vxRgMFIneFYX4tYcZ6A=
-github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom v0.1.7/go.mod h1:S7iNhVxysYBV07/4ltuVxOSHwgjLtCX5/3p5kHXpDQM=
+github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom v0.1.8 h1:X7zURhUqQ6MwBWMo9RVqeGqSOKRVASvQhyGRWUSE2Cw=
+github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom v0.1.8/go.mod h1:Wv+CIh2tteyGPdGErXtYyhGccaKOgMgTR1VztIGH13k=
 github.com/hashicorp/consul-server-connection-manager v0.1.12 h1:c/7LIghSdVqQKu4v9SPzxeHot0pphQ/FtRzzDlN3Vrg=
 github.com/hashicorp/consul-server-connection-manager v0.1.12/go.mod h1:f1x48hfZMLUTqdwBVPTezV43COWTixtnLmSbxjD0SHg=
 github.com/hashicorp/consul/api v1.34.4 h1:0U4YZ1Yp7K9WK9ex0gTJraFim26l02wCvsmf2ukalVE=


### PR DESCRIPTION
### Changes proposed in this PR ###  
- updated pymdown-extensions version from 10.0 → 11.0.1 
-

the pymdown-extensions ReDoS finding in the gateway07 requirements.txt. 

Quick context: this is a vendored fork of upstream Gateway API v0.7.1 that we pulled in for Consul-specific CRD customizations. The requirements.txt is purely for building the MkDocs static docs that came with that fork — it's not a runtime dependency and there's no CI pipeline or active Netlify deployment wired up to run make docs on PRs, so there's no automated path for an attacker to actually trigger this. 

That said, it's a trivial one-line fix (bump pymdown-extensions from 10.0 to 11.0.1) and we'll patch it to keep the scanner clean.

### How I've tested this PR ###

Ran the PoC from the advisory (SECVULN-52294 / GHSA-gm37-52c6-37mw) against `pymdown-extensions==11.0.1`. All four previously-vulnerable extensions (`caret`, `tilde`, `betterem`, `magiclink`) rendered the attack payloads instantly, confirming the fix:

| Extension | Input size | Render time (v10.0) | Render time (v11.0.1) |
|---|---|---|---|
| `pymdownx.caret` | 47 bytes | > 5s (hang) | 9.8 ms ✅ |
| `pymdownx.tilde` | 47 bytes | > 5s (hang) | 1.8 ms ✅ |
| `pymdownx.betterem` | 47 bytes | > 5s (hang) | 3.3 ms ✅ |
| `pymdownx.magiclink` | 49 bytes | > 5s (hang) | 6.0 ms ✅ |

All five `pymdownx` extensions referenced in `mkdocs.yml` (`emoji`, `highlight`, `inlinehilite`, `superfences`, `snippets`) were also verified to load and render cleanly with the new version alongside `mkdocs==1.6.1` and `mkdocs-material==9.1.12` — no compatibility regressions.

A full `mkdocs build` was attempted but could not be completed locally due to a pre-existing incompatibility between `mkdocs-macros-plugin==0.7.0` and modern `setuptools` (`pkg_resources` removal in setuptools ≥71). This failure was confirmed to be **pre-existing** — it reproduces identically on the old `pymdown-extensions==10.0` — and is unrelated to this change.


### How I expect reviewers to test this PR ###


### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
