### PR TITLE
Prepare release 1.8.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 1.8.17 (September 10, 2026)
+
+SECURITY:
+
+* Upgrade go version to 1.26.7 to address security vulnerabilities. [[GH-5627](https://github.com/hashicorp/consul-k8s/issues/5627)]
+* dockerfile: Remove unnecessary `root` group membership for the user in ubi-based consul-k8s-control-plane image. [[GH-5640](https://github.com/hashicorp/consul-k8s/issues/5640)]
+* security: upgrade `golang.org/x/crypto` to v0.57.0, `golang.org/x/net` to v0.59.0, and `google.golang.org/grpc` to v1.83.2 across the control-plane, CLI, acceptance, CNI, and custom gateway-api modules to resolve security vulnerabilities. [[GH-5648](https://github.com/hashicorp/consul-k8s/issues/5648)]
+
+IMPROVEMENTS:
+
+* Helm: Expose `connectInject.cni.tolerations` as a configurable Helm value to allow operators to override CNI DaemonSet tolerations. Defaults to tolerating `CriticalAddonsOnly` and `NoExecute` taints when not set. [[GH-5562](https://github.com/hashicorp/consul-k8s/issues/5562)]
+* security: build FIPS artifacts against the in-tree Go Cryptographic Module (FIPS 140-3, `GOFIPS140=v1.0.0`, CMVP Certificate #5247) instead of BoringCrypto/CNG. FIPS binaries now run in FIPS mode via a baked-in `//go:debug fips140=on`, are pure Go (no cgo), and the artifact/version label changes from `fips1402` to `fips1403`. [[GH-5492](https://github.com/hashicorp/consul-k8s/issues/5492)]
+
+BUG FIXES:
+
+* api-gateway: Fix generate-manifest to correctly generate GatewayPolicy manifests. [[GH-5604](https://github.com/hashicorp/consul-k8s/issues/5604)]
+
 ## 2.0.3 (August 11, 2026)
 
 SECURITY:

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: consul
-version: 1.8.13-dev
-appVersion: 1.21-dev
+version: 1.8.17
+appVersion: 1.21.5
 kubeVersion: ">=1.22.0-0"
 description: Official HashiCorp Consul Chart
 home: https://www.consul.io
@@ -13,14 +13,14 @@ sources:
   - https://github.com/hashicorp/consul
   - https://github.com/hashicorp/consul-k8s
 annotations:
-  artifacthub.io/prerelease: "true"
+  artifacthub.io/prerelease: false"true"
   artifacthub.io/images: |
     - name: consul
-      image: docker.mirror.hashicorp.services/hashicorppreview/consul:1.21-dev
+      image: hashicorp/consul:1.21.5
     - name: consul-k8s-control-plane
-      image: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.8.13-dev
+      image: hashicorp/consul-k8s-control-plane:1.8.17
     - name: consul-dataplane
-      image: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.8-dev
+      image: hashicorp/consul-dataplane:1.8.17
     - name: envoy
       image: envoyproxy/envoy:v1.38.3
   artifacthub.io/license: MPL-2.0

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -13,7 +13,7 @@ sources:
   - https://github.com/hashicorp/consul
   - https://github.com/hashicorp/consul-k8s
 annotations:
-  artifacthub.io/prerelease: false"true"
+  artifacthub.io/prerelease: false
   artifacthub.io/images: |
     - name: consul
       image: hashicorp/consul:1.21.5
@@ -22,7 +22,7 @@ annotations:
     - name: consul-dataplane
       image: hashicorp/consul-dataplane:1.8.17
     - name: envoy
-      image: envoyproxy/envoy:v1.38.3
+      image: envoyproxy/envoy:v1.38.4
   artifacthub.io/license: MPL-2.0
   artifacthub.io/links: |
     - name: Documentation

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -67,7 +67,7 @@ global:
   # image: "hashicorp/consul-enterprise:1.10.0-ent"
   # ```
   # @default: hashicorp/consul:<latest version>
-  image: docker.mirror.hashicorp.services/hashicorppreview/consul:1.21-dev
+  image: hashicorp/consul:1.21.5
 
   # Array of objects containing image pull secret names that will be applied to each service account.
   # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.
@@ -87,7 +87,7 @@ global:
   # image that is used for functionality such as catalog sync.
   # This can be overridden per component.
   # @default: hashicorp/consul-k8s-control-plane:<latest version>
-  imageK8S: docker.mirror.hashicorp.services/hashicorppreview/consul-k8s-control-plane:1.8.13-dev
+  imageK8S: hashicorp/consul-k8s-control-plane:1.8.17
 
   # The image pull policy used globally for images controlled by Consul (consul, consul-dataplane, consul-k8s, consul-telemetry-collector).
   # One of "IfNotPresent", "Always", "Never", and "". Refer to https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
@@ -794,7 +794,7 @@ global:
   # The name (and tag) of the consul-dataplane Docker image used for the
   # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
   # @default: hashicorp/consul-dataplane:<latest supported version>
-  imageConsulDataplane: docker.mirror.hashicorp.services/hashicorppreview/consul-dataplane:1.8-dev
+  imageConsulDataplane: hashicorp/consul-dataplane:1.8.17
 
   # Disable this once the manifests are generated and subsequent helm upgrades
   

--- a/version/version.go
+++ b/version/version.go
@@ -17,12 +17,12 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
-	Version = "1.8.14"
+	Version = "1.8.17"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
Automated release preparation for consul-k8s 1.8.17.

Generated by `prepare-release-branch.sh` (output of `make prepare-release`).

- Release version: 1.8.17
- Release date: September 10, 2026
- Consul version: 1.21.5
- Consul Dataplane version: 1.8.17
- Last release tag: v1.8.16

Base branch `release/1.8.17` was created from `release/1.8.x`.