### PR TITLE
api-gateway: add externalTrafficPolicy to GatewayClassConfig

### DIFF
--- a/.changelog/5155.txt
+++ b/.changelog/5155.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api-gateway: add `externalTrafficPolicy` to `GatewayClassConfig` to allow setting the field on the generated gateway Service, so it is no longer reverted on every reconcile.
+```

--- a/charts/consul/templates/crd-gatewayclassconfigs-v1.yaml
+++ b/charts/consul/templates/crd-gatewayclassconfigs-v1.yaml
@@ -142,6 +142,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              externalTrafficPolicy:
+                description: |-
+                  ExternalTrafficPolicy determines whether the gateway service routes external
+                  traffic to node-local or cluster-wide endpoints. If unspecified, Kubernetes
+                  defaults this to "Cluster". Only applies to NodePort and LoadBalancer
+                  ServiceTypes; it is ignored for ClusterIP, which Kubernetes does not permit
+                  to set this field.
+                enum:
+                - Cluster
+                - Local
+                type: string
               mapPrivilegedContainerPorts:
                 description: The value to add to privileged ports ( ports < 1024)
                   for gateway containers

--- a/control-plane/api-gateway-custom/gatekeeper/service.go
+++ b/control-plane/api-gateway-custom/gatekeeper/service.go
@@ -104,10 +104,26 @@ func (g *Gatekeeper) service(gateway gwv1beta1.Gateway, gcc v1alpha1.GatewayClas
 			Annotations: annotations,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: common.LabelsForGateway(&gateway),
-			Type:     *gcc.Spec.ServiceType,
-			Ports:    ports,
+			Selector:              common.LabelsForGateway(&gateway),
+			Type:                  *gcc.Spec.ServiceType,
+			Ports:                 ports,
+			ExternalTrafficPolicy: externalTrafficPolicy(gcc),
 		},
+	}
+}
+
+// externalTrafficPolicy is only valid on NodePort and LoadBalancer services;
+// Kubernetes rejects it on ClusterIP services, so it's omitted there even if
+// configured.
+func externalTrafficPolicy(gcc v1alpha1.GatewayClassConfig) corev1.ServiceExternalTrafficPolicy {
+	if gcc.Spec.ExternalTrafficPolicy == nil {
+		return ""
+	}
+	switch *gcc.Spec.ServiceType {
+	case corev1.ServiceTypeNodePort, corev1.ServiceTypeLoadBalancer:
+		return *gcc.Spec.ExternalTrafficPolicy
+	default:
+		return ""
 	}
 }
 
@@ -125,6 +141,14 @@ func mergeServiceInto(existing, desired *corev1.Service) {
 	// we don't want to override that, so reset it to what exists in the store.
 	if hasEqualPorts(duplicate, desired) {
 		existing.Spec.Ports = duplicate.Spec.Ports
+	}
+
+	// Kubernetes auto-assigns HealthCheckNodePort when ExternalTrafficPolicy is
+	// Local, and the field cannot be changed once set. Preserve it while the
+	// service still needs it; otherwise let it be wiped, which Kubernetes
+	// requires when a service transitions away from needing it.
+	if desired.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyLocal {
+		existing.Spec.HealthCheckNodePort = duplicate.Spec.HealthCheckNodePort
 	}
 
 	// If the Service already exists, add any desired annotations + labels to existing set

--- a/control-plane/api-gateway-custom/gatekeeper/service_test.go
+++ b/control-plane/api-gateway-custom/gatekeeper/service_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package gatekeeper
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	gwv1beta1 "github.com/hashicorp/consul-k8s/control-plane/gateway07/gateway-api-0.7.1-custom/apis/v1beta1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestService_ExternalTrafficPolicy(t *testing.T) {
+	gateway := gwv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"}}
+	serviceType := corev1.ServiceTypeLoadBalancer
+
+	t.Run("unset by default", func(t *testing.T) {
+		gcc := v1alpha1.GatewayClassConfig{Spec: v1alpha1.GatewayClassConfigSpec{ServiceType: &serviceType}}
+		svc := (&Gatekeeper{}).service(gateway, gcc)
+		require.Empty(t, svc.Spec.ExternalTrafficPolicy)
+	})
+
+	t.Run("set from GatewayClassConfig", func(t *testing.T) {
+		policy := corev1.ServiceExternalTrafficPolicyLocal
+		gcc := v1alpha1.GatewayClassConfig{Spec: v1alpha1.GatewayClassConfigSpec{ServiceType: &serviceType, ExternalTrafficPolicy: &policy}}
+		svc := (&Gatekeeper{}).service(gateway, gcc)
+		require.Equal(t, corev1.ServiceExternalTrafficPolicyLocal, svc.Spec.ExternalTrafficPolicy)
+	})
+
+	// Kubernetes rejects ExternalTrafficPolicy on a ClusterIP service, so it
+	// must never be set even if the GatewayClassConfig requests it.
+	t.Run("omitted for ClusterIP services", func(t *testing.T) {
+		clusterIP := corev1.ServiceTypeClusterIP
+		policy := corev1.ServiceExternalTrafficPolicyLocal
+		gcc := v1alpha1.GatewayClassConfig{Spec: v1alpha1.GatewayClassConfigSpec{ServiceType: &clusterIP, ExternalTrafficPolicy: &policy}}
+		svc := (&Gatekeeper{}).service(gateway, gcc)
+		require.Empty(t, svc.Spec.ExternalTrafficPolicy)
+	})
+}
+
+// TestMergeServiceInto_HealthCheckNodePort guards against a real Kubernetes API
+// server rejection: HealthCheckNodePort is auto-assigned by Kubernetes when
+// ExternalTrafficPolicy is Local, and it cannot be changed once set. Since
+// mergeServiceInto resets existing.Spec to our generated (zero-valued) desired
+// spec on every reconcile, it must preserve the previously-assigned value for as
+// long as the policy stays Local, or every subsequent reconcile would send an
+// update the API server rejects.
+func TestMergeServiceInto_HealthCheckNodePort(t *testing.T) {
+	t.Run("preserved while ExternalTrafficPolicy stays Local", func(t *testing.T) {
+		existing := &corev1.Service{Spec: corev1.ServiceSpec{
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+			HealthCheckNodePort:   30123,
+		}}
+		desired := &corev1.Service{Spec: corev1.ServiceSpec{
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+		}}
+
+		mergeServiceInto(existing, desired)
+
+		require.EqualValues(t, 30123, existing.Spec.HealthCheckNodePort)
+	})
+
+	t.Run("wiped when policy no longer needs it", func(t *testing.T) {
+		existing := &corev1.Service{Spec: corev1.ServiceSpec{
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+			HealthCheckNodePort:   30123,
+		}}
+		desired := &corev1.Service{Spec: corev1.ServiceSpec{
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster,
+		}}
+
+		mergeServiceInto(existing, desired)
+
+		require.Zero(t, existing.Spec.HealthCheckNodePort)
+	})
+}

--- a/control-plane/api-gateway/gatekeeper/service.go
+++ b/control-plane/api-gateway/gatekeeper/service.go
@@ -104,10 +104,26 @@ func (g *Gatekeeper) service(gateway gwv1.Gateway, gcc v1alpha1.GatewayClassConf
 			Annotations: annotations,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: common.LabelsForGateway(&gateway),
-			Type:     *gcc.Spec.ServiceType,
-			Ports:    ports,
+			Selector:              common.LabelsForGateway(&gateway),
+			Type:                  *gcc.Spec.ServiceType,
+			Ports:                 ports,
+			ExternalTrafficPolicy: externalTrafficPolicy(gcc),
 		},
+	}
+}
+
+// externalTrafficPolicy is only valid on NodePort and LoadBalancer services;
+// Kubernetes rejects it on ClusterIP services, so it's omitted there even if
+// configured.
+func externalTrafficPolicy(gcc v1alpha1.GatewayClassConfig) corev1.ServiceExternalTrafficPolicy {
+	if gcc.Spec.ExternalTrafficPolicy == nil {
+		return ""
+	}
+	switch *gcc.Spec.ServiceType {
+	case corev1.ServiceTypeNodePort, corev1.ServiceTypeLoadBalancer:
+		return *gcc.Spec.ExternalTrafficPolicy
+	default:
+		return ""
 	}
 }
 
@@ -125,6 +141,14 @@ func mergeServiceInto(existing, desired *corev1.Service) {
 	// we don't want to override that, so reset it to what exists in the store.
 	if hasEqualPorts(duplicate, desired) {
 		existing.Spec.Ports = duplicate.Spec.Ports
+	}
+
+	// Kubernetes auto-assigns HealthCheckNodePort when ExternalTrafficPolicy is
+	// Local, and the field cannot be changed once set. Preserve it while the
+	// service still needs it; otherwise let it be wiped, which Kubernetes
+	// requires when a service transitions away from needing it.
+	if desired.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyLocal {
+		existing.Spec.HealthCheckNodePort = duplicate.Spec.HealthCheckNodePort
 	}
 
 	// If the Service already exists, add any desired annotations + labels to existing set

--- a/control-plane/api-gateway/gatekeeper/service_test.go
+++ b/control-plane/api-gateway/gatekeeper/service_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package gatekeeper
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul-k8s/control-plane/api/v1alpha1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestService_ExternalTrafficPolicy(t *testing.T) {
+	gateway := gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"}}
+	serviceType := corev1.ServiceTypeLoadBalancer
+
+	t.Run("unset by default", func(t *testing.T) {
+		gcc := v1alpha1.GatewayClassConfig{Spec: v1alpha1.GatewayClassConfigSpec{ServiceType: &serviceType}}
+		svc := (&Gatekeeper{}).service(gateway, gcc)
+		require.Empty(t, svc.Spec.ExternalTrafficPolicy)
+	})
+
+	t.Run("set from GatewayClassConfig", func(t *testing.T) {
+		policy := corev1.ServiceExternalTrafficPolicyLocal
+		gcc := v1alpha1.GatewayClassConfig{Spec: v1alpha1.GatewayClassConfigSpec{ServiceType: &serviceType, ExternalTrafficPolicy: &policy}}
+		svc := (&Gatekeeper{}).service(gateway, gcc)
+		require.Equal(t, corev1.ServiceExternalTrafficPolicyLocal, svc.Spec.ExternalTrafficPolicy)
+	})
+
+	// Kubernetes rejects ExternalTrafficPolicy on a ClusterIP service, so it
+	// must never be set even if the GatewayClassConfig requests it.
+	t.Run("omitted for ClusterIP services", func(t *testing.T) {
+		clusterIP := corev1.ServiceTypeClusterIP
+		policy := corev1.ServiceExternalTrafficPolicyLocal
+		gcc := v1alpha1.GatewayClassConfig{Spec: v1alpha1.GatewayClassConfigSpec{ServiceType: &clusterIP, ExternalTrafficPolicy: &policy}}
+		svc := (&Gatekeeper{}).service(gateway, gcc)
+		require.Empty(t, svc.Spec.ExternalTrafficPolicy)
+	})
+}
+
+// TestMergeServiceInto_HealthCheckNodePort guards against a real Kubernetes API
+// server rejection: HealthCheckNodePort is auto-assigned by Kubernetes when
+// ExternalTrafficPolicy is Local, and it cannot be changed once set. Since
+// mergeServiceInto resets existing.Spec to our generated (zero-valued) desired
+// spec on every reconcile, it must preserve the previously-assigned value for as
+// long as the policy stays Local, or every subsequent reconcile would send an
+// update the API server rejects.
+func TestMergeServiceInto_HealthCheckNodePort(t *testing.T) {
+	t.Run("preserved while ExternalTrafficPolicy stays Local", func(t *testing.T) {
+		existing := &corev1.Service{Spec: corev1.ServiceSpec{
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+			HealthCheckNodePort:   30123,
+		}}
+		desired := &corev1.Service{Spec: corev1.ServiceSpec{
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+		}}
+
+		mergeServiceInto(existing, desired)
+
+		require.EqualValues(t, 30123, existing.Spec.HealthCheckNodePort)
+	})
+
+	t.Run("wiped when policy no longer needs it", func(t *testing.T) {
+		existing := &corev1.Service{Spec: corev1.ServiceSpec{
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+			HealthCheckNodePort:   30123,
+		}}
+		desired := &corev1.Service{Spec: corev1.ServiceSpec{
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster,
+		}}
+
+		mergeServiceInto(existing, desired)
+
+		require.Zero(t, existing.Spec.HealthCheckNodePort)
+	})
+}

--- a/control-plane/api/v1alpha1/api_gateway_types.go
+++ b/control-plane/api/v1alpha1/api_gateway_types.go
@@ -42,6 +42,14 @@ type GatewayClassConfigSpec struct {
 	// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer
 	ServiceType *corev1.ServiceType `json:"serviceType,omitempty"`
 
+	// +kubebuilder:validation:Enum=Cluster;Local
+	// ExternalTrafficPolicy determines whether the gateway service routes external
+	// traffic to node-local or cluster-wide endpoints. If unspecified, Kubernetes
+	// defaults this to "Cluster". Only applies to NodePort and LoadBalancer
+	// ServiceTypes; it is ignored for ClusterIP, which Kubernetes does not permit
+	// to set this field.
+	ExternalTrafficPolicy *corev1.ServiceExternalTrafficPolicy `json:"externalTrafficPolicy,omitempty"`
+
 	// NodeSelector is a selector which must be true for the pod to fit on a node.
 	// Selector which must match a node's labels for the pod to be scheduled on that node.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/control-plane/api/v1alpha1/zz_generated.deepcopy.go
+++ b/control-plane/api/v1alpha1/zz_generated.deepcopy.go
@@ -540,6 +540,11 @@ func (in *GatewayClassConfigSpec) DeepCopyInto(out *GatewayClassConfigSpec) {
 		*out = new(v1.ServiceType)
 		**out = **in
 	}
+	if in.ExternalTrafficPolicy != nil {
+		in, out := &in.ExternalTrafficPolicy, &out.ExternalTrafficPolicy
+		*out = new(v1.ServiceExternalTrafficPolicy)
+		**out = **in
+	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
 		*out = make(map[string]string, len(*in))

--- a/control-plane/config/crd/bases/consul.hashicorp.com_gatewayclassconfigs.yaml
+++ b/control-plane/config/crd/bases/consul.hashicorp.com_gatewayclassconfigs.yaml
@@ -134,6 +134,17 @@ spec:
                         type: object
                     type: object
                 type: object
+              externalTrafficPolicy:
+                description: |-
+                  ExternalTrafficPolicy determines whether the gateway service routes external
+                  traffic to node-local or cluster-wide endpoints. If unspecified, Kubernetes
+                  defaults this to "Cluster". Only applies to NodePort and LoadBalancer
+                  ServiceTypes; it is ignored for ClusterIP, which Kubernetes does not permit
+                  to set this field.
+                enum:
+                - Cluster
+                - Local
+                type: string
               mapPrivilegedContainerPorts:
                 description: The value to add to privileged ports ( ports < 1024)
                   for gateway containers


### PR DESCRIPTION
## Summary

Adds `ExternalTrafficPolicy` to `GatewayClassConfig`, so the `Service` generated for a Consul API Gateway can be configured with `externalTrafficPolicy: Local` to preserve the real client source IP.

Fixes #5155. There was previously no supported way to do this: a manual `kubectl patch` on the generated `Service` gets reverted on the controller's next reconcile, since the whole `Service.Spec` is regenerated from the `GatewayClassConfig` every pass.

- Added `ExternalTrafficPolicy *corev1.ServiceExternalTrafficPolicy` to `GatewayClassConfigSpec` (`control-plane/api/v1alpha1/api_gateway_types.go`), wired through to the generated `Service` in both `api-gateway/gatekeeper/service.go` and `api-gateway-custom/gatekeeper/service.go`.
- The field is omitted for `ClusterIP` services, since Kubernetes rejects `externalTrafficPolicy` there — the same fix Cilium's own Gateway API controller needed (cilium/cilium#38928).
- `HealthCheckNodePort`, which Kubernetes auto-assigns when `ExternalTrafficPolicy: Local` and makes immutable once set, is now preserved across reconciles in `mergeServiceInto` to avoid a permanent reconcile-failure loop — the reconciler otherwise regenerates a zero-valued `Service.Spec` every pass and would send an update the API server rejects.
- Updated the CRD YAML (chart template + `config/crd/bases`) and generated deepcopy code to match.
- Added a changelog entry.

## Test plan

- [x] `go build ./...` in `control-plane`
- [x] `go test ./api-gateway/... ./api-gateway-custom/... ./api/...` — full existing suites pass
- [x] New unit tests covering: the field being set/unset on the generated `Service`, the `ClusterIP` omission guard, and the `HealthCheckNodePort` preservation/wipe behavior in `mergeServiceInto`
- [x] `TestControllerDoesNotInfinitelyReconcile` (both `api-gateway/controllers` and `api-gateway-custom/controllers`), run against a real `consul` binary, to directly confirm no reconcile-loop regression
- [x] `golangci-lint run` clean on all changed files
