### PR TITLE
test: fix helm-test Dockerfile - google-cloud-sdk apt package renamed to google-cloud-cli

### DIFF
--- a/charts/consul/test/docker/Test.dockerfile
+++ b/charts/consul/test/docker/Test.dockerfile
@@ -33,8 +33,8 @@ RUN pip3 install yq
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
   curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
   apt-get update -y && \
-  apt-get install google-cloud-sdk -y && \
-  apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+  apt-get install google-cloud-cli -y && \
+  apt-get install google-cloud-cli-gke-gcloud-auth-plugin
 
 # terraform
 RUN curl -sSL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -o /tmp/tf.zip \


### PR DESCRIPTION
## Problem

`build-helm-test (amd64)` in consul-k8s-workflows started failing on main with:

```
E: Package 'google-cloud-sdk' has no installation candidate
```

Failing run: https://github.com/hashicorp/consul-k8s-workflows/actions/runs/33363342353/job/99438538493

## Root cause

Google removed the `google-cloud-sdk` apt package from `packages.cloud.google.com/apt cloud-sdk` around Aug 26-27, 2026. It last resolved successfully in our CI on Aug 24 (https://github.com/hashicorp/consul-k8s-workflows/actions/runs/32694869506/job/97383246580) and was gone by Aug 31. apt itself reports the replacement:

```
However the following packages replace it:
  google-cloud-cli
```

This is unrelated to any recent consul-k8s code change - it's an upstream apt repo change that broke `charts/consul/test/docker/Test.dockerfile`.

## Fix

Swap `google-cloud-sdk` -> `google-cloud-cli` and `google-cloud-sdk-gke-gcloud-auth-plugin` -> `google-cloud-cli-gke-gcloud-auth-plugin` in the gcloud install step of `Test.dockerfile`.

Verified against the live apt index: `google-cloud-sdk` returns 0 packages, `google-cloud-cli*` returns 48.