### PR TITLE
Upgrade google apt package name for GCP and reflect correct capture target in help of debug cli

### DIFF
--- a/charts/consul/test/docker/Test.dockerfile
+++ b/charts/consul/test/docker/Test.dockerfile
@@ -30,11 +30,11 @@ RUN apt-get install -y \
 RUN pip3 install yq
 
 # gcloud
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
   apt-get update -y && \
-  apt-get install google-cloud-sdk -y && \
-  apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+  apt-get install google-cloud-cli -y && \
+  apt-get install google-cloud-cli-gke-gcloud-auth-plugin -y
 
 # terraform
 RUN curl -sSL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -o /tmp/tf.zip \

--- a/cli/cmd/debug/debug.go
+++ b/cli/cmd/debug/debug.go
@@ -199,7 +199,7 @@ func (c *DebugCommand) init() {
 		Name:    flagCapture,
 		Target:  &c.capture,
 		Default: []string{"all"},
-		Usage:   "List of components to capture. Supported values are: all, helm, crds, sidecar, pods, proxy. (e.g. -capture pods -capture proxy).",
+		Usage:   "List of components to capture. Supported values are: all, helm, crds, sidecar, logs, proxy. (e.g. -capture logs -capture proxy).",
 		Aliases: []string{"c"},
 	})
 	f.StringVar(&flag.StringVar{

--- a/cli/cmd/debug/debugPodLogs.go
+++ b/cli/cmd/debug/debugPodLogs.go
@@ -202,7 +202,7 @@ func (l *LogCapture) pushWorkloadContainers() {
 // - and fetches log for each of the pods and write it to /pod dir within debug archive
 // - also, writes log capture status to logCaptureAudit file and errors to logCaptureErrors file.
 func (l *LogCapture) captureLogs() error {
-	l.UI.Output("\nCapturing pods logs.....")
+	l.UI.Output("\nCapturing pod logs.....")
 	err := l.getConsulK8sComponents()
 	if err != nil {
 		l.UI.Output("%s", err, terminal.WithWarningStyle())

--- a/cli/cmd/debug/debugPodLogs_test.go
+++ b/cli/cmd/debug/debugPodLogs_test.go
@@ -37,7 +37,7 @@ func TestCapturePodLogs(t *testing.T) {
 				logContent := fmt.Sprintf("Logs for pod %s in namespace %s\n", podName, ns)
 				return io.NopCloser(bytes.NewReader([]byte(logContent))), nil
 			},
-			expectedOutputBuffer: []string{"Capturing pods logs....."},
+			expectedOutputBuffer: []string{"Capturing pod logs....."},
 			errorExpected:        false,
 		},
 		"test another namespace": {
@@ -47,7 +47,7 @@ func TestCapturePodLogs(t *testing.T) {
 				logContent := fmt.Sprintf("Logs for pod %s in namespace %s\n", podName, ns)
 				return io.NopCloser(bytes.NewReader([]byte(logContent))), nil
 			},
-			expectedOutputBuffer: []string{"Capturing pods logs....."},
+			expectedOutputBuffer: []string{"Capturing pod logs....."},
 			errorExpected:        false,
 		},
 		"test log collection with since": {
@@ -57,7 +57,7 @@ func TestCapturePodLogs(t *testing.T) {
 				logContent := fmt.Sprintf("Logs for pod %s in namespace %s\n", podName, ns)
 				return io.NopCloser(bytes.NewReader([]byte(logContent))), nil
 			},
-			expectedOutputBuffer: []string{"Capturing pods logs....."},
+			expectedOutputBuffer: []string{"Capturing pod logs....."},
 			errorExpected:        false,
 		},
 		"log capture failure": {
@@ -123,7 +123,7 @@ func TestCapturePodLogs(t *testing.T) {
 
 			require.NoError(t, err, "did not expect error capturing pod logs")
 			actual := buf.String()
-			require.Contains(t, actual, "Capturing pods logs.....")
+			require.Contains(t, actual, "Capturing pod logs.....")
 
 			// verify log files
 			expectedContainers := []string{"init-container", "nginx-container"}

--- a/cli/cmd/debug/debug_test.go
+++ b/cli/cmd/debug/debug_test.go
@@ -509,7 +509,7 @@ func TestDebugRun(t *testing.T) {
 			expectDebugArchive: true,
 			expectedOutputBuffer: []string{"Starting debugger:", "Helm capture successful",
 				"Crds capture successful", "Sidecar capture successful", "Proxy capture successful",
-				"Capturing pods logs.....", "Logs capture successful", "Index capture successful", "Saved debug archive"},
+				"Capturing pod logs.....", "Logs capture successful", "Index capture successful", "Saved debug archive"},
 		},
 		"success case with all targets with since": {
 			args: []string{"-archive=false", "-since=10s", "-output=tc2"}, // Default is all capture targets
@@ -529,7 +529,7 @@ func TestDebugRun(t *testing.T) {
 			expectDebugArchive: false,
 			expectedOutputBuffer: []string{"Starting debugger:", "Helm capture successful",
 				"Crds capture successful", "Sidecar capture successful", "Proxy capture successful",
-				"Capturing pods logs.....", "Logs capture successful", "Index capture successful", "Saved debug directory"},
+				"Capturing pod logs.....", "Logs capture successful", "Index capture successful", "Saved debug directory"},
 		},
 		"helm capture fail": {
 			args: []string{"-archive=false", "-duration=10s", "-output=tc3"},
@@ -549,7 +549,7 @@ func TestDebugRun(t *testing.T) {
 			expectDebugArchive: false,
 			expectedOutputBuffer: []string{"Starting debugger:", "Helm capture failed with error", "testing helm error",
 				"Crds capture successful", "Sidecar capture successful", "Proxy capture successful",
-				"Capturing pods logs.....", "Logs capture successful", "Index capture successful", "Saved debug directory"},
+				"Capturing pod logs.....", "Logs capture successful", "Index capture successful", "Saved debug directory"},
 		},
 		"envoy proxy data capture fail": {
 			args: []string{"-archive=false", "-duration=10s", "-output=tc4"},
@@ -569,7 +569,7 @@ func TestDebugRun(t *testing.T) {
 			expectDebugArchive: false,
 			expectedOutputBuffer: []string{"Starting debugger:", "Helm capture successful",
 				"Crds capture successful", "Sidecar capture successful", "Proxy capture failed with error", errMultipleErrorsOccuredAndWritten.Error(),
-				"Capturing pods logs.....", "Logs capture successful", "Index capture successful", "Saved debug directory"},
+				"Capturing pod logs.....", "Logs capture successful", "Index capture successful", "Saved debug directory"},
 		},
 		"log capture fail": {
 			args: []string{"-archive=true", "-duration=10s", "-output=tc5"},
@@ -589,7 +589,7 @@ func TestDebugRun(t *testing.T) {
 			expectDebugArchive: true,
 			expectedOutputBuffer: []string{"Starting debugger:", "Helm capture successful",
 				"Crds capture successful", "Sidecar capture successful", "Proxy capture successful",
-				"Capturing pods logs.....", "Logs capture failed with error", errMultipleErrorsOccuredAndWritten.Error(),
+				"Capturing pod logs.....", "Logs capture failed with error", errMultipleErrorsOccuredAndWritten.Error(),
 				"Index capture successful", "Saved debug archive"},
 		},
 	}


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Simple documentation change to reflect correct capture target in help of debug cli and minor grammatical change.
- Currently our [consul-k8s acceptance pipeline](https://github.com/hashicorp/consul-k8s-workflows/actions/runs/33356528275/job/99379667744) is failing where it is not able to build consul-k8s docker image for GCP which will be used for cloud acceptance test. It is failing because `Google deprecated and renamed their apt package in 2023. The old package name google-cloud-sdk no longer exists in their apt repository — it was replaced by google-cloud-cli.` 
**Updating it to newer package name, the [consul-k8s acceptance pipeline](https://github.com/hashicorp/consul-k8s-workflows/actions/runs/33356506249/job/99379605155) passed.** 


### How I've tested this PR ###
Not testing required for fix 1.
Acceptance test pipeline success is sufficient to test fix 2.


### How I expect reviewers to test this PR ###

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
