### PR TITLE
ci: skip coverage on draft PRs; run when ready for review

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@
 name: pr
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
     branches:
       - main
       - "release/**"
@@ -53,7 +53,7 @@ jobs:
       - conditional-skip
       - check-release-only
       - get-go-version
-    if: needs.conditional-skip.outputs.skip-ci != 'true' && needs.check-release-only.outputs.release-only != 'true'
+    if: needs.conditional-skip.outputs.skip-ci != 'true' && needs.check-release-only.outputs.release-only != 'true' && !github.event.pull_request.draft
     uses: ./.github/workflows/coverage.yml
     with:
       go-version: ${{ needs.get-go-version.outputs.go-version }}


### PR DESCRIPTION
## Summary

Skip coverage reporting and gates on draft PRs. Coverage only runs once the PR is marked ready for review.

## Why

- Draft PRs are works-in-progress and **cannot be merged** — running coverage gates and posting a coverage comment on them is noise before the author is done.
- Failing coverage gates on a draft creates false urgency and wastes CI minutes on code that may change significantly.
- Coverage should only enforce at the point the author signals the PR is ready.

## How it works

Two changes to `pr.yml`:

1. **Add `ready_for_review` to trigger types** — so when a draft is converted to ready, GitHub fires a `pull_request` event and coverage runs automatically. Without this, converting a draft would not retrigger the workflow.

2. **Add `!github.event.pull_request.draft` to the `coverage` job `if:`** — this stops the entire coverage workflow (`coverage.yml`, which contains the report, patch gate, regression gate and PR comment) from being called on draft events. Single guard, controls everything.

## What is NOT changed

- `coverage.yml` itself is unchanged — the guard is at the call site in `pr.yml`
- `reusable-coverage-report.yml` is unchanged
- All other jobs (test dispatch, pass-required-checks-on-skip) are unaffected